### PR TITLE
fix(app): hide disposal card and tip count info

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/TipDisposalSlot/__tests__/TipDisposalSlot.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/TipDisposalSlot/__tests__/TipDisposalSlot.test.tsx
@@ -36,7 +36,7 @@ describe('TipDisposalSlot', () => {
   it('render text', () => {
     render(props)
     screen.getByText('TRASH')
-    screen.getByText('Tips in trash')
-    screen.getByText('1 tips')
+    // screen.getByText('Tips in trash')
+    // screen.getByText('1 tips')
   })
 })

--- a/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/TipDisposalSlot/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/TipDisposalSlot/index.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-import { COLORS, RobotInfoLabel, StyledText } from '@opentrons/components'
-import { EMPTY } from '@opentrons/step-generation'
+import { RobotInfoLabel } from '@opentrons/components'
 
 import styles from './tipdisposalslot.module.css'
 
@@ -17,16 +16,16 @@ export function TipDisposalSlot({
   disposalType,
 }: TipDisposalSlotProps): JSX.Element {
   const { t } = useTranslation('protocol_visualization')
-  const { tipState } = robotState
-  const totalEmptyTips = Object.values(tipState.tipracks).reduce(
-    (sum, rack) =>
-      sum +
-      Object.values(rack).reduce(
-        (rackSum, tipVal) => rackSum + (tipVal === EMPTY ? 1 : 0),
-        0
-      ),
-    0
-  )
+  // temporary commenting out for Rs 9.0.0
+  // const totalEmptyTips = Object.values(tipState.tipracks).reduce(
+  //   (sum, rack) =>
+  //     sum +
+  //     Object.values(rack).reduce(
+  //       (rackSum, tipVal) => rackSum + (tipVal === EMPTY ? 1 : 0),
+  //       0
+  //     ),
+  //   0
+  // )
   return (
     <div className={styles.container}>
       <div className={styles.header}>
@@ -35,7 +34,7 @@ export function TipDisposalSlot({
         />
       </div>
       <div className={styles.main_content}>
-        <div className={styles.text_container}>
+        {/* <div className={styles.text_container}>
           <StyledText desktopStyle="captionRegular" color={COLORS.grey60}>
             {disposalType === 'trash'
               ? t('tips_in_trash')
@@ -44,7 +43,7 @@ export function TipDisposalSlot({
           <StyledText desktopStyle="captionRegular">
             {t('remaining_tips', { remaining: totalEmptyTips })}
           </StyledText>
-        </div>
+        </div> */}
         {/* Note this is for phase-2
           <div className={styles.text_container}>
           <StyledText desktopStyle="captionRegular" color={COLORS.grey60}>

--- a/app/src/organisms/Desktop/ProtocolVisualization/StepDetailContainer/__tests__/StepDetailContainer.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/StepDetailContainer/__tests__/StepDetailContainer.test.tsx
@@ -6,7 +6,7 @@ import { renderWithProviders } from '/app/__testing-utils__'
 import { LabwareSlotContainer } from '../../LabwareSlotContainer'
 import { PipetteContainer } from '../../PipetteContainer'
 import { StepDetailContainer } from '../../StepDetailContainer'
-import { TipDisposalContainer } from '../../TipDisposalContainer'
+// import { TipDisposalContainer } from '../../TipDisposalContainer'
 import { TipPickupContainer } from '../../TipPickupContainer'
 
 import type { ComponentProps } from 'react'
@@ -14,7 +14,7 @@ import type { RunTimeCommand } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '@opentrons/step-generation'
 
 vi.mock('../../PipetteContainer')
-vi.mock('../../TipDisposalContainer')
+// vi.mock('../../TipDisposalContainer')
 vi.mock('../../TipPickupContainer')
 vi.mock('../../LabwareSlotContainer')
 
@@ -98,9 +98,9 @@ describe('StepDetailContainer', () => {
     vi.mocked(LabwareSlotContainer).mockReturnValue(
       <div>mock LabwareSlotContainer </div>
     )
-    vi.mocked(TipDisposalContainer).mockReturnValue(
-      <div>mock Tip Disposal Container</div>
-    )
+    // vi.mocked(TipDisposalContainer).mockReturnValue(
+    //   <div>mock Tip Disposal Container</div>
+    // )
 
     vi.mocked(TipPickupContainer).mockReturnValue(
       <div>mock Tip Pickup Container</div>
@@ -114,6 +114,6 @@ describe('StepDetailContainer', () => {
   it('renders the pipette containers and tip container', () => {
     render(props)
     expect(screen.getAllByText('mock Pipette Container')).toHaveLength(2)
-    screen.getByText('mock Tip Disposal Container')
+    // screen.getByText('mock Tip Disposal Container')
   })
 })

--- a/app/src/organisms/Desktop/ProtocolVisualization/StepDetailContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/StepDetailContainer/index.tsx
@@ -96,7 +96,8 @@ export function StepDetailContainer({
     if (topMostLabwareOnSlot != null) {
       components.push('labware')
     }
-    components.push('disposal')
+    // temporary filtering out the disposal card for RS 9.0.0
+    // components.push('disposal')
 
     return components
   }


### PR DESCRIPTION
closes RQA-5205

# Overview

comment out the disposal card and tip count info in the spotlight view for trash and waste chute

## Test Plan and Hands on Testing

just test that the disposal card doesn't show up and the trash and waste chute spotlight view don't show the tip count

## Changelog

comment out stuff and leave comments

## Risk assessment


low