### PR TITLE
feat(system-server,robot-server): Require authorization for /settings and /system/oem_mode/enable

### DIFF
--- a/auth-server/tests/integration/test_oauth_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_oauth_flows.tavern.yaml
@@ -21,7 +21,7 @@ stages:
         refresh_token: !anystr
         expires_in: !anyint
         token_type: Bearer
-        scope: &default_scope auth_settings.write runs.write users.read users.write
+        scope: &default_scope auth_settings.write robot_settings.write runs.write users.read users.write
       save:
         json:
           initial_access_token: access_token
@@ -209,7 +209,7 @@ stages:
         refresh_token: !anystr
         expires_in: !anyint
         token_type: Bearer
-        scope: auth_settings.write runs.write users.read users.write
+        scope: auth_settings.write robot_settings.write runs.write users.read users.write
       save:
         json:
           refresh_token: refresh_token

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -78,8 +78,6 @@ log = logging.getLogger(__name__)
 router = APIRouter()
 
 
-# TODO: (ba, 2024-04-11): We should have a proper IPC mechanism to talk between
-# the servers instead of one off endpoint calls like these.
 async def _set_oem_mode_request(enable: bool, authorization_header: str | None) -> int:
     """PUT request to set the OEM Mode for the system server."""
     headers = (

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -3,7 +3,7 @@ from dataclasses import asdict
 from typing import Annotated, Any, Dict, List, Optional, Union, cast
 
 import aiohttp
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Header
 from starlette import status
 
 from opentrons.config import (
@@ -36,6 +36,8 @@ from opentrons_shared_data.pipette import (
     types as pip_types,
 )
 from opentrons_shared_data.robot.types import RobotTypeEnum
+from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.scopes import Scope
 from server_utils.persistence.persistence_directory import PersistenceResetter
 
 from robot_server.deck_configuration.fastapi_dependencies import (
@@ -78,11 +80,19 @@ router = APIRouter()
 
 # TODO: (ba, 2024-04-11): We should have a proper IPC mechanism to talk between
 # the servers instead of one off endpoint calls like these.
-async def _set_oem_mode_request(enable: bool) -> int:
+async def _set_oem_mode_request(enable: bool, authorization_header: str | None) -> int:
     """PUT request to set the OEM Mode for the system server."""
+    headers = (
+        {"Authorization": authorization_header}
+        if authorization_header is not None
+        else None
+    )
+
     async with aiohttp.ClientSession() as session:
         async with session.put(
-            "http://127.0.0.1:31950/system/oem_mode/enable", json={"enable": enable}
+            "http://127.0.0.1:31950/system/oem_mode/enable",
+            headers=headers,
+            json={"enable": enable},
         ) as resp:
             return resp.status
 
@@ -97,11 +107,13 @@ async def _set_oem_mode_request(enable: bool) -> int:
         status.HTTP_400_BAD_REQUEST: {"model": LegacyErrorResponse},
         status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": LegacyErrorResponse},
     },
+    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
 )
 async def post_settings(
     update: AdvancedSettingRequest,
     hardware: Annotated[HardwareControlAPI, Depends(get_hardware)],
     robot_type: Annotated[RobotTypeEnum, Depends(get_robot_type_enum)],
+    authorization: Annotated[str | None, Header()] = None,
 ) -> AdvancedSettingsResponse:
     """Update advanced setting (feature flag)"""
     try:
@@ -111,7 +123,9 @@ async def post_settings(
                 # Unlike opentrons.advanced_settings, system-server cannot store
                 # `None`/`null` to restore to default. Storing `False` instead is close
                 # enough.
-                update.value if update.value is not None else False
+                update.value if update.value is not None else False,
+                # Forward along the client's authorization, if it has authorization.
+                authorization_header=authorization,
             )
             if resp != 200:
                 # TODO: raise correct error here

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -35,7 +35,13 @@ from opentrons.hardware_control import API, HardwareControlAPI, ThreadedAsyncLoc
 from opentrons.protocol_api import labware
 from opentrons.types import Mount, Point
 from opentrons_shared_data.labware.types import LabwareDefinition
-from server_utils.fastapi_utils.app_state import AppState, get_app_state
+from server_utils.auth.resource_server.authorization_checker import (
+    AlwaysAllowedAuthorizationChecker,
+    AuthorizationChecker,
+)
+from server_utils.auth.resource_server.fastapi_dependencies import (
+    get_authorization_checker,
+)
 
 from robot_server.app import app
 from robot_server.hardware import get_hardware, get_ot2_hardware
@@ -47,7 +53,7 @@ from robot_server.runs.dependencies import get_run_data_manager
 from robot_server.runs.run_data_manager import RunDataManager
 from robot_server.service.notifications.notification_client import (
     NotificationClient,
-    _notification_client_accessor,
+    get_notification_client,
 )
 from robot_server.service.session.manager import SessionManager
 from robot_server.versioning import API_VERSION_HEADER, LATEST_API_VERSION_HEADER_VALUE
@@ -211,20 +217,30 @@ def _override_run_data_manager_with_mock(run_data: MagicMock) -> Iterator[None]:
 
 
 @pytest.fixture
-def _override_app_state_with_notification_client(decoy: Decoy) -> Iterator[None]:
+def _override_notification_client_with_mock(decoy: Decoy) -> Iterator[None]:
     """Override app_state to include a mocked notification client."""
-    mock_app_state = AppState()
     mock_notification_client = decoy.mock(cls=NotificationClient)
 
-    _notification_client_accessor.set_on(mock_app_state, mock_notification_client)
+    async def get_notification_client_override() -> NotificationClient:
+        return mock_notification_client
 
-    async def get_app_state_override() -> AppState:
-        """Override for get_app_state."""
-        return mock_app_state
-
-    app.dependency_overrides[get_app_state] = get_app_state_override
+    app.dependency_overrides[get_notification_client] = get_notification_client_override
     yield
-    del app.dependency_overrides[get_app_state]
+    del app.dependency_overrides[get_notification_client]
+
+
+@pytest.fixture
+def _override_authorization_checker_with_always_allowed(decoy: Decoy) -> Iterator[None]:
+    authorization_checker = AlwaysAllowedAuthorizationChecker()
+
+    async def get_authorization_checker_override() -> AuthorizationChecker:
+        return authorization_checker
+
+    app.dependency_overrides[get_authorization_checker] = (
+        get_authorization_checker_override
+    )
+    yield
+    del app.dependency_overrides[get_authorization_checker]
 
 
 @pytest.fixture
@@ -233,7 +249,8 @@ def api_client(
     _override_sql_engine_with_mock: None,
     _override_version_with_mock: None,
     _override_ot2_hardware_with_mock: None,
-    _override_app_state_with_notification_client: None,
+    _override_notification_client_with_mock: None,
+    _override_authorization_checker_with_always_allowed: None,
 ) -> TestClient:
     client = TestClient(app)
     client.headers.update(
@@ -249,7 +266,8 @@ def api_client_camera_overrides(
     _override_version_with_mock: None,
     _override_ot2_hardware_with_mock: None,
     _override_run_data_manager_with_mock: None,
-    _override_app_state_with_notification_client: None,
+    _override_notification_client_with_mock: None,
+    _override_authorization_checker_with_always_allowed: None,
 ) -> TestClient:
     client = TestClient(app)
     client.headers.update(

--- a/server-utils/server_utils/auth/resource_server/auth_server.py
+++ b/server-utils/server_utils/auth/resource_server/auth_server.py
@@ -69,7 +69,13 @@ class LocalHTTPClient(Client):
 
         if auth_server_uds is not None:
             connector = aiohttp.UnixConnector(path=auth_server_uds)
-            session = aiohttp.ClientSession(connector=connector)
+            session = aiohttp.ClientSession(
+                connector=connector,
+                # We're connecting over a Unix socket, so this URL is nonsensical,
+                # but aiohttp seems to require it as a placeholder.
+                # https://github.com/aio-libs/aiohttp/issues/11324.
+                base_url="http://localhost",
+            )
         elif auth_server_url is not None:
             session = aiohttp.ClientSession(base_url=auth_server_url)
         else:

--- a/server-utils/server_utils/auth/resource_server/fastapi_dependencies.py
+++ b/server-utils/server_utils/auth/resource_server/fastapi_dependencies.py
@@ -164,6 +164,6 @@ def _get_authorization_checker(
     """A FastAPI dependency to retrieve the server's singleton `AuthorizationChecker`."""
     authorization_checker = _authorization_checker_accessor.get_from(app_state)
     assert authorization_checker is not None, (
-        "Forgot to initialize notification client as part of server startup?"
+        "Forgot to initialize authorization checker as part of server startup?"
     )
     return authorization_checker

--- a/server-utils/server_utils/auth/resource_server/fastapi_dependencies.py
+++ b/server-utils/server_utils/auth/resource_server/fastapi_dependencies.py
@@ -87,7 +87,7 @@ def require_scopes(*required_scopes: Scope) -> Callable[..., Awaitable[None]]:
             ),
         ],
         authorization_checker: Annotated[
-            AuthorizationChecker, fastapi.Depends(_get_authorization_checker)
+            AuthorizationChecker, fastapi.Depends(get_authorization_checker)
         ],
     ) -> None:
         authorization_result = await authorization_checker.check(
@@ -158,10 +158,14 @@ async def build_authorization_checker(
             yield AuthServerAuthorizationChecker(client)
 
 
-def _get_authorization_checker(
+def get_authorization_checker(
     app_state: Annotated[AppState, fastapi.Depends(get_app_state)],
 ) -> AuthorizationChecker:
-    """A FastAPI dependency to retrieve the server's singleton `AuthorizationChecker`."""
+    """A FastAPI dependency to retrieve the server's singleton `AuthorizationChecker`.
+
+    Endpoints should not normally need to use this directly. Use `require_scopes()`,
+    which is higher-level, instead. This is exposed for testing.
+    """
     authorization_checker = _authorization_checker_accessor.get_from(app_state)
     assert authorization_checker is not None, (
         "Forgot to initialize authorization checker as part of server startup?"

--- a/server-utils/server_utils/auth/scopes.py
+++ b/server-utils/server_utils/auth/scopes.py
@@ -24,6 +24,11 @@ class Scope(enum.Enum):
         "Edit settings related to authentication, authorization, and access control.",
     )
 
+    ROBOT_SETTINGS_WRITE = (
+        "robot_settings.write",
+        "Edit general robot settings."
+    )
+
     RUNS_WRITE = (
         "runs.write",
         "Create and control protocol runs.",

--- a/server-utils/server_utils/persistence/__init__.py
+++ b/server-utils/server_utils/persistence/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities to help a server implement persistent data storage."""

--- a/system-server/system_server/app_setup.py
+++ b/system-server/system_server/app_setup.py
@@ -1,6 +1,6 @@
 """Main FastAPI application."""
 
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 from typing import AsyncGenerator
 
 from fastapi import FastAPI
@@ -8,6 +8,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_redoc_html
 from fastapi.responses import HTMLResponse
 
+from server_utils.auth.resource_server.fastapi_dependencies import (
+    build_authorization_checker,
+    install_authorization_checker,
+)
 from server_utils.fastapi_utils.server_timing_middleware import server_timing_middleware
 
 from system_server._version import version
@@ -19,12 +23,19 @@ _REDOC_CDN_URL = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    # Load settings and (throw away the result) so that we detect errors early
-    # on in startup, instead of the first time someone happens to use a setting.
-    get_settings()
+    async with AsyncExitStack() as exit_stack:
+        settings = get_settings()
 
-    # Start serving requests.
-    yield
+        authorization_checker = await exit_stack.enter_async_context(
+            build_authorization_checker(
+                auth_server_uds=settings.auth_server_uds,
+                auth_server_url=settings.auth_server_url,
+            )
+        )
+        install_authorization_checker(app.state, authorization_checker)
+
+        # Start serving requests.
+        yield
 
 
 app = FastAPI(

--- a/system-server/system_server/app_setup.py
+++ b/system-server/system_server/app_setup.py
@@ -1,7 +1,7 @@
 """Main FastAPI application."""
 
-import logging
-from typing import Any
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -17,7 +17,14 @@ from system_server.settings import get_settings
 _REDOC_CDN_URL = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js"
 
 
-log = logging.getLogger(__name__)
+@asynccontextmanager
+async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    # Load settings and (throw away the result) so that we detect errors early
+    # on in startup, instead of the first time someone happens to use a setting.
+    get_settings()
+
+    # Start serving requests.
+    yield
 
 
 app = FastAPI(
@@ -30,6 +37,7 @@ app = FastAPI(
     docs_url=None,
     # redoc_url is replaced by our own /redoc router, below.
     redoc_url=None,
+    lifespan=_lifespan,
 )
 
 app.add_middleware(
@@ -44,27 +52,6 @@ app.middleware("http")(server_timing_middleware())
 
 # main router
 app.include_router(router=router)
-
-
-@app.on_event("startup")
-async def on_startup() -> None:
-    """Handle app startup."""
-    # Load settings and (throw away the result) so that we detect errors early
-    # on in startup, instead of the first time someone happens to use a setting.
-    get_settings()
-
-
-@app.on_event("shutdown")
-async def on_shutdown() -> None:
-    """Handle app shutdown."""
-    # Placeholder for actual shutdown processes
-    shutdown_results: list[Any] = []
-    log.info("shutdown")
-
-    shutdown_errors = [r for r in shutdown_results if isinstance(r, BaseException)]
-
-    for e in shutdown_errors:
-        log.warning("Error during shutdown", exc_info=e)
 
 
 # This is a workaround for a broken /redoc page in versions of FastAPI <0.115.3.

--- a/system-server/system_server/settings/settings.py
+++ b/system-server/system_server/settings/settings.py
@@ -48,6 +48,28 @@ class SystemServerSettings(BaseSettings):
         ),
     ] = None
 
+    auth_server_uds: Annotated[
+        str | None,
+        Field(
+            description=(
+                "The path to the Unix domain socket where auth-server is listening."
+                " This is mutually exclusive with auth_server_url."
+                " If both are unset, access control is not enforced."
+            ),
+        ),
+    ] = None
+
+    auth_server_url: Annotated[
+        str | None,
+        Field(
+            description=(
+                "The base URL (e.g. `http://localhost:1234`) where auth-server is listening."
+                " This is mutually exclusive with auth_server_uds."
+                " If both are unset, access control is not enforced."
+            ),
+        ),
+    ] = None
+
     model_config = SettingsConfigDict(
         env_file=Environment().dot_env_path, env_prefix="OT_SYSTEM_SERVER_"
     )

--- a/system-server/system_server/system/oem_mode/router.py
+++ b/system-server/system_server/system/oem_mode/router.py
@@ -3,6 +3,7 @@
 import os
 import re
 from pathlib import Path
+from textwrap import dedent
 from typing import Annotated
 
 import filetype  # type: ignore[import-untyped]
@@ -40,7 +41,22 @@ oem_mode_router = APIRouter()
 @oem_mode_router.put(
     "/system/oem_mode/enable",
     summary="Enable or disable OEM Mode",
-    description="Enable or disable OEM Mode",
+    description=dedent(
+        """\
+        Enable or disable OEM Mode.
+
+        Currently, this endpoint does not *completely* enable OEM mode, so it should not
+        be used directly. Use `POST /settings` instead. This may change in the future.
+        """
+        # To elaborate on the description above:
+        # The part of OEM mode that this endpoint doesn't do is telling the ODD to avoid
+        # branded language in its UX copy. That's currently done by the ODD querying
+        # the OEM mode status in robot-server's `GET /settings`, which in turn is set
+        # via robot-server's `POST /settings`. Ideally, system-server would have a pair
+        # of PUT+GET endpoints serving as the single source of truth, and either
+        # robot-server's `/settings` endpoints would proxy to them, or we'd outright
+        # delete OEM mode from `/settings`.
+    ),
     responses={
         status.HTTP_200_OK: {"message": "OEM Mode changed successfully."},
         status.HTTP_400_BAD_REQUEST: {"message": "OEM Mode did not change."},

--- a/system-server/system_server/system/oem_mode/router.py
+++ b/system-server/system_server/system/oem_mode/router.py
@@ -16,6 +16,9 @@ from fastapi import (
     status,
 )
 
+from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.scopes import Scope
+
 from .models import EnableOEMMode
 from .oem_settings_store import (
     OEMSettingsStore,
@@ -40,11 +43,12 @@ oem_mode_router = APIRouter()
     description="Enable or disable OEM Mode",
     responses={
         status.HTTP_200_OK: {"message": "OEM Mode changed successfully."},
-        status.HTTP_400_BAD_REQUEST: {"message": "OEM Mode did not changed."},
+        status.HTTP_400_BAD_REQUEST: {"message": "OEM Mode did not change."},
         status.HTTP_500_INTERNAL_SERVER_ERROR: {
             "message": "OEM Mode unhandled exception."
         },
     },
+    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
 )
 async def enable_oem_mode_endpoint(
     response: Response,
@@ -80,6 +84,7 @@ async def enable_oem_mode_endpoint(
             "message": "OEM Mode splash unhandled exception."
         },
     },
+    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
 )
 async def upload_splash_image(
     response: Response,


### PR DESCRIPTION
## Overview

This adds access control to the HTTP endpoints for setting up OEM mode.

Since it doesn't seem like any other endpoints in system-server will need access control, this closes EXEC-2368.

## Changelog

* system-server can now decorate an endpoint with `require_scopes()`, like robot-server, to add access control to it.
* When access control mode is enabled, the following system-server endpoints now require authorization:
  * `PUT /system/oem_mode/enable`
  * `POST /system/oem_mode/upload_splash`
* The remaining system-server endpoints are left alone, so they still allow unauthenticated access:
  * `POST /system/register`
  * `POST/GET /system/authorize`
  *  `GET /system/connected`
* robot-server's `POST /settings` endpoint now also requires authorization. I'm doing this in this PR because, in real-world usage, it's tied together with the `/system/oem_mode` endpoints. See the comments and code for details.

## Test Plan and Hands on Testing

Test on a robot:

* [x] Temporarily add `OT_SYSTEM_SERVER_auth_server_uds=/run/opentrons-auth-server.sock` to system-server's service file, and `OT_ROBOT_SERVER_auth_server_uds=/run/opentrons-auth-server.sock` to robot-server's service file.
* [x] With access control mode disabled, OEM mode can be enabled and disabled through the Opentrons App, as normal.
* [x] With access control mode enabled:
  * [x] Without an OAuth 2 bearer token, `PUT /system/oem_mode_enable` and `POST /settings` are inaccessible.
  * [x] With a token, `POST /settings` works as normal, and can be used to enable or disable OEM mode.


## Review requests

Does this treatment of `POST /settings` seem OK? I could polish the implementation and shore up the automated tests and such, but if we're that concerned about it, I sort of think that the time would be better spent on simplifying the fundamentals: remove `enableOEMMode` from `POST /settings` and get system-server to be the single source of truth.

## Risk assessment

Medium. `POST /settings` is now a 3-way interaction between servers.