### PR TITLE
chore(docs): Re-lock docs/uv.lock, and include docs/ in common Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ APP_SHELL_ODD_DIR := app-shell-odd
 AUTH_SERVER_DIR := auth-server
 COMPONENTS_DIR := components
 DISCOVERY_CLIENT_DIR := discovery-client
+DOCS_DIR := docs
 G_CODE_TESTING_DIR := g-code-testing
 HARDWARE_DIR := hardware
 LABWARE_LIBRARY_DIR := labware-library
@@ -26,7 +27,7 @@ SYSTEM_SERVER_DIR := system-server
 UPDATE_SERVER_DIR := update-server
 USB_BRIDGE_DIR := usb-bridge
 
-PYTHON_DIRS := $(API_DIR) $(AUTH_SERVER_DIR) $(G_CODE_TESTING_DIR) $(HARDWARE_DIR) $(ROBOT_SERVER_DIR) $(SERVER_UTILS_DIR) $(SHARED_DATA_DIR) $(SYSTEM_SERVER_DIR) $(UPDATE_SERVER_DIR) $(USB_BRIDGE_DIR)
+PYTHON_DIRS := $(API_DIR) $(AUTH_SERVER_DIR) $(DOCS_DIR) $(G_CODE_TESTING_DIR) $(HARDWARE_DIR) $(ROBOT_SERVER_DIR) $(SERVER_UTILS_DIR) $(SHARED_DATA_DIR) $(SYSTEM_SERVER_DIR) $(UPDATE_SERVER_DIR) $(USB_BRIDGE_DIR)
 
 # This may be set as an environment variable (and is by CI tasks that upload
 # to test pypi) to add a .dev extension to the python package versions. If

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -29,3 +29,22 @@ serve:
 pdf-flex:
 	uv run --python 3.10 mkdocs build -f ./flex/mkdocs.yml && \
 	uv run --python 3.10 python flex/export_to_pdf.py flex/site/print_page/index.html site/Opentrons-Flex-Instruction-Manual.pdf 'Opentrons Flex Instruction Manual'
+
+.PHONY: lock
+lock:
+	uv lock
+
+.PHONY: test
+test:
+# No tests in this project.
+#This target exists to support `make test-py` in the top-level Makefile.
+
+.PHONY: lint
+lint:
+# No linting to do in this project.
+# This target exists to support `make lint-py` in the top-level Makefile.
+
+.PHONY: format
+format:
+# No formatting to do in this project.
+# This target exists to support `make format-py` in the top-level Makefile.

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -760,9 +760,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "anyio", specifier = "==4.9.0" },
-    { name = "atomicwrites", marker = "sys_platform == 'win32'", specifier = "==1.4.0" },
     { name = "build", specifier = "~=1.2.0" },
-    { name = "colorama", marker = "sys_platform == 'win32'", specifier = "==0.4.4" },
     { name = "coverage", specifier = "==7.4.1" },
     { name = "decoy", specifier = ">=2.2.0,<3" },
     { name = "hypothesis", specifier = ">=6.96.1,<7" },
@@ -831,9 +829,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "atomicwrites", marker = "sys_platform == 'win32'", specifier = "==1.4.0" },
     { name = "build", specifier = "~=1.2.0" },
-    { name = "colorama", marker = "sys_platform == 'win32'", specifier = "==0.4.4" },
     { name = "jsonschema", specifier = "==4.17.3" },
     { name = "mypy", specifier = "==1.19.1" },
     { name = "numpy", specifier = "==1.26.4" },


### PR DESCRIPTION
## Overview

The `docs/` project was omitted from the fix in #20683 because it wasn't included in our top-level Makefile's list of `PYTHON_DIRS`. This fixes that.

## Test Plan and Hands on Testing

The following top-level Makefile commands still work locally:

* [x] `make setup-py`
* [x] `make teardown-py`
* [x] `make lock-py`
* [x] `make lint-py`
* [x] `make format-py`

## Changelog

* Include `docs/` in `PYTHON_DIRS`.
* Add empty targets for `make -C docs lint`, `make -C docs test`, and `make -C docs format`, so that the top-level commands `make lint-py`, `make test-py`, and `make format-py` will still work.
* Add a real target for `make -C docs lock`.
* Run `make lock-py`, which now calls `make -C docs lock`, to make sure all Python lockfiles are up to date.

## Review requests

Any reason to keep `docs/` out of `PYTHON_DIRS`?

## Risk assessment

There's some risk of breaking a top-level command like `make lint-py`, but I tried to be careful about testing it.