### PR TITLE
feat(abr-testing): ABR video capture

### DIFF
--- a/abr-testing/abr_testing/protocols/helpers/background_helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers/background_helpers.py
@@ -62,16 +62,16 @@ def change_robot_video_length(time: str, ip: str) -> None:
 
 def video_capture_buffer(max_time: int, m3u8_path: str):
     """Keeps a running video capture buffer of given time."""
-    storage_path: str = "data/testing_data/video_capture_buffer"
+    storage_path: str = "data/testing_data/videos/video_capture_buffer"
     os.makedirs(storage_path, exist_ok=True)
 
     # Runs forever in the background
 
 
     # Hello future programmer. Below is an ffmpeg command.
-    # ffmpeg makes no sense.
+    # ffmpeg is ugly. ffmpeg makes no sense.
     # just know that this is what this does:
-    # 1. streams from the givem m3u8_path
+    # 1. streams from the given m3u8_path
     # 2. segments the stream into 1 second clips
     # 3. converts each of these one second clips to mp4
     # 4. stores these clips in the above "storage_path" directory

--- a/abr-testing/abr_testing/protocols/helpers/background_helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers/background_helpers.py
@@ -66,6 +66,16 @@ def video_capture_buffer(max_time: int, m3u8_path: str):
     os.makedirs(storage_path, exist_ok=True)
 
     # Runs forever in the background
+
+
+    # Hello future programmer. Below is an ffmpeg command.
+    # ffmpeg makes no sense.
+    # just know that this is what this does:
+    # 1. streams from the givem m3u8_path
+    # 2. segments the stream into 1 second clips
+    # 3. converts each of these one second clips to mp4
+    # 4. stores these clips in the above "storage_path" directory
+    # it also runs perpetually (but don't worry, it is killed below)
     cmd = [
         "ffmpeg", "-y", "-i", m3u8_path,
         "-f", "segment",

--- a/abr-testing/abr_testing/protocols/helpers/background_helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers/background_helpers.py
@@ -11,6 +11,7 @@ from abr_testing.automation import slack
 from abr_testing.tools import check_robot_status as robot_status
 from abr_testing.protocols.helpers import run_helpers
 from collections import deque
+from datetime import datetime
 
 
 def detect_robot_status(ip: str) -> None:
@@ -25,7 +26,7 @@ def detect_robot_status(ip: str) -> None:
 
     # Process will be constantly running
     while True:
-        time.sleep(300)
+        time.sleep(30)
 
         # Reset running_robot and completed_robot information to prevent possible data corruption
         running_robots: List[str] = []
@@ -41,6 +42,83 @@ def detect_robot_status(ip: str) -> None:
             on_robot=True,
             past_run_status=past_run_statuses,
         )
+
+
+def change_robot_video_length(time: str, ip: str) -> None:
+    """Changes the length of the robot video to the given time."""
+    key = "hls_playlist_length"
+    ssh_command = f"""
+    mount -o remount,rw / &&
+    sed -i "s/{key} *[0-9][0-9]*s;/{key} {time}s;/g" /etc/nginx/nginx.conf &&
+    systemctl daemon-reload &&
+    systemctl restart nginx 
+    """
+
+    try:
+        subprocess.run(ssh_command, shell=True, check=True)
+        print(f"Successfully updated livestream length on {ip}")
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to update {ip}: {e}")
+
+def video_capture_buffer(max_time: int, m3u8_path: str):
+    """Keeps a running video capture buffer of given time."""
+    storage_path: str = "data/testing_data/video_capture_buffer"
+    os.makedirs(storage_path, exist_ok=True)
+
+    # Runs forever in the background
+    cmd = [
+        "ffmpeg", "-y", "-i", m3u8_path,
+        "-f", "segment",
+        "-segment_time", "1",
+        "-strftime", "1",
+        "-c:v", "libx264", "-c:a", "aac",
+        f"{storage_path}/%Y-%m-%d_%H-%M-%S.mp4"
+    ]
+    """
+    Note to self:
+        1. stdout and stderr are subprocess' way of outputing logs and errors to the terminal
+        2. DEVNULL is a "black hole" file
+        3. here, we are telling subprocess to stfu instead of attacking our terminal
+    """
+    process = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    # give ffmpeg a second to get started
+    time.sleep(1)
+
+    # cleans up
+    try:
+        while True:
+            # creates buffer
+
+            # Filter for .mp4 only so we don't accidentally try to delete temp files
+            buffer: list[str] = sorted([f for f in os.listdir(storage_path) if f.endswith(".mp4")])
+
+            # enforces maximum time
+            if len(buffer) >= max_time + 1:
+                attempted_removals: int = 0
+
+                def _remove_item(attempted_removals: int = 0):
+                    #only try 3 times
+                    if attempted_removals > 3:
+                        return
+
+                    try:
+                        os.remove(f"{storage_path}/{buffer[0]}")
+                    except IndexError:
+                        # assume ffmpeg hasn't done anything yet
+                        pass
+                    except OSError:
+                        # wait a second, then try again
+                        time.sleep(1)
+                        attempted_removals+=1
+                        _remove_item(attempted_removals)
+
+                _remove_item(attempted_removals)
+
+
+            time.sleep(1)
+    finally:
+        process.terminate()
+
 
 
 def launch_background_tasks() -> None:

--- a/abr-testing/abr_testing/protocols/helpers/background_helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers/background_helpers.py
@@ -11,7 +11,6 @@ from abr_testing.automation import slack
 from abr_testing.tools import check_robot_status as robot_status
 from abr_testing.protocols.helpers import run_helpers
 from collections import deque
-from datetime import datetime
 
 
 def detect_robot_status(ip: str) -> None:
@@ -51,7 +50,7 @@ def change_robot_video_length(time: str, ip: str) -> None:
     mount -o remount,rw / &&
     sed -i "s/{key} *[0-9][0-9]*s;/{key} {time}s;/g" /etc/nginx/nginx.conf &&
     systemctl daemon-reload &&
-    systemctl restart nginx 
+    systemctl restart nginx
     """
 
     try:
@@ -60,13 +59,13 @@ def change_robot_video_length(time: str, ip: str) -> None:
     except subprocess.CalledProcessError as e:
         print(f"Failed to update {ip}: {e}")
 
-def video_capture_buffer(max_time: int, m3u8_path: str):
+
+def video_capture_buffer(max_time: int, m3u8_path: str) -> None:
     """Keeps a running video capture buffer of given time."""
     storage_path: str = "data/testing_data/videos/video_capture_buffer"
     os.makedirs(storage_path, exist_ok=True)
 
     # Runs forever in the background
-
 
     # Hello future programmer. Below is an ffmpeg command.
     # ffmpeg is ugly. ffmpeg makes no sense.
@@ -77,12 +76,21 @@ def video_capture_buffer(max_time: int, m3u8_path: str):
     # 4. stores these clips in the above "storage_path" directory
     # it also runs perpetually (but don't worry, it is killed below)
     cmd = [
-        "ffmpeg", "-y", "-i", m3u8_path,
-        "-f", "segment",
-        "-segment_time", "1",
-        "-strftime", "1",
-        "-c:v", "libx264", "-c:a", "aac",
-        f"{storage_path}/%Y-%m-%d_%H-%M-%S.mp4"
+        "ffmpeg",
+        "-y",
+        "-i",
+        m3u8_path,
+        "-f",
+        "segment",
+        "-segment_time",
+        "1",
+        "-strftime",
+        "1",
+        "-c:v",
+        "libx264",
+        "-c:a",
+        "aac",
+        f"{storage_path}/%Y-%m-%d_%H-%M-%S.mp4",
     ]
     """
     Note to self:
@@ -90,7 +98,9 @@ def video_capture_buffer(max_time: int, m3u8_path: str):
         2. DEVNULL is a "black hole" file
         3. here, we are telling subprocess to stfu instead of attacking our terminal
     """
-    process = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    process = subprocess.Popen(
+        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
     # give ffmpeg a second to get started
     time.sleep(1)
 
@@ -100,14 +110,16 @@ def video_capture_buffer(max_time: int, m3u8_path: str):
             # creates buffer
 
             # Filter for .mp4 only so we don't accidentally try to delete temp files
-            buffer: list[str] = sorted([f for f in os.listdir(storage_path) if f.endswith(".mp4")])
+            buffer: list[str] = sorted(
+                [f for f in os.listdir(storage_path) if f.endswith(".mp4")]
+            )
 
             # enforces maximum time
             if len(buffer) >= max_time + 1:
                 attempted_removals: int = 0
 
-                def _remove_item(attempted_removals: int = 0):
-                    #only try 3 times
+                def _remove_item(attempted_removals: int = 0) -> None:
+                    # only try 3 times
                     if attempted_removals > 3:
                         return
 
@@ -119,16 +131,14 @@ def video_capture_buffer(max_time: int, m3u8_path: str):
                     except OSError:
                         # wait a second, then try again
                         time.sleep(1)
-                        attempted_removals+=1
+                        attempted_removals += 1
                         _remove_item(attempted_removals)
 
                 _remove_item(attempted_removals)
 
-
             time.sleep(1)
     finally:
         process.terminate()
-
 
 
 def launch_background_tasks() -> None:

--- a/abr-testing/abr_testing/protocols/helpers/background_helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers/background_helpers.py
@@ -66,15 +66,11 @@ def video_capture_buffer(max_time: int, m3u8_path: str) -> None:
     os.makedirs(storage_path, exist_ok=True)
 
     # Runs forever in the background
-
-    # Hello future programmer. Below is an ffmpeg command.
-    # ffmpeg is ugly. ffmpeg makes no sense.
-    # just know that this is what this does:
-    # 1. streams from the given m3u8_path
-    # 2. segments the stream into 1 second clips
-    # 3. converts each of these one second clips to mp4
-    # 4. stores these clips in the above "storage_path" directory
-    # it also runs perpetually (but don't worry, it is killed below)
+    # FMMPEG Command Description:
+    # 1. Streams from the given m3u8_path
+    # 2. Segments the stream into 1 second clips
+    # 3. Converts each of these one second clips to mp4
+    # 4. Stores these clips in the above "storage_path" directory
     cmd = [
         "ffmpeg",
         "-y",
@@ -92,12 +88,7 @@ def video_capture_buffer(max_time: int, m3u8_path: str) -> None:
         "aac",
         f"{storage_path}/%Y-%m-%d_%H-%M-%S.mp4",
     ]
-    """
-    Note to self:
-        1. stdout and stderr are subprocess' way of outputing logs and errors to the terminal
-        2. DEVNULL is a "black hole" file
-        3. here, we are telling subprocess to stfu instead of attacking our terminal
-    """
+
     process = subprocess.Popen(
         cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
     )

--- a/abr-testing/abr_testing/protocols/helpers/run_background.sh
+++ b/abr-testing/abr_testing/protocols/helpers/run_background.sh
@@ -19,11 +19,11 @@ pkill -f "video_capture_buffer"
 pkill -f "detect_robot_status"
 
 
-
 (python3 -c "from background_helpers import detect_robot_status; detect_robot_status('$IP_ADDRESS')" &)
 sleep 0.5
 statusProcessID=$!
 
+VIDEO_LENGTH=30
 (python3 -c "from background_helpers import video_capture_buffer;
 video_capture_buffer($VIDEO_LENGTH, '/var/www/localhost/html/stream/hls/stream.m3u8')" &)
 videoBufferProcessID=$!

--- a/abr-testing/abr_testing/protocols/helpers/run_background.sh
+++ b/abr-testing/abr_testing/protocols/helpers/run_background.sh
@@ -8,10 +8,14 @@ cd "$(dirname "$0")"
 
 # CHECK: Is there a lockfile?
 if [ -f "$LOCKFILE" ]; then
-    # Is the process ID inside that file actually still running?
-    if kill -0 "$(cat "$LOCKFILE")" 2>/dev/null; then
-        exit 0 # It's already running, so this script just give up.
-    fi
+    # Read the lockfile line by line
+    while read -r pid; do
+        # Is this specific PID actually still running?
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+            echo "Process $pid is still running. Exiting."
+            exit 0
+        fi
+    done < "$LOCKFILE"
 fi
 
 # check what already exists and kill it

--- a/abr-testing/abr_testing/protocols/helpers/run_background.sh
+++ b/abr-testing/abr_testing/protocols/helpers/run_background.sh
@@ -28,6 +28,8 @@ sleep 0.5
 statusProcessID=$!
 
 VIDEO_LENGTH=30
+(python3 -c "from background_helpers import change_robot_video_length; change_robot_video_length('$VIDEO_LENGTH',
+'$IP_ADDRESS'")
 (python3 -c "from background_helpers import video_capture_buffer;
 video_capture_buffer($VIDEO_LENGTH, '/var/www/localhost/html/stream/hls/stream.m3u8')" &)
 videoBufferProcessID=$!

--- a/abr-testing/abr_testing/protocols/helpers/run_background.sh
+++ b/abr-testing/abr_testing/protocols/helpers/run_background.sh
@@ -4,7 +4,7 @@ IP_ADDRESS=$(networkctl status | grep "Address:" | awk '{print $2}')
 
 # Navigate to relevant file
 cd "$(dirname "$0")"
-pwd
+#pwd
 
 # CHECK: Is there a lockfile?
 if [ -f "$LOCKFILE" ]; then
@@ -15,18 +15,25 @@ if [ -f "$LOCKFILE" ]; then
 fi
 
 # check what already exists and kill it
-pkill -f "background_helpers"
+pkill -f "video_capture_buffer"
+pkill -f "detect_robot_status"
 
 
 
 (python3 -c "from background_helpers import detect_robot_status; detect_robot_status('$IP_ADDRESS')" &)
 sleep 0.5
-processID=$!
+statusProcessID=$!
 
-if kill -0 "$processID" 2>/dev/null; then
+(python3 -c "from background_helpers import video_capture_buffer;
+video_capture_buffer($VIDEO_LENGTH, '/var/www/localhost/html/stream/hls/stream.m3u8')" &)
+videoBufferProcessID=$!
+
+
+if kill -0 "$statusProcessID" 2>/dev/null && kill -0 "$videoBufferProcessID" 2>/dev/null; then
   # Push the Python process ID to the Lockfile
-  echo "$processID" > "$LOCKFILE"
-  echo "background process successfully launched"
+  echo "$statusProcessID" > "$LOCKFILE"
+  echo "$videoBufferProcessID" >> "$LOCKFILE"
+  echo "background processes successfully launched"
 else
-  echo "background process failed to launch"
+  echo "background processes failed to launch"
 fi

--- a/abr-testing/abr_testing/protocols/helpers/run_background.sh
+++ b/abr-testing/abr_testing/protocols/helpers/run_background.sh
@@ -4,7 +4,6 @@ IP_ADDRESS=$(networkctl status | grep "Address:" | awk '{print $2}')
 
 # Navigate to relevant file
 cd "$(dirname "$0")"
-#pwd
 
 # CHECK: Is there a lockfile?
 if [ -f "$LOCKFILE" ]; then

--- a/abr-testing/abr_testing/protocols/helpers/run_helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers/run_helpers.py
@@ -674,6 +674,37 @@ def get_livestream_video(length: int) -> str:
     convert_m3u8_to_mp4(video_path, new_video_path, length)
     return new_video_path
 
+def access_livestream_buffer() -> str:
+    """Get latest livestream buffer. Clips returned are a full 30 seconds long"""
+    """This is designed to be a replacement for the above function."""
+    storage_path: str = "data/testing_data/videos/video_capture_buffer"
+    video_clip_files: list[str] = sorted([f for f in os.listdir(storage_path) if f.endswith(".mp4")])
+
+    # Just skip the most recent second, ffmpeg might still be writing
+    # Note: This may create a 1-second blind spot. Ask how long the robot tends to take to enter error recovery/
+    # Error out after the error actually happens
+    if len(video_clip_files) > 1:
+        video_clip_files = video_clip_files[:-1]
+
+    txt_file_path: str = "data/testing_data/videos/buffer_addresses.txt"
+    output_file_path: str = "data/testing_data/videos/output.mp4"
+
+    # write all of the files in the buffer to a new file
+    with open(txt_file_path, "w") as file:
+        for files in video_clip_files:
+            file.write(f"file '{os.path.join(storage_path, files)}'\n")
+
+    # stitch all of the files in the buffer into one video
+    subprocess.run(f"ffmpeg -y -f concat -safe 0 -i {txt_file_path} -c copy {output_file_path}", shell=True)
+
+    # delete the text file
+    if os.path.exists(txt_file_path):
+        os.remove(txt_file_path)
+
+    # return the output file path
+    return output_file_path
+
+
 
 def create_robot_log_zip() -> Tuple[str, str]:
     """Create a zip file of logs saved locally on robot."""

--- a/abr-testing/abr_testing/protocols/helpers/run_helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers/run_helpers.py
@@ -658,6 +658,8 @@ def get_last_image_capture() -> str:
 
 def convert_m3u8_to_mp4(m3u8_pth: str, mp4_pth: str, dur: int = 30) -> None:
     """Convert m3u8 video to mp4 format."""
+    ffmpeg_cmd = f'ffmpeg -i "{m3u8_pth}" -t {dur} -c:v mpeg4 -c:a aac -movflags +faststart "{mp4_pth}" -y'
+
     subprocess.run(
         f'ffmpeg -i "{m3u8_pth}" -t {dur} -c:v mpeg4 -c:a aac -movflags +faststart "{mp4_pth}" -y',
         shell=True,

--- a/abr-testing/abr_testing/protocols/helpers/run_helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers/run_helpers.py
@@ -658,10 +658,13 @@ def get_last_image_capture() -> str:
 
 def convert_m3u8_to_mp4(m3u8_pth: str, mp4_pth: str, dur: int = 30) -> None:
     """Convert m3u8 video to mp4 format."""
-    ffmpeg_cmd = f'ffmpeg -i "{m3u8_pth}" -t {dur} -c:v mpeg4 -c:a aac -movflags +faststart "{mp4_pth}" -y'
+    ffmpeg_cmd = (
+        f'ffmpeg -i "{m3u8_pth}" -t {dur} -c:v mpeg4 -c:a aac -movflags +faststart '
+        f'"{mp4_pth}" -y'
+    )
 
     subprocess.run(
-        f'ffmpeg -i "{m3u8_pth}" -t {dur} -c:v mpeg4 -c:a aac -movflags +faststart "{mp4_pth}" -y',
+        ffmpeg_cmd,
         shell=True,
         check=True,
     )
@@ -674,15 +677,18 @@ def get_livestream_video(length: int) -> str:
     convert_m3u8_to_mp4(video_path, new_video_path, length)
     return new_video_path
 
+
 def access_livestream_buffer() -> str:
-    """Get latest livestream buffer. Clips returned are a full 30 seconds long"""
+    """Get latest livestream buffer. Clips returned are a full 30 seconds long."""
     """This is designed to be a replacement for the above function."""
     storage_path: str = "data/testing_data/videos/video_capture_buffer"
-    video_clip_files: list[str] = sorted([f for f in os.listdir(storage_path) if f.endswith(".mp4")])
+    video_clip_files: list[str] = sorted(
+        [f for f in os.listdir(storage_path) if f.endswith(".mp4")]
+    )
 
     # Just skip the most recent second, ffmpeg might still be writing
-    # Note: This may create a 1-second blind spot. Ask how long the robot tends to take to enter error recovery/
-    # Error out after the error actually happens
+    # Note: This may create a 1-second blind spot. Ask how long the robot tends to take to
+    # enter error recovery/error out after the error actually happens
     if len(video_clip_files) > 1:
         video_clip_files = video_clip_files[:-1]
 
@@ -695,7 +701,10 @@ def access_livestream_buffer() -> str:
             file.write(f"file '{os.path.join(storage_path, files)}'\n")
 
     # stitch all of the files in the buffer into one video
-    subprocess.run(f"ffmpeg -y -f concat -safe 0 -i {txt_file_path} -c copy {output_file_path}", shell=True)
+    subprocess.run(
+        f"ffmpeg -y -f concat -safe 0 -i {txt_file_path} -c copy {output_file_path}",
+        shell=True,
+    )
 
     # delete the text file
     if os.path.exists(txt_file_path):
@@ -703,7 +712,6 @@ def access_livestream_buffer() -> str:
 
     # return the output file path
     return output_file_path
-
 
 
 def create_robot_log_zip() -> Tuple[str, str]:

--- a/abr-testing/abr_testing/protocols/helpers/run_helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers/run_helpers.py
@@ -670,25 +670,14 @@ def convert_m3u8_to_mp4(m3u8_pth: str, mp4_pth: str, dur: int = 30) -> None:
     )
 
 
-def get_livestream_video(length: int) -> str:
-    """Get latest livestream video."""
-    video_path = "/var/www/localhost/html/stream/hls/stream.m3u8"
-    new_video_path = "/data/testing_data/livestream_video.mp4"
-    convert_m3u8_to_mp4(video_path, new_video_path, length)
-    return new_video_path
-
-
 def access_livestream_buffer() -> str:
     """Get latest livestream buffer. Clips returned are a full 30 seconds long."""
-    """This is designed to be a replacement for the above function."""
     storage_path: str = "data/testing_data/videos/video_capture_buffer"
     video_clip_files: list[str] = sorted(
         [f for f in os.listdir(storage_path) if f.endswith(".mp4")]
     )
 
     # Just skip the most recent second, ffmpeg might still be writing
-    # Note: This may create a 1-second blind spot. Ask how long the robot tends to take to
-    # enter error recovery/error out after the error actually happens
     if len(video_clip_files) > 1:
         video_clip_files = video_clip_files[:-1]
 
@@ -706,11 +695,9 @@ def access_livestream_buffer() -> str:
         shell=True,
     )
 
-    # delete the text file
     if os.path.exists(txt_file_path):
         os.remove(txt_file_path)
 
-    # return the output file path
     return output_file_path
 
 
@@ -732,7 +719,7 @@ def send_slack_error_message_with_attachments(
 ) -> None:
     """Send error slack message with log files and video clip attached."""
     log_path, ip = create_robot_log_zip()
-    video_path = get_livestream_video(length)
+    video_path = access_livestream_buffer()
     slack_bot.send_error_message(protocol_name, error_str, ip, [log_path, video_path])
 
 

--- a/abr-testing/abr_testing/tools/check_robot_status.py
+++ b/abr-testing/abr_testing/tools/check_robot_status.py
@@ -4,6 +4,7 @@ from collections import deque
 
 import requests
 from abr_testing.automation import slack
+from abr_testing.protocols.helpers import run_helpers
 import configparser
 import os
 from typing import List, Dict, Any, Tuple
@@ -65,7 +66,7 @@ def get_current_run_details_from_robot(
                         if (len(past_run_status_list) == 0) or not (
                             past_run_status_list[-1] == run_status
                         ):
-                            slack_bot.send_slack_message(message)
+                            slack_bot.send_slack_message(message, run_helpers.access_livestream_buffer())
                     else:
                         slack_bot.send_slack_message(message)
                         completed_robots.append(robot_name)

--- a/abr-testing/abr_testing/tools/check_robot_status.py
+++ b/abr-testing/abr_testing/tools/check_robot_status.py
@@ -66,7 +66,9 @@ def get_current_run_details_from_robot(
                         if (len(past_run_status_list) == 0) or not (
                             past_run_status_list[-1] == run_status
                         ):
-                            slack_bot.send_slack_message(message, run_helpers.access_livestream_buffer())
+                            slack_bot.send_slack_message(
+                                message, [run_helpers.access_livestream_buffer()]
+                            )
                     else:
                         slack_bot.send_slack_message(message)
                         completed_robots.append(robot_name)


### PR DESCRIPTION
# Overview

This PR adds video capture functionality to the ABR suite. While a version of this functionality existed before, the way ffmpeg processed m3u8 meant that when trying to record the 30 seconds before an event, the video returned would display the 30 seconds after. This PR fixes that issue by using a 30-clip-long linear buffer of 1-second clips (essentially just 30 seconds) generated by a persistent ffmpeg stream. These clips are all saved in a directory, and this directory is accessed to find all of the clips. The clips are then stitched together when needed.

## Test Plan and Hands on Testing

No testing as of yet, waiting for the ABR suite to calm down a little. There's already enough going wrong, I don't need to add another potential point of failure just yet.

## Changelog

### background_helpers.py
Error Recovery checks were updated to poll every 30 seconds instead of 300 (5 minutes). This is to line up with the size of the buffer.

A new change_robot_video_length() function was added. This was simply to change the length of the video that the robots saved locally on their machines. May remove, as this had no effect.

a new video_capture_buffer() function was added. This launches the persistent ffmpeg stream, tracks the files that the stream generates, and enforces the buffer's maximum length. 

### run_background.sh
Lockfile logic updated to handle multiple processes within it. 

2 new processes launched:
- change_robot_video_length [discrete]
- video_capture_buffer [persistent]

### run_helpers.py
A new access_live_stream() function was added to access the files stored in the buffer directory, stitch them together, and output a new file that stores the full 30-second mp4.

This function replaces the "get_livestream_video()" function. Changes were made to functions who called that function to now call this one. x

### check_robot_status.py
in get_run_details_from_robot(), when error recovery is detected, it uses access_live_stream() from run_helpers.py to create a video of the most recent thirty seconds. It then sends this video alongside the error recovery message.

## Review requests

I'm really worried about one particular race condition here. The way I access the buffer is by collecting the names of all the video files and feeding them to ffmpeg to stitch together. But in the event that one of these files gets removed from the buffer after the name is processed but before ffmpeg actually processes it, the system falls apart. I may be over thinking this, and tried to mitigate by making sure the list of files is sorted so that the first video that the accessor processes would also be the one that's most likely to get thrown out by the buffer, but I'm not sure. Anyways, any advice in this regard would be much appreciated. 

Will polling every 30 seconds be too hard on the system?

## Risk assessment

Low. Only affects ABR-suite.
