### PR TITLE
feat(app): add flex exclusive app feature flag

### DIFF
--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -1,8 +1,8 @@
 {
   "__dev_internal__enableLabwareCreator": "Enable App Labware Creator",
   "__dev_internal__enableRunNotes": "Display Notes During a Protocol Run",
-  "__dev_internal__flexOnlyApp": "Deprecate old robot app",
   "__dev_internal__forceHttpPolling": "Poll all network requests instead of using MQTT",
+  "__dev_internal__ignoreOT2App": "Deprecate old robot in app",
   "__dev_internal__lpcRedesign": "LPC Redesign",
   "__dev_internal__protocolStats": "Protocol Stats",
   "__dev_internal__protocolTimeline": "Protocol Timeline",

--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -1,6 +1,7 @@
 {
   "__dev_internal__enableLabwareCreator": "Enable App Labware Creator",
   "__dev_internal__enableRunNotes": "Display Notes During a Protocol Run",
+  "__dev_internal__flexOnlyApp": "Deprecate old robot app",
   "__dev_internal__forceHttpPolling": "Poll all network requests instead of using MQTT",
   "__dev_internal__lpcRedesign": "LPC Redesign",
   "__dev_internal__protocolStats": "Protocol Stats",

--- a/app/src/redux/config/constants.ts
+++ b/app/src/redux/config/constants.ts
@@ -9,7 +9,7 @@ export const DEV_INTERNAL_FLAGS: DevInternalFlag[] = [
   'reactQueryDevtools',
   'reactScan',
   'quickTransferProtocolContentsLog',
-  'flexOnlyApp',
+  'ignoreOT2App',
 ]
 
 // action type constants

--- a/app/src/redux/config/constants.ts
+++ b/app/src/redux/config/constants.ts
@@ -9,6 +9,7 @@ export const DEV_INTERNAL_FLAGS: DevInternalFlag[] = [
   'reactQueryDevtools',
   'reactScan',
   'quickTransferProtocolContentsLog',
+  'flexOnlyApp',
 ]
 
 // action type constants

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -17,6 +17,7 @@ export type DevInternalFlag =
   | 'reactQueryDevtools'
   | 'reactScan'
   | 'quickTransferProtocolContentsLog'
+  | 'flexOnlyApp'
 
 export type FeatureFlags = Partial<Record<DevInternalFlag, boolean | undefined>>
 

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -17,7 +17,7 @@ export type DevInternalFlag =
   | 'reactQueryDevtools'
   | 'reactScan'
   | 'quickTransferProtocolContentsLog'
-  | 'flexOnlyApp'
+  | 'ignoreOT2App'
 
 export type FeatureFlags = Partial<Record<DevInternalFlag, boolean | undefined>>
 


### PR DESCRIPTION
Closes [EXEC-2362](https://opentrons.atlassian.net/browse/EXEC-2362)

# Overview

Adds a feature flag that we can use to hide UI elements and logic that would otherwise apply to the OT-2.

<img width="918" height="759" alt="Screenshot 2026-02-19 at 3 36 12 PM" src="https://github.com/user-attachments/assets/608c8c38-8851-4c36-bcc4-8ea6380e7dfc" />


## Test Plan and Hands on Testing

- Verified toggling the new feature flag works as expected.

## Changelog

- Added a "Flex exclusive app" feature flag.

## Risk assessment

- none

[EXEC-2362]: https://opentrons.atlassian.net/browse/EXEC-2362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ