### PR TITLE
fix(app): modify the condition to display WellView container

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -107,8 +107,9 @@ export function LabwareSlotContainer(
       : activeWellName
   const shouldShowWellContainer =
     selectedWellName != null &&
-    commandType !== 'comment' &&
-    commandType !== 'waitForResume'
+    !['comment', 'waitForDuration', 'waitForResume', 'waitForTasks'].includes(
+      commandType
+    )
   const wellGroup: WellGroup | null =
     selectedWellName != null
       ? {

--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -72,7 +72,7 @@ export function LabwareSlotContainer(
     'displayName' in labwareLoadCommandParams
       ? labwareLoadCommandParams.displayName
       : null
-  const { params } = currentCommand
+  const { params, commandType } = currentCommand
   const commandWellName =
     'wellName' in params && typeof params.wellName === 'string'
       ? params.wellName
@@ -107,8 +107,8 @@ export function LabwareSlotContainer(
       : activeWellName
   const shouldShowWellContainer =
     selectedWellName != null &&
-    currentCommand.commandType !== 'comment' &&
-    currentCommand.commandType !== 'pause'
+    commandType !== 'comment' &&
+    commandType !== 'pause'
   const wellGroup: WellGroup | null =
     selectedWellName != null
       ? {

--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -41,6 +41,9 @@ interface LabwareSlotContainerProps {
   moduleEntities: ModuleEntities
 }
 
+// TODO: this is a temp fix in an interest of time
+// but we should investigate why the dropTip and pickUpTip
+// commands are showing the well container
 const HIDE_WELL_CONTAINER_COMMAND_TYPES = [
   'comment',
   'waitForDuration',

--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -105,6 +105,10 @@ export function LabwareSlotContainer(
     commandLabwareId === topLabwareOnSlotId && commandWellName != null
       ? commandWellName
       : activeWellName
+  const shouldShowWellContainer =
+    selectedWellName != null &&
+    currentCommand.commandType !== 'comment' &&
+    currentCommand.commandType !== 'pause'
   const wellGroup: WellGroup | null =
     selectedWellName != null
       ? {
@@ -149,7 +153,7 @@ export function LabwareSlotContainer(
 
   return (
     <>
-      {selectedWellName != null ? (
+      {shouldShowWellContainer ? (
         <WellContainer
           wells={wells}
           params={params}

--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -108,7 +108,7 @@ export function LabwareSlotContainer(
   const shouldShowWellContainer =
     selectedWellName != null &&
     commandType !== 'comment' &&
-    commandType !== 'pause'
+    commandType !== 'waitForResume'
   const wellGroup: WellGroup | null =
     selectedWellName != null
       ? {

--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -40,6 +40,16 @@ interface LabwareSlotContainerProps {
   pipetteEntities: PipetteEntities
   moduleEntities: ModuleEntities
 }
+
+const HIDE_WELL_CONTAINER_COMMAND_TYPES = [
+  'comment',
+  'waitForDuration',
+  'waitForResume',
+  'waitForTasks',
+  'dropTip',
+  'pickUpTip',
+]
+
 export function LabwareSlotContainer(
   props: LabwareSlotContainerProps
 ): JSX.Element {
@@ -107,9 +117,7 @@ export function LabwareSlotContainer(
       : activeWellName
   const shouldShowWellContainer =
     selectedWellName != null &&
-    !['comment', 'waitForDuration', 'waitForResume', 'waitForTasks'].includes(
-      commandType
-    )
+    !HIDE_WELL_CONTAINER_COMMAND_TYPES.includes(commandType)
   const wellGroup: WellGroup | null =
     selectedWellName != null
       ? {


### PR DESCRIPTION
# Overview
modify the condition to display WellView container

<img width="1024" height="763" alt="Screenshot 2026-02-18 at 4 55 34 PM" src="https://github.com/user-attachments/assets/e75c144e-5c00-4010-b87c-06cc6e585e1d" />


close RQA-5216 and partially close RQA-5217 (WellView part)

## Test Plan and Hands on Testing
- import the protocol that is attached to the ticket
- visualize the protocol
- move to step 7 (comment)

## Changelog
- hide WellView when commandType is 'comment', 'waitForDuration', 'waitForResume', or 'waitForTasks'

## Review requests

## Risk assessment
low
