### PR TITLE
feat(protocol-designer): allow return tip for 96ch with `COLUMN` pick up

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DropTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DropTipField.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
-import { ALL, COLUMN } from '@opentrons/shared-data'
+import { ALL, SINGLE } from '@opentrons/shared-data'
 
 import { DropdownStepFormField } from '/protocol-designer/components/molecules'
 import { getEnableAdditionalPartialTipSelection } from '/protocol-designer/feature-flags/selectors'
@@ -63,9 +63,7 @@ export function DropTipField(props: DropTipFieldProps): JSX.Element {
     getEnableAdditionalPartialTipSelection
   )
   const isReturnTipValid =
-    nozzles === ALL ||
-    nozzles == null ||
-    (enableAdditionalPartialTip ? nozzles === COLUMN && channels === 96 : false)
+    nozzles === ALL || nozzles == null || (channels === 1 && nozzles === SINGLE)
 
   const isTipDropLocationReturnTip = Object.values(labwareEntities).some(
     ({ labwareDefURI }) => labwareDefURI === tiprackDefUri
@@ -85,7 +83,11 @@ export function DropTipField(props: DropTipFieldProps): JSX.Element {
     <DropdownStepFormField
       {...props}
       updateValue={updateValue}
-      options={isReturnTipValid ? [...options, returnOption] : options}
+      options={
+        isReturnTipValid || enableAdditionalPartialTip
+          ? [...options, returnOption]
+          : options
+      }
       value={dropdownItem ? String(dropdownItem) : null}
       title={i18n.format(
         t('step_edit_form.field.location.dropTip'),

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DropTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DropTipField.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
-import { ALL, COLUMN, SINGLE } from '@opentrons/shared-data'
+import { ALL, COLUMN } from '@opentrons/shared-data'
 
 import { DropdownStepFormField } from '/protocol-designer/components/molecules'
 import { getEnableAdditionalPartialTipSelection } from '/protocol-designer/feature-flags/selectors'
@@ -65,7 +65,6 @@ export function DropTipField(props: DropTipFieldProps): JSX.Element {
   const isReturnTipValid =
     nozzles === ALL ||
     nozzles == null ||
-    (channels === 1 && nozzles === SINGLE) ||
     (enableAdditionalPartialTip ? nozzles === COLUMN && channels === 96 : false)
 
   const isTipDropLocationReturnTip = Object.values(labwareEntities).some(

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DropTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DropTipField.tsx
@@ -2,9 +2,10 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
-import { ALL, SINGLE } from '@opentrons/shared-data'
+import { ALL, COLUMN, SINGLE } from '@opentrons/shared-data'
 
 import { DropdownStepFormField } from '/protocol-designer/components/molecules'
+import { getEnableAdditionalPartialTipSelection } from '/protocol-designer/feature-flags/selectors'
 import {
   getAdditionalEquipmentEntities,
   getLabwareEntities,
@@ -58,9 +59,14 @@ export function DropTipField(props: DropTipFieldProps): JSX.Element {
     name: t('form:step_edit_form.field.dropTip.option.return'),
     value: tiprackDefUri,
   }
-
+  const enableAdditionalPartialTip = useSelector(
+    getEnableAdditionalPartialTipSelection
+  )
   const isReturnTipValid =
-    nozzles === ALL || nozzles == null || (channels === 1 && nozzles === SINGLE)
+    nozzles === ALL ||
+    nozzles == null ||
+    (channels === 1 && nozzles === SINGLE) ||
+    (enableAdditionalPartialTip ? nozzles === COLUMN && channels === 96 : false)
 
   const isTipDropLocationReturnTip = Object.values(labwareEntities).some(
     ({ labwareDefURI }) => labwareDefURI === tiprackDefUri


### PR DESCRIPTION
# Overview

Allow 96ch to return tips during `COLUMN` tip pick up

## Test Plan and Hands on Testing

smoke tested with 96ch

https://github.com/user-attachments/assets/f7733355-6322-47ac-bede-374703ff7bcc

## Changelog

- Extend conditional `isReturnTipValid` to include COLUMN nozzle configuration
- Removed logic relating to single tip pick up for 1ch because that is now included in ALL nozzle configuration 

## Risk assessment

low - hidden behind feature flag

closes AUTH-2368