### PR TITLE
fix(app): Fix drop tip wizard CTA

### DIFF
--- a/app/src/assets/localization/en/robot_calibration.json
+++ b/app/src/assets/localization/en/robot_calibration.json
@@ -74,7 +74,7 @@
   "jog_pipette_to_touch_slot": "<block>Jog the pipette until the tip is barely touching (less than 0.1 mm) the deck in slot 5.</block><block>If the pipette is over the embossed 5, on the ridge of the slot, or hard to see, switch to the x- and y-axis controls to move the pipette across the deck.</block>",
   "jog_pipette_to_touch_trash": "Jog the pipette until the tip is barely touching (less than 0.1 mm) the flat surface of the trash bin.",
   "jog_too_far_or_bend_tip": "Jog too far or bend a tip?",
-  "jump_size": "jump size",
+  "jump_size": "Jump Size",
   "large": "Large",
   "last_calibrated": "Last calibrated",
   "last_completed_on": "Last completed {{timestamp}}",

--- a/app/src/molecules/InProgressModal/InProgressModal.tsx
+++ b/app/src/molecules/InProgressModal/InProgressModal.tsx
@@ -1,17 +1,6 @@
-import styled from 'styled-components'
+import { Flex, Icon, LegacyStyledText } from '@opentrons/components'
 
-import {
-  ALIGN_CENTER,
-  COLORS,
-  DIRECTION_COLUMN,
-  Flex,
-  Icon,
-  JUSTIFY_CENTER,
-  LegacyStyledText,
-  RESPONSIVENESS,
-  SPACING,
-  TYPOGRAPHY,
-} from '@opentrons/components'
+import styles from './inprogressmodal.module.css'
 
 import type { ReactNode } from 'react'
 
@@ -23,85 +12,30 @@ interface Props {
   children?: JSX.Element
 }
 
-const StyledDescription = styled(LegacyStyledText)`
-  ${TYPOGRAPHY.h1Default}
-  margin-top: ${SPACING.spacing24};
-  margin-bottom: ${SPACING.spacing8};
-  text-align: ${TYPOGRAPHY.textAlignCenter};
-
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    font-weight: ${TYPOGRAPHY.fontWeightBold};
-    font-size: ${TYPOGRAPHY.fontSize32};
-    margin-top: ${SPACING.spacing32};
-    margin-bottom: ${SPACING.spacing4};
-    margin-left: 4.5rem;
-    margin-right: 4.5rem;
-    line-height: ${TYPOGRAPHY.lineHeight42};
-  }
-`
-
-const StyledBody = styled(LegacyStyledText)`
-  ${TYPOGRAPHY.pRegular}
-  text-align: ${TYPOGRAPHY.textAlignCenter};
-
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    ${TYPOGRAPHY.level4HeaderRegular}
-    color: ${COLORS.grey60}
-  }
-`
-
-const StyledModal = styled(Flex)`
-  align-items: ${ALIGN_CENTER};
-  flex-direction: ${DIRECTION_COLUMN};
-  justify-content: ${JUSTIFY_CENTER};
-  padding: ${SPACING.spacing32};
-  height: 24.625rem;
-  width: 100%;
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    max-height: 29.5rem;
-    height: 100%;
-  }
-`
-
-const StyledSpinner = styled(Icon)`
-  color: ${COLORS.grey60};
-  width: 5.125rem;
-  height: 5.125rem;
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    width: 6.25rem;
-    height: 6.25rem;
-  }
-`
-
-const DescriptionContainer = styled(Flex)`
-  padding-left: 6.5625rem;
-  padding-right: 6.5625rem;
-  gap: ${SPACING.spacing8};
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    padding-left: ${SPACING.spacing40};
-    padding-right: ${SPACING.spacing40};
-    gap: ${SPACING.spacing4};
-  }
-`
-
 export function InProgressModal(props: Props): JSX.Element {
   const { alternativeSpinner, children, description, body } = props
 
   return (
-    <StyledModal>
+    <Flex className={styles.modal}>
       {alternativeSpinner ?? (
-        <StyledSpinner name="ot-spinner" aria-label="spinner" spin />
+        <Icon
+          className={styles.spinner}
+          name="ot-spinner"
+          aria-label="spinner"
+          spin
+        />
       )}
-      <DescriptionContainer
-        flexDirection={DIRECTION_COLUMN}
-        alignItems={ALIGN_CENTER}
-      >
+      <Flex className={styles.description_container}>
         {description != null && (
-          <StyledDescription>{description}</StyledDescription>
+          <LegacyStyledText className={styles.description}>
+            {description}
+          </LegacyStyledText>
         )}
-        {body != null && <StyledBody>{body}</StyledBody>}
-      </DescriptionContainer>
+        {body != null && (
+          <LegacyStyledText className={styles.body}>{body}</LegacyStyledText>
+        )}
+      </Flex>
       {children}
-    </StyledModal>
+    </Flex>
   )
 }

--- a/app/src/molecules/InProgressModal/inprogressmodal.module.css
+++ b/app/src/molecules/InProgressModal/inprogressmodal.module.css
@@ -1,0 +1,81 @@
+.modal {
+  display: flex;
+  width: 100%;
+  height: 24.625rem;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-32);
+  gap: var(--spacing-24);
+}
+
+@media (height = 600px) and (width = 1024px) {
+  .modal {
+    height: 100%;
+    max-height: 29.5rem;
+    gap: var(--spacing-32);
+  }
+}
+
+.description {
+  font-size: var(--font-size-h1);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--line-height-24);
+  text-align: center;
+}
+
+@media (height = 600px) and (width = 1024px) {
+  .description {
+    margin-right: 4.5rem;
+    margin-left: 4.5rem;
+    font-size: var(--font-size-32);
+    font-weight: var(--font-weight-bold);
+    line-height: var(--line-height-42);
+  }
+}
+
+.body {
+  font-size: var(--font-size-p);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-20);
+  text-align: center;
+}
+
+@media (height = 600px) and (width = 1024px) {
+  .body {
+    color: var(--grey-60);
+    font-size: var(--font-size-28);
+    font-weight: var(--font-weight-regular);
+    line-height: var(--line-height-36);
+  }
+}
+
+.spinner {
+  width: 5.125rem;
+  height: 5.125rem;
+  color: var(--grey-60);
+}
+
+@media (height = 600px) and (width = 1024px) {
+  .spinner {
+    width: 6.25rem;
+    height: 6.25rem;
+  }
+}
+
+.description_container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-right: 6.5625rem;
+  padding-left: 6.5625rem;
+  gap: var(--spacing-8);
+}
+
+@media (height = 600px) and (width = 1024px) {
+  .description_container {
+    padding-right: var(--spacing-40);
+    padding-left: var(--spacing-40);
+    gap: var(--spacing-4);
+  }
+}

--- a/app/src/molecules/JogControls/StepSizeControl.tsx
+++ b/app/src/molecules/JogControls/StepSizeControl.tsx
@@ -105,15 +105,9 @@ export function StepSizeControl(props: StepSizeControlProps): JSX.Element {
         ]}
       >
         <Flex flexDirection={DIRECTION_COLUMN} flex="1">
-          <Flex flexDirection={DIRECTION_ROW}>
+          <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing8}>
             <StyledIcon name="jump-size" width="1.2rem" />
-            <StyledText
-              textTransform={TEXT_TRANSFORM_CAPITALIZE}
-              css={TYPOGRAPHY.pSemiBold}
-              marginLeft={SPACING.spacing8}
-            >
-              {t('jump_size')}
-            </StyledText>
+            <StyledText css={TYPOGRAPHY.pSemiBold}>{t('jump_size')}</StyledText>
           </Flex>
           <StyledText
             color={COLORS.grey60}
@@ -137,7 +131,7 @@ export function StepSizeControl(props: StepSizeControlProps): JSX.Element {
 }
 
 export function TouchStepSizeControl(props: StepSizeControlProps): JSX.Element {
-  const { i18n, t } = useTranslation('robot_calibration')
+  const { t } = useTranslation('robot_calibration')
   return (
     <Flex
       flex="3"
@@ -147,9 +141,7 @@ export function TouchStepSizeControl(props: StepSizeControlProps): JSX.Element {
       padding={SPACING.spacing16}
       gridGap={SPACING.spacing16}
     >
-      <TouchControlLabel>
-        {i18n.format(t('jump_size'), 'capitalize')}
-      </TouchControlLabel>
+      <TouchControlLabel>{t('jump_size')}</TouchControlLabel>
 
       <StepSizeButtons {...props} />
     </Flex>

--- a/app/src/organisms/DropTipWizardFlows/steps/BeforeBeginning.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/BeforeBeginning.tsx
@@ -70,6 +70,7 @@ export const BeforeBeginning = ({
           </StyledText>
           <MediumButton
             css={ODD_MEDIUM_BUTTON_STYLE}
+            justifyContent={JUSTIFY_FLEX_START}
             buttonType={flowType === 'blowout' ? 'primary' : 'secondary'}
             onClick={() => {
               setFlowType('blowout')
@@ -78,6 +79,7 @@ export const BeforeBeginning = ({
           />
           <MediumButton
             css={ODD_MEDIUM_BUTTON_STYLE}
+            justifyContent={JUSTIFY_FLEX_START}
             buttonType={flowType === 'drop_tips' ? 'primary' : 'secondary'}
             onClick={() => {
               setFlowType('drop_tips')
@@ -240,7 +242,6 @@ const CONTAINER_STYLE = css`
 
 const ODD_MEDIUM_BUTTON_STYLE = css`
   flex: 1;
-  justify-content: ${JUSTIFY_FLEX_START};
   padding-left: ${SPACING.spacing24};
   height: 5.25rem;
 `

--- a/app/src/organisms/DropTipWizardFlows/steps/JogToPosition.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/JogToPosition.tsx
@@ -4,12 +4,15 @@ import { css } from 'styled-components'
 import {
   DIRECTION_COLUMN,
   Flex,
+  LegacyStyledText,
   RESPONSIVENESS,
   SPACING,
+  StyledText,
 } from '@opentrons/components'
 
 import { JogControls } from '/app/molecules/JogControls'
 
+import { DT_ROUTES } from '../constants'
 import { DropTipFooterButtons } from '../shared'
 
 import type { DropTipWizardContainerProps } from '../types'
@@ -30,6 +33,21 @@ export const JogToPosition = ({
 
   return (
     <>
+      {!isOnDevice && (
+        <Flex css={TITLE_SECTION_STYLE}>
+          <StyledText
+            desktopStyle="headingSmallBold"
+            oddStyle="level4HeaderSemiBold"
+          >
+            {t('position_the_pipette')}
+          </StyledText>
+          <LegacyStyledText forwardedAs="p">
+            {currentRoute === DT_ROUTES.BLOWOUT
+              ? t('position_and_blowout')
+              : t('position_and_drop_tip')}
+          </LegacyStyledText>
+        </Flex>
+      )}
       <Flex
         css={
           modalStyle === 'simple'
@@ -37,8 +55,7 @@ export const JogToPosition = ({
             : INTERVENTION_CONTENT_SECTION_STYLE
         }
       >
-        <JogControls jog={handleJog} isOnDevice={isOnDevice} />
-
+        <JogControls jog={handleJog} isOnDevice={isOnDevice} height="100%" />
         <DropTipFooterButtons
           primaryBtnOnClick={proceed}
           primaryBtnTextOverride={t('shared:confirm_position')}
@@ -48,6 +65,15 @@ export const JogToPosition = ({
     </>
   )
 }
+
+const TITLE_SECTION_STYLE = css`
+  flex-direction: ${DIRECTION_COLUMN};
+  grid-gap: ${SPACING.spacing16};
+
+  @media (${RESPONSIVENESS.touchscreenMediaQuerySpecs}) {
+    display: none;
+  }
+`
 
 const SHARED_CONTENT_SECTION_STYLE = `
   flex-direction: ${DIRECTION_COLUMN};


### PR DESCRIPTION
Closes [RQA-5207](https://opentrons.atlassian.net/browse/RQA-5207)

# Overview

Our fix for [RQA-5165](https://opentrons.atlassian.net/browse/RQA-5165) removed unneeded copy from the ODD (which was expected), but also the desktop app. This PR adds back the copy, fixing some styling migration issues along the way.

53be388648bdad0e09c249c442d16cecf9f8d3ab - Addresses copy and a title case issue with "Jump Size". 

### Current Behavior

<img width="695" height="400" alt="Screenshot 2026-02-13 at 2 28 08 PM" src="https://github.com/user-attachments/assets/77856819-1fb1-4f3a-9be0-d5471d7776b7" />

### Fixed Behavior

<img width="1031" height="763" alt="Screenshot 2026-02-13 at 1 14 20 PM" src="https://github.com/user-attachments/assets/ddf9d280-72b1-4c2e-b98f-d6774073c32a" />

53d84c4987977de225969d53015a88ddc4e0dee7 - The `InProgressModal`, which we use in several places, had some padding issues post styling migration. This commit converts the component to use CSS modules and fixes the padding issue.

### Current Behavior

<img width="709" height="491" alt="Screenshot 2026-02-13 at 2 28 03 PM" src="https://github.com/user-attachments/assets/1650c06f-6e66-4543-872e-a83e547517c9" />

### Fixed Behavior

<img width="1014" height="770" alt="Screenshot 2026-02-13 at 2 26 30 PM" src="https://github.com/user-attachments/assets/61771572-3936-4ac7-94d4-9658c57804a7" />


[7eb5c7b](https://github.com/Opentrons/opentrons/pull/20862/commits/7eb5c7bedeed26ca0bcb7e94bd3ffb26e5bb14b2) - The first step of the ODD screen has some button text alignment issues after the styling migration. This fixes that issue.

## Test Plan and Hands on Testing

- See images.
- Ensured no regressions on analogous ODD view.

## Changelog

- Fixed missing CTA when jogging to a particular location in drop tip wizard.
- Fixed styling regressions in the "robot motion in progress" modal.

## Risk assessment

- low, only styling and copy adjustments

[RQA-5207]: https://opentrons.atlassian.net/browse/RQA-5207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RQA-5165]: https://opentrons.atlassian.net/browse/RQA-5165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ