### PR TITLE
refactor(abr-testing): update abr error script to use jira query language

### DIFF
--- a/abr-testing/abr_testing/automation/jira_tool.py
+++ b/abr-testing/abr_testing/automation/jira_tool.py
@@ -26,24 +26,10 @@ class JiraTicket:
 
     def issues_on_board(self, project_key: str) -> List[List[Any]]:
         """Print Issues on board."""
-        params = {"jql": f"project = {project_key}", "fields": "*all"}
-        response = requests.get(
-            f"{self.url}/rest/api/3/search/jql",
-            headers=self.headers,
-            params=params,
-            auth=self.auth,
-        )
-
-        response.raise_for_status()
-        try:
-            board_data = response.json()
-            all_issues = board_data["issues"]
-        except json.JSONDecodeError as e:
-            print("Error decoding json: ", e)
-        # convert issue id's into array and have one key as
-        # the issue key and one be summary, return entire array
+        all_issues = self.get_project_issues(project_key)
+        issues_dict = all_issues["issues"]
         issue_ids = []
-        for i in all_issues:
+        for i in issues_dict:
             issue_id = i.get("id")
             issue_summary = i["fields"].get("summary")
             issue_ids.append([issue_id, issue_summary])
@@ -119,7 +105,6 @@ class JiraTicket:
         summary: str,
         description: str,
         project_key: str,
-        reporter_id: str,
         assignee_id: str,
         issue_type: str,
         priority: str,
@@ -129,31 +114,28 @@ class JiraTicket:
     ) -> Tuple[str, str]:
         """Create ticket."""
         # Check if software version is a field on JIRA, if not replaces with existing version
-        # TODO: automate parent linking
         data = {
             "fields": {
-                "project": {"id": "10273", "key": project_key},
+                "project": {"key": project_key},
                 "issuetype": {"name": issue_type},
                 "summary": summary,
-                "reporter": {"id": reporter_id},
                 "assignee": {"id": assignee_id},
-                # "parent": {"key": parent_name},
                 "labels": labels,
                 "priority": {"name": priority},
                 "components": [{"name": component} for component in components],
                 "description": {
-                    "content": [
-                        {
-                            "content": [{"text": description, "type": "text"}],
-                            "type": "paragraph",
-                        }
-                    ],
                     "type": "doc",
                     "version": 1,
-                }
-                # Include other required fields as needed
+                    "content": [
+                        {
+                            "type": "paragraph",
+                            "content": [{"type": "text", "text": description}],
+                        }
+                    ],
+                },
             }
         }
+
         available_versions = self.get_project_versions(project_key)
 
         if affects_versions in available_versions:
@@ -203,17 +185,22 @@ class JiraTicket:
             print(f"JSON decoding error occurred. Response content: {error_message}.")
 
     def get_project_issues(self, project_key: str) -> Dict[str, Any]:
-        """Retrieve all issues for the given project key."""
-        # TODO: add field for ticket type.
-        headers = {"Accept": "application/json"}
-        query = {"jql": f"project={project_key}", "fields": "*all"}
+        """Get all issues for a project."""
+        url = f"{self.url}/rest/api/3/search/jql"
+        query = {
+            "jql": 'project = "Robotics ABR"',
+            "maxResults": "273",
+            "reconcileIssues": "2154",
+            "fields": "assignee, summary, id",
+        }
         response = requests.request(
             "GET",
-            f"{self.url}/rest/api/3/search/jql",
-            headers=headers,
-            params=query,
+            url,
+            headers=self.headers,
             auth=self.auth,
+            params=query,
         )
+
         return response.json()
 
     def get_project_versions(self, project_key: str) -> List[str]:
@@ -254,10 +241,10 @@ class JiraTicket:
             json.dump(users, file, indent=4)
         return file_path
 
-    def get_jira_users(self, storage_directory: Path) -> str:
+    def get_jira_users(self, storage_directory: Path, project_key: str) -> str:
         """Get all Jira users associated with the project key."""
         try:
-            issues = self.get_project_issues("RABR")
+            issues = self.get_project_issues(project_key)
             users = self.extract_users_from_issues(issues)
             file_path = self.save_users_to_file(users, storage_directory)
         except requests.RequestException as e:

--- a/abr-testing/abr_testing/data_collection/abr_robot_error.py
+++ b/abr-testing/abr_testing/data_collection/abr_robot_error.py
@@ -7,6 +7,7 @@ from abr_testing.automation import jira_tool, google_sheets_tool, google_drive_t
 import shutil
 import os
 import subprocess
+import platform
 from datetime import datetime, timedelta
 import sys
 import json
@@ -15,6 +16,17 @@ from pathlib import Path
 import pandas as pd
 from statistics import mean, StatisticsError
 from abr_testing.tools import plate_reader
+
+
+def open_folder(path: str) -> None:
+    """Open file folder on mac or windows."""
+    system = platform.system()
+    if system == "Windows":
+        subprocess.Popen(["explorer", path])
+    elif system == "Darwin":
+        subprocess.Popen(["open", path])
+    else:
+        raise OSError("Unsupported operating system")
 
 
 def retrieve_version_file(
@@ -763,4 +775,4 @@ if __name__ == "__main__":
     else:
         print("Ticket created.")
     # Open folder directory incase uploads to ticket were incomplete - only works on windows
-    subprocess.Popen(["explorer", error_folder_path])
+    open_folder(error_folder_path)

--- a/abr-testing/abr_testing/data_collection/abr_robot_error.py
+++ b/abr-testing/abr_testing/data_collection/abr_robot_error.py
@@ -561,6 +561,30 @@ Please confirm with the ABR-LPC sheet and re-LPC."
     )
 
 
+def write_errored_run_to_google_sheet() -> None:
+    """Add row to google sheet with run details and link to ticket."""
+    file_values = plate_reader.read_hellma_plate_files(storage_directory, 101934)
+    (
+        runs_and_robots,
+        headers,
+        runs_and_lpc,
+        headers_lpc,
+    ) = abr_google_drive.create_data_dictionary(
+        run_id,
+        Path(error_folder_path),
+        issue_url,
+        file_values,
+    )
+    start_row = google_sheet.get_index_row() + 1
+    try:
+        google_sheet.batch_update_cells(runs_and_robots, "A", start_row, "0")
+    except requests.exceptions.RequestException as e:
+        print(
+            f"⚠️Warning: Did not record this run on ABR-run-data google sheet. Error: {e}"
+        )
+    print("Wrote run to ABR-run-data")
+
+
 if __name__ == "__main__":
     """Create ticket for specified robot."""
     parser = argparse.ArgumentParser(description="Pulls run logs from ABR robots.")
@@ -735,28 +759,7 @@ if __name__ == "__main__":
         except FileNotFoundError:
             print("Run file not uploaded.")
         run_id = os.path.basename(error_run_log).split("_")[1].split(".")[0]
-        # Get hellma readings
-        file_values = plate_reader.read_hellma_plate_files(storage_directory, 101934)
-
-        (
-            runs_and_robots,
-            headers,
-            runs_and_lpc,
-            headers_lpc,
-        ) = abr_google_drive.create_data_dictionary(
-            run_id,
-            Path(error_folder_path),
-            issue_url,
-            file_values,
-        )
-        start_row = google_sheet.get_index_row() + 1
-        try:
-            google_sheet.batch_update_cells(runs_and_robots, "A", start_row, "0")
-        except requests.exceptions.RequestException as e:
-            print(
-                f"⚠️Warning: Did not record this run on ABR-run-data google sheet. Error: {e}"
-            )
-        print("Wrote run to ABR-run-data")
+        write_errored_run_to_google_sheet()
     else:
         print("Ticket created.")
     # Open folder directory incase uploads to ticket were incomplete - only works on windows

--- a/abr-testing/abr_testing/data_collection/abr_robot_error.py
+++ b/abr-testing/abr_testing/data_collection/abr_robot_error.py
@@ -585,14 +585,6 @@ if __name__ == "__main__":
         nargs=1,
         help="Email connected to JIRA account.",
     )
-    # TODO: write function to get reporter_id from email.
-    parser.add_argument(
-        "reporter_id",
-        metavar="REPORTER_ID",
-        type=str,
-        nargs=1,
-        help="JIRA Reporter ID.",
-    )
     # TODO: improve help comment on jira board id.
     parser.add_argument(
         "board_id",
@@ -614,10 +606,10 @@ if __name__ == "__main__":
     api_token = args.jira_api_token[0]
     email = args.email[0]
     board_id = args.board_id[0]
-    reporter_id = args.reporter_id[0]
     log_zip_path = read_robot_logs.get_logs(storage_directory, ip)
     ticket = jira_tool.JiraTicket(url, api_token, email)
-    users_file_path = ticket.get_jira_users(storage_directory)
+    project_key = "RABR"
+    users_file_path = ticket.get_jira_users(storage_directory, project_key)
     assignee_id = get_user_id(users_file_path, assignee)
     run_log_file_path = ""
     protocol_found = False
@@ -677,16 +669,12 @@ if __name__ == "__main__":
     image_files = retrieve_protocol_images(one_run, ip, storage_directory)
 
     print(f"Making ticket for {summary}.")
-    # TODO: make argument or see if I can get rid of with using board_id.
-    project_key = "RABR"
-    # TODO: read board to see if ticket for run id already exists.
     all_issues = ticket.issues_on_board(project_key)
     # CREATE TICKET
     issue_key, raw_issue_url = ticket.create_ticket(
         summary,
         whole_description_str,
         project_key,
-        reporter_id,
         assignee_id,
         "Bug",
         "Medium",
@@ -761,17 +749,15 @@ if __name__ == "__main__":
             issue_url,
             file_values,
         )
-
         start_row = google_sheet.get_index_row() + 1
-        google_sheet.batch_update_cells(runs_and_robots, "A", start_row, "0")
+        try:
+            google_sheet.batch_update_cells(runs_and_robots, "A", start_row, "0")
+        except requests.exceptions.RequestException as e:
+            print(
+                f"⚠️Warning: Did not record this run on ABR-run-data google sheet. Error: {e}"
+            )
         print("Wrote run to ABR-run-data")
-        # Add LPC to google sheet
-        google_sheet_lpc = google_sheets_tool.google_sheet(
-            credentials_path, "ABR-LPC", 0
-        )
-        start_row_lpc = google_sheet_lpc.get_index_row() + 1
-        google_sheet_lpc.batch_update_cells(runs_and_lpc, "A", start_row_lpc, "0")
     else:
         print("Ticket created.")
-    # Open folder directory incase uploads to ticket were incomplete
+    # Open folder directory incase uploads to ticket were incomplete - only works on windows
     subprocess.Popen(["explorer", error_folder_path])

--- a/abr-testing/abr_testing/data_collection/abr_robot_error.py
+++ b/abr-testing/abr_testing/data_collection/abr_robot_error.py
@@ -774,5 +774,5 @@ if __name__ == "__main__":
         write_errored_run_to_google_sheet()
     else:
         print("Ticket created.")
-    # Open folder directory incase uploads to ticket were incomplete - only works on windows
+    # Open folder directory incase uploads to ticket were incomplete
     open_folder(error_folder_path)


### PR DESCRIPTION
# Overview

Uses JIRA query language ([JQL](https://support.atlassian.com/jira-software-cloud/docs/what-is-advanced-search-in-jira-cloud/)) to do advanced searches of tickets on the ABR board.

This update was needed because they updated the structure of their [API calls](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/#api-rest-api-3-search-jql-get).

## Test Plan and Hands on Testing

- smoke tested on windows and mac

## Changelog

- updated `get_project_issues()` to use new api call syntax
- removed need for reporterId in arguments and in ticket creation. This argument is not actually needed because the reporter Id is added when the link opens in your browser. If you are not logged into JIRA when you try to use the script, this will not work regardless of if this is defined. 
- removed writing to ABR lpc google sheet because it is no longer being used and moved google sheet writing into a separate function in order to decrease main function complexity
- updated open error log folder at the end to work on mac and windows

## Risk assessment

- low, does not affect robot stack