### PR TITLE
chore(app): filter some expected sentry errors

### DIFF
--- a/app-shell/src/sentry.ts
+++ b/app-shell/src/sentry.ts
@@ -49,6 +49,32 @@ export const initializeSentry = (isAnalyticsEnabled: boolean): void => {
         electronMinidumpIntegration(),
         functionToStringIntegration(),
       ],
+      beforeSend(event, hint) {
+        const error = hint.originalException || hint.syntheticException
+        const errorMessage = ((): string => {
+          // this function is called on messages passed with captureMessage, which are
+          // just strings
+          if (typeof error === 'string') {
+            return error
+          }
+          if (error == null || Object.keys(error).length === 0) {
+            return ''
+          }
+          // @ts-expect-error - Object has keys.
+          else if ('message' in error && typeof error.message === 'string') {
+            return error.message
+          } else {
+            return event.message ?? ''
+          }
+        })()
+        if (
+          errorMessage.includes('ERR_INTERNET_DISCONNECTED') ||
+          errorMessage.includes('EHOSTUNREACH')
+        ) {
+          return null
+        }
+        return event
+      },
     })
 
     isSentryInitialized = true

--- a/app/src/App/sentry.ts
+++ b/app/src/App/sentry.ts
@@ -84,7 +84,9 @@ export const initializeSentry = (isAnalyticsEnabled: boolean): void => {
         if (
           errorMessage.includes('Failed to fetch') ||
           errorMessage.includes('Failed to load resource') ||
-          errorMessage.includes('ERR_INTERNET_DISCONNECTED')
+          errorMessage.includes(
+            'video-only background media was paused to save power'
+          )
         ) {
           return null
         }


### PR DESCRIPTION
The node errors need to be caught and filtered in node. Also, we don't care if somebody closes their laptop while streaming the camera.
