### PR TITLE
feat(app, shared-data): wire up vacuum module in ODD protocol setup

### DIFF
--- a/app/src/organisms/ModuleCard/VacuumModule/__tests__/VacuumModuleSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/VacuumModule/__tests__/VacuumModuleSlideout.test.tsx
@@ -72,7 +72,7 @@ describe('VacuumModuleSlideout', () => {
     render(props)
 
     expect(
-      screen.getByText('Set Vacuum for Millipore MultiScreen® Vacuum Manifold')
+      screen.getByText('Set Vacuum for Vacuum Module GEN1')
     ).toBeInTheDocument()
   })
 

--- a/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ModuleCard.test.tsx
@@ -447,7 +447,7 @@ describe('ModuleCard', () => {
     })
     expect(screen.queryByText('Module setup required.')).not.toBeInTheDocument()
   })
-  ;[mockFlexStacker, mockVacuumModule].forEach(module =>
+  ;[mockFlexStacker, mockVacuumModule].forEach(module => {
     it('renders module setup link for no-calibration required modules', () => {
       render({
         ...props,
@@ -459,8 +459,8 @@ describe('ModuleCard', () => {
       expect(vi.mocked(handleModuleWizardFlows)).toHaveBeenCalled()
       expect(vi.mocked(getRequestById)).toHaveBeenCalled()
     })
-  )
-  ;[mockFlexStacker, mockVacuumModule].forEach(module =>
+  })
+  ;[mockFlexStacker, mockVacuumModule].forEach(module => {
     it('renders module setup link for no-calibration required modules if firmware update available', () => {
       mockFlexStacker.hasAvailableUpdate = true
 
@@ -474,7 +474,7 @@ describe('ModuleCard', () => {
       expect(vi.mocked(handleModuleWizardFlows)).toHaveBeenCalled()
       expect(vi.mocked(getRequestById)).toHaveBeenCalled()
     })
-  )
+  })
   it('renders firmware update for no-calibration required modules only if its already in the deck config', () => {
     vi.mocked(useNotifyDeckConfigurationQuery).mockReturnValue({
       data: [
@@ -595,7 +595,7 @@ describe('ModuleCard', () => {
       module: mockVacuumModule,
     })
 
-    screen.getByText('Millipore MultiScreen® Vacuum Manifold')
+    screen.getByText('Vacuum Module GEN1')
     screen.getByText('Mock Vacuum Module Data')
     screen.getByAltText('vacuumModuleMilliporeV1')
   })

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ModuleTableItem.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ModuleTableItem.tsx
@@ -16,7 +16,6 @@ import {
 } from '@opentrons/components'
 import { useHost } from '@opentrons/react-api-client'
 import {
-  ABSORBANCE_READER_TYPE,
   FLEX_STACKER_MODULE_TYPE,
   getFixtureDisplayName,
   getModuleDeckLabel,
@@ -32,6 +31,8 @@ import { LocationConflictModal } from '/app/organisms/LocationConflictModal'
 import { handleModuleWizardFlows } from '/app/organisms/ModuleWizardFlows'
 import { useToaster } from '/app/organisms/ToasterOven'
 import { getModuleTooHot } from '/app/transformations/modules'
+
+import { getDoesModuleRequireCalibration } from './utils'
 
 import type { TFunction } from 'i18next'
 import type { AttachedModule, CommandData } from '@opentrons/api-client'
@@ -81,12 +82,7 @@ export const getModuleDisplayStatus = (
       return 'connected'
     }
 
-    // Absorbance reader module does not require calibration
-    if (
-      attachedModule.moduleType !== ABSORBANCE_READER_TYPE &&
-      attachedModule.moduleOffset?.last_modified == null
-    ) {
-      // check if instrument ready to perform module calibration
+    if (getDoesModuleRequireCalibration(attachedModule)) {
       return !calibrationStatus.complete
         ? 'calibrationBlocked'
         : 'needsCalibration'

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/__tests__/ProtocolSetupModulesAndDeck.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/__tests__/ProtocolSetupModulesAndDeck.test.tsx
@@ -47,7 +47,14 @@ vi.mock('/app/resources/modules')
 vi.mock('/app/redux/discovery')
 vi.mock('/app/resources/deck_configuration')
 vi.mock('/app/transformations/analysis')
-vi.mock('../utils')
+// Only mock getUnmatchedModulesForProtocol so ModuleTableItem's getDoesModuleRequireCalibration stays real
+vi.mock('../utils', async importOriginal => {
+  const actual = await importOriginal<typeof import('../utils')>()
+  return {
+    ...actual,
+    getUnmatchedModulesForProtocol: vi.fn(),
+  }
+})
 vi.mock('../SetupInstructionsModal')
 vi.mock('/app/organisms/ModuleWizardFlows')
 vi.mock('/app/organisms/DoorOpenControl/useIsDoorOpen')

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/__tests__/ProtocolSetupModulesAndDeck.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/__tests__/ProtocolSetupModulesAndDeck.test.tsx
@@ -41,6 +41,7 @@ import { getUnmatchedModulesForProtocol } from '../utils'
 
 import type { UseQueryResult } from 'react-query'
 import type { CutoutConfig, DeckConfiguration } from '@opentrons/shared-data'
+import type * as ProtocolSetupUtils from '../utils'
 
 vi.mock('/app/resources/runs')
 vi.mock('/app/resources/modules')
@@ -49,7 +50,7 @@ vi.mock('/app/resources/deck_configuration')
 vi.mock('/app/transformations/analysis')
 // Only mock getUnmatchedModulesForProtocol so ModuleTableItem's getDoesModuleRequireCalibration stays real
 vi.mock('../utils', async importOriginal => {
-  const actual = await importOriginal<typeof import('../utils')>()
+  const actual = await importOriginal<typeof ProtocolSetupUtils>()
   return {
     ...actual,
     getUnmatchedModulesForProtocol: vi.fn(),

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/__tests__/utils.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/__tests__/utils.test.tsx
@@ -1,10 +1,23 @@
 import { describe, expect, it } from 'vitest'
 
-import { getModuleDef } from '@opentrons/shared-data'
+import { AttachedModule } from '@opentrons/api-client'
+import {
+  ABSORBANCE_READER_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
+  getModuleDef,
+  HEATERSHAKER_MODULE_TYPE,
+  MAGNETIC_MODULE_TYPE,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+  VACUUM_MODULE_TYPE,
+} from '@opentrons/shared-data'
 
 import { mockTemperatureModuleGen2 } from '/app/redux/modules/__fixtures__'
 
-import { getUnmatchedModulesForProtocol } from '../utils'
+import {
+  getDoesModuleRequireCalibration,
+  getUnmatchedModulesForProtocol,
+} from '../utils'
 
 const temperatureProtocolModule = {
   moduleId: 'mockTempModuleId',
@@ -71,6 +84,51 @@ describe('getUnmatchedModulesForProtocol', () => {
     expect(result).toEqual({
       missingModuleIds: ['mockMagneticModuleId'],
       remainingAttachedModules: [mockTemperatureModuleGen2],
+    })
+  })
+})
+
+describe('getDoesModuleRequireCalibration', () => {
+  ;[
+    TEMPERATURE_MODULE_TYPE,
+    MAGNETIC_MODULE_TYPE,
+    THERMOCYCLER_MODULE_TYPE,
+    HEATERSHAKER_MODULE_TYPE,
+  ].forEach(moduleType => {
+    const mockModule = {
+      moduleType,
+    } as AttachedModule
+    it(`returns true for ${moduleType} that requires calibration`, () => {
+      expect(getDoesModuleRequireCalibration(mockModule)).toBe(true)
+    })
+  })
+  ;[
+    TEMPERATURE_MODULE_TYPE,
+    MAGNETIC_MODULE_TYPE,
+    THERMOCYCLER_MODULE_TYPE,
+    HEATERSHAKER_MODULE_TYPE,
+  ].forEach(moduleType => {
+    const mockModule = {
+      moduleType,
+      moduleOffset: {
+        last_modified: '2026-02-23T14:42:20.131798+00:00',
+      },
+    } as AttachedModule
+    it(`returns false for ${moduleType} that has calibration data`, () => {
+      expect(getDoesModuleRequireCalibration(mockModule)).toBe(false)
+    })
+  })
+  ;[
+    ABSORBANCE_READER_TYPE,
+    FLEX_STACKER_MODULE_TYPE,
+    VACUUM_MODULE_TYPE,
+  ].forEach(moduleType => {
+    const mockModule = {
+      moduleType,
+      moduleOffset: undefined,
+    } as AttachedModule
+    it('returns false for modules that do not require calibration', () => {
+      expect(getDoesModuleRequireCalibration(mockModule)).toBe(false)
     })
   })
 })

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/__tests__/utils.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/__tests__/utils.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 
-import { AttachedModule } from '@opentrons/api-client'
 import {
   ABSORBANCE_READER_TYPE,
   FLEX_STACKER_MODULE_TYPE,
@@ -18,6 +17,8 @@ import {
   getDoesModuleRequireCalibration,
   getUnmatchedModulesForProtocol,
 } from '../utils'
+
+import type { AttachedModule } from '@opentrons/api-client'
 
 const temperatureProtocolModule = {
   moduleId: 'mockTempModuleId',

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/utils.ts
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/utils.ts
@@ -1,6 +1,13 @@
 import {
+  ABSORBANCE_READER_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
   getModuleType,
+  HEATERSHAKER_MODULE_TYPE,
+  MAGNETIC_MODULE_TYPE,
   NON_CONNECTING_MODULE_TYPES,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+  VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import type { AttachedModule } from '/app/redux/modules/types'
@@ -51,4 +58,25 @@ export function getUnmatchedModulesForProtocol(
       { missingModuleIds: [], remainingAttachedModules: attachedModules }
     )
   return { missingModuleIds, remainingAttachedModules }
+}
+
+export const getDoesModuleRequireCalibration = (
+  attachedModule: AttachedModule
+): boolean => {
+  const { moduleType, moduleOffset } = attachedModule
+  switch (moduleType) {
+    case ABSORBANCE_READER_TYPE:
+    case VACUUM_MODULE_TYPE:
+    case FLEX_STACKER_MODULE_TYPE:
+      return false
+    case TEMPERATURE_MODULE_TYPE:
+    case THERMOCYCLER_MODULE_TYPE:
+    case HEATERSHAKER_MODULE_TYPE:
+    case MAGNETIC_MODULE_TYPE:
+      return moduleOffset?.last_modified == null
+    // should not hit
+    default:
+      console.log(`unknown module type: ${moduleType}`)
+      return false
+  }
 }

--- a/shared-data/module/definitions/3/vacuumModuleMilliporeV1.json
+++ b/shared-data/module/definitions/3/vacuumModuleMilliporeV1.json
@@ -56,7 +56,7 @@
       }
     }
   },
-  "displayName": "Millipore MultiScreen® Vacuum Manifold",
+  "displayName": "Vacuum Module GEN1",
   "quirks": [],
   "slotTransforms": {},
   "orientation": {


### PR DESCRIPTION
# Overview

Adds vacuum module support in ODD protocol setup screens. Testing requires stubbing in the vacuum module for now, but we will get the vacuum module items for free once analysis includes them. To correctly handle the module status, I refactor `getModuleDisplayStatus` to call a new utility `getDoesModuleRequireCalibration`, which takes into account its called module's type and calibration status (if one exists) to determine if calibration is required.
 
Also, updates the universal display name for the VM (stored on its definition)

Closes EXEC-2375

## Test Plan and Hands on Testing

### ODD

Another one that is tricky to test hands-on until the data layer is complete 😅 

Here are some screenshots of protocol details hardware and protocol setup hardware, respectively:
<img width="966" height="437" alt="Screenshot 2026-02-23 at 3 52 36 PM" src="https://github.com/user-attachments/assets/cd166e22-469a-4cd1-8149-8b25e723a843" />
<img width="988" height="359" alt="Screenshot 2026-02-23 at 3 49 27 PM" src="https://github.com/user-attachments/assets/0d900a59-aa75-4c21-aaf5-8bb0b2e198cb" />

I've also updated and/or added unit tests for new utilities and updated ODD components.

### Desktop

The desktop app is only implicated here via the VM display name change. You can smoke test by creating simulating a Flex w/ VM and checking out the VM module card and slideout, which are accessible components calling the module's display name.

## Changelog

- refactor calibration required logic in ODD protocol details and setup screens
- align vacuum module display name to Product's spec (`Millipore MultiScreen® Vacuum Manifold` -> `Vacuum Module GEN1`)
- write new and update existing unit tests

## Review requests

Nothing in particular, see test plan

## Risk assessment

- low