### PR TITLE
fix(app):  handle array deserialization in USB IPC on Windows

### DIFF
--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -62,12 +62,19 @@ export async function appShellRequestor<Data>(
     throw result.error
   }
 
+  // TODO(jh, 2026-02-26): The below is a hack to get around the fact that Blob data
+  // doesn't (de)serialize properly somewhere in the IPC chain, seemingly only on Windows. Investigate
+  // a more robust solution.
+
   // Blob data doesn't serialize properly across the IPC, so we parse it from
-  // an Array type sent from the shell layer.
-  if (config.responseType === 'blob' && Array.isArray(result.data)) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    const uint8Array = new Uint8Array(result.data)
-    result.data = new Blob([uint8Array]) as Data
+  // an Array type sent from the shell layer. On Windows, large arrays may be
+  // serialized as objects with numeric string keys (e.g., {"0":80,"1":75,...}).
+  if (config.responseType === 'blob' && result.data != null) {
+    const arrayData = Array.isArray(result.data)
+      ? result.data
+      : Object.values(result.data as Record<string, number>)
+
+    result.data = new Blob([new Uint8Array(arrayData as number[])]) as Data
   }
 
   return result


### PR DESCRIPTION
Closes [RQA-5230](https://opentrons.atlassian.net/browse/RQA-5230) and likely [RESC-539](https://opentrons.atlassian.net/browse/RESC-539)

# Overview

When downloading image zip files from a robot via USB on Windows, the downloaded file was corrupted. Instead of a valid zip file containing binary data, the file contained JSON.

On Windows, when large arrays travel through Electron's IPC serialization layer, they can be transformed from proper JavaScript arrays into objects with numeric string keys, which doesn't appear to happen on Mac.

A working solution is to handle the serialization outcome in which the expected axios response type is `blob` but is not the expected array and transform it to an array. While catching and handling this case on the shell side would be sensible, it appears insufficient, hinting at a deserialization issue across the IPC mechanism.

## Test Plan and Hands on Testing

- Verified that all image download entry points on Windows result in image and zip files that are accessible. These entry points are the only ones with `blob` type data.

## Changelog

- Fixed a bug in which opening image zip files downloaded on Windows USB fails due to a corrupted file.

## Risk assessment

- low, this change is orthogonal to existing behavior, and the only `blob` type checking we do is for image data, and all the access points on the app have been audited.


[RQA-5230]: https://opentrons.atlassian.net/browse/RQA-5230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RESC-539]: https://opentrons.atlassian.net/browse/RESC-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ