### PR TITLE
chore(update-server): Fix `make dev` invocation

### DIFF
--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -37,9 +37,12 @@ lock:
 	$(UV) lock
 
 .PHONY: dev
-dev: export ENABLE_VIRTUAL_SMOOTHIE := true
 dev:
-	$(python) -m otupdate --log-level debug --port $(port)
+	$(python) -m otupdate.buildroot --log-level debug --port $(port)
+
+.PHONY: dev-flex
+dev-flex:
+	$(python) -m otupdate.openembedded --log-level debug --port $(port)
 
 .PHONY: clean
 clean:

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -4,7 +4,6 @@ include ../scripts/python-uv.mk
 # using bash instead of /bin/bash in SHELL prevents macOS optimizing away our PATH update
 SHELL := bash
 
-PATH := $(shell cd .. && yarn bin):$(PATH)
 SHX := npx shx
 
 # add yarn CLI dev deps to PATH (for cross platform POSIX commands via shx)


### PR DESCRIPTION
## Overview

The dev update-server (`make -C update-server dev`) is broadly broken for a number of reasons. One reason is that we were launching it with an outdated command.

## Test Plan and Hands on Testing

* [x] `make dev` and `make dev-flex` should now fail with a *different* error, having to do with trying to read a system-specific file.

## Changelog

* Update the `-m` path.
* Split the targets into `make dev` and `make dev-flex`, matching the conventions elsewhere.
* Delete a duplicate `$PATH` assignment.
* Delete an unused `ENABLE_VIRTUAL_SMOOTHIE` assignment. (`ENABLE_VIRTUAL_SMOOTHIE` is only an `api` and `robot-server` thing).

## Review requests

None.

## Risk assessment

Low.