### PR TITLE
feat(shared-data, app): command annotation schema V2 frontend wireup

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -27,7 +27,7 @@ interface AnnotatedStepsProps {
   setIsAtBottom?: Dispatch<SetStateAction<boolean>>
 }
 
-type GroupNode = Extract<GroupedCommands[number], { annotationIndex: number }>
+type GroupNode = Extract<GroupedCommands[number], { annotationId: string }>
 
 interface GroupRow {
   type: 'group'
@@ -89,11 +89,6 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
         : [],
     [isValidRobotSideAnalysis]
   )
-  const annotations = analysis?.commandAnnotations ?? []
-  const annotationNames = useMemo(
-    () => annotations.map(annotation => annotation?.machineReadableName ?? ''),
-    [annotations]
-  )
   const commandIndexById = useMemo(
     () =>
       new Map(analysis.commands.map((command, index) => [command.id, index])),
@@ -102,25 +97,25 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
   const groupedCommandsHighlightedInfo = useMemo(
     () =>
       groupedCommands?.map(node => {
-        if ('annotationIndex' in node) {
+        if ('annotationId' in node) {
+          const updatedSubCommands = node.subCommands.map(subNode => ({
+            ...subNode,
+            isHighlighted:
+              currentCommandIndex === commandIndexById.get(subNode.command.id),
+          }))
+
           return {
             ...node,
-            isHighlighted: node.subCommands.some(
+            subCommands: updatedSubCommands,
+            isHighlighted: updatedSubCommands.some(
               subNode => subNode.isHighlighted
             ),
-            subCommands: node.subCommands.map(subNode => ({
-              ...subNode,
-              isHighlighted:
-                currentCommandIndex ===
-                commandIndexById.get(subNode.command.id),
-            })),
           }
-        } else {
-          return {
-            ...node,
-            isHighlighted:
-              currentCommandIndex === commandIndexById.get(node.command.id),
-          }
+        }
+        return {
+          ...node,
+          isHighlighted:
+            currentCommandIndex === commandIndexById.get(node.command.id),
         }
       }),
     [groupedCommands, currentCommandIndex, commandIndexById]
@@ -175,10 +170,9 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     ) {
       groupedCommandsHighlightedInfo.forEach((group, index) => {
         const nextIndex = groupedCommandsHighlightedInfo[index + 1]
-        const nextIsGrouped =
-          nextIndex != null && 'annotationIndex' in nextIndex
+        const nextIsGrouped = nextIndex != null && 'annotationId' in nextIndex
 
-        if ('annotationIndex' in group) {
+        if ('annotationId' in group) {
           const subCommandStartNumber = commandNumber + 1
           commandNumber += group.subCommands.length
 
@@ -186,7 +180,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
           nextRows.push({
             type: 'group',
             group,
-            annotationType: annotationNames[group.annotationIndex] ?? '',
+            annotationType: group.annotation?.userSpecifiedName ?? '',
             commandStartNumber: subCommandStartNumber,
           })
           group.subCommands.forEach(subCommand => {
@@ -238,7 +232,6 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     filteredCommands,
     currentCommandIndex,
     analysis.errors,
-    annotationNames,
   ])
 
   const [listRef, listRefCallback] = useListCallbackRef()

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/index.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/index.tsx
@@ -9,7 +9,7 @@ import { useRobot } from '/app/redux-resources/robots'
 import {
   fetchProtocols,
   getStoredProtocol,
-  // getStoredProtocolGroupedCommands,
+  getStoredProtocolGroupedCommands,
 } from '/app/redux/protocol-storage'
 
 import { VisualizerContainer } from '../../../../organisms/Desktop/ProtocolVisualization/VisualizerContainer'
@@ -30,9 +30,9 @@ export function ProtocolVisualization(): JSX.Element {
 
   // this is used for step grouping which won't be introduced until
   // PV phase 2
-  // const groupedCommands = useSelector((state: State) =>
-  //   getStoredProtocolGroupedCommands(state, protocolKey)
-  // )
+  const groupedCommands = useSelector((state: State) =>
+    getStoredProtocolGroupedCommands(state, protocolKey)
+  )
 
   useEffect(() => {
     dispatch(fetchProtocols())
@@ -43,7 +43,7 @@ export function ProtocolVisualization(): JSX.Element {
       <VisualizerContainer
         analysisOutput={storedProtocol.mostRecentAnalysis}
         runId={runId}
-        groupedCommands={null}
+        groupedCommands={groupedCommands}
         protocolKey={protocolKey}
         srcFileNames={storedProtocol.srcFileNames}
       />

--- a/app/src/redux/protocol-storage/types.ts
+++ b/app/src/redux/protocol-storage/types.ts
@@ -4,6 +4,7 @@ import type {
   ProtocolAnalysisOutput,
   RunTimeCommand,
 } from '@opentrons/shared-data'
+import type { CommandAnnotationV2 } from '@opentrons/shared-data/commandAnnotation/types'
 
 export type ProtocolSort =
   | 'alphabetical'
@@ -14,10 +15,12 @@ export type ProtocolSort =
   | 'ot2'
 
 interface ParentNode {
-  annotationIndex: number
+  annotationId: string
   subCommands: LeafNode[]
   isHighlighted: boolean
+  annotation?: CommandAnnotationV2
 }
+
 export interface LeafNode {
   command: RunTimeCommand
   isHighlighted: boolean

--- a/app/src/redux/protocol-storage/utils.ts
+++ b/app/src/redux/protocol-storage/utils.ts
@@ -1,47 +1,71 @@
 import type {
   CompletedProtocolAnalysis,
   ProtocolAnalysisOutput,
+  RunTimeCommand,
 } from '@opentrons/shared-data'
+import type { CommandAnnotationV2 } from '@opentrons/shared-data/commandAnnotation/types'
 import type { GroupedCommands } from './types'
 
 export const getGroupedCommands = (
   mostRecentAnalysis: ProtocolAnalysisOutput | CompletedProtocolAnalysis
 ): GroupedCommands => {
   const annotations = mostRecentAnalysis?.commandAnnotations ?? []
-  return mostRecentAnalysis.commands.reduce<GroupedCommands>((acc, c) => {
-    const foundAnnotationIndex = annotations.findIndex(
-      a => c.key != null && a.commandKeys.includes(c.key)
+
+  // we won't support showing the command annotations if they are schema V1
+  if (
+    annotations.some(
+      a =>
+        a.annotationType === 'secondOrderCommand' ||
+        a.annotationType === 'custom'
     )
-    const lastAccNode = acc[acc.length - 1]
-    if (
-      acc.length > 0 &&
-      c.key != null &&
-      'annotationIndex' in lastAccNode &&
-      lastAccNode.annotationIndex != null &&
-      annotations[lastAccNode.annotationIndex]?.commandKeys.includes(c.key)
-    ) {
-      return [
-        ...acc.slice(0, -1),
-        {
-          ...lastAccNode,
-          subCommands: [
-            ...lastAccNode.subCommands,
-            { command: c, isHighlighted: false },
-          ],
-          isHighlighted: false,
-        },
-      ]
-    } else if (foundAnnotationIndex >= 0) {
-      return [
-        ...acc,
-        {
-          annotationIndex: foundAnnotationIndex,
-          subCommands: [{ command: c, isHighlighted: false }],
-          isHighlighted: false,
-        },
-      ]
-    } else {
-      return [...acc, { command: c, isHighlighted: false }]
-    }
-  }, [])
+  ) {
+    return []
+  } else {
+    const annotationsV2 = annotations as CommandAnnotationV2[]
+    const annotationMap = new Map(
+      annotationsV2.map(annotation => [annotation.annotationId, annotation])
+    )
+
+    return mostRecentAnalysis.commands.reduce<GroupedCommands>(
+      (acc: GroupedCommands, command: RunTimeCommand) => {
+        const annotationId = command.commandAnnotationIds?.[0]
+
+        const lastAccNode = acc[acc.length - 1]
+
+        if (
+          lastAccNode != null &&
+          annotationId != null &&
+          'annotationId' in lastAccNode &&
+          lastAccNode.annotationId === annotationId
+        ) {
+          return [
+            ...acc.slice(0, -1),
+            {
+              ...lastAccNode,
+              subCommands: [
+                ...lastAccNode.subCommands,
+                { command: command, isHighlighted: false },
+              ],
+              isHighlighted: false,
+            },
+          ]
+        }
+
+        if (annotationId != null) {
+          return [
+            ...acc,
+            {
+              annotationId,
+              annotation: annotationMap.get(annotationId),
+              subCommands: [{ command, isHighlighted: false }],
+              isHighlighted: false,
+            },
+          ]
+        }
+
+        return [...acc, { command, isHighlighted: false }]
+      },
+      []
+    )
+  }
 }

--- a/shared-data/command/types/index.ts
+++ b/shared-data/command/types/index.ts
@@ -67,6 +67,7 @@ export interface CommonCommandRunTimeInfo<
   intent?: CommandIntent
   notes?: CommandNote[] | null
   failedCommandId?: string // only present if intent === 'fixit'
+  commandAnnotationIds?: string[]
 }
 export interface CommonCommandCreateInfo {
   intent?: CommandIntent

--- a/shared-data/commandAnnotation/types/index.ts
+++ b/shared-data/commandAnnotation/types/index.ts
@@ -13,6 +13,16 @@ export interface SecondOrderCommandAnnotation extends SharedCommandAnnotationPro
   userSpecifiedName?: string
   userSpecifiedDescription?: string
 }
-export type CommandAnnotation =
+export type CommandAnnotationV1 =
   | SecondOrderCommandAnnotation
   | CustomCommandAnnotation
+
+export interface UserCommandAnnotation {
+  annotationType: 'userCommand'
+  annotationId: string
+  params: { [key: string]: any }
+  userSpecifiedName: string
+  userSpecifiedDescription?: string
+}
+
+export type CommandAnnotationV2 = UserCommandAnnotation

--- a/shared-data/js/protocols.ts
+++ b/shared-data/js/protocols.ts
@@ -20,7 +20,10 @@ import protocolSchema7 from '../protocol/schemas/7.json'
 import protocolSchema8 from '../protocol/schemas/8.json'
 
 import type { CreateCommand } from '../command/types'
-import type { CommandAnnotation } from '../commandAnnotation/types'
+import type {
+  CommandAnnotationV1,
+  CommandAnnotationV2,
+} from '../commandAnnotation/types'
 import type * as ProtocolSchemas from '../protocol'
 
 export type { ProtocolSchemas }
@@ -75,7 +78,7 @@ const validateCommands8 = (
 
 const validateCommandAnnotations8 = (
   toValidate: ProtocolSchemas.ProtocolStructureV8
-): Promise<CommandAnnotation[]> =>
+): Promise<CommandAnnotationV1[] | CommandAnnotationV2> =>
   new Promise<object>((resolve, reject) => {
     const requestedSchema = toValidate.commandAnnotationSchemaId
     switch (requestedSchema) {

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -1,5 +1,8 @@
 import type { LoadedLabwareLocation, RunTimeCommand } from '../command/types'
-import type { CommandAnnotation } from '../commandAnnotation/types'
+import type {
+  CommandAnnotationV1,
+  CommandAnnotationV2,
+} from '../commandAnnotation/types'
 import type { AddressableAreaName, CutoutFixtureId, CutoutId } from '../deck'
 import type {
   ABSORBANCE_READER_TYPE,
@@ -1074,7 +1077,7 @@ export interface CompletedProtocolAnalysis {
   errors: AnalysisError[]
   robotType?: RobotType | null
   runTimeParameters?: RunTimeParameter[]
-  commandAnnotations?: CommandAnnotation[]
+  commandAnnotations?: CommandAnnotationV1[] | CommandAnnotationV2[]
   commandPreconditions?: CommandPreconditions
 }
 

--- a/shared-data/protocol/types/schemaV8/index.ts
+++ b/shared-data/protocol/types/schemaV8/index.ts
@@ -1,5 +1,8 @@
 import type { CreateCommand } from '../../../command/types'
-import type { CommandAnnotation } from '../../../commandAnnotation/types'
+import type {
+  CommandAnnotationV1,
+  CommandAnnotationV2,
+} from '../../../commandAnnotation/types'
 import type {
   CommandPreconditions,
   Liquid,
@@ -63,6 +66,11 @@ export interface CommandV16Mixin {
   commands: CreateCommand[]
 }
 
+export interface CommandV17Mixin {
+  commandSchemaId: 'opentronsCommandSchemaV17'
+  commands: CreateCommand[]
+}
+
 export interface CommandAnnotationsStructure {
   commandAnnotationSchemaId: string
   commandAnnotations: any[]
@@ -70,7 +78,12 @@ export interface CommandAnnotationsStructure {
 
 export interface CommandAnnotationV1Mixin {
   commandAnnotationSchemaId: 'opentronsCommandAnnotationSchemaV1'
-  commandAnnotations: CommandAnnotation[]
+  commandAnnotations: CommandAnnotationV1[]
+}
+
+export interface CommandAnnotationV2Mixin {
+  commandAnnotationSchemaId: 'opentronsCommandAnnotationSchemaV2'
+  commandAnnotations: CommandAnnotationV2[]
 }
 
 export interface LabwareStructure {
@@ -161,6 +174,7 @@ export type ProtocolFile<DesignerApplicationData = {}> =
       | CommandV14Mixin
       | CommandV15Mixin
       | CommandV16Mixin
+      | CommandV17Mixin
     ) &
     CommandAnnotationV1Mixin
 
@@ -190,7 +204,7 @@ export interface ProtocolAnalysisOutput {
   errors: AnalysisError[]
   runTimeParameters: RunTimeParameter[]
   robotType?: RobotType
-  commandAnnotations?: CommandAnnotation[]
+  commandAnnotations?: CommandAnnotationV1[] | CommandAnnotationV2[]
   commandPreconditions?: CommandPreconditions
   result: 'ok' | 'not-ok' | 'error' | 'parameter-value-required'
 }


### PR DESCRIPTION
# Overview

You can visualize the command annotations as a group in protocol viz and also adds the `commandAnnotations` v2 schema types into shared-data


https://github.com/user-attachments/assets/ae014d9b-06c3-434b-974e-2bb23c7b2290



## Test Plan and Hands on Testing

view the recording but also you can test yourself with with the `simpleFlexV8.json` fixture in our repo or making your own protocol with command annotations.

## Changelog

add the new types to shared-data
refactor how you get the grouped commands in protocol-storage
wire up into PV to see visually

## Risk assessment

medium, it isn't behind a feature flag but it is only exposed if you utilize the `commandAnnotationIds` and other command annotation patterns correctly for schema v2
