### PR TITLE
fix(app, components, protocol-designer): remove punctuation from `InlineNotification` from heading when message is present

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupCamera/__tests__/SetupCamera.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupCamera/__tests__/SetupCamera.test.tsx
@@ -146,7 +146,7 @@ describe('SetupCamera', () => {
 
     render(mockProps)
 
-    screen.getByText('Camera is required to run this protocol.')
+    screen.getByText('Camera is required to run this protocol')
     screen.getByText('Enable the camera to start the run.')
   })
 
@@ -210,7 +210,7 @@ describe('SetupCamera', () => {
   it('renders the image storage almost full notification if storage is almost full', () => {
     render(mockProps)
 
-    screen.getByText('Image storage almost full.')
+    screen.getByText('Image storage almost full')
     screen.getByText(
       'The run may fail if storage space is not freed up by clearing images from a previous run record.'
     )

--- a/components/src/atoms/InlineNotification/index.tsx
+++ b/components/src/atoms/InlineNotification/index.tsx
@@ -73,6 +73,7 @@ export function InlineNotification(
     onLinkClick,
   } = props
   // TODO (sb: 8/20/25) RSQ-189 Remove punctuation from this component and add to translation strings
+  const fullHeading = `${heading}${message ? '' : '. '}`
   const fullmessage = `${message}.`
   const inlineNotificationProps = INLINE_NOTIFICATION_PROPS_BY_TYPE[type]
   const iconProps = {
@@ -104,7 +105,7 @@ export function InlineNotification(
                     font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
                   `}
                 >
-                  {heading}
+                  {fullHeading}
                 </span>
                 {/* this break is because the desktop wants this on two lines, but also wants/
                   inline text layout on ODD. Soooo here you go */}

--- a/components/src/atoms/InlineNotification/index.tsx
+++ b/components/src/atoms/InlineNotification/index.tsx
@@ -73,7 +73,6 @@ export function InlineNotification(
     onLinkClick,
   } = props
   // TODO (sb: 8/20/25) RSQ-189 Remove punctuation from this component and add to translation strings
-  const fullHeading = `${heading}${message ? '. ' : ''}`
   const fullmessage = `${message}.`
   const inlineNotificationProps = INLINE_NOTIFICATION_PROPS_BY_TYPE[type]
   const iconProps = {
@@ -105,7 +104,7 @@ export function InlineNotification(
                     font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
                   `}
                 >
-                  {fullHeading}
+                  {heading}
                 </span>
                 {/* this break is because the desktop wants this on two lines, but also wants/
                   inline text layout on ODD. Soooo here you go */}

--- a/protocol-designer/src/assets/localization/en/tip_selection.json
+++ b/protocol-designer/src/assets/localization/en/tip_selection.json
@@ -19,7 +19,7 @@
   "no_tiprack_selected": "Select a tiprack to continue",
   "no_valid_tips_available": {
     "title": "Not enough tips to complete action",
-    "body": "Add another tip rack to your deck or change your tip management during transfer and mix steps."
+    "body": "Add another tip rack to your deck or change your tip management during transfer and mix steps"
   },
   "not_enough_tips_selected": "Not enough tips selected ({{count}} pickups remaining)",
   "pickups_remaining": "{{count}} pickups remaining",


### PR DESCRIPTION
# Overview

Remove punctuation from headings in `InlineNotifications` that have messages

## Test Plan and Hands on Testing

Confirmed redundant punctuation was removed from no tips `InlineNotification`
<img width="386" height="771" alt="Screenshot 2026-02-25 at 11 22 47 AM" src="https://github.com/user-attachments/assets/74e27bf5-db05-4ee7-8054-e97c4b9bef9e" />
- I ran unit tests on all pages included inline notification and cross checked designs to ensure this is intended before removing punctuation from header
- smoke tested app
**Camera**
- [Image storage almost full ](https://www.figma.com/design/PDkgB4AZ9PiLLJkwBATcU3/Feature--Camera-Enablement?node-id=5231-13415&t=jW8matOfPwFd9CJf-4) 
- [Camera is required to run this protocol](https://www.figma.com/design/PDkgB4AZ9PiLLJkwBATcU3/Feature--Camera-Enablement?node-id=5098-31519&t=jW8matOfPwFd9CJf-4)

## Changelog

- removed redundant punctuation from message body of no tips InlineNotification
- corrected logic for `fullHeading` to only have punctuation if there is no message
- corrected unit tests where punctuation was previously expected

## Review requests

- any other spots that need to be checked that would not be caught in unit test?

## Risk assessment

- medium - changes widely used component
