### PR TITLE
feat(app-shell-odd): prevent a few Electron shortcuts

### DIFF
--- a/app-shell-odd/src/ui.ts
+++ b/app-shell-odd/src/ui.ts
@@ -76,6 +76,9 @@ export function waitForRobotServerAndShowMainWindow(
     mainWindow.webContents.send('window-type', 'odd-main')
   })
 
+  // prevent fullscreen for safe
+  mainWindow.setFullScreen(false)
+
   // prevent Electron shortcuts that Desktop app shows in menu
   mainWindow.webContents.on('before-input-event', (event, input) => {
     const key = input.key.toLowerCase()

--- a/app-shell-odd/src/ui.ts
+++ b/app-shell-odd/src/ui.ts
@@ -76,15 +76,40 @@ export function waitForRobotServerAndShowMainWindow(
     mainWindow.webContents.send('window-type', 'odd-main')
   })
 
-  // prevent Ctrl + Shift + I from opening devtools
-  // Reload Ctrl + R / Ctrl + Shift + R
+  // prevent Electron shortcuts that Desktop app shows in menu
   mainWindow.webContents.on('before-input-event', (event, input) => {
     const key = input.key.toLowerCase()
     const ctrlOrMeta = input.control || input.meta
-    if (ctrlOrMeta && input.shift && key === 'i') {
-      event.preventDefault()
-    }
-    if (ctrlOrMeta && key === 'r') {
+    const ctrlMeta = input.control && input.meta
+
+    // Ctrl + Shift + I from opening devtools
+    const isDevTools = ctrlOrMeta && input.shift && key === 'i'
+
+    // Reload Ctrl + R / Ctrl + Shift + R
+    const isReload = ctrlOrMeta && key === 'r'
+
+    // Zoom In: add is for numpad
+    const isPlusKey = key === '+' || key === '=' || key === 'add'
+    const isZoomIn = ctrlOrMeta && isPlusKey
+
+    // Zoom Out: subtract is for numpad
+    const isMinusKey = key === '-' || key === '_' || key === 'subtract'
+    const isZoomOut = ctrlOrMeta && isMinusKey
+
+    // Actual Size Cmd + 0/ Ctrl + 0
+    // This might not be needed since this shortcut is used when zooming in/out
+    const isActualZoom = ctrlOrMeta && key === '0'
+
+    const isFullScreen = (ctrlMeta && key === 'f') || key === 'f11'
+
+    if (
+      isDevTools ||
+      isReload ||
+      isZoomIn ||
+      isZoomOut ||
+      isActualZoom ||
+      isFullScreen
+    ) {
       event.preventDefault()
     }
   })

--- a/app-shell-odd/src/ui.ts
+++ b/app-shell-odd/src/ui.ts
@@ -85,8 +85,10 @@ export function waitForRobotServerAndShowMainWindow(
     const ctrlOrMeta = input.control || input.meta
     const ctrlMeta = input.control && input.meta
 
-    // Ctrl + Shift + I from opening devtools
-    const isDevTools = ctrlOrMeta && input.shift && key === 'i'
+    // Open Chrome Devtools: Ctrl + Shift + i / ⌘+⌥+I
+    const isDevToolsByShift = ctrlOrMeta && input.shift && key === 'i'
+    const isDevToolsByAltMeta = input.meta && input.alt && key === 'i'
+    const isDevTools = isDevToolsByShift || isDevToolsByAltMeta
 
     // Reload Ctrl + R / Ctrl + Shift + R
     const isReload = ctrlOrMeta && key === 'r'

--- a/app-shell-odd/src/ui.ts
+++ b/app-shell-odd/src/ui.ts
@@ -79,14 +79,12 @@ export function waitForRobotServerAndShowMainWindow(
   // prevent Ctrl + Shift + I from opening devtools
   // Reload Ctrl + R / Ctrl + Shift + R
   mainWindow.webContents.on('before-input-event', (event, input) => {
-    if (
-      input.control &&
-      input.shift &&
-      (input.key === 'i' || input.key === 'I')
-    ) {
+    const key = input.key.toLowerCase()
+    const ctrlOrMeta = input.control || input.meta
+    if (ctrlOrMeta && input.shift && key === 'i') {
       event.preventDefault()
     }
-    if (input.control && (input.key === 'r' || input.key === 'R')) {
+    if (ctrlOrMeta && key === 'r') {
       event.preventDefault()
     }
   })

--- a/app-shell-odd/src/ui.ts
+++ b/app-shell-odd/src/ui.ts
@@ -76,6 +76,21 @@ export function waitForRobotServerAndShowMainWindow(
     mainWindow.webContents.send('window-type', 'odd-main')
   })
 
+  // prevent Ctrl + Shift + I from opening devtools
+  // Reload Ctrl + R / Ctrl + Shift + R
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (
+      input.control &&
+      input.shift &&
+      (input.key === 'i' || input.key === 'I')
+    ) {
+      event.preventDefault()
+    }
+    if (input.control && (input.key === 'r' || input.key === 'R')) {
+      event.preventDefault()
+    }
+  })
+
   _NODE_ENV_ !== 'development' &&
     setTimeout(function () {
       systemd


### PR DESCRIPTION


# Overview
this pr prevents ctrl + shit + i (open dev tool), ctrl + r (soft reload) and, ctrl + shift + r (hard reload)

close EXEC-2403


## Test Plan and Hands on Testing
- push this branch to a Flex
- the followings don't do anything
   - hit `ctrl + shift + i`
   - hit `ctrl + r`
   - hit `ctrl + shift + r`


## Changelog
- add `before-input-event` to prevent the above shortcuts

## Review requests


## Risk assessment
low
