### PR TITLE
feat(api): add M125 SetPressurePID and M126 GetPressurePID to tune the pressure control on the vacuum module

### DIFF
--- a/api/src/opentrons/drivers/vacuum_module/driver.py
+++ b/api/src/opentrons/drivers/vacuum_module/driver.py
@@ -9,6 +9,7 @@ from .types import (
     HardwareRevision,
     LEDColor,
     LEDPattern,
+    PressureControlTunings,
     PressureState,
     PumpState,
     VacuumModuleInfo,
@@ -76,6 +77,23 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
             float(match.group("H")),
             bool(int(match.group("E"))),
             VentState(int(match.group("V"))),
+        )
+
+    @classmethod
+    def parse_get_pressure_pid(cls, response: str) -> PressureControlTunings:
+        """Parse the get pressure pid."""
+        pattern = r"P:(?P<P>\d.+) I:(?P<I>\d.+) D:(?P<D>\d.+) O:(?P<O>-?\d.+) V:(?P<V>\d.+) H:(?P<H>\d.+)"
+        _RE = re.compile(rf"^{GCODE.GET_PRESSURE_PID} {pattern}$")
+        match = _RE.match(response)
+        if not match:
+            raise ValueError(f"Incorrect Response for get pressure pid: {response}")
+        return PressureControlTunings(
+            float(match.group("P")),
+            float(match.group("I")),
+            float(match.group("D")),
+            float(match.group("O")),
+            float(match.group("V")),
+            float(match.group("H")),
         )
 
     @classmethod
@@ -280,3 +298,41 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
         resp = await self._connection.send_command(command)
         if not re.match(rf"^{GCODE.SET_VENT_STATE}$", resp):
             raise ValueError(f"Incorrect Response for set vent state: {resp}")
+
+    async def set_pressure_control_tunings(
+        self,
+        kp: Optional[float] = None,
+        ki: Optional[float] = None,
+        kd: Optional[float] = None,
+        overshoot: Optional[float] = None,
+        k_velocity: Optional[float] = None,
+        k_holding: Optional[float] = None,
+        reset: bool = False,
+    ) -> None:
+        """Sets the PID tuning parameters for the pressure control."""
+
+        command = GCODE.SET_PRESSURE_PID.build_command()
+        if kp is not None:
+            command.add_float("P", kp, GCODE_ROUNDING_PRECISION)
+        if ki is not None:
+            command.add_float("I", ki, GCODE_ROUNDING_PRECISION)
+        if kd is not None:
+            command.add_float("D", kd, GCODE_ROUNDING_PRECISION)
+        if overshoot is not None:
+            command.add_float("O", overshoot, GCODE_ROUNDING_PRECISION)
+        if k_velocity is not None:
+            command.add_float("V", k_velocity, GCODE_ROUNDING_PRECISION)
+        if k_holding is not None:
+            command.add_float("H", k_holding, GCODE_ROUNDING_PRECISION)
+        command.add_int("R", int(reset))
+
+        resp = await self._connection.send_command(command)
+        if not re.match(rf"^{GCODE.SET_PRESSURE_PID}$", resp):
+            raise ValueError(f"Incorrect Response for set pressure pid: {resp}")
+
+    async def get_pressure_control_tunings(self) -> PressureControlTunings:
+        """Get the pressure control pid tunings."""
+        resp = await self._connection.send_command(
+            GCODE.GET_PRESSURE_PID.build_command()
+        )
+        return self.parse_get_pressure_pid(resp)

--- a/api/src/opentrons/drivers/vacuum_module/types.py
+++ b/api/src/opentrons/drivers/vacuum_module/types.py
@@ -18,6 +18,8 @@ class GCODE(StrEnum):
     SET_PUMP_STATE = "M122"
     GET_PUMP_STATE = "M123"
     SET_VENT_STATE = "M124"
+    SET_PRESSURE_PID = "M125"
+    GET_PRESSURE_PID = "M126"
 
     def build_command(self) -> CommandBuilder:
         """Build command."""
@@ -103,6 +105,18 @@ class PressureState:
     pressure_atm: float
     vacuum_enabled: bool
     vent_state: VentState
+
+
+@dataclass
+class PressureControlTunings:
+    """Get the pressure control tuning values."""
+
+    kp: float
+    ki: float
+    kd: float
+    overshoot_error: float
+    k_velocity: float
+    k_holding: float
 
 
 @dataclass

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1216,7 +1216,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         Raises:
             UnexpectedTipRemovalError: If no tip is attached to the pipette.
-            RuntimeError: 
+            RuntimeError:
                 - If no location is specified and the location cache is `None`.
                     This should happen if `touch_tip()` is called without first calling a
                     method that takes a location, like

--- a/api/tests/opentrons/drivers/vacuum_module/test_driver.py
+++ b/api/tests/opentrons/drivers/vacuum_module/test_driver.py
@@ -277,3 +277,34 @@ async def test_get_pump_state(
     connection.reset_mock()
 
     assert pump_state == types.PumpState(0, 0, 0, 0, False, True)
+
+
+async def test_set_pressure_control_tunings(
+    subject: VacuumModuleDriver, connection: AsyncMock
+) -> None:
+    """It should send a set pressure pid command"""
+    connection.send_command.return_value = "M125"
+
+    await subject.set_pressure_control_tunings(kp=1)
+
+    set_pressure_pid = (
+        types.GCODE.SET_PRESSURE_PID.build_command().add_float("P", 1).add_int("R", 0)
+    )
+
+    connection.send_command.assert_any_call(set_pressure_pid)
+    connection.reset_mock()
+
+
+async def test_get_pressure_control_tunings(
+    subject: VacuumModuleDriver, connection: AsyncMock
+) -> None:
+    """It should send a get pressure pid command"""
+    connection.send_command.return_value = "M126 P:1.0 I:0.0 D:0.0 O:-2.0 V:20.0 H:43.0"
+
+    pressure_state = await subject.get_pressure_control_tunings()
+
+    get_pressure = types.GCODE.GET_PRESSURE_PID.build_command()
+    connection.send_command.assert_any_call(get_pressure)
+    connection.reset_mock()
+
+    assert pressure_state == types.PressureControlTunings(1, 0, 0, -2, 20, 43)


### PR DESCRIPTION
# Overview

Hardware testing needs to tune the responsiveness for the pressure control of the vacuum module, so lets add gcodes to set the PID parameters. This pull request goes in conjunction with [Opentrons/opentrons-modules#551](https://github.com/Opentrons/opentrons-modules/pull/551).

```
M125 SetPressurePID
M126 GetPressurePID
```

## Test Plan and Hands on Testing

- make sure we can send/receive the M125 and M126 gcodes
```
>>> await dev.get_pressure_control_tunings()
PressureControlTunings(kp=13.1, ki=4.6, kd=0.1, overshoot_error=-2.0, k_velocity=20.0, k_holding=43.0)
>>> await dev.set_pressure_control_tunings(kp=1)
>>> await dev.get_pressure_control_tunings()
PressureControlTunings(kp=1.0, ki=4.6, kd=0.1, overshoot_error=-2.0, k_velocity=20.0, k_holding=43.0)
>>> await dev.set_vacuum_state(True, -400)
>>> await dev.set_vacuum_state(False, -400)
>>> await dev.set_pressure_control_tunings(kp=0, ki=0, kd=0)
>>> await dev.get_pressure_control_tunings()
PressureControlTunings(kp=0.0, ki=0.0, kd=0.0, overshoot_error=-2.0, k_velocity=20.0, k_holding=43.0)
```

## Changelog

- Added M125 SetPressurePID GGode
- Added M126 GetPressurePID GCode

## Review requests
## Risk assessment