### PR TITLE
fix(abr-testing): Decrease duplicate slack pings

### DIFF
--- a/abr-testing/abr_testing/protocols/active_protocols/10_ZymoBIOMICS_Magbead_DNA_Cells_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/10_ZymoBIOMICS_Magbead_DNA_Cells_Flex.py
@@ -72,7 +72,8 @@ def add_parameters(parameters: protocol_api.ParameterContext) -> None:
 
 def run(protocol: protocol_api.ProtocolContext) -> None:
     """Protocol Set Up."""
-    background_helpers.launch_background_tasks()
+    if not protocol.is_simulating():
+        background_helpers.launch_background_tasks()
 
     protocol.capture_image(filename="start_of_run")
     length = protocol.params.error_capture_duration  # type: ignore[attr-defined]

--- a/abr-testing/abr_testing/protocols/active_protocols/11_IDT xGen 1000 ul 96ch.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/11_IDT xGen 1000 ul 96ch.py
@@ -58,7 +58,8 @@ def add_parameters(parameters: ParameterContext) -> None:
 
 def run(protocol: ProtocolContext) -> None:
     """Protocol."""
-    background_helpers.launch_background_tasks()
+    if not protocol.is_simulating():
+        background_helpers.launch_background_tasks()
 
     protocol.capture_image(filename="start_of_run")
 

--- a/abr-testing/abr_testing/protocols/active_protocols/12_Illumina RNA all parts.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/12_Illumina RNA all parts.py
@@ -71,7 +71,8 @@ def add_parameters(parameters: ParameterContext) -> None:
 
 def run(protocol: ProtocolContext) -> None:
     """Protocol."""
-    background_helpers.launch_background_tasks()
+    if not protocol.is_simulating():
+        background_helpers.launch_background_tasks()
 
     protocol.capture_image(filename="start_of_run")
     length = protocol.params.error_capture_duration  # type: ignore[attr-defined]

--- a/abr-testing/abr_testing/protocols/active_protocols/13_Stacker_Labware_Stamping_Test.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/13_Stacker_Labware_Stamping_Test.py
@@ -130,7 +130,8 @@ def unload_tipracks_from_stacker(
 
 def run(ctx: ProtocolContext) -> None:
     """Run the protocol."""
-    background_helpers.launch_background_tasks()
+    if not ctx.is_simulating:
+        background_helpers.launch_background_tasks()
 
     ctx.capture_image(filename="start_of_run")
     length = ctx.params.error_capture_duration  # type: ignore[attr-defined]

--- a/abr-testing/abr_testing/protocols/active_protocols/13_Stacker_Labware_Stamping_Test.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/13_Stacker_Labware_Stamping_Test.py
@@ -130,7 +130,7 @@ def unload_tipracks_from_stacker(
 
 def run(ctx: ProtocolContext) -> None:
     """Run the protocol."""
-    if not ctx.is_simulating:
+    if not ctx.is_simulating():
         background_helpers.launch_background_tasks()
 
     ctx.capture_image(filename="start_of_run")

--- a/abr-testing/abr_testing/protocols/active_protocols/14_IDT xGen 200 ul 96ch.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/14_IDT xGen 200 ul 96ch.py
@@ -58,7 +58,8 @@ def add_parameters(parameters: ParameterContext) -> None:
 
 def run(protocol: ProtocolContext) -> None:
     """Protocol."""
-    background_helpers.launch_background_tasks()
+    if not protocol.is_simulating():
+        background_helpers.launch_background_tasks()
 
     protocol.capture_image(filename="start_of_run")
 

--- a/abr-testing/abr_testing/protocols/active_protocols/1_Simple Normalize Long Right.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/1_Simple Normalize Long Right.py
@@ -28,7 +28,8 @@ def add_parameters(parameters: ParameterContext) -> None:
 
 def run(protocol: ProtocolContext) -> None:
     """Protocol."""
-    background_helpers.launch_background_tasks()
+    if not protocol.is_simulating():
+        background_helpers.launch_background_tasks()
 
     all_data = protocol.params.parameters_csv.parse_as_csv()  # type: ignore[attr-defined]
     probe_height_bool = protocol.params.probe_liquid_height  # type: ignore[attr-defined]

--- a/abr-testing/abr_testing/protocols/active_protocols/2_BMS_PCR_Protocol.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/2_BMS_PCR_Protocol.py
@@ -31,7 +31,8 @@ def add_parameters(parameters: ParameterContext) -> None:
 
 def run(protocol: ProtocolContext) -> None:
     """Protocol."""
-    background_helpers.launch_background_tasks()
+    if not protocol.is_simulating():
+        background_helpers.launch_background_tasks()
 
     protocol.capture_image(filename="start_of_run")
     length = protocol.params.error_capture_duration  # type: ignore[attr-defined]

--- a/abr-testing/abr_testing/protocols/active_protocols/4_Illumina DNA Enrichment.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/4_Illumina DNA Enrichment.py
@@ -75,7 +75,8 @@ def add_parameters(parameters: ParameterContext) -> None:
 
 def run(protocol: ProtocolContext) -> None:
     """Protocol."""
-    background_helpers.launch_background_tasks()
+    if not protocol.is_simulating():
+        background_helpers.launch_background_tasks()
 
     protocol.capture_image(filename="start_of_run")
     length = protocol.params.error_capture_duration  # type: ignore[attr-defined]

--- a/abr-testing/abr_testing/protocols/active_protocols/5_MiSeq Library Preparation.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/5_MiSeq Library Preparation.py
@@ -41,7 +41,8 @@ def add_parameters(parameters: ParameterContext) -> None:
 
 def run(protocol: ProtocolContext) -> None:
     """Protocol."""
-    background_helpers.launch_background_tasks()
+    if not protocol.is_simulating():
+        background_helpers.launch_background_tasks()
 
     # Load Parameters
     protocol.capture_image(filename="start_of_run")

--- a/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
@@ -85,7 +85,8 @@ def add_parameters(p: ParameterContext) -> None:
 
 def run(protocol: ProtocolContext) -> None:
     """Main function to run the protocol."""
-    background_helpers.launch_background_tasks()
+    if not protocol.is_simulating():
+        background_helpers.launch_background_tasks()
 
     global open_location
     protocol.capture_image(filename="start_of_run")

--- a/abr-testing/abr_testing/protocols/active_protocols/7_HDQ_DNA_Bacteria_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/7_HDQ_DNA_Bacteria_Flex.py
@@ -64,7 +64,8 @@ def add_parameters(parameters: ParameterContext) -> None:
 
 def run(protocol: ProtocolContext) -> None:
     """Protocol."""
-    background_helpers.launch_background_tasks()
+    if not protocol.is_simulating():
+        background_helpers.launch_background_tasks()
 
     protocol.capture_image(filename="start_of_run")
     length = protocol.params.error_capture_duration  # type: ignore[attr-defined]

--- a/abr-testing/abr_testing/protocols/active_protocols/8_Milllipore_Duolink_RoundWell.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/8_Milllipore_Duolink_RoundWell.py
@@ -209,7 +209,8 @@ def discard(
 # ----------------------------
 def run(ctx: ProtocolContext) -> None:
     """Run the protocol."""
-    background_helpers.launch_background_tasks()
+    if not ctx.is_simulating():
+        background_helpers.launch_background_tasks()
 
     num_sample = ctx.params.num_sample  # type: ignore[attr-defined]
     length = ctx.params.error_capture_duration  # type: ignore[attr-defined]

--- a/abr-testing/abr_testing/protocols/active_protocols/9_Magmax_RNA_Cells_Flex.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/9_Magmax_RNA_Cells_Flex.py
@@ -79,7 +79,8 @@ def add_parameters(parameters: ParameterContext) -> None:
 
 def run(protocol: ProtocolContext) -> None:
     """Protocol."""
-    background_helpers.launch_background_tasks()
+    if not protocol.is_simulating():
+        background_helpers.launch_background_tasks()
 
     protocol.capture_image(filename="start_of_run")
 

--- a/abr-testing/abr_testing/protocols/helpers/background_helpers.py
+++ b/abr-testing/abr_testing/protocols/helpers/background_helpers.py
@@ -25,7 +25,7 @@ def detect_robot_status(ip: str) -> None:
 
     # Process will be constantly running
     while True:
-        time.sleep(300)
+        time.sleep(30)
 
         # Reset running_robot and completed_robot information to prevent possible data corruption
         running_robots: List[str] = []

--- a/abr-testing/abr_testing/tools/check_robot_status.py
+++ b/abr-testing/abr_testing/tools/check_robot_status.py
@@ -48,7 +48,7 @@ def get_current_run_details_from_robot(
         most_recent_run = run_list[-1]
         if most_recent_run["current"]:
             run_status = most_recent_run["status"]
-            if run_status == "awaiting-recovery":
+            if "awaiting-recovery" in run_status:
                 if (
                     robot_name not in completed_robots
                     and robot_name not in running_robots

--- a/abr-testing/abr_testing/tools/check_robot_status.py
+++ b/abr-testing/abr_testing/tools/check_robot_status.py
@@ -63,7 +63,7 @@ def get_current_run_details_from_robot(
                         past_run_status_list: list = list(past_run_status)
 
                         if (len(past_run_status_list) == 0) or not (
-                            past_run_status_list[-1] == run_status
+                            "awaiting-recovery" in past_run_status_list[-1]
                         ):
                             slack_bot.send_slack_message(message)
                     else:


### PR DESCRIPTION
# Overview

The previous safeguard against duplicate error recovery slack pings was to keep a running deque of the previous 10 robot statuses and only ping the slack channel after leaving and re-entering error-recovery. This reduced the frequency that duplicate pings appeared, but didn't entirely eliminate it. It didn't take into account the fact that "awaiting_recovery" is not the only error-recovery status on the robot. This PR adds that knowledge to the safeguard

## Test Plan and Hands on Testing
On ABR 4, I tested the following flow

Before change:
**Trigger error recovery** -> robot status == "awating_recovery" -> slack channel ping
**Open door during error recovery** -> robot status == "awaiting_recovery_door_opent" -> added to deque as new run status
**Close door** -> robot status == "awaiting_recovery" -> robot thinks its re-entered recovery and pings slack

## Changelog

### Protocols
Changed protocols to only launch background processes when the protocols are not simulating

### background_helpers.py
Increase polling frequency

### check_robot_status.py
Instead of checking if the current and most recent status == "awaiting_recovery", the check is now if "awaiting_recovery" can be found anywhere in the name of the status.

## Risk assessment

Low, only affects ABR suite.
