### PR TITLE
fix(app): ensure wellName is a part of labwareDef safegaurd in PV

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/LabwareOnDeck.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/LabwareOnDeck.tsx
@@ -46,12 +46,11 @@ export function LabwareOnDeck(props: LabwareOnDeckProps): JSX.Element {
     pipetteTemporalProperties != null
       ? pipetteTemporalProperties[1].wellName
       : null
-  const wellGroup: WellGroup | null =
-    activeWellName != null
-      ? {
-          [activeWellName]: null,
-        }
-      : null
+
+  const wellName = activeWellName ?? 'A1'
+
+  const wellGroup: WellGroup =
+    labwareDef.wells[wellName] != null ? { [wellName]: null } : {}
 
   const allWellContentsForActiveItem = getAllWellContentsAtFrame(
     liquidState,

--- a/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/SecondWindow/LabwareSlot/index.tsx
@@ -128,13 +128,13 @@ export function LabwareSlot(props: LabwareSlotContainerProps): JSX.Element {
       ? pipetteTemporalProperties[1].wellName
       : null
   const wellGroup: WellGroup | null =
-    activeWellName != null
+    activeWellName != null && labwareDef.wells[activeWellName] != null
       ? {
           [activeWellName]: null,
         }
       : null
   const hoveredWellGroup: WellGroup | null =
-    hoveredWellName != null
+    hoveredWellName != null && labwareDef.wells[hoveredWellName] != null
       ? {
           [hoveredWellName]: null,
         }


### PR DESCRIPTION
closes RQA-5221

# Overview

ensure wellname is actually a part of the labwareDef, just fix some of the logic

## Test Plan and Hands on Testing

smoke test that the protocol doesn't whitescreen anymore and also make sure secondary window doesn't whitescreen either

## Changelog

add some more error handling to the wellName info

## Risk assessment

low
