### PR TITLE
fix(protocol-designer): fix logic for retrieving column name from well name

### DIFF
--- a/protocol-designer/src/components/organisms/SlotDetailModal/utils.ts
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/utils.ts
@@ -1,6 +1,6 @@
-import { getColumnFromWellName } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils'
-
 import type { TFunction } from 'i18next'
+
+const getRowFromSlotName = (slotName: string): string => slotName.slice(0, 1)
 
 export function getDeckLabel(
   slotName: string,
@@ -13,7 +13,7 @@ export function getDeckLabel(
 
   if (isHopper) {
     return t('shared:stacker', {
-      slot: getColumnFromWellName(slotName),
+      slot: getRowFromSlotName(slotName),
     })
   }
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -112,7 +112,10 @@ export const getHoveredOffsetFromWell = (args: {
 }
 
 export const getColumnFromWellName = (wellName: string): string =>
-  wellName.slice(-2, -1)
+  // remove the first character denoting the well row
+  // this feels robust enough, since tipracks are configured 8x12,
+  // so the row should only be a single character (letter)
+  wellName.slice(1)
 
 export const getIsPickupCompatibleWithPossibleAdapter = (
   stack: string[],


### PR DESCRIPTION
# Overview

Fixes logic in a uitlity that parses an arbitrary well name to return its stringified column. Example: given well `'G3'`, the utility should return `'3'`.

This currently breaks any manual tip selection for column pickup (8- or 96-channel)

Closes AUTH-2755

## Test Plan and Hands on Testing

- upload protocol attached to ticket
- open existing transfer step and navigate to tip selection modal
- unselect bad selection, then hover any well
- verify correct hover and selection behavior for column pickup

## Changelog

fix utility for getting column from well name, bubbled up to all tip selection functionality

## Review requests

see test plan

## Risk assessment

medium, small footprint, but fixes a critical tip selection bug