### PR TITLE
fix(app): fix ODD welcome screen size to hold WiFi, USB, and Ethernet

### DIFF
--- a/app/src/pages/ODD/NetworkSetupMenu/index.tsx
+++ b/app/src/pages/ODD/NetworkSetupMenu/index.tsx
@@ -11,6 +11,7 @@ import {
   SPACING,
   StepMeter,
   TYPOGRAPHY,
+  VIEWPORT,
 } from '@opentrons/components'
 
 import { CardButton } from '/app/molecules/CardButton'
@@ -42,16 +43,25 @@ export function NetworkSetupMenu(): JSX.Element {
   const { t } = useTranslation(['device_settings', 'branded'])
 
   return (
-    <>
+    <Flex
+      flexDirection={DIRECTION_COLUMN}
+      style={{
+        ...VIEWPORT.ODD_VIEWPORT_STYLES,
+        boxSizing: 'border-box',
+        overflow: 'hidden',
+      }}
+    >
       <StepMeter totalSteps={6} currentStep={1} />
       <Flex
-        padding={`${SPACING.spacing32} ${SPACING.spacing60} ${SPACING.spacing60}`}
+        padding={`${SPACING.spacing24} ${SPACING.spacing40} ${SPACING.spacing24}`}
         flexDirection={DIRECTION_COLUMN}
+        flex="1"
+        minHeight={0}
       >
         <Flex
           justifyContent={JUSTIFY_CENTER}
           alignItems={ALIGN_CENTER}
-          marginBottom="3.09375rem"
+          marginBottom={SPACING.spacing16}
         >
           <LegacyStyledText
             forwardedAs="h2"
@@ -64,7 +74,7 @@ export function NetworkSetupMenu(): JSX.Element {
         <Flex
           justifyContent={JUSTIFY_CENTER}
           alignItems={ALIGN_CENTER}
-          marginBottom={SPACING.spacing40}
+          marginBottom={SPACING.spacing24}
         >
           <LegacyStyledText
             forwardedAs="h4"
@@ -78,18 +88,21 @@ export function NetworkSetupMenu(): JSX.Element {
         <Flex
           flexDirection={DIRECTION_ROW}
           columnGap={SPACING.spacing8}
-          height="17rem"
+          flex="1"
+          minHeight={0}
+          minWidth={0}
         >
           {NetworkSetupOptions.map(networkOption => (
-            <CardButton
-              key={networkOption.title}
-              {...networkOption}
-              title={t(networkOption.title)}
-              description={t(networkOption.description)}
-            />
+            <Flex key={networkOption.title} flex="1" minWidth={0}>
+              <CardButton
+                {...networkOption}
+                title={t(networkOption.title)}
+                description={t(networkOption.description)}
+              />
+            </Flex>
           ))}
         </Flex>
       </Flex>
-    </>
+    </Flex>
   )
 }

--- a/components/src/ui-style-constants/viewport.ts
+++ b/components/src/ui-style-constants/viewport.ts
@@ -1,12 +1,14 @@
 // Note (kk:08/29/2023) Needed this in this ts file to avoid check-js errors on CI
+export const ODD_VIEWPORT_STYLES = {
+  width: '1024px',
+  height: '600px',
+} as const
+
 const customViewports = {
   onDeviceDisplay: {
     name: 'Touchscreen',
     type: 'tablet',
-    styles: {
-      width: '1024px',
-      height: '600px',
-    },
+    styles: ODD_VIEWPORT_STYLES,
   },
 }
 


### PR DESCRIPTION
allows you to see usb, WiFi, and ethernet at the same time on the ODD

RQA-5227

# Overview

Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.

## Test Plan and Hands on Testing

1. Smoke tested ODD onboarding flow 
2. Tested welcoming screen (had to edit make file to allow me to get there and then reverted change) 

## Changelog
It used to be 
<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/ba46619f-8a8e-46fa-9277-54a83ae0bb80" />
but now it fits all of them


## Review requests


## Risk assessment
- Could have interfered with other ODD componets