### PR TITLE
fix(components, protocol-designer): remove slot clips from PD deck components

### DIFF
--- a/components/src/hardware-sim/BaseDeck/SingleSlotFixture.tsx
+++ b/components/src/hardware-sim/BaseDeck/SingleSlotFixture.tsx
@@ -16,6 +16,7 @@ interface SingleSlotFixtureProps extends SVGProps<SVGGElement> {
   slotClipColor?: SVGProps<SVGPathElement>['stroke']
   showExpansion?: boolean
   stroke?: string
+  showSlotClips?: boolean
 }
 
 export function SingleSlotFixture(
@@ -28,6 +29,7 @@ export function SingleSlotFixture(
     slotClipColor,
     showExpansion = false,
     stroke = 'none',
+    showSlotClips = true,
     ...restProps
   } = props
 
@@ -60,10 +62,14 @@ export function SingleSlotFixture(
           strokeWidth={2}
           d="M-97.7,417.1h238.8c2.4,0,4.3-1.9,4.3-4.3v-97.4c0-2.4-1.9-4.3-4.3-4.3H-97.7c-2.4,0-4.3,1.9-4.3,4.3v97.4 C-102,415.1-100.1,417.1-97.7,417.1z"
         />
-        <SlotClip d="M-1.9,398.9V409H8.9" stroke={slotClipColor} />
-        <SlotClip d="M-1.9,329.8v-10.5H8.7" stroke={slotClipColor} />
-        <SlotClip d="M129.9,398.9V409h-10.8" stroke={slotClipColor} />
-        <SlotClip d="M129.9,329.8v-10.7h-10.8" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M-1.9,398.9V409H8.9" stroke={slotClipColor} />
+            <SlotClip d="M-1.9,329.8v-10.5H8.7" stroke={slotClipColor} />
+            <SlotClip d="M129.9,398.9V409h-10.8" stroke={slotClipColor} />
+            <SlotClip d="M129.9,329.8v-10.7h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutA2: (
@@ -74,10 +80,14 @@ export function SingleSlotFixture(
           stroke={stroke}
           strokeWidth={2}
         />
-        <SlotClip d="M162.1,398.9V409h10.8" stroke={slotClipColor} />,
-        <SlotClip d="M162.1,329.8v-10.5h10.6" stroke={slotClipColor} />,
-        <SlotClip d="M293.9,398.9V409h-10.8" stroke={slotClipColor} />,
-        <SlotClip d="M293.9,329.8v-10.7h-10.8" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M162.1,398.9V409h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M162.1,329.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M293.9,398.9V409h-10.8" stroke={slotClipColor} />,
+            <SlotClip d="M293.9,329.8v-10.7h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutA3: (
@@ -88,10 +98,14 @@ export function SingleSlotFixture(
           stroke={stroke}
           strokeWidth={2}
         />
-        <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
-        <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
-        <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
-        <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutB1: (
@@ -102,10 +116,14 @@ export function SingleSlotFixture(
           stroke={stroke}
           strokeWidth={2}
         />
-        <SlotClip d="M-1.9,291.9V302H8.9" stroke={slotClipColor} />,
-        <SlotClip d="M-1.9,222.8v-10.5H8.7" stroke={slotClipColor} />,
-        <SlotClip d="M129.9,291.9V302h-10.8" stroke={slotClipColor} />,
-        <SlotClip d="M129.9,222.8v-10.7h-10.8" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M-1.9,291.9V302H8.9" stroke={slotClipColor} />,
+            <SlotClip d="M-1.9,222.8v-10.5H8.7" stroke={slotClipColor} />,
+            <SlotClip d="M129.9,291.9V302h-10.8" stroke={slotClipColor} />,
+            <SlotClip d="M129.9,222.8v-10.7h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutB2: (
@@ -116,10 +134,14 @@ export function SingleSlotFixture(
           stroke={stroke}
           strokeWidth={2}
         />
-        <SlotClip d="M162.1,291.9V302h10.8" stroke={slotClipColor} />,
-        <SlotClip d="M162.1,222.8v-10.5h10.6" stroke={slotClipColor} />,
-        <SlotClip d="M293.9,291.9V302h-10.8" stroke={slotClipColor} />,
-        <SlotClip d="M293.9,222.8v-10.7h-10.8" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M162.1,291.9V302h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M162.1,222.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M293.9,291.9V302h-10.8" stroke={slotClipColor} />,
+            <SlotClip d="M293.9,222.8v-10.7h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutB3: (
@@ -130,10 +152,14 @@ export function SingleSlotFixture(
           stroke={stroke}
           strokeWidth={2}
         />
-        <SlotClip d="M326,291.9V302h10.8" stroke={slotClipColor} />,
-        <SlotClip d="M326,222.8v-10.5h10.6" stroke={slotClipColor} />,
-        <SlotClip d="M457.8,291.9V302H447" stroke={slotClipColor} />,
-        <SlotClip d="M457.8,222.8v-10.7H447" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M326,291.9V302h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M326,222.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,291.9V302H447" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,222.8v-10.7H447" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutC1: (
@@ -144,10 +170,14 @@ export function SingleSlotFixture(
           stroke={stroke}
           strokeWidth={2}
         />
-        <SlotClip d="M-1.9,185v10.1H8.9" stroke={slotClipColor} />
-        <SlotClip d="M-1.9,115.8v-10.5H8.7" stroke={slotClipColor} />
-        <SlotClip d="M129.9,185v10.1h-10.8" stroke={slotClipColor} />
-        <SlotClip d="M129.9,115.8v-10.7h-10.8" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M-1.9,185v10.1H8.9" stroke={slotClipColor} />
+            <SlotClip d="M-1.9,115.8v-10.5H8.7" stroke={slotClipColor} />
+            <SlotClip d="M129.9,185v10.1h-10.8" stroke={slotClipColor} />
+            <SlotClip d="M129.9,115.8v-10.7h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutC2: (
@@ -158,10 +188,14 @@ export function SingleSlotFixture(
           stroke={stroke}
           strokeWidth={2}
         />
-        <SlotClip d="M162.1,185v10.1h10.8" stroke={slotClipColor} />,
-        <SlotClip d="M162.1,115.8v-10.5h10.6" stroke={slotClipColor} />,
-        <SlotClip d="M293.9,185v10.1h-10.8" stroke={slotClipColor} />,
-        <SlotClip d="M293.9,115.8v-10.7h-10.8" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M162.1,185v10.1h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M162.1,115.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M293.9,185v10.1h-10.8" stroke={slotClipColor} />,
+            <SlotClip d="M293.9,115.8v-10.7h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutC3: (
@@ -172,10 +206,14 @@ export function SingleSlotFixture(
           stroke={stroke}
           strokeWidth={2}
         />
-        <SlotClip d="M326,185v10.1h10.8" stroke={slotClipColor} />,
-        <SlotClip d="M326,115.8v-10.5h10.6" stroke={slotClipColor} />,
-        <SlotClip d="M457.8,185v10.1H447" stroke={slotClipColor} />,
-        <SlotClip d="M457.8,115.8v-10.7H447" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M326,185v10.1h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M326,115.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,185v10.1H447" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,115.8v-10.7H447" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutD1: (
@@ -186,10 +224,14 @@ export function SingleSlotFixture(
           strokeWidth={2}
           d="M-97.7,96.1h238.8c2.4,0,4.3-1.9,4.3-4.3V-5.6c0-2.4-1.9-4.3-4.3-4.3H-97.7c-2.4,0-4.3,1.9-4.3,4.3v97.4C-102,94.2-100.1,96.1-97.7,96.1z"
         />
-        <SlotClip d="M-1.9,77.9V88H8.9" stroke={slotClipColor} />
-        <SlotClip d="M-1.9,8.8V-1.7H8.7" stroke={slotClipColor} />
-        <SlotClip d="M129.9,77.9V88h-10.8" stroke={slotClipColor} />
-        <SlotClip d="M129.9,8.8V-1.9h-10.8" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M-1.9,77.9V88H8.9" stroke={slotClipColor} />
+            <SlotClip d="M-1.9,8.8V-1.7H8.7" stroke={slotClipColor} />
+            <SlotClip d="M129.9,77.9V88h-10.8" stroke={slotClipColor} />
+            <SlotClip d="M129.9,8.8V-1.9h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutD2: (
@@ -200,10 +242,14 @@ export function SingleSlotFixture(
           strokeWidth={2}
           d="M150.8,96.1h154.3c2.4,0,4.3-1.9,4.3-4.3V-5.6c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.4C146.5,94.2,148.4,96.1,150.8,96.1z"
         />
-        <SlotClip d="M162.1,77.9V88h10.8" stroke={slotClipColor} />
-        <SlotClip d="M162.1,8.8V-1.7h10.6" stroke={slotClipColor} />
-        <SlotClip d="M293.9,77.9V88h-10.8" stroke={slotClipColor} />
-        <SlotClip d="M293.9,8.8V-1.9h-10.8" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M162.1,77.9V88h10.8" stroke={slotClipColor} />
+            <SlotClip d="M162.1,8.8V-1.7h10.6" stroke={slotClipColor} />
+            <SlotClip d="M293.9,77.9V88h-10.8" stroke={slotClipColor} />
+            <SlotClip d="M293.9,8.8V-1.9h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutD3: (
@@ -214,10 +260,14 @@ export function SingleSlotFixture(
           stroke={stroke}
           strokeWidth={2}
         />
-        <SlotClip d="M326,77.9V88h10.8" stroke={slotClipColor} />
-        <SlotClip d="M326,8.8V-1.7h10.6" stroke={slotClipColor} />
-        <SlotClip d="M457.8,77.9V88H447" stroke={slotClipColor} />
-        <SlotClip d="M457.8,8.8V-1.9H447" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M326,77.9V88h10.8" stroke={slotClipColor} />
+            <SlotClip d="M326,8.8V-1.7h10.6" stroke={slotClipColor} />
+            <SlotClip d="M457.8,77.9V88H447" stroke={slotClipColor} />
+            <SlotClip d="M457.8,8.8V-1.9H447" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
   }

--- a/components/src/hardware-sim/BaseDeck/StagingAreaFixture.tsx
+++ b/components/src/hardware-sim/BaseDeck/StagingAreaFixture.tsx
@@ -17,6 +17,7 @@ interface StagingAreaFixtureProps extends SVGProps<SVGGElement> {
   fixtureBaseColor?: SVGProps<SVGPathElement>['fill']
   slotClipColor?: SVGProps<SVGPathElement>['stroke']
   showExtensions?: boolean
+  showSlotClips?: boolean
 }
 
 export function StagingAreaFixture(
@@ -27,6 +28,7 @@ export function StagingAreaFixture(
     deckDefinition,
     fixtureBaseColor,
     slotClipColor,
+    showSlotClips = true,
     ...restProps
   } = props
 
@@ -49,14 +51,18 @@ export function StagingAreaFixture(
           d="M314.8,417.1h329.9c2.4,0,4.3-1.9,4.3-4.3v-97.4c0-2.4-1.9-4.3-4.3-4.3H314.8c-2.4,0-4.3,1.9-4.3,4.3v97.4C310.5,415.1,312.4,417.1,314.8,417.1z"
           fill={fixtureBaseColor}
         />
-        <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
-        <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
-        <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
-        <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
-        <SlotClip d="M490,398.9v10.1h10.8" stroke={slotClipColor} />,
-        <SlotClip d="M490,329.8v-10.5h10.6" stroke={slotClipColor} />,
-        <SlotClip d="M621.8,398.9v10.1h-10.8" stroke={slotClipColor} />,
-        <SlotClip d="M621.8,329.8v-10.7h-10.8" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
+            <SlotClip d="M490,398.9v10.1h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M490,329.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,398.9v10.1h-10.8" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,329.8v-10.7h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutB3: (
@@ -65,14 +71,18 @@ export function StagingAreaFixture(
           d="M314.8,310h329.9c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H314.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C310.5,308.1,312.4,310,314.8,310z"
           fill={fixtureBaseColor}
         />
-        <SlotClip d="M326,291.9V302h10.8" stroke={slotClipColor} />,
-        <SlotClip d="M326,222.8v-10.5h10.6" stroke={slotClipColor} />,
-        <SlotClip d="M457.8,291.9V302H447" stroke={slotClipColor} />,
-        <SlotClip d="M457.8,222.8v-10.7H447" stroke={slotClipColor} />
-        <SlotClip d="M490,291.9v10.1h10.8" stroke={slotClipColor} />,
-        <SlotClip d="M490,222.8v-10.5h10.6" stroke={slotClipColor} />,
-        <SlotClip d="M621.8,291.9v10.1h-10.8" stroke={slotClipColor} />,
-        <SlotClip d="M621.8,222.8v-10.7h-10.8" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M326,291.9V302h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M326,222.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,291.9V302H447" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,222.8v-10.7H447" stroke={slotClipColor} />
+            <SlotClip d="M490,291.9v10.1h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M490,222.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,291.9v10.1h-10.8" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,222.8v-10.7h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutC3: (
@@ -81,14 +91,18 @@ export function StagingAreaFixture(
           d="M314.8,203.1h329.9c2.4,0,4.3-1.9,4.3-4.3v-97.4c0-2.4-1.9-4.3-4.3-4.3H314.8c-2.4,0-4.3,1.9-4.3,4.3v97.4C310.5,201.2,312.4,203.1,314.8,203.1z"
           fill={fixtureBaseColor}
         />
-        <SlotClip d="M326,185v10.1h10.8" stroke={slotClipColor} />,
-        <SlotClip d="M326,115.8v-10.5h10.6" stroke={slotClipColor} />,
-        <SlotClip d="M457.8,185v10.1H447" stroke={slotClipColor} />,
-        <SlotClip d="M457.8,115.8v-10.7H447" stroke={slotClipColor} />
-        <SlotClip d="M490,185v10.1h10.8" stroke={slotClipColor} />,
-        <SlotClip d="M490,115.8v-10.5h10.6" stroke={slotClipColor} />,
-        <SlotClip d="M621.8,185v10.1h-10.8" stroke={slotClipColor} />,
-        <SlotClip d="M621.8,115.8v-10.7h-10.8" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M326,185v10.1h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M326,115.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,185v10.1H447" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,115.8v-10.7H447" stroke={slotClipColor} />
+            <SlotClip d="M490,185v10.1h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M490,115.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,185v10.1h-10.8" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,115.8v-10.7h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutD3: (
@@ -97,14 +111,18 @@ export function StagingAreaFixture(
           d="M314.8,96.1h329.9c2.4,0,4.3-1.9,4.3-4.3V-5.6c0-2.4-1.9-4.3-4.3-4.3H314.8c-2.4,0-4.3,1.9-4.3,4.3v97.4C310.5,94.2,312.4,96.1,314.8,96.1z"
           fill={fixtureBaseColor}
         />
-        <SlotClip d="M326,77.9V88h10.8" stroke={slotClipColor} />
-        <SlotClip d="M326,8.8V-1.7h10.6" stroke={slotClipColor} />
-        <SlotClip d="M457.8,77.9V88H447" stroke={slotClipColor} />
-        <SlotClip d="M457.8,8.8V-1.9H447" stroke={slotClipColor} />
-        <SlotClip d="M490,77.9v10.1h10.8" stroke={slotClipColor} />,
-        <SlotClip d="M490,8.8v-10.5h10.6" stroke={slotClipColor} />,
-        <SlotClip d="M621.8,77.9v10.1h-10.8" stroke={slotClipColor} />,
-        <SlotClip d="M621.8,8.8v-10.7h-10.8" stroke={slotClipColor} />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M326,77.9V88h10.8" stroke={slotClipColor} />
+            <SlotClip d="M326,8.8V-1.7h10.6" stroke={slotClipColor} />
+            <SlotClip d="M457.8,77.9V88H447" stroke={slotClipColor} />
+            <SlotClip d="M457.8,8.8V-1.9H447" stroke={slotClipColor} />
+            <SlotClip d="M490,77.9v10.1h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M490,8.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,77.9v10.1h-10.8" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,8.8v-10.7h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
   }

--- a/components/src/hardware-sim/BaseDeck/WasteChuteStagingAreaFixture.tsx
+++ b/components/src/hardware-sim/BaseDeck/WasteChuteStagingAreaFixture.tsx
@@ -19,6 +19,7 @@ interface WasteChuteStagingAreaFixtureProps extends SVGProps<SVGGElement> {
   showExtensions?: boolean
   showHighlight?: boolean
   tagInfo?: DeckLabelProps[]
+  showSlotClips?: boolean
 }
 
 export function WasteChuteStagingAreaFixture(
@@ -32,6 +33,7 @@ export function WasteChuteStagingAreaFixture(
     wasteChuteColor = COLORS.grey50,
     showHighlight,
     tagInfo,
+    showSlotClips = true,
     ...restProps
   } = props
 
@@ -58,10 +60,14 @@ export function WasteChuteStagingAreaFixture(
         d="M314.8,96.1h329.9c2.4,0,4.3-1.9,4.3-4.3V-5.6c0-2.4-1.9-4.3-4.3-4.3H314.8c-2.4,0-4.3,1.9-4.3,4.3v97.4C310.5,94.2,312.4,96.1,314.8,96.1z"
         fill={fixtureBaseColor}
       />
-      <SlotClip d="M490,77.9v10.1h10.8" stroke={slotClipColor} />,
-      <SlotClip d="M490,8.8v-10.5h10.6" stroke={slotClipColor} />,
-      <SlotClip d="M621.8,77.9v10.1h-10.8" stroke={slotClipColor} />,
-      <SlotClip d="M621.8,8.8v-10.7h-10.8" stroke={slotClipColor} />
+      {showSlotClips ? (
+        <>
+          <SlotClip d="M490,77.9v10.1h10.8" stroke={slotClipColor} />,
+          <SlotClip d="M490,8.8v-10.5h10.6" stroke={slotClipColor} />,
+          <SlotClip d="M621.8,77.9v10.1h-10.8" stroke={slotClipColor} />,
+          <SlotClip d="M621.8,8.8v-10.7h-10.8" stroke={slotClipColor} />
+        </>
+      ) : null}
       <WasteChute
         wasteIconColor={fixtureBaseColor}
         backgroundColor={wasteChuteColor}

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
@@ -289,6 +289,7 @@ export function DeckSetupContainer(
                             slotClipColor={darkFill}
                             showExpansion={cutoutId === 'cutoutA1'}
                             fixtureBaseColor={lightFill}
+                            showSlotClips={false}
                           />
                         ) : null
                       })}
@@ -304,6 +305,7 @@ export function DeckSetupContainer(
                               deckDefinition={deckDef}
                               slotClipColor={darkFill}
                               fixtureBaseColor={lightFill}
+                              showSlotClips={false}
                             />
                           )
                         }
@@ -319,6 +321,7 @@ export function DeckSetupContainer(
                                   deckDefinition={deckDef}
                                   slotClipColor={COLORS.transparent}
                                   fixtureBaseColor={lightFill}
+                                  showSlotClips={false}
                                 />
                                 <FlexTrash
                                   robotType={robotType}
@@ -361,6 +364,7 @@ export function DeckSetupContainer(
                               deckDefinition={deckDef}
                               slotClipColor={darkFill}
                               fixtureBaseColor={lightFill}
+                              showSlotClips={false}
                             />
                           )
                         }

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
@@ -165,6 +165,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
                       showExpansion={cutoutId === 'cutoutA1'}
                       fixtureBaseColor={lightFill}
                       slotClipColor={darkFill}
+                      showSlotClips={false}
                     />
                   ) : null
                 })}
@@ -175,6 +176,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
                     deckDefinition={deckDef}
                     fixtureBaseColor={lightFill}
                     slotClipColor={darkFill}
+                    showSlotClips={false}
                   />
                 ))}
                 {trash != null
@@ -186,6 +188,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
                             deckDefinition={deckDef}
                             slotClipColor={COLORS.transparent}
                             fixtureBaseColor={lightFill}
+                            showSlotClips={false}
                           />
                           <FlexTrash
                             robotType={robotType}
@@ -212,6 +215,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
                     deckDefinition={deckDef}
                     fixtureBaseColor={lightFill}
                     slotClipColor={darkFill}
+                    showSlotClips={false}
                   />
                 ))}
               </>


### PR DESCRIPTION
# Overview

PD designs specify that deck slot SVG components should not render slot clips. This PR refactors the shared hardware sim slot components to optionally skip rendering the slot clips, and correctly renders no slot clips in their respective PD implementations.

Closes AUTH-2782

## Test Plan and Hands on Testing

#### PD

Inspect the following at both Protocol Overview thumbnail and Editor deck screen
- import or create any PD protocol with a staging area and waste chute-provided staging area  (leave the staging areas empty)
- verify that no slot clips are present on standard slots or staging area slots

#### App
Smoke tested protocol thumbnails, protocol details, and protocol run setup screens to verify that those implementations of our hardware sim slot components were not affected

## Changelog

- refactor shared hardware sim slot fixture components to optionally skip rendering slot clips
- implement the above in PD deck components

## Review requests

- see test plan

## Risk assessment

low