### PR TITLE
fix(app): change order for getting active labware for PV

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveSlotForLabwareDetails.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveSlotForLabwareDetails.ts
@@ -41,19 +41,19 @@ export const getActiveSlotForLabwareDetails = (
   )?.entityId
   let slot = null
 
-  if (entityUnderPipette != null) {
+  if ('labwareId' in currentCommand.params) {
+    const isTiprack =
+      labwareEntities[currentCommand.params.labwareId].def.parameters.isTiprack
+    if (!isTiprack) {
+      slot = currentCommand.params.labwareId
+    }
+  } else if (entityUnderPipette != null) {
     slot = getSlotFromPipetteLocation(
       entityUnderPipette,
       labware,
       trashBinEntities,
       wasteChuteEntities
     )
-  } else if ('labwareId' in currentCommand.params) {
-    const isTiprack =
-      labwareEntities[currentCommand.params.labwareId].def.parameters.isTiprack
-    if (!isTiprack) {
-      slot = currentCommand.params.labwareId
-    }
   }
 
   return slot


### PR DESCRIPTION
closes RQA-5127

# Overview

I think the fix is as simple as changing the order of the if/else statement so that you get the labwareId assosciated with the step first and if that doesn't exist, get the robotstate.pipette's entityId

## Test Plan and Hands on Testing

smoke test the protocol in the ticket but also smoke test steps that have a labware view in general

## Changelog

change if/else statement order

## Risk assessment

medium, it changes the logic for getting the active labware view