### PR TITLE
chore(api): add mypy_path src to fix issue with linting the api module.

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -211,6 +211,8 @@ filterwarnings = [
 plugins = ["pydantic.mypy", "decoy.mypy", "numpy.typing.mypy_plugin"]
 show_error_codes = true
 warn_unused_configs = true
+explicit_package_bases = true
+mypy_path = "src"
 strict = true
 
 [tool.pydantic-mypy]


### PR DESCRIPTION
# Overview

Fix issue with linting the api module by adding `mypy_path = "src"` to the api/pyproject.toml file to tell mypy to find modules in the src directory when importing them.