### PR TITLE
fix(app) modify tiprack/labware container rendering condition

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -107,8 +107,9 @@ export function LabwareSlotContainer(
       : activeWellName
   const shouldShowWellContainer =
     selectedWellName != null &&
-    commandType !== 'comment' &&
-    commandType !== 'waitForResume'
+    !['comment', 'waitForDuration', 'waitForResume', 'waitForTasks'].includes(
+      commandType
+    )
   const wellGroup: WellGroup | null =
     selectedWellName != null
       ? {

--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -72,7 +72,7 @@ export function LabwareSlotContainer(
     'displayName' in labwareLoadCommandParams
       ? labwareLoadCommandParams.displayName
       : null
-  const { params } = currentCommand
+  const { params, commandType } = currentCommand
   const commandWellName =
     'wellName' in params && typeof params.wellName === 'string'
       ? params.wellName
@@ -107,8 +107,8 @@ export function LabwareSlotContainer(
       : activeWellName
   const shouldShowWellContainer =
     selectedWellName != null &&
-    currentCommand.commandType !== 'comment' &&
-    currentCommand.commandType !== 'pause'
+    commandType !== 'comment' &&
+    commandType !== 'pause'
   const wellGroup: WellGroup | null =
     selectedWellName != null
       ? {

--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -105,6 +105,10 @@ export function LabwareSlotContainer(
     commandLabwareId === topLabwareOnSlotId && commandWellName != null
       ? commandWellName
       : activeWellName
+  const shouldShowWellContainer =
+    selectedWellName != null &&
+    currentCommand.commandType !== 'comment' &&
+    currentCommand.commandType !== 'pause'
   const wellGroup: WellGroup | null =
     selectedWellName != null
       ? {
@@ -149,7 +153,7 @@ export function LabwareSlotContainer(
 
   return (
     <>
-      {selectedWellName != null ? (
+      {shouldShowWellContainer ? (
         <WellContainer
           wells={wells}
           params={params}

--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -108,7 +108,7 @@ export function LabwareSlotContainer(
   const shouldShowWellContainer =
     selectedWellName != null &&
     commandType !== 'comment' &&
-    commandType !== 'pause'
+    commandType !== 'waitForResume'
   const wellGroup: WellGroup | null =
     selectedWellName != null
       ? {

--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -40,6 +40,16 @@ interface LabwareSlotContainerProps {
   pipetteEntities: PipetteEntities
   moduleEntities: ModuleEntities
 }
+
+const HIDE_WELL_CONTAINER_COMMAND_TYPES = [
+  'comment',
+  'waitForDuration',
+  'waitForResume',
+  'waitForTasks',
+  'dropTip',
+  'pickUpTip',
+]
+
 export function LabwareSlotContainer(
   props: LabwareSlotContainerProps
 ): JSX.Element {
@@ -107,9 +117,7 @@ export function LabwareSlotContainer(
       : activeWellName
   const shouldShowWellContainer =
     selectedWellName != null &&
-    !['comment', 'waitForDuration', 'waitForResume', 'waitForTasks'].includes(
-      commandType
-    )
+    !HIDE_WELL_CONTAINER_COMMAND_TYPES.includes(commandType)
   const wellGroup: WellGroup | null =
     selectedWellName != null
       ? {

--- a/app/src/organisms/Desktop/ProtocolVisualization/StepDetailContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/StepDetailContainer/index.tsx
@@ -35,7 +35,8 @@ export function StepDetailContainer({
   const tiprackActiveSlot = getActiveSlotForTiprackDetails(
     Object.values(pipettes),
     robotState,
-    invariantContext
+    invariantContext,
+    currentCommand
   )
   const tiprackStack =
     tiprackActiveSlot != null
@@ -53,6 +54,10 @@ export function StepDetailContainer({
   const topMostLabwareOnSlot =
     stackOfLabwareOnSlot?.length > 1 ? stackOfLabwareOnSlot[0] : null
   const tiprackOnSlot = tiprackStack.length > 1 ? tiprackStack[0] : null
+  const isTopMostLabwareTiprack =
+    topMostLabwareOnSlot != null
+      ? labwareEntities[topMostLabwareOnSlot]?.def.parameters.isTiprack === true
+      : false
 
   const { left: leftMountPipetteName, right: rightMountPipetteName } =
     commands.length > 0
@@ -93,7 +98,7 @@ export function StepDetailContainer({
     if (tiprackOnSlot != null && labwareEntities[tiprackOnSlot] != null) {
       components.push('tiprack')
     }
-    if (topMostLabwareOnSlot != null) {
+    if (topMostLabwareOnSlot != null && !isTopMostLabwareTiprack) {
       components.push('labware')
     }
     // temporary filtering out the disposal card for RS 9.0.0

--- a/app/src/organisms/Desktop/ProtocolVisualization/StepDetailContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/StepDetailContainer/index.tsx
@@ -22,6 +22,12 @@ interface StepDetailContainerProps {
   currentCommand: RunTimeCommand
 }
 
+const HIDE_LABWARE_CARD_FOR_TIPRACK_COMMAND_TYPES = [
+  'pickUpTip',
+  'dropTip',
+  'dropTipInPlace',
+]
+
 export function StepDetailContainer({
   protocolKey,
   commands,
@@ -58,6 +64,10 @@ export function StepDetailContainer({
     topMostLabwareOnSlot != null
       ? labwareEntities[topMostLabwareOnSlot]?.def.parameters.isTiprack === true
       : false
+  const shouldHideLabwareCardForTiprackCommand =
+    isTopMostLabwareTiprack &&
+      currentCommand.commandType
+    )
 
   const { left: leftMountPipetteName, right: rightMountPipetteName } =
     commands.length > 0
@@ -98,7 +108,10 @@ export function StepDetailContainer({
     if (tiprackOnSlot != null && labwareEntities[tiprackOnSlot] != null) {
       components.push('tiprack')
     }
-    if (topMostLabwareOnSlot != null && !isTopMostLabwareTiprack) {
+    if (
+      topMostLabwareOnSlot != null &&
+      !shouldHideLabwareCardForTiprackCommand
+    ) {
       components.push('labware')
     }
     // temporary filtering out the disposal card for RS 9.0.0

--- a/app/src/organisms/Desktop/ProtocolVisualization/StepDetailContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/StepDetailContainer/index.tsx
@@ -66,6 +66,7 @@ export function StepDetailContainer({
       : false
   const shouldHideLabwareCardForTiprackCommand =
     isTopMostLabwareTiprack &&
+    HIDE_LABWARE_CARD_FOR_TIPRACK_COMMAND_TYPES.includes(
       currentCommand.commandType
     )
 

--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveSlotForTiprackDetails.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveSlotForTiprackDetails.ts
@@ -38,16 +38,23 @@ export const getActiveSlotForTiprackDetails = (
   const { labware } = robotState
   const { trashBinEntities, wasteChuteEntities, labwareEntities } =
     invariantContext
-  const tiprackUnderPipette = pipettes.find(
-    pipette => pipette.tiprackId != null
-  )?.tiprackId
-  const tiprackFromCurrentCommand =
+  const tiprackUnderPipette =
+    pipettes.find(
+      (pipette): pipette is PipetteTemporalProperties & { tiprackId: string } =>
+        typeof pipette.tiprackId === 'string'
+    )?.tiprackId ?? null
+  const currentCommandLabwareId =
     'labwareId' in currentCommand.params &&
-    labwareEntities[currentCommand.params.labwareId]?.def.parameters
-      .isTiprack === true
+    typeof currentCommand.params.labwareId === 'string'
       ? currentCommand.params.labwareId
       : null
-  const tiprackToShow = tiprackUnderPipette ?? tiprackFromCurrentCommand
+  const tiprackFromCurrentCommand =
+    currentCommandLabwareId != null &&
+    labwareEntities[currentCommandLabwareId]?.def.parameters.isTiprack === true
+      ? currentCommandLabwareId
+      : null
+  const tiprackToShow: string | null =
+    tiprackUnderPipette ?? tiprackFromCurrentCommand
   let slot = null
 
   if (tiprackToShow != null) {

--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveSlotForTiprackDetails.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveSlotForTiprackDetails.ts
@@ -1,5 +1,6 @@
 import { getSlotInLocationStack } from '@opentrons/step-generation'
 
+import type { RunTimeCommand } from '@opentrons/shared-data'
 import type {
   DeckSlot,
   InvariantContext,
@@ -31,18 +32,27 @@ const getSlotFromPipetteLocation = (
 export const getActiveSlotForTiprackDetails = (
   pipettes: PipetteTemporalProperties[],
   robotState: RobotState,
-  invariantContext: InvariantContext
+  invariantContext: InvariantContext,
+  currentCommand: RunTimeCommand
 ): DeckSlot | null => {
   const { labware } = robotState
-  const { trashBinEntities, wasteChuteEntities } = invariantContext
+  const { trashBinEntities, wasteChuteEntities, labwareEntities } =
+    invariantContext
   const tiprackUnderPipette = pipettes.find(
     pipette => pipette.tiprackId != null
   )?.tiprackId
+  const tiprackFromCurrentCommand =
+    'labwareId' in currentCommand.params &&
+    labwareEntities[currentCommand.params.labwareId]?.def.parameters
+      .isTiprack === true
+      ? currentCommand.params.labwareId
+      : null
+  const tiprackToShow = tiprackUnderPipette ?? tiprackFromCurrentCommand
   let slot = null
 
-  if (tiprackUnderPipette != null) {
+  if (tiprackToShow != null) {
     slot = getSlotFromPipetteLocation(
-      tiprackUnderPipette,
+      tiprackToShow,
       labware,
       trashBinEntities,
       wasteChuteEntities


### PR DESCRIPTION
# Overview

modify tiprack/labware container rendering condition

<img width="935" height="764" alt="Screenshot 2026-02-18 at 9 08 48 PM" src="https://github.com/user-attachments/assets/4e8101a4-6a43-4e54-9d8f-ed2bbbb60c09" />

<img width="939" height="769" alt="Screenshot 2026-02-18 at 9 08 54 PM" src="https://github.com/user-attachments/assets/ecf56c00-9636-48ed-a4fc-03ccbd7aba4c" />

<img width="935" height="771" alt="Screenshot 2026-02-18 at 9 09 00 PM" src="https://github.com/user-attachments/assets/3520194f-08be-4b64-9d2a-a48e14cebb91" />




this pr 's base is https://github.com/Opentrons/opentrons/pull/20878

## Test Plan and Hands on Testing
- import the protocol that is attached to the ticket
- visualize the protocol
- check step 55 and 56 are aligned with what the ticket pointed out
aspirate/dispense/blowout shows WellView in the same command

## Changelog


## Review requests


## Risk assessment
low