### PR TITLE
fix(step-generation, app): create correct stack when moving labware to...

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabware.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabware.tsx
@@ -2,7 +2,6 @@ import { Fragment } from 'react'
 
 import { CenterLabwareInSlot, COLORS, StyledText } from '@opentrons/components'
 import {
-  FLEX_STACKER_MODULE_TYPE,
   getAddressableAreaFromSlotId,
   getPositionFromSlotId,
   PROTOCOL_ENGINE_LID_STACK_LOADNAME,
@@ -51,17 +50,12 @@ export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
     selectedRunTimeCommand,
   } = props
   const { labware, modules, pipettes } = robotState
-  const { moduleEntities } = invariantContext
 
   return (
     <>
       {Object.entries(labware).map(([id, lw]) => {
         if (
-          Object.keys(modules).some(
-            moduleId =>
-              lw.stack.includes(moduleId) &&
-              moduleEntities[moduleId].type !== FLEX_STACKER_MODULE_TYPE
-          ) ||
+          Object.keys(modules).some(moduleId => lw.stack.includes(moduleId)) ||
           //  filter out the fake PE lid stack definition!
           //  we shouldn't be exposing it to users at all
           labwareEntitiesExtended[id].def.parameters.loadName ===
@@ -88,7 +82,6 @@ export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
         )
         const showCommandSummary =
           isActiveLayerVisible && selectedRunTimeCommand != null
-
         return (
           <Fragment key={id}>
             <g transform={`translate(${slotPosition[0]}, ${slotPosition[1]})`}>

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -155,15 +155,29 @@ export function forMoveLabware(
       }
     }
   }
-
   const newLocationStack: string[] = []
   if (locationIsOffDeck(newLocation)) {
     newLocationStack.push(newLocation)
   } else if ('moduleId' in newLocation) {
-    newLocationStack.push(
-      newLocation.moduleId,
-      modules[newLocation.moduleId].slot
-    )
+    //  NOTE: this special-case is only for PV. PD should not
+    //  be affected because the newLocation shouldn't include the moduleId
+    //  for PD stacking/moveLabware architecture when moving labware
+    //  into the stacker shuttle.
+    //  example: for PD moving labware to shuttle -> [labwareId, slot]
+    //  for PV moving labware to shuttle -> [labwareId, moduleId, slot] by default
+    //  (by default due to the PE architecture!!!!!!!)
+    //  so we have to special-case it here to be [labwareId, slot]
+    if (
+      modules[newLocation.moduleId].moduleState.type ===
+      FLEX_STACKER_MODULE_TYPE
+    ) {
+      newLocationStack.push(modules[newLocation.moduleId].slot)
+    } else {
+      newLocationStack.push(
+        newLocation.moduleId,
+        modules[newLocation.moduleId].slot
+      )
+    }
   } else if ('slotName' in newLocation) {
     // need to handle slotName being a labwareId or a slotId (misleading property name)
     const { slotName } = newLocation

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -160,13 +160,9 @@ export function forMoveLabware(
     newLocationStack.push(newLocation)
   } else if ('moduleId' in newLocation) {
     //  NOTE: this special-case is only for PV. PD should not
-    //  be affected because the newLocation shouldn't include the moduleId
-    //  for PD stacking/moveLabware architecture when moving labware
-    //  into the stacker shuttle.
-    //  example: for PD moving labware to shuttle -> [labwareId, slot]
-    //  for PV moving labware to shuttle -> [labwareId, moduleId, slot] by default
-    //  (by default due to the PE architecture!!!!!!!)
-    //  so we have to special-case it here to be [labwareId, slot]
+    //  be affected. PV's newLocation comes from the command.params
+    //  which includes moduleId when moving a labware onto the stacker shuttle
+    //  but for PD, the newLocation does not include the moduleId
     if (
       modules[newLocation.moduleId].moduleState.type ===
       FLEX_STACKER_MODULE_TYPE


### PR DESCRIPTION
…shuttle in PV

closes RQA-5212

# Overview

Turns out the "newLocation" for PV from the command.params show `moduleId` for moving al abware into the shuttle but for PD, we didn't follow that pattern and instead remove the moduleId. so ya thats why this behavior was a bug and why the fix is isolated for PV only

## Test Plan and Hands on Testing

test protocol in ticket

## Changelog

fix bug where the tiprack with lid was incorrectly showing up

## Risk assessment

medium, should only affect PV but also is going in near code freeze for RS 9.0.0
