### PR TITLE
fix(app): show labware command summary on TC for PV

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewModules.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewModules.tsx
@@ -107,7 +107,8 @@ export function DeckViewModules(props: DeckViewModulesProps): JSX.Element {
           !showLabwareCommandSummary
         return (
           <Fragment key={id}>
-            {isThermocyclerLidClosed && labwareLoadedOnModuleId != null ? (
+            {moduleType !== THERMOCYCLER_MODULE_TYPE &&
+            labwareLoadedOnModuleId != null ? (
               <CenterLabwareInModuleChildSlot
                 deckId={deckDef.otId}
                 slotId={slot}

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewStacker.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewStacker.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react'
+
 import {
   CenterLabwareInModuleChildSlot,
   COLORS,
@@ -9,6 +11,7 @@ import {
 } from '@opentrons/shared-data'
 
 import { DeckViewOverlay } from './DeckViewOverlay'
+import { LabwareCommandSummary } from './LabwareCommandSummary'
 import { LabwareOnDeck } from './LabwareOnDeck'
 
 import type { Dispatch, SetStateAction } from 'react'
@@ -72,28 +75,44 @@ export function DeckViewStacker(props: DeckViewStackerProps): JSX.Element {
   return (
     <>
       {renderLabware ? (
-        <CenterLabwareInModuleChildSlot
-          deckId={deckDef.otId}
-          slotId={slot}
-          moduleDefinition={moduleDef}
-          labwareDefinition={
-            labwareEntitiesExtended[labwareLoadedOnModuleId].def
-          }
-        >
-          <LabwareOnDeck
-            robotState={robotState}
-            labwareDef={labwareEntitiesExtended[labwareLoadedOnModuleId].def}
-            liquids={liquids}
-            labwareId={labwareLoadedOnModuleId}
-            x={
-              0 +
-              (moduleType === FLEX_STACKER_MODULE_TYPE ? STACKER_X_OFFSET : 0)
+        <>
+          <CenterLabwareInModuleChildSlot
+            deckId={deckDef.otId}
+            slotId={slot}
+            moduleDefinition={moduleDef}
+            labwareDefinition={
+              labwareEntitiesExtended[labwareLoadedOnModuleId].def
             }
-            y={0}
-            setSelectedSlot={setSelectedSlot}
-            setHoveredSlot={setHoveredSlot}
-          />
-        </CenterLabwareInModuleChildSlot>
+          >
+            <LabwareOnDeck
+              robotState={robotState}
+              labwareDef={labwareEntitiesExtended[labwareLoadedOnModuleId].def}
+              liquids={liquids}
+              labwareId={labwareLoadedOnModuleId}
+              x={
+                0 +
+                (moduleType === FLEX_STACKER_MODULE_TYPE ? STACKER_X_OFFSET : 0)
+              }
+              y={0}
+              setSelectedSlot={setSelectedSlot}
+              setHoveredSlot={setHoveredSlot}
+            />
+            <Fragment key={labwareLoadedOnModuleId}>
+              {showModuleCommandSummary &&
+              moduleType === THERMOCYCLER_MODULE_TYPE &&
+              selectedRunTimeCommand != null ? (
+                <LabwareCommandSummary
+                  commandType={selectedRunTimeCommand.commandType}
+                  position={[0, 0, 0]}
+                  labwareDef={
+                    labwareEntitiesExtended[labwareLoadedOnModuleId].def
+                  }
+                  showModuleIcon={false}
+                />
+              ) : null}
+            </Fragment>
+          </CenterLabwareInModuleChildSlot>
+        </>
       ) : null}
       {moduleType === THERMOCYCLER_MODULE_TYPE ? (
         <DeckViewOverlay


### PR DESCRIPTION
closes RQA-5202

# Overview

special case adding the labware command summary in the TC since it shows labware differently from other modules

## Test Plan and Hands on Testing

follow the steps in the ticket attached

## Changelog

add the labwraeOnDeck render with the command summary for the labware on a TC 

## Risk assessment

low
