### PR TITLE
fix(app): add gap between title and radio buttons in ER options page

### DIFF
--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
@@ -85,7 +85,7 @@ export function SelectRecoveryOptionHome({
           isSticky: true,
         }}
       >
-        <Flex flexDirection={DIRECTION_COLUMN}>
+        <Flex css={CONTENT_STYLE}>
           <StyledText
             oddStyle="level4HeaderSemiBold"
             desktopStyle="headingSmallBold"
@@ -120,6 +120,11 @@ const CONTENT_WRAPPER_OVERRIDE_STYLE = css`
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
     grid-gap: ${SPACING.spacing12};
   }
+`
+
+const CONTENT_STYLE = css`
+  flex-direction: ${DIRECTION_COLUMN};
+  gap: ${SPACING.spacing16};
 `
 
 interface RecoveryOptionsProps {


### PR DESCRIPTION
# Overview

According to designs, there should be a 1rem gap between error recovery action title and radio buttons.

Closes EXEC-2394

## Test Plan and Hands on Testing

- enter any error recovery flow and launch error recovery (easiest way is to run a protocol and purposely miss a tip during pickup)
- verify that in error recovery options screen, there is padding between "Choose a recovery action" title text and radio buttons section (same style for both desktop and ODD)

<img width="293" height="177" alt="Screenshot 2026-02-26 at 11 08 05 AM" src="https://github.com/user-attachments/assets/1dc37948-8aa2-4070-bd45-7228b12b0ff1" />

<br/>

<img width="195" height="58" alt="Screenshot 2026-02-26 at 11 08 17 AM" src="https://github.com/user-attachments/assets/cc4dc754-151c-4fdd-8fe8-4d4c67f13ebe" />  

## Changelog

- add style for ER options container

## Review requests

see test plan

## Risk assessment

⬇️⬇️