### PR TITLE
chore(cursor): add protocol authoring skills

### DIFF
--- a/.cursor/skills/.markdownlint.json
+++ b/.cursor/skills/.markdownlint.json
@@ -1,0 +1,4 @@
+{
+  "MD013": false,
+  "MD060": false
+}

--- a/.cursor/skills/protocol-authoring/SKILL.md
+++ b/.cursor/skills/protocol-authoring/SKILL.md
@@ -1,0 +1,409 @@
+---
+name: protocol-authoring
+description: Create valid Opentrons Python API protocols for OT-2 and Flex robots. Use when creating, writing, editing, or helping with protocol files, liquid handling automation, or Opentrons protocol development. Also use when debugging protocol errors to trace into API source code.
+---
+
+# Opentrons Protocol Authoring
+
+## Behavior Defaults — READ FIRST
+
+This skill is primarily used by **developers, SDETs, and QA** who need protocols for testing and development. Follow these defaults unless the user explicitly says otherwise:
+
+1. **Don't ask unnecessary questions.** Pick reasonable labware, volumes, and pipettes. Just produce a valid, working protocol.
+2. **Keep protocols minimal.** Use the fewest steps needed to demonstrate the requested behavior. Don't generate dozens of repeated transfers — 2–4 operations are enough to validate a feature.
+3. **Always define liquids** with `protocol.define_liquid()` and `well.load_liquid()` for all source wells.
+4. **Default to liquid class functions** (`transfer_with_liquid_class`, `distribute_with_liquid_class`, `consolidate_with_liquid_class`) on Flex with API >= 2.24. Fall back to plain `transfer`/`distribute`/`consolidate` only for OT-2 or when the user explicitly asks.
+5. **Default to Flex** unless the user specifies OT-2.
+6. **Use the latest API version** unless the user specifies otherwise. Look up `MAX_SUPPORTED_VERSION` in `api/src/opentrons/protocols/api_support/definitions.py` to get the current value.
+7. **Default liquid class**: `water`. Use `glycerol_50` or `ethanol_80` if the protocol context calls for viscous or volatile liquids.
+8. **Reasonable defaults**: `flex_1channel_1000` pipette, `opentrons_flex_96_tiprack_1000ul` tip rack, `nest_96_wellplate_2ml_deep` plate, 100 µL transfer volume.
+
+## Quick Start — Flex Protocol (Default)
+
+```python
+from opentrons import protocol_api
+
+metadata = {
+    "protocolName": "Liquid Class Transfer Demo",
+    "author": "Opentrons",
+    "description": "Minimal transfer using liquid classes",
+}
+
+requirements = {"robotType": "Flex", "apiLevel": "<MAX_SUPPORTED_VERSION>"}
+# ^^^ Replace <MAX_SUPPORTED_VERSION> with the value from
+# api/src/opentrons/protocols/api_support/definitions.py
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    trash = protocol.load_trash_bin("A3")
+
+    tiprack = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "D2")
+    source_plate = protocol.load_labware("nest_96_wellplate_2ml_deep", "D1")
+    dest_plate = protocol.load_labware("nest_96_wellplate_2ml_deep", "C1")
+
+    pipette = protocol.load_instrument(
+        "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+    )
+
+    # Define and load liquids
+    sample = protocol.define_liquid(
+        name="Sample", description="Aqueous sample", display_color="#0088FF"
+    )
+    source_plate["A1"].load_liquid(liquid=sample, volume=500)
+    source_plate["A2"].load_liquid(liquid=sample, volume=500)
+
+    # Use liquid class transfer (default: water)
+    water = protocol.get_liquid_class(name="water")
+    pipette.transfer_with_liquid_class(
+        liquid_class=water,
+        volume=100,
+        source=[source_plate["A1"], source_plate["A2"]],
+        dest=[dest_plate["A1"], dest_plate["A2"]],
+        new_tip="always",
+    )
+```
+
+## Quick Start — OT-2 Protocol
+
+```python
+from opentrons import protocol_api
+
+metadata = {
+    "protocolName": "OT-2 Transfer Demo",
+    "author": "Opentrons",
+    "description": "Minimal transfer for OT-2",
+}
+
+requirements = {"robotType": "OT-2", "apiLevel": "<MAX_SUPPORTED_VERSION>"}
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    tiprack = protocol.load_labware("opentrons_96_tiprack_300ul", "1")
+    source_plate = protocol.load_labware("nest_96_wellplate_2ml_deep", "2")
+    dest_plate = protocol.load_labware("nest_96_wellplate_2ml_deep", "3")
+
+    pipette = protocol.load_instrument(
+        "p300_single_gen2", mount="left", tip_racks=[tiprack]
+    )
+
+    sample = protocol.define_liquid(
+        name="Sample", description="Aqueous sample", display_color="#0088FF"
+    )
+    source_plate["A1"].load_liquid(liquid=sample, volume=500)
+
+    pipette.transfer(100, source_plate["A1"], dest_plate["A1"])
+```
+
+## Required Elements
+
+1. **`requirements` dict** — `robotType` (`"Flex"` or `"OT-2"`) and `apiLevel`
+2. **`def run(protocol):`** — entry point receiving `ProtocolContext`
+3. **Flex only**: must load trash bin or waste chute before any `drop_tip`
+
+`metadata` dict is optional but recommended. `apiLevel` goes in `metadata` OR `requirements`, not both.
+
+**Look up the current max API version** from `MAX_SUPPORTED_VERSION` in `api/src/opentrons/protocols/api_support/definitions.py`. Flex requires >= 2.15.
+
+## Liquid Classes (Default for Flex)
+
+Available liquid classes (Flex, API >= 2.24):
+
+| Name          | Type     | When to Use                         |
+| ------------- | -------- | ----------------------------------- |
+| `water`       | Aqueous  | Default for most protocols          |
+| `glycerol_50` | Viscous  | Viscous samples, glycerol solutions |
+| `ethanol_80`  | Volatile | Ethanol, volatile solvents          |
+
+```python
+water = protocol.get_liquid_class(name="water")
+
+# Transfer (1-to-1)
+pipette.transfer_with_liquid_class(
+    liquid_class=water, volume=100,
+    source=[plate["A1"]], dest=[plate["B1"]],
+    new_tip="always",
+)
+
+# Distribute (1-to-many)
+pipette.distribute_with_liquid_class(
+    liquid_class=water, volume=50,
+    source=reservoir["A1"], dest=plate.rows()[0][:4],
+    new_tip="once",
+)
+
+# Consolidate (many-to-1)
+pipette.consolidate_with_liquid_class(
+    liquid_class=water, volume=50,
+    source=plate.rows()[0][:4], dest=reservoir["A1"],
+    new_tip="once",
+)
+```
+
+## Defining Liquids (Always Do This)
+
+```python
+sample = protocol.define_liquid(
+    name="Sample", description="Aqueous sample", display_color="#0088FF"
+)
+buffer = protocol.define_liquid(
+    name="Buffer", description="Wash buffer", display_color="#00CC66"
+)
+reagent = protocol.define_liquid(
+    name="Reagent", description="Reaction reagent", display_color="#FF4444"
+)
+
+source_plate["A1"].load_liquid(liquid=sample, volume=500)
+reservoir["A1"].load_liquid(liquid=buffer, volume=10000)
+```
+
+Common display colors: `#0088FF` (blue/sample), `#00CC66` (green/buffer), `#FF4444` (red/reagent), `#FFB800` (yellow/media), `#9933FF` (purple/enzyme), `#FF6B35` (orange/beads).
+
+## OT-2 vs Flex Key Differences
+
+| Feature        | OT-2            | Flex                                       |
+| -------------- | --------------- | ------------------------------------------ |
+| Deck slots     | 1–11 (numeric)  | A1–D4 (alphanumeric)                       |
+| Trash          | Fixed (slot 12) | Must call `load_trash_bin()`               |
+| Liquid classes | Not supported   | `get_liquid_class()` (API 2.24+)           |
+| Gripper        | N/A             | `move_labware(lw, dest, use_gripper=True)` |
+| 96-channel     | N/A             | `flex_96channel_1000`                      |
+
+### Flex Deck Layout
+
+```text
+     1        2        3        4 (staging)
+A  [ A1 ]  [ A2 ]  [ A3 ]  [ A4 ]
+B  [ B1 ]  [ B2 ]  [ B3 ]  [ B4 ]
+C  [ C1 ]  [ C2 ]  [ C3 ]  [ C4 ]
+D  [ D1 ]  [ D2 ]  [ D3 ]  [ D4 ]
+```
+
+### OT-2 Deck Layout
+
+```text
+ 10    11    12(trash)
+  7     8     9
+  4     5     6
+  1     2     3
+```
+
+## Pipettes
+
+### Flex
+
+| Name                  | Channels | Range     |
+| --------------------- | -------- | --------- |
+| `flex_1channel_50`    | 1        | 1–50 µL   |
+| `flex_1channel_200`   | 1        | 1–200 µL  |
+| `flex_1channel_1000`  | 1        | 5–1000 µL |
+| `flex_8channel_50`    | 8        | 1–50 µL   |
+| `flex_8channel_200`   | 8        | 1–200 µL  |
+| `flex_8channel_1000`  | 8        | 5–1000 µL |
+| `flex_96channel_1000` | 96       | 5–1000 µL |
+
+### OT-2
+
+| Name                | Channels | Range       |
+| ------------------- | -------- | ----------- |
+| `p20_single_gen2`   | 1        | 1–20 µL     |
+| `p300_single_gen2`  | 1        | 20–300 µL   |
+| `p1000_single_gen2` | 1        | 100–1000 µL |
+| `p20_multi_gen2`    | 8        | 1–20 µL     |
+| `p300_multi_gen2`   | 8        | 20–300 µL   |
+
+## Common Labware
+
+**Flex tip racks**: `opentrons_flex_96_tiprack_50ul`, `opentrons_flex_96_tiprack_200ul`, `opentrons_flex_96_tiprack_1000ul`
+
+**OT-2 tip racks**: `opentrons_96_tiprack_20ul`, `opentrons_96_tiprack_300ul`, `opentrons_96_tiprack_1000ul`
+
+**Plates**: `nest_96_wellplate_2ml_deep`, `corning_96_wellplate_360ul_flat`, `opentrons_96_wellplate_200ul_pcr_full_skirt`, `nest_96_wellplate_200ul_flat`
+
+**Reservoirs**: `nest_12_reservoir_15ml`, `nest_1_reservoir_195ml`, `nest_1_reservoir_290ml`
+
+**Tube racks**: `opentrons_24_tuberack_nest_1.5ml_snapcap`, `opentrons_6_tuberack_nest_50ml_conical`
+
+## Modules Quick Reference
+
+```python
+temp_mod = protocol.load_module("temperature module gen2", "D1")
+tc = protocol.load_module("thermocycler module gen2")        # A1+B1 on Flex
+hs = protocol.load_module("heaterShakerModuleV1", "C1")
+mag_block = protocol.load_module("magneticBlockV1", "C1")    # Flex only
+mag_mod = protocol.load_module("magnetic module gen2", "1")   # OT-2 only
+apr = protocol.load_module("absorbanceReaderV1", "B3")        # Flex, API 2.21+
+stacker = protocol.load_module("flexStackerModuleV1", "D4")   # Flex, API 2.25+
+```
+
+For detailed module operations, see [reference-modules.md](reference-modules.md).
+
+## Runtime Parameters (API 2.18+)
+
+```python
+def add_parameters(parameters: protocol_api.Parameters) -> None:
+    parameters.add_int(variable_name="sample_count", display_name="Samples",
+                       default=8, minimum=1, maximum=96)
+    parameters.add_bool(variable_name="dry_run", display_name="Dry Run", default=False)
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    count = protocol.params.sample_count
+```
+
+For complete RTP guide, see [reference-rtp.md](reference-rtp.md).
+
+## Working Directories (Monorepo Root)
+
+All local dev artifacts live in these gitignored directories:
+
+| Directory             | Purpose                            |
+| --------------------- | ---------------------------------- |
+| `tmp-protocols/`      | Protocol `.py` files               |
+| `tmp-custom-labware/` | Custom labware `.json` definitions |
+| `tmp-csv/`            | CSV files for RTP inputs           |
+
+## Custom Labware
+
+Custom labware JSON files go in `tmp-custom-labware/`. The `parameters.loadName` in the JSON is the string passed to `load_labware()`.
+
+### Creating a Custom Labware Definition
+
+The easiest starting point is copying an existing definition from `shared-data/labware/definitions/2/<name>/<version>.json` and modifying the key fields:
+
+```json
+{
+  "namespace": "custom",
+  "version": 1,
+  "parameters": {
+    "loadName": "my_custom_plate"
+  },
+  "metadata": {
+    "displayName": "My Custom Plate"
+  }
+  ...
+}
+```
+
+**Required changes** when deriving from an existing definition:
+
+- `parameters.loadName` → your unique load name (no spaces, underscores OK)
+- `namespace` → `"custom"` (must not be `"opentrons"`)
+- `version` → `1`
+- `metadata.displayName` → human-readable name
+
+Save as `tmp-custom-labware/<loadName>.json` (file name convention matches `loadName`).
+
+### Using Custom Labware in a Protocol
+
+```python
+plate = protocol.load_labware("my_custom_plate", "D1")
+```
+
+No special import needed — the CLI handles loading the definition at run time.
+
+### For a proper custom labware definition from scratch, use the [Opentrons Labware Creator](https://labware.opentrons.com/create/)
+
+## CSV Runtime Parameters
+
+CSV files go in `tmp-csv/`. They are used exclusively via the `add_csv_file` RTP type (API 2.20+).
+
+### Defining a CSV Parameter
+
+```python
+def add_parameters(parameters: protocol_api.Parameters) -> None:
+    parameters.add_csv_file(
+        variable_name="transfer_map",
+        display_name="Transfer Map",
+        description="CSV with columns: source_well, dest_well, volume_ul",
+    )
+```
+
+### Using the CSV in `run()`
+
+```python
+rows = protocol.params.transfer_map.parse_as_csv()
+# rows is a list of lists; rows[0] is the header row
+for row in rows[1:]:
+    src, dst, vol = row[0].strip(), row[1].strip(), float(row[2].strip())
+    pipette.transfer(vol, source[src], dest[dst])
+```
+
+### Example CSV (`tmp-csv/transfer_map.csv`)
+
+```text
+source_well,dest_well,volume_ul
+A1,A1,100
+A2,A2,150
+A3,A3,75
+```
+
+> **Note**: `opentrons_simulate` cannot accept RTP files. Protocols with CSV RTPs must be verified with `opentrons analyze`. See the `protocol-verification` skill.
+
+## Additional References
+
+### Skill Reference Files (in this directory)
+
+| File                                                         | When to use                                                                     |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| [reference-liquid-handling.md](reference-liquid-handling.md) | Detailed liquid handling patterns, tip math, transfer anti-patterns             |
+| [reference-modules.md](reference-modules.md)                 | Module load names, operations, Flex Stacker, APR                                |
+| [reference-rtp.md](reference-rtp.md)                         | Runtime parameters — all types, CSV RTPs                                        |
+| [reference-source-map.md](reference-source-map.md)           | Source code navigation for debugging                                            |
+| [reference-labware-deck.md](reference-labware-deck.md)       | Common labware load names, deck layout rules (Flex + OT-2), OT-2→Flex migration |
+| [reference-96channel.md](reference-96channel.md)             | 96-channel pipette constraints, nozzle configs, tip adapter rules               |
+| [reference-examples-index.md](reference-examples-index.md)   | Index of AI server example docs — what each covers and when to read it          |
+
+### AI Server Source Docs (read on demand)
+
+Located in `opentrons-ai-server/api/storage/docs/`. Use [reference-examples-index.md](reference-examples-index.md) to decide which file to read. Do not read all of them — they total ~10,000 lines. Read only what the current task needs.
+
+| File                            | Contents                                                           |
+| ------------------------------- | ------------------------------------------------------------------ |
+| `full-examples.md`              | Complete production protocols (PCR, reagent transfer, HS)          |
+| `casual_examples.md`            | Casual NL → protocol mappings, pooling, triplicates                |
+| `serial_dilution_examples.md`   | Serial dilution patterns (single/multi-channel, row/column-wise)   |
+| `pcr_protocols_with_csv.md`     | PCR + CSV RTP well mapping, thermocycler profiles                  |
+| `transfer_function_notes.md`    | `transfer()` deep dive — loops, tip behavior, modules              |
+| `out_of_tips_error_219.md`      | Tip math, multi-channel capacity, index error prevention           |
+| `commands-v0.0.1.md`            | Common command patterns and pitfalls                               |
+| `standard-loadname-info.md`     | Full labware catalog (86 items)                                    |
+| `96-channel-pipette.md`         | Full 96-channel guide (see `reference-96channel.md` for summary)   |
+| `deck_layout.md`                | Full deck rules (see `reference-labware-deck.md` for summary)      |
+| `OT2ToFlex.md`                  | Full migration guide (see `reference-labware-deck.md` for summary) |
+| `transfer_with_liquid_class.md` | Liquid class transfer differences and custom properties            |
+| `flex_stacker_usage.md`         | Flex Stacker patterns (see `reference-modules.md` for summary)     |
+| `runtime_parameters.md`         | RTP examples (see `reference-rtp.md` for summary)                  |
+
+## Keeping This Skill Current
+
+**Update this skill whenever you discover something new.** These files are the team's shared knowledge base — stale information hurts everyone.
+
+| Trigger                                                                         | What to update                                                                                                         |
+| ------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| A new API method, parameter, or behavior is used                                | Add it to the relevant section in `SKILL.md` or the appropriate `reference-*.md`                                       |
+| A bug or constraint is found via source inspection                              | Add it to `reference-source-map.md` under the relevant debugging section                                               |
+| `MAX_SUPPORTED_VERSION` changes                                                 | Check `api/src/opentrons/protocols/api_support/definitions.py` and add any new API-version-gated features to the skill |
+| A new labware load name is used                                                 | Add it to the Common Labware list                                                                                      |
+| A new liquid class becomes available in `shared-data/liquid-class/definitions/` | Add it to the Liquid Classes table                                                                                     |
+| Actual behavior differs from what this skill says                               | Correct the skill, not just the protocol                                                                               |
+| A new module is supported                                                       | Add it to the Modules section and `reference-modules.md`                                                               |
+
+**How to update**: use the Write or StrReplace tools on the relevant skill file. Keep edits focused — fix only what changed. Don't rewrite sections that are still accurate.
+
+## Common Mistakes
+
+- Forgetting `load_trash_bin()` on Flex
+- Using OT-2 pipette names on Flex or vice versa
+- Putting `apiLevel` in both `metadata` and `requirements`
+- Using numeric slots on Flex or alpha on OT-2
+- Exceeding pipette volume range
+- Using `transfer` with `new_tip="never"` without calling `pick_up_tip()` first
+- Forgetting to `define_liquid` / `load_liquid` for source wells
+- Using plain `transfer` on Flex when `transfer_with_liquid_class` is available
+- Calling `apr.initialize()` without `apr.close_lid()` first (APR lid must be closed before init)
+- Passing only the top well (e.g. `plate["A1"]`) to 8-channel `*_with_liquid_class` — must pass full column or set `group_wells=False`
+- Using f-strings or variable references in `metadata` dict — the parser requires static literals only (no `f"..."`, no `{var}`, no function calls)
+- Wrapping `transfer()` in a `for` loop over wells — `transfer()` handles iteration internally; pass lists instead
+- Using 8-channel pipette with `wells()` instead of `columns()` — 8-channel picks up an entire column at once
+- Not accounting for 8-channel tip math: one `pick_up_tip()` = 8 tips; a single 96-well rack supports only 12 column operations
+- Loading a 96-channel pipette without `adapter="opentrons_flex_96_tiprack_adapter"` for full (ALL) tip pickup
+- Using `start="A1"` for 96-channel COLUMN mode — always use `start="A12"` to avoid deck edge collision
+- Placing a tube rack in a staging area slot (A4–D4) — gripper cannot safely move tube racks
+- Loading the Heater-Shaker or Temperature Module in column 2 slots (A2, B2, C2, D2) — forbidden on Flex

--- a/.cursor/skills/protocol-authoring/reference-96channel.md
+++ b/.cursor/skills/protocol-authoring/reference-96channel.md
@@ -1,0 +1,181 @@
+# Flex 96-Channel Pipette Reference
+
+> **Full source doc**: `opentrons-ai-server/api/storage/docs/96-channel-pipette.md`
+> (1580 lines — read it for complete labware compatibility lists, advanced patterns, and full protocol examples)
+
+---
+
+## Critical Constraints
+
+The 96-channel pipette (`flex_96channel_1000`) has fundamental physical constraints that shape protocol design:
+
+- **Cannot access tubes** — no microcentrifuge tubes (1.5 mL, 2 mL), conical tubes (15 mL, 50 mL), PCR strip tubes, or any non-standard well spacing.
+- **Occupies both pipette mounts** — you cannot load another pipette on a robot with the 96-channel.
+- **Requires 9 mm well spacing** — only plate-format labware is compatible.
+- **All reagents must be pre-aliquoted** into plates or reservoirs before the protocol runs.
+
+---
+
+## Compatible Labware (96-Channel)
+
+**Reservoirs:**
+
+- `nest_1_reservoir_195ml` — preferred for bulk reagent dispensing (all 96 tips access the same well)
+- `nest_1_reservoir_290ml`
+- `agilent_1_reservoir_290ml`
+- `axygen_1_reservoir_90ml`
+
+**96-Well Plates:**
+
+- `nest_96_wellplate_2ml_deep` — samples
+- `corning_96_wellplate_360ul_flat`
+- `nest_96_wellplate_200ul_flat`
+- `nest_96_wellplate_100ul_pcr_full_skirt`
+- `biorad_96_wellplate_200ul_pcr`
+- `opentrons_96_wellplate_200ul_pcr_full_skirt`
+
+**NOT compatible:** 12-well reservoirs, tube racks, strip tubes.
+
+---
+
+## Tip Rack Configuration
+
+| Use Case                             | Tip Rack          | Adapter                                           |
+| ------------------------------------ | ----------------- | ------------------------------------------------- |
+| Full 96-tip pickup                   | Any Flex tip rack | **Required**: `opentrons_flex_96_tiprack_adapter` |
+| Partial pickup (COLUMN, SINGLE, ROW) | Any Flex tip rack | **No adapter**                                    |
+
+```python
+# Full pickup — adapter via load_labware()
+tips_full = protocol.load_labware(
+    "opentrons_flex_96_tiprack_1000ul", "C2",
+    adapter="opentrons_flex_96_tiprack_adapter"
+)
+
+# Partial pickup — no adapter
+tips_partial = protocol.load_labware(
+    "opentrons_flex_96_tiprack_1000ul", "C1"
+)
+```
+
+---
+
+## Nozzle Layout Configurations
+
+Import constants from `opentrons.protocol_api`:
+
+```python
+from opentrons.protocol_api import ALL, COLUMN, ROW, SINGLE
+```
+
+| Style    | Tips Used | Use Case                                      | Required `start`     |
+| -------- | --------- | --------------------------------------------- | -------------------- |
+| `ALL`    | 96        | Full plate replication, bulk dispensing       | N/A                  |
+| `COLUMN` | 8         | Column-by-column work, behaves like 8-channel | `"A12"` (not `"A1"`) |
+| `ROW`    | 12        | Row-by-row operations                         | `"H1"`               |
+| `SINGLE` | 1         | Precision single-well work                    | `"H12"` or `"A1"`    |
+
+```python
+# Full plate operation
+pipette.configure_nozzle_layout(style=ALL, tip_racks=[tips_full])
+
+# Column mode (8 tips) — MUST use "A12", not "A1"
+pipette.configure_nozzle_layout(style=COLUMN, start="A12", tip_racks=[tips_partial])
+
+# Single tip mode — use H12 (has pressure sensor)
+pipette.configure_nozzle_layout(style=SINGLE, start="H12", tip_racks=[tips_partial])
+```
+
+---
+
+## Critical: Column Mode Start Position
+
+**Always use `start="A12"` for COLUMN mode**, not `"A1"`.
+
+Using `"A1"` causes a `PartialTipMovementNotAllowedError` because the nozzle block extends to the left and hits the deck edge.
+
+```python
+# CORRECT
+pipette.configure_nozzle_layout(style=COLUMN, start="A12", tip_racks=[tips_partial])
+
+# WRONG — causes collision error
+pipette.configure_nozzle_layout(style=COLUMN, start="A1", tip_racks=[tips_partial])
+```
+
+---
+
+## Reservoir Strategy: 8-Channel vs. 96-Channel
+
+```python
+# 8-channel: 12-well reservoir, one well per column
+reservoir_12 = protocol.load_labware("nest_12_reservoir_15ml", "D1")
+p8.aspirate(100, reservoir_12.wells()[col_index])
+
+# 96-channel: single-well reservoir, all 96 tips from same well
+reservoir_1 = protocol.load_labware("nest_1_reservoir_195ml", "D1")
+p96.aspirate(100, reservoir_1["A1"])  # All 96 tips access this well simultaneously
+p96.dispense(100, plate["A1"])        # Dispenses to all 96 wells
+```
+
+**Volume planning for single-well reservoirs:** add 10–20% excess for dead volume.
+
+---
+
+## Minimal 96-Channel Protocol Template
+
+```python
+from opentrons import protocol_api
+from opentrons.protocol_api import ALL, COLUMN
+
+metadata = {"protocolName": "96-Channel Transfer Demo"}
+requirements = {"robotType": "Flex", "apiLevel": "<MAX_SUPPORTED_VERSION>"}
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    trash = protocol.load_trash_bin("A3")
+
+    # Full pickup requires adapter
+    tips = protocol.load_labware(
+        "opentrons_flex_96_tiprack_1000ul", "C2",
+        adapter="opentrons_flex_96_tiprack_adapter"
+    )
+
+    reservoir = protocol.load_labware("nest_1_reservoir_195ml", "D1")
+    dest_plate = protocol.load_labware("nest_96_wellplate_2ml_deep", "D2")
+
+    p96 = protocol.load_instrument("flex_96channel_1000", tip_racks=[tips])
+
+    reagent = protocol.define_liquid(
+        name="Reagent", description="Buffer", display_color="#00AAFF"
+    )
+    reservoir["A1"].load_liquid(liquid=reagent, volume=10000)
+
+    p96.configure_nozzle_layout(style=ALL, tip_racks=[tips])
+    p96.transfer(100, reservoir["A1"], dest_plate["A1"])
+```
+
+---
+
+## Tip Management
+
+```python
+pipette.drop_tip()        # Drop in trash (cannot return full pickup to partial rack)
+pipette.return_tip()      # Return to original position (only safe for full pickup to full rack)
+pipette.reset_tipracks()  # Reset all tip rack usage counters (useful for repeated runs)
+```
+
+- After a **partial configuration change**, re-specify `tip_racks` in `configure_nozzle_layout`.
+- Minimize nozzle layout configuration changes — group operations by configuration type.
+
+---
+
+## Pressure Sensor / Liquid Detection
+
+Pressure sensors are located at channels **A1** and **H12**. Liquid detection only works with these channels in `SINGLE` mode:
+
+```python
+pipette.configure_nozzle_layout(style=SINGLE, start="H12")
+if pipette.detect_liquid_presence(well):
+    pipette.aspirate(volume, well)
+else:
+    protocol.pause("Check liquid levels in well")
+```

--- a/.cursor/skills/protocol-authoring/reference-examples-index.md
+++ b/.cursor/skills/protocol-authoring/reference-examples-index.md
@@ -1,0 +1,202 @@
+# AI Server Docs — Knowledge Index
+
+These files live in `opentrons-ai-server/api/storage/docs/` and contain curated protocol knowledge, examples, and pitfall guides. **Do not duplicate their content** — use this index to know _when_ to read each file.
+
+---
+
+## Quick Decision Guide
+
+| I need to…                                                       | Read this file                                     |
+| ---------------------------------------------------------------- | -------------------------------------------------- |
+| Find real complete protocol examples (PCR, HS, reagent transfer) | `full-examples.md`                                 |
+| Understand how casual/NL descriptions map to protocol code       | `casual_examples.md`                               |
+| Write a serial dilution protocol                                 | `serial_dilution_examples.md`                      |
+| Write a PCR protocol that reads well mapping from CSV            | `pcr_protocols_with_csv.md`                        |
+| Fix a transfer() iteration bug or understand tip behavior        | `transfer_function_notes.md`                       |
+| Debug an "out of tips" or index error                            | `out_of_tips_error_219.md`                         |
+| Look up a specific labware load name                             | `standard-loadname-info.md`                        |
+| Use the 96-channel pipette                                       | See `reference-96channel.md` in this skills dir    |
+| Migrate OT-2 protocol to Flex                                    | See `reference-labware-deck.md` in this skills dir |
+| Understand deck slot restrictions                                | See `reference-labware-deck.md` in this skills dir |
+
+---
+
+## File Summaries
+
+### `commands-v0.0.1.md` (~1260 lines, ~90% code)
+
+**Topic:** Common command patterns and pitfalls.
+
+**Key unique knowledge:**
+
+- `transfer()` iterates internally — wrapping it in a `for` loop is a common anti-pattern.
+- Temperature module requires aluminum block adapter for PCR plates.
+- Thermocycler occupies slots 7+8+10+11 on OT-2, A1+B1 on Flex.
+- Multi-channel well access: always use `columns()` not `wells()`.
+- Many-to-many transfer behavior when source/dest lengths differ.
+
+**When to read:** You need a quick code example for a specific command or want to verify common patterns.
+
+---
+
+### `transfer_function_notes.md` (~650 lines, ~60% prose)
+
+**Topic:** Deep guide to the `transfer()` function — behavior, pitfalls, module integration.
+
+**Key unique knowledge:**
+
+- `transfer()` handles well iteration automatically — never put it inside a `for` loop iterating over wells.
+- `new_tip='once'` inside a manual loop is incorrect; pass lists of source/dest to `transfer()` instead.
+- Multi-channel: 8 tips consumed per `pick_up_tip()`, so 12 columns × 8 = 96 tips per rack.
+- Many-to-many pairing rules: shorter list is repeated or truncated based on mode.
+- CSV-driven transfer patterns: parse rows and pass lists to `transfer()`.
+- Module integration patterns (thermocycler, heater-shaker).
+
+**When to read:** Any time you use `transfer()` with complex well lists, tip management, or modules.
+
+---
+
+### `transfer_with_liquid_class.md` (~235 lines, ~60% code)
+
+**Topic:** Differences between `transfer()` and `transfer_with_liquid_class()`.
+
+**Key unique knowledge (also in `reference-liquid-handling.md`):**
+
+- Liquid class requires API ≥ 2.24 and Flex only.
+- Source and dest lists must be the same length (1:1 pairing).
+- Use `distribute_with_liquid_class()` for 1-to-many, `consolidate_with_liquid_class()` for many-to-1.
+- Liquid classes auto-handle mixing, air gaps, touch-tip — no manual params.
+- `trash_location` parameter takes the trash fixture, not a well.
+
+**When to read:** Debugging `transfer_with_liquid_class` parameter errors or implementing custom liquid class properties.
+
+---
+
+### `out_of_tips_error_219.md` (~383 lines, ~50% prose)
+
+**Topic:** Preventing "out of tips" and index errors — tip math, multi-channel calculation, strategies.
+
+**Key unique knowledge:**
+
+- Single-channel: 1 tip per `pick_up_tip()`. A single 96-tip rack supports 96 operations.
+- Multi-channel (8-channel): **8 tips per `pick_up_tip()`**. A single 96-tip rack supports only 12 column operations (96 / 8 = 12).
+- Many-to-many tip count = number of operations = size of larger group.
+- Nested loops multiply tip consumption: validate total tip count before writing the loop.
+- Index errors: `plate.rows()[0][i]` will raise `IndexError` if `i > 11` (columns are 0-indexed, 0–11).
+- Use `move_labware()` for mid-protocol tip replenishment.
+
+**When to read:** Before running any multi-channel or nested-loop protocol; whenever you see `OutOfTipsError` or `IndexError`.
+
+---
+
+### `standard-loadname-info.md` (~747 lines, ~95% structured data)
+
+**Topic:** Complete Opentrons standard labware catalog — all 86 labware items with load names, dimensions, volumes, and well shapes.
+
+**When to read:** When you need to find the exact `loadName` for any labware not in `reference-labware-deck.md`. Also use to check well counts, volumes, or well shape (flat/V/U-bottom) for protocol design.
+
+---
+
+### `deck_layout.md` (~170 lines, ~80% prose)
+
+**Topic:** Deck slot placement guidelines for OT-2 and Flex — modules, fixtures, labware order.
+
+**Note:** Key facts are already extracted into `reference-labware-deck.md` in this skills dir. Read this source doc only when you need full details on edge cases or the Confluence/manual references.
+
+---
+
+### `OT2ToFlex.md` (~210 lines, ~60% prose)
+
+**Topic:** How to convert OT-2 protocols to Flex — metadata, pipettes, slots, modules, trash.
+
+**Note:** Key conversion tables are already extracted into `reference-labware-deck.md` in this skills dir. Read this source doc for detailed Magnetic Module → Magnetic Block conversion examples.
+
+---
+
+### `full-examples.md` (~1263 lines, ~90% code)
+
+**Topic:** Complete, production-ready protocol examples — PCR setup, reagent transfer, heater-shaker workflows.
+
+**Key unique knowledge:**
+
+- Real-world protocol structures with all boilerplate included.
+- Module integration sequences (temperature module → thermocycler handoff).
+- Tip management across multi-step protocols.
+- Column-wise well allocation patterns for multi-channel pipettes.
+
+**When to read:** Starting a new protocol from scratch and want a complete working starting point. Also useful for module integration patterns you haven't seen before.
+
+---
+
+### `casual_examples.md` (~979 lines, ~70% code)
+
+**Topic:** Natural language protocol descriptions paired with their implementations.
+
+**Key unique knowledge:**
+
+- How vague language maps to specific API calls ("distribute to every other well" → slicing with `[::2]`).
+- Triplicate/duplicate transfer patterns (each source → 3 destinations).
+- Pooling operations (many-to-one consolidation).
+- Serial dilution with variable dilution factors.
+- Heater-shaker incubation + shaking patterns.
+
+**When to read:** The user's request is in casual/natural language and you're uncertain how to interpret it. Also good for pooling or replicate patterns.
+
+---
+
+### `serial_dilution_examples.md` (~1346 lines, ~70% code)
+
+**Topic:** Serial dilution protocols — single-channel, multi-channel, row-wise, column-wise, variable factors.
+
+**Key unique knowledge:**
+
+- Diluent must be distributed to all destination wells **before** transferring sample (common mistake to do them simultaneously).
+- Row-wise vs column-wise differences in well indexing.
+- `mix_after` parameter for proper mixing at each step.
+- Air gap usage to prevent cross-contamination.
+- Variable dilution factor calculation patterns.
+- Multi-channel serial dilution uses `columns()`, single-channel uses `wells()`.
+
+**When to read:** Any serial dilution protocol. These examples cover the full range of common lab patterns.
+
+---
+
+### `pcr_protocols_with_csv.md` (~1065 lines, ~90% code)
+
+**Topic:** PCR protocols that read well/volume mapping from CSV runtime parameters.
+
+**Key unique knowledge:**
+
+- CSV-driven mastermix → destination well mapping patterns.
+- Triplicate/duplicate sample transfer from CSV data.
+- Thermocycler temperature profile execution (complete PCR cycle examples).
+- Multi-step PCR workflow: mastermix distribution → sample addition → thermocycling.
+- Column-wise multi-channel sample allocation from CSV.
+- Volume calculation from CSV data (volumes as strings → float conversion).
+
+**When to read:** Any protocol that reads a well map, sample list, or volume list from a CSV RTP. Also use for complete thermocycler PCR workflows.
+
+---
+
+### `runtime_parameters.md` (~320 lines, ~80% code)
+
+**Topic:** Runtime parameter definitions — `add_int`, `add_float`, `add_bool`, `add_str`.
+
+**Note:** Key patterns are already in `reference-rtp.md` in this skills dir. Read this source doc for additional parameter validation examples or less common field patterns.
+
+---
+
+### `flex_stacker_usage.md` (~194 lines, ~50% prose)
+
+**Topic:** Flex Stacker Module patterns, constraints, and lid management.
+
+**Note:** Key patterns are already in `reference-modules.md` in this skills dir. Read this source doc for full protocol flow examples and waste hierarchy decisions.
+
+---
+
+## How to Use These Docs
+
+1. **Start with this index** — identify which file(s) are relevant.
+2. **Read the file** using the Read tool when you need its content.
+3. **Do not copy content** from these files into protocols verbatim — adapt it.
+4. **Update this index** if you discover a doc covers something not listed here.

--- a/.cursor/skills/protocol-authoring/reference-labware-deck.md
+++ b/.cursor/skills/protocol-authoring/reference-labware-deck.md
@@ -1,0 +1,207 @@
+# Labware & Deck Layout Reference
+
+> **Full source docs** (read these for complete catalog or deep detail):
+>
+> - Full labware catalog (86 entries): `opentrons-ai-server/api/storage/docs/standard-loadname-info.md`
+> - Deck layout rules (full): `opentrons-ai-server/api/storage/docs/deck_layout.md`
+> - OT-2 → Flex migration guide: `opentrons-ai-server/api/storage/docs/OT2ToFlex.md`
+
+---
+
+## Most-Used Labware Load Names
+
+### Well Plates
+
+| Load Name                                     | Wells | Max Vol | Shape    |
+| --------------------------------------------- | ----- | ------- | -------- |
+| `nest_96_wellplate_2ml_deep`                  | 96    | 2 mL    | U-bottom |
+| `corning_96_wellplate_360ul_flat`             | 96    | 360 µL  | Flat     |
+| `nest_96_wellplate_200ul_flat`                | 96    | 200 µL  | Flat     |
+| `nest_96_wellplate_100ul_pcr_full_skirt`      | 96    | 100 µL  | V-bottom |
+| `biorad_96_wellplate_200ul_pcr`               | 96    | 200 µL  | V-bottom |
+| `opentrons_96_wellplate_200ul_pcr_full_skirt` | 96    | 200 µL  | V-bottom |
+| `corning_384_wellplate_112ul_flat`            | 384   | 112 µL  | Flat     |
+| `corning_24_wellplate_3.4ml_flat`             | 24    | 3.4 mL  | Flat     |
+
+### Reservoirs
+
+| Load Name                   | Wells | Max Vol    |
+| --------------------------- | ----- | ---------- |
+| `nest_1_reservoir_195ml`    | 1     | 195 mL     |
+| `nest_1_reservoir_290ml`    | 1     | 290 mL     |
+| `nest_12_reservoir_15ml`    | 12    | 15 mL/well |
+| `agilent_1_reservoir_290ml` | 1     | 290 mL     |
+
+### Tube Racks
+
+| Load Name                                                | Tubes | Max Vol  |
+| -------------------------------------------------------- | ----- | -------- |
+| `opentrons_24_tuberack_eppendorf_1.5ml_safelock_snapcap` | 24    | 1.5 mL   |
+| `opentrons_24_tuberack_generic_2ml_screwcap`             | 24    | 2 mL     |
+| `opentrons_10_tuberack_falcon_4x50ml_6x15ml_conical`     | 10    | 50/15 mL |
+| `opentrons_6_tuberack_falcon_50ml_conical`               | 6     | 50 mL    |
+
+### Flex Tip Racks
+
+| Volume  | Standard                           | Filter                                   |
+| ------- | ---------------------------------- | ---------------------------------------- |
+| 50 µL   | `opentrons_flex_96_tiprack_50ul`   | `opentrons_flex_96_filtertiprack_50ul`   |
+| 200 µL  | `opentrons_flex_96_tiprack_200ul`  | `opentrons_flex_96_filtertiprack_200ul`  |
+| 1000 µL | `opentrons_flex_96_tiprack_1000ul` | `opentrons_flex_96_filtertiprack_1000ul` |
+
+### OT-2 Tip Racks
+
+| Volume  | Load Name                     |
+| ------- | ----------------------------- |
+| 10 µL   | `opentrons_96_tiprack_10ul`   |
+| 20 µL   | `opentrons_96_tiprack_20ul`   |
+| 300 µL  | `opentrons_96_tiprack_300ul`  |
+| 1000 µL | `opentrons_96_tiprack_1000ul` |
+
+### Adapters (Flex)
+
+| Load Name                                                      | Use                                |
+| -------------------------------------------------------------- | ---------------------------------- |
+| `opentrons_flex_96_tiprack_adapter`                            | Required for 96-channel tip pickup |
+| `opentrons_96_deep_well_adapter_nest_wellplate_2ml_deep`       | Deep well plate on thermocycler    |
+| `opentrons_96_pcr_adapter_nest_wellplate_100ul_pcr_full_skirt` | PCR plate on thermocycler          |
+| `opentrons_96_flat_bottom_adapter_nest_wellplate_200ul_flat`   | Flat plate on temp module          |
+
+---
+
+## Flex Deck Layout
+
+Deck coordinates: **D1–D3** (front row) → **C1–C3** → **B1–B3** → **A1–A3** (back row)
+
+### Module Placement (Flex)
+
+| Module                  | Recommended | Allowed                        | Forbidden              |
+| ----------------------- | ----------- | ------------------------------ | ---------------------- |
+| Heater-Shaker           | D1          | A1, B1, C1, D1, A3, B3, C3, D3 | A2, B2, C2, D2         |
+| Magnetic Block          | D2          | Any non-staging-area slot      | A4, B4, C4, D4         |
+| Temperature Module      | D1          | A1, B1, C1, D1, A3, B3, C3, D3 | A2, B2, C2, D2         |
+| Thermocycler            | A1+B1       | A1+B1 only                     | All other slots        |
+| Absorbance Plate Reader | D3          | A3, B3, C3, D3                 | All column 1 & 2 slots |
+
+### Fixture Placement (Flex)
+
+| Fixture            | Placement                                         |
+| ------------------ | ------------------------------------------------- |
+| Trash bin          | A3 (recommended); also A1, B1, C1, D1, B3, C3, D3 |
+| Waste chute        | D3 only                                           |
+| Staging area slots | A3, B3, C3, or D3 → unlocks A4, B4, C4, D4        |
+
+**Staging area constraints:**
+
+- Column 4 slots (A4–D4) are **gripper-accessible only** — no pipetting allowed there.
+- Tube racks cannot be placed in staging area slots (gripper cannot safely move them).
+- Trash bin and staging area slot cannot share the same deck position.
+
+### Labware Placement Order (Flex)
+
+Place shortest to tallest from front-left to back-right:
+
+| Labware Type        | Recommended Slots                     |
+| ------------------- | ------------------------------------- |
+| Well plates         | D1, D2, D3                            |
+| Reservoirs          | C1, C2, C3                            |
+| Tube racks          | B1, B2, B3                            |
+| Tip racks           | A2, A1 (A3 only if no trash there)    |
+| 96-tip rack adapter | A2, B2, C2, D2 (avoid module columns) |
+
+---
+
+## OT-2 Deck Layout
+
+Deck slots: **1–11**, trash bin fixed at position 12.
+
+### Module Placement (OT-2)
+
+| Module             | Recommended | Allowed              | Forbidden       |
+| ------------------ | ----------- | -------------------- | --------------- |
+| Heater-Shaker      | 1           | 1, 3, 4, 6, 7        | 2, 5, 8, 9, 11  |
+| Magnetic Module    | 1           | 1, 3, 4, 6, 7, 9, 10 | 2, 5, 8, 11     |
+| Temperature Module | 3           | 1, 4, 6, 7, 9, 10    | 2, 5, 8, 11     |
+| Thermocycler       | 7+8+10+11   | 7+8+10+11 only       | All other slots |
+
+**OT-2 module notes:**
+
+- Magnetic Block (Gen3) and Absorbance Plate Reader are Flex-only.
+- Thermocycler occupies slots 7, 8, 10, and 11 simultaneously.
+
+### Labware Placement Order (OT-2)
+
+| Labware Type | Recommended Slots            |
+| ------------ | ---------------------------- |
+| Well plates  | 1, 2, 3                      |
+| Reservoirs   | 4, 5, 6                      |
+| Tube racks   | 7, 8, 9                      |
+| Tip racks    | 11, 10, 9 (back-right first) |
+
+---
+
+## OT-2 → Flex Slot Conversion
+
+| OT-2 | Flex |     | OT-2       | Flex |
+| ---- | ---- | --- | ---------- | ---- |
+| 1    | D1   |     | 7          | B1   |
+| 2    | D2   |     | 8          | B2   |
+| 3    | D3   |     | 9          | B3   |
+| 4    | C1   |     | 10         | A1   |
+| 5    | C2   |     | 11         | A2   |
+| 6    | C3   |     | 12 (trash) | A3   |
+
+Slots A4, B4, C4, D4 exist only on Flex (staging area, gripper-only).
+
+---
+
+## OT-2 → Flex Migration Checklist
+
+### 1. Metadata & Requirements
+
+Move `apiLevel` out of `metadata` into `requirements`; do **not** specify it in both.
+
+```python
+# OT-2
+metadata = {"protocolName": "My Protocol", "apiLevel": "2.19"}
+
+# Flex
+metadata = {"protocolName": "My Protocol"}
+requirements = {"robotType": "Flex", "apiLevel": "2.19"}
+```
+
+### 2. Trash Bin (must load before any `drop_tip()`)
+
+```python
+trash = protocol.load_trash_bin("A3")
+```
+
+### 3. Pipette Names
+
+| OT-2                | Flex equivalent      |
+| ------------------- | -------------------- |
+| `p20_single_gen2`   | `flex_1channel_50`   |
+| `p20_multi_gen2`    | `flex_8channel_50`   |
+| `p300_single_gen2`  | `flex_1channel_1000` |
+| `p300_multi_gen2`   | `flex_8channel_1000` |
+| `p1000_single_gen2` | `flex_1channel_1000` |
+
+### 4. Module Load Names
+
+| OT-2 Module                | Flex Action                                                                               |
+| -------------------------- | ----------------------------------------------------------------------------------------- |
+| `temperature module gen2`  | Same load name works                                                                      |
+| `thermocycler module gen2` | Same load name works                                                                      |
+| `heaterShakerModuleV1`     | Same load name works                                                                      |
+| `magnetic module gen2`     | **Not compatible.** Use `magnetic_block` + `protocol.move_labware(..., use_gripper=True)` |
+
+**Magnetic Module → Magnetic Block conversion:**
+
+```python
+# OT-2: pipette entire plate to magnetic module, then engage
+mag_mod.engage()
+
+# Flex: move plate with gripper to magnetic block (no pipetting needed)
+hs_mod.open_labware_latch()
+protocol.move_labware(sample_plate, mag_block, use_gripper=True)
+```

--- a/.cursor/skills/protocol-authoring/reference-liquid-handling.md
+++ b/.cursor/skills/protocol-authoring/reference-liquid-handling.md
@@ -1,0 +1,416 @@
+# Liquid Handling Reference — Detailed Patterns
+
+## Building Block Commands
+
+These are the low-level commands for full control over pipette actions.
+
+### Tip Management
+
+```python
+pipette.pick_up_tip()                      # Auto from tip_racks
+pipette.pick_up_tip(tiprack["A1"])         # Specific well
+pipette.drop_tip()                          # Drop in trash
+pipette.drop_tip(tiprack["A1"])            # Drop in specific location
+pipette.return_tip()                        # Return to pickup location
+```
+
+### Aspirate / Dispense
+
+```python
+pipette.aspirate(volume=100, location=plate["A1"])
+pipette.aspirate(100, plate["A1"].bottom(z=2))     # 2mm above bottom
+pipette.aspirate(100, plate["A1"].top(z=-5))        # 5mm below top
+
+pipette.dispense(volume=100, location=plate["B1"])
+pipette.dispense(100, plate["B1"].bottom(z=2))
+
+# Rate modifier (fraction of default flow rate)
+pipette.aspirate(100, plate["A1"], rate=0.5)   # Half speed
+pipette.dispense(100, plate["B1"], rate=2.0)    # Double speed
+```
+
+### Blow Out, Touch Tip, Air Gap, Mix
+
+```python
+pipette.blow_out()                          # Blow out in current location
+pipette.blow_out(plate["A1"])              # Blow out in specific well
+pipette.blow_out(protocol.fixed_trash["A1"])  # OT-2 trash
+
+pipette.touch_tip()                         # Touch all sides of current well
+pipette.touch_tip(plate["A1"])
+pipette.touch_tip(radius=0.75, v_offset=-2)  # Customize position
+
+pipette.air_gap(volume=10)                  # Add air gap after aspirate
+
+pipette.mix(repetitions=3, volume=50)       # Mix in current well
+pipette.mix(3, 50, plate["A1"])             # Mix in specific well
+```
+
+### Location Modifiers
+
+```python
+well = plate["A1"]
+
+well.top()                    # Top center of well
+well.top(z=-5)                # 5mm below top
+well.bottom()                 # Bottom center
+well.bottom(z=2)              # 2mm above bottom
+well.center()                 # Center of well
+
+# Meniscus-relative (API 2.23+, Flex only)
+well.meniscus(z=-1)           # 1mm below meniscus
+```
+
+## Complex Commands
+
+### Transfer (1-to-1)
+
+```python
+# Single well to single well
+pipette.transfer(100, plate["A1"], plate["B1"])
+
+# Multiple wells (pairwise)
+pipette.transfer(100, plate.wells()[:4], plate.wells()[4:8])
+
+# Variable volumes
+pipette.transfer([50, 100, 150], sources, dests)
+```
+
+### Distribute (1-to-many)
+
+```python
+# One source, many destinations
+pipette.distribute(50, reservoir["A1"], plate.rows()[0])
+
+# With disposal volume (avoids dripping between dispenses)
+pipette.distribute(50, reservoir["A1"], plate.rows()[0], disposal_volume=10)
+```
+
+### Consolidate (many-to-1)
+
+```python
+# Many sources, one destination
+pipette.consolidate(50, plate.rows()[0], reservoir["A1"])
+```
+
+### Full Parameter Reference
+
+```python
+pipette.transfer(
+    volume=100,                         # µL (or list of volumes)
+    source=plate["A1"],                 # Well or list of wells
+    dest=plate["B1"],                   # Well or list of wells
+    new_tip="always",                   # "always" | "once" | "never"
+    trash=True,                         # True=trash, False=return tip
+    mix_before=(3, 50),                 # (reps, vol) — mix at source before aspirate
+    mix_after=(2, 50),                  # (reps, vol) — mix at dest after dispense
+    blow_out=True,                      # Blow out after dispense
+    blowout_location="trash",          # "trash" | "source well" | "destination well"
+    touch_tip=True,                     # Touch tip after dispense
+    air_gap=10,                         # Air gap volume after each aspirate
+    disposal_volume=10,                 # Extra volume for distribute/consolidate
+    carryover=True,                     # Split volume across multiple aspirates if > max
+)
+```
+
+## Liquid Classes (API 2.24+, Flex Only)
+
+Liquid classes optimize pipetting parameters (flow rate, tip position, delays) for specific liquid types.
+
+### Built-in Liquid Classes
+
+| Name          | Type     | Description     |
+| ------------- | -------- | --------------- |
+| `water`       | Aqueous  | Deionized water |
+| `ethanol_80`  | Volatile | 80% ethanol     |
+| `glycerol_50` | Viscous  | 50% glycerol    |
+
+### Usage (Single-Channel)
+
+```python
+water_class = protocol.get_liquid_class(name="water")
+
+pipette.transfer_with_liquid_class(
+    liquid_class=water_class,
+    volume=50,
+    source=[plate["A1"]],
+    dest=[plate["B1"]],
+    new_tip="always",
+)
+
+pipette.distribute_with_liquid_class(
+    liquid_class=water_class,
+    volume=50,
+    source=reservoir["A1"],
+    dest=[plate["A1"], plate["A2"], plate["A3"]],
+    new_tip="once",
+)
+
+pipette.consolidate_with_liquid_class(
+    liquid_class=water_class,
+    volume=50,
+    source=[plate["A1"], plate["A2"]],
+    dest=reservoir["A1"],
+    new_tip="once",
+)
+```
+
+### Usage (8-Channel) — `group_wells` Matters
+
+By default, `group_wells=True` and the liquid class functions validate that **all wells** the multi-channel pipette will physically access are included in `source`/`dest`. For an 8-channel, you must pass the full column (8 wells), not just the top well.
+
+```python
+eight_ch = protocol.load_instrument("flex_8channel_1000", mount="right", tip_racks=[tiprack])
+
+# CORRECT — pass full columns
+eight_ch.transfer_with_liquid_class(
+    liquid_class=water_class,
+    volume=100,
+    source=plate.columns()[0],      # [A1, B1, C1, D1, E1, F1, G1, H1]
+    dest=plate.columns()[1],        # [A2, B2, C2, D2, E2, F2, G2, H2]
+    new_tip="always",
+)
+
+# WRONG — only top well → raises ValueError:
+#   "Pipette will access source wells not provided in the liquid handling
+#    command. Set group_wells to False or include these wells: [B1, C1, ...]"
+eight_ch.transfer_with_liquid_class(
+    liquid_class=water_class,
+    volume=100,
+    source=[plate["A1"]],           # ← missing B1-H1
+    dest=[plate["A2"]],
+    new_tip="always",
+)
+```
+
+For distribute/consolidate with an 8-channel, concatenate columns:
+
+```python
+# Distribute: reservoir (single trough) → 3 plate columns
+eight_ch.distribute_with_liquid_class(
+    liquid_class=water_class,
+    volume=50,
+    source=reservoir["A1"],
+    dest=plate.columns()[2] + plate.columns()[3] + plate.columns()[4],
+    new_tip="once",
+)
+
+# Consolidate: 2 plate columns → reservoir
+eight_ch.consolidate_with_liquid_class(
+    liquid_class=water_class,
+    volume=50,
+    source=plate.columns()[0] + plate.columns()[1],
+    dest=reservoir["A1"],
+    new_tip="once",
+)
+```
+
+> Reservoir wells (single trough) do not need column expansion — all 8 tips access the same well.
+
+## Common Patterns
+
+### Serial Dilution
+
+```python
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    tiprack = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "D2")
+    reservoir = protocol.load_labware("nest_12_reservoir_15ml", "D1")
+    plate = protocol.load_labware("corning_96_wellplate_360ul_flat", "C1")
+    trash = protocol.load_trash_bin("A3")
+
+    pipette = protocol.load_instrument(
+        "flex_8channel_200", mount="right", tip_racks=[tiprack]
+    )
+
+    # Distribute diluent to all columns
+    pipette.distribute(100, reservoir["A1"], plate.rows()[0][1:])
+
+    # Serial dilution across columns
+    pipette.pick_up_tip()
+    for i in range(11):
+        pipette.transfer(
+            100,
+            plate.rows()[0][i],
+            plate.rows()[0][i + 1],
+            mix_after=(3, 50),
+            new_tip="never",
+        )
+    pipette.drop_tip()
+```
+
+### Plate Stamping (96-channel)
+
+```python
+pipette_96 = protocol.load_instrument("flex_96channel_1000", mount="left")
+
+pipette_96.pick_up_tip(tiprack)
+pipette_96.aspirate(100, source_plate["A1"])
+pipette_96.dispense(100, dest_plate["A1"])
+pipette_96.drop_tip()
+```
+
+### Cherry Picking
+
+```python
+transfers = [
+    ("A1", "B3", 50),
+    ("C2", "D1", 100),
+    ("E5", "F7", 75),
+]
+
+for src, dest, vol in transfers:
+    pipette.transfer(vol, source_plate[src], dest_plate[dest])
+```
+
+### Bead Cleanup (Flex with Magnetic Block)
+
+```python
+mag_block = protocol.load_module("magneticBlockV1", "C1")
+
+# Add beads and mix
+pipette.transfer(50, bead_reservoir["A1"], plate["A1"], mix_after=(10, 100))
+protocol.delay(minutes=5)  # Incubate
+
+# Engage magnet
+protocol.move_labware(plate, mag_block, use_gripper=True)
+protocol.delay(minutes=2)  # Wait for separation
+
+# Remove supernatant
+pipette.pick_up_tip()
+pipette.aspirate(150, plate["A1"].bottom(z=1))
+pipette.dispense(150, trash_well)
+pipette.drop_tip()
+
+# Wash
+for _ in range(2):
+    pipette.transfer(200, wash_reservoir["A1"], plate["A1"])
+    protocol.delay(seconds=30)
+    pipette.transfer(200, plate["A1"].bottom(z=1), trash_well)
+
+# Elute
+protocol.move_labware(plate, "D1", use_gripper=True)
+pipette.transfer(50, elution_buffer["A1"], plate["A1"], mix_after=(10, 40))
+protocol.delay(minutes=2)
+
+protocol.move_labware(plate, mag_block, use_gripper=True)
+protocol.delay(minutes=2)
+pipette.transfer(50, plate["A1"].bottom(z=1), elution_plate["A1"])
+```
+
+### Flow Rate Control
+
+```python
+# Set flow rates directly (µL/s)
+pipette.flow_rate.aspirate = 50
+pipette.flow_rate.dispense = 100
+pipette.flow_rate.blow_out = 200
+
+# Or use rate parameter (multiplier)
+pipette.aspirate(100, plate["A1"], rate=0.5)  # 50% of default
+```
+
+---
+
+## Tip Math — Capacity Planning
+
+Calculate required tips _before_ writing loops to avoid `OutOfTipsError` at runtime.
+
+| Pipette Type        | Tips per `pick_up_tip()` | Tips per 96-well rack | Max ops per rack    |
+| ------------------- | ------------------------ | --------------------- | ------------------- |
+| Single-channel      | 1                        | 96                    | 96                  |
+| 8-channel           | 8                        | 96                    | 12 (one per column) |
+| 96-channel (ALL)    | 96                       | 96                    | 1                   |
+| 96-channel (COLUMN) | 8                        | 96                    | 12                  |
+
+**Formula:** `tip_racks_needed = ceil(total_operations / max_ops_per_rack)`
+
+```python
+import math
+
+num_samples = 48
+columns_needed = math.ceil(num_samples / 8)   # 6 columns for 8-channel
+tip_racks_needed = math.ceil(columns_needed / 12)  # 1 rack is enough
+
+# Many-to-many: tip count = size of larger group
+sources = plate.wells()[:8]
+dests = plate.wells()[8:24]
+# transfer() uses 24 tips (size of larger group) with new_tip='always'
+```
+
+**Index error prevention:** `plate.rows()[0]` has indices 0–11 (12 columns). `plate.wells()` has indices 0–95. Validate loop bounds against labware dimensions.
+
+> Full guide with examples: `opentrons-ai-server/api/storage/docs/out_of_tips_error_219.md`
+
+---
+
+## `transfer()` Anti-Patterns
+
+### Don't wrap `transfer()` in a well-iteration loop
+
+`transfer()` handles iteration internally. Wrapping it in a loop creates redundant tip pickups and often produces wrong results.
+
+```python
+# WRONG — each call transfers only one well, wastes tips
+for i in range(8):
+    pipette.transfer(100, source_plate.wells()[i], dest_plate.wells()[i])
+
+# CORRECT — pass lists; transfer() pairs them automatically
+pipette.transfer(
+    100,
+    source_plate.wells()[:8],
+    dest_plate.wells()[:8],
+    new_tip="always"
+)
+```
+
+### `new_tip='once'` in a manual loop is incorrect
+
+```python
+# WRONG — tip is only picked up once, but you wrote the loop yourself
+for well in source_plate.wells():
+    pipette.pick_up_tip()
+    pipette.transfer(100, well, dest_plate["A1"], new_tip="once")  # redundant pick_up inside transfer
+    pipette.drop_tip()
+
+# CORRECT — let transfer() manage tip behavior with a list
+pipette.transfer(100, source_plate.wells(), [dest_plate["A1"]] * 96, new_tip="always")
+```
+
+### Multi-channel must use `columns()`, not `wells()`
+
+```python
+# WRONG — 8-channel picks up column A, but well index is for single-channel
+pipette.transfer(100, source_plate.wells()[:12], dest_plate.wells()[:12])
+
+# CORRECT — pass columns; each element is a list of 8 wells
+pipette.transfer(100, source_plate.columns()[:6], dest_plate.columns()[:6])
+```
+
+> Full transfer() guide: `opentrons-ai-server/api/storage/docs/transfer_function_notes.md`
+
+---
+
+### Well Iteration Patterns
+
+```python
+# All wells in order (A1, B1, C1, ... A2, B2, ...)
+for well in plate.wells():
+    pipette.transfer(100, reservoir["A1"], well)
+
+# By row (A1-A12, then B1-B12, ...)
+for row in plate.rows():
+    for well in row:
+        pipette.transfer(100, reservoir["A1"], well)
+
+# By column
+for col in plate.columns():
+    for well in col:
+        pipette.transfer(100, reservoir["A1"], well)
+
+# Specific wells
+wells = [plate["A1"], plate["B3"], plate["C5"]]
+pipette.transfer(100, reservoir["A1"], wells)
+
+# Slice of wells
+first_24 = plate.wells()[:24]
+```

--- a/.cursor/skills/protocol-authoring/reference-modules.md
+++ b/.cursor/skills/protocol-authoring/reference-modules.md
@@ -1,0 +1,264 @@
+# Module Reference — Detailed Operations
+
+## Module Load Names
+
+| Module                  | Load Name                  | Robot     | API Min |
+| ----------------------- | -------------------------- | --------- | ------- |
+| Temperature Module Gen2 | `temperature module gen2`  | Both      | 2.0     |
+| Thermocycler Gen2       | `thermocycler module gen2` | Both      | 2.0     |
+| Heater-Shaker           | `heaterShakerModuleV1`     | Both      | 2.13    |
+| Magnetic Module Gen2    | `magnetic module gen2`     | OT-2 only | 2.0     |
+| Magnetic Block          | `magneticBlockV1`          | Flex only | 2.15    |
+| Absorbance Plate Reader | `absorbanceReaderV1`       | Flex only | 2.21    |
+| Flex Stacker            | `flexStackerModuleV1`      | Flex only | 2.25    |
+
+## Temperature Module
+
+```python
+temp_mod = protocol.load_module("temperature module gen2", "D1")
+adapter = temp_mod.load_adapter("opentrons_96_well_aluminum_block")
+plate = adapter.load_labware("nest_96_wellplate_200ul_flat")
+
+temp_mod.set_temperature(4)          # Block until target reached
+temp_mod.start_set_temperature(4)    # Async (API 2.27+)
+temp_mod.await_temperature(4)        # Wait for async target
+temp_mod.deactivate()
+
+# Properties
+temp_mod.temperature       # Current temperature
+temp_mod.target            # Target temperature (None if deactivated)
+temp_mod.status            # "idle", "holding at target", "cooling", "heating"
+```
+
+### Common Adapters
+
+- `opentrons_96_well_aluminum_block` — standard 96-well aluminum adapter
+- `opentrons_24_aluminumblock_nest_1.5ml_snapcap`
+- `opentrons_24_aluminumblock_generic_2ml_screwcap`
+
+## Thermocycler
+
+The Thermocycler occupies two deck slots: A1+B1 on Flex, 7+8+10+11 on OT-2. No slot argument needed.
+
+```python
+tc = protocol.load_module("thermocycler module gen2")
+plate = tc.load_labware("nest_96_wellplate_200ul_pcr_full_skirt")
+
+# Lid control
+tc.open_lid()
+tc.close_lid()
+
+# Block temperature
+tc.set_block_temperature(
+    temperature=95,
+    hold_time_seconds=30,       # or hold_time_minutes
+    block_max_volume=50,        # µL, improves accuracy
+)
+
+# Lid temperature
+tc.set_lid_temperature(105)
+
+# PCR profile
+tc.execute_profile(
+    steps=[
+        {"temperature": 95, "hold_time_seconds": 15},
+        {"temperature": 60, "hold_time_seconds": 60},
+        {"temperature": 72, "hold_time_seconds": 60},
+    ],
+    repetitions=30,
+    block_max_volume=50,
+)
+
+# Async profile (API 2.27+)
+task = tc.start_execute_profile(
+    steps=[...],
+    repetitions=30,
+    block_max_volume=50,
+)
+# ... do other things ...
+protocol.wait_for_tasks([task])
+
+# Deactivate
+tc.deactivate_block()
+tc.deactivate_lid()
+
+# Properties
+tc.lid_position           # "open" or "closed"
+tc.block_temperature      # Current block temp
+tc.lid_temperature        # Current lid temp
+```
+
+### Typical PCR Workflow
+
+```python
+tc.open_lid()
+# ... load plate, add reagents ...
+tc.close_lid()
+tc.set_lid_temperature(105)
+
+# Initial denature
+tc.set_block_temperature(95, hold_time_seconds=120, block_max_volume=50)
+
+# Cycling
+tc.execute_profile(
+    steps=[
+        {"temperature": 95, "hold_time_seconds": 15},
+        {"temperature": 60, "hold_time_seconds": 60},
+        {"temperature": 72, "hold_time_seconds": 60},
+    ],
+    repetitions=30,
+    block_max_volume=50,
+)
+
+# Final extension
+tc.set_block_temperature(72, hold_time_minutes=5, block_max_volume=50)
+
+# Hold at 4°C
+tc.set_block_temperature(4)
+tc.deactivate_lid()
+tc.open_lid()
+```
+
+## Heater-Shaker
+
+```python
+hs = protocol.load_module("heaterShakerModuleV1", "D1")
+adapter = hs.load_adapter("opentrons_96_pcr_adapter")
+plate = adapter.load_labware("nest_96_wellplate_200ul_pcr_full_skirt")
+
+# Latch control (must close before shaking)
+hs.open_labware_latch()
+hs.close_labware_latch()
+
+# Shaking
+hs.set_and_wait_for_shake_speed(rpm=1000)   # 200–3000 RPM
+hs.deactivate_shaker()                       # Must stop before pipetting (not stop_shaking)
+
+# Temperature
+hs.set_and_wait_for_temperature(celsius=37)
+hs.set_target_temperature(celsius=37)         # Async
+hs.wait_for_temperature()
+hs.deactivate_heater()
+
+# Properties
+hs.current_temperature
+hs.target_temperature
+hs.current_speed
+hs.target_speed
+hs.status   # "idle", "running", "stalled"
+```
+
+### Heater-Shaker Adapters
+
+- `opentrons_96_pcr_adapter` — for PCR plates
+- `opentrons_96_deep_well_adapter` — for deep well plates
+- `opentrons_96_flat_bottom_adapter` — for flat bottom plates
+- `opentrons_universal_flat_adapter` — universal
+
+### Important: Pipetting with Heater-Shaker
+
+The pipette cannot access the Heater-Shaker while it is shaking. Always call `hs.stop_shaking()` before aspirating/dispensing on the HS. The latch must be closed during shaking but can be open for pipette access.
+
+## Magnetic Block (Flex Only)
+
+Unpowered passive module. Simply place a plate on it for bead separation.
+
+```python
+mag_block = protocol.load_module("magneticBlockV1", "C1")
+
+# Move plate to magnetic block for separation
+protocol.move_labware(plate, mag_block, use_gripper=True)
+protocol.delay(minutes=2)  # Wait for beads to separate
+
+# Move plate off for pipetting
+protocol.move_labware(plate, "D1", use_gripper=True)
+```
+
+## Magnetic Module (OT-2 Only)
+
+```python
+mag_mod = protocol.load_module("magnetic module gen2", "1")
+plate = mag_mod.load_labware("nest_96_wellplate_2ml_deep")
+
+mag_mod.engage(height_from_base=6)  # mm from labware base
+mag_mod.disengage()
+
+# Properties
+mag_mod.status  # "engaged" or "disengaged"
+```
+
+## Absorbance Plate Reader (Flex Only, API 2.21+)
+
+```python
+apr = protocol.load_module("absorbanceReaderV1", "B3")
+
+# IMPORTANT: lid must be closed BEFORE initialize
+apr.close_lid()
+apr.initialize("single", [450], reference_wavelength=600)
+# Modes: "single" (1 wavelength) or "multi" (up to 6)
+# Multi example: apr.initialize("multi", [450, 570, 600])
+apr.open_lid()
+
+# Move plate in
+protocol.move_labware(plate, apr, use_gripper=True)
+apr.close_lid()
+
+# Read
+result = apr.read(export_filename="data.csv")
+
+# Move plate out
+apr.open_lid()
+protocol.move_labware(plate, "D1", use_gripper=True)
+```
+
+> **Gotcha**: calling `apr.initialize()` without first calling `apr.close_lid()` raises `CannotPerformModuleAction: Cannot perform Initialize action on Absorbance Reader without calling .close_lid() first.`
+
+## Flex Stacker (Flex Only, API 2.25+)
+
+```python
+stacker = protocol.load_module("flexStackerModuleV1", "D4")
+stacker.set_stored_labware(
+    load_name="opentrons_flex_96_tiprack_1000ul",
+    count=6,
+    lid="opentrons_flex_tiprack_lid",  # Optional
+)
+
+# Retrieve labware from stacker
+tip_rack = stacker.retrieve()
+
+# Move and use
+protocol.move_labware(tip_rack, "C2", use_gripper=True)
+
+# Store labware back
+stacker.store(tip_rack)
+```
+
+## Concurrent Module Operations (API 2.27+)
+
+```python
+# Start async operations
+hs_task = hs.set_target_temperature(celsius=37)
+tc_task = tc.start_execute_profile(steps=[...], repetitions=30)
+temp_task = temp_mod.start_set_temperature(4)
+
+# Wait for all to complete
+protocol.wait_for_tasks([hs_task, tc_task, temp_task])
+```
+
+## Lid Operations (API 2.23+, Flex Only)
+
+```python
+# Load a stack of lids
+lids = protocol.load_lid_stack(
+    load_name="opentrons_tough_pcr_auto_sealing_lid",
+    location="A4",
+    quantity=5,
+    adapter="opentrons_flex_deck_riser",
+)
+
+# Move lid onto plate
+protocol.move_lid(source_location=lids, new_location=plate, use_gripper=True)
+
+# Remove lid
+protocol.move_lid(source_location=plate, new_location=waste_chute, use_gripper=True)
+```

--- a/.cursor/skills/protocol-authoring/reference-rtp.md
+++ b/.cursor/skills/protocol-authoring/reference-rtp.md
@@ -1,0 +1,241 @@
+# Runtime Parameters (RTP) Reference
+
+Runtime Parameters allow users to customize protocol behavior at run time without editing the Python file. Available in API 2.18+.
+
+## Structure
+
+Add an `add_parameters` function **before** `run`:
+
+```python
+from opentrons import protocol_api
+
+requirements = {"robotType": "Flex", "apiLevel": "2.18"}
+
+def add_parameters(parameters: protocol_api.Parameters) -> None:
+    # Define parameters here
+    pass
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    # Access parameters via protocol.params
+    value = protocol.params.variable_name
+```
+
+## Parameter Types
+
+### Integer (`add_int`)
+
+```python
+# With min/max range
+parameters.add_int(
+    variable_name="sample_count",
+    display_name="Number of Samples",
+    default=8,
+    minimum=1,
+    maximum=96,
+    description="How many samples to process",
+    unit="samples",
+)
+
+# With choices
+parameters.add_int(
+    variable_name="plate_count",
+    display_name="Plate Count",
+    default=2,
+    choices=[
+        {"display_name": "1 plate", "value": 1},
+        {"display_name": "2 plates", "value": 2},
+        {"display_name": "3 plates", "value": 3},
+    ],
+)
+```
+
+### Float (`add_float`)
+
+```python
+# With min/max range
+parameters.add_float(
+    variable_name="transfer_volume",
+    display_name="Transfer Volume",
+    default=100.0,
+    minimum=10.0,
+    maximum=1000.0,
+    unit="µL",
+)
+
+# With choices
+parameters.add_float(
+    variable_name="concentration",
+    display_name="Concentration",
+    default=1.0,
+    choices=[
+        {"display_name": "Low (0.5x)", "value": 0.5},
+        {"display_name": "Normal (1.0x)", "value": 1.0},
+        {"display_name": "High (2.0x)", "value": 2.0},
+    ],
+)
+```
+
+### Boolean (`add_bool`)
+
+```python
+parameters.add_bool(
+    variable_name="dry_run",
+    display_name="Dry Run",
+    default=False,
+    description="When on, skip actual liquid transfers",
+)
+```
+
+### String (`add_str`)
+
+```python
+# Always uses choices (no free text)
+parameters.add_str(
+    variable_name="pipette_type",
+    display_name="Pipette",
+    default="flex_1channel_1000",
+    choices=[
+        {"display_name": "1-channel 1000µL", "value": "flex_1channel_1000"},
+        {"display_name": "8-channel 1000µL", "value": "flex_8channel_1000"},
+    ],
+    description="Which pipette to use",
+)
+```
+
+### CSV File (API 2.20+)
+
+```python
+parameters.add_csv_file(
+    variable_name="plate_map",
+    display_name="Plate Map CSV",
+    description="CSV file with well, volume columns",
+)
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    csv_data = protocol.params.plate_map
+    rows = csv_data.parse_as_csv()  # Returns list of lists
+    for row in rows[1:]:  # Skip header
+        well, volume = row[0], float(row[1])
+        pipette.transfer(volume, source, plate[well])
+```
+
+## Common Parameter Fields
+
+| Field                 | Required | Description                                         |
+| --------------------- | -------- | --------------------------------------------------- |
+| `variable_name`       | Yes      | Python variable name (used in `protocol.params.X`)  |
+| `display_name`        | Yes      | Human-readable label shown in the Opentrons App     |
+| `default`             | Yes      | Default value                                       |
+| `description`         | No       | Help text shown in the App                          |
+| `unit`                | No       | Unit label (e.g., "µL", "samples", "RPM")           |
+| `minimum` / `maximum` | No\*     | Range for int/float (\*required if no `choices`)    |
+| `choices`             | No\*     | List of `{"display_name": ..., "value": ...}` dicts |
+
+A numeric parameter must have either `minimum`/`maximum` OR `choices`, not both.
+
+## Accessing Parameters
+
+```python
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    # Direct access
+    count = protocol.params.sample_count
+
+    # Iterate all parameters
+    for name, value in protocol.params.get_all().items():
+        protocol.comment(f"{name} = {value}")
+```
+
+## Common Use Cases
+
+### Configurable Pipette Selection
+
+```python
+def add_parameters(parameters: protocol_api.Parameters) -> None:
+    parameters.add_str(
+        variable_name="pipette_type",
+        display_name="Pipette",
+        default="flex_1channel_1000",
+        choices=[
+            {"display_name": "1-ch 50µL", "value": "flex_1channel_50"},
+            {"display_name": "1-ch 1000µL", "value": "flex_1channel_1000"},
+            {"display_name": "8-ch 1000µL", "value": "flex_8channel_1000"},
+        ],
+    )
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    pipette = protocol.load_instrument(
+        protocol.params.pipette_type, mount="left", tip_racks=[tiprack]
+    )
+```
+
+### Dry Run Mode
+
+```python
+def add_parameters(parameters: protocol_api.Parameters) -> None:
+    parameters.add_bool(
+        variable_name="dry_run",
+        display_name="Dry Run",
+        default=False,
+        description="Move to wells without transferring liquid",
+    )
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    if not protocol.params.dry_run:
+        pipette.transfer(100, source, dest)
+    else:
+        protocol.comment("DRY RUN: would transfer 100µL")
+```
+
+### Variable Sample Count
+
+```python
+def add_parameters(parameters: protocol_api.Parameters) -> None:
+    parameters.add_int(
+        variable_name="num_samples",
+        display_name="Number of Samples",
+        default=24,
+        minimum=1,
+        maximum=96,
+    )
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    n = protocol.params.num_samples
+    source_wells = source_plate.wells()[:n]
+    dest_wells = dest_plate.wells()[:n]
+    pipette.transfer(100, source_wells, dest_wells)
+```
+
+### CSV-Driven Cherry Picking (API 2.20+)
+
+```python
+def add_parameters(parameters: protocol_api.Parameters) -> None:
+    parameters.add_csv_file(
+        variable_name="cherrypick_map",
+        display_name="Cherry Pick Map",
+        description="CSV: source_well, dest_well, volume",
+    )
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    rows = protocol.params.cherrypick_map.parse_as_csv()
+    for row in rows[1:]:
+        src_well, dst_well, vol = row[0], row[1], float(row[2])
+        pipette.transfer(vol, source_plate[src_well], dest_plate[dst_well])
+```
+
+## Analyzing Protocols with RTPs
+
+When analyzing a protocol that has runtime parameters, you can provide values:
+
+```bash
+opentrons analyze protocol.py \
+    --json-output=output.json \
+    --rtp-values='{"sample_count": 48, "dry_run": true}'
+```
+
+For CSV parameters, use `--rtp-files`:
+
+```bash
+opentrons analyze protocol.py \
+    --json-output=output.json \
+    --rtp-files='{"plate_map": "/path/to/map.csv"}'
+```

--- a/.cursor/skills/protocol-authoring/reference-source-map.md
+++ b/.cursor/skills/protocol-authoring/reference-source-map.md
@@ -1,0 +1,188 @@
+# Source Code Map — Debugging & API Investigation
+
+When a protocol fails, throws unexpected errors, or behaves unexpectedly, use this map to trace into the source code. This helps uncover bugs, suggest API improvements, and correct documentation.
+
+## Protocol API — Public Interface
+
+These are the classes and methods that protocol authors call directly. Start here when investigating API behavior or error messages.
+
+| What                             | File                                                            | Key Contents                                                                                                                                                                                                                                                                    |
+| -------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ProtocolContext`                | `api/src/opentrons/protocol_api/protocol_context.py`            | `load_labware`, `load_instrument`, `load_module`, `load_trash_bin`, `load_waste_chute`, `move_labware`, `define_liquid`, `get_liquid_class`, `delay`, `comment`, `pause`, `move_lid`, `load_lid_stack`, `wait_for_tasks`                                                        |
+| `InstrumentContext` (pipette)    | `api/src/opentrons/protocol_api/instrument_context.py`          | `aspirate`, `dispense`, `mix`, `blow_out`, `touch_tip`, `pick_up_tip`, `drop_tip`, `return_tip`, `transfer`, `distribute`, `consolidate`, `transfer_with_liquid_class`, `distribute_with_liquid_class`, `consolidate_with_liquid_class`, `configure_nozzle_layout`, `flow_rate` |
+| `Labware`                        | `api/src/opentrons/protocol_api/labware.py`                     | `wells`, `rows`, `columns`, `wells_by_name`, well access (`labware["A1"]`), `load_liquid`, `load_empty`                                                                                                                                                                         |
+| Module contexts                  | `api/src/opentrons/protocol_api/module_contexts.py`             | `TemperatureModuleContext`, `MagneticModuleContext`, `ThermocyclerContext`, `HeaterShakerContext`, `MagneticBlockContext`, `AbsorbancePlateReaderContext`, `FlexStackerContext`                                                                                                 |
+| Parameters                       | `api/src/opentrons/protocol_api/_parameter_context.py`          | `add_int`, `add_float`, `add_bool`, `add_str`, `add_csv_file`                                                                                                                                                                                                                   |
+| Validation                       | `api/src/opentrons/protocol_api/validation.py`                  | Input validation for all API calls (volumes, locations, tip states)                                                                                                                                                                                                             |
+| Liquid properties                | `api/src/opentrons/protocol_api/_liquid_properties.py`          | Liquid class property resolution                                                                                                                                                                                                                                                |
+| Liquid class transfer validation | `api/src/opentrons/protocol_api/_transfer_liquid_validation.py` | Validation for `*_with_liquid_class` methods                                                                                                                                                                                                                                    |
+| Nozzle layout config             | `api/src/opentrons/protocol_api/_nozzle_layout.py`              | `ALL`, `SINGLE`, `COLUMN`, `ROW`, `PARTIAL_COLUMN`                                                                                                                                                                                                                              |
+| API version constants            | `api/src/opentrons/protocols/api_support/definitions.py`        | `MAX_SUPPORTED_VERSION`, `MIN_SUPPORTED_VERSION`, `MIN_SUPPORTED_VERSION_FOR_FLEX`                                                                                                                                                                                              |
+| API version feature flags        | `api/src/opentrons/protocols/api_support/types.py`              | `APIVersion` class, version comparison                                                                                                                                                                                                                                          |
+
+## Protocol Engine Core — Where Commands Execute
+
+When tracing what happens _after_ a protocol API call, look here. The engine translates API calls into robot commands.
+
+| What                          | File                                                                           | Key Contents                                                                     |
+| ----------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| Engine protocol core          | `api/src/opentrons/protocol_api/core/engine/protocol.py`                       | Engine-side implementation of `ProtocolContext` methods                          |
+| Engine instrument core        | `api/src/opentrons/protocol_api/core/engine/instrument.py`                     | Engine-side pipette operations, tip tracking, liquid handling                    |
+| Engine labware core           | `api/src/opentrons/protocol_api/core/engine/labware.py`                        | Labware state, well lookups                                                      |
+| Engine module core            | `api/src/opentrons/protocol_api/core/engine/module_core.py`                    | Module command execution                                                         |
+| Deck conflict checking        | `api/src/opentrons/protocol_api/core/engine/deck_conflict.py`                  | `DeckConflictError` — slot occupancy validation                                  |
+| Pipette movement conflict     | `api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py`      | Physical movement collision detection                                            |
+| Transfer executor             | `api/src/opentrons/protocol_api/core/engine/transfer_components_executor.py`   | Executes individual transfer steps (aspirate, dispense, mix, blow_out sequences) |
+| Default liquid class versions | `api/src/opentrons/protocol_api/core/engine/_default_liquid_class_versions.py` | Maps liquid class names to their definition versions                             |
+| Default labware versions      | `api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py`      | Maps labware load names to default versions                                      |
+| Human-readable command text   | `api/src/opentrons/protocol_api/core/engine/stringify.py`                      | Generates the text shown in simulation runlog                                    |
+
+## Transfer / Complex Command Logic
+
+When debugging `transfer`, `distribute`, `consolidate`, or their liquid class variants:
+
+| What                   | File                                                                              | Key Contents                                                                      |
+| ---------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Transfer orchestration | `api/src/opentrons/protocols/advanced_control/transfers/transfer.py`              | Core transfer algorithm — volume splitting, multi-aspirate/dispense, tip strategy |
+| Transfer utilities     | `api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py` | Helper functions for liquid class transfers                                       |
+| Transfer common types  | `api/src/opentrons/protocols/advanced_control/transfers/common.py`                | `TransferTipPolicyV2`, shared types                                               |
+| Mix implementation     | `api/src/opentrons/protocols/advanced_control/mix.py`                             | Mix command logic                                                                 |
+
+## Simulation & Analysis
+
+| What                     | File                                                      | Key Contents                                                          |
+| ------------------------ | --------------------------------------------------------- | --------------------------------------------------------------------- |
+| Simulation entry point   | `api/src/opentrons/simulate.py`                           | `simulate()`, `main()`, CLI argument parsing for `opentrons_simulate` |
+| Analysis entry point     | `api/src/opentrons/cli/analyze.py`                        | `analyze()` function, JSON output schema, `--check` logic             |
+| CLI router               | `api/src/opentrons/cli/__init__.py`                       | Click CLI group, `analyze` subcommand registration                    |
+| Protocol parsing         | `api/src/opentrons/protocols/parse.py`                    | Parses `.py` and `.json` protocols, extracts metadata/requirements    |
+| Protocol execution       | `api/src/opentrons/protocols/execution/execute.py`        | Runs protocol's `run()` function                                      |
+| Python protocol executor | `api/src/opentrons/protocols/execution/execute_python.py` | Python-specific execution logic                                       |
+| Execution errors         | `api/src/opentrons/protocols/execution/errors.py`         | Protocol execution error types                                        |
+
+## Runtime Parameters
+
+| What                  | File                                                                | Key Contents                                               |
+| --------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Parameter definitions | `api/src/opentrons/protocols/parameters/parameter_definition.py`    | `ParameterDefinition` class — validation, choices, min/max |
+| Parameter validation  | `api/src/opentrons/protocols/parameters/validation.py`              | Input validation for parameter values                      |
+| CSV parameter         | `api/src/opentrons/protocols/parameters/csv_parameter_interface.py` | `parse_as_csv()` implementation                            |
+| Parameter types       | `api/src/opentrons/protocols/parameters/types.py`                   | Type definitions for parameters                            |
+| Parameter exceptions  | `api/src/opentrons/protocols/parameters/exceptions.py`              | Parameter-specific error types                             |
+
+## Shared Data — Definitions
+
+| What                      | File/Directory                                             | Key Contents                                                 |
+| ------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------ |
+| Liquid class definitions  | `shared-data/liquid-class/definitions/1/`                  | JSON definitions for `water/`, `glycerol_50/`, `ethanol_80/` |
+| Liquid class schema       | `shared-data/liquid-class/schemas/1.json`                  | JSON schema for liquid class definitions                     |
+| Liquid class Python types | `shared-data/python/opentrons_shared_data/liquid_classes/` | `liquid_class_definition.py`, `types.py`                     |
+| Labware definitions       | `shared-data/labware/definitions/`                         | JSON definitions for all labware                             |
+| Pipette definitions       | `shared-data/pipette/definitions/`                         | Pipette specifications (volume ranges, channels)             |
+| Module definitions        | `shared-data/module/definitions/`                          | Module specifications                                        |
+| Deck definitions          | `shared-data/deck/definitions/`                            | Deck layouts for OT-2 and Flex                               |
+| Command schemas           | `shared-data/command/schemas/`                             | JSON schemas for protocol commands                           |
+
+## Documentation Source
+
+| What                        | Directory                                    | Key Contents                                    |
+| --------------------------- | -------------------------------------------- | ----------------------------------------------- |
+| Python API docs (MkDocs)    | `docs/python-api/docs/`                      | All user-facing documentation topics            |
+| MkDocs config               | `docs/python-api/mkdocs.yml`                 | Doc site structure and navigation               |
+| Example protocols           | `api/docs/v2/example_protocols/`             | Tutorial protocol files (serial dilution, etc.) |
+| Test protocols (real-world) | `analyses-snapshot-testing/files/protocols/` | Hundreds of protocols covering all features     |
+| Custom labware examples     | `analyses-snapshot-testing/files/labware/`   | Custom labware JSON definitions used in tests   |
+
+## Finding Relevant Examples
+
+**Do not list all files** — search for what you need:
+
+```bash
+# Always include _S_ to get working protocols only — _X_ files are intentional failure cases
+ls analyses-snapshot-testing/files/protocols/ | grep "_S_" | grep -i "Flex.*TC"
+ls analyses-snapshot-testing/files/protocols/ | grep "_S_" | grep -i "liquid_class\|LiquidClass"
+ls analyses-snapshot-testing/files/protocols/ | grep "_S_" | grep -i "rtp\|RTP\|parameter"
+ls analyses-snapshot-testing/files/protocols/ | grep "_S_" | grep -i "GRIP"
+ls analyses-snapshot-testing/files/protocols/ | grep "_S_" | grep -i "96.*ch\|96ch\|P200_96"
+ls analyses-snapshot-testing/files/protocols/ | grep "_S_" | grep -i "stacker\|FS"
+```
+
+### Filename convention
+
+```text
+{Robot}_{Status}_{ApiVersion}_{Pipettes}_{Modules}_{Description}.py
+ Flex      S        v2_24       P1000M     GRIP_TC   LiquidClassTransfer.py
+```
+
+- **Robot**: `Flex` or `OT2`
+- **Status**: `S` = success expected ✅ | `X` = failure expected ❌ — **only use `_S_` files as reference examples**
+- **Modules**: `GRIP`, `HS`, `MB`, `TC`, `TM`, `MM`, `APR`, `FS`
+
+Always filter for `_S_` when looking for working examples:
+
+```bash
+ls analyses-snapshot-testing/files/protocols/ | grep "_S_" | grep -i "liquid_class"
+ls analyses-snapshot-testing/files/protocols/ | grep "_S_" | grep -i "Flex.*TC"
+```
+
+## Update the Skill When You Learn Something
+
+After any source code investigation, **record what you found** so the next agent doesn't have to rediscover it.
+
+- **New constraint or gotcha** → add a named subsection under "Debugging Workflow" below (like the meniscus constraint example)
+- **Wrong or missing info in `SKILL.md`** → correct it directly
+- **New source file relevant to a feature** → add a row to the appropriate table above
+- **Doc mismatch** (code behaves differently from `docs/python-api/docs/`)→ note it in the relevant debugging section with the correct behavior
+
+Keep entries brief: one paragraph or a small code block is enough.
+
+## Debugging Workflow
+
+### 1. Protocol Throws an Error
+
+1. Read the traceback — identify the exception class and message
+2. Search for the exception class in `api/src/opentrons/protocol_api/` to find where it's raised
+3. Read the validation logic to understand what constraint was violated
+4. Check if the error message is helpful — if not, that's a documentation/API improvement opportunity
+
+### 2. Unexpected Behavior (No Error)
+
+1. Identify which API method behaves unexpectedly
+2. Find the method in the public interface files (see table above)
+3. Trace into the engine core (`core/engine/`) to see the implementation
+4. Check the transfer logic in `protocols/advanced_control/transfers/` for complex commands
+5. Compare behavior against `docs/python-api/docs/` to see if docs match implementation
+
+### 3. Meniscus Tracking Constraint
+
+`well.meniscus()` requires the well to have been initialized via `load_liquid()` (or a `LiquidProbe` command). Calling `.meniscus()` on an empty destination well raises:
+
+```text
+LiquidHeightUnknownError: Must LiquidProbe or LoadLiquid before specifying WellOrigin.MENISCUS
+```
+
+**Rule**: only call `.meniscus()` on source wells that have had `load_liquid()` called. For destination wells that start empty, use `.bottom(z=N)` instead.
+
+Source: `api/src/opentrons/protocol_api/core/engine/well.py` (well position resolution), `api/src/opentrons/protocol_api/core/engine/instrument.py` (liquid height checks).
+
+### 4. Liquid Class Issues
+
+1. Check the liquid class JSON definition in `shared-data/liquid-class/definitions/1/<name>/`
+2. Check the version mapping in `core/engine/_default_liquid_class_versions.py`
+3. Trace through `_liquid_properties.py` for property resolution
+4. Check `_transfer_liquid_validation.py` for validation of liquid class transfer parameters
+
+### 4. Labware / Deck Layout Issues
+
+1. Check labware definition exists in `shared-data/labware/definitions/`
+2. Check deck conflict logic in `core/engine/deck_conflict.py`
+3. Check slot validation in `protocol_api/validation.py`
+
+### 5. Suggesting Improvements
+
+When you find an issue, categorize your suggestion:
+
+- **Bug**: behavior contradicts documentation or raises incorrect errors → file against `api/` with repro protocol
+- **API improvement**: missing validation, confusing error message, unintuitive API → suggest change to `protocol_api/` files
+- **Documentation correction**: docs don't match actual behavior → suggest change to `docs/python-api/docs/`
+- **Liquid class improvement**: missing pipette/tip combination, suboptimal parameters → suggest change to `shared-data/liquid-class/definitions/`

--- a/.cursor/skills/protocol-verification/SKILL.md
+++ b/.cursor/skills/protocol-verification/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: protocol-verification
+description: Simulate and analyze Opentrons protocols to verify correctness. Use when asked to verify, simulate, analyze, validate, or check a protocol, or when needing to confirm a newly created protocol works.
+---
+
+# Protocol Verification — Simulate & Analyze
+
+After creating or modifying a protocol, verify it using the binaries in `api/.venv/bin/`. All commands run from the **monorepo root**.
+
+## Prerequisites
+
+The `api/` venv must exist. If it doesn't (first time, or after teardown):
+
+```bash
+make -C api setup
+```
+
+This creates `api/.venv/` with all entry points installed. You only need to do this once.
+
+## Entry Points
+
+| Tool     | Binary                                          | Notes                                 |
+| -------- | ----------------------------------------------- | ------------------------------------- |
+| Simulate | `api/.venv/bin/opentrons_simulate`              | Registered script entry point         |
+| Analyze  | `api/.venv/bin/python -m opentrons.cli analyze` | Module command — no standalone binary |
+
+> **Do not use `uv run`** for one-off simulate/analyze calls. It checks and potentially rebuilds the venv on every invocation, adding significant latency. Call the venv binaries directly.
+
+## Working Directories
+
+All local dev artifacts are gitignored and live at the monorepo root:
+
+| Directory             | Purpose                            |
+| --------------------- | ---------------------------------- |
+| `tmp-protocols/`      | Protocol `.py` files               |
+| `tmp-custom-labware/` | Custom labware `.json` definitions |
+| `tmp-csv/`            | CSV files for RTP inputs           |
+
+## Simulation
+
+Produces a **human-readable runlog** of every command the robot would execute. Use for quick validation.
+
+> **⛔ RTP protocols cannot be simulated.** `opentrons_simulate` has no `--rtp-values` or `--rtp-files` flag. If the protocol defines `add_parameters()` (any RTP — including CSV, int, bool, str, or float), **you must tell the user this upfront and use `opentrons analyze` instead.** Do not attempt to simulate an RTP protocol and let it fail; explain the limitation first, then switch to analyze automatically.
+
+```bash
+# Standard
+api/.venv/bin/opentrons_simulate tmp-protocols/my_protocol.py
+
+# With custom labware (can be specified multiple times)
+api/.venv/bin/opentrons_simulate tmp-protocols/my_protocol.py \
+    -L tmp-custom-labware/
+```
+
+The current working directory is **always** searched for custom labware implicitly.
+
+### Simulation Options
+
+| Flag                          | Description                                           |
+| ----------------------------- | ----------------------------------------------------- |
+| `-l`, `--log-level`           | `debug`, `info`, `warning` (default), `error`, `none` |
+| `-L`, `--custom-labware-path` | Directory to search for custom labware (repeatable)   |
+| `-e`, `--estimate-duration`   | Estimate protocol run time (experimental)             |
+| `-o`, `--output`              | `runlog` (default) or `nothing`                       |
+
+### Interpreting Results
+
+- **Success**: runlog prints, exit code 0
+- **Failure**: Python traceback with error message, exit code 1
+
+Common errors:
+
+- `DeckConflictError` — labware placement conflict
+- `LabwareDefinitionDoesNotExist` — invalid labware name
+- `OutOfTipsError` — not enough tips for the protocol
+- `LiquidHeightUnknownError` — `.meniscus()` called on a well without `load_liquid()` — see `reference-source-map.md`
+- `IncompatibleAddressableAreaError` — wrong slot for robot type
+
+## Analysis
+
+Produces **structured JSON** with predicted commands, labware layout, pipettes, modules, and errors. Use for deep inspection or CI validation. Also the only way to verify protocols with CSV RTPs.
+
+```bash
+# Standard
+api/.venv/bin/python -m opentrons.cli analyze tmp-protocols/my_protocol.py \
+    --check --human-json-output=-
+
+# With custom labware — pass the JSON file(s) as extra positional arguments
+api/.venv/bin/python -m opentrons.cli analyze \
+    tmp-protocols/my_protocol.py \
+    tmp-custom-labware/my_custom_plate.json \
+    --check --json-output=-
+
+# With primitive RTP values (int, float, bool, str)
+api/.venv/bin/python -m opentrons.cli analyze tmp-protocols/my_protocol.py \
+    --check --json-output=- \
+    --rtp-values='{"sample_count": 8, "dry_run": false}'
+
+# With CSV RTP file
+api/.venv/bin/python -m opentrons.cli analyze tmp-protocols/my_protocol.py \
+    --check --json-output=- \
+    --rtp-files='{"transfer_map": "tmp-csv/transfer_map.csv"}'
+
+# Combined: custom labware + CSV RTP
+api/.venv/bin/python -m opentrons.cli analyze \
+    tmp-protocols/my_protocol.py \
+    tmp-custom-labware/my_custom_plate.json \
+    --check --json-output=- \
+    --rtp-files='{"transfer_map": "tmp-csv/transfer_map.csv"}'
+```
+
+### Analysis Options
+
+| Flag                       | Description                                                         |
+| -------------------------- | ------------------------------------------------------------------- |
+| `--json-output=FILE`       | Machine-readable JSON (`-` for stdout)                              |
+| `--human-json-output=FILE` | Pretty-printed JSON (`-` for stdout)                                |
+| `--check`                  | Exit non-zero if protocol has errors                                |
+| `--rtp-values=JSON`        | Primitive RTP values as JSON string (`int`, `float`, `bool`, `str`) |
+| `--rtp-files=JSON`         | CSV RTP file paths as JSON string — keys are `variable_name`s       |
+| `--log-output=PATH`        | Log destination (`-` stdout, `stderr` default, or file path)        |
+| `--log-level`              | `DEBUG`, `INFO`, `WARNING` (default), `ERROR`                       |
+
+> **Custom labware in analyze**: there is no `-L` flag. Pass each labware JSON as an extra positional file argument. The `analyze` command recognizes them by their JSON schema and registers them before running.
+
+### JSON Output Structure
+
+```json
+{
+  "createdAt": "...",
+  "result": "ok",
+  "robotType": "OT-3",
+  "config": {"protocolType": "python", "apiVersion": [2, 28]},
+  "metadata": {"protocolName": "..."},
+  "commands": [...],
+  "labware": [...],
+  "pipettes": [...],
+  "modules": [...],
+  "liquids": [...],
+  "errors": [],
+  "runTimeParameters": [...]
+}
+```
+
+Key fields: `result` (`"ok"` / `"not-ok"` / `"parameter-value-required"`), `errors` (empty = valid), `commands` (full ordered command list).
+
+### With Runtime Parameters
+
+```bash
+api/.venv/bin/python -m opentrons.cli analyze protocol.py \
+    --check --json-output=output.json \
+    --rtp-values='{"sample_count": 48, "dry_run": false}'
+
+# CSV parameter files
+api/.venv/bin/python -m opentrons.cli analyze protocol.py \
+    --check --json-output=output.json \
+    --rtp-files='{"plate_map": "/path/to/map.csv"}'
+```
+
+## Standard Verification Workflow
+
+**Before running anything**, check whether the protocol defines `add_parameters()`. If it does, skip simulate entirely and go straight to analyze — then tell the user why.
+
+```bash
+# 1. Quick check — simulate (only if protocol has NO add_parameters())
+api/.venv/bin/opentrons_simulate tmp-protocols/my_protocol.py
+
+# 1b. Quick check — simulate with custom labware (still no RTPs)
+api/.venv/bin/opentrons_simulate tmp-protocols/my_protocol.py \
+    -L tmp-custom-labware/
+
+# 2. Deep check — analyze (required for any protocol with add_parameters())
+api/.venv/bin/python -m opentrons.cli analyze \
+    tmp-protocols/my_protocol.py \
+    [tmp-custom-labware/my_plate.json] \
+    --check --human-json-output=- \
+    [--rtp-values='{"key": value}'] \
+    [--rtp-files='{"csv_param": "tmp-csv/file.csv"}']
+```
+
+**Decision guide:**
+
+| Scenario                                 | Use                          | Agent behavior                                                                                                          |
+| ---------------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| No RTPs, no custom labware               | simulate                     | Run simulate directly                                                                                                   |
+| Custom labware only                      | simulate with `-L`           | Run simulate directly                                                                                                   |
+| **Any RTP** (`add_parameters()` present) | **analyze only**             | **Tell the user: "`opentrons_simulate` cannot run RTP protocols — switching to `opentrons analyze`"**, then run analyze |
+| Custom labware + any RTP                 | analyze with extra JSON args | Same — explain, then analyze                                                                                            |
+
+## Snapshot Testing Integration
+
+For protocols to be tracked for regression, use `analyses-snapshot-testing/`:
+
+```bash
+cd analyses-snapshot-testing/
+
+# Naming: {Robot}_{Status}_{Version}_{Pipettes}_{Modules}_{Description}.py
+# Example: Flex_S_v2_28_P1000_GRIP_SerialDilution.py
+
+make prep
+make snapshot-test-update PROTOCOL_NAMES=Flex_S_v2_28_P1000_GRIP_SerialDilution OVERRIDE_PROTOCOL_NAMES=none
+```
+
+See the `analyses-snapshot-testing` skill for full details.
+
+## Keeping This Skill Current
+
+When simulate or analyze surfaces a new error pattern, constraint, or CLI behavior that isn't already documented here, **add it to the Troubleshooting section** or update the relevant command example. The next person hitting the same issue will thank you.
+
+## Troubleshooting
+
+### `api/.venv/` doesn't exist
+
+```bash
+make -C api setup
+```
+
+### Simulation succeeds but analysis shows errors
+
+Analysis is stricter. Check the `errors` array in JSON output for details.
+
+### Protocol works in simulation but fails on robot
+
+Simulation doesn't verify physical constraints: actual tip presence, liquid volumes, module calibration, or physical deck geometry.
+
+### Slow runs
+
+If you accidentally used `uv run` instead of the venv binaries, it checks/rebuilds the venv each time. Switch to `api/.venv/bin/...` for instant invocations.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Local development scratch directories (protocols, custom labware, CSV inputs)
+tmp-protocols/
+tmp-custom-labware/
+tmp-csv/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
## Summary

Adds two Cursor agent skills to the monorepo that give the AI coding assistant specialized, self-contained knowledge for working with Opentrons Python API protocols.

> These files are generated and improved through creating protocols with an agent  

**`protocol-authoring`** — covers everything needed to write valid protocols:
- Core skill entry point (`SKILL.md`) with decision trees for robot type, pipette selection, and module usage
- Reference docs for labware/deck layout, liquid handling, 96-channel pipetting, modules, RTPs, and a source-code map for tracing into API internals
- pulled in content from, and references documents in `opentrons-ai-server` 

**`protocol-verification`** — covers simulate & analyze workflows:
- How to run `opentrons_simulate` and `opentrons analyze` against the local `api/.venv`
- RTP limitations, custom labware flags, JSON output interpretation, and common error patterns

Also updates `.gitignore` to ignore the `tmp-protocols/`, `tmp-custom-labware/`, and `tmp-csv/` scratch directories used during local protocol development.

## Test plan
- [x] Open a new Cursor chat, ask it to write a Flex protocol — confirm it reads `protocol-authoring/SKILL.md` first (did this many times)
- [x] Ask it to simulate/analyze a protocol — confirm it reads `protocol-verification/SKILL.md` and calls the correct venv binary

> Anecdotally, this is performing superiorly to OpentronsAI with the frontier models Sonnet 4.6 and Opus 4.6.