### PR TITLE
feat(ai-server): increase token max

### DIFF
--- a/opentrons-ai-server/api/domain/anthropic_predict.py
+++ b/opentrons-ai-server/api/domain/anthropic_predict.py
@@ -55,7 +55,7 @@ REPO_ROOT: Path = Path(Path(__file__)).parent.parent.parent.parent
 class AnthropicPredict:
     def __init__(self, settings: Settings) -> None:
         self.settings: Settings = settings
-        self.max_tokens: int = 20000
+        self.max_tokens: int = settings.anthropic_max_tokens
         self.client: Anthropic = Anthropic(api_key=settings.anthropic_api_key.get_secret_value())
         self.model_name: str = settings.anthropic_model_name
         self.model_helper: str = settings.model_helper
@@ -283,15 +283,17 @@ class AnthropicPredict:
 
         # With the Files API, uploaded files should be automatically accessible
         # when file IDs are mentioned in the message content (which we do in _create_file_attachment_blocks)
-        response: Message = self.client.messages.create(  # type: ignore[call-overload]
+        # Use streaming to avoid the SDK's 10-minute limit for long-running requests (e.g. large max_tokens).
+        with self.client.messages.stream(
             max_tokens=self.max_tokens,
             messages=messages,
             model=self.model_name,
             system=self.system_prompt,
-            tools=self.tools,
+            tools=self.tools,  # type: ignore[arg-type]
             metadata={"user_id": user_id},
             temperature=0.0,
-        )
+        ) as stream:
+            response: Message = stream.get_final_message()
 
         logger.info(
             f"Token usage: {message_type.capitalize()}",
@@ -614,14 +616,16 @@ class AnthropicPredict:
 
             messages.append({"role": "user", "content": self.PROMPT_PD.format(USER_PROMPT=prompt)})
 
-            response: Message = self.client.messages.create(
+            # Use streaming to avoid the SDK's 10-minute limit for long-running requests.
+            with self.client.messages.stream(
                 max_tokens=self.max_tokens,
                 messages=messages,
                 model=self.model_name,
                 system=self.system_prompt_pd,
                 metadata={"user_id": user_id},
                 temperature=0.0,
-            )
+            ) as stream:
+                response: Message = stream.get_final_message()
             if response.content and response.content[0].type == "text":
                 response_text = response.content[0].text
                 return response_text

--- a/opentrons-ai-server/api/domain/anthropic_predict.py
+++ b/opentrons-ai-server/api/domain/anthropic_predict.py
@@ -9,7 +9,7 @@ import requests
 import structlog
 import weave
 from anthropic import Anthropic
-from anthropic.types import ContentBlockParam, DocumentBlockParam, Message, MessageParam, TextBlockParam
+from anthropic.types import ContentBlockParam, DocumentBlockParam, Message, MessageParam, TextBlockParam, ToolParam
 from weave.trace.context.call_context import set_tracing_enabled
 
 from api.domain.config_anthropic import DOCUMENTS, PROMPT, PROMPT_FIND_RELEVANT_DOCS, SYSTEM_PROMPT
@@ -88,7 +88,7 @@ class AnthropicPredict:
                 "content": [TextBlockParam(type="text", text=self.get_api_docs(), cache_control={"type": "ephemeral"})],
             }
         ]
-        self.tools: List[Dict[str, Any]] = [
+        self.tools: List[ToolParam] = [
             {
                 "name": "simulate_protocol",
                 "description": "Simulates the python protocol on user input. Returned value is text indicating if protocol is successful.",
@@ -289,7 +289,7 @@ class AnthropicPredict:
             messages=messages,
             model=self.model_name,
             system=self.system_prompt,
-            tools=self.tools,  # type: ignore[arg-type]
+            tools=self.tools,
             metadata={"user_id": user_id},
             temperature=0.0,
         ) as stream:

--- a/opentrons-ai-server/api/models/internal_server_error.py
+++ b/opentrons-ai-server/api/models/internal_server_error.py
@@ -3,7 +3,12 @@ from pydantic import BaseModel
 
 class InternalServerError(BaseModel):
     message: str = "Internal server error"
-    exception_object: Exception
+    exception_message: str = ""
 
-    class Config:
-        arbitrary_types_allowed = True
+    def __init__(self, *, exception_message: str = "", exception_object: Exception | None = None, **kwargs: object) -> None:
+        kwargs_copy = dict(kwargs)
+        kwargs_copy.pop("exception_object", None)
+        if exception_object is not None:
+            super().__init__(exception_message=str(exception_object), **kwargs_copy)
+        else:
+            super().__init__(exception_message=exception_message, **kwargs_copy)

--- a/opentrons-ai-server/api/settings.py
+++ b/opentrons-ai-server/api/settings.py
@@ -31,6 +31,7 @@ class Settings(BaseSettings):
     service_name: str = "local-ai-api"
     openai_model_name: str = "gpt-4-1106-preview"
     anthropic_model_name: str = "claude-sonnet-4-5-20250929"
+    anthropic_max_tokens: int = 64000
     model_helper: str = "claude-sonnet-4-5-20250929"
     model: str = "claude"
     auth0_domain: str = "opentrons-dev.us.auth0.com"


### PR DESCRIPTION
## Summary

Fixes customer 500 errors from the internal AI API: raises the Anthropic token limit to 64k (aligned with Claude 4.5), makes the limit configurable, fixes 500 response serialization, and uses streaming so long requests no longer hit the SDK’s 10-minute limit.

## Changes

### Token limit ([AUTH-2768](https://opentrons.atlassian.net/browse/AUTH-2768))

- **Setting**: Added `anthropic_max_tokens` to `api/settings.py` (default `64000`). Configurable via `ANTHROPIC_MAX_TOKENS` (env / `.env` / AWS Secrets Manager).
- **Usage**: `AnthropicPredict` now uses `settings.anthropic_max_tokens` instead of a hardcoded `20000`.

### 500 response serialization

- **Issue**: When the handler raised `HTTPException(500, detail=InternalServerError(exception_object=e).model_dump())`, the response body contained a non–JSON-serializable `Exception` instance, so FastAPI’s JSON response crashed with `TypeError: Object of type ValueError is not JSON serializable`.
- **Fix**: `InternalServerError` now uses `exception_message: str` instead of `exception_object: Exception`. The custom `__init__` still accepts `exception_object=` and sets `exception_message=str(exception_object)`, so existing call sites are unchanged and the 500 detail is always JSON-serializable.

### Long requests (10-minute limit)

- **Issue**: Anthropic’s SDK raises `ValueError` for non-streaming `messages.create()` calls that can run longer than 10 minutes (e.g. with 64k `max_tokens`).
- **Fix**: Main chat paths use the streaming API and then take the full message:
  - `_process_message`: `messages.stream(...)` then `stream.get_final_message()` (same kwargs as before).
  - `process_message_pd`: same pattern.
- `get_relevant_api_docs` still uses `messages.create()` (small `max_tokens`); unchanged.

## Deployment

- [x] Update Staging Environment Variables
- [x] Update Prod Environment Variables


[AUTH-2768]: https://opentrons.atlassian.net/browse/AUTH-2768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ