### PR TITLE
refactor(components, protocol-designer, app): refactor Checkbox to replace Btn with input

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -27,7 +27,7 @@ const config: StorybookConfig = {
         // That doesn't work for us because we have one monorepo-wide Storybook
         // installation, while each project has its own local Vite config.
         // So we treat Storybook as its own Vite project with its own config.
-        viteConfigPath: '.storybook/vite.config.mjs',
+        viteConfigPath: '.storybook/vite.config.mts',
       },
     },
   },

--- a/app/src/organisms/WellSelection/Selection384Wells.tsx
+++ b/app/src/organisms/WellSelection/Selection384Wells.tsx
@@ -281,7 +281,7 @@ function StartingWell({
             key={well}
             isChecked={startingWellState[well]}
             labelText={well}
-            onClick={() => {
+            onChange={() => {
               if (channels === 96) {
                 if (startingWellState[well]) {
                   deselectWells([well])

--- a/components/src/atoms/Checkbox/Checkbox.stories.tsx
+++ b/components/src/atoms/Checkbox/Checkbox.stories.tsx
@@ -1,3 +1,6 @@
+import { action } from '@storybook/addon-actions'
+import { useArgs } from '@storybook/preview-api'
+
 import { Checkbox } from './index'
 
 import type { Meta, StoryObj } from '@storybook/react'
@@ -5,19 +8,43 @@ import type { Meta, StoryObj } from '@storybook/react'
 const meta: Meta<typeof Checkbox> = {
   title: 'Helix/Atoms/Checkbox',
   component: Checkbox,
+  args: {
+    onChange: action('onChange'),
+  },
 }
 
 type Story = StoryObj<typeof Checkbox>
 
 export const Basic: Story = {
+  name: 'Checkbox',
   args: {
     isChecked: true,
-    labelText: 'Button Text',
-    onClick: () => {
-      console.log('clicked')
-    },
+    labelText: 'Checkbox Label',
     tabIndex: 1,
     disabled: false,
+  },
+  render: function Render(args) {
+    const [{ isChecked }, updateArgs] = useArgs()
+    const checked = Boolean(isChecked)
+
+    return (
+      <Checkbox
+        {...args}
+        isChecked={checked}
+        onChange={e => {
+          args.onChange(e)
+          updateArgs({ isChecked: !checked })
+        }}
+      />
+    )
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    isChecked: false,
+    labelText: 'Disabled Checkbox',
+    disabled: true,
   },
 }
 

--- a/components/src/atoms/Checkbox/__tests__/Checkbox.test.tsx
+++ b/components/src/atoms/Checkbox/__tests__/Checkbox.test.tsx
@@ -17,7 +17,7 @@ describe('Checkbox', () => {
 
   beforeEach(() => {
     props = {
-      onClick: vi.fn(),
+      onChange: vi.fn(),
       isChecked: false,
       labelText: 'fake checkbox label',
       tabIndex: 1,
@@ -32,27 +32,36 @@ describe('Checkbox', () => {
   it('renders label with disabled true', () => {
     props.disabled = true
     render(props)
-    const checkBoxInput = screen.getByRole('checkbox', {
+    const checkboxInput = screen.getByRole('checkbox', {
       name: 'fake checkbox label',
     })
-    expect(checkBoxInput).toBeDisabled()
+    expect(checkboxInput).toBeDisabled()
   })
 
-  it('renders label with correct style - tabIndex 1', () => {
+  it('renders checkbox with tabIndex 1', () => {
     props.tabIndex = 1
     render(props)
-    const checkBoxInput = screen.getByRole('checkbox', {
+    const checkboxInput = screen.getByRole('checkbox', {
       name: 'fake checkbox label',
     })
-    expect(checkBoxInput).toHaveAttribute('tabindex', '1')
+    expect(checkboxInput).toHaveAttribute('tabindex', '1')
+  })
+
+  it('renders checkbox as checked when isChecked is true', () => {
+    props.isChecked = true
+    render(props)
+    const checkboxInput = screen.getByRole('checkbox', {
+      name: 'fake checkbox label',
+    })
+    expect(checkboxInput).toBeChecked()
   })
 
   it('calls mock function when clicking checkbox', () => {
     render(props)
-    const checkBoxInput = screen.getByRole('checkbox', {
+    const checkboxInput = screen.getByRole('checkbox', {
       name: 'fake checkbox label',
     })
-    fireEvent.click(checkBoxInput)
-    expect(props.onClick).toHaveBeenCalled()
+    fireEvent.click(checkboxInput)
+    expect(props.onChange).toHaveBeenCalled()
   })
 })

--- a/components/src/atoms/Checkbox/checkbox.module.css
+++ b/components/src/atoms/Checkbox/checkbox.module.css
@@ -1,5 +1,5 @@
 .checkbox_label,
-.chckbox_label {
+.checkbox_label {
   display: flex;
   width: var(--checkbox-width, max-content);
   flex-direction: row;
@@ -56,7 +56,7 @@
 }
 
 .checkbox_label:has(.checkbox_input_hidden:focus-visible),
-.chckbox_label:has(.checkbox_input_hidden:focus-visible) {
+.checkbox_label:has(.checkbox_input_hidden:focus-visible) {
   outline: 3px solid var(--blue-50);
   outline-offset: 2px;
 }
@@ -71,7 +71,7 @@
 
 @media (height = 600px) and (width = 1024px) {
   .checkbox_label,
-  .chckbox_label {
+  .checkbox_label {
     width: 100%;
     padding: var(--spacing-20);
     border-radius: var(--border-radius-16);

--- a/components/src/atoms/Checkbox/checkbox.module.css
+++ b/components/src/atoms/Checkbox/checkbox.module.css
@@ -1,0 +1,114 @@
+.checkbox_label,
+.chckbox_label {
+  display: flex;
+  width: var(--checkbox-width, max-content);
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-12) var(--spacing-16);
+  border: none;
+  gap: var(--spacing-12);
+  user-select: none;
+}
+
+.checkbox_label_unchecked {
+  background-color: var(--blue-30);
+  color: var(--black-90);
+}
+
+.checkbox_label_checked {
+  background-color: var(--blue-50);
+  color: var(--white);
+}
+
+.checkbox_label_round {
+  border-radius: 200px;
+}
+
+.checkbox_label_neutral {
+  border-radius: var(--border-radius-8);
+}
+
+.checkbox_label_enabled {
+  cursor: pointer;
+}
+
+.checkbox_label_disabled {
+  background-color: var(--grey-30);
+  color: var(--grey-40);
+  cursor: default;
+}
+
+.checkbox_label_enabled.checkbox_label_unchecked:active {
+  background-color: var(--blue-40);
+}
+
+.checkbox_label_enabled.checkbox_label_checked:active {
+  background-color: var(--blue-55);
+}
+
+.checkbox_label_enabled.checkbox_label_unchecked:hover {
+  background-color: var(--blue-35);
+}
+
+.checkbox_label_enabled.checkbox_label_checked:hover {
+  background-color: var(--blue-55);
+}
+
+.checkbox_label:has(.checkbox_input_hidden:focus-visible),
+.chckbox_label:has(.checkbox_input_hidden:focus-visible) {
+  outline: 3px solid var(--blue-50);
+  outline-offset: 2px;
+}
+
+.checkbox_label_unchecked:has(.checkbox_input_hidden:focus-visible) {
+  background-color: var(--blue-35);
+}
+
+.checkbox_label_checked:has(.checkbox_input_hidden:focus-visible) {
+  background-color: var(--blue-50);
+}
+
+@media (height = 600px) and (width = 1024px) {
+  .checkbox_label,
+  .chckbox_label {
+    width: 100%;
+    padding: var(--spacing-20);
+    border-radius: var(--border-radius-16);
+    cursor: auto;
+  }
+}
+
+.checkbox_input_hidden {
+  position: absolute;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  border-width: 0;
+  margin: -1px;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.checkbox_wrapper {
+  display: flex;
+  width: 1rem;
+  height: 1rem;
+}
+
+@media (height = 600px) and (width = 1024px) {
+  .checkbox_wrapper {
+    width: 1.75rem;
+    height: 1.75rem;
+  }
+}
+
+.checkbox_wrapper_unchecked {
+  border: 2px solid var(--black-90);
+  border-radius: var(--border-radius-4);
+}
+
+.checkbox_wrapper_unchecked_disabled {
+  border-color: var(--grey-40);
+}

--- a/components/src/atoms/Checkbox/checkbox.module.css
+++ b/components/src/atoms/Checkbox/checkbox.module.css
@@ -1,4 +1,3 @@
-.checkbox_label,
 .checkbox_label {
   display: flex;
   width: var(--checkbox-width, max-content);
@@ -55,7 +54,6 @@
   background-color: var(--blue-55);
 }
 
-.checkbox_label:has(.checkbox_input_hidden:focus-visible),
 .checkbox_label:has(.checkbox_input_hidden:focus-visible) {
   outline: 3px solid var(--blue-50);
   outline-offset: 2px;
@@ -70,7 +68,6 @@
 }
 
 @media (height = 600px) and (width = 1024px) {
-  .checkbox_label,
   .checkbox_label {
     width: 100%;
     padding: var(--spacing-20);

--- a/components/src/atoms/Checkbox/index.tsx
+++ b/components/src/atoms/Checkbox/index.tsx
@@ -1,109 +1,68 @@
-import { css } from 'styled-components'
+import clsx from 'clsx'
 
-import { BORDERS, COLORS } from '../../helix-design-system'
+import { COLORS } from '../../helix-design-system'
 import { Icon } from '../../icons'
-import { Btn, Flex } from '../../primitives'
-import {
-  ALIGN_CENTER,
-  CURSOR_AUTO,
-  CURSOR_DEFAULT,
-  CURSOR_POINTER,
-  DIRECTION_ROW,
-  DISPLAY_FLEX,
-  FLEX_MAX_CONTENT,
-  JUSTIFY_SPACE_BETWEEN,
-} from '../../styles'
-import { RESPONSIVENESS, SPACING } from '../../ui-style-constants'
+import { FLEX_MAX_CONTENT } from '../../styles'
 import { StyledText } from '../StyledText'
+import styles from './checkbox.module.css'
 
-import type { MouseEventHandler } from 'react'
+import type { ChangeEventHandler, CSSProperties } from 'react'
+
+type CheckboxStyle = CSSProperties & {
+  '--checkbox-width'?: string
+}
 
 export interface CheckboxProps {
-  /** checkbox is checked if value is true */
   isChecked: boolean
-  /** label text that describes the option */
   labelText: string
-  /** callback click/tap handler */
-  onClick: MouseEventHandler
-  /** html tabindex property */
+  onChange: ChangeEventHandler<HTMLInputElement>
   tabIndex?: number
-  /** if disabled is true, mouse events will not trigger onClick callback */
   disabled?: boolean
-  /** optional borderRadius type */
   type?: 'round' | 'neutral'
-  /** optional width for helix */
   width?: string
 }
+
 export function Checkbox(props: CheckboxProps): JSX.Element {
   const {
     isChecked,
     labelText,
-    onClick,
+    onChange,
     tabIndex = 0,
     disabled = false,
     width = FLEX_MAX_CONTENT,
     type = 'round',
   } = props
 
-  const CHECKBOX_STYLE = css`
-    width: ${width};
-    grid-gap: ${SPACING.spacing12};
-    border: none;
-    align-items: ${ALIGN_CENTER};
-    flex-direction: ${DIRECTION_ROW};
-    color: ${isChecked ? COLORS.white : COLORS.black90};
-    background-color: ${isChecked ? COLORS.blue50 : COLORS.blue30};
-    border-radius: ${type === 'round'
-      ? BORDERS.borderRadiusFull
-      : BORDERS.borderRadius8};
-    padding: ${SPACING.spacing12} ${SPACING.spacing16};
-    justify-content: ${JUSTIFY_SPACE_BETWEEN};
-    cursor: ${CURSOR_POINTER};
-
-    &:active {
-      background-color: ${isChecked ? COLORS.blue55 : COLORS.blue40};
-    }
-    &:focus-visible {
-      background-color: ${isChecked ? COLORS.blue50 : COLORS.blue35};
-      outline: 3px ${BORDERS.styleSolid} ${COLORS.blue50};
-      outline-offset: 2px;
-    }
-    &:disabled {
-      background-color: ${COLORS.grey30};
-      color: ${COLORS.grey40};
-      cursor: ${CURSOR_DEFAULT};
-    }
-    &:disabled:hover {
-      background-color: ${COLORS.grey30}; /* Prevent hover from overriding */
-    }
-    &:hover {
-      background-color: ${isChecked ? COLORS.blue55 : COLORS.blue35};
-    }
-
-    @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-      padding: ${SPACING.spacing20};
-      border-radius: ${BORDERS.borderRadius16};
-      width: 100%;
-      cursor: ${CURSOR_AUTO};
-    }
-  `
+  const checkboxStyle: CheckboxStyle = {
+    '--checkbox-width': width,
+  }
 
   return (
-    <Btn
-      display={DISPLAY_FLEX}
-      alignItems={ALIGN_CENTER}
-      role="checkbox"
-      aria-checked={isChecked}
-      onClick={onClick}
-      tabIndex={tabIndex}
-      disabled={disabled}
-      css={CHECKBOX_STYLE}
+    <label
+      className={clsx(styles.chckbox_label, {
+        [styles.checkbox_label_checked]: isChecked,
+        [styles.checkbox_label_unchecked]: !isChecked,
+        [styles.checkbox_label_round]: type === 'round',
+        [styles.checkbox_label_neutral]: type !== 'round',
+        [styles.checkbox_label_disabled]: disabled,
+        [styles.checkbox_label_enabled]: !disabled,
+      })}
+      // eslint-disable-next-line react/forbid-dom-props -- width is a runtime prop and cannot be represented with static classes.
+      style={checkboxStyle}
     >
+      <input
+        type="checkbox"
+        className={styles.checkbox_input_hidden}
+        checked={isChecked}
+        onChange={onChange}
+        disabled={disabled}
+        tabIndex={tabIndex}
+      />
       <StyledText desktopStyle="bodyDefaultRegular" oddStyle="bodyTextSemiBold">
         {labelText}
       </StyledText>
       <Check isChecked={isChecked} disabled={disabled} />
-    </Btn>
+    </label>
   )
 }
 
@@ -112,28 +71,23 @@ interface CheckProps {
   color?: string
   disabled?: boolean
 }
+
 export function Check(props: CheckProps): JSX.Element {
   const { isChecked, color = COLORS.white, disabled = false } = props
-  // todo(mm, 2025-09-30): For accessibility, keyboard usability, etc., can this be
-  // a real <input type="checkbox"> instead of a div?
+
   return isChecked ? (
-    <Flex css={CHECK_STYLE}>
+    <div className={styles.checkbox_wrapper}>
       <Icon name="ot-checkbox" color={color} />
-    </Flex>
+    </div>
   ) : (
-    <Flex
-      css={CHECK_STYLE}
-      border={`2px solid ${disabled ? COLORS.grey40 : COLORS.black90}`}
-      borderRadius={BORDERS.borderRadius4}
+    <div
+      className={clsx(
+        styles.checkbox_wrapper,
+        styles.checkbox_wrapper_unchecked,
+        {
+          [styles.checkbox_wrapper_unchecked_disabled]: disabled,
+        }
+      )}
     />
   )
 }
-
-const CHECK_STYLE = css`
-  width: 1rem;
-  height: 1rem;
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    width: 1.75rem;
-    height: 1.75rem;
-  }
-`

--- a/components/src/atoms/Checkbox/index.tsx
+++ b/components/src/atoms/Checkbox/index.tsx
@@ -13,12 +13,19 @@ type CheckboxStyle = CSSProperties & {
 }
 
 export interface CheckboxProps {
+  /** checkbox is checked if value is true */
   isChecked: boolean
+  /** label text that describes the option */
   labelText: string
+  /** callback change handler */
   onChange: ChangeEventHandler<HTMLInputElement>
+  /** html tabindex property */
   tabIndex?: number
+  /** if disabled is true, mouse events will not trigger onClick callback */
   disabled?: boolean
+  /** optional borderRadius type */
   type?: 'round' | 'neutral'
+  /** optional width for helix */
   width?: string
 }
 
@@ -39,7 +46,7 @@ export function Checkbox(props: CheckboxProps): JSX.Element {
 
   return (
     <label
-      className={clsx(styles.chckbox_label, {
+      className={clsx(styles.checkbox_label, {
         [styles.checkbox_label_checked]: isChecked,
         [styles.checkbox_label_unchecked]: !isChecked,
         [styles.checkbox_label_round]: type === 'round',

--- a/e2e-testing/automation/base_page.py
+++ b/e2e-testing/automation/base_page.py
@@ -1,5 +1,6 @@
 """Base page object with common functionality."""
 
+import re
 from typing import Any
 
 from playwright.sync_api import Locator, Page, expect
@@ -31,6 +32,17 @@ class BasePage:
     def click_test_id(self, test_id: str) -> None:
         """Click an element by test ID."""
         self.page.get_by_test_id(test_id).click()
+
+    def click_checkbox_label(self, label_text: str) -> None:
+        """Click a checkbox by exact visible label text.
+
+        This avoids partial matches like "Tip Rack 50 µL" matching
+        "Filter Tip Rack 50 µL", and avoids clicking hidden checkbox inputs.
+        """
+
+        label = self.page.locator("label").filter(has=self.page.get_by_text(re.compile(rf"^{re.escape(label_text)}$")))
+        expect(label).to_have_count(1, timeout=5000)
+        label.first.click()
 
     def dismiss_release_notes_toast(self) -> None:
         """Close the update toast if it appears."""

--- a/e2e-testing/automation/pd_pages/mix_step_form.py
+++ b/e2e-testing/automation/pd_pages/mix_step_form.py
@@ -190,9 +190,14 @@ class MixStepForm(BasePage):
         # Try checkbox role (Checkbox component from @opentrons/components)
         checkbox = self.page.get_by_role("checkbox").nth(index)
         if checkbox.count() > 0:
-            self.wait_for_visible(checkbox)
-            checkbox.click()
-            return
+            try:
+                self.wait_for_visible(checkbox)
+                checkbox.click()
+                return
+            except Exception:
+                # New Checkbox implementation may expose a hidden input;
+                # continue to label/test-id based fallbacks.
+                pass
 
         # Try CheckboxExpandStepFormField - these use ListButton with a Btn containing Check icon
         # The inner Btn has a testId like "delay_checkbox", "blowout_checkbox", etc.

--- a/e2e-testing/automation/pd_pages/pipette_modal.py
+++ b/e2e-testing/automation/pd_pages/pipette_modal.py
@@ -49,7 +49,7 @@ class PipetteModal(BasePage):
             tip_racks: List of tip rack names, e.g., ["Filter Tip Rack 1000 µL"]
         """
         for tip_rack in tip_racks:
-            self.page.get_by_role("checkbox", name=tip_rack, exact=True).click()
+            self.click_checkbox_label(tip_rack)
 
     def save_pipette_selection(self) -> None:
         """Save the pipette configuration."""

--- a/e2e-testing/automation/pd_pages/protocol_editor_page.py
+++ b/e2e-testing/automation/pd_pages/protocol_editor_page.py
@@ -337,7 +337,7 @@ class ProtocolEditorPage(BasePage):
             field_name: The name of the checkbox field to toggle.
         """
 
-        self.page.get_by_role("checkbox", name=field_name, exact=True).click()
+        self.click_checkbox_label(field_name)
 
     def _add_lid(self, labware: str, test_id: str) -> None:
         """Add a lid to the selected labware.

--- a/e2e-testing/tests/pd/test_pd_create_new_flex.py
+++ b/e2e-testing/tests/pd/test_pd_create_new_flex.py
@@ -12,6 +12,8 @@ This test verifies the complete Flex onboarding workflow including:
 - Liquid definition and assignment
 """
 
+import re
+
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -55,7 +57,7 @@ def test_flex_onboarding_workflow(page: Page, pd_base_url: str) -> None:
     page.get_by_text("50 µL").click()
 
     # Select Tip Rack 50 µL (not Filter Tip Rack) - use exact match
-    page.get_by_role("checkbox", name="Tip Rack 50 µL", exact=True).click()
+    page.locator("label").filter(has=page.get_by_text(re.compile(r"^Tip Rack 50 µL$"))).first.click()
 
     # Save pipette configuration
     page.get_by_role("button", name="Save").click()

--- a/e2e-testing/utility.py
+++ b/e2e-testing/utility.py
@@ -1,4 +1,5 @@
 import functools
+import re
 
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page, TimeoutError, expect
@@ -110,7 +111,7 @@ def create_new_protocol_flow(pipette: str, gripper: bool, tc: bool, waste_chute:
     page.get_by_text("Add a pipette").click()
     page.get_by_text(pipette).click()
     page.get_by_text("50 µL").click()
-    page.get_by_role("checkbox", name="Tip Rack 50 µL", exact=True).click()
+    page.locator("label").filter(has=page.get_by_text(re.compile(r"^Tip Rack 50 µL$"))).first.click()
     page.get_by_role("button", name="Save").click()
     page.get_by_text("Yes", exact=True).click()
     if gripper:

--- a/protocol-designer/src/components/molecules/CheckboxStepFormField/index.tsx
+++ b/protocol-designer/src/components/molecules/CheckboxStepFormField/index.tsx
@@ -47,7 +47,7 @@ export function CheckboxStepFormField(
             width="100%"
             type="neutral"
             isChecked={disabled ? false : Boolean(value)}
-            onClick={() => {
+            onChange={() => {
               updateValue(!value)
             }}
             labelText={label ?? ''}

--- a/protocol-designer/src/components/organisms/EditInstrumentsModal/PipetteConfiguration.tsx
+++ b/protocol-designer/src/components/organisms/EditInstrumentsModal/PipetteConfiguration.tsx
@@ -218,7 +218,7 @@ export function PipetteConfiguration({
                       }
                       isChecked={selectedTips.includes(option.value)}
                       labelText={removeOpentronsPhrases(option.name)}
-                      onClick={() => {
+                      onChange={() => {
                         const updatedTips = selectedTips.includes(option.value)
                           ? selectedTips.filter(v => v !== option.value)
                           : [...selectedTips, option.value]

--- a/protocol-designer/src/components/organisms/SelectPipetteModal/SelectPipetteTips.tsx
+++ b/protocol-designer/src/components/organisms/SelectPipetteModal/SelectPipetteTips.tsx
@@ -93,7 +93,7 @@ export function SelectPipetteTips(props: SelectPipetteTipsProps): JSX.Element {
               key={value}
               isChecked={selectedValues.includes(value)}
               labelText={removeOpentronsPhrases(name)}
-              onClick={() => {
+              onChange={() => {
                 handleSelectTips(value)
               }}
             />


### PR DESCRIPTION
# Overview
refactor Checkbox component to replace Btn with input type"checkbox" to support more accessibility + usability and migrate from styled-component to css modules

close AUTH-2779


https://opentrons.slack.com/archives/CSCLVUW3C/p1772209692655419


Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.

## Test Plan and Hands on Testing
- the branch's Storybook shows the same look as well as sandbox
- when focusing Checkbox, check space key can do check/uncheck

## Changelog
- refactor Checkbox component and update its test
- add css module file for Checkbox
- update components that use Checkbox

## Review requests


## Risk assessment
low-mid