### PR TITLE
feat(robot-server, api): fetch command annotations from current run

### DIFF
--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -154,7 +154,7 @@ class CommandPointer:
 class CommandAnnotationsSlice:
     """A subset of all commands annotations in state."""
 
-    command_annotations: List[UserCommandAnnotation]
+    command_annotations: List[CommandAnnotation]
     cursor: int
     total_length: int
 
@@ -965,13 +965,17 @@ class CommandView:
         """Return a list of all commands annotated so far."""
         return [annotation for annotation in self._state.command_annotations.values()]
 
-    def get_command_annotations_slice(self, cursor: int, length: int) -> CommandAnnotationsSlice:
+    def get_command_annotations_slice(
+        self, cursor: int, length: int
+    ) -> CommandAnnotationsSlice:
         """Get a subset of command annotations around a given cursor."""
         # start is inclusive, stop is exclusive
         all_annotations = list(self._state.command_annotations.values())
         total_length = len(all_annotations)
-        actual_cursor = max(0, min(cursor, total_length - 1))   # 0 <= cursor < total_length
-        stop = min(total_length, actual_cursor + length)    # stop <= total_length
+        actual_cursor = max(
+            0, min(cursor, total_length - 1)
+        )  # 0 <= cursor < total_length
+        stop = min(total_length, actual_cursor + length)  # stop <= total_length
 
         sliced_annotations = all_annotations[actual_cursor:stop]
         return CommandAnnotationsSlice(

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -151,6 +151,15 @@ class CommandPointer:
 
 
 @dataclass(frozen=True)
+class CommandAnnotationsSlice:
+    """A subset of all commands annotations in state."""
+
+    command_annotations: List[UserCommandAnnotation]
+    cursor: int
+    total_length: int
+
+
+@dataclass(frozen=True)
 class _RecoveryTargetInfo:
     """Info about the failed command that we're currently recovering from."""
 
@@ -955,6 +964,21 @@ class CommandView:
     def get_all_command_annotations(self) -> List[CommandAnnotation]:
         """Return a list of all commands annotated so far."""
         return [annotation for annotation in self._state.command_annotations.values()]
+
+    def get_command_annotations_slice(self, cursor: int, length: int) -> CommandAnnotationsSlice:
+        """Get a subset of command annotations around a given cursor."""
+        # start is inclusive, stop is exclusive
+        all_annotations = list(self._state.command_annotations.values())
+        total_length = len(all_annotations)
+        actual_cursor = max(0, min(cursor, total_length - 1))   # 0 <= cursor < total_length
+        stop = min(total_length, actual_cursor + length)    # stop <= total_length
+
+        sliced_annotations = all_annotations[actual_cursor:stop]
+        return CommandAnnotationsSlice(
+            command_annotations=sliced_annotations,
+            cursor=actual_cursor,
+            total_length=total_length,
+        )
 
     def get_recovery_target(self) -> Optional[CommandPointer]:
         """Return the command currently undergoing error recovery, if any."""

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -6,6 +6,8 @@ import enum
 from typing import Any, AsyncGenerator, Dict, List, Mapping, Optional, Tuple, Union
 
 from anyio import move_on_after
+from opentrons.protocol_engine.state.commands import CommandAnnotationsSlice
+from opentrons.protocol_engine.types import UserCommandAnnotation
 
 from opentrons_shared_data.errors import GeneralError
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
@@ -275,13 +277,21 @@ class RunOrchestrator:
             else self._protocol_runner.run_time_parameters
         )
 
-    def get_command_annotations(self) -> List[LegacyCommandAnnotation]:
-        """Get the list of command annotations defined in the protocol, if any."""
+    def get_all_legacy_command_annotations(self) -> List[LegacyCommandAnnotation]:
+        """Get the list of legacy command annotations defined in the protocol, if any."""
         return (
             []
             if self._protocol_runner is None
             else self._protocol_runner.command_annotations
         )
+
+    def get_total_command_annotations_count(self) -> int:
+        """Get the total number of command annotations defined in the protocol, if any."""
+        return len(self._protocol_engine.state_view.commands.get_all_command_annotations())
+
+    def get_command_annotation(self, annotation_id: str) -> UserCommandAnnotation:
+        """Get the command annotation by ID."""
+        return self._protocol_engine.state_view.commands.get_command_annotation(annotation_id)
 
     def get_current_command(self) -> Optional[CommandPointer]:
         """Get the "current" command, if any."""
@@ -313,6 +323,12 @@ class RunOrchestrator:
         """
         return self._protocol_engine.state_view.commands.get_slice(
             cursor=cursor, length=length, include_fixit_commands=include_fixit_commands
+        )
+
+    def get_command_annotations_slice(self, cursor: int, length: int) -> CommandAnnotationsSlice:
+        """Get a slice of run annotations commands."""
+        return self._protocol_engine.state_view.commands.get_command_annotations_slice(
+            cursor=cursor, length=length
         )
 
     def get_command_error_slice(

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -6,8 +6,6 @@ import enum
 from typing import Any, AsyncGenerator, Dict, List, Mapping, Optional, Tuple, Union
 
 from anyio import move_on_after
-from opentrons.protocol_engine.state.commands import CommandAnnotationsSlice
-from opentrons.protocol_engine.types import UserCommandAnnotation
 
 from opentrons_shared_data.errors import GeneralError
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
@@ -53,6 +51,8 @@ from ..protocol_engine.types import (
 from ..protocol_reader import JsonProtocolConfig, ProtocolSource, PythonProtocolConfig
 from ..protocols.parse import PythonParseMode
 from . import JsonRunner, PythonAndLegacyRunner, RunResult, protocol_runner
+from opentrons.protocol_engine.state.commands import CommandAnnotationsSlice
+from opentrons.protocol_engine.types import CommandAnnotation
 from opentrons.types import NozzleMapInterface
 
 
@@ -287,11 +287,15 @@ class RunOrchestrator:
 
     def get_total_command_annotations_count(self) -> int:
         """Get the total number of command annotations defined in the protocol, if any."""
-        return len(self._protocol_engine.state_view.commands.get_all_command_annotations())
+        return len(
+            self._protocol_engine.state_view.commands.get_all_command_annotations()
+        )
 
-    def get_command_annotation(self, annotation_id: str) -> UserCommandAnnotation:
+    def get_command_annotation(self, annotation_id: str) -> CommandAnnotation:
         """Get the command annotation by ID."""
-        return self._protocol_engine.state_view.commands.get_command_annotation(annotation_id)
+        return self._protocol_engine.state_view.commands.get_command_annotation(
+            annotation_id
+        )
 
     def get_current_command(self) -> Optional[CommandPointer]:
         """Get the "current" command, if any."""
@@ -325,7 +329,9 @@ class RunOrchestrator:
             cursor=cursor, length=length, include_fixit_commands=include_fixit_commands
         )
 
-    def get_command_annotations_slice(self, cursor: int, length: int) -> CommandAnnotationsSlice:
+    def get_command_annotations_slice(
+        self, cursor: int, length: int
+    ) -> CommandAnnotationsSlice:
         """Get a slice of run annotations commands."""
         return self._protocol_engine.state_view.commands.get_command_annotations_slice(
             cursor=cursor, length=length

--- a/api/src/opentrons/protocol_runner/run_orchestrator.py
+++ b/api/src/opentrons/protocol_runner/run_orchestrator.py
@@ -332,7 +332,7 @@ class RunOrchestrator:
     def get_command_annotations_slice(
         self, cursor: int, length: int
     ) -> CommandAnnotationsSlice:
-        """Get a slice of run annotations commands."""
+        """Get a slice of command annotations in the run."""
         return self._protocol_engine.state_view.commands.get_command_annotations_slice(
             cursor=cursor, length=length
         )

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -28,6 +28,7 @@ from opentrons.protocol_engine.errors.exceptions import (
 )
 from opentrons.protocol_engine.notes.notes import CommandNote
 from opentrons.protocol_engine.state.commands import (
+    CommandAnnotationsSlice,
     CommandErrorSlice,
     CommandStore,
     CommandView,
@@ -1438,3 +1439,100 @@ def test_get_all_command_annotations() -> None:
             params={"a": 1},
         ),
     ]
+
+
+def test_get_command_annotations_slice_empty() -> None:
+    """It should return an empty slice when there are no annotations."""
+    subject = CommandStore(
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+        is_door_open=False,
+    )
+    subject_view = CommandView(subject.state)
+
+    result = subject_view.get_command_annotations_slice(cursor=0, length=10)
+
+    assert result == CommandAnnotationsSlice(
+        command_annotations=[],
+        cursor=0,
+        total_length=0,
+    )
+
+
+_sample_command_annotations = [
+    UserCommandAnnotation(
+        annotationId="annotation-1",
+        userSpecifiedName="Step 1",
+        userSpecifiedDescription="Step 1 description",
+        params={},
+    ),
+    UserCommandAnnotation(
+        annotationId="annotation-2",
+        userSpecifiedName="Step 2",
+        userSpecifiedDescription="Step 2 description",
+        params={},
+    ),
+    UserCommandAnnotation(
+        annotationId="annotation-3",
+        userSpecifiedName="Step 3",
+        userSpecifiedDescription="Step 3 description",
+        params={},
+    ),
+    UserCommandAnnotation(
+        annotationId="annotation-4",
+        userSpecifiedName="Step 4",
+        userSpecifiedDescription="Step 4 description",
+        params={},
+    )
+]
+
+@pytest.mark.parametrize(
+    argnames=["cursor", "length", "expected_slice"],
+    argvalues=[
+        (0, 2, CommandAnnotationsSlice(
+            command_annotations=[_sample_command_annotations[0], _sample_command_annotations[1]], cursor=0, total_length=4
+        )),
+        (1, 2, CommandAnnotationsSlice(
+            command_annotations=[_sample_command_annotations[1], _sample_command_annotations[2]], cursor=1, total_length=4
+        )),
+        (2, 4, CommandAnnotationsSlice(
+            command_annotations=[_sample_command_annotations[2], _sample_command_annotations[3]], cursor=2, total_length=4
+        )),
+        (4, 10, CommandAnnotationsSlice
+            (command_annotations=[_sample_command_annotations[3]], cursor=3, total_length=4
+        )),
+        (-4, 10, CommandAnnotationsSlice
+            (command_annotations=[
+                _sample_command_annotations[0],
+                _sample_command_annotations[1],
+                _sample_command_annotations[2],
+                _sample_command_annotations[3]
+            ],
+            cursor=0,
+            total_length=4,
+        )),
+    ],
+)
+def test_get_command_annotations_slice_with_annotations(
+    cursor: int, length: int, expected_slice: CommandAnnotationsSlice
+) -> None:
+    """It should return the expected slice of command annotations."""
+    subject = CommandStore(
+        config=_make_config(),
+        error_recovery_policy=_placeholder_error_recovery_policy,
+        is_door_open=False,
+    )
+    subject_view = CommandView(subject.state)
+
+    # Create multiple annotations (refer to _sample_command_annotations for the actual annotations)
+    for i in range(1, 5):
+        subject.handle_action(
+            actions.CreateUserCommandAnnotation(
+                annotation_id=f"annotation-{i}",
+                user_defined_name=f"Step {i}",
+                user_description=f"Step {i} description",
+                params={},
+            )
+        )
+
+    assert subject_view.get_command_annotations_slice(cursor=cursor, length=length) == expected_slice

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -1460,57 +1460,99 @@ def test_get_command_annotations_slice_empty() -> None:
 
 
 _sample_command_annotations = [
-    UserCommandAnnotation(
-        annotationId="annotation-1",
-        userSpecifiedName="Step 1",
-        userSpecifiedDescription="Step 1 description",
+    CommandAnnotation(
+        id="annotation-1",
+        source="userCommand",
+        name="Step 1",
+        description="Step 1 description",
         params={},
     ),
-    UserCommandAnnotation(
-        annotationId="annotation-2",
-        userSpecifiedName="Step 2",
-        userSpecifiedDescription="Step 2 description",
+    CommandAnnotation(
+        id="annotation-2",
+        source="userCommand",
+        name="Step 2",
+        description="Step 2 description",
         params={},
     ),
-    UserCommandAnnotation(
-        annotationId="annotation-3",
-        userSpecifiedName="Step 3",
-        userSpecifiedDescription="Step 3 description",
+    CommandAnnotation(
+        id="annotation-3",
+        source="userCommand",
+        name="Step 3",
+        description="Step 3 description",
         params={},
     ),
-    UserCommandAnnotation(
-        annotationId="annotation-4",
-        userSpecifiedName="Step 4",
-        userSpecifiedDescription="Step 4 description",
+    CommandAnnotation(
+        id="annotation-4",
+        source="userCommand",
+        name="Step 4",
+        description="Step 4 description",
         params={},
-    )
+    ),
 ]
+
 
 @pytest.mark.parametrize(
     argnames=["cursor", "length", "expected_slice"],
     argvalues=[
-        (0, 2, CommandAnnotationsSlice(
-            command_annotations=[_sample_command_annotations[0], _sample_command_annotations[1]], cursor=0, total_length=4
-        )),
-        (1, 2, CommandAnnotationsSlice(
-            command_annotations=[_sample_command_annotations[1], _sample_command_annotations[2]], cursor=1, total_length=4
-        )),
-        (2, 4, CommandAnnotationsSlice(
-            command_annotations=[_sample_command_annotations[2], _sample_command_annotations[3]], cursor=2, total_length=4
-        )),
-        (4, 10, CommandAnnotationsSlice
-            (command_annotations=[_sample_command_annotations[3]], cursor=3, total_length=4
-        )),
-        (-4, 10, CommandAnnotationsSlice
-            (command_annotations=[
-                _sample_command_annotations[0],
-                _sample_command_annotations[1],
-                _sample_command_annotations[2],
-                _sample_command_annotations[3]
-            ],
-            cursor=0,
-            total_length=4,
-        )),
+        (
+            0,
+            2,
+            CommandAnnotationsSlice(
+                command_annotations=[
+                    _sample_command_annotations[0],
+                    _sample_command_annotations[1],
+                ],
+                cursor=0,
+                total_length=4,
+            ),
+        ),
+        (
+            1,
+            2,
+            CommandAnnotationsSlice(
+                command_annotations=[
+                    _sample_command_annotations[1],
+                    _sample_command_annotations[2],
+                ],
+                cursor=1,
+                total_length=4,
+            ),
+        ),
+        (
+            2,
+            4,
+            CommandAnnotationsSlice(
+                command_annotations=[
+                    _sample_command_annotations[2],
+                    _sample_command_annotations[3],
+                ],
+                cursor=2,
+                total_length=4,
+            ),
+        ),
+        (
+            4,
+            10,
+            CommandAnnotationsSlice(
+                command_annotations=[_sample_command_annotations[3]],
+                cursor=3,
+                total_length=4,
+            ),
+        ),
+        (
+            -4,
+            10,
+            CommandAnnotationsSlice(
+                command_annotations=[
+                    _sample_command_annotations[0],
+                    _sample_command_annotations[1],
+                    _sample_command_annotations[2],
+                    _sample_command_annotations[3],
+                ],
+                cursor=0,
+                total_length=4,
+            ),
+        ),
     ],
 )
 def test_get_command_annotations_slice_with_annotations(
@@ -1529,10 +1571,13 @@ def test_get_command_annotations_slice_with_annotations(
         subject.handle_action(
             actions.CreateUserCommandAnnotation(
                 annotation_id=f"annotation-{i}",
-                user_defined_name=f"Step {i}",
-                user_description=f"Step {i} description",
+                name=f"Step {i}",
+                description=f"Step {i} description",
                 params={},
             )
         )
 
-    assert subject_view.get_command_annotations_slice(cursor=cursor, length=length) == expected_slice
+    assert (
+        subject_view.get_command_annotations_slice(cursor=cursor, length=length)
+        == expected_slice
+    )

--- a/robot-server/robot_server/runs/router/__init__.py
+++ b/robot-server/robot_server/runs/router/__init__.py
@@ -5,6 +5,7 @@ from server_utils.fastapi_utils.light_router import LightRouter
 from .actions_router import actions_router
 from .base_router import base_router
 from .camera_router import camera_router
+from .command_annotations_router import command_annotations_router
 from .commands_router import commands_router
 from .error_recovery_policy_router import error_recovery_policy_router
 from .labware_router import labware_router
@@ -13,6 +14,7 @@ runs_router = LightRouter()
 
 runs_router.include_router(base_router)
 runs_router.include_router(commands_router)
+runs_router.include_router(command_annotations_router)
 runs_router.include_router(actions_router)
 runs_router.include_router(labware_router)
 runs_router.include_router(camera_router)

--- a/robot-server/robot_server/runs/router/command_annotations_router.py
+++ b/robot-server/robot_server/runs/router/command_annotations_router.py
@@ -8,7 +8,7 @@ from starlette import status
 from opentrons.protocol_engine.errors.exceptions import (
     CommandAnnotationNotFoundError as CommandAnnotationNotFoundInEngineError,
 )
-from opentrons.protocol_engine.types import UserCommandAnnotation
+from opentrons.protocol_engine.types import CommandAnnotation
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (
     MultiBodyMeta,
@@ -59,7 +59,7 @@ class PreSerializedCommandAnnotationsNotAvailable(ErrorDetails):
         "The command annotations are returned in the order that they were created"
     ),
     responses={
-        status.HTTP_200_OK: {"model": SimpleMultiBody[UserCommandAnnotation]},
+        status.HTTP_200_OK: {"model": SimpleMultiBody[CommandAnnotation]},
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
     },
 )
@@ -84,7 +84,7 @@ async def get_command_annotations_list(
             description="The maximum number of command annotations to return from the list."
         ),
     ] = _DEFAULT_COMMAND_ANNOTATIONS_LIST_LENGTH,
-) -> PydanticResponse[SimpleMultiBody[UserCommandAnnotation]]:
+) -> PydanticResponse[SimpleMultiBody[CommandAnnotation]]:
     """Get a list of command annotations in the specified run.
 
     Arguments:
@@ -128,7 +128,7 @@ async def get_command_annotations_list(
     summary="Get full details of a specific command annotation in the specified run.",
     description="Get full details of a specific command annotation in the specified run.",
     responses={
-        status.HTTP_200_OK: {"model": SimpleBody[UserCommandAnnotation]},
+        status.HTTP_200_OK: {"model": SimpleBody[CommandAnnotation]},
         status.HTTP_404_NOT_FOUND: {
             "model": Union[
                 ErrorBody[RunNotFound], ErrorBody[CommandAnnotationNotFound]
@@ -140,7 +140,7 @@ async def get_command_annotation(
     runId: str,
     commandAnnotationId: str,
     run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
-) -> PydanticResponse[SimpleBody[UserCommandAnnotation]]:
+) -> PydanticResponse[SimpleBody[CommandAnnotation]]:
     """Get a specific command annotation.
 
     Arguments:

--- a/robot-server/robot_server/runs/router/command_annotations_router.py
+++ b/robot-server/robot_server/runs/router/command_annotations_router.py
@@ -48,7 +48,6 @@ class PreSerializedCommandAnnotationsNotAvailable(ErrorDetails):
     detail: str = "Pre-serialized command annotations are only available once a run has finished running."
 
 
-# Route to get a list of command annotations according to page length requested
 @PydanticResponse.wrap_route(
     command_annotations_router.get,
     path="/runs/{runId}/commandAnnotations",
@@ -166,6 +165,3 @@ async def get_command_annotation(
         content=SimpleBody.model_construct(data=annotation),
         status_code=status.HTTP_200_OK,
     )
-
-
-# Route to get the specific annotation by id

--- a/robot-server/robot_server/runs/router/command_annotations_router.py
+++ b/robot-server/robot_server/runs/router/command_annotations_router.py
@@ -1,0 +1,171 @@
+"""Router for /runs command annotations endpoints."""
+
+from typing import Annotated, Final, Literal, Optional, Union
+
+from fastapi.params import Depends, Query
+from starlette import status
+
+from opentrons.protocol_engine.errors.exceptions import (
+    CommandAnnotationNotFoundError as CommandAnnotationNotFoundInEngineError,
+)
+from opentrons.protocol_engine.types import UserCommandAnnotation
+from server_utils.fastapi_utils.light_router import LightRouter
+from server_utils.fastapi_utils.models.json_api import (
+    MultiBodyMeta,
+    PydanticResponse,
+    SimpleBody,
+    SimpleMultiBody,
+)
+
+from robot_server.errors.error_responses import ErrorBody, ErrorDetails
+from robot_server.runs.dependencies import get_run_data_manager
+from robot_server.runs.router.base_router import RunNotFound
+from robot_server.runs.run_data_manager import RunDataManager
+from robot_server.runs.run_models import RunNotFoundError
+from robot_server.runs.run_store import (
+    CommandAnnotationNotFoundError as CommandAnnotationNotFoundInRunStoreError,
+)
+
+_DEFAULT_COMMAND_ANNOTATIONS_LIST_LENGTH: Final = 20
+
+command_annotations_router = LightRouter()
+
+
+class CommandAnnotationNotFound(ErrorDetails):
+    """An error if a given command annotation is not found."""
+
+    id: Literal["CommandAnnotationNotFound"] = "CommandAnnotationNotFound"
+    title: str = "Command annotation not found"
+
+
+class PreSerializedCommandAnnotationsNotAvailable(ErrorDetails):
+    """An error if one tries to fetch pre-serialized annotations before they are written to the database."""
+
+    id: Literal["PreSerializedCommandAnnotationsNotAvailable"] = (
+        "PreSerializedCommandAnnotationsNotAvailable"
+    )
+    title: str = "Pre-serialized command annotations not available"
+    detail: str = "Pre-serialized command annotations are only available once a run has finished running."
+
+
+# Route to get a list of command annotations according to page length requested
+@PydanticResponse.wrap_route(
+    command_annotations_router.get,
+    path="/runs/{runId}/commandAnnotations",
+    summary="Get a list of all command annotations in the specified run.",
+    description=(
+        "Get a list of all command annotations in the specified run. "
+        "\n\n"
+        "The command annotations are returned in the order that they were created"
+    ),
+    responses={
+        status.HTTP_200_OK: {"model": SimpleMultiBody[UserCommandAnnotation]},
+        status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
+    },
+)
+async def get_command_annotations_list(
+    runId: str,
+    run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
+    cursor: Annotated[
+        Optional[int],
+        Query(
+            description=(
+                "The starting index of the desired first command annotation in the list."
+                " If unspecified, the cursor will be automatically assigned an index such that"
+                " the latest `pageLength` number of command annotations are returned from the list."
+                " If total number of command annotations in the run are less than `pageLength`"
+                " then cursor is set to zero and all command annotations are returned."
+            )
+        ),
+    ] = None,
+    pageLength: Annotated[
+        int,
+        Query(
+            description="The maximum number of command annotations to return from the list."
+        ),
+    ] = _DEFAULT_COMMAND_ANNOTATIONS_LIST_LENGTH,
+) -> PydanticResponse[SimpleMultiBody[UserCommandAnnotation]]:
+    """Get a list of command annotations in the specified run.
+
+    Arguments:
+        runId: Unique run identifier.
+        run_data_manager: Run data retrieval interface.
+        cursor: Cursor index for the collection response.
+        pageLength: Maximum number of items (annotations) to return.
+    """
+    try:
+        total_command_annotations_count = (
+            run_data_manager.get_total_command_annotations_count(
+                run_id=runId,
+            )
+        )
+        if cursor is None:
+            cursor = max(total_command_annotations_count - 1, 0)
+            cursor = max(cursor - pageLength + 1, 0)
+            cursor = min(cursor, total_command_annotations_count)
+
+        annotations_slice = run_data_manager.get_command_annotations_slice(
+            run_id=runId, cursor=cursor, length=pageLength
+        )
+    except RunNotFoundError as e:
+        raise RunNotFound.from_exc(e).as_error(status.HTTP_404_NOT_FOUND) from e
+
+    meta = MultiBodyMeta(
+        cursor=annotations_slice.cursor, totalLength=annotations_slice.total_length
+    )
+
+    return await PydanticResponse.create(
+        content=SimpleMultiBody.model_construct(
+            data=annotations_slice.command_annotations, meta=meta
+        ),
+        status_code=status.HTTP_200_OK,
+    )
+
+
+@PydanticResponse.wrap_route(
+    command_annotations_router.get,
+    path="/runs/{runId}/commandAnnotations/{commandAnnotationId}",
+    summary="Get full details of a specific command annotation in the specified run.",
+    description="Get full details of a specific command annotation in the specified run.",
+    responses={
+        status.HTTP_200_OK: {"model": SimpleBody[UserCommandAnnotation]},
+        status.HTTP_404_NOT_FOUND: {
+            "model": Union[
+                ErrorBody[RunNotFound], ErrorBody[CommandAnnotationNotFound]
+            ],
+        },
+    },
+)
+async def get_command_annotation(
+    runId: str,
+    commandAnnotationId: str,
+    run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
+) -> PydanticResponse[SimpleBody[UserCommandAnnotation]]:
+    """Get a specific command annotation.
+
+    Arguments:
+        runId: Unique run identifier.
+        run_data_manager: Run data retrieval interface.
+        commandAnnotationId: Unique command annotation identifier.
+    """
+    try:
+        annotation = run_data_manager.get_command_annotation(
+            run_id=runId, annotation_id=commandAnnotationId
+        )
+    except RunNotFoundError as e:
+        raise RunNotFound.from_exc(e).as_error(status.HTTP_404_NOT_FOUND) from e
+    except (
+        CommandAnnotationNotFoundInEngineError,
+        CommandAnnotationNotFoundInRunStoreError,
+    ) as e:
+        raise CommandAnnotationNotFound.from_exc(e).as_error(
+            status.HTTP_404_NOT_FOUND
+        ) from e
+
+    return await PydanticResponse.create(
+        content=SimpleBody.model_construct(data=annotation),
+        status_code=status.HTTP_200_OK,
+    )
+
+
+# Route to get the specific annotation by id

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -333,6 +333,7 @@ async def get_run_commands(
             error=c.error,
             notes=c.notes,
             failedCommandId=c.failedCommandId,
+            commandAnnotationIds=c.commandAnnotations if c.commandAnnotations else None,
         )
         for c in command_slice.commands
     ]

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -333,7 +333,9 @@ async def get_run_commands(
             error=c.error,
             notes=c.notes,
             failedCommandId=c.failedCommandId,
-            commandAnnotationIds=c.commandAnnotations if c.commandAnnotations else None,
+            commandAnnotationIds=c.commandAnnotationIds
+            if c.commandAnnotationIds
+            else None,
         )
         for c in command_slice.commands
     ]

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -16,12 +16,14 @@ from opentrons.protocol_engine import (
 )
 from opentrons.protocol_engine.resources.camera_provider import CameraProvider
 from opentrons.protocol_engine.resources.file_provider import FileProvider
+from opentrons.protocol_engine.state.commands import CommandAnnotationsSlice
 from opentrons.protocol_engine.state.module_substates import FlexStackerSubState
 from opentrons.protocol_engine.types import (
     CSVRuntimeParamPaths,
     DeckConfigurationType,
     PrimitiveRunTimeParamValuesType,
     RunTimeParameter,
+    UserCommandAnnotation,
 )
 from opentrons.system import camera
 from opentrons.types import NozzleMapInterface
@@ -552,6 +554,45 @@ class RunDataManager:
         if run_id == self._run_orchestrator_store.current_run_id:
             return len(self._run_orchestrator_store.get_command_errors())
         return self._run_store.get_command_errors_count(run_id)
+
+    def get_total_command_annotations_count(self, run_id: str) -> int:
+        """Get the total number of command annotations in the specified run."""
+        if run_id == self._run_orchestrator_store.current_run_id:
+            return self._run_orchestrator_store.get_total_command_annotations_count()
+        else:
+            raise NotImplementedError(
+                "Fetching annotations from historical runs is not implemented yet"
+            )
+
+    def get_command_annotations_slice(
+        self, run_id: str, cursor: int, length: int
+    ) -> CommandAnnotationsSlice:
+        """Get a slice of the run's commands annotations.
+
+        Args:
+            run_id: ID of the run.
+            cursor: Requested index of the first command annotation in the returned slice.
+            length: Length of slice to return.
+        """
+        if run_id == self._run_orchestrator_store.current_run_id:
+            return self._run_orchestrator_store.get_command_annotations_slice(
+                cursor=cursor, length=length
+            )
+        else:
+            raise NotImplementedError(
+                "Fetching annotations from historical runs is not implemented yet"
+            )
+
+    def get_command_annotation(
+        self, run_id: str, annotation_id: str
+    ) -> UserCommandAnnotation:
+        """Get a run's command annotation by ID."""
+        if run_id == self._run_orchestrator_store.current_run_id:
+            return self._run_orchestrator_store.get_command_annotation(annotation_id)
+        else:
+            raise NotImplementedError(
+                "Fetching annotations from historical runs is not implemented yet"
+            )
 
     def get_nozzle_maps(self, run_id: str) -> Mapping[str, NozzleMapInterface]:
         """Get current nozzle maps keyed by pipette id."""

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -19,11 +19,11 @@ from opentrons.protocol_engine.resources.file_provider import FileProvider
 from opentrons.protocol_engine.state.commands import CommandAnnotationsSlice
 from opentrons.protocol_engine.state.module_substates import FlexStackerSubState
 from opentrons.protocol_engine.types import (
+    CommandAnnotation,
     CSVRuntimeParamPaths,
     DeckConfigurationType,
     PrimitiveRunTimeParamValuesType,
     RunTimeParameter,
-    UserCommandAnnotation,
 )
 from opentrons.system import camera
 from opentrons.types import NozzleMapInterface
@@ -585,7 +585,7 @@ class RunDataManager:
 
     def get_command_annotation(
         self, run_id: str, annotation_id: str
-    ) -> UserCommandAnnotation:
+    ) -> CommandAnnotation:
         """Get a run's command annotation by ID."""
         if run_id == self._run_orchestrator_store.current_run_id:
             return self._run_orchestrator_store.get_command_annotation(annotation_id)

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -93,6 +93,10 @@ class RunCommandSummary(ResourceModel):
             "FIXIT command use only. Reference of the failed command id we are trying to fix."
         ),
     )
+    commandAnnotationIds: Optional[List[str]] = Field(
+        None,
+        description="List of command annotation ids associated with this command.",
+    )
 
 
 class Run(ResourceModel):

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -41,13 +41,13 @@ from opentrons.protocol_engine.resources.file_provider import FileProvider
 from opentrons.protocol_engine.state.commands import CommandAnnotationsSlice
 from opentrons.protocol_engine.state.module_substates import FlexStackerSubState
 from opentrons.protocol_engine.types import (
+    CommandAnnotation,
     CSVRuntimeParamPaths,
     DeckConfigurationType,
     EngineStatus,
     PostRunHardwareState,
     PrimitiveRunTimeParamValuesType,
     RunTimeParameter,
-    UserCommandAnnotation,
 )
 from opentrons.protocol_runner import (
     RunOrchestrator,
@@ -466,7 +466,7 @@ class RunOrchestratorStore:
             cursor=cursor, length=length
         )
 
-    def get_command_annotation(self, annotation_id: str) -> UserCommandAnnotation:
+    def get_command_annotation(self, annotation_id: str) -> CommandAnnotation:
         """Get the specified command annotation."""
         return self.run_orchestrator.get_command_annotation(annotation_id)
 

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -453,7 +453,7 @@ class RunOrchestratorStore:
         return self.run_orchestrator.get_command(command_id=command_id)
 
     def get_total_command_annotations_count(self) -> int:
-        """Get the total number of annotated commands."""
+        """Get the total number of command annotations in the run."""
         return self.run_orchestrator.get_total_command_annotations_count()
 
     def get_command_annotations_slice(

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -38,6 +38,7 @@ from opentrons.protocol_engine.resources.camera_provider import (
     CameraSettings,
 )
 from opentrons.protocol_engine.resources.file_provider import FileProvider
+from opentrons.protocol_engine.state.commands import CommandAnnotationsSlice
 from opentrons.protocol_engine.state.module_substates import FlexStackerSubState
 from opentrons.protocol_engine.types import (
     CSVRuntimeParamPaths,
@@ -46,6 +47,7 @@ from opentrons.protocol_engine.types import (
     PostRunHardwareState,
     PrimitiveRunTimeParamValuesType,
     RunTimeParameter,
+    UserCommandAnnotation,
 )
 from opentrons.protocol_runner import (
     RunOrchestrator,
@@ -335,7 +337,7 @@ class RunOrchestratorStore:
         run_data = self.run_orchestrator.get_state_summary()
         commands = self.run_orchestrator.get_all_commands()
         run_time_parameters = self.run_orchestrator.get_run_time_parameters()
-        command_annotations = self.run_orchestrator.get_command_annotations()
+        command_annotations = self.run_orchestrator.get_all_legacy_command_annotations()
         preconditions = self.run_orchestrator.get_preconditions()
 
         if self._run_orchestrator is not None:
@@ -449,6 +451,24 @@ class RunOrchestratorStore:
     def get_command(self, command_id: str) -> Command:
         """Get a run's command by ID."""
         return self.run_orchestrator.get_command(command_id=command_id)
+
+    def get_total_command_annotations_count(self) -> int:
+        """Get the total number of annotated commands."""
+        return self.run_orchestrator.get_total_command_annotations_count()
+
+    def get_command_annotations_slice(
+        self,
+        cursor: int,
+        length: int,
+    ) -> CommandAnnotationsSlice:
+        """Get a slice of run commands."""
+        return self.run_orchestrator.get_command_annotations_slice(
+            cursor=cursor, length=length
+        )
+
+    def get_command_annotation(self, annotation_id: str) -> UserCommandAnnotation:
+        """Get the specified command annotation."""
+        return self.run_orchestrator.get_command_annotation(annotation_id)
 
     def get_status(self) -> EngineStatus:
         """Get the current execution status of the run."""

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -114,6 +114,14 @@ class CommandNotFoundError(ValueError):
         super().__init__(f"Command {command_id} was not found.")
 
 
+class CommandAnnotationNotFoundError(ValueError):
+    """Error raised when a given command annotation ID is not found in the store."""
+
+    def __init__(self, command_annotation_id: str) -> None:
+        """Initialize the error message from the missing ID."""
+        super().__init__(f"Command annotation {command_annotation_id} was not found.")
+
+
 class RunStore:
     """Methods for storing and retrieving run resources."""
 

--- a/robot-server/tests/integration/http_api/runs/test_get_command_annotations_in_current_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_get_command_annotations_in_current_run.tavern.yaml
@@ -188,15 +188,15 @@ stages:
       status_code: 200
       json:
         data:
-          - annotationType: userCommand
-            annotationId: '{annotation_id_1}'
-            userSpecifiedName: 'My step group'
-            userSpecifiedDescription: "It's a comment, that's it."
+          - source: userCommand
+            id: '{annotation_id_1}'
+            name: 'My step group'
+            description: "It's a comment, that's it."
             params: {}
-          - annotationType: userCommand
-            annotationId: '{annotation_id_2}'
-            userSpecifiedName: 'My step group 2'
-            userSpecifiedDescription: "Another comment!"
+          - source: userCommand
+            id: '{annotation_id_2}'
+            name: 'My step group 2'
+            description: "Another comment!"
             params: {}
         meta:
           cursor: 0
@@ -210,10 +210,10 @@ stages:
       status_code: 200
       json:
         data:
-          annotationType: userCommand
-          annotationId: '{annotation_id_1}'
-          userSpecifiedName: 'My step group'
-          userSpecifiedDescription: "It's a comment, that's it."
+          source: userCommand
+          id: '{annotation_id_1}'
+          name: 'My step group'
+          description: "It's a comment, that's it."
           params: {}
 
   - name: Fetch the command annotations by ID 2
@@ -224,8 +224,8 @@ stages:
       status_code: 200
       json:
         data:
-          annotationType: userCommand
-          annotationId: '{annotation_id_2}'
-          userSpecifiedName: 'My step group 2'
-          userSpecifiedDescription: "Another comment!"
+          source: userCommand
+          id: '{annotation_id_2}'
+          name: 'My step group 2'
+          description: "Another comment!"
           params: {}

--- a/robot-server/tests/integration/http_api/runs/test_get_command_annotations_in_current_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_get_command_annotations_in_current_run.tavern.yaml
@@ -1,0 +1,231 @@
+test_name: Get command annotations from the current run
+
+marks:
+  - ot3_only
+  - usefixtures:
+      - ot3_server_base_url
+stages:
+  - name: Set allowStepGrouping to True
+    request:
+      method: POST
+      url: '{ot3_server_base_url}/settings'
+      json:
+        id: 'allowStepGrouping'
+        value: true
+    response:
+      status_code: 200
+
+  - name: Upload a protocol with user command annotations
+    request:
+      url: '{ot3_server_base_url}/protocols'
+      method: POST
+      files:
+        files: 'tests/integration/protocols/basic_step_grouping.py'
+    response:
+      status_code: 201
+      save:
+        json:
+          protocol_id: data.id
+
+  - name: Create a run from protocol
+    request:
+      url: '{ot3_server_base_url}/runs'
+      method: POST
+      json:
+        data:
+          protocolId: '{protocol_id}'
+    response:
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          ok: True
+          createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+          status: idle
+          current: True
+          actions: []
+          errors: []
+          hasEverEnteredErrorRecovery: False
+          pipettes: []
+          modules: []
+          labware: []
+          labwareOffsets: []
+          runTimeParameters: []
+          outputFileIds: []
+          protocolId: '{protocol_id}'
+          liquids: []
+          liquidClasses: []
+      save:
+        json:
+          original_run_data: data
+          run_id: data.id
+
+  - name: Play the protocol
+    request:
+      url: '{ot3_server_base_url}/runs/{run_id}/actions'
+      method: POST
+      json:
+        data:
+          actionType: play
+    response:
+      status_code: 201
+      json:
+        data:
+          id: !anystr
+          actionType: play
+          createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+      save:
+        json:
+          play_action_id: data.id
+
+  - name: Wait for the protocol to complete, keep the run current
+    max_retries: 10
+    delay_after: 0.1
+    request:
+      url: '{ot3_server_base_url}/runs/{run_id}'
+      method: GET
+    response:
+      status_code: 200
+      strict:
+        - json:off
+      json:
+        data:
+          status: succeeded
+
+  - name: Verify commands have annotations
+    request:
+      url: '{ot3_server_base_url}/runs/{run_id}/commands'
+      method: GET
+    response:
+      status_code: 200
+      json:
+        links:
+          current:
+            href: !anystr
+            meta:
+              runId: '{run_id}'
+              commandId: !anystr
+              index: 5
+              key: !anystr
+              createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+        meta:
+          cursor: 0
+          totalLength: 6
+        data:
+          - id: !anystr
+            key: !anystr
+            commandType: home
+            createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            startedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            completedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            status: succeeded
+            notes: [ ]
+            params: { }
+          - id: !anystr
+            key: !anystr
+            commandType: comment
+            createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            startedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            completedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            status: succeeded
+            notes: [ ]
+            params:
+              message: 'This is not in a step group.'
+          - id: !anystr
+            key: !anystr
+            commandType: comment
+            createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            startedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            completedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            status: succeeded
+            notes: [ ]
+            params:
+              message: 'This will have a command annotation ID.'
+            commandAnnotationIds:
+              - !anystr
+          - id: !anystr
+            key: !anystr
+            commandType: comment
+            createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            startedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            completedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            status: succeeded
+            notes: [ ]
+            params:
+              message: 'This is also not in a step group.'
+          - id: !anystr
+            key: !anystr
+            commandType: comment
+            createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            startedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            completedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            status: succeeded
+            notes: [ ]
+            params:
+              message: 'This will have a command annotation ID as well.'
+            commandAnnotationIds:
+              - !anystr
+          - id: !anystr
+            key: !anystr
+            commandType: comment
+            createdAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            startedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            completedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
+            status: succeeded
+            notes: [ ]
+            params:
+              message: 'This is also also not in a step group.'
+      save:
+        json:
+          annotation_id_1: data[2].commandAnnotationIds[0]
+          annotation_id_2: data[4].commandAnnotationIds[0]
+
+  - name: Fetch the full list of command annotations
+    request:
+      url: '{ot3_server_base_url}/runs/{run_id}/commandAnnotations?pageLength=10'
+      method: GET
+    response:
+      status_code: 200
+      json:
+        data:
+          - annotationType: userCommand
+            annotationId: '{annotation_id_1}'
+            userSpecifiedName: 'My step group'
+            userSpecifiedDescription: "It's a comment, that's it."
+            params: {}
+          - annotationType: userCommand
+            annotationId: '{annotation_id_2}'
+            userSpecifiedName: 'My step group 2'
+            userSpecifiedDescription: "Another comment!"
+            params: {}
+        meta:
+          cursor: 0
+          totalLength: 2
+
+  - name: Fetch the command annotations by ID 1
+    request:
+      url: '{ot3_server_base_url}/runs/{run_id}/commandAnnotations/{annotation_id_1}'
+      method: GET
+    response:
+      status_code: 200
+      json:
+        data:
+          annotationType: userCommand
+          annotationId: '{annotation_id_1}'
+          userSpecifiedName: 'My step group'
+          userSpecifiedDescription: "It's a comment, that's it."
+          params: {}
+
+  - name: Fetch the command annotations by ID 2
+    request:
+      url: '{ot3_server_base_url}/runs/{run_id}/commandAnnotations/{annotation_id_2}'
+      method: GET
+    response:
+      status_code: 200
+      json:
+        data:
+          annotationType: userCommand
+          annotationId: '{annotation_id_2}'
+          userSpecifiedName: 'My step group 2'
+          userSpecifiedDescription: "Another comment!"
+          params: {}

--- a/robot-server/tests/runs/router/test_command_annotations_router.py
+++ b/robot-server/tests/runs/router/test_command_annotations_router.py
@@ -7,7 +7,7 @@ from opentrons.protocol_engine.errors import (
     CommandAnnotationNotFoundError as CommandAnnotationNotFoundInEngineError,
 )
 from opentrons.protocol_engine.state.commands import CommandAnnotationsSlice
-from opentrons.protocol_engine.types import UserCommandAnnotation
+from opentrons.protocol_engine.types import CommandAnnotation
 from server_utils.fastapi_utils.models.json_api import MultiBodyMeta
 
 from robot_server.errors.error_responses import ApiError
@@ -30,14 +30,16 @@ async def test_get_command_annotations_slice(
     """It should get a slice of run annotations commands."""
     expected_annotations = CommandAnnotationsSlice(
         command_annotations=[
-            UserCommandAnnotation(
-                annotationId="annotation-id-1",
-                userSpecifiedName="foo",
+            CommandAnnotation(
+                id="annotation-id-1",
+                source="userCommand",
+                name="foo",
                 params={},
             ),
-            UserCommandAnnotation(
-                annotationId="annotation-id-2",
-                userSpecifiedName="bar",
+            CommandAnnotation(
+                id="annotation-id-2",
+                source="engineCommand",
+                name="bar",
                 params={},
             ),
         ],
@@ -197,10 +199,10 @@ async def test_get_specified_command_annotation(
     mock_run_data_manager: RunDataManager,
 ) -> None:
     """Should return the correct command annotation."""
-    expected_annotation = UserCommandAnnotation(
-        annotationId="annotation-id",
-        annotationType="userCommand",
-        userSpecifiedName="foo",
+    expected_annotation = CommandAnnotation(
+        id="annotation-id",
+        source="userCommand",
+        name="foo",
         params={},
     )
     decoy.when(

--- a/robot-server/tests/runs/router/test_command_annotations_router.py
+++ b/robot-server/tests/runs/router/test_command_annotations_router.py
@@ -1,0 +1,246 @@
+"""Tests for the /runs/.../commandAnnotations route."""
+
+import pytest
+from decoy import Decoy, matchers
+
+from opentrons.protocol_engine.errors import (
+    CommandAnnotationNotFoundError as CommandAnnotationNotFoundInEngineError,
+)
+from opentrons.protocol_engine.state.commands import CommandAnnotationsSlice
+from opentrons.protocol_engine.types import UserCommandAnnotation
+from server_utils.fastapi_utils.models.json_api import MultiBodyMeta
+
+from robot_server.errors.error_responses import ApiError
+from robot_server.runs.router.command_annotations_router import (
+    _DEFAULT_COMMAND_ANNOTATIONS_LIST_LENGTH,
+    get_command_annotation,
+    get_command_annotations_list,
+)
+from robot_server.runs.run_data_manager import RunDataManager
+from robot_server.runs.run_models import RunNotFoundError
+from robot_server.runs.run_store import (
+    CommandAnnotationNotFoundError as CommandAnnotationNotFoundInRunStoreError,
+)
+
+
+async def test_get_command_annotations_slice(
+    decoy: Decoy,
+    mock_run_data_manager: RunDataManager,
+) -> None:
+    """It should get a slice of run annotations commands."""
+    expected_annotations = CommandAnnotationsSlice(
+        command_annotations=[
+            UserCommandAnnotation(
+                annotationId="annotation-id-1",
+                userSpecifiedName="foo",
+                params={},
+            ),
+            UserCommandAnnotation(
+                annotationId="annotation-id-2",
+                userSpecifiedName="bar",
+                params={},
+            ),
+        ],
+        cursor=100,
+        total_length=400,
+    )
+    decoy.when(
+        mock_run_data_manager.get_command_annotations_slice(
+            run_id="run-id", cursor=1, length=4
+        )
+    ).then_return(expected_annotations)
+    result = await get_command_annotations_list(
+        runId="run-id",
+        run_data_manager=mock_run_data_manager,
+        cursor=1,
+        pageLength=4,
+    )
+    assert result.content.data == expected_annotations.command_annotations
+    assert result.content.meta == MultiBodyMeta(
+        cursor=expected_annotations.cursor,
+        totalLength=expected_annotations.total_length,
+    )
+    assert result.status_code == 200
+
+
+async def test_get_command_annotations_list_raises_error(
+    decoy: Decoy,
+    mock_run_data_manager: RunDataManager,
+) -> None:
+    """It should 404 if you attempt to get a command annotation from a non-existent run."""
+    decoy.when(
+        mock_run_data_manager.get_command_annotations_slice(
+            run_id="run-id", cursor=1, length=4
+        )
+    ).then_raise(RunNotFoundError("uh oh"))
+    with pytest.raises(ApiError) as exc_info:
+        await get_command_annotations_list(
+            runId="run-id",
+            run_data_manager=mock_run_data_manager,
+            cursor=1,
+            pageLength=4,
+        )
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.content["errors"][0]["detail"] == matchers.StringMatching(
+        "uh oh"
+    )
+
+
+@pytest.mark.parametrize(
+    argnames=["total_annotations_in_run", "expected_cursor"],
+    argvalues=[
+        (10, 0),
+        (100, 80),
+        (0, 0),
+        (20, 0),
+        (21, 1),
+    ],
+)
+async def test_get_command_annotations_slice_uses_default_values(
+    decoy: Decoy,
+    mock_run_data_manager: RunDataManager,
+    total_annotations_in_run: int,
+    expected_cursor: int,
+) -> None:
+    """It should use correct default values for cursor and page length according to the total number of annotations in the run."""
+    expected_page_length = _DEFAULT_COMMAND_ANNOTATIONS_LIST_LENGTH
+    sample_cmd_annotations_slice = CommandAnnotationsSlice(
+        command_annotations=[],
+        cursor=123,
+        total_length=456,
+    )
+    decoy.when(
+        mock_run_data_manager.get_total_command_annotations_count("run-id")
+    ).then_return(total_annotations_in_run)
+    decoy.when(
+        mock_run_data_manager.get_command_annotations_slice(
+            run_id="run-id",
+            cursor=expected_cursor,
+            length=expected_page_length,
+        )
+    ).then_return(sample_cmd_annotations_slice)
+    result = await get_command_annotations_list(
+        runId="run-id",
+        run_data_manager=mock_run_data_manager,
+        cursor=None,
+    )
+    assert result.content.data == sample_cmd_annotations_slice.command_annotations
+    assert result.content.meta == MultiBodyMeta(cursor=123, totalLength=456)
+
+
+@pytest.mark.parametrize(
+    argnames=["page_length", "total_annotations_in_run", "expected_cursor"],
+    argvalues=[(10, 14, 4), (2, 100, 98), (100, 5, 0)],
+)
+async def test_get_command_annotations_slice_cursor_calculation_non_default_page_length(
+    decoy: Decoy,
+    mock_run_data_manager: RunDataManager,
+    page_length: int,
+    total_annotations_in_run: int,
+    expected_cursor: int,
+) -> None:
+    """It should use correct cursor for non-default page lengths."""
+    sample_cmd_annotations_slice = CommandAnnotationsSlice(
+        command_annotations=[],
+        cursor=123,
+        total_length=456,
+    )
+    decoy.when(
+        mock_run_data_manager.get_total_command_annotations_count("run-id")
+    ).then_return(total_annotations_in_run)
+    decoy.when(
+        mock_run_data_manager.get_command_annotations_slice(
+            run_id="run-id",
+            cursor=expected_cursor,
+            length=page_length,
+        )
+    ).then_return(sample_cmd_annotations_slice)
+    result = await get_command_annotations_list(
+        runId="run-id",
+        run_data_manager=mock_run_data_manager,
+        cursor=None,
+        pageLength=page_length,
+    )
+    assert result.content.data == sample_cmd_annotations_slice.command_annotations
+    assert result.content.meta == MultiBodyMeta(cursor=123, totalLength=456)
+
+
+async def test_get_command_annotations_slice_with_non_default_cursor(
+    decoy: Decoy,
+    mock_run_data_manager: RunDataManager,
+) -> None:
+    """It should use the provided cursor value."""
+    sample_cmd_annotations_slice = CommandAnnotationsSlice(
+        command_annotations=[],
+        cursor=123,
+        total_length=456,
+    )
+    decoy.when(
+        mock_run_data_manager.get_command_annotations_slice(
+            run_id="run-id",
+            cursor=100,
+            length=4,
+        )
+    ).then_return(sample_cmd_annotations_slice)
+    result = await get_command_annotations_list(
+        runId="run-id",
+        run_data_manager=mock_run_data_manager,
+        cursor=100,
+        pageLength=4,
+    )
+    assert result.content.data == sample_cmd_annotations_slice.command_annotations
+    assert result.content.meta == MultiBodyMeta(cursor=123, totalLength=456)
+
+
+async def test_get_specified_command_annotation(
+    decoy: Decoy,
+    mock_run_data_manager: RunDataManager,
+) -> None:
+    """Should return the correct command annotation."""
+    expected_annotation = UserCommandAnnotation(
+        annotationId="annotation-id",
+        annotationType="userCommand",
+        userSpecifiedName="foo",
+        params={},
+    )
+    decoy.when(
+        mock_run_data_manager.get_command_annotation("run-id", "annotation-id")
+    ).then_return(expected_annotation)
+    result = await get_command_annotation(
+        runId="run-id",
+        run_data_manager=mock_run_data_manager,
+        commandAnnotationId="annotation-id",
+    )
+    assert result.content.data == expected_annotation
+    assert result.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        RunNotFoundError("womp womp womp"),
+        CommandAnnotationNotFoundInEngineError("womp womp womp"),
+        CommandAnnotationNotFoundInRunStoreError("womp womp womp"),
+    ],
+)
+async def test_get_command_annotation_raises_errors(
+    decoy: Decoy,
+    mock_run_data_manager: RunDataManager,
+    exception: Exception,
+) -> None:
+    """It should 404 if you attempt to get a non-existent command annotation."""
+    decoy.when(
+        mock_run_data_manager.get_command_annotation("run-id", "annotation-id")
+    ).then_raise(exception)
+
+    with pytest.raises(ApiError) as exc_info:
+        await get_command_annotation(
+            runId="run-id",
+            run_data_manager=mock_run_data_manager,
+            commandAnnotationId="annotation-id",
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.content["errors"][0]["detail"] == matchers.StringMatching(
+        "womp womp womp"
+    )

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -1349,9 +1349,10 @@ def test_get_command_annotations_slice_current_run(
     """It should get the specified slice of command annotations."""
     annotations_slice = CommandAnnotationsSlice(
         command_annotations=[
-            UserCommandAnnotation(
-                annotationId="annotation-id",
-                userSpecifiedName="user-specified-name",
+            CommandAnnotation(
+                id="annotation-id",
+                source="userCommand",
+                name="user-specified-name",
                 params={},
             )
         ],
@@ -1374,9 +1375,10 @@ def test_get_command_annotation_from_current_run(
     mock_run_orchestrator_store: RunOrchestratorStore,
 ) -> None:
     """Should get the command annotation by id from run store."""
-    cmd_annotation = UserCommandAnnotation(
-        annotationId="annotation-id",
-        userSpecifiedName="user-specified-name",
+    cmd_annotation = CommandAnnotation(
+        id="annotation-id",
+        source="userCommand",
+        name="user-specified-name",
         params={},
     )
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("run-id")

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -27,6 +27,7 @@ from opentrons.protocol_engine import (
     types as pe_types,
 )
 from opentrons.protocol_engine.resources import CameraProvider, FileProvider
+from opentrons.protocol_engine.state.commands import CommandAnnotationsSlice
 from opentrons.protocol_engine.types import (
     BooleanParameter,
     CommandAnnotation,
@@ -164,7 +165,7 @@ def run_time_parameters() -> List[pe_types.RunTimeParameter]:
 
 
 @pytest.fixture
-def command_annotations() -> List[pe_types.LegacyCommandAnnotation]:
+def legacy_command_annotations() -> List[pe_types.LegacyCommandAnnotation]:
     """Get a LegacyCommandAnnotation list."""
     return [
         pe_types.SecondOrderCommandAnnotationLegacy(
@@ -753,7 +754,7 @@ async def test_update_current(
     decoy: Decoy,
     engine_state_summary: StateSummary,
     run_time_parameters: List[pe_types.RunTimeParameter],
-    command_annotations: List[pe_types.LegacyCommandAnnotation],
+    legacy_command_annotations: List[pe_types.LegacyCommandAnnotation],
     command_preconditions: CommandPreconditions,
     run_resource: RunResource,
     run_command: commands.Command,
@@ -771,7 +772,7 @@ async def test_update_current(
             commands=[run_command],
             state_summary=engine_state_summary,
             parameters=run_time_parameters,
-            command_annotations=command_annotations,
+            command_annotations=legacy_command_annotations,
             command_preconditions=command_preconditions,
         )
     )
@@ -902,7 +903,7 @@ async def test_create_archives_existing(
     decoy: Decoy,
     engine_state_summary: StateSummary,
     run_time_parameters: List[pe_types.RunTimeParameter],
-    command_annotations: List[pe_types.LegacyCommandAnnotation],
+    legacy_command_annotations: List[pe_types.LegacyCommandAnnotation],
     command_preconditions: CommandPreconditions,
     run_resource: RunResource,
     run_command: commands.Command,
@@ -923,7 +924,7 @@ async def test_create_archives_existing(
             commands=[run_command],
             state_summary=engine_state_summary,
             parameters=run_time_parameters,
-            command_annotations=command_annotations,
+            command_annotations=legacy_command_annotations,
             command_preconditions=command_preconditions,
         )
     )
@@ -1338,6 +1339,52 @@ def test_get_all_commands_as_preserialized_list_errors_for_active_runs(
     decoy.when(mock_run_orchestrator_store.get_is_run_terminal()).then_return(False)
     with pytest.raises(PreSerializedCommandsNotAvailableError):
         subject.get_all_commands_as_preserialized_list("current-run-id", True)
+
+
+def test_get_command_annotations_slice_current_run(
+    decoy: Decoy,
+    subject: RunDataManager,
+    mock_run_orchestrator_store: RunOrchestratorStore,
+) -> None:
+    """It should get the specified slice of command annotations."""
+    annotations_slice = CommandAnnotationsSlice(
+        command_annotations=[
+            UserCommandAnnotation(
+                annotationId="annotation-id",
+                userSpecifiedName="user-specified-name",
+                params={},
+            )
+        ],
+        cursor=2,
+        total_length=200,
+    )
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("current-run-id")
+    decoy.when(
+        mock_run_orchestrator_store.get_command_annotations_slice(cursor=1, length=10)
+    ).then_return(annotations_slice)
+    result = subject.get_command_annotations_slice(
+        run_id="current-run-id", cursor=1, length=10
+    )
+    assert result == annotations_slice
+
+
+def test_get_command_annotation_from_current_run(
+    decoy: Decoy,
+    subject: RunDataManager,
+    mock_run_orchestrator_store: RunOrchestratorStore,
+) -> None:
+    """Should get the command annotation by id from run store."""
+    cmd_annotation = UserCommandAnnotation(
+        annotationId="annotation-id",
+        userSpecifiedName="user-specified-name",
+        params={},
+    )
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("run-id")
+    decoy.when(
+        mock_run_orchestrator_store.get_command_annotation("annotation-id")
+    ).then_return(cmd_annotation)
+    result = subject.get_command_annotation("run-id", "annotation-id")
+    assert result == cmd_annotation
 
 
 async def test_get_current_run_labware_definition(


### PR DESCRIPTION
Closes AUTH-2752

# Overview

This PR enables fetching command annotations from a current run by adding the following endpoints:
- `/runs/{run_id}/commandAnnotations/{annotation_id}` : to fetch a single command annotation using its ID
- `/runs/{run_id}/commandAnnotations` : to fetch a slice of command annotations in the run by providing slicing info of `cursor` and `pageLength`. This slicing is very similar to commands list slicing.

## Test Plan and Hands on Testing

- Added unit tests
- Added tavern tests that verify uploading a protocol with step grouping, running it and fetching its command annotations from the still-current run

## Changelog

Robot server:
- added command annotations router that adds the above two routes
- added unit tests and integration tests
API:
- added getter methods for fetching the command annotations and their info from the engine state
- added tests

## Review requests

- I've thought about if we would want to provide command annotations fetching in a different way- for example by specifying a list of annotation IDs in the request.. which could be useful when the app is showing only a window of commands and we need annotations info for only those commands. Or by fetching annotations by the command ID (the endpoint will return full annotation objects for the specified command ID). But haven't implemented them in this PR for fear of trying to future proof something we don't know we will need. Mentioning them here so we can give this a thought when implementing the UI for step grouping.
- Other than that, usual code sanity stuff

## Risk assessment

- Very low. Mostly addition of new things with minimal changes to existing code.
