### PR TITLE
chore(server-utils): `make push` should push to auth-server and update-server

### DIFF
--- a/server-utils/Makefile
+++ b/server-utils/Makefile
@@ -107,5 +107,7 @@ push: wheel
 
 .PHONY: push-ot3
 push-ot3: wheel
-	$(call push-python,$(host),$(ssh_key),$(ssh_opts),$(wheel_file),/opt/opentrons-system-server/)
+	$(call push-python,$(host),$(ssh_key),$(ssh_opts),$(wheel_file),/opt/opentrons-auth-server/)
 	$(call push-python,$(host),$(ssh_key),$(ssh_opts),$(wheel_file),/opt/opentrons-robot-server/)
+	$(call push-python,$(host),$(ssh_key),$(ssh_opts),$(wheel_file),/opt/opentrons-system-server/)
+	$(call push-python,$(host),$(ssh_key),$(ssh_opts),$(wheel_file),/opt/opentrons-update-server/)


### PR DESCRIPTION
## Overview

The dev command `make -C server-utils push-ot3` has a hard-coded list of all the servers that depend on server-utils. It needed to be updated to include update-server, which has [recently gained](https://github.com/Opentrons/opentrons/pull/20953) a dependency on server-utils, and auth-server, which is altogether new.

## Test Plan and Hands on Testing

* [x] Command runs without errors

## Review requests

None.

## Risk assessment

Low.