### PR TITLE
refactor(system-server): Modernize type annotations

### DIFF
--- a/system-server/system_server/app_setup.py
+++ b/system-server/system_server/app_setup.py
@@ -1,7 +1,7 @@
 """Main FastAPI application."""
 
 import logging
-from typing import Any, List
+from typing import Any
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -58,7 +58,7 @@ async def on_startup() -> None:
 async def on_shutdown() -> None:
     """Handle app shutdown."""
     # Placeholder for actual shutdown processes
-    shutdown_results: List[Any] = []
+    shutdown_results: list[Any] = []
     log.info("shutdown")
 
     shutdown_errors = [r for r in shutdown_results if isinstance(r, BaseException)]

--- a/system-server/system_server/connection/authorization_tracker.py
+++ b/system-server/system_server/connection/authorization_tracker.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List
 
 from system_server.jwt import Registrant
 
@@ -19,7 +18,7 @@ class AuthorizationTracker:
     """Class to track active authorizations on the server."""
 
     def __init__(self) -> None:
-        self._connections: List[_Authorization] = []
+        self._connections: list[_Authorization] = []
 
     def add_connection(self, registrant: Registrant, expiration: datetime) -> None:
         """Add a new connection, or refresh an existing one.
@@ -49,7 +48,7 @@ class AuthorizationTracker:
         self._update_active_connections()
         return len(self._connections)
 
-    def get_connected(self) -> List[Registrant]:
+    def get_connected(self) -> list[Registrant]:
         """Get a list of all of the current active connections."""
         self._update_active_connections()
         return [n.registrant for n in self._connections]

--- a/system-server/system_server/jwt/system_jwt.py
+++ b/system-server/system_server/jwt/system_jwt.py
@@ -3,7 +3,6 @@
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Optional
 
 import jwt
 
@@ -57,8 +56,8 @@ def create_jwt(
     duration: timedelta,
     registrant: Registrant,
     audience: str,
-    now: Optional[datetime] = None,
-    id: Optional[str] = None,
+    now: datetime | None = None,
+    id: str | None = None,
 ) -> str:
     """Generate a signed JWT with the specified parameters.
 

--- a/system-server/system_server/persistence/__init__.py
+++ b/system-server/system_server/persistence/__init__.py
@@ -3,12 +3,11 @@
 import logging
 from asyncio import Lock
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Final
 from uuid import UUID
 
 import sqlalchemy
 from fastapi import Depends
-from typing_extensions import Final
 
 from server_utils.fastapi_utils.app_state import (
     AppState,

--- a/system-server/system_server/persistence/__init__.py
+++ b/system-server/system_server/persistence/__init__.py
@@ -3,6 +3,7 @@
 import logging
 from asyncio import Lock
 from pathlib import Path
+from typing import Annotated
 from uuid import UUID
 
 import sqlalchemy
@@ -43,7 +44,7 @@ _authorization_tracker_lock = Lock()
 
 
 async def get_persistence_directory(
-    app_state: AppState = Depends(get_app_state),
+    app_state: Annotated[AppState, Depends(get_app_state)],
 ) -> Path:
     """Return the root persistence directory, creating it if necessary."""
     async with _persistence_dir_lock:
@@ -68,8 +69,8 @@ async def get_persistence_directory(
 
 
 async def get_sql_engine(
-    app_state: AppState = Depends(get_app_state),
-    persistence_directory: Path = Depends(get_persistence_directory),
+    app_state: Annotated[AppState, Depends(get_app_state)],
+    persistence_directory: Annotated[Path, Depends(get_persistence_directory)],
 ) -> sqlalchemy.engine.Engine:
     """Return a singleton SQL engine referring to a ready-to-use database."""
     async with _sql_lock:
@@ -87,8 +88,8 @@ async def get_sql_engine(
 
 
 async def get_persistent_uuid(
-    app_state: AppState = Depends(get_app_state),
-    persistence_directory: Path = Depends(get_persistence_directory),
+    app_state: Annotated[AppState, Depends(get_app_state)],
+    persistence_directory: Annotated[Path, Depends(get_persistence_directory)],
 ) -> UUID:
     """Return a singleton UUID for signing purposes."""
     async with _uuid_lock:
@@ -102,7 +103,7 @@ async def get_persistent_uuid(
 
 
 async def get_authorization_tracker(
-    app_state: AppState = Depends(get_app_state),
+    app_state: Annotated[AppState, Depends(get_app_state)],
 ) -> AuthorizationTracker:
     """Return a singleton authorization tracker for the server instance."""
     async with _authorization_tracker_lock:

--- a/system-server/system_server/persistence/migrations.py
+++ b/system-server/system_server/persistence/migrations.py
@@ -17,10 +17,9 @@ Database schema versions:
 
 import logging
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Final
 
 import sqlalchemy
-from typing_extensions import Final
 
 from .tables import migration_table
 
@@ -47,7 +46,7 @@ def migrate(sql_engine: sqlalchemy.engine.Engine) -> None:
             _mark_latest_revision(transaction)
 
 
-def _get_schema_version(transaction: sqlalchemy.engine.Connection) -> Optional[int]:
+def _get_schema_version(transaction: sqlalchemy.engine.Connection) -> int | None:
     """Get the starting version of the database.
 
     Returns:

--- a/system-server/system_server/persistence/persistent_directory.py
+++ b/system-server/system_server/persistence/persistent_directory.py
@@ -3,17 +3,16 @@
 import logging
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Optional
+from typing import Final
 
 from anyio import Path as AsyncPath
-from typing_extensions import Final
 
 _TEMP_PERSISTENCE_DIR_PREFIX: Final = "opentrons-system-server-"
 
 _log = logging.getLogger(__name__)
 
 
-async def create_persistent_directory(path: Optional[Path]) -> Path:
+async def create_persistent_directory(path: Path | None) -> Path:
     """Create a persistent directory.
 
     If the directory in `path` doesn't exist, this function will generate

--- a/system-server/system_server/service/check_jwt_headers.py
+++ b/system-server/system_server/service/check_jwt_headers.py
@@ -1,6 +1,7 @@
 """HTTP API registration token logic."""
 
 import logging
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import Depends, Header, HTTPException, Request, status
@@ -14,11 +15,13 @@ _log = logging.getLogger(__name__)
 
 async def check_registration_token_header(
     request: Request,
-    authenticationBearer: str = Header(
-        ...,
-        description="An authentication header bearing a token provided by the `/system/register` endpoint.",
-    ),
-    signing_key: UUID = Depends(get_persistent_uuid),
+    authenticationBearer: Annotated[
+        str,
+        Header(
+            description="An authentication header bearing a token provided by the `/system/register` endpoint.",
+        ),
+    ],
+    signing_key: Annotated[UUID, Depends(get_persistent_uuid)],
 ) -> None:
     """A header requirement that requests a registration token from /system/register."""
     _log.info(f"Verifying registration token: {authenticationBearer}")
@@ -45,11 +48,13 @@ async def get_registration_token_header(request: Request) -> str:
 
 async def check_authorization_token_header(
     request: Request,
-    authenticationBearer: str = Header(
-        ...,
-        description="An authentication header bearing a token provided by the `/system/authorize` endpoint.",
-    ),
-    signing_key: UUID = Depends(get_persistent_uuid),
+    authenticationBearer: Annotated[
+        str,
+        Header(
+            description="An authentication header bearing a token provided by the `/system/authorize` endpoint.",
+        ),
+    ],
+    signing_key: Annotated[UUID, Depends(get_persistent_uuid)],
 ) -> None:
     """A header requirement that requests a authorization token from /system/authorize."""
     _log.info(f"Verifying authorization token: {authenticationBearer}")

--- a/system-server/system_server/settings/settings.py
+++ b/system-server/system_server/settings/settings.py
@@ -2,6 +2,7 @@
 
 import typing
 from functools import lru_cache
+from typing import Annotated
 
 from dotenv import load_dotenv, set_key
 from pydantic import Field
@@ -21,10 +22,10 @@ def get_settings() -> "SystemServerSettings":
 class Environment(BaseSettings):
     """Environment related settings."""
 
-    dot_env_path: typing.Optional[str] = Field(
-        default=None,
-        description="Path to a .env file to define system server settings.",
-    )
+    dot_env_path: Annotated[
+        typing.Optional[str],
+        Field(description="Path to a .env file to define system server settings."),
+    ] = None
     model_config = SettingsConfigDict(env_prefix="OT_SYSTEM_SERVER_")
 
 
@@ -35,37 +36,44 @@ class SystemServerSettings(BaseSettings):
     OT_SYSTEM_SERVER_, e.g. OT_SYSTEM_SERVER_persistence_directory.
     """
 
-    persistence_directory: typing.Optional[str] = Field(
-        default=None,
-        description=(
-            "A directory for the server to store things persistently across boots."
-            " If this directory doesn't already exist, the server will create it."
-            " If this is the string `automatically_make_temporary`,"
-            " the server will use a fresh temporary directory"
-            " (effectively not persisting anything)."
+    persistence_directory: Annotated[
+        typing.Optional[str],
+        Field(
+            description=(
+                "A directory for the server to store things persistently across boots."
+                " If this directory doesn't already exist, the server will create it."
+                " If this is the string `automatically_make_temporary`,"
+                " the server will use a fresh temporary directory"
+                " (effectively not persisting anything)."
+            )
         ),
-    )
+    ] = None
 
-    oem_mode_enabled: typing.Optional[bool] = Field(
-        default=False,
-        description=(
-            "A flag used to change the default splash screen on system startup."
-            " If this flag is disabled (default), the Opentrons loading video will be shown."
-            " If this flag is enabled but `oem_mode_splash_custom` is not set,"
-            " then the default OEM Mode splash screen will be shown."
-            " If this flag is enabled and `oem_mode_splash_custom` is set to a"
-            " PNG filepath, the custom splash screen will be shown."
+    oem_mode_enabled: Annotated[
+        typing.Optional[bool],
+        Field(
+            description=(
+                "A flag used to change the default splash screen on system startup."
+                " If this flag is disabled (default), the Opentrons loading video will be shown."
+                " If this flag is enabled but `oem_mode_splash_custom` is not set,"
+                " then the default OEM Mode splash screen will be shown."
+                " If this flag is enabled and `oem_mode_splash_custom` is set to a"
+                " PNG filepath, the custom splash screen will be shown."
+            ),
         ),
-    )
+    ] = False
 
-    oem_mode_splash_custom: typing.Optional[str] = Field(
-        default=None,
-        description=(
-            "The filepath of the PNG image used as the custom splash screen."
-            " Read the description of the `oem_mode_enabled` flag to know how"
-            " the splash screen changes when the flag is enabled/disabled."
+    oem_mode_splash_custom: Annotated[
+        typing.Optional[str],
+        Field(
+            description=(
+                "The filepath of the PNG image used as the custom splash screen."
+                " Read the description of the `oem_mode_enabled` flag to know how"
+                " the splash screen changes when the flag is enabled/disabled."
+            ),
         ),
-    )
+    ] = None
+
     model_config = SettingsConfigDict(
         env_file=Environment().dot_env_path, env_prefix="OT_SYSTEM_SERVER_"
     )

--- a/system-server/system_server/settings/settings.py
+++ b/system-server/system_server/settings/settings.py
@@ -1,6 +1,5 @@
 """System server configuration options."""
 
-import typing
 from functools import lru_cache
 from typing import Annotated
 
@@ -23,7 +22,7 @@ class Environment(BaseSettings):
     """Environment related settings."""
 
     dot_env_path: Annotated[
-        typing.Optional[str],
+        str | None,
         Field(description="Path to a .env file to define system server settings."),
     ] = None
     model_config = SettingsConfigDict(env_prefix="OT_SYSTEM_SERVER_")
@@ -37,7 +36,7 @@ class SystemServerSettings(BaseSettings):
     """
 
     persistence_directory: Annotated[
-        typing.Optional[str],
+        str | None,
         Field(
             description=(
                 "A directory for the server to store things persistently across boots."
@@ -50,7 +49,7 @@ class SystemServerSettings(BaseSettings):
     ] = None
 
     oem_mode_enabled: Annotated[
-        typing.Optional[bool],
+        bool | None,
         Field(
             description=(
                 "A flag used to change the default splash screen on system startup."
@@ -64,7 +63,7 @@ class SystemServerSettings(BaseSettings):
     ] = False
 
     oem_mode_splash_custom: Annotated[
-        typing.Optional[str],
+        str | None,
         Field(
             description=(
                 "The filepath of the PNG image used as the custom splash screen."

--- a/system-server/system_server/system/authorize/models.py
+++ b/system-server/system_server/system/authorize/models.py
@@ -1,9 +1,11 @@
 """Models for /system/register."""
 
+from typing import Annotated
+
 from pydantic import BaseModel, Field
 
 
 class PostAuthorizeResponse(BaseModel):
     """Model for the response to POST /system/register."""
 
-    token: str = Field(..., description="the authorization token")
+    token: Annotated[str, Field(description="the authorization token")]

--- a/system-server/system_server/system/authorize/router.py
+++ b/system-server/system_server/system/authorize/router.py
@@ -1,7 +1,7 @@
 """Router for all /system/ endpoints."""
 
 from textwrap import dedent
-from typing import List, Optional
+from typing import Annotated, List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, Response, status
@@ -41,9 +41,11 @@ authorize_router = APIRouter()
     dependencies=[Depends(check_registration_token_header)],
 )
 async def authorize(
-    token: str = Depends(get_registration_token_header),
-    signing_uuid: UUID = Depends(get_persistent_uuid),
-    authorization_tracker: AuthorizationTracker = Depends(get_authorization_tracker),
+    token: Annotated[str, Depends(get_registration_token_header)],
+    signing_uuid: Annotated[UUID, Depends(get_persistent_uuid)],
+    authorization_tracker: Annotated[
+        AuthorizationTracker, Depends(get_authorization_tracker)
+    ],
 ) -> PostAuthorizeResponse:
     """Router for /system/authorize endpoint."""
     key = str(signing_uuid)
@@ -72,11 +74,12 @@ async def authorize(
     },
 )
 async def check_authorization(
-    token: str = Depends(get_authorization_token_header),
-    signing_uuid: UUID = Depends(get_persistent_uuid),
-    scopes: Optional[List[str]] = Query(
-        None, description="List of scopes to verify token access to."
-    ),
+    token: Annotated[str, Depends(get_authorization_token_header)],
+    signing_uuid: Annotated[UUID, Depends(get_persistent_uuid)],
+    scopes: Annotated[
+        Optional[List[str]],
+        Query(description="List of scopes to verify token access to."),
+    ] = None,
 ) -> Response:
     """Check an authorization token for validity."""
     # NOTE: The `scopes` parameter is included as a placeholder for future validation.

--- a/system-server/system_server/system/authorize/router.py
+++ b/system-server/system_server/system/authorize/router.py
@@ -1,7 +1,7 @@
 """Router for all /system/ endpoints."""
 
 from textwrap import dedent
-from typing import Annotated, List, Optional
+from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, Response, status
@@ -77,7 +77,7 @@ async def check_authorization(
     token: Annotated[str, Depends(get_authorization_token_header)],
     signing_uuid: Annotated[UUID, Depends(get_persistent_uuid)],
     scopes: Annotated[
-        Optional[List[str]],
+        list[str] | None,
         Query(description="List of scopes to verify token access to."),
     ] = None,
 ) -> Response:

--- a/system-server/system_server/system/connected/models.py
+++ b/system-server/system_server/system/connected/models.py
@@ -1,6 +1,6 @@
 """Models for /system/register."""
 
-from typing import Annotated, List
+from typing import Annotated
 
 from pydantic import BaseModel, Field
 
@@ -21,5 +21,5 @@ class GetConnectedResponse(BaseModel):
     """Model for the response to GET /system/connected."""
 
     connections: Annotated[
-        List[Connection], Field(description="the current active connections")
+        list[Connection], Field(description="the current active connections")
     ]

--- a/system-server/system_server/system/connected/models.py
+++ b/system-server/system_server/system/connected/models.py
@@ -1,6 +1,6 @@
 """Models for /system/register."""
 
-from typing import List
+from typing import Annotated, List
 
 from pydantic import BaseModel, Field
 
@@ -8,16 +8,18 @@ from pydantic import BaseModel, Field
 class Connection(BaseModel):
     """Model for a single entry in response to GET /system/connected."""
 
-    subject: str = Field(..., description="the human registered to this connection")
-    agent: str = Field(..., description="the application type for this connection")
-    agentId: str = Field(
-        ..., description="a unique identifier for the instance of the agent"
-    )
+    subject: Annotated[
+        str, Field(description="the human registered to this connection")
+    ]
+    agent: Annotated[str, Field(description="the application type for this connection")]
+    agentId: Annotated[
+        str, Field(description="a unique identifier for the instance of the agent")
+    ]
 
 
 class GetConnectedResponse(BaseModel):
     """Model for the response to GET /system/connected."""
 
-    connections: List[Connection] = Field(
-        ..., description="the current active connections"
-    )
+    connections: Annotated[
+        List[Connection], Field(description="the current active connections")
+    ]

--- a/system-server/system_server/system/connected/router.py
+++ b/system-server/system_server/system/connected/router.py
@@ -1,6 +1,7 @@
 """Router for all /system/connected endpoints."""
 
 from textwrap import dedent
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, status
 
@@ -29,7 +30,9 @@ connected_router = APIRouter()
     response_model=GetConnectedResponse,
 )
 async def get_connected(
-    authorization_tracker: AuthorizationTracker = Depends(get_authorization_tracker),
+    authorization_tracker: Annotated[
+        AuthorizationTracker, Depends(get_authorization_tracker)
+    ],
 ) -> GetConnectedResponse:
     """Get connected registrants."""
     connections = authorization_tracker.get_connected()

--- a/system-server/system_server/system/oem_mode/models.py
+++ b/system-server/system_server/system/oem_mode/models.py
@@ -1,9 +1,11 @@
 """Models for /system/oem_mode."""
 
+from typing import Annotated
+
 from pydantic import BaseModel, Field
 
 
 class EnableOEMMode(BaseModel):
     """Enable OEM Mode model."""
 
-    enable: bool = Field(..., description="Enable or Disable OEM Mode.")
+    enable: Annotated[bool, Field(description="Enable or Disable OEM Mode.")]

--- a/system-server/system_server/system/register/dependencies.py
+++ b/system-server/system_server/system/register/dependencies.py
@@ -1,18 +1,24 @@
 """Dependencies for /system/register endpoints."""
 
+from typing import Annotated
+
 from fastapi import Query
 
 from system_server.jwt import Registrant
 
 
 def create_registrant(
-    subject: str = Query(
-        ..., description="Identifies the human intending to register with the robot"
-    ),
-    agent: str = Query(..., description="Identifies the app type making the request"),
-    agentId: str = Query(
-        ..., description="A unique identifier for the instance of the agent"
-    ),
+    subject: Annotated[
+        str,
+        Query(description="Identifies the human intending to register with the robot"),
+    ],
+    agent: Annotated[
+        str, Query(description="Identifies the app type making the request")
+    ],
+    agentId: Annotated[
+        str,
+        Query(description="A unique identifier for the instance of the agent"),
+    ],
 ) -> Registrant:
     """Define a unique Registrant to create a registration token for.
 

--- a/system-server/system_server/system/register/models.py
+++ b/system-server/system_server/system/register/models.py
@@ -1,9 +1,11 @@
 """Models for /system/register."""
 
+from typing import Annotated
+
 from pydantic import BaseModel, Field
 
 
 class PostRegisterResponse(BaseModel):
     """Model for the response to POST /system/register."""
 
-    token: str = Field(..., description="the registration token")
+    token: Annotated[str, Field(description="the registration token")]

--- a/system-server/system_server/system/register/router.py
+++ b/system-server/system_server/system/register/router.py
@@ -1,6 +1,7 @@
 """Router for /system/register endpoint."""
 
 from textwrap import dedent
+from typing import Annotated
 from uuid import UUID
 
 import sqlalchemy
@@ -28,7 +29,8 @@ register_router = APIRouter()
         This registers a client (basically just storing the information you pass in)
         and returns a registration token that you can pass to `/system/authorize`.
         Identical information is deduplicated, so this is safe to call multiple times.
-        """),
+        """
+    ),
     responses={
         status.HTTP_200_OK: {"model": PostRegisterResponse},
         status.HTTP_201_CREATED: {"model": PostRegisterResponse},
@@ -36,9 +38,9 @@ register_router = APIRouter()
 )
 async def register_endpoint(
     response: Response,
-    registrant: Registrant = Depends(create_registrant),
-    signing_uuid: UUID = Depends(get_persistent_uuid),
-    engine: sqlalchemy.engine.Engine = Depends(get_sql_engine),
+    registrant: Annotated[Registrant, Depends(create_registrant)],
+    signing_uuid: Annotated[UUID, Depends(get_persistent_uuid)],
+    engine: Annotated[sqlalchemy.engine.Engine, Depends(get_sql_engine)],
 ) -> PostRegisterResponse:
     """Router for /system/register endpoint."""
     token, new_token = get_or_create_registration_token(

--- a/system-server/system_server/system/register/storage.py
+++ b/system-server/system_server/system/register/storage.py
@@ -2,7 +2,6 @@
 
 import logging
 from datetime import timedelta
-from typing import Dict, Optional, Tuple
 
 import sqlalchemy
 
@@ -13,7 +12,7 @@ from system_server.persistence import registration_table
 _log = logging.getLogger(__name__)
 
 
-def _create_registration_row(registrant: Registrant, token: str) -> Dict[str, object]:
+def _create_registration_row(registrant: Registrant, token: str) -> dict[str, object]:
     """Helper to serialize into a sql row."""
     return {
         "agent": registrant.agent,
@@ -25,7 +24,7 @@ def _create_registration_row(registrant: Registrant, token: str) -> Dict[str, ob
 
 def _get_registration_token(
     sql_connection: sqlalchemy.engine.Connection, registrant: Registrant
-) -> Optional[str]:
+) -> str | None:
     """Get the JWT for a registrant, if it exists.
 
     This function searches the database to check if a token exists for
@@ -96,7 +95,7 @@ def _add_registration_token(
 
 def get_or_create_registration_token(
     sql_engine: sqlalchemy.engine.Engine, registrant: Registrant, signing_key: str
-) -> Tuple[str, bool]:
+) -> tuple[str, bool]:
     """Get the token for a registrant, or create a new one if necessary.
 
     If a token is found in the database, this function performs validation on it. If

--- a/system-server/system_server/systemd.py
+++ b/system-server/system_server/systemd.py
@@ -1,13 +1,12 @@
 """Systemd bindings with fallbacks for test."""
 
 import logging.config
-from typing import Dict, Union
 
 try:
     # systemd journal is available, we can use its handler
     import systemd.journal  # noqa: F401
 
-    def log_handler(topic_name: str, log_level: int) -> Dict[str, Union[int, str]]:
+    def log_handler(topic_name: str, log_level: int) -> dict[str, int | str]:
         """Initialize log handler."""
         return {
             "class": "systemd.journal.JournalHandler",
@@ -21,7 +20,7 @@ try:
 except ImportError:
     # systemd journal isn't available, probably running tests
 
-    def log_handler(topic_name: str, log_level: int) -> Dict[str, Union[int, str]]:
+    def log_handler(topic_name: str, log_level: int) -> dict[str, int | str]:
         """Initialize log handler."""
         return {
             "class": "logging.StreamHandler",

--- a/system-server/tests/connection/test_authorization_tracker.py
+++ b/system-server/tests/connection/test_authorization_tracker.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta
-from typing import List
 
 import pytest
 
@@ -8,7 +7,7 @@ from system_server.jwt import Registrant
 
 
 @pytest.fixture
-def registrant_list() -> List[Registrant]:
+def registrant_list() -> list[Registrant]:
     return [Registrant(f"sub{n}", f"agent{n}", f"agent_id{n}") for n in range(100)]
 
 
@@ -42,7 +41,7 @@ async def test_authorization_tracking_counting() -> None:
     assert subject.active_connections() == 1
 
 
-async def test_authorization_tracking_getter(registrant_list: List[Registrant]) -> None:
+async def test_authorization_tracking_getter(registrant_list: list[Registrant]) -> None:
     subject = AuthorizationTracker()
     # Generate a list of registrants
     expiration = datetime.now() + timedelta(days=100)
@@ -59,7 +58,7 @@ async def test_authorization_tracking_getter(registrant_list: List[Registrant]) 
 
 
 async def test_authorization_tracking_overwrite(
-    registrant_list: List[Registrant],
+    registrant_list: list[Registrant],
 ) -> None:
     subject = AuthorizationTracker()
     # Generate a list of registrants

--- a/system-server/tests/dev_server.py
+++ b/system-server/tests/dev_server.py
@@ -7,12 +7,11 @@ import sys
 import tempfile
 from pathlib import Path
 from types import TracebackType
-from typing import Optional
 
 
 class DevServer:
     def __init__(
-        self, port: int | None = None, persistence_directory: Optional[Path] = None
+        self, port: int | None = None, persistence_directory: Path | None = None
     ) -> None:
         """Initialize a dev server."""
         self.server_temp_directory: str = tempfile.mkdtemp()
@@ -30,9 +29,9 @@ class DevServer:
 
     def __exit__(
         self,
-        exc_type: Optional[BaseException],
-        exc_val: Optional[BaseException],
-        exc_tb: Optional[TracebackType],
+        exc_type: BaseException | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> None:
         self.stop()
 

--- a/system-server/tests/persistence/test_tables.py
+++ b/system-server/tests/persistence/test_tables.py
@@ -1,6 +1,6 @@
 """Tests for SQL registration table."""
 
-from typing import List, cast
+from typing import cast
 
 import sqlalchemy
 
@@ -63,7 +63,7 @@ def test_creating_tables_emits_expected_statements() -> None:
     Based on:
     https://docs.sqlalchemy.org/en/14/faq/metadata_schema.html#faq-ddl-as-string
     """
-    actual_statements: List[str] = []
+    actual_statements: list[str] = []
 
     def record_statement(
         sql: sqlalchemy.schema.DDLElement, *multiparams: object, **params: object


### PR DESCRIPTION
## Overview

This updates our type annotation syntax in system-server to match current conventions, especially in FastAPI and Pydantic.

No behavioral changes.

## Test Plan and Hands on Testing

Just CI.

## Changelog

* FastAPI dependencies like `foo: T = Depends(get_foo)` become `foo: Annotated[T, Depends(get_foo)]`
* Pydantic fields like `foo: T = Field(default, description="...")` become `foo: Annotated[T, Field(description="...")] = default`
* Type annotations like `typing.List[str]` become just `list[str]`
* `typing_extensions.Final` becomes `typing.Final`

## Review requests

None in particular.

## Risk assessment

Low.