### PR TITLE
fix(app): fix create a new instance when re-render a component

### DIFF
--- a/app/src/organisms/EmergencyStop/EstopTakeover.tsx
+++ b/app/src/organisms/EmergencyStop/EstopTakeover.tsx
@@ -50,8 +50,8 @@ export function EstopTakeover({ robotName }: EstopTakeoverProps): JSX.Element {
   const localRobot = useSelector(getLocalRobot)
   const localRobotName = localRobot?.name ?? 'no name'
 
-  const TargetEstopModal = (): JSX.Element | null => {
-    return estopState === NOT_PRESENT ? (
+  const targetEstopModal =
+    estopState === NOT_PRESENT ? (
       <EstopMissingModal
         robotName={robotName != null ? robotName : localRobotName}
         closeModal={closeModal}
@@ -68,13 +68,12 @@ export function EstopTakeover({ robotName }: EstopTakeoverProps): JSX.Element {
         }}
       />
     ) : null
-  }
 
   return (
     <>
-      {showEmergencyStopModal && !isUnboxingFlowOngoing ? (
-        <TargetEstopModal />
-      ) : null}
+      {showEmergencyStopModal && !isUnboxingFlowOngoing
+        ? targetEstopModal
+        : null}
     </>
   )
 }

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/ErrorContent.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/ErrorContent.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next'
+
+import { RUN_STATUS_SUCCEEDED } from '@opentrons/api-client'
+import { LegacyStyledText } from '@opentrons/components'
+
+import styles from './errorcontent.module.css'
+
+import type { RunStatus } from '@opentrons/api-client'
+import type { RunCommandError } from '@opentrons/shared-data'
+
+interface ErrorContentProps {
+  errors: RunCommandError[]
+  isSingleError: boolean
+  runStatus: RunStatus | null
+}
+export function ErrorContent({
+  errors,
+  isSingleError,
+  runStatus,
+}: ErrorContentProps): JSX.Element {
+  const { t, i18n } = useTranslation('run_details')
+  return (
+    <>
+      <LegacyStyledText forwardedAs="p" className={styles.error_info_text}>
+        {isSingleError
+          ? t('error_info', {
+              errorType: errors[0].errorType,
+              errorCode: errors[0].errorCode,
+            })
+          : runStatus === RUN_STATUS_SUCCEEDED
+            ? t(errors.length > 1 ? 'no_of_warnings' : 'no_of_warning', {
+                count: errors.length,
+              })
+            : t(errors.length > 1 ? 'no_of_errors' : 'no_of_error', {
+                count: errors.length,
+              })}
+      </LegacyStyledText>
+      <div className={styles.error_container}>
+        <div className={styles.error_list}>
+          {errors.map((error, index) => (
+            <LegacyStyledText
+              forwardedAs="p"
+              className={styles.error_detail_text}
+              key={index}
+            >
+              {isSingleError
+                ? error.detail
+                : `${error.errorCode}: ${error.detail}`}
+            </LegacyStyledText>
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/ErrorContent.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/ErrorContent.tsx
@@ -18,7 +18,7 @@ export function ErrorContent({
   isSingleError,
   runStatus,
 }: ErrorContentProps): JSX.Element {
-  const { t, i18n } = useTranslation('run_details')
+  const { t } = useTranslation('run_details')
   return (
     <>
       <LegacyStyledText forwardedAs="p" className={styles.error_info_text}>

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/__tests__/ErrorContent.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/__tests__/ErrorContent.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, screen } from '@testing-library/react'
+import be from 'date-fns/esm/locale/be/index.js'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { RUN_STATUS_FAILED, RUN_STATUS_SUCCEEDED } from '@opentrons/api-client'
+
+import { renderWithProviders } from '/app/__testing-utils__'
+import { i18n } from '/app/i18n'
+
+import { ErrorContent } from '../ErrorContent'
+
+import type { ComponentProps } from 'react'
+import type { RunCommandError } from '@opentrons/shared-data'
+
+const render = (props: ComponentProps<typeof ErrorContent>) => {
+  return renderWithProviders(<ErrorContent {...props} />, {
+    i18nInstance: i18n,
+  })
+}
+
+const singleError: RunCommandError = {
+  id: 'd0245210-dfb9-4f1c-8ad0-3416b603a7ba',
+  errorType: 'hardwareCommunicationError',
+  isDefined: false,
+  createdAt: '2023-04-09T21:41:51.333171+00:00',
+  detail: 'Error with code 1000 (highest priority)',
+  errorInfo: {},
+  errorCode: '1000',
+  wrappedErrors: [],
+}
+
+const multipleErrors: RunCommandError[] = [
+  {
+    id: 'd0245210-dfb9-4f1c-8ad0-3416b603a7ba',
+    errorType: 'roboticsInteractionError',
+    isDefined: false,
+    createdAt: '2023-04-09T21:41:51.333171+00:00',
+    detail: 'Error with code 2001 (second highest priortiy)',
+    errorInfo: {},
+    errorCode: '2001',
+    wrappedErrors: [],
+  },
+  {
+    id: 'd0245210-dfb9-4f1c-8ad0-3416b603a7bb',
+    errorType: 'generalError',
+    isDefined: false,
+    createdAt: '2023-04-09T21:41:51.333171+00:00',
+    detail: 'Error with code 4000 (lowest priority)',
+    errorInfo: {},
+    errorCode: '4000',
+    wrappedErrors: [],
+  },
+]
+
+describe('ErrorContent', () => {
+  let props: ComponentProps<typeof ErrorContent>
+
+  beforeEach(() => {
+    props = {
+      errors: [singleError],
+      isSingleError: true,
+      runStatus: RUN_STATUS_FAILED,
+    }
+  })
+
+  it('renders single-error header and detail without code prefix', () => {
+    render(props)
+    screen.getByText('Error 1000: hardwareCommunicationError')
+    screen.getByText('Error with code 1000 (highest priority)')
+  })
+
+  it('renders plural error count and error code prefixes when run failed', () => {
+    props = {
+      errors: multipleErrors,
+      isSingleError: false,
+      runStatus: RUN_STATUS_FAILED,
+    }
+    render(props)
+
+    screen.getByText('2 errors')
+    screen.getByText('2001: Error with code 2001 (second highest priortiy)')
+    screen.getByText('4000: Error with code 4000 (lowest priority)')
+  })
+
+  it('renders warning count when run succeeded', () => {
+    props = {
+      errors: multipleErrors,
+      isSingleError: false,
+      runStatus: RUN_STATUS_SUCCEEDED,
+    }
+    render(props)
+
+    screen.getByText('2 warnings')
+  })
+})

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/__tests__/ErrorContent.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/__tests__/ErrorContent.test.tsx
@@ -1,6 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
-import be from 'date-fns/esm/locale/be/index.js'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, it } from 'vitest'
 
 import { RUN_STATUS_FAILED, RUN_STATUS_SUCCEEDED } from '@opentrons/api-client'
 

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/__tests__/RunFailedModal.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/__tests__/RunFailedModal.test.tsx
@@ -9,11 +9,13 @@ import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 
 import { RunFailedModal } from '..'
+import { ErrorContent } from '../ErrorContent'
 
 import type { ComponentProps } from 'react'
 import type { NavigateFunction } from 'react-router-dom'
 
 vi.mock('@opentrons/react-api-client')
+vi.mock('../ErrorContent')
 
 const RUN_ID = 'mock_runID'
 const mockFn = vi.fn()
@@ -108,13 +110,13 @@ describe('RunFailedModal', () => {
     vi.mocked(useStopRunMutation).mockReturnValue({
       stopRun: mockStopRun,
     } as any)
+    vi.mocked(ErrorContent).mockReturnValue(<div>mock ErrorContent</div>)
   })
 
-  it('should render the highest priority error', () => {
+  it('should pass highest priority error to ErrorContent', () => {
     render(props)
     screen.getByText('Run failed')
-    screen.getByText('Error 1000: hardwareCommunicationError')
-    screen.getByText('Error with code 1000 (highest priority)')
+    screen.getByText('mock ErrorContent')
     screen.getByText(
       'Download the robot logs from the Opentrons App and send it to support@opentrons.com for assistance.'
     )
@@ -126,6 +128,7 @@ describe('RunFailedModal', () => {
     const button = screen.getByText('Close')
     fireEvent.click(button)
     expect(mockStopRun).toHaveBeenCalled()
+    expect(props.setShowRunFailedModal).toHaveBeenCalled()
     expect(mockNavigate).toHaveBeenCalledWith('/dashboard')
   })
 })

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/errorcontent.module.css
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/errorcontent.module.css
@@ -1,0 +1,42 @@
+.error_info_text {
+  font-weight: var(--font-weight-bold);
+}
+
+.error_container {
+  display: flex;
+  width: 100%;
+  max-height: 11rem;
+  flex-direction: column;
+  padding: var(--spacing-16) var(--spacing-20);
+  border-radius: var(--border-radius-8);
+  background-color: var(--grey-35);
+  gap: var(--spacing-8);
+  overflow-wrap: break-word;
+  white-space: normal;
+  word-break: normal;
+}
+
+.error_list {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+.error_list::-webkit-scrollbar {
+  width: 0.75rem;
+  background-color: var(--grey-35);
+}
+
+.error_list::-webkit-scrollbar-track {
+  margin-top: var(--spacing-16);
+  margin-bottom: var(--spacing-16);
+}
+
+.error_list::-webkit-scrollbar-thumb {
+  border-radius: 11px;
+  background: var(--grey-50);
+}
+
+.error_detail_text {
+  text-align: left;
+}

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/index.tsx
@@ -10,6 +10,7 @@ import { SmallButton } from '/app/atoms/buttons'
 import { OddModal } from '/app/molecules/OddModal'
 import { getHighestPriorityError } from '/app/transformations/runs'
 
+import { ErrorContent } from './ErrorContent'
 import styles from './runfailedmodal.module.css'
 
 import type {
@@ -72,49 +73,6 @@ export function RunFailedModal({
     })
   }
 
-  interface ErrorContentProps {
-    errors: RunCommandError[]
-    isSingleError: boolean
-  }
-  const ErrorContent = ({
-    errors,
-    isSingleError,
-  }: ErrorContentProps): JSX.Element => {
-    return (
-      <>
-        <LegacyStyledText forwardedAs="p" className={styles.error_info_text}>
-          {isSingleError
-            ? t('error_info', {
-                errorType: errors[0].errorType,
-                errorCode: errors[0].errorCode,
-              })
-            : runStatus === RUN_STATUS_SUCCEEDED
-              ? t(errors.length > 1 ? 'no_of_warnings' : 'no_of_warning', {
-                  count: errors.length,
-                })
-              : t(errors.length > 1 ? 'no_of_errors' : 'no_of_error', {
-                  count: errors.length,
-                })}
-        </LegacyStyledText>
-        <div className={styles.error_container}>
-          <div className={styles.error_list}>
-            {errors.map((error, index) => (
-              <LegacyStyledText
-                forwardedAs="p"
-                className={styles.error_detail_text}
-                key={index}
-              >
-                {isSingleError
-                  ? error.detail
-                  : `${error.errorCode}: ${error.detail}`}
-              </LegacyStyledText>
-            ))}
-          </div>
-        </div>
-      </>
-    )
-  }
-
   return (
     <OddModal
       header={modalHeader}
@@ -133,6 +91,7 @@ export function RunFailedModal({
                   : []
             }
             isSingleError={!!highestPriorityError}
+            runStatus={runStatus}
           />
         </div>
         <LegacyStyledText forwardedAs="p" className={styles.contact_text}>

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/index.tsx
@@ -18,7 +18,6 @@ import type {
   RunError,
   RunStatus,
 } from '@opentrons/api-client'
-import type { RunCommandError } from '@opentrons/shared-data'
 import type { OddModalHeaderBaseProps } from '/app/molecules/OddModal/types'
 
 interface RunFailedModalProps {

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/runfailedmodal.module.css
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/runfailedmodal.module.css
@@ -13,49 +13,6 @@
   gap: var(--spacing-16);
 }
 
-.error_info_text {
-  font-weight: var(--font-weight-bold);
-}
-
-.error_container {
-  display: flex;
-  width: 100%;
-  max-height: 11rem;
-  flex-direction: column;
-  padding: var(--spacing-16) var(--spacing-20);
-  border-radius: var(--border-radius-8);
-  background-color: var(--grey-35);
-  gap: var(--spacing-8);
-  overflow-wrap: break-word;
-  white-space: normal;
-  word-break: normal;
-}
-
-.error_list {
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-}
-
-.error_list::-webkit-scrollbar {
-  width: 0.75rem;
-  background-color: var(--grey-35);
-}
-
-.error_list::-webkit-scrollbar-track {
-  margin-top: var(--spacing-16);
-  margin-bottom: var(--spacing-16);
-}
-
-.error_list::-webkit-scrollbar-thumb {
-  border-radius: 11px;
-  background: var(--grey-50);
-}
-
-.error_detail_text {
-  text-align: left;
-}
-
 .contact_text {
   overflow-wrap: break-word;
   text-align: left;


### PR DESCRIPTION

# Overview
fix create a new instance when re-render a component

```shell
✗ Component "ErrorContent" defined inside "RunFailedModal" — creates new instance every render, destroying state (2)
    Move to a separate file or to module scope above the parent component
    src/organisms/ODD/RunningProtocol/RunFailedModal/index.tsx: 79
    src/organisms/EmergencyStop/EstopTakeover.tsx: 53
```

close AUTH-2783

## Test Plan and Hands on Testing


## Changelog
- for RunFailedModal, export ErrorContent and add a test
- for EstopTakeover,  convert ‎`TargetEstopModal` from an inline component to a variable
- update RunFailedModal test

## Review requests


## Risk assessment
low
