### PR TITLE
feat(e2e): auth-server client

### DIFF
--- a/.github/workflows/auth-server-e2e-test.yaml
+++ b/.github/workflows/auth-server-e2e-test.yaml
@@ -1,0 +1,83 @@
+# Auth Server E2E Tests
+# The e2e-testing conftest auto-starts the auth-server when no
+# AUTH_SERVER_URL is set, so we just need both Python environments
+# installed and let pytest handle the rest.
+
+name: 'Auth Server E2E Tests'
+
+on:
+  pull_request:
+    paths:
+      - 'auth-server/**'
+      - 'server-utils/**'
+      - 'e2e-testing/tests/auth/**'
+      - 'e2e-testing/automation/auth_client.py'
+      - 'e2e-testing/uv.lock'
+      - 'e2e-testing/pyproject.toml'
+      - 'e2e-testing/pytest.ini'
+      - '.github/workflows/auth-server-e2e-test.yaml'
+      - '.github/actions/python/**'
+      - 'Makefile'
+      - 'scripts/**.mk'
+      - 'scripts/**.py'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  CI: 'true'
+
+jobs:
+  e2e-test:
+    name: 'auth-server E2E tests'
+    runs-on: 'ubuntu-24.04'
+    timeout-minutes: 15
+    steps:
+      - uses: 'actions/checkout@v4'
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # -- Auth-server setup (so `make -C ../auth-server dev` works) ---
+      - uses: 'actions/setup-node@v6'
+        with:
+          node-version: '22.22.0'
+
+      - uses: './.github/actions/python/setup-uv'
+        with:
+          project: 'auth-server'
+
+      # -- E2E test runner setup ---------------------------------------
+      - name: 'Setup UV for E2E tests'
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: '3.12'
+          cache-dependency-glob: |
+            e2e-testing/uv.lock
+            e2e-testing/pyproject.toml
+
+      - name: 'Install E2E test dependencies'
+        working-directory: e2e-testing
+        run: make setup
+
+      # -- Run tests (conftest auto-starts auth-server) ----------------
+      - name: 'Run auth E2E tests'
+        working-directory: e2e-testing
+        run: make test-auth
+
+      # -- Artifacts ---------------------------------------------------
+      - name: 'Upload test results'
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: auth-e2e-results
+          path: |
+            e2e-testing/test-results/
+          retention-days: 7
+          if-no-files-found: warn

--- a/e2e-testing/.env.example
+++ b/e2e-testing/.env.example
@@ -1,1 +1,4 @@
 APPLITOOLS_API_KEY=your_applitools_api_key_here
+
+# Default robot IP for the CLI tools (e2e-testing/scripts/)
+ROBOT_IP=192.168.0.20

--- a/e2e-testing/Makefile
+++ b/e2e-testing/Makefile
@@ -23,7 +23,7 @@ lint:
 
 .PHONY: typecheck
 typecheck:
-	uv run mypy automation tests conftest.py
+	uv run mypy automation tests scripts conftest.py
 
 .PHONY: prep
 prep: 
@@ -124,6 +124,10 @@ test-ll-prod:
 .PHONY: test-auth
 test-auth:
 	uv run pytest -m authE2E $(PYTEST_ARGS)
+
+.PHONY: check-auth
+check-auth:
+	uv run python scripts/check_auth.py $(ROBOT_IP)
 
 .PHONY: test-compare
 test-compare:

--- a/e2e-testing/Makefile
+++ b/e2e-testing/Makefile
@@ -116,6 +116,15 @@ test-ll-staging-headed:
 test-ll-prod:
 	TEST_ENV=prod uv run pytest -m llE2E $(PYTEST_ARGS)
 
+# ── Auth-server E2E tests ────────────────────────────────────────────
+# Auto-starts a local auth-server if one isn't already running.
+# Point AUTH_SERVER_URL at a remote server to skip local startup:
+#   AUTH_SERVER_URL=http://host:33950 make test-auth
+
+.PHONY: test-auth
+test-auth:
+	uv run pytest -m authE2E $(PYTEST_ARGS)
+
 .PHONY: test-compare
 test-compare:
 	@if [ "$(HEADLESS)" = "false" ]; then \

--- a/e2e-testing/README.md
+++ b/e2e-testing/README.md
@@ -1,6 +1,6 @@
 # E2E Testing
 
-End-to-end tests for the Opentrons **Protocol Designer (PD)** and **Labware Library (LL)** using Playwright and pytest. Soon we will add app tests and API testing.
+End-to-end tests for the Opentrons **Protocol Designer (PD)**, **Labware Library (LL)**, and **Auth Server** using Playwright (PD/LL) and httpx (Auth Server) with pytest.
 
 ## Prerequisites
 
@@ -63,6 +63,18 @@ make test-ll-staging                             # Against staging
 make test-ll-prod                                # Against production
 ```
 
+### Auth Server
+
+```bash
+make test-auth                                   # Auto-starts auth-server if needed
+make test-auth PYTEST_ARGS="-k test_name"        # Run one test
+AUTH_SERVER_URL=http://host:33950 make test-auth  # Point at a remote server
+```
+
+The auth tests use **httpx** (not Playwright) to exercise the auth-server's OAuth 2 password-grant flow, token refresh, introspection, and settings endpoints.
+
+**Auto-start behavior:** When no `AUTH_SERVER_URL` is set and nothing is already listening on `:33950`, the test fixture automatically runs `make -C ../auth-server dev`, waits for it to become ready, and tears it down after the session. If the auth-server is already running, the fixture reuses it.
+
 ### Other Targets
 
 ```bash
@@ -97,13 +109,15 @@ make test-ll TEST_ENV=prod      # Equivalent to make test-ll-prod
 
 ## Directory Layout
 
-- `automation/` — Page objects and shared helpers
+- `automation/` — Page objects, clients, and shared helpers
   - `base_page.py` — Shared `BasePage` class inherited by all page objects
+  - `auth_client.py` — httpx-based OAuth 2 client for auth-server E2E tests
   - `pd_pages/` — Protocol Designer page objects (import from `automation.pd_pages`)
   - `ll_pages/` — Labware Library page objects (import from `automation.ll_pages`)
 - `tests/` — Test files organized by application
   - `pd/` — PD tests (marked `@pytest.mark.pdE2E`)
   - `ll/` — LL tests (marked `@pytest.mark.llE2E`)
+  - `auth/` — Auth Server tests (marked `@pytest.mark.authE2E`)
 - `fixtures/` — Protocol JSON files, labware definitions, and test data
 - `conftest.py` — Pytest fixtures for server lifecycle, page creation, video recording, and Applitools
 - `eyes.py` — Applitools Eyes wrapper and pytest fixture
@@ -125,12 +139,15 @@ Tests use the **Page Object Model** pattern for maintainability:
 
 ### Key Fixtures (conftest.py)
 
-| Fixture       | Scope    | Purpose                                                                                        |
-| ------------- | -------- | ---------------------------------------------------------------------------------------------- |
-| `pd_base_url` | session  | Resolves PD URL; starts local preview server when `TEST_ENV=local`                             |
-| `ll_base_url` | session  | Resolves LL URL; starts local preview server when `TEST_ENV=local`                             |
-| `page`        | function | Creates a Playwright page, navigates to the correct app URL based on test markers, saves video |
-| `eyes`        | function | Applitools Eyes session (or `None` when disabled)                                              |
+| Fixture         | Scope    | Purpose                                                                                        |
+| --------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `pd_base_url`   | session  | Resolves PD URL; starts local preview server when `TEST_ENV=local`                             |
+| `ll_base_url`   | session  | Resolves LL URL; starts local preview server when `TEST_ENV=local`                             |
+| `page`          | function | Creates a Playwright page, navigates to the correct app URL based on test markers, saves video |
+| `eyes`          | function | Applitools Eyes session (or `None` when disabled)                                              |
+| `auth_base_url` | session  | Resolves auth-server URL; auto-starts `make -C ../auth-server dev` if nothing is running       |
+| `auth_client`   | session  | Shared `AuthClient` (httpx) instance pointed at `auth_base_url`                                |
+| `admin_token`   | function | Fresh admin access token for tests that need one                                               |
 
 ### Environment Variables
 
@@ -142,6 +159,7 @@ Tests use the **Page Object Model** pattern for maintainability:
 | `PD_SERVER_URL`      | auto    | Override PD URL                       |
 | `LL_SERVER_URL`      | auto    | Override LL URL                       |
 | `LL_SERVER_PORT`     | `4176`  | Preferred port for LL local server    |
+| `AUTH_SERVER_URL`    | auto    | Override auth-server URL              |
 | `APPLITOOLS_API_KEY` | (unset) | Enable Applitools visual checks       |
 
 ## Development Workflow
@@ -191,6 +209,7 @@ make troubleshoot
 
 - **PD tests** (`tests/pd/`) — Onboarding, imports, protocol steps, settings, drag-and-drop, URL navigation, etc.
 - **LL tests** (`tests/ll/`) — Navigation, labware creator forms for well plates, reservoirs, tube racks, etc.
+- **Auth tests** (`tests/auth/`) — OAuth 2 password grant, token refresh, introspection, settings endpoints, error cases
 - **Unit tests** — `test_testfiles.py` validates fixture JSON files
 
 ### Test Reports and Artifacts
@@ -220,7 +239,7 @@ All tests automatically generate comprehensive reports and recordings:
 5. Keep page objects environment-aware (use `self.is_sandbox`)
 6. Add type annotations (enforced by mypy)
 7. Document test steps with comments and print statements so agents can maintain them
-8. Mark PD tests `@pytest.mark.pdE2E`, LL tests `@pytest.mark.llE2E` — never both
+8. Mark PD tests `@pytest.mark.pdE2E`, LL tests `@pytest.mark.llE2E`, Auth tests `@pytest.mark.authE2E`
 
 ## Visual Snapshots (Applitools Eyes)
 
@@ -279,4 +298,5 @@ Notes:
 
 - **`.github/workflows/pd-e2e-test.yaml`** — PD E2E tests
 - **`.github/workflows/ll-e2e-test.yaml`** — LL E2E tests
+- **`.github/workflows/auth-server-e2e-test.yaml`** — Auth Server E2E tests
 - **`.github/workflows/e2e-test-checks.yaml`** — Lint + typecheck

--- a/e2e-testing/README.md
+++ b/e2e-testing/README.md
@@ -107,6 +107,20 @@ make test-pd TEST_ENV=staging   # Equivalent to make test-pd-staging
 make test-ll TEST_ENV=prod      # Equivalent to make test-ll-prod
 ```
 
+## CLI Scripts
+
+Interactive Rich CLI tools for probing live robots. These read `ROBOT_IP` from `.env` or accept it as a CLI argument.
+
+### check_auth — Auth-server health check
+
+```bash
+make check-auth                          # prompts for IP (or reads ROBOT_IP from .env)
+make check-auth ROBOT_IP=10.0.0.42       # pass IP directly
+uv run python scripts/check_auth.py      # run the script directly
+```
+
+Checks connectivity to auth-server and robot-server, displays auth settings, attempts token exchange for both test users, and introspects the tokens. Useful for quickly verifying a robot's auth-server is alive and configured correctly.
+
 ## Directory Layout
 
 - `automation/` — Page objects, clients, and shared helpers
@@ -114,6 +128,8 @@ make test-ll TEST_ENV=prod      # Equivalent to make test-ll-prod
   - `auth_client.py` — httpx-based OAuth 2 client for auth-server E2E tests
   - `pd_pages/` — Protocol Designer page objects (import from `automation.pd_pages`)
   - `ll_pages/` — Labware Library page objects (import from `automation.ll_pages`)
+- `scripts/` — Interactive CLI tools for probing live robots
+  - `check_auth.py` — Auth-server connectivity and OAuth 2 flow check
 - `tests/` — Test files organized by application
   - `pd/` — PD tests (marked `@pytest.mark.pdE2E`)
   - `ll/` — LL tests (marked `@pytest.mark.llE2E`)

--- a/e2e-testing/automation/auth_client.py
+++ b/e2e-testing/automation/auth_client.py
@@ -1,0 +1,193 @@
+"""HTTP client for testing the auth-server's OAuth 2 endpoints.
+
+Implements the Resource Owner Password Credentials (ROPC) flow
+against the auth-server and provides helpers for token introspection
+and settings management. Designed for use in E2E tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+# Hardcoded client_id expected by the auth-server (see auth_server/oauth2/backend.py).
+DEFAULT_CLIENT_ID = "opentrons_app"
+
+# Well-known test users baked into the auth-server for testing.
+ADMIN_USERNAME = "test_admin"
+ADMIN_PASSWORD = "test_admin_password"
+USER_USERNAME = "test_user"
+USER_PASSWORD = "test_user_password"
+
+
+@dataclass
+class TokenResponse:
+    """Parsed successful token response from the OAuth 2 token endpoint."""
+
+    access_token: str
+    token_type: str
+    expires_in: int
+    refresh_token: str | None
+    scope: str
+
+    @classmethod
+    def from_json(cls, data: dict[str, Any]) -> TokenResponse:
+        return cls(
+            access_token=data["access_token"],
+            token_type=data["token_type"],
+            expires_in=data["expires_in"],
+            refresh_token=data.get("refresh_token"),
+            scope=data.get("scope", ""),
+        )
+
+
+class AuthClient:
+    """E2E test client for the auth-server.
+
+    Wraps httpx.Client to provide typed helpers for the OAuth 2 password-grant
+    flow, token refresh, introspection, and auth-settings management.
+
+    Usage::
+
+        with AuthClient(base_url="http://localhost:33950") as client:
+            token = client.get_token("test_admin", "test_admin_password")
+            assert token.access_token
+            # Use the token to hit robot-server
+            resp = client.get(
+                "/some/protected/endpoint",
+                headers=client.auth_header(token),
+            )
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        client_id: str = DEFAULT_CLIENT_ID,
+        timeout: float = 30.0,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.client_id = client_id
+        self._client = httpx.Client(base_url=self.base_url, timeout=timeout)
+
+    # -- Context-manager support ---------------------------------------------------
+
+    def __enter__(self) -> AuthClient:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        self._client.close()
+
+    # -- OAuth 2 Password Grant ----------------------------------------------------
+
+    def get_token(
+        self,
+        username: str,
+        password: str,
+        *,
+        scope: str | None = None,
+    ) -> TokenResponse:
+        """Exchange username + password for an access token (ROPC grant).
+
+        Raises ``httpx.HTTPStatusError`` on non-2xx responses.
+        """
+        data: dict[str, str] = {
+            "grant_type": "password",
+            "client_id": self.client_id,
+            "username": username,
+            "password": password,
+        }
+        if scope is not None:
+            data["scope"] = scope
+
+        response = self._client.post("/auth/oauth2/token", data=data)
+        response.raise_for_status()
+        return TokenResponse.from_json(response.json())
+
+    def refresh_token(
+        self,
+        refresh_token: str,
+        *,
+        scope: str | None = None,
+    ) -> TokenResponse:
+        """Exchange a refresh token for a new access token.
+
+        Raises ``httpx.HTTPStatusError`` on non-2xx responses.
+        """
+        data: dict[str, str] = {
+            "grant_type": "refresh_token",
+            "client_id": self.client_id,
+            "refresh_token": refresh_token,
+        }
+        if scope is not None:
+            data["scope"] = scope
+
+        response = self._client.post("/auth/oauth2/token", data=data)
+        response.raise_for_status()
+        return TokenResponse.from_json(response.json())
+
+    # -- Token Introspection -------------------------------------------------------
+
+    def introspect(self, token: str) -> dict[str, Any]:
+        """Introspect a token (RFC 7662).
+
+        Returns the parsed JSON body. Check ``result["active"]`` to see if the
+        token is still valid.
+        """
+        response = self._client.post(
+            "/auth/oauth2/introspect",
+            data={"token": token, "client_id": self.client_id},
+        )
+        response.raise_for_status()
+        return response.json()
+
+    # -- Auth Settings -------------------------------------------------------------
+
+    def get_settings(self) -> dict[str, Any]:
+        """GET /auth/settings."""
+        response = self._client.get("/auth/settings")
+        response.raise_for_status()
+        return response.json()
+
+    def patch_settings(self, data: dict[str, Any]) -> dict[str, Any]:
+        """PATCH /auth/settings."""
+        response = self._client.patch("/auth/settings", json={"data": data})
+        response.raise_for_status()
+        return response.json()
+
+    def reset_settings(self) -> dict[str, Any]:
+        """DELETE /auth/settings (reset to defaults)."""
+        response = self._client.delete("/auth/settings")
+        response.raise_for_status()
+        return response.json()
+
+    # -- Convenience ---------------------------------------------------------------
+
+    @staticmethod
+    def auth_header(token: TokenResponse) -> dict[str, str]:
+        """Build an ``Authorization`` header dict from a token response.
+
+        Useful for passing to robot-server requests that sit behind auth::
+
+            headers = AuthClient.auth_header(token)
+            httpx.get("http://robot:31950/runs", headers=headers)
+        """
+        return {"Authorization": f"Bearer {token.access_token}"}
+
+    def get_token_raw(
+        self,
+        *,
+        grant_type: str = "password",
+        **form_fields: str,
+    ) -> httpx.Response:
+        """Low-level POST to the token endpoint.
+
+        Returns the raw ``httpx.Response`` without raising or parsing,
+        useful for testing error cases.
+        """
+        data: dict[str, str] = {"grant_type": grant_type, **form_fields}
+        return self._client.post("/auth/oauth2/token", data=data)

--- a/e2e-testing/pyproject.toml
+++ b/e2e-testing/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pytest-playwright>=0.6.2",
     "pytest-timeout>=2.3.1",
     "python-dotenv>=1.2.1",
+    "rich>=13.0.0",
     "ruff>=0.14.2",
 ]
 

--- a/e2e-testing/pyproject.toml
+++ b/e2e-testing/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "eyes-playwright>=6.4.20",
+    "httpx>=0.26.0",
     "mypy>=1.13.0",
     "playwright>=1.55.0",
     "pytest>=8.0.0",

--- a/e2e-testing/pytest.ini
+++ b/e2e-testing/pytest.ini
@@ -23,6 +23,7 @@ markers =
     unit: marks tests as unit tests
     pdE2E: marks tests as Protocol Designer E2E tests
     llE2E: marks tests as Labware Library E2E tests
+    authE2E: marks tests as Auth Server E2E tests
 
     compare_versions: Run test against local and prod simultaneously for visual comparison
     

--- a/e2e-testing/scripts/check_auth.py
+++ b/e2e-testing/scripts/check_auth.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Interactive CLI to check auth-server status on a robot.
+
+Uses the AuthClient to probe a robot's auth-server and display
+connection info, settings, and token exchange results.
+
+Usage:
+    uv run python scripts/check_auth.py              # uses ROBOT_IP from .env or prompts
+    uv run python scripts/check_auth.py 10.0.0.42    # override with positional arg
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import httpx
+from dotenv import load_dotenv
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Prompt
+from rich.table import Table
+
+from automation.auth_client import (
+    ADMIN_PASSWORD,
+    ADMIN_USERNAME,
+    USER_PASSWORD,
+    USER_USERNAME,
+    AuthClient,
+)
+
+load_dotenv()
+
+console = Console()
+
+AUTH_SERVER_PORT = 33950
+ROBOT_SERVER_PORT = 31950
+
+
+def resolve_robot_ip() -> str:
+    """Figure out the robot IP from CLI args > env > interactive prompt."""
+    if len(sys.argv) > 1:
+        return sys.argv[1]
+
+    env_ip = os.environ.get("ROBOT_IP")
+    if env_ip:
+        console.print(f"[dim]Using ROBOT_IP from .env:[/dim] [bold]{env_ip}[/bold]")
+        return env_ip
+
+    ip = Prompt.ask("[bold]Robot IP address[/bold]", console=console)
+    if not ip:
+        console.print("[red]No IP provided.[/red]")
+        raise SystemExit(1)
+    return ip
+
+
+def check_reachable(ip: str, port: int, label: str, timeout: float = 3.0) -> bool:
+    """Try to connect to a host:port and report the result."""
+    url = f"http://{ip}:{port}"
+    try:
+        start = time.monotonic()
+        resp = httpx.get(f"{url}/health", timeout=timeout)
+        elapsed_ms = (time.monotonic() - start) * 1000
+        console.print(
+            f"  [green]:heavy_check_mark:[/green] {label} on [bold]{url}[/bold]  "
+            f"[dim]({resp.status_code}, {elapsed_ms:.0f}ms)[/dim]"
+        )
+        return True
+    except httpx.ConnectError:
+        console.print(f"  [red]:cross_mark:[/red] {label} on [bold]{url}[/bold]  [dim]connection refused[/dim]")
+        return False
+    except httpx.TimeoutException:
+        console.print(f"  [yellow]:warning:[/yellow] {label} on [bold]{url}[/bold]  [dim]timed out[/dim]")
+        return False
+    except Exception as exc:
+        console.print(f"  [red]:cross_mark:[/red] {label} on [bold]{url}[/bold]  [dim]{exc}[/dim]")
+        return False
+
+
+def check_auth_settings(client: AuthClient) -> None:
+    """Fetch and display auth settings."""
+    console.print("\n[bold]Auth Settings[/bold]")
+    try:
+        settings = client.get_settings()
+        data = settings.get("data", settings)
+        table = Table(show_header=False, box=None, padding=(0, 2))
+        table.add_column("Key", style="cyan")
+        table.add_column("Value", style="white")
+        for key, value in data.items() if isinstance(data, dict) else [("raw", data)]:
+            table.add_row(str(key), str(value))
+        console.print(table)
+    except Exception as exc:
+        console.print(f"  [red]Failed to get settings:[/red] {exc}")
+
+
+def check_token_exchange(client: AuthClient, username: str, password: str, label: str) -> None:
+    """Try a password-grant token exchange and display the result."""
+    try:
+        start = time.monotonic()
+        token = client.get_token(username, password)
+        elapsed_ms = (time.monotonic() - start) * 1000
+        console.print(f"  [green]:heavy_check_mark:[/green] {label}  [dim]({elapsed_ms:.0f}ms)[/dim]")
+
+        table = Table(show_header=False, box=None, padding=(0, 2))
+        table.add_column("Field", style="cyan")
+        table.add_column("Value", style="white")
+        table.add_row("access_token", token.access_token[:40] + "...")
+        table.add_row("token_type", token.token_type)
+        table.add_row("expires_in", f"{token.expires_in}s")
+        table.add_row("refresh_token", (token.refresh_token or "")[:40] + "..." if token.refresh_token else "None")
+        table.add_row("scope", token.scope)
+        console.print(table)
+
+        introspect = client.introspect(token.access_token)
+        active = introspect.get("active", False)
+        status = "[green]active[/green]" if active else "[red]inactive[/red]"
+        console.print(f"  Introspection: {status}  user=[bold]{introspect.get('username', '?')}[/bold]")
+
+    except httpx.HTTPStatusError as exc:
+        console.print(
+            f"  [red]:cross_mark:[/red] {label}  [dim]{exc.response.status_code}: {exc.response.text[:120]}[/dim]"
+        )
+    except Exception as exc:
+        console.print(f"  [red]:cross_mark:[/red] {label}  [dim]{exc}[/dim]")
+
+
+def main() -> None:
+    console.print(
+        Panel(
+            "[bold]Opentrons Auth Server Check[/bold]\n"
+            "[dim]Probe a robot's auth-server and validate the OAuth 2 flow[/dim]",
+            border_style="blue",
+        )
+    )
+
+    ip = resolve_robot_ip()
+    console.print(f"\n[bold]Target:[/bold] {ip}\n")
+
+    # -- Connectivity checks ---------------------------------------------------
+    console.print("[bold]Connectivity[/bold]")
+    auth_ok = check_reachable(ip, AUTH_SERVER_PORT, "auth-server")
+    check_reachable(ip, ROBOT_SERVER_PORT, "robot-server")
+
+    if not auth_ok:
+        console.print(
+            "\n[red bold]Auth-server is not reachable.[/red bold] "
+            "Make sure the robot is on and the auth-server is running."
+        )
+        raise SystemExit(1)
+
+    # -- Auth settings ---------------------------------------------------------
+    auth_url = f"http://{ip}:{AUTH_SERVER_PORT}"
+    with AuthClient(base_url=auth_url) as client:
+        check_auth_settings(client)
+
+        # -- Token exchange ----------------------------------------------------
+        console.print("\n[bold]Token Exchange (password grant)[/bold]")
+        check_token_exchange(client, ADMIN_USERNAME, ADMIN_PASSWORD, f"admin ({ADMIN_USERNAME})")
+        console.print()
+        check_token_exchange(client, USER_USERNAME, USER_PASSWORD, f"user  ({USER_USERNAME})")
+
+    console.print("\n[green bold]Done.[/green bold]")
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e-testing/tests/auth/conftest.py
+++ b/e2e-testing/tests/auth/conftest.py
@@ -1,0 +1,155 @@
+"""Fixtures for auth-server E2E tests."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+import urllib.request
+from collections.abc import Generator
+
+import pytest
+
+from automation.auth_client import (
+    ADMIN_PASSWORD,
+    ADMIN_USERNAME,
+    AuthClient,
+    TokenResponse,
+)
+
+# Default port used by ``make dev`` in auth-server/.
+AUTH_SERVER_DEFAULT_PORT = 33950
+AUTH_SERVER_PORTS = [33950]
+
+
+def _is_auth_server_running(url: str, timeout: int = 2) -> bool:
+    """Check if the auth-server is responding at *url*.
+
+    We probe ``GET /auth/settings`` because it's a cheap, always-available
+    endpoint that doesn't require authentication.
+    """
+    try:
+        urllib.request.urlopen(f"{url}/auth/settings", timeout=timeout)
+        return True
+    except Exception:
+        return False
+
+
+def _find_running_auth_server() -> str | None:
+    """Return the URL of a running auth-server, or None."""
+    for port in AUTH_SERVER_PORTS:
+        url = f"http://localhost:{port}"
+        if _is_auth_server_running(url):
+            return url
+    return None
+
+
+def _wait_for_auth_server(url: str, timeout: int = 60) -> bool:
+    """Block until the auth-server at *url* starts responding."""
+    start = time.monotonic()
+    while time.monotonic() - start < timeout:
+        if _is_auth_server_running(url):
+            return True
+        time.sleep(1)
+    return False
+
+
+def _start_auth_server() -> Generator[str, None, None]:
+    """Start or reuse a local auth-server.
+
+    Mirrors the pattern used by ``_start_pd_server`` / ``_start_ll_server``
+    in the top-level conftest:
+
+    1. If the server is already running, reuse it.
+    2. If ``SKIP_SERVER_START`` is set, yield the fallback URL without
+       starting anything.
+    3. Otherwise, start ``make -C ../auth-server dev`` and wait for it.
+    """
+    skip_server = os.environ.get("SKIP_SERVER_START", "false").lower() == "true"
+
+    existing = _find_running_auth_server()
+    if existing:
+        print(f"\n✓ Auth-server already running on {existing}, skipping startup")
+        yield existing
+        return
+
+    if skip_server:
+        fallback_url = f"http://localhost:{AUTH_SERVER_DEFAULT_PORT}"
+        print(
+            "\n⚠️  SKIP_SERVER_START is set and no existing auth-server detected; "
+            "returning fallback URL without starting server."
+        )
+        yield fallback_url
+        return
+
+    print("\nStarting auth-server...")
+    print("=" * 80)
+
+    server_process = subprocess.Popen(
+        ["make", "-C", "../auth-server", "dev"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    server_url = f"http://localhost:{AUTH_SERVER_DEFAULT_PORT}"
+
+    if not _wait_for_auth_server(server_url, timeout=60):
+        # Dump whatever output the process produced before failing.
+        if server_process.stdout:
+            output = server_process.stdout.read()
+            if output:
+                print(output)
+        server_process.kill()
+        raise RuntimeError(
+            f"Auth-server failed to start on {server_url} within 60 seconds. Check output above for errors."
+        )
+
+    print(f"✅ Auth-server is ready on {server_url}")
+    print("=" * 80)
+
+    try:
+        yield server_url
+    finally:
+        print("\nStopping auth-server...")
+        server_process.terminate()
+        try:
+            server_process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            print("⚠️  Auth-server did not exit in time; sending SIGKILL.")
+            server_process.kill()
+            server_process.wait(timeout=5)
+        if server_process.stdout:
+            server_process.stdout.close()
+
+
+@pytest.fixture(scope="session")
+def auth_base_url() -> Generator[str, None, None]:
+    """Resolve the auth-server base URL.
+
+    If ``AUTH_SERVER_URL`` is set, use that directly (for remote / CI targets).
+    Otherwise, start a local auth-server the same way PD/LL servers are started.
+    """
+    env_url = os.environ.get("AUTH_SERVER_URL")
+    if env_url:
+        yield env_url
+        return
+
+    yield from _start_auth_server()
+
+
+@pytest.fixture(scope="session")
+def auth_client(auth_base_url: str) -> Generator[AuthClient, None, None]:
+    """Session-scoped auth-server client.
+
+    The client is shared across all tests in a session so we don't
+    open/close connections per test.
+    """
+    with AuthClient(base_url=auth_base_url) as client:
+        yield client
+
+
+@pytest.fixture()
+def admin_token(auth_client: AuthClient) -> TokenResponse:
+    """A fresh admin access token for each test that requests it."""
+    return auth_client.get_token(ADMIN_USERNAME, ADMIN_PASSWORD)

--- a/e2e-testing/tests/auth/test_auth_smoke.py
+++ b/e2e-testing/tests/auth/test_auth_smoke.py
@@ -1,0 +1,122 @@
+"""Smoke tests for the auth-server OAuth 2 password-grant flow.
+
+These tests verify the live auth-server is up and that the core
+ROPC (Resource Owner Password Credentials) flow works end-to-end:
+  - token exchange
+  - token refresh
+  - token introspection
+  - settings endpoints
+  - error cases (bad credentials, invalid grant type)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from automation.auth_client import (
+    ADMIN_PASSWORD,
+    ADMIN_USERNAME,
+    USER_PASSWORD,
+    USER_USERNAME,
+    AuthClient,
+    TokenResponse,
+)
+
+pytestmark = pytest.mark.authE2E
+
+
+class TestPasswordGrant:
+    """Token exchange via username + password."""
+
+    def test_admin_can_get_token(self, auth_client: AuthClient) -> None:
+        token = auth_client.get_token(ADMIN_USERNAME, ADMIN_PASSWORD)
+        assert token.access_token
+        assert token.token_type.lower() == "bearer"
+        assert token.expires_in > 0
+        assert token.refresh_token is not None
+
+    def test_user_can_get_token(self, auth_client: AuthClient) -> None:
+        token = auth_client.get_token(USER_USERNAME, USER_PASSWORD)
+        assert token.access_token
+        assert token.refresh_token is not None
+
+    def test_bad_password_is_rejected(self, auth_client: AuthClient) -> None:
+        resp = auth_client.get_token_raw(
+            grant_type="password",
+            client_id="opentrons_app",
+            username=ADMIN_USERNAME,
+            password="wrong_password",
+        )
+        # RFC 6749 §5.2: token endpoint returns 400 for invalid_grant.
+        assert resp.status_code == 400
+
+    def test_unknown_user_is_rejected(self, auth_client: AuthClient) -> None:
+        resp = auth_client.get_token_raw(
+            grant_type="password",
+            client_id="opentrons_app",
+            username="nonexistent_user",
+            password="anything",
+        )
+        assert resp.status_code == 400
+
+    def test_bad_client_id_is_rejected(self, auth_client: AuthClient) -> None:
+        resp = auth_client.get_token_raw(
+            grant_type="password",
+            client_id="bad_client",
+            username=ADMIN_USERNAME,
+            password=ADMIN_PASSWORD,
+        )
+        assert resp.status_code == 401
+
+
+class TestTokenRefresh:
+    """Refresh-token flow."""
+
+    def test_can_refresh_token(self, auth_client: AuthClient) -> None:
+        original = auth_client.get_token(ADMIN_USERNAME, ADMIN_PASSWORD)
+        assert original.refresh_token is not None
+
+        refreshed = auth_client.refresh_token(original.refresh_token)
+        assert refreshed.access_token
+        assert refreshed.access_token != original.access_token
+
+    def test_invalid_refresh_token_is_rejected(self, auth_client: AuthClient) -> None:
+        resp = auth_client.get_token_raw(
+            grant_type="refresh_token",
+            client_id="opentrons_app",
+            refresh_token="bogus_token",
+        )
+        assert resp.status_code in (400, 401)
+
+
+class TestIntrospection:
+    """Token introspection (RFC 7662)."""
+
+    def test_active_token_introspects_as_active(
+        self,
+        auth_client: AuthClient,
+        admin_token: TokenResponse,
+    ) -> None:
+        result = auth_client.introspect(admin_token.access_token)
+        assert result["active"] is True
+        assert result["username"] == ADMIN_USERNAME
+        assert "scope" in result
+
+    def test_bogus_token_introspects_as_inactive(
+        self,
+        auth_client: AuthClient,
+    ) -> None:
+        result = auth_client.introspect("totally_fake_token")
+        assert result["active"] is False
+
+
+class TestSettings:
+    """Auth settings endpoints."""
+
+    def test_get_settings(self, auth_client: AuthClient) -> None:
+        settings = auth_client.get_settings()
+        assert "data" in settings
+
+    def test_reset_settings(self, auth_client: AuthClient) -> None:
+        settings = auth_client.reset_settings()
+        assert "data" in settings

--- a/e2e-testing/tests/auth/test_auth_smoke.py
+++ b/e2e-testing/tests/auth/test_auth_smoke.py
@@ -25,98 +25,101 @@ from automation.auth_client import (
 pytestmark = pytest.mark.authE2E
 
 
-class TestPasswordGrant:
-    """Token exchange via username + password."""
-
-    def test_admin_can_get_token(self, auth_client: AuthClient) -> None:
-        token = auth_client.get_token(ADMIN_USERNAME, ADMIN_PASSWORD)
-        assert token.access_token
-        assert token.token_type.lower() == "bearer"
-        assert token.expires_in > 0
-        assert token.refresh_token is not None
-
-    def test_user_can_get_token(self, auth_client: AuthClient) -> None:
-        token = auth_client.get_token(USER_USERNAME, USER_PASSWORD)
-        assert token.access_token
-        assert token.refresh_token is not None
-
-    def test_bad_password_is_rejected(self, auth_client: AuthClient) -> None:
-        resp = auth_client.get_token_raw(
-            grant_type="password",
-            client_id="opentrons_app",
-            username=ADMIN_USERNAME,
-            password="wrong_password",
-        )
-        # RFC 6749 §5.2: token endpoint returns 400 for invalid_grant.
-        assert resp.status_code == 400
-
-    def test_unknown_user_is_rejected(self, auth_client: AuthClient) -> None:
-        resp = auth_client.get_token_raw(
-            grant_type="password",
-            client_id="opentrons_app",
-            username="nonexistent_user",
-            password="anything",
-        )
-        assert resp.status_code == 400
-
-    def test_bad_client_id_is_rejected(self, auth_client: AuthClient) -> None:
-        resp = auth_client.get_token_raw(
-            grant_type="password",
-            client_id="bad_client",
-            username=ADMIN_USERNAME,
-            password=ADMIN_PASSWORD,
-        )
-        assert resp.status_code == 401
+# -- Password grant -------------------------------------------------------
 
 
-class TestTokenRefresh:
-    """Refresh-token flow."""
-
-    def test_can_refresh_token(self, auth_client: AuthClient) -> None:
-        original = auth_client.get_token(ADMIN_USERNAME, ADMIN_PASSWORD)
-        assert original.refresh_token is not None
-
-        refreshed = auth_client.refresh_token(original.refresh_token)
-        assert refreshed.access_token
-        assert refreshed.access_token != original.access_token
-
-    def test_invalid_refresh_token_is_rejected(self, auth_client: AuthClient) -> None:
-        resp = auth_client.get_token_raw(
-            grant_type="refresh_token",
-            client_id="opentrons_app",
-            refresh_token="bogus_token",
-        )
-        assert resp.status_code in (400, 401)
+def test_admin_can_get_token(auth_client: AuthClient) -> None:
+    token = auth_client.get_token(ADMIN_USERNAME, ADMIN_PASSWORD)
+    assert token.access_token
+    assert token.token_type.lower() == "bearer"
+    assert token.expires_in > 0
+    assert token.refresh_token is not None
 
 
-class TestIntrospection:
-    """Token introspection (RFC 7662)."""
-
-    def test_active_token_introspects_as_active(
-        self,
-        auth_client: AuthClient,
-        admin_token: TokenResponse,
-    ) -> None:
-        result = auth_client.introspect(admin_token.access_token)
-        assert result["active"] is True
-        assert result["username"] == ADMIN_USERNAME
-        assert "scope" in result
-
-    def test_bogus_token_introspects_as_inactive(
-        self,
-        auth_client: AuthClient,
-    ) -> None:
-        result = auth_client.introspect("totally_fake_token")
-        assert result["active"] is False
+def test_user_can_get_token(auth_client: AuthClient) -> None:
+    token = auth_client.get_token(USER_USERNAME, USER_PASSWORD)
+    assert token.access_token
+    assert token.refresh_token is not None
 
 
-class TestSettings:
-    """Auth settings endpoints."""
+def test_bad_password_is_rejected(auth_client: AuthClient) -> None:
+    resp = auth_client.get_token_raw(
+        grant_type="password",
+        client_id="opentrons_app",
+        username=ADMIN_USERNAME,
+        password="wrong_password",
+    )
+    # RFC 6749 §5.2: token endpoint returns 400 for invalid_grant.
+    assert resp.status_code == 400
 
-    def test_get_settings(self, auth_client: AuthClient) -> None:
-        settings = auth_client.get_settings()
-        assert "data" in settings
 
-    def test_reset_settings(self, auth_client: AuthClient) -> None:
-        settings = auth_client.reset_settings()
-        assert "data" in settings
+def test_unknown_user_is_rejected(auth_client: AuthClient) -> None:
+    resp = auth_client.get_token_raw(
+        grant_type="password",
+        client_id="opentrons_app",
+        username="nonexistent_user",
+        password="anything",
+    )
+    assert resp.status_code == 400
+
+
+def test_bad_client_id_is_rejected(auth_client: AuthClient) -> None:
+    resp = auth_client.get_token_raw(
+        grant_type="password",
+        client_id="bad_client",
+        username=ADMIN_USERNAME,
+        password=ADMIN_PASSWORD,
+    )
+    assert resp.status_code == 401
+
+
+# -- Token refresh ---------------------------------------------------------
+
+
+def test_can_refresh_token(auth_client: AuthClient) -> None:
+    original = auth_client.get_token(ADMIN_USERNAME, ADMIN_PASSWORD)
+    assert original.refresh_token is not None
+
+    refreshed = auth_client.refresh_token(original.refresh_token)
+    assert refreshed.access_token
+    assert refreshed.access_token != original.access_token
+
+
+def test_invalid_refresh_token_is_rejected(auth_client: AuthClient) -> None:
+    resp = auth_client.get_token_raw(
+        grant_type="refresh_token",
+        client_id="opentrons_app",
+        refresh_token="bogus_token",
+    )
+    assert resp.status_code in (400, 401)
+
+
+# -- Token introspection ---------------------------------------------------
+
+
+def test_active_token_introspects_as_active(
+    auth_client: AuthClient,
+    admin_token: TokenResponse,
+) -> None:
+    result = auth_client.introspect(admin_token.access_token)
+    assert result["active"] is True
+    assert result["username"] == ADMIN_USERNAME
+    assert "scope" in result
+
+
+def test_bogus_token_introspects_as_inactive(auth_client: AuthClient) -> None:
+    result = auth_client.introspect("totally_fake_token")
+    assert result["active"] is False
+
+
+# -- Settings --------------------------------------------------------------
+
+
+def test_get_settings(auth_client: AuthClient) -> None:
+    settings = auth_client.get_settings()
+    assert "data" in settings
+
+
+def test_reset_settings(auth_client: AuthClient) -> None:
+    settings = auth_client.reset_settings()
+    assert "data" in settings

--- a/e2e-testing/uv.lock
+++ b/e2e-testing/uv.lock
@@ -127,6 +127,7 @@ dependencies = [
     { name = "pytest-playwright" },
     { name = "pytest-timeout" },
     { name = "python-dotenv" },
+    { name = "rich" },
     { name = "ruff" },
 ]
 
@@ -141,6 +142,7 @@ requires-dist = [
     { name = "pytest-playwright", specifier = ">=0.6.2" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
+    { name = "rich", specifier = ">=13.0.0" },
     { name = "ruff", specifier = ">=0.14.2" },
 ]
 
@@ -277,6 +279,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -349,6 +363,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73", size = 50964, upload-time = "2025-12-22T06:53:51.801Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -575,6 +598,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/99/a4cab2acbb884f80e558b0771e97e21e939c5dfb460f488d19df485e8298/rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8", size = 230143, upload-time = "2026-02-01T16:20:47.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/45/615f5babd880b4bd7d405cc0dc348234c5ffb6ed1ea33e152ede08b2072d/rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69", size = 309963, upload-time = "2026-02-01T16:20:46.078Z" },
 ]
 
 [[package]]

--- a/e2e-testing/uv.lock
+++ b/e2e-testing/uv.lock
@@ -3,6 +3,19 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -106,6 +119,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "eyes-playwright" },
+    { name = "httpx" },
     { name = "mypy" },
     { name = "playwright" },
     { name = "pytest" },
@@ -119,6 +133,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "eyes-playwright", specifier = ">=6.4.20" },
+    { name = "httpx", specifier = ">=0.26.0" },
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "playwright", specifier = ">=1.55.0" },
     { name = "pytest", specifier = ">=8.0.0" },
@@ -192,6 +207,43 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
     { url = "https://files.pythonhosted.org/packages/0d/da/343cd760ab2f92bac1845ca07ee3faea9fe52bee65f7bcb19f16ad7de08b/greenlet-3.2.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:015d48959d4add5d6c9f6c5210ee3803a830dce46356e3bc326d6776bde54681", size = 1680760, upload-time = "2025-11-04T12:42:25.341Z" },
     { url = "https://files.pythonhosted.org/packages/e3/a5/6ddab2b4c112be95601c13428db1d8b6608a8b6039816f2ba09c346c08fc/greenlet-3.2.4-cp314-cp314-win_amd64.whl", hash = "sha256:e37ab26028f12dbb0ff65f29a8d3d44a765c61e729647bf2ddfbbed621726f01", size = 303425, upload-time = "2025-08-07T13:32:27.59Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add an httpx-based `AuthClient` class (`e2e-testing/automation/auth_client.py`) that
  implements the OAuth 2 Resource Owner Password Credentials (ROPC) flow against the
  auth-server. This is a reusable client for E2E and integration tests that need to
  authenticate against the auth-server before hitting protected robot-server endpoints.

- Add initial smoke tests (`e2e-testing/tests/auth/test_auth_smoke.py`) covering token
  exchange, refresh, introspection, settings, and error cases. These validate the client
  works and serve as a baseline for future cross-service tests.

- The test conftest auto-starts a local auth-server (via `make -C ../auth-server dev`)
  when nothing is already running, mirroring how PD/LL tests auto-start their servers.
  Set `AUTH_SERVER_URL` to point at a remote server or robot instead.

- Add `make test-auth` target and `authE2E` pytest marker.

- Add `.github/workflows/auth-server-e2e-test.yaml` CI workflow.

## Motivation

The auth-server already has thorough Tavern integration tests that run hermetically
(one ephemeral server per test). This PR adds a complementary layer:

- A **reusable Python client** (`AuthClient`) that future tests can import to get tokens
  and make authenticated requests to robot-server.
- Tests that can run against **any live target** -- local dev, CI, staging, or a physical
  robot -- not just an ephemeral test server.
- The foundation for **cross-service E2E tests** (auth-server + robot-server) once
  robot-server enforces token validation.

## Test plan

- [x] `make test-auth` passes locally (with auth-server already running)
- [x] `make test-auth` auto-starts auth-server when nothing is running
- [x] `make -C e2e-testing typecheck` passes (no mypy errors)
- [x] `make -C e2e-testing lint` passes (no ruff errors)
- [x] CI workflow runs successfully on this PR - This works but I am not sure we want this yet or at all, just wanted to show it.