### PR TITLE
feat(app): add vacuum manifold to module wizard flows

### DIFF
--- a/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
+++ b/app/src/organisms/ModuleCard/ModuleOverflowMenu.tsx
@@ -11,10 +11,7 @@ import {
   useHoverTooltip,
 } from '@opentrons/components'
 import {
-  ABSORBANCE_READER_TYPE,
-  FLEX_STACKER_MODULE_TYPE,
   HEATERSHAKER_MODULE_TYPE,
-  MODULE_MODELS_OT2_ONLY,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
@@ -24,6 +21,7 @@ import { useIsLegacySessionInProgress } from '/app/resources/legacy_sessions'
 import { useCurrentRunId, useRunStatuses } from '/app/resources/runs'
 
 import { useModuleOverflowMenu } from './hooks'
+import { getCanCalibrateModule, getIsModuleCalibrated } from './utils'
 
 import type { AttachedModule } from '/app/redux/modules/types'
 
@@ -121,12 +119,7 @@ export const ModuleOverflowMenu = (
   return (
     <Flex position={POSITION_RELATIVE}>
       <MenuList>
-        {isFlex &&
-        module.moduleType !== ABSORBANCE_READER_TYPE &&
-        module.moduleType !== FLEX_STACKER_MODULE_TYPE &&
-        !MODULE_MODELS_OT2_ONLY.some(
-          modModel => modModel === module.moduleModel
-        ) ? (
+        {getCanCalibrateModule(module, isFlex) ? (
           <>
             <MenuItem
               onClick={handleCalibrateClick}
@@ -134,7 +127,7 @@ export const ModuleOverflowMenu = (
               {...targetProps}
             >
               {i18n.format(
-                module.moduleOffset?.last_modified != null
+                getIsModuleCalibrated(module)
                   ? t('recalibrate')
                   : t('calibrate'),
                 'capitalize'

--- a/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -440,36 +440,41 @@ describe('ModuleCard', () => {
     screen.getByText('Module setup required.')
   })
   it('does not render calibration update banner for OT-2-specific modules', () => {
+    vi.mocked(useIsFlex).mockReturnValue(false)
     render({
       ...props,
       module: mockMagneticModule,
     })
     expect(screen.queryByText('Module setup required.')).not.toBeInTheDocument()
   })
-  it('renders module setup link for no-calibration required modules', () => {
-    render({
-      ...props,
-      module: mockFlexStacker,
+  ;[mockFlexStacker, mockVacuumModule].forEach(module =>
+    it('renders module setup link for no-calibration required modules', () => {
+      render({
+        ...props,
+        module,
+      })
+      screen.getByText('Set up module for use.')
+      const button = screen.getByText('Set up module')
+      fireEvent.click(button)
+      expect(vi.mocked(handleModuleWizardFlows)).toHaveBeenCalled()
+      expect(vi.mocked(getRequestById)).toHaveBeenCalled()
     })
-    screen.getByText('Set up module for use.')
-    const button = screen.getByText('Set up module')
-    fireEvent.click(button)
-    expect(vi.mocked(handleModuleWizardFlows)).toHaveBeenCalled()
-    expect(vi.mocked(getRequestById)).toHaveBeenCalled()
-  })
-  it('renders module setup link for no-calibration required modules if firmware update available', () => {
-    mockFlexStacker.hasAvailableUpdate = true
+  )
+  ;[mockFlexStacker, mockVacuumModule].forEach(module =>
+    it('renders module setup link for no-calibration required modules if firmware update available', () => {
+      mockFlexStacker.hasAvailableUpdate = true
 
-    render({
-      ...props,
-      module: mockFlexStacker,
+      render({
+        ...props,
+        module,
+      })
+      screen.getByText('Set up module for use.')
+      const button = screen.getByText('Set up module')
+      fireEvent.click(button)
+      expect(vi.mocked(handleModuleWizardFlows)).toHaveBeenCalled()
+      expect(vi.mocked(getRequestById)).toHaveBeenCalled()
     })
-    screen.getByText('Set up module for use.')
-    const button = screen.getByText('Set up module')
-    fireEvent.click(button)
-    expect(vi.mocked(handleModuleWizardFlows)).toHaveBeenCalled()
-    expect(vi.mocked(getRequestById)).toHaveBeenCalled()
-  })
+  )
   it('renders firmware update for no-calibration required modules only if its already in the deck config', () => {
     vi.mocked(useNotifyDeckConfigurationQuery).mockReturnValue({
       data: [

--- a/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleOverflowMenu.test.tsx
@@ -1,6 +1,13 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import {
+  FLEX_STACKER_MODULE_TYPE,
+  FLEX_STACKER_MODULE_V1,
+  VACUUM_MODULE_MILLIPORE_V1,
+  VACUUM_MODULE_TYPE,
+} from '@opentrons/shared-data'
+
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useIsFlex } from '/app/redux-resources/robots'
@@ -158,6 +165,23 @@ const mockThermocyclerGen2LidClosed = {
   moduleType: 'thermocyclerModuleType',
   data: {
     lidStatus: 'closed',
+  },
+} as any
+
+const mockFlexStacker = {
+  id: 'flex_stacker_id',
+  moduleModel: FLEX_STACKER_MODULE_V1,
+  moduleType: FLEX_STACKER_MODULE_TYPE,
+  data: {
+    status: 'idle',
+  },
+} as any
+const mockVacuumModule = {
+  id: 'vacuum_id',
+  moduleModel: VACUUM_MODULE_MILLIPORE_V1,
+  moduleType: VACUUM_MODULE_TYPE,
+  data: {
+    status: 'idle',
   },
 } as any
 
@@ -508,6 +532,18 @@ describe('ModuleOverflowMenu', () => {
     const calibrate = screen.queryByRole('button', { name: 'Calibrate' })
     expect(calibrate).not.toBeInTheDocument()
   })
+  ;[mockFlexStacker, mockVacuumModule].forEach(module =>
+    it('not render calibrate button when a module is no-calibration required', () => {
+      props = {
+        ...props,
+        module,
+      }
+      render(props)
+
+      const calibrate = screen.queryByRole('button', { name: 'Calibrate' })
+      expect(calibrate).not.toBeInTheDocument()
+    })
+  )
 
   it('renders a disabled calibrate button if the pipettes are not attached or need a firmware update', () => {
     vi.mocked(useIsFlex).mockReturnValue(true)

--- a/app/src/organisms/ModuleCard/__tests__/hooks.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/hooks.test.tsx
@@ -715,7 +715,7 @@ describe('useModuleOverflowMenu', () => {
     expect(flexStackerMenu[0].menuButtons).toHaveLength(2)
   })
 
-  it.only('should return vacuum module menu items and call handleSlideoutClick when module is idle', () => {
+  it('should return vacuum module menu items and call handleSlideoutClick when module is idle', () => {
     const mockHandleSlideoutClick = vi.fn()
     const wrapper: FunctionComponent<{ children: ReactNode }> = ({
       children,

--- a/app/src/organisms/ModuleCard/constants.tsx
+++ b/app/src/organisms/ModuleCard/constants.tsx
@@ -7,6 +7,13 @@ import {
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
+import {
+  ABSORBANCE_READER_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
+  VACUUM_MODULE_TYPE,
+} from '@opentrons/shared-data'
+
+import type { ModuleType } from '@opentrons/shared-data'
 
 export const MODULE_INFO_CONTAINER_STYLE = css`
   grid-gap: ${SPACING.spacing8};
@@ -36,3 +43,9 @@ export const MODULE_INFO_DETAIL_TEXT_STYLE = css`
 
   desktopstyle: 'bodyDefaultRegular';
 `
+
+export const NO_CALIBRATION_TYPE: ModuleType[] = [
+  ABSORBANCE_READER_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
+  VACUUM_MODULE_TYPE,
+]

--- a/app/src/organisms/ModuleCard/index.tsx
+++ b/app/src/organisms/ModuleCard/index.tsx
@@ -34,7 +34,6 @@ import {
   getModuleDisplayName,
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
-  MODULE_MODELS_OT2_ONLY,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
   VACUUM_MODULE_TYPE,
@@ -79,7 +78,11 @@ import { TemperatureModuleSlideout } from './TemperatureModuleSlideout'
 import { TestShakeSlideout } from './TestShakeSlideout'
 import { ThermocyclerModuleData } from './ThermocyclerModuleData'
 import { ThermocyclerModuleSlideout } from './ThermocyclerModuleSlideout'
-import { getModuleCardImage } from './utils'
+import {
+  getModuleCalibrationRequired,
+  getModuleCardImage,
+  getModuleSetupRequired,
+} from './utils'
 import { VacuumModuleData } from './VacuumModule/VacuumModuleData'
 import { VacuumModuleSlideout } from './VacuumModule/VacuumModuleSlideout'
 
@@ -95,10 +98,6 @@ import type { Dispatch, State } from '/app/redux/types'
 const HAS_SETUP_INSTRUCTIONS_TYPE: ModuleType[] = [
   FLEX_STACKER_MODULE_TYPE,
   HEATERSHAKER_MODULE_TYPE,
-]
-const NO_CALIBRATION_TYPE: ModuleType[] = [
-  ABSORBANCE_READER_TYPE,
-  FLEX_STACKER_MODULE_TYPE,
 ]
 
 const POLL_INTERVAL_MS = 5000
@@ -202,30 +201,8 @@ export const ModuleCard = (props: ModuleCardProps): JSX.Element | null => {
   const isFlex = useIsFlex(robotName)
   const deckConfig = useNotifyDeckConfigurationQuery().data
 
-  const getSetupWizardFlow = (): {
-    requireModuleCalibration: boolean
-    requireModuleSetup: boolean
-  } => {
-    if (!isFlex)
-      return { requireModuleCalibration: false, requireModuleSetup: false }
-    if (NO_CALIBRATION_TYPE.includes(module.moduleType)) {
-      return {
-        requireModuleCalibration: false,
-        requireModuleSetup: !deckConfig?.some(
-          c => c.opentronsModuleSerialNumber === module.serialNumber
-        ),
-      }
-    }
-    return {
-      requireModuleCalibration:
-        !MODULE_MODELS_OT2_ONLY.some(
-          modModel => modModel === module.moduleModel
-        ) && module.moduleOffset?.last_modified == null,
-      requireModuleSetup: false,
-    }
-  }
-  const { requireModuleCalibration, requireModuleSetup } = getSetupWizardFlow()
-
+  const requireModuleCalibration = getModuleCalibrationRequired(module, isFlex)
+  const requireModuleSetup = getModuleSetupRequired(module, isFlex, deckConfig)
   const isTooHot = getModuleTooHot(module)
 
   let moduleData: JSX.Element = <div></div>

--- a/app/src/organisms/ModuleCard/utils.ts
+++ b/app/src/organisms/ModuleCard/utils.ts
@@ -14,8 +14,11 @@ import vacuumModule from '/app/assets/images/vacuum_module_v1.png'
 import { updateModule } from '/app/redux/modules'
 import { useDispatchApiRequest } from '/app/redux/robot-api'
 
+import { NO_CALIBRATION_TYPE } from './constants'
+
 import type { TFunction } from 'i18next'
 import type { ChipType } from '@opentrons/components'
+import type { DeckConfiguration } from '@opentrons/shared-data'
 import type {
   AttachedModule,
   VacuumModuleStatus,
@@ -119,4 +122,38 @@ export const getPumpStatusProps = (
     return { text: t('pump_error'), type: 'error' }
   }
   return { text: t('pump_engaged'), type: 'info' }
+}
+
+export const getCanCalibrateModule = (
+  module: AttachedModule,
+  isFlex: boolean
+): boolean => isFlex && !NO_CALIBRATION_TYPE.includes(module.moduleType)
+
+export const getIsModuleCalibrated = (module: AttachedModule): boolean =>
+  module.moduleOffset?.last_modified != null
+
+export const getModuleCalibrationRequired = (
+  module: AttachedModule,
+  isFlex: boolean
+): boolean => {
+  if (!getCanCalibrateModule(module, isFlex)) {
+    return false
+  }
+  return !getIsModuleCalibrated(module)
+}
+
+export const getModuleSetupRequired = (
+  module: AttachedModule,
+  isFlex: boolean,
+  deckConfig?: DeckConfiguration
+): boolean => {
+  if (!isFlex) {
+    return false
+  }
+  return !(
+    deckConfig?.some(
+      ({ opentronsModuleSerialNumber }) =>
+        opentronsModuleSerialNumber === module.serialNumber
+    ) ?? false
+  )
 }

--- a/app/src/organisms/ModuleWizardFlows/constants.ts
+++ b/app/src/organisms/ModuleWizardFlows/constants.ts
@@ -4,6 +4,7 @@ import {
   HEATERSHAKER_MODULE_TYPE,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
+  VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import type { ModuleType } from '@opentrons/shared-data'
@@ -44,5 +45,6 @@ export const FLEX_SLOT_NAMES_BY_MOD_TYPE: {
   [HEATERSHAKER_MODULE_TYPE]: ['D1', 'C1', 'B1', 'A1', 'D3', 'C3', 'B3', 'A3'],
   [TEMPERATURE_MODULE_TYPE]: ['D1', 'C1', 'B1', 'A1', 'D3', 'C3', 'B3', 'A3'],
   [THERMOCYCLER_MODULE_TYPE]: ['B1'],
+  [VACUUM_MODULE_TYPE]: ['A3'],
 }
 export const LEFT_SLOTS: string[] = ['A1', 'B1', 'C1', 'D1']

--- a/app/src/organisms/ModuleWizardFlows/getModuleSetupSteps.ts
+++ b/app/src/organisms/ModuleWizardFlows/getModuleSetupSteps.ts
@@ -1,6 +1,7 @@
 import {
   ABSORBANCE_READER_TYPE,
   FLEX_STACKER_MODULE_TYPE,
+  VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import { SECTIONS } from './constants'
@@ -25,6 +26,12 @@ export const getModuleSetupSteps = (
         { section: SECTIONS.SELECT_LOCATION },
         { section: SECTIONS.CLOSE_DOOR },
         { section: SECTIONS.INSTALL_SHUTTLE },
+        { section: SECTIONS.SUCCESS },
+      ]
+    case VACUUM_MODULE_TYPE:
+      return [
+        { section: SECTIONS.UPDATE_FIRMWARE },
+        { section: SECTIONS.SELECT_LOCATION },
         { section: SECTIONS.SUCCESS },
       ]
     default:


### PR DESCRIPTION
# Overview

Wire up wizard flow for vacuum manifold setup.

Closes EXEC-2242

https://github.com/user-attachments/assets/98f8368a-0f3e-4443-b86b-09ba607d42a5

## Test Plan and Hands on Testing

#### Flex
- spin up a Flex dev server with a vacuum module attached ([instructions](https://opentrons.atlassian.net/wiki/x/_QF2WAE))
- navigate to dev robot's device details page
- find vacuum module card
- click overflow menu and verify that 'calibrate' option is not present
- verify that setup up notification shows on the card
- click "Set up module"
- walk through wizard and verify that design requirements are satisfied
- scroll to deck config and verify that vacuum module is configured as expected, and the inline notification on the VM card is no longer there

#### OT-2 (implicated from utility refactors)
- check any OT-2 device details page and smoke test that there are no unintended changes (no inline notifications on module cards, no calibration option in the overflow menu)

## Changelog

List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.

## Review requests

see test plan.

## Risk assessment

lowish. a few refactors in the scope of the `ModuleCard` subdir