### PR TITLE
fix(components): viz command summary for configuring stackers

### DIFF
--- a/components/src/assets/localization/en/command_type_summary.json
+++ b/components/src/assets/localization/en/command_type_summary.json
@@ -31,7 +31,7 @@
   "flexStacker/openLatch": "Open",
   "flexStacker/prepareShuttle": "Prepare",
   "flexStacker/retrieve": "Retrieve",
-  "flexStacker/setStoredLabware": "Store",
+  "flexStacker/setStoredLabware": "Configure",
   "flexStacker/store": "Store",
   "getNextTip": "Get next tip",
   "getTipPresence": "Get tip",


### PR DESCRIPTION
# Overview

Fixes RQA-5209:
Steps that configure a stacker for a particular type of labware should have the command summary “Configure”. 

Turns out we just had the wrong text in the localization file.

## Test Plan and Hands on Testing

Correct text in dev app:
<img width="1455" height="908" alt="image" src="https://github.com/user-attachments/assets/e0b26988-a080-4918-9599-0909fe87371b" />

## Changelog

-1 +1

## Review requests

- No reason not to get this in alpha 12, right?

## Risk assessment

v low, copy only