### PR TITLE
chore(docs): update copyright date on 2026 publications

### DIFF
--- a/docs/flex/mkdocs.yml
+++ b/docs/flex/mkdocs.yml
@@ -125,4 +125,4 @@ extra_css:
   - ../shared/opentrons-theme.css
   - print-pdf.css
 
-copyright: '© Opentrons 2025. All rights reserved. <br /> Trademarks: Opentrons®, Opentrons drop logo (Opentrons Labworks, Inc.). <br /> Registered names, trademarks, etc. used in this document, even when not specifically marked as such, are not to be considered unprotected by law.'
+copyright: '© Opentrons 2026. All rights reserved. <br /> Trademarks: Opentrons®, Opentrons drop logo (Opentrons Labworks, Inc.). <br /> Registered names, trademarks, etc. used in this document, even when not specifically marked as such, are not to be considered unprotected by law.'

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -99,4 +99,4 @@ extra:
   apiLevel: 2.27
   robot_stack_version: 8.8.0
 
-copyright: '© Opentrons 2025. All rights reserved. <br /> Trademarks: Opentrons®, Opentrons drop logo (Opentrons Labworks, Inc.). <br /> Registered names, trademarks, etc. used in this document, even when not specifically marked as such, are not to be considered unprotected by law.'
+copyright: '© Opentrons 2026. All rights reserved. <br /> Trademarks: Opentrons®, Opentrons drop logo (Opentrons Labworks, Inc.). <br /> Registered names, trademarks, etc. used in this document, even when not specifically marked as such, are not to be considered unprotected by law.'

--- a/docs/ot-2/mkdocs.yml
+++ b/docs/ot-2/mkdocs.yml
@@ -85,4 +85,4 @@ extra_css:
   - manual.css
   - ../opentrons-theme.css
 
-copyright: '© Opentrons 2025. All rights reserved. <br /> Trademarks: Opentrons®, Opentrons drop logo (Opentrons Labworks, Inc.). <br /> Registered names, trademarks, etc. used in this document, even when not specifically marked as such, are not to be considered unprotected by law.'
+copyright: '© Opentrons 2026. All rights reserved. <br /> Trademarks: Opentrons®, Opentrons drop logo (Opentrons Labworks, Inc.). <br /> Registered names, trademarks, etc. used in this document, even when not specifically marked as such, are not to be considered unprotected by law.'


### PR DESCRIPTION
# Overview

smdh it's february and i can't believe i'm still writing 2025 on all my docs

## Test Plan and Hands on Testing

Sandbox

## Changelog

Updated 2025 -> 2026 on all publications that have actually had changes this year. Honestly, only the one in `docs/mkdocs.yml` matters, because it's the only copyright text that gets deployed.

## Review requests

What year is it?

## Risk assessment

nil