### PR TITLE
test(app): test VM desktop protocol details

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/__tests__/RobotConfigurationDetails.test.tsx
@@ -59,6 +59,19 @@ const mockRequiredModuleDetails = [
   } as LoadModuleRunTimeCommand,
 ]
 
+const mockRequiredVacuumModuleDetails = {
+  id: 'vacuum-module-stub',
+  createdAt: new Date().toISOString(),
+  commandType: 'loadModule' as const,
+  key: 'vacuum-module-stub-key',
+  params: {
+    model: 'vacuumModuleMilliporeV1',
+    location: {
+      slotName: 'A3',
+    },
+  } as any,
+} as LoadModuleRunTimeCommand
+
 const render = (props: ComponentProps<typeof RobotConfigurationDetails>) => {
   return renderWithProviders(<RobotConfigurationDetails {...props} />, {
     i18nInstance: i18n,
@@ -193,5 +206,23 @@ describe('RobotConfigurationDetails', () => {
     render(props)
     screen.getByText('right mount')
     screen.getAllByText('Loading...')
+  })
+
+  it('renders the vacuum module with correct location when the protocol contains a vacuum module', () => {
+    props = {
+      leftMountPipetteName: null,
+      rightMountPipetteName: 'p10_single',
+      extensionInstrumentName: null,
+      requiredModuleDetails: [
+        ...mockRequiredModuleDetails,
+        mockRequiredVacuumModuleDetails,
+      ],
+      requiredFixtureDetails: [],
+      isLoading: false,
+      robotType: OT2_STANDARD_MODEL,
+    }
+    render(props)
+    screen.getByText('Slot A3+A4')
+    screen.getByText('Vacuum Module GEN1')
   })
 })


### PR DESCRIPTION
# Overview

We will get vacuum module load info for free from analysis commands, so this PR just tests that given expected VM analysis, the UI will match designs on desktop's `ProtocolDetails` > `RobotConfigurationDetails`.

A followup subtask contained on the [parent](https://opentrons.atlassian.net/browse/EXEC-2347) ticket will confirm that the data layer is implemented correctly.

Closes EXEC-2377

## Test Plan and Hands on Testing

- wrote unit test mocking VM in analysis
- stubbed in a VM to analysis in `app/src/organisms/Desktop/ProtocolDetails/index.tsx` and verified that the VM info rendered correctly:
  
<img width="419" height="291" alt="Screenshot 2026-02-24 at 9 53 18 AM" src="https://github.com/user-attachments/assets/6c404bad-d000-4c65-b7e7-c634a75dcb32" />


## Changelog

- add unit test checking VM rendering in desktop protocol details

## Review requests

see test plan, not much!

## Risk assessment

low