### PR TITLE
refactor(auth-server): Use shared utilities for access control

### DIFF
--- a/auth-server/auth_server/app.py
+++ b/auth-server/auth_server/app.py
@@ -8,10 +8,16 @@ from fastapi.openapi.docs import get_redoc_html
 from fastapi.responses import HTMLResponse
 
 from server_utils import systemd_utils
+from server_utils.auth.resource_server.fastapi_dependencies import (
+    install_authorization_checker,
+)
 
-from auth_server.oauth2.fastapi_dependencies import init_oauth2_backend
+from auth_server.authorization_checker import build_authorization_checker
+from auth_server.oauth2.backend import build as build_oauth2_backend
+from auth_server.oauth2.fastapi_dependencies import install_oauth2_backend
 from auth_server.oauth2.router import router as oauth2_router
 from auth_server.settings.router import router as settings_router
+from auth_server.settings.store import SettingsStore, install_settings_store
 from auth_server.users.router import router as users_router
 
 _REDOC_CDN_URL = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js"
@@ -19,7 +25,15 @@ _REDOC_CDN_URL = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    init_oauth2_backend(app.state)
+    settings_store = SettingsStore()
+    install_settings_store(app.state, settings_store)
+
+    oauth2_backend = build_oauth2_backend()
+    install_oauth2_backend(app.state, oauth2_backend)
+
+    authorization_checker = build_authorization_checker(settings_store, oauth2_backend)
+    install_authorization_checker(app.state, authorization_checker)
+
     systemd_utils.notify_up()
     yield
 

--- a/auth-server/auth_server/authorization_checker.py
+++ b/auth-server/auth_server/authorization_checker.py
@@ -1,0 +1,97 @@
+"""Setup to help this server enforce access control on its own endpoints.
+
+For background, this server acts as both:
+
+* An authorization server. We check user credentials, and return tokens to clients that
+  grant them access to various protected resources across the robot's HTTP APIs.
+* A resource server. We have our own protected resources, like `/auth/settings` and
+  `/auth/users`.
+
+This module helps with the resource server part, not the authorization server part.
+For the authorization server part, see the `oauth2` directory.
+
+Other resource servers, like robot-server, implement access control with an
+`AuthorizationChecker` that queries the auth-server (us) over a local HTTP request.
+(See the utilities in `server_utils`.) We want to share as much of that logic as
+possible, but we can't do it exactly the same way, because we *are* the auth server,
+and we don't have a clean way to connect to ourselves over HTTP. So, we use a special
+customized `AuthorizationChecker` that retrieves data directly from our internal stores
+instead of going over HTTP.
+"""
+
+from typing import Annotated, override
+
+import fastapi
+
+from server_utils.auth.resource_server.auth_server import (
+    CLIENT_ID,
+    AuthSettingsResponse,
+    Client,
+    TokenIntrospectionRequestFormData,
+    TokenIntrospectionResponse,
+)
+from server_utils.auth.resource_server.authorization_checker import (
+    AuthorizationChecker,
+    AuthServerAuthorizationChecker,
+)
+
+from auth_server.oauth2.backend import Backend as OAuth2Backend
+from auth_server.oauth2.fastapi_dependencies import get_oauth2_backend
+from auth_server.settings.store import SettingsStore, get_settings_store
+
+
+def build_authorization_checker(
+    settings_store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],
+    oauth2_backend: Annotated[OAuth2Backend, fastapi.Depends(get_oauth2_backend)],
+) -> AuthorizationChecker:
+    """Construct the server's singleton `AuthorizationChecker`."""
+    return AuthServerAuthorizationChecker(
+        client=_SelfClient(settings_store, oauth2_backend)
+    )
+
+
+class _SelfClient(Client):
+    """A client implementation where this server queries auth info from itself."""
+
+    def __init__(
+        self,
+        settings_store: SettingsStore,
+        oauth2_backend: OAuth2Backend,
+    ) -> None:
+        self._settings_store = settings_store
+        self._oauth2_backend = oauth2_backend
+
+    @override
+    async def get_auth_settings(self) -> AuthSettingsResponse:
+        # Mimic an HTTP response body from our own /auth/settings endpoint.
+        response_body = {
+            "data": self._settings_store.get().model_dump(mode="json", by_alias=True)
+        }
+        converted_response_body = AuthSettingsResponse.model_validate(response_body)
+        return converted_response_body
+
+    @override
+    async def introspect_token(self, token: str) -> TokenIntrospectionResponse:
+        # Mimic an HTTP request and response from our own /auth/oauth2/introspect endpoint.
+        request_form_data: TokenIntrospectionRequestFormData = {
+            "token": token,
+            "client_id": CLIENT_ID,
+        }
+        _raw_response_headers, raw_response_body, raw_response_status_code = (
+            self._oauth2_backend.create_introspect_response(
+                # The uri param apparently does not matter.
+                uri="",
+                # The type stubs are wrong; `body` can in fact be a `list[tuple[str, str]]`.
+                body=[(name, value) for name, value in request_form_data.items()],  # type: ignore[arg-type]
+            )
+        )
+        if not 200 <= raw_response_status_code < 300:
+            raise RuntimeError(
+                f"Internal token introspection request failed."
+                f" Status code: {raw_response_status_code}."
+                f" Body: {repr(raw_response_body)}."
+            )
+        parsed_response = TokenIntrospectionResponse.model_validate_json(
+            raw_response_body
+        )
+        return parsed_response

--- a/auth-server/auth_server/oauth2/__init__.py
+++ b/auth-server/auth_server/oauth2/__init__.py
@@ -1,0 +1,1 @@
+"""OAuth 2 standards compliant endpoints, and the code to support them."""

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -69,7 +69,8 @@ _validate_call_config: pydantic.ConfigDict = {
 class _RequestValidator(oauthlib.oauth2.RequestValidator):
     """Our main bindings to oauthlib.
 
-    oauthlib calls these methods internally. We implement them with
+    oauthlib calls these methods internally. We implement them with our customizations
+    for storage and validation.
 
     oauthlib has poor support for type checking, even with the stubs from Typeshed.
     So we use `@pydantic.validate_call` liberally to protect ourselves from

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -227,40 +227,6 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
 
     @override
     @pydantic.validate_call(config=_validate_call_config)
-    def validate_bearer_token(
-        self,
-        # Despite the docs, token can apparently be None if this is called
-        # through verify_request().
-        token: str | None,
-        scopes: list[str],
-        request: oauthlib.common.Request,
-    ) -> bool:
-        """Check if a bearer (access) token is allowed to access the given scopes."""
-        if token is None:
-            _log.info("The request provided no bearer token.")
-            return False
-
-        issuance = self.__token_store.find_active_access_token(token, now=_now())
-        if issuance is not None:
-            # find_active_access_token() already checked the expiration for us,
-            # so we just need to check scope membership.
-            requested_scopes = set(scopes)
-            issued_scopes = {scope.api_name for scope in issuance.scopes}
-            if requested_scopes.issubset(issued_scopes):
-                return True
-            else:
-                _log.info(
-                    f"The request provided a bearer token with insufficient scopes."
-                    f" Required: {requested_scopes}."
-                    f" Provided: {issued_scopes}."
-                )
-                return False
-        else:
-            _log.info("The request provided an expired or nonexistent bearer token.")
-            return False
-
-    @override
-    @pydantic.validate_call(config=_validate_call_config)
     def validate_refresh_token(  # type: ignore[override]
         self,
         refresh_token: str,

--- a/auth-server/auth_server/oauth2/fastapi_dependencies.py
+++ b/auth-server/auth_server/oauth2/fastapi_dependencies.py
@@ -8,17 +8,16 @@ from server_utils.fastapi_utils.app_state import (
     get_app_state,
 )
 
-from .backend import Backend, build
+from .backend import Backend
 
 _app_state_accessor = AppStateAccessor[Backend]("oauth2_backend")
 
 
-def init_oauth2_backend(app_state: AppState) -> None:
+def install_oauth2_backend(app_state: AppState, backend: Backend) -> None:
     """Initialize the server's singleton OAuth 2 backend and store it for later retrieval.
 
     This should be called once at server startup.
     """
-    backend = build()
     _app_state_accessor.set_on(app_state, backend)
 
 

--- a/auth-server/auth_server/oauth2/fastapi_dependencies.py
+++ b/auth-server/auth_server/oauth2/fastapi_dependencies.py
@@ -14,7 +14,7 @@ _app_state_accessor = AppStateAccessor[Backend]("oauth2_backend")
 
 
 def install_oauth2_backend(app_state: AppState, backend: Backend) -> None:
-    """Initialize the server's singleton OAuth 2 backend and store it for later retrieval.
+    """Store the server's singleton OAuth 2 backend in server state for later retrieval.
 
     This should be called once at server startup.
     """

--- a/auth-server/auth_server/oauth2/router.py
+++ b/auth-server/auth_server/oauth2/router.py
@@ -1,4 +1,4 @@
-"""HTTP routes to implement OAuth 2 flows."""
+"""HTTP routes to implement OAuth 2 flows, as an authorization server."""
 
 from typing import Annotated
 

--- a/auth-server/auth_server/settings/router.py
+++ b/auth-server/auth_server/settings/router.py
@@ -3,6 +3,8 @@ from typing import Annotated
 
 import fastapi
 
+from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.models.json_api import (
     RequestModel,
     SimpleBody,
@@ -36,10 +38,11 @@ async def get_settings(  # noqa: D103
         The new settings are returned.
         """
     ),
+    dependencies=[fastapi.Depends(require_scopes(Scope.AUTH_SETTINGS_WRITE))],
 )
 async def patch_settings(  # noqa: D103
     request_body: RequestModel[PatchSettingsRequestData],
-    store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)]
+    store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],
 ) -> SimpleBody[SettingsResponseData]:
     store.patch(request_body.data)
     new_settings = store.get()
@@ -56,6 +59,7 @@ async def patch_settings(  # noqa: D103
         The new settings are returned.
         """
     ),
+    dependencies=[fastapi.Depends(require_scopes(Scope.AUTH_SETTINGS_WRITE))],
 )
 async def delete_settings(  # noqa: D103
     store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],

--- a/auth-server/auth_server/settings/store.py
+++ b/auth-server/auth_server/settings/store.py
@@ -47,7 +47,12 @@ class SettingsStore:
 _accessor = AppStateAccessor[SettingsStore]("settings_store")
 
 
-async def get_settings_store(
+def install_settings_store(app_state: AppState, settings_store: SettingsStore) -> None:
+    """Place the server's singleton SettingsStore in server state, for later retrieval by get_settings_store()."""
+    _accessor.set_on(app_state, settings_store)
+
+
+def get_settings_store(
     app_state: Annotated[AppState, fastapi.Depends(get_app_state)],
 ) -> SettingsStore:
     """Return the server's singleton SettingsStore."""

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -2,6 +2,7 @@ from typing import Annotated
 
 import fastapi
 
+from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.models.json_api import (
     PydanticResponse,
@@ -21,27 +22,6 @@ from auth_server.users.store import (
 )
 
 router = fastapi.APIRouter()
-
-
-def _verify_scopes(
-    request: fastapi.Request,
-    oauth2_backend: Backend,
-    scopes: list[Scope],
-    body: str | None = None,
-) -> None:
-    """Verify OAuth2 scopes. Raises 403 if invalid."""
-    valid, _ = oauth2_backend.verify_request(
-        str(request.url),
-        http_method=request.method,  # type: ignore[arg-type]
-        body=body,
-        headers=dict(request.headers),
-        scopes=[scope.api_name for scope in scopes],
-    )
-    if not valid:
-        raise fastapi.HTTPException(
-            status_code=fastapi.status.HTTP_403_FORBIDDEN,
-            detail="Forbidden",
-        )
 
 
 def _validate_user_create_input(
@@ -81,6 +61,7 @@ def _validate_user_create_input(
     responses={
         fastapi.status.HTTP_201_CREATED: {"model": SimpleBody[UserResponse]},
     },
+    dependencies=[fastapi.Depends(require_scopes(Scope.USERS_WRITE))],
 )
 async def post_users(
     request: fastapi.Request,
@@ -88,8 +69,9 @@ async def post_users(
     oauth2_backend: Annotated[Backend, fastapi.Depends(get_oauth2_backend)],
 ) -> PydanticResponse[SimpleBody[UserResponse]]:
     """Create a user."""
-    scopes_required = [Scope.USERS_WRITE]
-    _verify_scopes(request, oauth2_backend, scopes_required)
+    # todo(mm, 2026-02-20): The new user's scopes should either depend on their account type,
+    # or they should be passed in the request body.
+    scopes_for_new_user = [Scope.USERS_WRITE]
     user_create = request_body.data
     _validate_user_create_input(
         user_create.userName,
@@ -108,7 +90,7 @@ async def post_users(
         password=user_create.password.get_secret_value(),
         full_name=user_create.fullName,
         account_type=user_create.accountType,
-        scopes=scopes_required,
+        scopes=scopes_for_new_user,
     )
     return await PydanticResponse.create(
         status_code=fastapi.status.HTTP_201_CREATED,
@@ -125,6 +107,7 @@ async def post_users(
         fastapi.status.HTTP_200_OK: {"model": SimpleBody[UserResponse]},
         fastapi.status.HTTP_404_NOT_FOUND: {"userNotFound": None},
     },
+    dependencies=[fastapi.Depends(require_scopes(Scope.USERS_READ))],
 )
 async def get_user(
     request: fastapi.Request,
@@ -132,7 +115,6 @@ async def get_user(
     oauth2_backend: Annotated[Backend, fastapi.Depends(get_oauth2_backend)],
 ) -> PydanticResponse[SimpleBody[UserResponse]]:
     """Get a user by its unique identifier."""
-    _verify_scopes(request, oauth2_backend, [Scope.USERS_WRITE])
     user = get(userName)
     if user is None:
         raise fastapi.HTTPException(
@@ -153,6 +135,7 @@ async def get_user(
     responses={
         fastapi.status.HTTP_204_NO_CONTENT: {"description": "User deleted"},
     },
+    dependencies=[fastapi.Depends(require_scopes(Scope.USERS_WRITE))],
 )
 async def delete_user(
     request: fastapi.Request,
@@ -160,7 +143,6 @@ async def delete_user(
     oauth2_backend: Annotated[Backend, fastapi.Depends(get_oauth2_backend)],
 ) -> PydanticResponse[SimpleEmptyBody]:
     """Delete a user by its unique identifier."""
-    _verify_scopes(request, oauth2_backend, [Scope.USERS_WRITE])
     user = get(userName)
     if user is None:
         raise fastapi.HTTPException(status_code=fastapi.status.HTTP_404_NOT_FOUND)
@@ -179,6 +161,7 @@ async def delete_user(
     responses={
         fastapi.status.HTTP_200_OK: {"model": SimpleBody[UserResponse]},
     },
+    dependencies=[fastapi.Depends(require_scopes(Scope.USERS_WRITE))],
 )
 async def update_user(
     request: fastapi.Request,
@@ -187,7 +170,6 @@ async def update_user(
     oauth2_backend: Annotated[Backend, fastapi.Depends(get_oauth2_backend)],
 ) -> PydanticResponse[SimpleBody[UserResponse]]:
     """Update a user by its unique identifier."""
-    _verify_scopes(request, oauth2_backend, [Scope.USERS_WRITE])
     update_user = request_body.data
     _validate_user_create_input(
         user_name=update_user.userName,

--- a/auth-server/tests/integration/conftest.py
+++ b/auth-server/tests/integration/conftest.py
@@ -1,0 +1,26 @@
+import httpx
+import pytest
+
+from ..dev_server import DevServer
+
+_ADMIN_USERNAME = "test_admin"
+_ADMIN_PASSWORD = "test_admin_password"
+_CLIENT_ID = "opentrons_app"
+
+
+@pytest.fixture
+async def admin_access_token(run_server: DevServer) -> str:
+    """ "Log in" as an admin and return an access token with admin privileges."""
+    async with httpx.AsyncClient() as client:
+        response = await client.post(
+            f"{run_server.base_url}/auth/oauth2/token",
+            data={
+                "client_id": _CLIENT_ID,
+                "grant_type": "password",
+                "username": _ADMIN_USERNAME,
+                "password": _ADMIN_PASSWORD,
+            },
+        )
+        response.raise_for_status()
+        body = response.json()
+    return f"Bearer {body['access_token']}"

--- a/auth-server/tests/integration/test_oauth_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_oauth_flows.tavern.yaml
@@ -21,7 +21,7 @@ stages:
         refresh_token: !anystr
         expires_in: !anyint
         token_type: Bearer
-        scope: runs.write users.read users.write
+        scope: &default_scope auth_settings.write runs.write users.read users.write
       save:
         json:
           initial_access_token: access_token
@@ -39,7 +39,7 @@ stages:
       json:
         active: true
         username: test_admin
-        scope: runs.write users.read users.write
+        scope: *default_scope
 
   - name: Introspect the refresh token to confirm that it's active
     request:
@@ -53,7 +53,7 @@ stages:
       json:
         active: true
         username: test_admin
-        scope: runs.write users.read users.write
+        scope: *default_scope
 
   - name: Exchange the refresh token for a new access token and refresh token
     request:
@@ -70,7 +70,7 @@ stages:
         refresh_token: !anystr
         expires_in: !anyint
         token_type: Bearer
-        scope: runs.write users.read users.write
+        scope: *default_scope
       save:
         json:
           refreshed_access_token: access_token
@@ -88,7 +88,7 @@ stages:
       json:
         active: true
         username: test_admin
-        scope: runs.write users.read users.write
+        scope: *default_scope
 
   - name: Introspect the new refresh token to confirm that it's active
     request:
@@ -102,7 +102,7 @@ stages:
       json:
         active: true
         username: test_admin
-        scope: runs.write users.read users.write
+        scope: *default_scope
 
 ---
 test_name: Getting a token should fail if the request asks for scopes beyond what the user is authorized for
@@ -209,7 +209,7 @@ stages:
         refresh_token: !anystr
         expires_in: !anyint
         token_type: Bearer
-        scope: runs.write users.read users.write
+        scope: auth_settings.write runs.write users.read users.write
       save:
         json:
           refresh_token: refresh_token

--- a/auth-server/tests/integration/test_protected_resource_access.tavern.yaml
+++ b/auth-server/tests/integration/test_protected_resource_access.tavern.yaml
@@ -5,6 +5,16 @@ marks:
       - run_server
 
 stages:
+  - name: Enable access control so protected resources require a valid token
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      json:
+        data:
+          accessControlEnabled: true
+    response:
+      status_code: 200
+
   - name: Accessing the resource without a token should fail
     request:
       method: POST
@@ -16,7 +26,7 @@ stages:
           fullName: Test User
           accountType: user
     response:
-      status_code: 403
+      status_code: 401
 
   - name: Accessing the resource with a bogus token should fail
     request:
@@ -31,7 +41,7 @@ stages:
       headers:
         Authorization: Bearer bogus_token_1234
     response:
-      status_code: 403
+      status_code: 401
 
   - name: Get an access token with insufficient scopes
     request:
@@ -42,7 +52,7 @@ stages:
         grant_type: password
         username: test_admin
         password: test_admin_password
-        scope: runs.write # Omit users.write.
+        scope: users.read runs.write # Omit users.write.
     response:
       status_code: 200
       json:
@@ -50,7 +60,7 @@ stages:
         refresh_token: !anystr
         expires_in: !anyint
         token_type: Bearer
-        scope: runs.write
+        scope: users.read runs.write
       save:
         json:
           access_token: access_token

--- a/auth-server/tests/integration/test_settings.tavern.yaml
+++ b/auth-server/tests/integration/test_settings.tavern.yaml
@@ -21,6 +21,7 @@ test_name: PATCH updates and returns new settings
 marks:
   - usefixtures:
       - run_server
+      - admin_access_token
 
 stages:
   - name: GET initial settings (accessControlEnabled false by default)
@@ -37,6 +38,8 @@ stages:
     request:
       method: PATCH
       url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
       json:
         data:
           accessControlEnabled: true
@@ -60,6 +63,8 @@ stages:
     request:
       method: PATCH
       url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
       json:
         data:
           accessControlEnabled: false
@@ -82,12 +87,15 @@ test_name: PATCH with null field leaves value unchanged
 marks:
   - usefixtures:
       - run_server
+      - admin_access_token
 
 stages:
   - name: PATCH to enable access control
     request:
       method: PATCH
       url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
       json:
         data:
           accessControlEnabled: true
@@ -101,6 +109,8 @@ stages:
     request:
       method: PATCH
       url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
       json:
         data:
           accessControlEnabled: null
@@ -116,12 +126,15 @@ test_name: DELETE resets to defaults
 marks:
   - usefixtures:
       - run_server
+      - admin_access_token
 
 stages:
   - name: PATCH to change some settings
     request:
       method: PATCH
       url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
       json:
         data:
           accessControlEnabled: true
@@ -135,6 +148,8 @@ stages:
     request:
       method: DELETE
       url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
     response:
       status_code: 200
       json:

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -3,30 +3,9 @@ test_name: Successful Create, delete, and update User flow
 marks:
   - usefixtures:
       - run_server
+      - admin_access_token
 
 stages:
-  - name: Get an access token with sufficient scopes
-    request:
-      method: POST
-      url: '{run_server.base_url}/auth/oauth2/token'
-      data:
-        client_id: opentrons_app
-        grant_type: password
-        username: test_admin
-        password: test_admin_password
-        scope: users.write users.read
-    response:
-      status_code: 200
-      json:
-        access_token: !anystr
-        refresh_token: !anystr
-        expires_in: !anyint
-        token_type: Bearer
-        scope: users.write users.read
-      save:
-        json:
-          first_access_token: access_token
-
   - name: Create a new user
     request:
       method: POST
@@ -37,8 +16,8 @@ stages:
           password: securepassword123
           fullName: Test New User
           accountType: user
-      headers:  
-        Authorization: 'Bearer {first_access_token}'
+      headers:
+        Authorization: '{admin_access_token}'
     response:
       status_code: 201
       json:
@@ -52,8 +31,8 @@ stages:
     request:
       method: POST
       url: '{run_server.base_url}/auth/users'
-      headers:  
-        Authorization: 'Bearer {first_access_token}'
+      headers:
+        Authorization: '{admin_access_token}'
       json:
         data:
           userName: test_new_user_password_less_than_8_characters
@@ -69,8 +48,8 @@ stages:
     request:
       method: GET
       url: '{run_server.base_url}/auth/users/test_new_user'
-      headers:  
-        Authorization: 'Bearer {first_access_token}'
+      headers:
+        Authorization: '{admin_access_token}'
     response:
       status_code: 200
       json:
@@ -88,8 +67,8 @@ stages:
         data:
           fullName: Test New User Updated
           accountType: admin
-      headers:  
-        Authorization: 'Bearer {first_access_token}'
+      headers:
+        Authorization: '{admin_access_token}'
     response:
       status_code: 200
       json:
@@ -107,8 +86,8 @@ stages:
         data:
           userName: test_new_user_updated
           password: securepassword123
-      headers:  
-        Authorization: 'Bearer {first_access_token}'
+      headers:
+        Authorization: '{admin_access_token}'
     response:
       status_code: 200
       json:
@@ -127,25 +106,19 @@ stages:
         grant_type: password
         username: test_new_user_updated
         password: securepassword123
-        scope: users.write
     response:
       status_code: 200
       json:
         access_token: !anystr
-        refresh_token: !anystr
-        expires_in: !anyint
-        token_type: Bearer
-        scope: users.write
-      save:
-        json:
-          access_token: access_token
+      strict:
+        - json:off
 
   - name: Delete the user
     request:
       method: DELETE
       url: '{run_server.base_url}/auth/users/test_new_user_updated'
-      headers:  
-        Authorization: 'Bearer {access_token}'
+      headers:
+        Authorization: '{admin_access_token}'
     response:
       status_code: 200
 
@@ -153,7 +126,7 @@ stages:
     request:
       method: GET
       url: '{run_server.base_url}/auth/users/test_new_user_updated'
-      headers:  
-        Authorization: 'Bearer {first_access_token}'
+      headers:
+        Authorization: '{admin_access_token}'
     response:
       status_code: 404

--- a/robot-server/robot_server/app_setup.py
+++ b/robot-server/robot_server/app_setup.py
@@ -11,7 +11,8 @@ from fastapi.responses import HTMLResponse
 
 from opentrons import __version__
 from server_utils.auth.resource_server.fastapi_dependencies import (
-    set_up_authorization_checker,
+    build_authorization_checker,
+    install_authorization_checker,
 )
 from server_utils.fastapi_utils.server_timing_middleware import server_timing_middleware
 
@@ -94,13 +95,13 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         )
         exit_stack.push_async_callback(clean_up_persistence, app.state)
 
-        await exit_stack.enter_async_context(
-            set_up_authorization_checker(
-                app.state,
+        authorization_checker = await exit_stack.enter_async_context(
+            build_authorization_checker(
                 auth_server_uds=settings.auth_server_uds,
                 auth_server_url=settings.auth_server_url,
             )
         )
+        install_authorization_checker(app.state, authorization_checker)
 
         exit_stack.enter_context(set_up_notification_client(app.state))
         initialize_pe_publisher_notifier(app.state)

--- a/server-utils/server_utils/auth/resource_server/auth_server.py
+++ b/server-utils/server_utils/auth/resource_server/auth_server.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import contextlib
 import typing
+from abc import ABC, abstractmethod
 
 import aiohttp
 import pydantic
@@ -23,12 +24,34 @@ TOKEN_INTROSPECTION_ENDPOINT_PATH = "auth/oauth2/introspect"
 # we should find a fix or workaround contained to auth-server, and not provide a client_id
 # in our requests here. If it isn't, we should use a client_id separate from the
 # Opentrons App, like "opentrons_resource_server" or something.
-_CLIENT_ID: ClientIDType = "opentrons_app"
+CLIENT_ID: ClientIDType = "opentrons_app"
 ClientIDType: typing.TypeAlias = typing.Literal["opentrons_app"]
 
 
-class Client:
-    """A client to interact with auth-server."""
+class Client(ABC):
+    """An interface for a resource server to query the Opentrons auth-server."""
+
+    @abstractmethod
+    async def get_auth_settings(self) -> AuthSettingsResponse:
+        """Ask the Opentrons auth-server what the current system-wide auth settings are.
+
+        If there's an internal error (e.g. the auth server is unconnectable),
+        the implementation should raise it as an exception.
+        """
+        pass
+
+    @abstractmethod
+    async def introspect_token(self, token: str) -> TokenIntrospectionResponse:
+        """Ask the Opentrons auth-server for information about an access token.
+
+        If there's an internal error (e.g. the auth server is unconnectable),
+        the implementation should raise it as an exception.
+        """
+        pass
+
+
+class LocalHTTPClient(Client):
+    """A client implementation that talks to auth-server over a local HTTP connection."""
 
     def __init__(
         self, *, auth_server_uds: str | None = None, auth_server_url: str | None = None
@@ -66,19 +89,19 @@ class Client:
         """When exited as a context manager, close the underlying connection."""
         await self._exit_stack.aclose()
 
+    @typing.override
     async def get_auth_settings(self) -> AuthSettingsResponse:
-        """Ask the auth server what the current system-wide auth settings are."""
         async with self._session.get(SETTINGS_ENDPOINT_PATH) as response:
             response_bytes = await response.read()
         response.raise_for_status()
         parsed_response = AuthSettingsResponse.model_validate_json(response_bytes)
         return parsed_response
 
+    @typing.override
     async def introspect_token(self, token: str) -> TokenIntrospectionResponse:
-        """Ask the auth server for information about an access token."""
         request_form_data: TokenIntrospectionRequestFormData = {
             "token": token,
-            "client_id": _CLIENT_ID,
+            "client_id": CLIENT_ID,
         }
 
         async with self._session.post(
@@ -116,12 +139,12 @@ class TokenIntrospectionRequestFormData(typing.TypedDict):
 
 
 class AuthSettingsResponse(_StrictBaseModel):
-    """A response body from auth-server's settings endpoint."""
+    """A response body from auth-server's /settings endpoint."""
 
     data: AuthSettingsResponseData
 
 
 class AuthSettingsResponseData(_StrictBaseModel):
-    """Response body data from auth-server's settings endpoint."""
+    """Response body data from auth-server's /settings endpoint."""
 
     accessControlEnabled: bool

--- a/server-utils/server_utils/auth/resource_server/fastapi_dependencies.py
+++ b/server-utils/server_utils/auth/resource_server/fastapi_dependencies.py
@@ -15,8 +15,7 @@ from typing import (
 import fastapi
 import fastapi.security
 
-from .auth_server import TOKEN_ENDPOINT_PATH
-from .auth_server import Client as AuthServerClient
+from .auth_server import TOKEN_ENDPOINT_PATH, LocalHTTPClient
 from .authorization_checker import (
     AlwaysAllowedAuthorizationChecker,
     AuthorizationChecker,
@@ -121,16 +120,28 @@ def require_scopes(*required_scopes: Scope) -> Callable[..., Awaitable[None]]:
     return dependency
 
 
+def install_authorization_checker(
+    app_state: AppState,
+    authorization_checker: AuthorizationChecker,
+) -> None:
+    """Store a singleton `AuthorizationChecker` in global server state for later retrieval.
+
+    This should be called once during server initialization.
+    """
+    _authorization_checker_accessor.set_on(app_state, authorization_checker)
+
+
 @asynccontextmanager
-async def set_up_authorization_checker(
-    app_state: AppState, *, auth_server_uds: str | None = None, auth_server_url: str | None = None
-) -> AsyncGenerator[None, None]:
-    """Set up the server's singleton `AuthorizationChecker`.
+async def build_authorization_checker(
+    *, auth_server_uds: str | None = None, auth_server_url: str | None = None
+) -> AsyncGenerator[AuthorizationChecker, None]:
+    """Build an `AuthorizationChecker` appropriately configured for most servers.
 
-    When this context manager is entered, the `AuthorizationChecker` is initialized
-    and placed on `app_state` for later retrieval via `_get_notification_client()`.
-
-    When this context manager is exited, the `AuthorizationChecker` is cleaned up.
+    `auth_server_uds` (a path to a Unix domain socket) or `auth_server_url` (a URL like
+    http://localhost:1234) describes how to connect to the auth-server. These should
+    typically be taken from CLI options or environment variables. If neither are
+    specified, a dummy `AuthorizationChecker` is returned that allows unauthenticated
+    access to everything.
     """
     if auth_server_uds is None and auth_server_url is None:
         _log.info(
@@ -138,20 +149,13 @@ async def set_up_authorization_checker(
             " Access control will be disabled."
             " (This is normal in dev mode and on OT-2s.)"
         )
-        authorization_checker: AuthorizationChecker = (
-            AlwaysAllowedAuthorizationChecker()
-        )
-        _authorization_checker_accessor.set_on(app_state, authorization_checker)
-        yield
+        yield AlwaysAllowedAuthorizationChecker()
 
     else:
-        async with AuthServerClient(
-            auth_server_uds=auth_server_uds,
-            auth_server_url=auth_server_url
+        async with LocalHTTPClient(
+            auth_server_uds=auth_server_uds, auth_server_url=auth_server_url
         ) as client:
-            authorization_checker = AuthServerAuthorizationChecker(client)
-            _authorization_checker_accessor.set_on(app_state, authorization_checker)
-            yield
+            yield AuthServerAuthorizationChecker(client)
 
 
 def _get_authorization_checker(

--- a/server-utils/server_utils/auth/scopes.py
+++ b/server-utils/server_utils/auth/scopes.py
@@ -19,7 +19,15 @@ class Scope(enum.Enum):
     # "api_name" is exposed as part of the HTTP API, and may be stored persistently.
     # "description" is developer-readable documentation for the OpenAPI spec.
 
-    # todo(mm, 2026-01-28): Replace these placeholder scopes with real ones.
+    AUTH_SETTINGS_WRITE = (
+        "auth_settings.write",
+        "Edit settings related to authentication, authorization, and access control.",
+    )
+
+    RUNS_WRITE = (
+        "runs.write",
+        "Create and control protocol runs.",
+    )
 
     USERS_READ = (
         "users.read",
@@ -28,12 +36,7 @@ class Scope(enum.Enum):
 
     USERS_WRITE = (
         "users.write",
-        "Read, write, and edit users.",
-    )
-
-    RUNS_WRITE = (
-        "runs.write",
-        "Create and control protocol runs.",
+        "Create, update, and delete users.",
     )
 
     _description: str


### PR DESCRIPTION
## Overview

This takes the access control pattern established in #20870 for robot-server and extends it to auth-server. This also adds access control on the `/settings` endpoints, which didn't have it yet.

Closes EXEC-2367.

## Test Plan and Hands on Testing

We're covered by existing integration tests.

## Changelog

Endpoints in auth-server can now use `require_scopes()`, consistent with robot-server.

```python
@router.post(
    path="/auth/users",
    ...,
    dependencies=[fastapi.Depends(require_scopes(Scope.USERS_WRITE))],
)
def post_users(...):
    ...
```

In robot-server, `require_scopes()` works by sending out a local HTTP request to auth-server. auth-server can't exactly do that, because it *is* auth-server, so it would be talking to itself. It needs some alternative implementation. But we want to share as much code as possible. So the main point of this PR is to find what we want to be that common core.

#20870 established that robot-server works like this:

1. A request hits a protected endpoint (e.g. `POST /runs`).
2. We call `require_scopes()` as a FastAPI dependency.
3. `require_scopes()` calls `AuthorizationChecker.check()`.
4. `AuthorizationChecker.check()` calls `HTTPClient.get_auth_settings()` and `HTTPClient.introspect_token()`. They retrieve some information from the external auth-server process, over HTTP.
5. Based on that information, `AuthorizationChecker.check()` approves or denies the request.

And now, with this PR, auth-server works exactly the same way, except for step 4, where:

4. `AuthorizationChecker.check()` calls **`_SelfClient.get_auth_settings()`** and **`_SelfClient.introspect_token()`**. They retrieve some information **directly from the server's internal Python objects.** 

## Review requests

Does this seem like the right approach? Potential alternatives:

* Make auth-server actually issue a full HTTP request to itself.
  * I gave up on this because Uvicorn doesn't make it easy to programmatically find out what socket or IP+port we're running on. :(
* Directly call the ASGI app.
  * e.g. with HTTPX and [Starlette's `TestClient`](https://starlette.dev/testclient/) (even though we're not running in tests)
  * Or with AIOHTTP and https://github.com/thearchitector/aiohttp-asgi-connector
* Use oauthlib's [`verify_request()`](https://oauthlib.readthedocs.io/en/latest/oauth2/endpoints/resource.html), like we were doing before.
  * But that means we can't share the scope validation code, or the error response generation code.

## Risk assessment

Low. This only affects auth-server's own resources (`/users` and `/settings`), which are covered by existing integration tests.