### PR TITLE
refactor(system-server): Resolve SQLAlchemy "removed in 2.0" deprecations

### DIFF
--- a/system-server/pyproject.toml
+++ b/system-server/pyproject.toml
@@ -137,6 +137,7 @@ dependency-metadata = [
 addopts = ["--cov=system_server", "--cov-report", "term-missing:skip-covered", "--cov-report", "xml:coverage.xml", "--color=yes", "--strict-markers"]
 asyncio_mode = "auto"
 filterwarnings = [
+    "error::sqlalchemy.exc.RemovedIn20Warning",
     "error::pydantic.PydanticDeprecatedSince20",
 ]
 

--- a/system-server/system_server/persistence/migrations.py
+++ b/system-server/system_server/persistence/migrations.py
@@ -58,7 +58,7 @@ def _get_schema_version(transaction: sqlalchemy.engine.Connection) -> int | None
     )
     migration = transaction.execute(select_latest_version).first()
 
-    return migration["version"] if migration is not None else None
+    return migration.version if migration is not None else None
 
 
 def _mark_latest_revision(transaction: sqlalchemy.engine.Connection) -> None:

--- a/system-server/system_server/system/register/storage.py
+++ b/system-server/system_server/system/register/storage.py
@@ -115,7 +115,7 @@ def get_or_create_registration_token(
         The JWT, and a boolean that is True if the JWT is newly created or False if
         it is a cached value.
     """
-    with sql_engine.connect() as conn:
+    with sql_engine.begin() as conn:
         token = _get_registration_token(conn, registrant)
         token_is_new = False
 

--- a/system-server/tests/persistence/test_migrations.py
+++ b/system-server/tests/persistence/test_migrations.py
@@ -46,11 +46,13 @@ def subject(database_path: Path) -> Generator[sqlalchemy.engine.Engine, None, No
 )
 def test_migration(subject: sqlalchemy.engine.Engine) -> None:
     """It should migrate a table if necessary."""
-    migrations = subject.execute(sqlalchemy.select(migration_table)).all()
+    with subject.begin() as connection:
+        migrations = connection.execute(sqlalchemy.select(migration_table)).all()
 
     assert [m.version for m in migrations] == [0]
 
     # all table queries work without raising
-    for table in TABLES:
-        values = subject.execute(sqlalchemy.select(table)).all()
-        assert values == []
+    with subject.begin() as connection:
+        for table in TABLES:
+            values = connection.execute(sqlalchemy.select(table)).all()
+            assert values == []


### PR DESCRIPTION
## Overview

system-server is currently on SQLAlchemy 1.4. In a handful of places, it's doing things that would be incompatible with SQLAlchemy 2.0, which are raising deprecation warnings. This fixes those.

See the individual commit messages for details on the exact warnings that are being resolved.

## Test Plan and Hands on Testing

Just CI.

## Review requests

None in particular.

## Risk assessment

Low.