### PR TITLE
feat(api, robot-server, shared-data): Add module definition geometric variants for modules with the same electronics.

### DIFF
--- a/api/src/opentrons/calibration_storage/deck_configuration.py
+++ b/api/src/opentrons/calibration_storage/deck_configuration.py
@@ -11,6 +11,7 @@ class _CutoutFixturePlacementModel(pydantic.BaseModel):
     cutoutId: str
     cutoutFixtureId: str
     opentronsModuleSerialNumber: Optional[str] = None
+    variant: Optional[str] = None
 
 
 class _DeckConfigurationModel(pydantic.BaseModel):
@@ -56,6 +57,7 @@ def deserialize_deck_configuration(
                 cutout_id=e.cutoutId,
                 cutout_fixture_id=e.cutoutFixtureId,
                 opentrons_module_serial_number=e.opentronsModuleSerialNumber,
+                variant=e.variant,
             )
             for e in parsed.cutoutFixtures
         ]

--- a/api/src/opentrons/calibration_storage/types.py
+++ b/api/src/opentrons/calibration_storage/types.py
@@ -43,3 +43,4 @@ class CutoutFixturePlacement:
     cutout_fixture_id: str
     cutout_id: str
     opentrons_module_serial_number: typing.Optional[str]
+    variant: typing.Optional[str]

--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -230,7 +230,7 @@ class ModuleType(StrEnum):
         if module_type == ModuleType.FLEX_STACKER:
             return "flexStackerModuleV1"
         if module_type == ModuleType.VACUUM_MODULE:
-            return "vacuumModuleMilliporeV1"
+            return "vacuumModuleV1"
         else:
             raise ValueError(
                 f"Module Type {module_type} does not have a related fixture ID."
@@ -269,8 +269,7 @@ class FlexStackerModuleModel(StrEnum):
 
 
 class VacuumModuleModel(StrEnum):
-    VACUUM_MODULE_MILLIPORE_V1 = "vacuumModuleMilliporeV1"
-    VACUUM_MODULE_OPENTRONS_V1 = "vacuumModuleOpentronsV1"
+    VACUUM_MODULE_V1 = "vacuumModuleV1"
 
 
 def module_model_from_string(model_string: str) -> ModuleModel:

--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -215,7 +215,9 @@ class ModuleType(StrEnum):
             return cls.VACUUM_MODULE
 
     @classmethod
-    def to_module_fixture_id(cls, module_type: ModuleType) -> str:
+    def to_module_fixture_id(
+        cls, module_type: ModuleType, variant: Optional[str] = None
+    ) -> str:
         if module_type == ModuleType.THERMOCYCLER:
             # Thermocyclers are "loaded" in B1 only
             return "thermocyclerModuleV2Front"
@@ -230,7 +232,8 @@ class ModuleType(StrEnum):
         if module_type == ModuleType.FLEX_STACKER:
             return "flexStackerModuleV1"
         if module_type == ModuleType.VACUUM_MODULE:
-            return "vacuumModuleV1"
+            default = variant or "Millipore"
+            return f"vacuumModule{default}V1"
         else:
             raise ValueError(
                 f"Module Type {module_type} does not have a related fixture ID."

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -714,6 +714,7 @@ class ProtocolCore(
         model: ModuleModel,
         deck_slot: Optional[DeckSlotName],
         configuration: Optional[str],
+        variant: Optional[str] = None,
     ) -> Union[ModuleCore, NonConnectedModuleCore]:
         """Load a module into the protocol."""
         assert configuration is None, "Module `configuration` is deprecated"
@@ -737,10 +738,15 @@ class ProtocolCore(
             cmd.LoadModuleParams(
                 model=EngineModuleModel(model),
                 location=DeckSlotLocation(slotName=normalized_deck_slot),
+                variant=variant,
+                moduleId=None,
             )
         )
 
-        module_core = self._get_module_core(load_module_result=result, model=model)
+        module_core = self._get_module_core(
+            load_module_result=result,
+            model=model,
+        )
 
         # FIXME(mm, 2023-02-21):
         # We're wrongly doing this conflict check *after* we've already loaded the

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -158,6 +158,7 @@ class AbstractProtocol(
         model: ModuleModel,
         deck_slot: Optional[DeckSlotName],
         configuration: Optional[str],
+        variant: Optional[str] = None,
     ) -> ModuleCoreType: ...
 
     @abstractmethod

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1862,9 +1862,11 @@ class VacuumModuleContext(ModuleContext):
         """Load a collar adapter to the vacuum module dock."""
 
         base_slot = self._core.get_deck_slot().id
-        area_name = f"{self.model}Dock{base_slot[0]}4"
+        # TODO: Make this get_variant()
+        variant = "Millipore"
+        base, ver = self.model.split("V")
+        area_name = f"{base}{variant}V{ver}Dock{base_slot[0]}4"
         location = AddressableAreaLocation(addressableAreaName=area_name)
-        # location = StagingSlotName.from_primitive(f"{self._core.get_deck_slot().id[0]}4")
         labware_core = self._protocol_core.load_adapter(
             load_name=name,
             namespace=namespace,
@@ -1906,7 +1908,12 @@ class VacuumModuleContext(ModuleContext):
             if drop_offset
             else None
         )
-        location = AddressableAreaLocation(addressableAreaName=f"{self.model}DockA4")
+        # TODO: Make this dynamic
+        variant = "Millipore"
+        base_slot = self._core.get_deck_slot().id
+        base, ver = self.model.split("V")
+        area_name = f"{base}{variant}V{ver}Dock{base_slot[0]}4"
+        location = AddressableAreaLocation(addressableAreaName=area_name)
         self._protocol_core.move_labware(
             labware._core,
             new_location=location,

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -918,6 +918,7 @@ class ProtocolContext(CommandPublisher):
         module_name: str,
         location: Optional[DeckLocation] = None,
         configuration: Optional[str] = None,
+        variant: Optional[str] = None,
     ) -> ModuleTypes:
         """
         Load a module onto the deck, given its name or model.
@@ -955,6 +956,9 @@ class ProtocolContext(CommandPublisher):
                 *Removed in version 2.14:*
                 This parameter dangerously modified the protocol's geometry system,
                 and it didn't function properly, so it was removed.
+
+            variant: Physical geometry variant when multiple definitions exist
+                for the same electronic model (e.g. 'Opentrons' or 'Millipore').
 
         Returns:
             The loaded and initialized module: a
@@ -1038,6 +1042,7 @@ class ProtocolContext(CommandPublisher):
             model=requested_model,
             deck_slot=deck_slot,
             configuration=configuration,
+            variant=variant,
         )
 
         module_context = _create_module_context(

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -412,8 +412,7 @@ _MODULE_MODELS: Dict[str, ModuleModel] = {
     "magneticBlockV1": MagneticBlockModel.MAGNETIC_BLOCK_V1,
     "absorbanceReaderV1": AbsorbanceReaderModel.ABSORBANCE_READER_V1,
     "flexStackerModuleV1": FlexStackerModuleModel.FLEX_STACKER_V1,
-    "vacuumModuleMilliporeV1": VacuumModuleModel.VACUUM_MODULE_MILLIPORE_V1,
-    "vacuumModuleOpentronsV1": VacuumModuleModel.VACUUM_MODULE_OPENTRONS_V1,
+    "vacuumModuleV1": VacuumModuleModel.VACUUM_MODULE_V1,
 }
 
 

--- a/api/src/opentrons/protocol_engine/commands/load_module.py
+++ b/api/src/opentrons/protocol_engine/commands/load_module.py
@@ -72,6 +72,11 @@ class LoadModuleParams(BaseModel):
         json_schema_extra=_remove_default,
     )
 
+    variant: str | SkipJsonSchema[None] = Field(
+        None,
+        description="Physical geometry variant when multiple definitions exist for the same electronic model (e.g. 'Opentrons' or 'Millipore').",
+    )
+
 
 class LoadModuleResult(BaseModel):
     """The results of loading a module."""
@@ -101,6 +106,12 @@ class LoadModuleResult(BaseModel):
         "Will be `None` if a module is not electrically connected to the robot (like the Magnetic Block).",
     )
 
+    variant: Optional[str] = Field(
+        None,
+        description="Physical geometry variant when multiple definitions exist"
+        "for the same electronic model (e.g. 'Opentrons' or 'Millipore').",
+    )
+
 
 class LoadModuleImplementation(
     AbstractCommandImpl[LoadModuleParams, SuccessData[LoadModuleResult]]
@@ -118,13 +129,16 @@ class LoadModuleImplementation(
         state_update = StateUpdate()
 
         module_type = params.model.as_type()
-        self._ensure_module_location(params.location.slotName, module_type)
+        self._ensure_module_location(
+            params.location.slotName, module_type, params.variant
+        )
 
         if self._state_view.modules.get_deck_supports_module_fixtures():
             addressable_area_module_reference = (
                 self._state_view.modules.ensure_and_convert_module_fixture_location(
                     deck_slot=params.location.slotName,
                     model=params.model,
+                    variant=params.variant,
                 )
             )
         else:
@@ -156,6 +170,7 @@ class LoadModuleImplementation(
                     addressableAreaName=addressable_area_module_reference
                 ),
                 module_id=params.moduleId,
+                variant=params.variant,
             )
 
         state_update.set_load_module(
@@ -171,12 +186,13 @@ class LoadModuleImplementation(
                 moduleId=loaded_module.module_id,
                 serialNumber=loaded_module.serial_number,
                 model=loaded_module.definition.model,
+                variant=params.variant,
             ),
             state_update=state_update,
         )
 
     def _ensure_module_location(
-        self, slot: DeckSlotName, module_type: ModuleType
+        self, slot: DeckSlotName, module_type: ModuleType, variant: Optional[str] = None
     ) -> None:
         # todo(mm, 2024-12-03): Theoretically, we should be able to deal with
         # addressable areas and deck configurations the same way between OT-2 and Flex.
@@ -189,7 +205,7 @@ class LoadModuleImplementation(
                     f"A {module_type.value} cannot be loaded into slot {slot}"
                 )
         else:
-            cutout_fixture_id = ModuleType.to_module_fixture_id(module_type)
+            cutout_fixture_id = ModuleType.to_module_fixture_id(module_type, variant)
             module_fixture = deck_configuration_provider.get_cutout_fixture(
                 cutout_fixture_id,
                 self._state_view.labware.get_deck_definition(),

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -489,6 +489,7 @@ class EquipmentHandler:
         model: ModuleModel,
         location: AddressableAreaLocation,
         module_id: Optional[str],
+        variant: Optional[str] = None,
     ) -> LoadedModuleData:
         """Ensure the required module is attached.
 
@@ -515,7 +516,7 @@ class EquipmentHandler:
                 HardwareModule(
                     serial_number=hw_mod.device_info["serial"],
                     definition=self._module_data_provider.get_definition(
-                        ModuleModel(hw_mod.model())
+                        ModuleModel(hw_mod.model()), variant=variant
                     ),
                 )
                 for hw_mod in self._hardware_api.attached_modules

--- a/api/src/opentrons/protocol_engine/resources/module_data_provider.py
+++ b/api/src/opentrons/protocol_engine/resources/module_data_provider.py
@@ -1,6 +1,6 @@
 """Module data resource provider."""
 
-from typing import Dict
+from typing import Dict, Optional
 
 from opentrons_shared_data.module import load_definition
 
@@ -21,9 +21,12 @@ class ModuleDataProvider:
     """Module data provider."""
 
     @staticmethod
-    def get_definition(model: ModuleModel) -> ModuleDefinition:
+    def get_definition(
+        model: ModuleModel, variant: Optional[str] = None
+    ) -> ModuleDefinition:
         """Get the module definition."""
-        data = load_definition(model_or_loadname=model.value, version="3")
+        definition_name = model.as_variant(variant)
+        data = load_definition(model_or_loadname=definition_name, version="3")
         return ModuleDefinition.model_validate(data)
 
     @staticmethod

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1105,17 +1105,12 @@ class GeometryView:
                         and labware_definition is not None
                     ):
                         # TODO: Fix
-                        # EXCEPTION: If the module is a Vacuum Module and we are loading
+                        # If the module is a Vacuum Module and we are loading
                         # into its designated staging dock, do NOT raise.
                         is_vacuum_module = "vacuumModule" in module_at_location.model
                         is_staging_area = any(
                             char in location.addressableAreaName for char in "4"
                         )
-                        quirks = labware_definition.parameters.quirks
-                        if is_vacuum_module and quirks is not None:
-                            name = f"{module_at_location.model}Dock{location.addressableAreaName}"
-                            is_dock = f"{module_at_location.model}" in list(quirks)
-
                         if not (is_vacuum_module and is_staging_area):
                             # Otherwise, proceed with standard standard collision check
                             self._modules.raise_if_module_in_location(

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1093,6 +1093,10 @@ class ModuleView:
                 f"Cannot get lid height of {definition.moduleType}"
             )
 
+    def get_variant(self, module_id: str) -> str:
+        """Get the geometric variant of this module."""
+        return self.get_definition(module_id).variant
+
     @staticmethod
     def get_magnet_home_to_base_offset(module_model: ModuleModel) -> float:
         """Return a Magnetic Module's home offset.
@@ -1420,9 +1424,7 @@ class ModuleView:
         return deck_type not in [DeckType.OT2_STANDARD, DeckType.OT2_SHORT_TRASH]
 
     def ensure_and_convert_module_fixture_location(
-        self,
-        deck_slot: DeckSlotName,
-        model: ModuleModel,
+        self, deck_slot: DeckSlotName, model: ModuleModel, variant: Optional[str] = None
     ) -> str:
         """Ensure module fixture load location is valid.
 
@@ -1464,7 +1466,8 @@ class ModuleView:
         elif model in [ModuleModel.VACUUM_MODULE_V1]:
             # only allowed in column 3
             assert deck_slot.value[-1] == "3"
-            return f"{model.value}{deck_slot.value}"
+            default = variant or "Millipore"
+            return f"vacuumModule{default}V1{deck_slot.value}"
 
         raise ValueError(
             f"Unknown module {model.name} has no addressable areas to provide."

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1461,10 +1461,7 @@ class ModuleView:
             # loaded to column 3 but the addressable area is in column 4
             assert deck_slot.value[-1] == "3"
             return f"flexStackerModuleV1{deck_slot.value[0]}4"
-        elif model in [
-            ModuleModel.VACUUM_MODULE_MILLIPORE_V1,
-            ModuleModel.VACUUM_MODULE_OPENTRONS_V1,
-        ]:
+        elif model in [ModuleModel.VACUUM_MODULE_V1]:
             # only allowed in column 3
             assert deck_slot.value[-1] == "3"
             return f"{model.value}{deck_slot.value}"

--- a/api/src/opentrons/protocol_engine/types/deck_configuration.py
+++ b/api/src/opentrons/protocol_engine/types/deck_configuration.py
@@ -68,8 +68,8 @@ class AddressableArea:
 # TODO make the below some sort of better type
 # TODO This should instead contain a proper cutout fixture type
 DeckConfigurationType = List[
-    Tuple[str, str, Optional[str]]
-]  # cutout_id, cutout_fixture_id, opentrons_module_serial_number
+    Tuple[str, str, Optional[str], Optional[str]]
+]  # cutout_id, cutout_fixture_id, opentrons_module_serial_number, variant
 
 
 # TODO(mm, 2023-05-10): Deduplicate with constants in

--- a/api/src/opentrons/protocol_engine/types/module.py
+++ b/api/src/opentrons/protocol_engine/types/module.py
@@ -46,8 +46,7 @@ class ModuleModel(StrEnum):
     MAGNETIC_BLOCK_V1 = "magneticBlockV1"
     ABSORBANCE_READER_V1 = "absorbanceReaderV1"
     FLEX_STACKER_MODULE_V1 = "flexStackerModuleV1"
-    VACUUM_MODULE_MILLIPORE_V1 = "vacuumModuleMilliporeV1"
-    VACUUM_MODULE_OPENTRONS_V1 = "vacuumModuleOpentronsV1"
+    VACUUM_MODULE_V1 = "vacuumModuleV1"
 
     @classmethod
     def from_hardware(cls, hardware_model: HardwareModuleModel) -> "ModuleModel":
@@ -123,7 +122,7 @@ class ModuleModel(StrEnum):
     @classmethod
     def is_vacuum_module(cls, model: ModuleModel) -> TypeGuard[VacuumModuleModel]:
         """Whether a given model is a Vacuum Module."""
-        return model in [cls.VACUUM_MODULE_OPENTRONS_V1, cls.VACUUM_MODULE_MILLIPORE_V1]
+        return model in [cls.VACUUM_MODULE_V1]
 
 
 TemperatureModuleModel = Literal[
@@ -139,9 +138,7 @@ HeaterShakerModuleModel = Literal[ModuleModel.HEATER_SHAKER_MODULE_V1]
 MagneticBlockModel = Literal[ModuleModel.MAGNETIC_BLOCK_V1]
 AbsorbanceReaderModel = Literal[ModuleModel.ABSORBANCE_READER_V1]
 FlexStackerModuleModel = Literal[ModuleModel.FLEX_STACKER_MODULE_V1]
-VacuumModuleModel = Literal[
-    ModuleModel.VACUUM_MODULE_MILLIPORE_V1, ModuleModel.VACUUM_MODULE_OPENTRONS_V1
-]
+VacuumModuleModel = Literal[ModuleModel.VACUUM_MODULE_V1]
 
 
 class ModuleDimensions(BaseModel):

--- a/api/src/opentrons/protocol_engine/types/module.py
+++ b/api/src/opentrons/protocol_engine/types/module.py
@@ -31,6 +31,13 @@ from opentrons.hardware_control.modules import (
     ModuleType as ModuleType,
 )
 
+_MODULE_VARIANTS: dict[str, dict[str, str]] = {
+    "vacuumModuleV1": {
+        "Opentrons": "vacuumModuleOpentronsV1",
+        "Millipore": "vacuumModuleMilliporeV1",
+    },
+}
+
 
 # TODO(mc, 2022-01-18): use opentrons_shared_data.module.types.ModuleModel
 class ModuleModel(StrEnum):
@@ -73,6 +80,12 @@ class ModuleModel(StrEnum):
             return ModuleType.VACUUM_MODULE
 
         assert False, f"Invalid ModuleModel {self}"
+
+    def as_variant(self, variant: str | None = None) -> str:
+        default = variant or ""
+        if ModuleModel.is_vacuum_module(self):
+            default = variant or "Millipore"
+        return _MODULE_VARIANTS.get(self.value, {}).get(default, self.value)
 
     @classmethod
     def is_temperature_module_model(
@@ -188,6 +201,8 @@ class ModuleDefinition(BaseModel):
 
     model: ModuleModel = Field(...)
 
+    variant: Optional[str] = Field(default=None)
+
     labwareOffset: LabwareOffsetVector = Field(...)
 
     dimensions: ModuleDimensions = Field(...)
@@ -238,6 +253,7 @@ class LoadedModule(BaseModel):
     model: ModuleModel
     location: Optional[DeckSlotLocation] = None
     serialNumber: Optional[str] = None
+    variant: Optional[str] = None
 
 
 class SpeedRange(NamedTuple):

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -122,7 +122,7 @@ async def test_module_caching() -> None:
         (HeaterShakerModuleModel.HEATER_SHAKER_V1, HeaterShaker),
         (AbsorbanceReaderModel.ABSORBANCE_READER_V1, AbsorbanceReader),
         (FlexStackerModuleModel.FLEX_STACKER_V1, FlexStacker),
-        (VacuumModuleModel.VACUUM_MODULE_MILLIPORE_V1, VacuumModule),
+        (VacuumModuleModel.VACUUM_MODULE_V1, VacuumModule),
     ],
 )
 async def test_create_simulating_module(

--- a/hardware-testing/hardware_testing/modules/vacuum_module/vacuum_module_slas_2026_demo.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/vacuum_module_slas_2026_demo.py
@@ -30,11 +30,11 @@ def run(ctx: ProtocolContext) -> None:
     # Create a virtual vm if one does not exist
     vm = [m for m in ctx._hw_manager.hardware.attached_modules if m.serial_number == "VMA1020250119002"]
     if not vm:
-        ctx._hw_manager.hardware.create_simulating_module(VacuumModuleModel.VACUUM_MODULE_MILLIPORE_V1, "VMA1020250119002")
+        ctx._hw_manager.hardware.create_simulating_module(VacuumModuleModel.VACUUM_MODULE_V1, "VMA1020250119002")
 
     # Load Modules
-    vm_mod  = ctx.load_module( module_name="vacuumModuleMilliporeV1", location="A3")
-    abs_mod = ctx.load_module( module_name="absorbanceReaderV1", location="D3")
+    vm_mod  = ctx.load_module(module_name="vacuumModuleV1", location="A3", variant="Millipore")
+    abs_mod = ctx.load_module(module_name="absorbanceReaderV1", location="D3")
     abs_mod.open_lid()
 
     # Load Tipracks

--- a/robot-server/robot_server/deck_configuration/models.py
+++ b/robot-server/robot_server/deck_configuration/models.py
@@ -39,6 +39,13 @@ class CutoutFixture(pydantic.BaseModel):
         ),
         default=None,
     )
+    variant: Optional[str] = pydantic.Field(
+        description=(
+            "The physical geometry variant of this module"
+            " [deck definition](https://github.com/Opentrons/opentrons/tree/edge/shared-data/deck)."
+        ),
+        default=None,
+    )
 
 
 class DeckConfigurationRequest(pydantic.BaseModel):

--- a/robot-server/robot_server/deck_configuration/store.py
+++ b/robot-server/robot_server/deck_configuration/store.py
@@ -78,7 +78,12 @@ class DeckConfigurationStore:  # noqa: D101
         """Get the robot's current deck configuration in an expected typing."""
         to_convert = await self.get()
         converted = [
-            (item.cutoutId, item.cutoutFixtureId, item.opentronsModuleSerialNumber)
+            (
+                item.cutoutId,
+                item.cutoutFixtureId,
+                item.opentronsModuleSerialNumber,
+                item.variant,
+            )
             for item in to_convert.cutoutFixtures
         ]
         return converted
@@ -146,6 +151,7 @@ def _http_types_to_storage_types(
             cutout_fixture_id=http_element.cutoutFixtureId,
             cutout_id=http_element.cutoutId,
             opentrons_module_serial_number=http_element.opentronsModuleSerialNumber,
+            variant=http_element.variant,
         )
         for http_element in http_val.cutoutFixtures
     ]
@@ -161,6 +167,7 @@ def _storage_types_to_http_types(
             cutoutFixtureId=storage_element.cutout_fixture_id,
             cutoutId=storage_element.cutout_id,
             opentronsModuleSerialNumber=storage_element.opentrons_module_serial_number,
+            variant=storage_element.variant,
         )
         for storage_element in storage_cutout_fixtures
     ]

--- a/robot-server/robot_server/modules/module_data_mapper.py
+++ b/robot-server/robot_server/modules/module_data_mapper.py
@@ -75,6 +75,7 @@ class ModuleDataMapper:
         live_data: LiveData,
         usb_port: HardwareUSBPort,
         module_offset: Optional[ModuleCalibrationData],
+        module_variant: Optional[str],
     ) -> AttachedModule:
         """Map hardware control data to an attached module response."""
         module_model = ModuleModel(model)
@@ -82,7 +83,9 @@ class ModuleDataMapper:
 
         module_cls: Type[AttachedModule]
         module_data: AttachedModuleData
-        module_definition = load_definition(model_or_loadname=model, version="3")
+        # TODO: variant should be dynamic
+        load_name = module_model.as_variant()
+        module_definition = load_definition(model_or_loadname=load_name, version="3")
         compatible_with_robot = (
             self.deck_type.value not in module_definition["incompatibleWithDecks"]
         )
@@ -231,4 +234,5 @@ class ModuleDataMapper:
             moduleModel=module_model,  # type: ignore[arg-type]
             data=module_data,  # type: ignore[arg-type]
             moduleOffset=module_offset,
+            moduleVariant=module_variant,
         )

--- a/robot-server/robot_server/modules/module_models.py
+++ b/robot-server/robot_server/modules/module_models.py
@@ -96,6 +96,9 @@ class _GenericModule(BaseModel, Generic[ModuleT, ModuleModelT, ModuleDataT]):
     moduleOffset: Optional[ModuleCalibrationData] = Field(
         None, description="The calibrated module offset."
     )
+    moduleVariant: Optional[str] = Field(
+        None, description="The physical variant of the device."
+    )
     compatibleWithRobot: bool = Field(
         ..., description="Whether the detected module is compatible with this robot."
     )

--- a/robot-server/robot_server/modules/module_models.py
+++ b/robot-server/robot_server/modules/module_models.py
@@ -421,19 +421,14 @@ class VacuumModuleData(BaseModel):
 class VacuumModule(
     _GenericModule[
         Literal[ModuleType.VACUUM_MODULE],
-        Literal[
-            ModuleModel.VACUUM_MODULE_MILLIPORE_V1,
-            ModuleModel.VACUUM_MODULE_OPENTRONS_V1,
-        ],
+        Literal[ModuleModel.VACUUM_MODULE_V1],
         VacuumModuleData,
     ]
 ):
     """An attached Vacuum Module."""
 
     moduleType: Literal[ModuleType.VACUUM_MODULE]
-    moduleModel: Literal[
-        ModuleModel.VACUUM_MODULE_MILLIPORE_V1, ModuleModel.VACUUM_MODULE_OPENTRONS_V1
-    ]
+    moduleModel: Literal[ModuleModel.VACUUM_MODULE_V1]
     data: VacuumModuleData
 
 

--- a/robot-server/robot_server/modules/router.py
+++ b/robot-server/robot_server/modules/router.py
@@ -12,6 +12,10 @@ from server_utils.fastapi_utils.light_router import LightRouter
 from .module_data_mapper import ModuleDataMapper
 from .module_identifier import ModuleIdentifier
 from .module_models import AttachedModule, ModuleCalibrationData
+from robot_server.deck_configuration.fastapi_dependencies import (
+    get_deck_configuration_store,
+)
+from robot_server.deck_configuration.store import DeckConfigurationStore
 from robot_server.hardware import get_hardware
 from robot_server.service.json_api import (
     MultiBodyMeta,
@@ -40,6 +44,9 @@ async def get_attached_modules(
     hardware: Annotated[HardwareControlAPI, Depends(get_hardware)],
     module_identifier: Annotated[ModuleIdentifier, Depends(ModuleIdentifier)],
     module_data_mapper: Annotated[ModuleDataMapper, Depends(ModuleDataMapper)],
+    deck_configuration_store: Annotated[
+        DeckConfigurationStore, Depends(get_deck_configuration_store)
+    ],
 ) -> PydanticResponse[SimpleMultiBody[AttachedModule]]:
     """Get a list of all attached modules."""
     if requested_version <= 2:
@@ -56,10 +63,19 @@ async def get_attached_modules(
         mod.module_id: mod for mod in module_calibration.load_all_module_calibrations()
     }
 
+    # Load any module variants from deck configuration
+    module_variants: Dict[str, str] = {}
+    deck_configuration = await deck_configuration_store.get_deck_configuration()
+    for fixture in deck_configuration:
+        _, _, sn, variant = fixture
+        if sn and variant:
+            module_variants[sn] = variant
+
     response_data: List[AttachedModule] = []
     for mod in hardware.attached_modules:
         serial_number = mod.device_info["serial"]
         calibrated = module_calibrations.get(serial_number)
+        variant = module_variants.get(serial_number)
         module_identity = module_identifier.identify(mod.device_info)
 
         response_data.append(
@@ -81,6 +97,7 @@ async def get_attached_modules(
                 )
                 if calibrated
                 else None,
+                module_variant=variant,
             )
         )
 

--- a/robot-server/tests/deck_configuration/test_validation.py
+++ b/robot-server/tests/deck_configuration/test_validation.py
@@ -232,7 +232,7 @@ def test_unrecognized_cutout_fixture() -> None:
                     "flexStackerModuleV1WithWasteChuteRightAdapterCovered",
                     "flexStackerModuleV1WithWasteChuteRightAdapterNoCover",
                     "flexStackerModuleV1WithMagneticBlockV1",
-                    "vacuumModuleV1"
+                    "vacuumModuleV1",
                 ]
             ),
         )

--- a/robot-server/tests/deck_configuration/test_validation.py
+++ b/robot-server/tests/deck_configuration/test_validation.py
@@ -232,7 +232,7 @@ def test_unrecognized_cutout_fixture() -> None:
                     "flexStackerModuleV1WithWasteChuteRightAdapterCovered",
                     "flexStackerModuleV1WithWasteChuteRightAdapterNoCover",
                     "flexStackerModuleV1WithMagneticBlockV1",
-                    "vacuumModuleMilliporeV1",
+                    "vacuumModuleV1"
                 ]
             ),
         )

--- a/shared-data/command/schemas/16.json
+++ b/shared-data/command/schemas/16.json
@@ -3224,7 +3224,7 @@
         "magneticBlockV1",
         "absorbanceReaderV1",
         "flexStackerModuleV1",
-        "vacuumModuleMilliporeV1"
+        "vacuumModuleV1"
       ],
       "title": "ModuleModel",
       "type": "string"

--- a/shared-data/command/schemas/17.json
+++ b/shared-data/command/schemas/17.json
@@ -3576,7 +3576,7 @@
         "magneticBlockV1",
         "absorbanceReaderV1",
         "flexStackerModuleV1",
-        "vacuumModuleMilliporeV1"
+        "vacuumModuleV1"
       ],
       "title": "ModuleModel",
       "type": "string"

--- a/shared-data/deck/definitions/5/ot3_standard.json
+++ b/shared-data/deck/definitions/5/ot3_standard.json
@@ -1001,6 +1001,32 @@
         "displayName": "Vacuum Module Dock in A4",
         "features": {},
         "orientation": "right"
+      },
+      {
+        "id": "vacuumModuleOpentronsV1A3",
+        "areaType": "vacuumModule",
+        "offsetFromCutoutFixture": [0.0, 0.0, 20.50],
+        "boundingBox": {
+          "xDimension": 128.0,
+          "yDimension": 86.0,
+          "zDimension": 0
+        },
+        "displayName": "Vacuum Module in A3",
+        "features": {},
+        "orientation": "right"
+      },
+      {
+        "id": "vacuumModuleOpentronsV1DockA4",
+        "areaType": "lidDock",
+        "offsetFromCutoutFixture": [162.0, 0.0, 26.0],
+        "boundingBox": {
+          "xDimension": 128.5,
+          "yDimension": 86.5,
+          "zDimension": 0
+        },
+        "displayName": "Vacuum Module Dock in A4",
+        "features": {},
+        "orientation": "right"
       }
     ],
     "cutouts": [
@@ -1434,6 +1460,17 @@
       "displayName": "Slot With a Vacuum Module Millipore Base",
       "providesAddressableAreas": {
         "cutoutA3": ["vacuumModuleMilliporeV1A3", "vacuumModuleMilliporeV1DockA4"]
+      },
+      "fixtureGroup": {},
+      "height": 10.65
+    },
+    {
+      "id": "vacuumModuleOpentronsV1",
+      "expectOpentronsModuleSerialNumber": true,
+      "mayMountTo": ["cutoutA3"],
+      "displayName": "Slot With a Vacuum Module Opentrons Base",
+      "providesAddressableAreas": {
+        "cutoutA3": ["vacuumModuleOpentronsV1A3", "vacuumModuleOpentronsV1DockA4"]
       },
       "fixtureGroup": {},
       "height": 10.65

--- a/shared-data/deck/types/schemaV5.ts
+++ b/shared-data/deck/types/schemaV5.ts
@@ -145,7 +145,7 @@ export type FlexModuleCutoutFixtureId =
   | 'absorbanceReaderV1'
   | 'flexStackerModuleV1'
   | 'flexStackerModuleV1WithMagneticBlockV1'
-  | 'vacuumModuleMilliporeV1'
+  | 'vacuumModuleV1'
 
 export type OT2SingleStandardSlot = 'singleStandardSlot'
 

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -52,8 +52,7 @@ export const HEATERSHAKER_MODULE_V1: 'heaterShakerModuleV1' =
 export const ABSORBANCE_READER_V1: 'absorbanceReaderV1' = 'absorbanceReaderV1'
 export const FLEX_STACKER_MODULE_V1: 'flexStackerModuleV1' =
   'flexStackerModuleV1'
-export const VACUUM_MODULE_MILLIPORE_V1: 'vacuumModuleMilliporeV1' =
-  'vacuumModuleMilliporeV1'
+export const VACUUM_MODULE_V1: 'vacuumModuleV1' = 'vacuumModuleV1'
 
 export const MAGNETIC_BLOCK_V1: 'magneticBlockV1' = 'magneticBlockV1'
 
@@ -123,7 +122,7 @@ export const ABSORBANCE_READER_MODELS = [ABSORBANCE_READER_V1]
 
 export const FLEX_STACKER_MODULE_MODELS = [FLEX_STACKER_MODULE_V1]
 
-export const VACUUM_MODULE_MODELS = [VACUUM_MODULE_MILLIPORE_V1]
+export const VACUUM_MODULE_MODELS = [VACUUM_MODULE_V1]
 
 export const MAGNETIC_BLOCK_MODELS = [MAGNETIC_BLOCK_V1]
 
@@ -691,8 +690,7 @@ export const FLEX_STACKER_WITH_WASTE_CHUTE_ADAPTER_NO_COVER_FIXTURE: 'flexStacke
   'flexStackerModuleV1WithWasteChuteRightAdapterNoCover'
 export const FLEX_STACKER_WITH_MAG_BLOCK_FIXTURE: 'flexStackerModuleV1WithMagneticBlockV1' =
   'flexStackerModuleV1WithMagneticBlockV1'
-export const VACUUM_MODULE_MILLIPORE_V1_FIXTURE: 'vacuumModuleMilliporeV1' =
-  'vacuumModuleMilliporeV1'
+export const VACUUM_MODULE_V1_FIXTURE: 'vacuumModuleV1' = 'vacuumModuleV1'
 
 export const FLEX_MODULE_AA_TYPE_BY_MODEL: {
   [moduleModel in ModuleModel]?: AreaType
@@ -703,7 +701,7 @@ export const FLEX_MODULE_AA_TYPE_BY_MODEL: {
   [THERMOCYCLER_MODULE_V2]: 'thermocycler',
   [ABSORBANCE_READER_V1]: 'absorbanceReader',
   [FLEX_STACKER_MODULE_V1]: 'flexStacker',
-  [VACUUM_MODULE_MILLIPORE_V1]: 'vacuumModule',
+  [VACUUM_MODULE_V1]: 'vacuumModule',
 }
 
 export const FLEX_USB_MODULE_FIXTURES: CutoutFixtureId[] = [
@@ -713,7 +711,7 @@ export const FLEX_USB_MODULE_FIXTURES: CutoutFixtureId[] = [
   THERMOCYCLER_V2_FRONT_FIXTURE,
   ABSORBANCE_READER_V1_FIXTURE,
   FLEX_STACKER_V1_FIXTURE,
-  VACUUM_MODULE_MILLIPORE_V1_FIXTURE,
+  VACUUM_MODULE_V1_FIXTURE,
 ]
 
 export const MAGNETIC_BLOCK_FIXTURES: CutoutFixtureIdsWithFakes[] = [
@@ -774,7 +772,7 @@ export const FLEX_STACKER_FIXTURES: CutoutFixtureId[] = [
 ]
 
 export const VACUUM_MODULE_FIXTURES: CutoutFixtureId[] = [
-  VACUUM_MODULE_MILLIPORE_V1_FIXTURE,
+  VACUUM_MODULE_V1_FIXTURE,
 ]
 
 export const MODULE_FIXTURES_BY_MODEL: {
@@ -789,7 +787,7 @@ export const MODULE_FIXTURES_BY_MODEL: {
   ],
   [ABSORBANCE_READER_V1]: [ABSORBANCE_READER_V1_FIXTURE],
   [FLEX_STACKER_MODULE_V1]: [FLEX_STACKER_V1_FIXTURE],
-  [VACUUM_MODULE_MILLIPORE_V1]: [VACUUM_MODULE_MILLIPORE_V1_FIXTURE],
+  [VACUUM_MODULE_V1]: [VACUUM_MODULE_V1_FIXTURE],
 }
 
 export const DEFAULT_AA_FOR_WASTE_CHUTE =

--- a/shared-data/js/modules.ts
+++ b/shared-data/js/modules.ts
@@ -23,7 +23,7 @@ import {
   THERMOCYCLER,
   THERMOCYCLER_MODULE_V1,
   THERMOCYCLER_MODULE_V2,
-  VACUUM_MODULE_MILLIPORE_V1,
+  VACUUM_MODULE_V1,
 } from './constants'
 
 import type {
@@ -35,6 +35,7 @@ import type {
 
 // TODO(bc, 2021-09-18): generate typescript types directly from JSON schema
 // having to maintain TS types side by side with the schema is a liability
+// TODO(ba, 2026-02-11): this needs to take in the varient as well
 export const getModuleDef = (moduleModel: ModuleModel): ModuleDefinition => {
   switch (moduleModel) {
     case MAGNETIC_MODULE_V1:
@@ -67,7 +68,7 @@ export const getModuleDef = (moduleModel: ModuleModel): ModuleDefinition => {
     case FLEX_STACKER_MODULE_V1:
       return flexStackerModuleV1 as unknown as ModuleDefinition
 
-    case VACUUM_MODULE_MILLIPORE_V1:
+    case VACUUM_MODULE_V1:
       return vacuumModuleMilloporeV1 as unknown as ModuleDefinition
 
     default:

--- a/shared-data/js/modules.ts
+++ b/shared-data/js/modules.ts
@@ -35,7 +35,7 @@ import type {
 
 // TODO(bc, 2021-09-18): generate typescript types directly from JSON schema
 // having to maintain TS types side by side with the schema is a liability
-// TODO(ba, 2026-02-11): this needs to take in the varient as well
+// TODO(ba, 2026-02-11): this needs to take in the variant as well
 export const getModuleDef = (moduleModel: ModuleModel): ModuleDefinition => {
   switch (moduleModel) {
     case MAGNETIC_MODULE_V1:

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -40,7 +40,7 @@ import type {
   THERMOCYCLER_MODULE_TYPE,
   THERMOCYCLER_MODULE_V1,
   THERMOCYCLER_MODULE_V2,
-  VACUUM_MODULE_MILLIPORE_V1,
+  VACUUM_MODULE_V1,
   VACUUM_MODULE_TYPE,
 } from './constants'
 import type { PipetteName } from './pipettes'
@@ -401,7 +401,7 @@ export type AbsorbanceReaderModel = typeof ABSORBANCE_READER_V1
 
 export type FlexStackerModuleModel = typeof FLEX_STACKER_MODULE_V1
 
-export type VacuumModuleModel = typeof VACUUM_MODULE_MILLIPORE_V1
+export type VacuumModuleModel = typeof VACUUM_MODULE_V1
 
 export type ModuleModel =
   | MagneticModuleModel

--- a/shared-data/module/definitions/3/vacuumModuleOpentronsV1.json
+++ b/shared-data/module/definitions/3/vacuumModuleOpentronsV1.json
@@ -1,8 +1,7 @@
 {
   "$otSharedSchema": "module/schemas/3",
   "moduleType": "vacuumModuleType",
-  "model": "vacuumModuleV1",
-  "variant": "Millipore",
+  "model": "vacuumModuleOpentronsV1",
   "labwareOffset": {
     "x": 0,
     "y": 0,
@@ -57,7 +56,7 @@
       }
     }
   },
-  "displayName": "Vacuum Module Millipore GEN1",
+  "displayName": "Vacuum Module Opentrons GEN1",
   "quirks": [],
   "slotTransforms": {},
   "orientation": {

--- a/shared-data/module/schemas/3.json
+++ b/shared-data/module/schemas/3.json
@@ -136,7 +136,11 @@
     },
     "model": {
       "type": "string",
-      "pattern": "^(temperatureModule|magneticModule|thermocyclerModule|heaterShakerModule|magneticBlock|absorbanceReader|flexStackerModule|vacuumModuleMillipore)V[0-9]+$"
+      "pattern": "^(temperatureModule|magneticModule|thermocyclerModule|heaterShakerModule|magneticBlock|absorbanceReader|flexStackerModule|vacuumModule)V[0-9]+$"
+    },
+    "variant": {
+      "type": "string",
+      "pattern": "^(Millipore|Opentrons)+$"
     },
     "labwareOffset": {
       "$ref": "#/definitions/coordinates",

--- a/shared-data/python/opentrons_shared_data/module/types.py
+++ b/shared-data/python/opentrons_shared_data/module/types.py
@@ -44,7 +44,7 @@ HeaterShakerModuleModel = Literal["heaterShakerModuleV1"]
 MagneticBlockModel = Literal["magneticBlockV1"]
 AbsorbanceReaderModel = Literal["absorbanceReaderV1"]
 FlexStackerModuleModel = Literal["flexStackerModuleV1"]
-VacuumModuleModel = Literal["vacuumModuleMilliporeV1"]
+VacuumModuleModel = Literal["vacuumModuleV1"]
 
 ModuleModel = Union[
     MagneticModuleModel,


### PR DESCRIPTION
# Overview

This pull request adds a physical geometry variant when multiple definitions exist for the same electronic model (e.g. 'Opentrons' or 'Millipore'). The load_module api is expanded to take in a "variant" keyword, which denotes the geometry to use for the given module_name.

```python3

    vm_mod  = ctx.load_module(module_name="vacuumModuleV1", location="A3", variant="Millipore")
    vm_mod  = ctx.load_module(module_name="vacuumModuleV1", location="A3", variant="Opentrons")
```

The variant is data the user tells us about, so the user selects the variant when changing the deck configuration. This means we need to store the variant in the deck configuration as well, so lets add that too.

## Test Plan and Hands on Testing

## Changelog

- Added `variant` arg to `ProtocolContext.load_module` to let you specify what geometrical def we load in for the given module.
- Added `variant` arg to deck configuration so the front-end can tell the backend what variant we should be using.


## Review requests

Is this a bad idea?

## Risk assessment