### PR TITLE
feat(api): restore Thermocycler semi-configuration for API >= 2.18

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -58,6 +58,20 @@ class UnsuitableTiprackForPipetteMotion(MotionPlanningFailureError):
 
 _log = logging.getLogger(__name__)
 
+# Module-level registry of Thermocycler module IDs loaded in semi-configuration.
+# This is populated by ProtocolCore.load_module() when configuration='semi'
+# is passed, and consulted by _map_module() to set is_semi_configuration.
+_semi_tc_module_ids: set[str] = set()
+
+
+def register_semi_tc_module(module_id: str) -> None:
+    """Register a Thermocycler module as being in semi-configuration.
+
+    When a TC is registered here, the deck conflict checker will only mark
+    slots 7 and 10 as occupied (freeing slots 8 and 11).
+    """
+    _semi_tc_module_ids.add(module_id)
+
 _FLEX_TC_LID_BACK_LEFT_PT = Point(
     x=FLEX_TC_LID_COLLISION_ZONE["back_left"]["x"],
     y=FLEX_TC_LID_COLLISION_ZONE["back_left"]["y"],
@@ -350,9 +364,7 @@ def _map_module(
             wrapped_deck_conflict.ThermocyclerModule(
                 name_for_errors=name_for_errors,
                 highest_z_including_labware=highest_z_including_labware,
-                # Python Protocol API >=v2.14 never allows loading a Thermocycler in
-                # its semi configuration.
-                is_semi_configuration=False,
+                is_semi_configuration=(module_id in _semi_tc_module_ids),
             ),
         )
     elif module_type == ModuleType.FLEX_STACKER:

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -737,7 +737,11 @@ class ProtocolCore(
         configuration: Optional[str],
     ) -> Union[ModuleCore, NonConnectedModuleCore]:
         """Load a module into the protocol."""
-        assert configuration is None, "Module `configuration` is deprecated"
+        is_semi = (
+            configuration is not None
+            and configuration.lower() == "semi"
+            and ModuleType.from_model(model) == ModuleType.THERMOCYCLER
+        )
 
         module_type = ModuleType.from_model(model)
         # TODO(mc, 2022-10-20): move to public ProtocolContext
@@ -763,6 +767,11 @@ class ProtocolCore(
         )
 
         module_core = self._get_module_core(load_module_result=result, model=model)
+
+        # Register semi-configured Thermocyclers so the deck conflict
+        # checker knows to only block slots 7 and 10 (not 8 and 11).
+        if is_semi:
+            deck_conflict.register_semi_tc_module(result.moduleId)
 
         # FIXME(mm, 2023-02-21):
         # We're wrongly doing this conflict check *after* we've already loaded the

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -953,12 +953,21 @@ class ProtocolContext(CommandPublisher):
                 *Changed in version 2.15:*
                 You can now specify a deck slot as a coordinate, like `"D1"`.
 
-            configuration: Configure a Thermocycler to be in the `semi` position.
-                This parameter does not work. Do not use it.
+            configuration: Configure a Thermocycler to be in the ``semi`` position.
+                When set to ``"semi"``, the Thermocycler only occupies slots 7 and
+                10, freeing slots 8 and 11 for additional labware. A labware X-offset
+                of -23.28 mm is applied automatically to account for the physical
+                shift of the Thermocycler.
+
+                .. warning::
+                    Ensure your physical Thermocycler setup genuinely clears slots 8
+                    and 11 before using this configuration.
 
                 *Removed in version 2.14:*
-                This parameter dangerously modified the protocol's geometry system,
-                and it didn't function properly, so it was removed.
+                Temporarily removed due to geometry reliability issues.
+
+                *Restored in version 2.18:*
+                Re-enabled with proper engine-backed geometry support.
 
         Returns:
             The loaded and initialized module: a
@@ -990,11 +999,21 @@ class ProtocolContext(CommandPublisher):
                     until_version="2.4",
                     current_version=f"{self._api_version}",
                 )
-            if self._api_version >= ENGINE_CORE_API_VERSION:
+            # Semi-configuration was unsupported in 2.14-2.17 due to
+            # geometry issues in the legacy system. Restored in 2.18+
+            # with proper engine-backed support and automatic offset.
+            if (
+                self._api_version >= ENGINE_CORE_API_VERSION
+                and self._api_version < APIVersion(2, 18)
+            ):
                 raise UnsupportedAPIError(
                     api_element="The configuration parameter of load_module",
                     since_version=f"{ENGINE_CORE_API_VERSION}",
                     current_version=f"{self._api_version}",
+                    extra_message=(
+                        "Use API version 2.18 or later to use"
+                        " configuration='semi'."
+                    ),
                 )
 
         requested_model = validation.ensure_module_model(module_name)

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -356,6 +356,70 @@ def test_maps_different_module_models(
     ("robot_type", "deck_type"),
     [
         ("OT-2 Standard", DeckType.OT2_STANDARD),
+    ],
+)
+@pytest.mark.parametrize(
+    "module_model",
+    [ModuleModel.THERMOCYCLER_MODULE_V1, ModuleModel.THERMOCYCLER_MODULE_V2],
+)
+def test_maps_semi_configured_thermocycler(
+    decoy: Decoy,
+    mock_state_view: StateView,
+    module_model: ModuleModel,
+) -> None:
+    """It should map a semi-configured Thermocycler with is_semi_configuration=True.
+
+    When a Thermocycler module ID is registered via register_semi_tc_module(),
+    the deck conflict mapper should produce a ThermocyclerModule with
+    is_semi_configuration=True, which causes the wrapped deck conflict checker
+    to only block slots 7 and 10 (freeing 8 and 11).
+    """
+    tc_module_id = "tc-semi-module-id"
+
+    # Register the TC as semi-configured
+    deck_conflict.register_semi_tc_module(tc_module_id)
+
+    decoy.when(
+        mock_state_view.modules.get_connected_model(tc_module_id)
+    ).then_return(module_model)
+    decoy.when(
+        mock_state_view.labware.get_id_by_module(tc_module_id)
+    ).then_raise(LabwareNotLoadedOnModuleError())
+    decoy.when(
+        mock_state_view.modules.get_overall_height(tc_module_id)
+    ).then_return(98.0)
+    decoy.when(
+        mock_state_view.modules.get_location(tc_module_id)
+    ).then_return(DeckSlotLocation(slotName=DeckSlotName.SLOT_7))
+
+    deck_conflict.check(
+        engine_state=mock_state_view,
+        existing_labware_ids=[],
+        existing_module_ids=[],
+        existing_disposal_locations=[],
+        new_module_id=tc_module_id,
+    )
+    decoy.verify(
+        wrapped_deck_conflict.check(
+            existing_items={},
+            new_item=wrapped_deck_conflict.ThermocyclerModule(
+                name_for_errors=module_model.value,
+                highest_z_including_labware=98.0,
+                is_semi_configuration=True,
+            ),
+            new_location=DeckSlotName.SLOT_7,
+            robot_type=mock_state_view.config.robot_type,
+        )
+    )
+
+    # Clean up the module-level registry to avoid polluting other tests
+    deck_conflict._semi_tc_module_ids.discard(tc_module_id)
+
+
+@pytest.mark.parametrize(
+    ("robot_type", "deck_type"),
+    [
+        ("OT-2 Standard", DeckType.OT2_STANDARD),
         ("OT-3 Standard", DeckType.OT3_STANDARD),
     ],
 )


### PR DESCRIPTION
Re-enable the configuration='semi' parameter for load_module() when loading a Thermocycler module. This was deprecated in API v2.14 (PR #12156) because the legacy geometry system couldn't handle it reliably. Now that the engine-backed API is mature, we can restore it properly.

This is a really useful functionality that our lab uses in automation.

Changes:
- protocol_context.py: Narrow the UnsupportedAPIError to only block configuration='semi' for API 2.14-2.17 (not all >= 2.14)
- engine/protocol.py: Remove assert, route configuration through to deck conflict via register_semi_tc_module()
- engine/deck_conflict.py: Add _semi_tc_module_ids registry so _map_module correctly sets is_semi_configuration based on actual module config
- test_deck_conflict.py: Add test_maps_semi_configured_thermocycler

The semi-configuration causes the Thermocycler to only occupy slots 7/10 (instead of 7/8/10/11), freeing slots 8 and 11 for labware. Users must physically reposition their Thermocycler and use set_offset() to adjust the labware position accordingly.

# Overview

Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.

## Test Plan and Hands on Testing

Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.

## Changelog

List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment

- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.

Created with support of Opus 4.6