### PR TITLE
ci(app): update slackapi/slack-github-action version from v1 to v2

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -433,22 +433,24 @@ jobs:
               echo "linux-${variant}=$_linux_build">>$GITHUB_OUTPUT
           done
       - name: 'slack notify internal-release'
-        uses: slackapi/slack-github-action@v1.14.0
+        uses: slackapi/slack-github-action@v2.1.1
         if: contains(fromJSON(needs.determine-build-type.outputs.variants), 'internal-release')
         continue-on-error: true
         with:
+          webhook: ${{ secrets.OT_APP_OT3_SLACK_NOTIFICATION_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: '{"branch_or_tag":"${{ github.ref_name }}","build_type":"${{ needs.determine-build-type.outputs.type }}", "gh_linkback":"https://github.com/Opentrons/opentrons/tree/${{ github.ref_name }}", "windows_build":"${{ env._ACCESS_URL }}/${{steps.names.outputs.windows-internal-release}}", "mac_build":"${{ env._ACCESS_URL }}/${{steps.names.outputs.mac-internal-release}}", "linux_build":"${{ env._ACCESS_URL }}/${{steps.names.outputs.linux-internal-release}}"}'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.OT_APP_OT3_SLACK_NOTIFICATION_WEBHOOK_URL }}
           _ACCESS_URL: https://${{env._APP_DEPLOY_BUCKET_OT3}}/${{env._APP_DEPLOY_FOLDER_OT3}}
       - name: 'slack notify release'
-        uses: slackapi/slack-github-action@v1.14.0
+        uses: slackapi/slack-github-action@v2.1.1
         if: contains(fromJSON(needs.determine-build-type.outputs.variants), 'release')
         continue-on-error: true
         with:
+          webhook: ${{ secrets.OT_APP_OT3_SLACK_NOTIFICATION_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: '{"branch_or_tag":"${{ github.ref_name }}","build_type":"${{ needs.determine-build-type.outputs.type }}", "gh_linkback":"https://github.com/Opentrons/opentrons/tree/${{ github.ref_name }}", "windows_build":"${{ env._ACCESS_URL }}/${{steps.names.outputs.windows-release}}", "mac_build":"${{ env._ACCESS_URL }}/${{steps.names.outputs.mac-release}}", "linux_build":"${{ env._ACCESS_URL }}/${{steps.names.outputs.linux-release}}"}'
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.OT_APP_ROBOTSTACK_SLACK_NOTIFICATION_WEBHOOK_URL }}
           _ACCESS_URL: https://${{env._APP_DEPLOY_BUCKET_ROBOTSTACK}}/${{env._APP_DEPLOY_FOLDER_ROBOTSTACK}}
 
       - name: 'backup upload folders before checkout'


### PR DESCRIPTION


# Overview
update slackapi/slack-github-action version from v1 to v2

close AUTH-2780

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

v1 uses the deprecated command

## Test Plan and Hands on Testing

## Changelog
- update slackapi/slack-github-action version from v1 to v2

close AUTH-2780

## Review requests


## Risk assessment
low
