### PR TITLE
chore(js): Change the "react-hooks/exhaustive-deps" lint warning into an error 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
     'react/display-name': 'off',
     'react-hooks/rules-of-hooks': 'error',
     'react-hooks/exhaustive-deps': [
-      'warn',
+      'error',
       {
         additionalHooks: '(useDrag|useDrop)',
       },

--- a/app/src/App/Navbar/index.tsx
+++ b/app/src/App/Navbar/index.tsx
@@ -23,6 +23,8 @@ export function Navbar({ routes }: { routes: RouteProps[] }): JSX.Element {
   const navRoutes = routes.filter(
     ({ navLinkTo }: RouteProps) => navLinkTo != null
   )
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedNavigate = useCallback(
     debounce((path: string) => {
       navigate(path)

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -249,16 +249,18 @@ const getTargetPath = (unfinishedUnboxingFlowRoute: string | null): string => {
 export function OnDeviceDisplayAppRoutes(): JSX.Element {
   const { isScrolling, refCallback, element } = useScrollRef()
   const location = useLocation()
-  useEffect(() => {
-    element?.scrollTo({
-      top: 0,
-      left: 0,
-      behavior: 'auto',
-    })
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [location.pathname])
+  useEffect(
+    () => {
+      element?.scrollTo({
+        top: 0,
+        left: 0,
+        behavior: 'auto',
+      })
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [location.pathname]
+  )
 
   const { unfinishedUnboxingFlowRoute } = useSelector(
     getOnDeviceDisplaySettings

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -255,7 +255,10 @@ export function OnDeviceDisplayAppRoutes(): JSX.Element {
       left: 0,
       behavior: 'auto',
     })
-  }, [location.pathname])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [location.pathname])
 
   const { unfinishedUnboxingFlowRoute } = useSelector(
     getOnDeviceDisplaySettings

--- a/app/src/App/OnDeviceDisplayAppFallback.tsx
+++ b/app/src/App/OnDeviceDisplayAppFallback.tsx
@@ -40,7 +40,10 @@ export function OnDeviceDisplayAppFallback({
   // immediately report to robot logs that something fatal happened
   useEffect(() => {
     dispatch(sendLog(`ODD app encountered a fatal error: ${error.message}`))
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   return (
     <OddModal header={modalHeader}>

--- a/app/src/App/OnDeviceDisplayAppFallback.tsx
+++ b/app/src/App/OnDeviceDisplayAppFallback.tsx
@@ -38,12 +38,14 @@ export function OnDeviceDisplayAppFallback({
   useSentryReport(error)
 
   // immediately report to robot logs that something fatal happened
-  useEffect(() => {
-    dispatch(sendLog(`ODD app encountered a fatal error: ${error.message}`))
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      dispatch(sendLog(`ODD app encountered a fatal error: ${error.message}`))
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   return (
     <OddModal header={modalHeader}>

--- a/app/src/App/_Navbar.tsx
+++ b/app/src/App/_Navbar.tsx
@@ -117,6 +117,8 @@ export function Navbar({ routes }: { routes: RouteProps[] }): JSX.Element {
   const navRoutes = routes.filter(
     ({ navLinkTo }: RouteProps) => navLinkTo != null
   )
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedNavigate = useCallback(
     debounce((path: string) => {
       navigate(path)

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -82,67 +82,71 @@ export function useProtocolReceiptToast(): void {
     hasRefetched.current = false
   }
 
-  useEffect(() => {
-    const newProtocolIds = difference(protocolIds, protocolIdsRef.current)
-    if (!hasRefetched.current && newProtocolIds.length > 0) {
-      Promise.all(
-        newProtocolIds.map(protocolId => {
-          if (host != null) {
-            return (
-              getProtocol(host, protocolId).then(
-                data =>
-                  data.data.data.metadata.protocolName ??
-                  data.data.data.files[0].name
-              ) ?? ''
-            )
-          } else {
-            return Promise.reject(
-              new Error(
-                'no host provider info inside of useProtocolReceiptToast'
+  useEffect(
+    () => {
+      const newProtocolIds = difference(protocolIds, protocolIdsRef.current)
+      if (!hasRefetched.current && newProtocolIds.length > 0) {
+        Promise.all(
+          newProtocolIds.map(protocolId => {
+            if (host != null) {
+              return (
+                getProtocol(host, protocolId).then(
+                  data =>
+                    data.data.data.metadata.protocolName ??
+                    data.data.data.files[0].name
+                ) ?? ''
               )
-            )
-          }
-        })
-      )
-        .then(protocolNames => {
-          protocolNames.forEach(name => {
-            makeToast(
-              t('protocol_added', {
-                protocol_name: truncateString(name, 30),
-              }) as string,
-              'success',
-              {
-                buttonText: i18n.format(t('shared:close'), 'capitalize'),
-                disableTimeout: true,
-                displayType: 'odd',
-              }
-            )
+            } else {
+              return Promise.reject(
+                new Error(
+                  'no host provider info inside of useProtocolReceiptToast'
+                )
+              )
+            }
           })
-        })
-        .then(() => {
-          queryClient
-            .invalidateQueries([host, 'protocols'])
-            .catch((e: Error) => {
-              console.error(`error invalidating protocols query: ${e.message}`)
+        )
+          .then(protocolNames => {
+            protocolNames.forEach(name => {
+              makeToast(
+                t('protocol_added', {
+                  protocol_name: truncateString(name, 30),
+                }) as string,
+                'success',
+                {
+                  buttonText: i18n.format(t('shared:close'), 'capitalize'),
+                  disableTimeout: true,
+                  displayType: 'odd',
+                }
+              )
             })
-        })
-        .then(() => {
-          createLiveCommand({
-            command: animationCommand,
-          }).catch((e: Error) => {
-            console.warn(`cannot run status bar animation: ${e.message}`)
           })
-        })
-        .catch((e: Error) => {
-          console.error(e)
-        })
-    }
-    protocolIdsRef.current = protocolIds
-    // dont want this hook to rerun when other deps change
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [protocolIds])
+          .then(() => {
+            queryClient
+              .invalidateQueries([host, 'protocols'])
+              .catch((e: Error) => {
+                console.error(
+                  `error invalidating protocols query: ${e.message}`
+                )
+              })
+          })
+          .then(() => {
+            createLiveCommand({
+              command: animationCommand,
+            }).catch((e: Error) => {
+              console.warn(`cannot run status bar animation: ${e.message}`)
+            })
+          })
+          .catch((e: Error) => {
+            console.error(e)
+          })
+      }
+      protocolIdsRef.current = protocolIds
+      // dont want this hook to rerun when other deps change
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [protocolIds]
+  )
 }
 
 const MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP: ModuleType[] = [
@@ -213,45 +217,52 @@ export function useModuleAttachedToast(
 
   const [firstRun, setFirstRun] = useState<boolean>(true)
 
-  useEffect(() => {
-    const newModuleSerials = difference(moduleSerials, moduleSerialsRef.current)
-    if (
-      !runInProgress &&
-      ongoingSubsystemUpdate == null &&
-      newModuleSerials.length > 0
-    ) {
-      setToastID(
-        makeToast(t('module_added') as string, 'info', {
-          buttonText: i18n.format(t('shared:close'), 'capitalize'),
-          linkText: t('module_added_link'),
-          onLinkClick: () => {
-            launchModuleSetupCallback(true)
-          },
-          disableTimeout: true,
-          displayType: 'odd',
-        })
+  useEffect(
+    () => {
+      const newModuleSerials = difference(
+        moduleSerials,
+        moduleSerialsRef.current
       )
-    }
+      if (
+        !runInProgress &&
+        ongoingSubsystemUpdate == null &&
+        newModuleSerials.length > 0
+      ) {
+        setToastID(
+          makeToast(t('module_added') as string, 'info', {
+            buttonText: i18n.format(t('shared:close'), 'capitalize'),
+            linkText: t('module_added_link'),
+            onLinkClick: () => {
+              launchModuleSetupCallback(true)
+            },
+            disableTimeout: true,
+            displayType: 'odd',
+          })
+        )
+      }
 
-    moduleSerialsRef.current = moduleSerials
-    setFirstRun(false)
-    // dont want this hook to rerun when other deps change
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [moduleSerials, runInProgress, firstRun])
+      moduleSerialsRef.current = moduleSerials
+      setFirstRun(false)
+      // dont want this hook to rerun when other deps change
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [moduleSerials, runInProgress, firstRun]
+  )
 
-  useEffect(() => {
-    // Close toast if there are no new modules to setup
-    if (toastID && currentlySetuppableModules.length === 0) {
-      launchModuleSetupCallback(false)
-      eatToast(toastID)
-      setToastID('')
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [toastID, currentlySetuppableModules])
+  useEffect(
+    () => {
+      // Close toast if there are no new modules to setup
+      if (toastID && currentlySetuppableModules.length === 0) {
+        launchModuleSetupCallback(false)
+        eatToast(toastID)
+        setToastID('')
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [toastID, currentlySetuppableModules]
+  )
 }
 
 export function useScrollRef(): {

--- a/app/src/App/hooks.ts
+++ b/app/src/App/hooks.ts
@@ -139,8 +139,10 @@ export function useProtocolReceiptToast(): void {
     }
     protocolIdsRef.current = protocolIds
     // dont want this hook to rerun when other deps change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [protocolIds])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [protocolIds])
 }
 
 const MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP: ModuleType[] = [
@@ -234,8 +236,10 @@ export function useModuleAttachedToast(
     moduleSerialsRef.current = moduleSerials
     setFirstRun(false)
     // dont want this hook to rerun when other deps change
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [moduleSerials, runInProgress, firstRun])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [moduleSerials, runInProgress, firstRun])
 
   useEffect(() => {
     // Close toast if there are no new modules to setup
@@ -244,7 +248,10 @@ export function useModuleAttachedToast(
       eatToast(toastID)
       setToastID('')
     }
-  }, [toastID, currentlySetuppableModules])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [toastID, currentlySetuppableModules])
 }
 
 export function useScrollRef(): {

--- a/app/src/local-resources/images/hooks/useInitializeCameraState.ts
+++ b/app/src/local-resources/images/hooks/useInitializeCameraState.ts
@@ -42,5 +42,8 @@ export function useInitializeCameraState(runId: string): void {
         })
       )
     }
-  }, [cameraSettingsExist, runCameraSettingsExist])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [cameraSettingsExist, runCameraSettingsExist])
 }

--- a/app/src/local-resources/images/hooks/useInitializeCameraState.ts
+++ b/app/src/local-resources/images/hooks/useInitializeCameraState.ts
@@ -16,34 +16,36 @@ export function useInitializeCameraState(runId: string): void {
   const cameraSettingsExist = cameraSettings != null
   const runCameraSettingsExist = runCameraSettings != null
 
-  useEffect(() => {
-    if (runCameraSettings != null) {
-      const { cameraEnabled, errorRecoveryCameraEnabled, liveStreamEnabled } =
-        runCameraSettings
+  useEffect(
+    () => {
+      if (runCameraSettings != null) {
+        const { cameraEnabled, errorRecoveryCameraEnabled, liveStreamEnabled } =
+          runCameraSettings
 
-      dispatch(
-        updateCameraUsageSettings({
-          runId,
-          cameraEnabled,
-          liveStreamEnabled,
-          recoveryEnabled: errorRecoveryCameraEnabled,
-        })
-      )
-    } else if (cameraSettings != null) {
-      const { cameraEnabled, errorRecoveryCameraEnabled, liveStreamEnabled } =
-        cameraSettings
+        dispatch(
+          updateCameraUsageSettings({
+            runId,
+            cameraEnabled,
+            liveStreamEnabled,
+            recoveryEnabled: errorRecoveryCameraEnabled,
+          })
+        )
+      } else if (cameraSettings != null) {
+        const { cameraEnabled, errorRecoveryCameraEnabled, liveStreamEnabled } =
+          cameraSettings
 
-      dispatch(
-        updateCameraUsageSettings({
-          runId,
-          cameraEnabled,
-          liveStreamEnabled,
-          recoveryEnabled: errorRecoveryCameraEnabled,
-        })
-      )
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [cameraSettingsExist, runCameraSettingsExist])
+        dispatch(
+          updateCameraUsageSettings({
+            runId,
+            cameraEnabled,
+            liveStreamEnabled,
+            recoveryEnabled: errorRecoveryCameraEnabled,
+          })
+        )
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [cameraSettingsExist, runCameraSettingsExist]
+  )
 }

--- a/app/src/local-resources/images/hooks/useToastOnErrorImage.ts
+++ b/app/src/local-resources/images/hooks/useToastOnErrorImage.ts
@@ -35,5 +35,8 @@ export function useToastOnErrorImage(runId: string): void {
         heading: t('image_during_error'),
       })
     }
-  }, [cmdDetails?.data.id])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [cmdDetails?.data.id])
 }

--- a/app/src/local-resources/images/hooks/useToastOnErrorImage.ts
+++ b/app/src/local-resources/images/hooks/useToastOnErrorImage.ts
@@ -27,16 +27,18 @@ export function useToastOnErrorImage(runId: string): void {
     mostRecentImg?.commandId ?? null
   )
 
-  useEffect(() => {
-    if (mostRecentImg != null && cmdDetails?.data.error != null) {
-      makeToast(t('image_in_gallery') as string, INFO_TOAST, {
-        duration: TOAST_DURATION_MS,
-        closeButton: true,
-        heading: t('image_during_error'),
-      })
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [cmdDetails?.data.id])
+  useEffect(
+    () => {
+      if (mostRecentImg != null && cmdDetails?.data.error != null) {
+        makeToast(t('image_in_gallery') as string, INFO_TOAST, {
+          duration: TOAST_DURATION_MS,
+          closeButton: true,
+          heading: t('image_during_error'),
+        })
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [cmdDetails?.data.id]
+  )
 }

--- a/app/src/molecules/LabwareOffsetSnippet/index.tsx
+++ b/app/src/molecules/LabwareOffsetSnippet/index.tsx
@@ -43,7 +43,10 @@ export function LabwareOffsetSnippet(
         onSnippetUpdate(generatedSnippet)
       }
     }
-  }, [labware, labwareOffsets, mode, onSnippetUpdate])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [labware, labwareOffsets, mode, onSnippetUpdate])
 
   return robotType === FLEX_ROBOT_TYPE ? (
     <JsonTextArea readOnly value={snippet ?? ''} spellCheck={false} />

--- a/app/src/molecules/LabwareOffsetSnippet/index.tsx
+++ b/app/src/molecules/LabwareOffsetSnippet/index.tsx
@@ -34,19 +34,21 @@ export function LabwareOffsetSnippet(
 
   const [snippet, setSnippet] = useState<string | null>(null)
 
-  useEffect(() => {
-    if (labware.length > 0 && labwareOffsets != null) {
-      const generatedSnippet = createSnippet(props)
-      setSnippet(generatedSnippet)
+  useEffect(
+    () => {
+      if (labware.length > 0 && labwareOffsets != null) {
+        const generatedSnippet = createSnippet(props)
+        setSnippet(generatedSnippet)
 
-      if (onSnippetUpdate != null && generatedSnippet != null) {
-        onSnippetUpdate(generatedSnippet)
+        if (onSnippetUpdate != null && generatedSnippet != null) {
+          onSnippetUpdate(generatedSnippet)
+        }
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [labware, labwareOffsets, mode, onSnippetUpdate])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [labware, labwareOffsets, mode, onSnippetUpdate]
+  )
 
   return robotType === FLEX_ROBOT_TYPE ? (
     <JsonTextArea readOnly value={snippet ?? ''} spellCheck={false} />

--- a/app/src/organisms/Desktop/Alerts/AlertsModal.tsx
+++ b/app/src/organisms/Desktop/Alerts/AlertsModal.tsx
@@ -53,44 +53,48 @@ export function AlertsModal({ toastIdRef }: AlertsModalProps): JSX.Element {
     isAppUpdateAvailable && !isAppUpdateIgnored
 
   // Only run this hook on app startup
-  useEffect(() => {
-    if (hasJustUpdated) {
-      makeToast(
-        t('branded:opentrons_app_successfully_updated') as string,
-        SUCCESS_TOAST,
-        {
-          closeButton: true,
-          disableTimeout: true,
-        }
-      )
-      dispatch(toggleConfigValue('update.hasJustUpdated'))
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      if (hasJustUpdated) {
+        makeToast(
+          t('branded:opentrons_app_successfully_updated') as string,
+          SUCCESS_TOAST,
+          {
+            closeButton: true,
+            disableTimeout: true,
+          }
+        )
+        dispatch(toggleConfigValue('update.hasJustUpdated'))
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
-  useEffect(() => {
-    if (createAppUpdateAvailableToast) {
-      toastIdRef.current = makeToast(
-        t('branded:opentrons_app_update_available_variation') as string,
-        WARNING_TOAST,
-        {
-          closeButton: true,
-          disableTimeout: true,
-          linkText: t('view_update'),
-          onLinkClick: () => {
-            setShowUpdateModal(true)
-          },
-        }
-      )
-    } else if (removeToast && toastIdRef.current) {
-      removeActiveAppUpdateToast()
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isAppUpdateAvailable, isAppUpdateIgnored])
+  useEffect(
+    () => {
+      if (createAppUpdateAvailableToast) {
+        toastIdRef.current = makeToast(
+          t('branded:opentrons_app_update_available_variation') as string,
+          WARNING_TOAST,
+          {
+            closeButton: true,
+            disableTimeout: true,
+            linkText: t('view_update'),
+            onLinkClick: () => {
+              setShowUpdateModal(true)
+            },
+          }
+        )
+      } else if (removeToast && toastIdRef.current) {
+        removeActiveAppUpdateToast()
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isAppUpdateAvailable, isAppUpdateIgnored]
+  )
 
   return (
     <>

--- a/app/src/organisms/Desktop/Alerts/AlertsModal.tsx
+++ b/app/src/organisms/Desktop/Alerts/AlertsModal.tsx
@@ -65,7 +65,10 @@ export function AlertsModal({ toastIdRef }: AlertsModalProps): JSX.Element {
       )
       dispatch(toggleConfigValue('update.hasJustUpdated'))
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   useEffect(() => {
     if (createAppUpdateAvailableToast) {
@@ -84,7 +87,10 @@ export function AlertsModal({ toastIdRef }: AlertsModalProps): JSX.Element {
     } else if (removeToast && toastIdRef.current) {
       removeActiveAppUpdateToast()
     }
-  }, [isAppUpdateAvailable, isAppUpdateIgnored])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isAppUpdateAvailable, isAppUpdateIgnored])
 
   return (
     <>

--- a/app/src/organisms/Desktop/CalibrationError/index.tsx
+++ b/app/src/organisms/Desktop/CalibrationError/index.tsx
@@ -42,7 +42,10 @@ export function useCalibrationError(
     if (sessionId != null) {
       dispatch(dismissAllRequests())
     }
-  }, [sessionId])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [sessionId])
 
   const reqs = useSelector((state: State) => {
     return getRequests(state, requestIds)

--- a/app/src/organisms/Desktop/CalibrationError/index.tsx
+++ b/app/src/organisms/Desktop/CalibrationError/index.tsx
@@ -38,14 +38,16 @@ export function useCalibrationError(
   const dispatch = useDispatch()
 
   // Dismiss all network requests during a unique session to prevent stale error state.
-  useEffect(() => {
-    if (sessionId != null) {
-      dispatch(dismissAllRequests())
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [sessionId])
+  useEffect(
+    () => {
+      if (sessionId != null) {
+        dispatch(dismissAllRequests())
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sessionId]
+  )
 
   const reqs = useSelector((state: State) => {
     return getRequests(state, requestIds)

--- a/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
@@ -131,27 +131,31 @@ export function ChooseProtocolSlideoutComponent(
     }
   }, [currentPage])
 
-  useEffect(() => {
-    setRunTimeParametersOverrides(
-      selectedProtocol?.mostRecentAnalysis?.runTimeParameters ?? []
-    )
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [selectedProtocol?.protocolKey])
-
-  useEffect(() => {
-    setHasParamError(errors.length > 0)
-    setHasMissingFileParam(
-      runTimeParametersOverrides.some(
-        parameter =>
-          parameter.type === 'csv_file' && parameter.file?.file == null
+  useEffect(
+    () => {
+      setRunTimeParametersOverrides(
+        selectedProtocol?.mostRecentAnalysis?.runTimeParameters ?? []
       )
-    )
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [runTimeParametersOverrides])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedProtocol?.protocolKey]
+  )
+
+  useEffect(
+    () => {
+      setHasParamError(errors.length > 0)
+      setHasMissingFileParam(
+        runTimeParametersOverrides.some(
+          parameter =>
+            parameter.type === 'csv_file' && parameter.file?.file == null
+        )
+      )
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [runTimeParametersOverrides]
+  )
 
   const runTimeParametersFromAnalysis =
     selectedProtocol?.mostRecentAnalysis?.runTimeParameters ?? []
@@ -751,12 +755,14 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
   ).filter(
     protocol => protocol.mostRecentAnalysis?.robotType === robot.robotModel
   )
-  useEffect(() => {
-    handleSelectProtocol(first(storedProtocols) ?? null)
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      handleSelectProtocol(first(storedProtocols) ?? null)
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   return storedProtocols.length > 0 ? (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>

--- a/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
@@ -135,7 +135,10 @@ export function ChooseProtocolSlideoutComponent(
     setRunTimeParametersOverrides(
       selectedProtocol?.mostRecentAnalysis?.runTimeParameters ?? []
     )
-  }, [selectedProtocol?.protocolKey])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [selectedProtocol?.protocolKey])
 
   useEffect(() => {
     setHasParamError(errors.length > 0)
@@ -145,7 +148,10 @@ export function ChooseProtocolSlideoutComponent(
           parameter.type === 'csv_file' && parameter.file?.file == null
       )
     )
-  }, [runTimeParametersOverrides])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [runTimeParametersOverrides])
 
   const runTimeParametersFromAnalysis =
     selectedProtocol?.mostRecentAnalysis?.runTimeParameters ?? []
@@ -747,7 +753,10 @@ function StoredProtocolList(props: StoredProtocolListProps): JSX.Element {
   )
   useEffect(() => {
     handleSelectProtocol(first(storedProtocols) ?? null)
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   return storedProtocols.length > 0 ? (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/AvailableRobotOption.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/AvailableRobotOption.tsx
@@ -113,12 +113,14 @@ export function AvailableRobotOption(
     iconName = 'usb'
   }
 
-  useEffect(() => {
-    dispatch(fetchStatus(robotName))
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      dispatch(fetchStatus(robotName))
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   return showIdleOnly && isBusy ? null : (
     <>

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/AvailableRobotOption.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/AvailableRobotOption.tsx
@@ -115,8 +115,10 @@ export function AvailableRobotOption(
 
   useEffect(() => {
     dispatch(fetchStatus(robotName))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   return showIdleOnly && isBusy ? null : (
     <>

--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -90,7 +90,10 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
   )
   useEffect(() => {
     setRunTimeParametersOverrides(runTimeParameters)
-  }, [protocolKey])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [protocolKey])
 
   const [targetProps, tooltipProps] = useHoverTooltip()
 

--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -88,12 +88,14 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
   const [hasMissingFileParam, setHasMissingFileParam] = useState<boolean>(
     runTimeParameters?.some(parameter => parameter.type === 'csv_file') ?? false
   )
-  useEffect(() => {
-    setRunTimeParametersOverrides(runTimeParameters)
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [protocolKey])
+  useEffect(
+    () => {
+      setRunTimeParametersOverrides(runTimeParameters)
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [protocolKey]
+  )
 
   const [targetProps, tooltipProps] = useHoverTooltip()
 

--- a/app/src/organisms/Desktop/Devices/PipetteCard/FlexPipetteCard.tsx
+++ b/app/src/organisms/Desktop/Devices/PipetteCard/FlexPipetteCard.tsx
@@ -79,6 +79,8 @@ export function FlexPipetteCard({
     setSelectedPipette(SINGLE_MOUNT_PIPETTES)
   }
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const { showDTWiz, enableDTWiz, disableDTWiz } = useDropTipWizardFlows()
 
   const handleLaunchPipetteWizardFlows = (

--- a/app/src/organisms/Desktop/Devices/PipetteCard/index.tsx
+++ b/app/src/organisms/Desktop/Devices/PipetteCard/index.tsx
@@ -73,6 +73,8 @@ export const PipetteCard = (props: PipetteCardProps): JSX.Element => {
   const [showSlideout, setShowSlideout] = useState(false)
   const [showAboutSlideout, setShowAboutSlideout] = useState(false)
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const { showDTWiz, disableDTWiz, enableDTWiz } = useDropTipWizardFlows()
 
   const settings =

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
@@ -116,46 +116,53 @@ export function useRunHeaderDropTip({
   )
 
   // Manage tip checking
-  useEffect(() => {
-    // If a user begins a new run without navigating away from the run page, reset tip status.
-    if (robotType === FLEX_ROBOT_TYPE) {
-      if (runStatus === RUN_STATUS_IDLE) {
-        resetTipStatus()
+  useEffect(
+    () => {
+      // If a user begins a new run without navigating away from the run page, reset tip status.
+      if (robotType === FLEX_ROBOT_TYPE) {
+        if (runStatus === RUN_STATUS_IDLE) {
+          resetTipStatus()
+        }
+        // Only run tip checking if it wasn't *just* handled during Error Recovery.
+        else if (
+          runSummaryNoFixit != null &&
+          !lastRunCommandPromptedErrorRecovery(
+            runSummaryNoFixit,
+            isEREnabled
+          ) &&
+          isRunCurrent &&
+          isRunTerminatingOrTerminal
+        ) {
+          void determineTipStatus()
+        }
       }
-      // Only run tip checking if it wasn't *just* handled during Error Recovery.
-      else if (
-        runSummaryNoFixit != null &&
-        !lastRunCommandPromptedErrorRecovery(runSummaryNoFixit, isEREnabled) &&
-        isRunCurrent &&
-        isRunTerminatingOrTerminal
-      ) {
-        void determineTipStatus()
-      }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [runStatus, robotType, isRunCurrent, runSummaryNoFixit, isEREnabled])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [runStatus, robotType, isRunCurrent, runSummaryNoFixit, isEREnabled]
+  )
 
   // If the run terminates with a "stopped" status, close the run if no tips are attached after running tip check at least once.
   // This marks the robot as "not busy" if drop tip CTAs are unnecessary.
-  useEffect(() => {
-    if (
-      isRunTerminatingOrTerminal &&
-      isRunCurrent &&
-      (initialPipettesWithTipsCount === 0 || robotType === OT2_ROBOT_TYPE)
-    ) {
-      closeCurrentRun()
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [
-    isRunTerminatingOrTerminal,
-    isRunCurrent,
-    enteredER,
-    initialPipettesWithTipsCount,
-  ])
+  useEffect(
+    () => {
+      if (
+        isRunTerminatingOrTerminal &&
+        isRunCurrent &&
+        (initialPipettesWithTipsCount === 0 || robotType === OT2_ROBOT_TYPE)
+      ) {
+        closeCurrentRun()
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      isRunTerminatingOrTerminal,
+      isRunCurrent,
+      enteredER,
+      initialPipettesWithTipsCount,
+    ]
+  )
 
   return {
     dropTipModalUtils,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
@@ -51,6 +51,8 @@ export function useRunHeaderDropTip({
   const isRunCurrent = useIsRunCurrent(runId)
   const enteredER = runRecord?.data.hasEverEnteredErrorRecovery ?? false
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const { showDTWiz, disableDTWiz, enableDTWiz } = useDropTipWizardFlows()
 
   const {
@@ -130,7 +132,10 @@ export function useRunHeaderDropTip({
         void determineTipStatus()
       }
     }
-  }, [runStatus, robotType, isRunCurrent, runSummaryNoFixit, isEREnabled])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [runStatus, robotType, isRunCurrent, runSummaryNoFixit, isEREnabled])
 
   // If the run terminates with a "stopped" status, close the run if no tips are attached after running tip check at least once.
   // This marks the robot as "not busy" if drop tip CTAs are unnecessary.
@@ -142,7 +147,10 @@ export function useRunHeaderDropTip({
     ) {
       closeCurrentRun()
     }
-  }, [
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [
     isRunTerminatingOrTerminal,
     isRunCurrent,
     enteredER,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ProtocolDropTipModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ProtocolDropTipModal.tsx
@@ -60,16 +60,18 @@ export function useProtocolDropTipModal({
   })
 
   // Close the modal if a different app closes the run context.
-  useEffect(() => {
-    if (isRunCurrent && !isHoming) {
-      setShowModal(areTipsAttached)
-    } else if (!isRunCurrent) {
-      setShowModal(false)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isRunCurrent, areTipsAttached, showModal]) // Continue to show the modal if a client dismisses the maintenance run on a different app.
+  useEffect(
+    () => {
+      if (isRunCurrent && !isHoming) {
+        setShowModal(areTipsAttached)
+      } else if (!isRunCurrent) {
+        setShowModal(false)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isRunCurrent, areTipsAttached, showModal]
+  ) // Continue to show the modal if a client dismisses the maintenance run on a different app.
 
   const onSkip = (): void => {
     void homePipettes()

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ProtocolDropTipModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ProtocolDropTipModal.tsx
@@ -66,7 +66,10 @@ export function useProtocolDropTipModal({
     } else if (!isRunCurrent) {
       setShowModal(false)
     }
-  }, [isRunCurrent, areTipsAttached, showModal]) // Continue to show the modal if a client dismisses the maintenance run on a different app.
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isRunCurrent, areTipsAttached, showModal]) // Continue to show the modal if a client dismisses the maintenance run on a different app.
 
   const onSkip = (): void => {
     void homePipettes()

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/hooks/useRunAnalytics.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/hooks/useRunAnalytics.ts
@@ -43,31 +43,35 @@ export function useRunAnalytics({
     source: SOURCE_RUN_RECORD,
     robotType: robotType,
   })
-  useEffect(() => {
-    const areReportConditionsValid =
-      isRunCurrent && runId != null && isTerminalRunStatus(runStatus)
-    if (areReportConditionsValid) {
-      reportImageCaptureUsage({
-        transactionId: runId,
-        amount: numberOfImages,
-      })
-      trackProtocolRunEvent({
-        name: ANALYTICS_PROTOCOL_RUN_ACTION.FINISH,
-        properties: robotAnalyticsData ?? undefined,
-      })
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [runStatus, isRunCurrent, runId, robotAnalyticsData])
+  useEffect(
+    () => {
+      const areReportConditionsValid =
+        isRunCurrent && runId != null && isTerminalRunStatus(runStatus)
+      if (areReportConditionsValid) {
+        reportImageCaptureUsage({
+          transactionId: runId,
+          amount: numberOfImages,
+        })
+        trackProtocolRunEvent({
+          name: ANALYTICS_PROTOCOL_RUN_ACTION.FINISH,
+          properties: robotAnalyticsData ?? undefined,
+        })
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [runStatus, isRunCurrent, runId, robotAnalyticsData]
+  )
 
   const { reportRecoveredRunResult } = useRecoveryAnalytics()
-  useEffect(() => {
-    if (isRunCurrent) {
-      reportRecoveredRunResult(runStatus, enteredER)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isRunCurrent, enteredER])
+  useEffect(
+    () => {
+      if (isRunCurrent) {
+        reportRecoveredRunResult(runStatus, enteredER)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isRunCurrent, enteredER]
+  )
 }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/hooks/useRunAnalytics.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/hooks/useRunAnalytics.ts
@@ -56,12 +56,18 @@ export function useRunAnalytics({
         properties: robotAnalyticsData ?? undefined,
       })
     }
-  }, [runStatus, isRunCurrent, runId, robotAnalyticsData])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [runStatus, isRunCurrent, runId, robotAnalyticsData])
 
   const { reportRecoveredRunResult } = useRecoveryAnalytics()
   useEffect(() => {
     if (isRunCurrent) {
       reportRecoveredRunResult(runStatus, enteredER)
     }
-  }, [isRunCurrent, enteredER])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isRunCurrent, enteredER])
 }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -231,18 +231,20 @@ export function ProtocolRunSetup({
     robotType: robotType,
   }
   const { reportPhotoAccessUsage } = useCameraAnalytics(baseProps)
-  useEffect(() => {
-    if (storageInfo.isImageStorageLow) {
-      reportPhotoAccessUsage({
-        ...baseProps,
-        transactionId: runId,
-        action: 'storageWarning',
-      })
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [storageInfo.isImageStorageLow !== null])
+  useEffect(
+    () => {
+      if (storageInfo.isImageStorageLow) {
+        reportPhotoAccessUsage({
+          ...baseProps,
+          transactionId: runId,
+          action: 'storageWarning',
+        })
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [storageInfo.isImageStorageLow !== null]
+  )
   // A separate app can apply camera settings.
   // We need to update the missing steps as a side effect.
   useEffect(() => {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -239,7 +239,10 @@ export function ProtocolRunSetup({
         action: 'storageWarning',
       })
     }
-  }, [storageInfo.isImageStorageLow !== null])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [storageInfo.isImageStorageLow !== null])
   // A separate app can apply camera settings.
   // We need to update the missing steps as a side effect.
   useEffect(() => {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SlotDetailModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SlotDetailModal.tsx
@@ -114,7 +114,10 @@ export function SlotDetailModal(
         ? filteredLiquidsInLoadOrder[0].id
         : undefined
     )
-  }, [selectedLabware])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [selectedLabware])
 
   if (protocolData == null) return null
   const liquidIds = filteredLiquidsInLoadOrder.map(liquid => liquid.id)

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SlotDetailModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SlotDetailModal.tsx
@@ -108,16 +108,18 @@ export function SlotDetailModal(
       : undefined
   )
 
-  useEffect(() => {
-    setSelectedLiquidId(
-      filteredLiquidsInLoadOrder.length > 0
-        ? filteredLiquidsInLoadOrder[0].id
-        : undefined
-    )
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [selectedLabware])
+  useEffect(
+    () => {
+      setSelectedLiquidId(
+        filteredLiquidsInLoadOrder.length > 0
+          ? filteredLiquidsInLoadOrder[0].id
+          : undefined
+      )
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedLabware]
+  )
 
   if (protocolData == null) return null
   const liquidIds = filteredLiquidsInLoadOrder.map(liquid => liquid.id)

--- a/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/ConnectModal/form-state.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/ConnectModal/form-state.ts
@@ -26,27 +26,29 @@ export const useResetFormOnSecurityChange = (): void => {
   const securityType = getValues('securityType')
   const prevSecurityType = usePrevious(securityType)
 
-  useEffect(() => {
-    if (prevSecurityType && securityType !== prevSecurityType) {
-      clearErrors('ssid')
-      clearErrors('securityType')
-      setValue('ssid', ssid)
-      setValue('securityType', securityType)
-      trigger(['ssid', 'securityType'])
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [
-    ssid,
-    ssidTouched,
-    ssidError,
-    securityType,
-    prevSecurityType,
-    control,
-    setValue,
-    trigger,
-  ])
+  useEffect(
+    () => {
+      if (prevSecurityType && securityType !== prevSecurityType) {
+        clearErrors('ssid')
+        clearErrors('securityType')
+        setValue('ssid', ssid)
+        setValue('securityType', securityType)
+        trigger(['ssid', 'securityType'])
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      ssid,
+      ssidTouched,
+      ssidError,
+      securityType,
+      prevSecurityType,
+      control,
+      setValue,
+      trigger,
+    ]
+  )
 }
 
 export const useConnectFormField = (

--- a/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/ConnectModal/form-state.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/ConnectModal/form-state.ts
@@ -34,7 +34,10 @@ export const useResetFormOnSecurityChange = (): void => {
       setValue('securityType', securityType)
       trigger(['ssid', 'securityType'])
     }
-  }, [
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [
     ssid,
     ssidTouched,
     ssidError,

--- a/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/DisconnectModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/DisconnectModal.tsx
@@ -113,14 +113,16 @@ export const DisconnectModal = ({
     disconnectModalBody = t('disconnect_from_wifi_network_failure', { ssid })
   }
 
-  useEffect(() => {
-    if (isDisconnected) {
-      dispatch(clearWifiStatus(robotName))
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isDisconnected])
+  useEffect(
+    () => {
+      if (isDisconnected) {
+        dispatch(clearWifiStatus(robotName))
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isDisconnected]
+  )
 
   return (
     <Modal

--- a/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/DisconnectModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/DisconnectModal.tsx
@@ -117,7 +117,10 @@ export const DisconnectModal = ({
     if (isDisconnected) {
       dispatch(clearWifiStatus(robotName))
     }
-  }, [isDisconnected])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isDisconnected])
 
   return (
     <Modal

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
@@ -302,7 +302,11 @@ function useStatusBarAnimation(isError: boolean): void {
     }
   }
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(startUpdatingAnimation, [])
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(startIdleAnimationIfFailed, [isError])
 }
 
@@ -312,7 +316,10 @@ function useCleanupRobotUpdateSessionOnDismount(): void {
     return () => {
       dispatch(clearRobotUpdateSession())
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 }
 
 function useGetModalText(

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
@@ -312,14 +312,16 @@ function useStatusBarAnimation(isError: boolean): void {
 
 function useCleanupRobotUpdateSessionOnDismount(): void {
   const dispatch = useDispatch()
-  useEffect(() => {
-    return () => {
-      dispatch(clearRobotUpdateSession())
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      return () => {
+        dispatch(clearRobotUpdateSession())
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 }
 
 function useGetModalText(

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
@@ -93,12 +93,14 @@ export function UpdateRobotModal({
     disabledReason = t(updateFromFileDisabledReason)
   else if (isRobotBusy) disabledReason = t('robot_busy_protocol')
 
-  useEffect(() => {
-    dispatch(robotUpdateChangelogSeen(robotName))
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [robotName])
+  useEffect(
+    () => {
+      dispatch(robotUpdateChangelogSeen(robotName))
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [robotName]
+  )
 
   let heading = ''
   if (updateType === UPGRADE || updateType === DOWNGRADE) {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
@@ -95,7 +95,10 @@ export function UpdateRobotModal({
 
   useEffect(() => {
     dispatch(robotUpdateChangelogSeen(robotName))
-  }, [robotName])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [robotName])
 
   let heading = ''
   if (updateType === UPGRADE || updateType === DOWNGRADE) {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/index.tsx
@@ -43,14 +43,20 @@ const UpdateBuildroot = NiceModal.create(
       if (robotName.current) {
         dispatch(setRobotUpdateSeen(robotName.current))
       }
-    }, [robotName])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [robotName])
 
     const ignoreUpdate = useCallback(() => {
       if (robotName.current) {
         dispatch(robotUpdateIgnored(robotName.current))
       }
       modal.remove()
-    }, [robotName, close])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [robotName, close])
 
     if (hasSeenSessionOnce.current)
       return (

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/index.tsx
@@ -39,24 +39,28 @@ const UpdateBuildroot = NiceModal.create(
     if (!hasSeenSessionOnce.current && session)
       hasSeenSessionOnce.current = true
 
-    useEffect(() => {
-      if (robotName.current) {
-        dispatch(setRobotUpdateSeen(robotName.current))
-      }
-    },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [robotName])
+    useEffect(
+      () => {
+        if (robotName.current) {
+          dispatch(setRobotUpdateSeen(robotName.current))
+        }
+      },
+      // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [robotName]
+    )
 
-    const ignoreUpdate = useCallback(() => {
-      if (robotName.current) {
-        dispatch(robotUpdateIgnored(robotName.current))
-      }
-      modal.remove()
-    },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [robotName, close])
+    const ignoreUpdate = useCallback(
+      () => {
+        if (robotName.current) {
+          dispatch(robotUpdateIgnored(robotName.current))
+        }
+        modal.remove()
+      },
+      // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [robotName, close]
+    )
 
     if (hasSeenSessionOnce.current)
       return (

--- a/app/src/organisms/Desktop/Devices/RunPreview/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RunPreview/index.tsx
@@ -85,6 +85,8 @@ export const RunPreviewComponent = (
       robotSideAnalysis != null
         ? getLabwareDefinitionsFromCommands(robotSideAnalysis.commands)
         : [],
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [isValidRobotSideAnalysis]
   )
 

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -87,6 +87,8 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
       analysis != null
         ? getLabwareDefinitionsFromCommands(analysis.commands)
         : [],
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [isValidRobotSideAnalysis]
   )
   const commandIndexById = useMemo(

--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
@@ -160,38 +160,40 @@ export function VisualizerContainer(
 
   //  update the data for the spotlight window
   //  whenever the command index changes
-  useEffect(() => {
-    if (selectedCommandId == null) return
+  useEffect(
+    () => {
+      if (selectedCommandId == null) return
 
-    const nextIndex = commands.findIndex(c => c.id === selectedCommandId)
-    if (nextIndex < 0) return
+      const nextIndex = commands.findIndex(c => c.id === selectedCommandId)
+      if (nextIndex < 0) return
 
-    const nextSpotlight = {
+      const nextSpotlight = {
+        protocolKey,
+        slot: selectedSlot,
+        command: commands[nextIndex],
+        robotState,
+        invariantContext,
+        analysis,
+        liquids,
+      }
+
+      if (nextSpotlight.slot != null && nextSpotlight.command != null) {
+        dispatch(stepDetailViewerUpdateAction(nextSpotlight))
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      selectedCommandId,
+      selectedSlot,
       protocolKey,
-      slot: selectedSlot,
-      command: commands[nextIndex],
       robotState,
       invariantContext,
       analysis,
       liquids,
-    }
-
-    if (nextSpotlight.slot != null && nextSpotlight.command != null) {
-      dispatch(stepDetailViewerUpdateAction(nextSpotlight))
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [
-    selectedCommandId,
-    selectedSlot,
-    protocolKey,
-    robotState,
-    invariantContext,
-    analysis,
-    liquids,
-    commands,
-  ])
+      commands,
+    ]
+  )
 
   const isThermocyclerAttached = Object.keys(robotState.modules).some(
     id => invariantContext.moduleEntities[id].type === THERMOCYCLER_MODULE_TYPE
@@ -220,22 +222,24 @@ export function VisualizerContainer(
 
   const thermocyclerSlots = ['A1', '8', '10', '11']
 
-  useEffect(() => {
-    if (
-      isThermocyclerAttached &&
-      selectedSlot != null &&
-      thermocyclerSlots.includes(selectedSlot)
-    ) {
-      if (robotType === FLEX_ROBOT_TYPE) {
-        setSelectedSlot('B1')
-      } else {
-        setSelectedSlot('7')
+  useEffect(
+    () => {
+      if (
+        isThermocyclerAttached &&
+        selectedSlot != null &&
+        thermocyclerSlots.includes(selectedSlot)
+      ) {
+        if (robotType === FLEX_ROBOT_TYPE) {
+          setSelectedSlot('B1')
+        } else {
+          setSelectedSlot('7')
+        }
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isThermocyclerAttached, selectedSlot])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isThermocyclerAttached, selectedSlot]
+  )
 
   const handleMouseDown = (
     e: MouseEvent<HTMLDivElement>,

--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
@@ -179,7 +179,10 @@ export function VisualizerContainer(
     if (nextSpotlight.slot != null && nextSpotlight.command != null) {
       dispatch(stepDetailViewerUpdateAction(nextSpotlight))
     }
-  }, [
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [
     selectedCommandId,
     selectedSlot,
     protocolKey,
@@ -229,7 +232,10 @@ export function VisualizerContainer(
         setSelectedSlot('7')
       }
     }
-  }, [isThermocyclerAttached, selectedSlot])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isThermocyclerAttached, selectedSlot])
 
   const handleMouseDown = (
     e: MouseEvent<HTMLDivElement>,

--- a/app/src/organisms/Desktop/RunProgressMeter/hooks/useRunProgressCopy.tsx
+++ b/app/src/organisms/Desktop/RunProgressMeter/hooks/useRunProgressCopy.tsx
@@ -64,6 +64,8 @@ export function useRunProgressCopy({
       analysis != null
         ? getLabwareDefinitionsFromCommands(analysis.commands)
         : [],
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [isValidRobotSideAnalysis]
   )
 

--- a/app/src/organisms/Desktop/SystemLanguagePreferenceModal/index.tsx
+++ b/app/src/organisms/Desktop/SystemLanguagePreferenceModal/index.tsx
@@ -135,7 +135,10 @@ export function SystemLanguagePreferenceModal(): JSX.Element | null {
           systemLanguage !== storedSystemLanguage
       )
     }
-  }, [i18n, systemLanguage, showBootModal])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [i18n, systemLanguage, showBootModal])
 
   return showBootModal || showUpdateModal ? (
     <Modal title={title}>

--- a/app/src/organisms/Desktop/SystemLanguagePreferenceModal/index.tsx
+++ b/app/src/organisms/Desktop/SystemLanguagePreferenceModal/index.tsx
@@ -91,54 +91,56 @@ export function SystemLanguagePreferenceModal(): JSX.Element | null {
   }
 
   // set initial language for boot modal; match app language to supported options
-  useEffect(() => {
-    if (systemLanguage != null) {
-      // prefer match entire locale, then match just language e.g. zh-Hant and zh-CN
-      const matchSystemLanguage: () => ArrayElement<
-        typeof LANGUAGES
-      > | null = () => {
-        try {
-          return (
-            LANGUAGES.find(lng => lng.value === systemLanguage) ??
-            LANGUAGES.find(
-              lng =>
-                new Intl.Locale(lng.value).language ===
-                new Intl.Locale(systemLanguage).language
-            ) ??
-            null
-          )
-        } catch (error: unknown) {
-          // Sometimes the language that we get from the shell will not be something
-          // js i18n can understand. Specifically, some linux systems will have their
-          // locale set to "C" (https://www.gnu.org/software/libc/manual/html_node/Standard-Locales.html)
-          // and that will cause Intl.Locale to throw. In this case, we'll treat it as
-          // unset and fall back to our default.
-          console.log(`Failed to search languages: ${error}`)
-          return null
+  useEffect(
+    () => {
+      if (systemLanguage != null) {
+        // prefer match entire locale, then match just language e.g. zh-Hant and zh-CN
+        const matchSystemLanguage: () => ArrayElement<
+          typeof LANGUAGES
+        > | null = () => {
+          try {
+            return (
+              LANGUAGES.find(lng => lng.value === systemLanguage) ??
+              LANGUAGES.find(
+                lng =>
+                  new Intl.Locale(lng.value).language ===
+                  new Intl.Locale(systemLanguage).language
+              ) ??
+              null
+            )
+          } catch (error: unknown) {
+            // Sometimes the language that we get from the shell will not be something
+            // js i18n can understand. Specifically, some linux systems will have their
+            // locale set to "C" (https://www.gnu.org/software/libc/manual/html_node/Standard-Locales.html)
+            // and that will cause Intl.Locale to throw. In this case, we'll treat it as
+            // unset and fall back to our default.
+            console.log(`Failed to search languages: ${error}`)
+            return null
+          }
         }
-      }
-      const matchedSystemLanguageOption = matchSystemLanguage()
+        const matchedSystemLanguageOption = matchSystemLanguage()
 
-      if (matchedSystemLanguageOption != null) {
-        // initial current option: set to detected system language
-        setCurrentOption(matchedSystemLanguageOption)
-        if (showBootModal) {
-          // for boot modal temp change app display language based on initial system locale
-          void i18n.changeLanguage(systemLanguage)
+        if (matchedSystemLanguageOption != null) {
+          // initial current option: set to detected system language
+          setCurrentOption(matchedSystemLanguageOption)
+          if (showBootModal) {
+            // for boot modal temp change app display language based on initial system locale
+            void i18n.changeLanguage(systemLanguage)
+          }
         }
+        // only show update modal if we support the language their system has updated to
+        setShowUpdateModal(
+          appLanguage != null &&
+            matchedSystemLanguageOption != null &&
+            storedSystemLanguage != null &&
+            systemLanguage !== storedSystemLanguage
+        )
       }
-      // only show update modal if we support the language their system has updated to
-      setShowUpdateModal(
-        appLanguage != null &&
-          matchedSystemLanguageOption != null &&
-          storedSystemLanguage != null &&
-          systemLanguage !== storedSystemLanguage
-      )
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [i18n, systemLanguage, showBootModal])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [i18n, systemLanguage, showBootModal]
+  )
 
   return showBootModal || showUpdateModal ? (
     <Modal title={title}>

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -125,7 +125,10 @@ export function AddFixtureModal({
       ),
     ]
     setAllModuleOptions(moduleOptions)
-  }, [cutoutId, addressableAreaId, existingCutoutFixtureId])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [cutoutId, addressableAreaId, existingCutoutFixtureId])
 
   const modalHeader: OddModalHeaderBaseProps = {
     title: t('add_to', {

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -106,29 +106,31 @@ export function AddFixtureModal({
   const [allModuleOptions, setAllModuleOptions] = useState<CutoutConfigMap[][]>(
     []
   )
-  useEffect(() => {
-    const options = [
-      ...getFixtureOptions(
-        cutoutId,
-        addressableAreaId,
-        existingCutoutFixtureId
-      ),
-      ...getWasteChuteOptions(cutoutId),
-    ]
-    setAllFixtureOptions(options)
-    const moduleOptions = [
-      ...getModuleOptions(
-        cutoutId,
-        unconfiguredMods,
-        addressableAreaId,
-        deckDef
-      ),
-    ]
-    setAllModuleOptions(moduleOptions)
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [cutoutId, addressableAreaId, existingCutoutFixtureId])
+  useEffect(
+    () => {
+      const options = [
+        ...getFixtureOptions(
+          cutoutId,
+          addressableAreaId,
+          existingCutoutFixtureId
+        ),
+        ...getWasteChuteOptions(cutoutId),
+      ]
+      setAllFixtureOptions(options)
+      const moduleOptions = [
+        ...getModuleOptions(
+          cutoutId,
+          unconfiguredMods,
+          addressableAreaId,
+          deckDef
+        ),
+      ]
+      setAllModuleOptions(moduleOptions)
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [cutoutId, addressableAreaId, existingCutoutFixtureId]
+  )
 
   const modalHeader: OddModalHeaderBaseProps = {
     title: t('add_to', {

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
@@ -68,6 +68,8 @@ export function DeviceDetailsDeckConfiguration({
   const [showSetupInstructionsModal, setShowSetupInstructionsModal] =
     useState<boolean>(false)
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const deckConfig =
     useNotifyDeckConfigurationQuery({
       refetchInterval: DECK_CONFIG_REFETCH_INTERVAL,

--- a/app/src/organisms/DropTipWizardFlows/DropTipWizardFlows.tsx
+++ b/app/src/organisms/DropTipWizardFlows/DropTipWizardFlows.tsx
@@ -66,16 +66,18 @@ export function DropTipWizardFlows(
 
   // If the flow unrenders for any reason (ex, the pipette card managing the flow unrenders), don't re-render the flow
   // after it closes.
-  useEffect(() => {
-    return () => {
-      if (issuedCommandsType === 'setup') {
-        void dropTipWithTypeUtils.dropTipCommands.handleCleanUpAndClose()
+  useEffect(
+    () => {
+      return () => {
+        if (issuedCommandsType === 'setup') {
+          void dropTipWithTypeUtils.dropTipCommands.handleCleanUpAndClose()
+        }
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [issuedCommandsType])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [issuedCommandsType]
+  )
 
   return (
     <DropTipWizard

--- a/app/src/organisms/DropTipWizardFlows/DropTipWizardFlows.tsx
+++ b/app/src/organisms/DropTipWizardFlows/DropTipWizardFlows.tsx
@@ -72,7 +72,10 @@ export function DropTipWizardFlows(
         void dropTipWithTypeUtils.dropTipCommands.handleCleanUpAndClose()
       }
     }
-  }, [issuedCommandsType])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [issuedCommandsType])
 
   return (
     <DropTipWizard

--- a/app/src/organisms/DropTipWizardFlows/TipsAttachedModal.tsx
+++ b/app/src/organisms/DropTipWizardFlows/TipsAttachedModal.tsx
@@ -45,6 +45,8 @@ const TipsAttachedModal = NiceModal.create(
     const modal = useModal()
 
     const { mount, specs } = aPipetteWithTip
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const { showDTWiz, disableDTWiz, enableDTWiz } = useDropTipWizardFlows()
     const { homePipettes, isHoming } = useHomePipettes({
       ...homePipetteProps,

--- a/app/src/organisms/DropTipWizardFlows/__tests__/DropTipWizardFlows.test.ts
+++ b/app/src/organisms/DropTipWizardFlows/__tests__/DropTipWizardFlows.test.ts
@@ -8,6 +8,8 @@ vi.mock('../hooks')
 
 describe('useDropTipWizardFlows', () => {
   it('should toggle showDTWiz state', () => {
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const { result } = renderHook(() => useDropTipWizardFlows())
 
     expect(result.current.showDTWiz).toBe(false)

--- a/app/src/organisms/DropTipWizardFlows/hooks/__tests__/useDropTipRouting.test.tsx
+++ b/app/src/organisms/DropTipWizardFlows/hooks/__tests__/useDropTipRouting.test.tsx
@@ -7,6 +7,8 @@ import { getInitialRouteAndStep, useDropTipRouting } from '../useDropTipRouting'
 
 describe('useDropTipRouting', () => {
   it('should initialize with the correct default values', () => {
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const { result } = renderHook(() => useDropTipRouting())
 
     expect(result.current.currentRoute).toBe(DT_ROUTES.BEFORE_BEGINNING)
@@ -15,6 +17,8 @@ describe('useDropTipRouting', () => {
   })
 
   it('should move to the next step when proceed is called', async () => {
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const { result } = renderHook(() => useDropTipRouting())
 
     await act(async () => {
@@ -31,6 +35,8 @@ describe('useDropTipRouting', () => {
   })
 
   it('should move to the previous step when goBack is called', async () => {
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const { result } = renderHook(() => useDropTipRouting())
 
     await act(async () => {
@@ -51,6 +57,8 @@ describe('useDropTipRouting', () => {
   })
 
   it('should reset to the first step of the BEFORE_BEGINNING route when proceeding from the last step', async () => {
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const { result } = renderHook(() => useDropTipRouting())
 
     await act(async () => {
@@ -65,6 +73,8 @@ describe('useDropTipRouting', () => {
   })
 
   it('should reset to the first step of the BEFORE_BEGINNING route when going back from the first step', async () => {
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const { result } = renderHook(() => useDropTipRouting())
 
     await act(async () => {
@@ -76,6 +86,8 @@ describe('useDropTipRouting', () => {
   })
 
   it('should proceed to the specified route when proceedToRouteAndStep is called', async () => {
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     const { result } = renderHook(() => useDropTipRouting())
 
     await act(async () => {

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
@@ -223,7 +223,10 @@ export function useDropTipCommands({
 
   useEffect(() => {
     processJogQueue()
-  }, [jogQueue.length, isJogging])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [jogQueue.length, isJogging])
 
   const handleJog = (axis: Axis, dir: Sign, step: StepSize): void => {
     setJogQueue(prevQueue => {

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
@@ -221,12 +221,14 @@ export function useDropTipCommands({
     }
   }
 
-  useEffect(() => {
-    processJogQueue()
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [jogQueue.length, isJogging])
+  useEffect(
+    () => {
+      processJogQueue()
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [jogQueue.length, isJogging]
+  )
 
   const handleJog = (axis: Axis, dir: Sign, step: StepSize): void => {
     setJogQueue(prevQueue => {

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipMaintenanceRun.tsx
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipMaintenanceRun.tsx
@@ -115,7 +115,10 @@ function useCreateDropTipMaintenanceRun({
         'Could not create maintenance run due to missing pipette data.'
       )
     }
-  }, [mount, instrumentModelName])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [mount, instrumentModelName])
 }
 
 interface UseMonitorMaintenanceRunForDeletionParams {
@@ -155,5 +158,8 @@ function useMonitorMaintenanceRunForDeletion({
         setClosedOnce(true)
       }
     }
-  }, [isMaintenanceRunType, createdMaintenanceRunId, activeMaintenanceRunId])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isMaintenanceRunType, createdMaintenanceRunId, activeMaintenanceRunId])
 }

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipMaintenanceRun.tsx
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipMaintenanceRun.tsx
@@ -99,26 +99,28 @@ function useCreateDropTipMaintenanceRun({
       },
     })
 
-  useEffect(() => {
-    if (
-      issuedCommandsType === 'setup' &&
-      mount != null &&
-      instrumentModelName != null
-    ) {
-      createTargetedMaintenanceRun({}).catch((e: Error) => {
-        setErrorDetails({
-          message: `Error creating maintenance run: ${e.message}`,
+  useEffect(
+    () => {
+      if (
+        issuedCommandsType === 'setup' &&
+        mount != null &&
+        instrumentModelName != null
+      ) {
+        createTargetedMaintenanceRun({}).catch((e: Error) => {
+          setErrorDetails({
+            message: `Error creating maintenance run: ${e.message}`,
+          })
         })
-      })
-    } else {
-      console.warn(
-        'Could not create maintenance run due to missing pipette data.'
-      )
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [mount, instrumentModelName])
+      } else {
+        console.warn(
+          'Could not create maintenance run due to missing pipette data.'
+        )
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [mount, instrumentModelName]
+  )
 }
 
 interface UseMonitorMaintenanceRunForDeletionParams {
@@ -142,24 +144,26 @@ function useMonitorMaintenanceRunForDeletion({
   ] = useState<boolean>(false)
   const [closedOnce, setClosedOnce] = useState<boolean>(false)
 
-  useEffect(() => {
-    if (isMaintenanceRunType && !closedOnce) {
-      if (
-        createdMaintenanceRunId !== null &&
-        activeMaintenanceRunId === createdMaintenanceRunId
-      ) {
-        setMonitorMaintenanceRunForDeletion(true)
+  useEffect(
+    () => {
+      if (isMaintenanceRunType && !closedOnce) {
+        if (
+          createdMaintenanceRunId !== null &&
+          activeMaintenanceRunId === createdMaintenanceRunId
+        ) {
+          setMonitorMaintenanceRunForDeletion(true)
+        }
+        if (
+          activeMaintenanceRunId !== createdMaintenanceRunId &&
+          monitorMaintenanceRunForDeletion
+        ) {
+          closeFlow()
+          setClosedOnce(true)
+        }
       }
-      if (
-        activeMaintenanceRunId !== createdMaintenanceRunId &&
-        monitorMaintenanceRunForDeletion
-      ) {
-        closeFlow()
-        setClosedOnce(true)
-      }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isMaintenanceRunType, createdMaintenanceRunId, activeMaintenanceRunId])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isMaintenanceRunType, createdMaintenanceRunId, activeMaintenanceRunId]
+  )
 }

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipRouting.tsx
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipRouting.tsx
@@ -207,14 +207,16 @@ export function useReportMap(
 ): void {
   const { currentStep, currentRoute } = map
 
-  useEffect(() => {
-    if (fixitUtils != null) {
-      fixitUtils.reportMap({ route: currentRoute, step: currentStep })
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [currentStep, currentRoute])
+  useEffect(
+    () => {
+      if (fixitUtils != null) {
+        fixitUtils.reportMap({ route: currentRoute, step: currentStep })
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [currentStep, currentRoute]
+  )
 }
 
 // If present, return fixit route overrides for setting the initial Drop Tip Wizard route.

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipRouting.tsx
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipRouting.tsx
@@ -49,6 +49,8 @@ export function useDropTipRouting(
 ): UseDropTipRoutingResult {
   const [initialRoute, initialStep] = useMemo(
     () => getInitialRouteAndStep(fixitUtils),
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
 
@@ -209,7 +211,10 @@ export function useReportMap(
     if (fixitUtils != null) {
       fixitUtils.reportMap({ route: currentRoute, step: currentStep })
     }
-  }, [currentStep, currentRoute])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [currentStep, currentRoute])
 }
 
 // If present, return fixit route overrides for setting the initial Drop Tip Wizard route.

--- a/app/src/organisms/DropTipWizardFlows/steps/ChooseLocation.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/ChooseLocation.tsx
@@ -51,14 +51,16 @@ export function ChooseLocation({
     useState<DropTipBlowoutLocationDetails | null>(null)
 
   // On initial render with values, synchronously set the first option as the selected option.
-  useLayoutEffect(() => {
-    if (dropTipCommandLocations.length > 0) {
-      setSelectedLocation(dropTipCommandLocations[0])
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [dropTipCommandLocations.length])
+  useLayoutEffect(
+    () => {
+      if (dropTipCommandLocations.length > 0) {
+        setSelectedLocation(dropTipCommandLocations[0])
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dropTipCommandLocations.length]
+  )
 
   const buildTitleCopy = (): string => {
     if (currentRoute === DT_ROUTES.BLOWOUT) {

--- a/app/src/organisms/DropTipWizardFlows/steps/ChooseLocation.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/ChooseLocation.tsx
@@ -55,7 +55,10 @@ export function ChooseLocation({
     if (dropTipCommandLocations.length > 0) {
       setSelectedLocation(dropTipCommandLocations[0])
     }
-  }, [dropTipCommandLocations.length])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [dropTipCommandLocations.length])
 
   const buildTitleCopy = (): string => {
     if (currentRoute === DT_ROUTES.BLOWOUT) {

--- a/app/src/organisms/DropTipWizardFlows/steps/ConfirmPosition.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/ConfirmPosition.tsx
@@ -42,18 +42,20 @@ export function useConfirmPosition(
     setIsRobotPipetteMoving(!isRobotPipetteMoving)
   }
 
-  useEffect(() => {
-    if (
-      isRobotPipetteMoving &&
-      currentStep !== CONFIRM_POSITION &&
-      currentStep !== CHOOSE_LOCATION_OPTION
-    ) {
-      toggleIsRobotPipetteMoving()
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [currentStep, isRobotPipetteMoving])
+  useEffect(
+    () => {
+      if (
+        isRobotPipetteMoving &&
+        currentStep !== CONFIRM_POSITION &&
+        currentStep !== CHOOSE_LOCATION_OPTION
+      ) {
+        toggleIsRobotPipetteMoving()
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [currentStep, isRobotPipetteMoving]
+  )
 
   return {
     toggleIsRobotPipetteMoving,

--- a/app/src/organisms/DropTipWizardFlows/steps/ConfirmPosition.tsx
+++ b/app/src/organisms/DropTipWizardFlows/steps/ConfirmPosition.tsx
@@ -50,7 +50,10 @@ export function useConfirmPosition(
     ) {
       toggleIsRobotPipetteMoving()
     }
-  }, [currentStep, isRobotPipetteMoving])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [currentStep, isRobotPipetteMoving])
 
   return {
     toggleIsRobotPipetteMoving,

--- a/app/src/organisms/EmergencyStop/EstopTakeover.tsx
+++ b/app/src/organisms/EmergencyStop/EstopTakeover.tsx
@@ -34,17 +34,19 @@ export function EstopTakeover({ robotName }: EstopTakeoverProps): JSX.Element {
       ? ESTOP_CURRENTLY_ENGAGED_REFETCH_INTERVAL_MS
       : ESTOP_CURRENTLY_DISENGAGED_REFETCH_INTERVAL_MS,
   })
-  useEffect(() => {
-    if (estopStatus) {
-      setEstopState(estopStatus.data.status)
-      setShowEmergencyStopModal(
-        estopStatus.data.status !== DISENGAGED || isWaitingForResumeOperation
-      )
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [estopStatus])
+  useEffect(
+    () => {
+      if (estopStatus) {
+        setEstopState(estopStatus.data.status)
+        setShowEmergencyStopModal(
+          estopStatus.data.status !== DISENGAGED || isWaitingForResumeOperation
+        )
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [estopStatus]
+  )
 
   const isUnboxingFlowOngoing = useIsUnboxingFlowOngoing()
   const closeModal = (): void => {

--- a/app/src/organisms/EmergencyStop/EstopTakeover.tsx
+++ b/app/src/organisms/EmergencyStop/EstopTakeover.tsx
@@ -41,7 +41,10 @@ export function EstopTakeover({ robotName }: EstopTakeoverProps): JSX.Element {
         estopStatus.data.status !== DISENGAGED || isWaitingForResumeOperation
       )
     }
-  }, [estopStatus])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [estopStatus])
 
   const isUnboxingFlowOngoing = useIsUnboxingFlowOngoing()
   const closeModal = (): void => {

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryInProgress.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryInProgress.tsx
@@ -179,60 +179,62 @@ export function useReleaseLabware({
     }
   }
 
-  useEffect(() => {
-    let intervalId: NodeJS.Timeout | null = null
-    switch (recoveryMap.route) {
-      case RECOVERY_MAP.ROBOT_RELEASING_LABWARE.ROUTE:
-      case RECOVERY_MAP.STACKER_RELEASING_LABWARE_LATCH.ROUTE:
-        intervalId = setInterval(() => {
-          setCountdown(prevCountdown => {
-            const updatedCountdown = prevCountdown - 1
+  useEffect(
+    () => {
+      let intervalId: NodeJS.Timeout | null = null
+      switch (recoveryMap.route) {
+        case RECOVERY_MAP.ROBOT_RELEASING_LABWARE.ROUTE:
+        case RECOVERY_MAP.STACKER_RELEASING_LABWARE_LATCH.ROUTE:
+          intervalId = setInterval(() => {
+            setCountdown(prevCountdown => {
+              const updatedCountdown = prevCountdown - 1
 
-            if (updatedCountdown === 0) {
-              if (intervalId != null) {
-                clearInterval(intervalId)
-              }
-              if (
-                recoveryMap.route ===
-                RECOVERY_MAP.STACKER_RELEASING_LABWARE_LATCH.ROUTE
-              ) {
-                void releaseLabwareLatch().then(() => {
-                  return handleMotionRouting(false).then(() => {
-                    proceedToValidNextStep()
-                  })
-                })
-              } else {
-                void releaseGripperJaws().then(() => {
-                  if (isDoorOpen) {
+              if (updatedCountdown === 0) {
+                if (intervalId != null) {
+                  clearInterval(intervalId)
+                }
+                if (
+                  recoveryMap.route ===
+                  RECOVERY_MAP.STACKER_RELEASING_LABWARE_LATCH.ROUTE
+                ) {
+                  void releaseLabwareLatch().then(() => {
                     return handleMotionRouting(false).then(() => {
-                      proceedToDoorStep()
-                    })
-                  }
-
-                  return handleMotionRouting(true)
-                    .then(() => homeExceptPlungers())
-                    .then(() => handleMotionRouting(false))
-                    .then(() => {
                       proceedToValidNextStep()
                     })
-                })
-              }
-            }
-            return updatedCountdown
-          })
-        }, 1000)
-        break
-    }
+                  })
+                } else {
+                  void releaseGripperJaws().then(() => {
+                    if (isDoorOpen) {
+                      return handleMotionRouting(false).then(() => {
+                        proceedToDoorStep()
+                      })
+                    }
 
-    return () => {
-      if (intervalId != null) {
-        clearInterval(intervalId)
+                    return handleMotionRouting(true)
+                      .then(() => homeExceptPlungers())
+                      .then(() => handleMotionRouting(false))
+                      .then(() => {
+                        proceedToValidNextStep()
+                      })
+                  })
+                }
+              }
+              return updatedCountdown
+            })
+          }, 1000)
+          break
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [recoveryMap.route])
+
+      return () => {
+        if (intervalId != null) {
+          clearInterval(intervalId)
+        }
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [recoveryMap.route]
+  )
 
   return countdown
 }

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryInProgress.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryInProgress.tsx
@@ -229,7 +229,10 @@ export function useReleaseLabware({
         clearInterval(intervalId)
       }
     }
-  }, [recoveryMap.route])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [recoveryMap.route])
 
   return countdown
 }

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/CancelRun.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/CancelRun.tsx
@@ -139,7 +139,10 @@ export function useOnCancelRun({
         }
       }
     }
-  }, [hasUserClicked, isLoadingTipStatus, areTipsAttached])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [hasUserClicked, isLoadingTipStatus, areTipsAttached])
 
   const handleCancelRunClick = (): void => {
     setHasUserClicked(true)

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/CancelRun.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/CancelRun.tsx
@@ -127,22 +127,24 @@ export function useOnCancelRun({
 
   const showBtnLoadingState = hasUserClicked && isLoadingTipStatus
 
-  useEffect(() => {
-    if (hasUserClicked) {
-      if (!isLoadingTipStatus) {
-        if (areTipsAttached) {
-          void proceedToRouteAndStep(DROP_TIP_FLOWS.ROUTE)
-        } else {
-          void handleMotionRouting(true, ROBOT_CANCELING.ROUTE).then(() => {
-            cancelRun()
-          })
+  useEffect(
+    () => {
+      if (hasUserClicked) {
+        if (!isLoadingTipStatus) {
+          if (areTipsAttached) {
+            void proceedToRouteAndStep(DROP_TIP_FLOWS.ROUTE)
+          } else {
+            void handleMotionRouting(true, ROBOT_CANCELING.ROUTE).then(() => {
+              cancelRun()
+            })
+          }
         }
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [hasUserClicked, isLoadingTipStatus, areTipsAttached])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [hasUserClicked, isLoadingTipStatus, areTipsAttached]
+  )
 
   const handleCancelRunClick = (): void => {
     setHasUserClicked(true)

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
@@ -67,12 +67,14 @@ export function IgnoreErrorStepHome({
 
   // Reset client choice to ignore all errors whenever navigating back to this view. This prevents unexpected
   // behavior after pressing "go back" and ending up on this screen.
-  useEffect(() => {
-    void ignoreErrorKindThisRun(false)
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      void ignoreErrorKindThisRun(false)
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   // In order to keep routing linear, all extended "skip" flows should be kept as separate recovery options with
   // go back functionality that routes to this view. Those "skip" views encapsulate the generic "skip" view.

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/IgnoreErrorSkipStep.tsx
@@ -69,7 +69,10 @@ export function IgnoreErrorStepHome({
   // behavior after pressing "go back" and ending up on this screen.
   useEffect(() => {
     void ignoreErrorKindThisRun(false)
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   // In order to keep routing linear, all extended "skip" flows should be kept as separate recovery options with
   // go back functionality that routes to this view. Those "skip" views encapsulate the generic "skip" view.

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
@@ -180,12 +180,14 @@ const RECOVERY_OPTION_CONTAINER_STYLE = css`
 export function useCurrentTipStatus(
   determineTipStatus: () => Promise<PipetteWithTip[]>
 ): void {
-  useEffect(() => {
-    void determineTipStatus()
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      void determineTipStatus()
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 }
 
 export function getRecoveryOptions(

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/SelectRecoveryOption.tsx
@@ -182,7 +182,10 @@ export function useCurrentTipStatus(
 ): void {
   useEffect(() => {
     void determineTipStatus()
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 }
 
 export function getRecoveryOptions(

--- a/app/src/organisms/ErrorRecoveryFlows/RecoverySplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoverySplash.tsx
@@ -108,17 +108,19 @@ export function RecoverySplash(props: RecoverySplashProps): JSX.Element | null {
   // Resume recovery when the run when the door is closed.
   // The CTA/flow for handling a door open event within the ER wizard is different, and because this splash always renders
   // behind the wizard, we want to ensure we only implicitly resume recovery when only viewing the splash from this app.
-  useEffect(() => {
-    if (
-      runStatus === RUN_STATUS_AWAITING_RECOVERY_PAUSED &&
-      resumePausedRecovery
-    ) {
-      recoveryActionMutationUtils.resumeRecovery()
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [runStatus, resumePausedRecovery])
+  useEffect(
+    () => {
+      if (
+        runStatus === RUN_STATUS_AWAITING_RECOVERY_PAUSED &&
+        resumePausedRecovery
+      ) {
+        recoveryActionMutationUtils.resumeRecovery()
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [runStatus, resumePausedRecovery]
+  )
   const buildDoorOpenAlert = (): void => {
     makeToast(t('close_door_to_resume') as string, WARNING_TOAST)
   }

--- a/app/src/organisms/ErrorRecoveryFlows/RecoverySplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoverySplash.tsx
@@ -115,7 +115,10 @@ export function RecoverySplash(props: RecoverySplashProps): JSX.Element | null {
     ) {
       recoveryActionMutationUtils.resumeRecovery()
     }
-  }, [runStatus, resumePausedRecovery])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [runStatus, resumePausedRecovery])
   const buildDoorOpenAlert = (): void => {
     makeToast(t('close_door_to_resume') as string, WARNING_TOAST)
   }

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useCurrentlyRecoveringFrom.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useCurrentlyRecoveringFrom.ts
@@ -26,16 +26,18 @@ export function useCurrentlyRecoveringFrom(
   const isRunInRecoveryMode = isRecoveryStatus(runStatus)
 
   // Prevent stale data on subsequent recoveries by clearing the query cache at the start of each recovery.
-  useEffect(() => {
-    if (isRunInRecoveryMode) {
-      void queryClient.invalidateQueries([host, 'runs', runId])
-    } else {
-      setIsReadyToShow(false)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isRunInRecoveryMode, host, runId])
+  useEffect(
+    () => {
+      if (isRunInRecoveryMode) {
+        void queryClient.invalidateQueries([host, 'runs', runId])
+      } else {
+        setIsReadyToShow(false)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isRunInRecoveryMode, host, runId]
+  )
 
   const { data: allCommandsQueryData, isFetching: isAllCommandsFetching } =
     useNotifyAllCommandsQuery(

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useCurrentlyRecoveringFrom.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useCurrentlyRecoveringFrom.ts
@@ -32,7 +32,10 @@ export function useCurrentlyRecoveringFrom(
     } else {
       setIsReadyToShow(false)
     }
-  }, [isRunInRecoveryMode, host, runId])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isRunInRecoveryMode, host, runId])
 
   const { data: allCommandsQueryData, isFetching: isAllCommandsFetching } =
     useNotifyAllCommandsQuery(

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useDeckMapUtils.ts
@@ -89,6 +89,8 @@ export function useDeckMapUtils({
         runRecord,
         currentModulesInfo,
       }),
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [runId, protocolAnalysis, runRecord, deckDef, failedLabwareUtils]
   )
 
@@ -111,6 +113,8 @@ export function useDeckMapUtils({
         currentLabwareInfo: remainingLabware,
         recoveryMap,
       }),
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [failedLabwareUtils, currentLabwareInfo]
   )
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -300,19 +300,21 @@ function useTipSelectionUtils(
     relevantPickUpTipCmd.commandType === 'pickUpTip'
       ? relevantPickUpTipCmd.params.wellName
       : null
-  useEffect(() => {
-    if (
-      relevantPickUpTipCmd != null &&
-      relevantPickUpTipCmd.commandType === 'pickUpTip'
-    ) {
-      setSelectedLocs({
-        [relevantPickUpTipCmd.params.wellName]: null,
-      })
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [initialWellName])
+  useEffect(
+    () => {
+      if (
+        relevantPickUpTipCmd != null &&
+        relevantPickUpTipCmd.commandType === 'pickUpTip'
+      ) {
+        setSelectedLocs({
+          [relevantPickUpTipCmd.params.wellName]: null,
+        })
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [initialWellName]
+  )
 
   const deselectTips = (locations: string[]): void => {
     setSelectedLocs(prevLocs =>

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useFailedLabwareUtils.ts
@@ -309,7 +309,10 @@ function useTipSelectionUtils(
         [relevantPickUpTipCmd.params.wellName]: null,
       })
     }
-  }, [initialWellName])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [initialWellName])
 
   const deselectTips = (locations: string[]): void => {
     setSelectedLocs(prevLocs =>

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -291,19 +291,21 @@ export function useRecoveryCommands({
     }
   }
 
-  const retryFailedCommand = useCallback((): Promise<CommandData[]> => {
-    const { commandType, params } = unvalidatedFailedCommand as FailedCommand // Null case is handled before command could be issued.
-    return chainRunRecoveryCommands(
-      [
-        // move back to the location of the command if it is an in-place command
-        buildRetryPrepMove(),
-        { commandType, params }, // retry the command that failed
-      ].filter(c => c != null) as CreateCommand[]
-    ) // the created command is the same command that failed
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [chainRunRecoveryCommands, unvalidatedFailedCommand?.key])
+  const retryFailedCommand = useCallback(
+    (): Promise<CommandData[]> => {
+      const { commandType, params } = unvalidatedFailedCommand as FailedCommand // Null case is handled before command could be issued.
+      return chainRunRecoveryCommands(
+        [
+          // move back to the location of the command if it is an in-place command
+          buildRetryPrepMove(),
+          { commandType, params }, // retry the command that failed
+        ].filter(c => c != null) as CreateCommand[]
+      ) // the created command is the same command that failed
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [chainRunRecoveryCommands, unvalidatedFailedCommand?.key]
+  )
 
   // Homes the Z-axis of all attached pipettes.
   const homePipetteZAxes = useCallback((): Promise<CommandData[]> => {
@@ -311,27 +313,29 @@ export function useRecoveryCommands({
   }, [chainRunRecoveryCommands])
 
   // Pick up the user-selected tips
-  const pickUpTips = useCallback((): Promise<CommandData[]> => {
-    const { selectedTipLocations, relevantPickUpTipLabware } =
-      failedLabwareUtils
+  const pickUpTips = useCallback(
+    (): Promise<CommandData[]> => {
+      const { selectedTipLocations, relevantPickUpTipLabware } =
+        failedLabwareUtils
 
-    const pickUpTipCmd = buildPickUpTips(
-      selectedTipLocations,
-      unvalidatedFailedCommand,
-      relevantPickUpTipLabware
-    )
-
-    if (pickUpTipCmd == null) {
-      return reportAndRouteFailedCmd(
-        new Error('Invalid use of pickUpTips command')
+      const pickUpTipCmd = buildPickUpTips(
+        selectedTipLocations,
+        unvalidatedFailedCommand,
+        relevantPickUpTipLabware
       )
-    } else {
-      return chainRunRecoveryCommands([pickUpTipCmd])
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [chainRunRecoveryCommands, unvalidatedFailedCommand, failedLabwareUtils])
+
+      if (pickUpTipCmd == null) {
+        return reportAndRouteFailedCmd(
+          new Error('Invalid use of pickUpTips command')
+        )
+      } else {
+        return chainRunRecoveryCommands([pickUpTipCmd])
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [chainRunRecoveryCommands, unvalidatedFailedCommand, failedLabwareUtils]
+  )
 
   const ignoreErrorKindThisRun = (ignoreErrors: boolean): Promise<void> => {
     setIgnoreErrors(ignoreErrors)
@@ -340,74 +344,80 @@ export function useRecoveryCommands({
 
   // Only send the finalized error policy to the server during a terminal recovery command that does not terminate the run.
   // If the request to update the policy fails, route to the error modal.
-  const handleIgnoringErrorKind = useCallback((): Promise<void> => {
-    if (ignoreErrors) {
-      if (unvalidatedFailedCommand?.error != null) {
-        const ifMatch: IfMatchType = isAssumeFalsePositiveResumeKind(
-          failedCommand
-        )
-          ? 'assumeFalsePositiveAndContinue'
-          : 'ignoreAndContinue'
-
-        const ignorePolicyRules = buildIgnorePolicyRules(
-          unvalidatedFailedCommand.commandType,
-          unvalidatedFailedCommand.error.errorType,
-          ifMatch
-        )
-
-        return updateErrorRecoveryPolicy(ignorePolicyRules, 'append')
-          .then(() => Promise.resolve())
-          .catch((e: Error) =>
-            reportAndRouteFailedCmd(
-              new Error(`Failed to update recovery policy: ${e.message}`)
-            )
+  const handleIgnoringErrorKind = useCallback(
+    (): Promise<void> => {
+      if (ignoreErrors) {
+        if (unvalidatedFailedCommand?.error != null) {
+          const ifMatch: IfMatchType = isAssumeFalsePositiveResumeKind(
+            failedCommand
           )
+            ? 'assumeFalsePositiveAndContinue'
+            : 'ignoreAndContinue'
+
+          const ignorePolicyRules = buildIgnorePolicyRules(
+            unvalidatedFailedCommand.commandType,
+            unvalidatedFailedCommand.error.errorType,
+            ifMatch
+          )
+
+          return updateErrorRecoveryPolicy(ignorePolicyRules, 'append')
+            .then(() => Promise.resolve())
+            .catch((e: Error) =>
+              reportAndRouteFailedCmd(
+                new Error(`Failed to update recovery policy: ${e.message}`)
+              )
+            )
+        } else {
+          return reportAndRouteFailedCmd(
+            new Error('Could not execute command. No failed command.')
+          )
+        }
       } else {
-        return reportAndRouteFailedCmd(
-          new Error('Could not execute command. No failed command.')
-        )
+        return Promise.resolve()
       }
-    } else {
-      return Promise.resolve()
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [
-    unvalidatedFailedCommand?.error?.errorType,
-    unvalidatedFailedCommand?.commandType,
-    ignoreErrors,
-  ])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      unvalidatedFailedCommand?.error?.errorType,
+      unvalidatedFailedCommand?.commandType,
+      ignoreErrors,
+    ]
+  )
 
-  const resumeRun = useCallback((): void => {
-    void handleIgnoringErrorKind()
-      .then(() => resumeRunFromRecovery(runId))
-      .then(() => {
-        analytics.reportActionSelectedResult(
-          selectedRecoveryOption,
-          'succeeded'
-        )
-        makeSuccessToast()
-      })
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [
-    runId,
-    ignoreErrors,
-    resumeRunFromRecovery,
-    handleIgnoringErrorKind,
-    selectedRecoveryOption,
-    makeSuccessToast,
-  ])
+  const resumeRun = useCallback(
+    (): void => {
+      void handleIgnoringErrorKind()
+        .then(() => resumeRunFromRecovery(runId))
+        .then(() => {
+          analytics.reportActionSelectedResult(
+            selectedRecoveryOption,
+            'succeeded'
+          )
+          makeSuccessToast()
+        })
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      runId,
+      ignoreErrors,
+      resumeRunFromRecovery,
+      handleIgnoringErrorKind,
+      selectedRecoveryOption,
+      makeSuccessToast,
+    ]
+  )
 
-  const cancelRun = useCallback((): void => {
-    analytics.reportActionSelectedResult(selectedRecoveryOption, 'succeeded')
-    stopRun(runId)
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [runId])
+  const cancelRun = useCallback(
+    (): void => {
+      analytics.reportActionSelectedResult(selectedRecoveryOption, 'succeeded')
+      stopRun(runId)
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [runId]
+  )
 
   const handleResumeAction = (): Promise<RunAction> => {
     if (isAssumeFalsePositiveResumeKind(failedCommand)) {
@@ -417,58 +427,64 @@ export function useRecoveryCommands({
     }
   }
 
-  const skipFailedCommand = useCallback((): void => {
-    void handleIgnoringErrorKind().then(() =>
-      handleResumeAction().then(() => {
-        analytics.reportActionSelectedResult(
-          selectedRecoveryOption,
-          'succeeded'
-        )
-        makeSuccessToast()
-      })
-    )
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [
-    runId,
-    resumeRunFromRecovery,
-    handleIgnoringErrorKind,
-    selectedRecoveryOption,
-    makeSuccessToast,
-  ])
+  const skipFailedCommand = useCallback(
+    (): void => {
+      void handleIgnoringErrorKind().then(() =>
+        handleResumeAction().then(() => {
+          analytics.reportActionSelectedResult(
+            selectedRecoveryOption,
+            'succeeded'
+          )
+          makeSuccessToast()
+        })
+      )
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      runId,
+      resumeRunFromRecovery,
+      handleIgnoringErrorKind,
+      selectedRecoveryOption,
+      makeSuccessToast,
+    ]
+  )
 
   const releaseGripperJaws = useCallback((): Promise<CommandData[]> => {
     return chainRunRecoveryCommands([RELEASE_GRIPPER_JAW])
   }, [chainRunRecoveryCommands])
 
-  const releaseLabwareLatch = useCallback((): Promise<CommandData[]> => {
-    const buildOpenLatchCommand = buildOpenLatch(unvalidatedFailedCommand)
-    if (buildOpenLatchCommand == null) {
-      return reportAndRouteFailedCmd(
-        new Error('Invalid use of open latch command')
-      )
-    } else {
-      return chainRunRecoveryCommands([buildOpenLatchCommand])
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [chainRunRecoveryCommands, unvalidatedFailedCommand])
+  const releaseLabwareLatch = useCallback(
+    (): Promise<CommandData[]> => {
+      const buildOpenLatchCommand = buildOpenLatch(unvalidatedFailedCommand)
+      if (buildOpenLatchCommand == null) {
+        return reportAndRouteFailedCmd(
+          new Error('Invalid use of open latch command')
+        )
+      } else {
+        return chainRunRecoveryCommands([buildOpenLatchCommand])
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [chainRunRecoveryCommands, unvalidatedFailedCommand]
+  )
 
-  const closeLabwareLatch = useCallback((): Promise<CommandData[]> => {
-    const buildCloseLatchCommand = buildCloseLatch(unvalidatedFailedCommand)
-    if (buildCloseLatchCommand == null) {
-      return reportAndRouteFailedCmd(
-        new Error('Invalid use of close latch command')
-      )
-    } else {
-      return chainRunRecoveryCommands([buildCloseLatchCommand])
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [chainRunRecoveryCommands, unvalidatedFailedCommand])
+  const closeLabwareLatch = useCallback(
+    (): Promise<CommandData[]> => {
+      const buildCloseLatchCommand = buildCloseLatch(unvalidatedFailedCommand)
+      if (buildCloseLatchCommand == null) {
+        return reportAndRouteFailedCmd(
+          new Error('Invalid use of close latch command')
+        )
+      } else {
+        return chainRunRecoveryCommands([buildCloseLatchCommand])
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [chainRunRecoveryCommands, unvalidatedFailedCommand]
+  )
 
   const homeExceptPlungers = useCallback((): Promise<CommandData[]> => {
     return chainRunRecoveryCommands([HOME_EXCEPT_PLUNGERS])
@@ -487,49 +503,57 @@ export function useRecoveryCommands({
     }
   }, [chainRunRecoveryCommands, unvalidatedFailedCommand])
 
-  const manualRetrieve = useCallback((): Promise<CommandData[]> => {
-    const manualRetrieveCommand = buildManualRetrieve(unvalidatedFailedCommand)
-    if (manualRetrieveCommand == null) {
-      return reportAndRouteFailedCmd(
-        new Error('Invalid use of manual retrieve command')
+  const manualRetrieve = useCallback(
+    (): Promise<CommandData[]> => {
+      const manualRetrieveCommand = buildManualRetrieve(
+        unvalidatedFailedCommand
       )
-    } else {
-      return chainRunRecoveryCommands([manualRetrieveCommand])
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [chainRunRecoveryCommands, unvalidatedFailedCommand])
+      if (manualRetrieveCommand == null) {
+        return reportAndRouteFailedCmd(
+          new Error('Invalid use of manual retrieve command')
+        )
+      } else {
+        return chainRunRecoveryCommands([manualRetrieveCommand])
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [chainRunRecoveryCommands, unvalidatedFailedCommand]
+  )
 
-  const manualStore = useCallback((): Promise<CommandData[]> => {
-    const manualStoreCommand = buildManualStore(unvalidatedFailedCommand)
-    if (manualStoreCommand == null) {
-      return reportAndRouteFailedCmd(
-        new Error('Invalid use of manual store command')
-      )
-    } else {
-      return chainRunRecoveryCommands([manualStoreCommand])
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [chainRunRecoveryCommands, unvalidatedFailedCommand])
+  const manualStore = useCallback(
+    (): Promise<CommandData[]> => {
+      const manualStoreCommand = buildManualStore(unvalidatedFailedCommand)
+      if (manualStoreCommand == null) {
+        return reportAndRouteFailedCmd(
+          new Error('Invalid use of manual store command')
+        )
+      } else {
+        return chainRunRecoveryCommands([manualStoreCommand])
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [chainRunRecoveryCommands, unvalidatedFailedCommand]
+  )
 
-  const moveLabwareWithoutPause = useCallback((): Promise<CommandData[]> => {
-    const moveLabwareCmd = buildMoveLabwareWithoutPause(
-      unvalidatedFailedCommand
-    )
-    if (moveLabwareCmd == null) {
-      return reportAndRouteFailedCmd(
-        new Error('Invalid use of MoveLabware command')
+  const moveLabwareWithoutPause = useCallback(
+    (): Promise<CommandData[]> => {
+      const moveLabwareCmd = buildMoveLabwareWithoutPause(
+        unvalidatedFailedCommand
       )
-    } else {
-      return chainRunRecoveryCommands([moveLabwareCmd])
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [chainRunRecoveryCommands, unvalidatedFailedCommand])
+      if (moveLabwareCmd == null) {
+        return reportAndRouteFailedCmd(
+          new Error('Invalid use of MoveLabware command')
+        )
+      } else {
+        return chainRunRecoveryCommands([moveLabwareCmd])
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [chainRunRecoveryCommands, unvalidatedFailedCommand]
+  )
 
   return {
     resumeRun,

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -147,6 +147,8 @@ export function useRecoveryCommands({
       chainRunCommands(commands, continuePastFailure)
         // the catch never occurs if continuePastCommandFailure is "true"
         .catch((e: Error) => reportAndRouteFailedCmd(e)),
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [analytics, selectedRecoveryOption]
   )
 
@@ -298,7 +300,10 @@ export function useRecoveryCommands({
         { commandType, params }, // retry the command that failed
       ].filter(c => c != null) as CreateCommand[]
     ) // the created command is the same command that failed
-  }, [chainRunRecoveryCommands, unvalidatedFailedCommand?.key])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [chainRunRecoveryCommands, unvalidatedFailedCommand?.key])
 
   // Homes the Z-axis of all attached pipettes.
   const homePipetteZAxes = useCallback((): Promise<CommandData[]> => {
@@ -323,7 +328,10 @@ export function useRecoveryCommands({
     } else {
       return chainRunRecoveryCommands([pickUpTipCmd])
     }
-  }, [chainRunRecoveryCommands, unvalidatedFailedCommand, failedLabwareUtils])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [chainRunRecoveryCommands, unvalidatedFailedCommand, failedLabwareUtils])
 
   const ignoreErrorKindThisRun = (ignoreErrors: boolean): Promise<void> => {
     setIgnoreErrors(ignoreErrors)
@@ -362,7 +370,10 @@ export function useRecoveryCommands({
     } else {
       return Promise.resolve()
     }
-  }, [
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [
     unvalidatedFailedCommand?.error?.errorType,
     unvalidatedFailedCommand?.commandType,
     ignoreErrors,
@@ -378,7 +389,10 @@ export function useRecoveryCommands({
         )
         makeSuccessToast()
       })
-  }, [
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [
     runId,
     ignoreErrors,
     resumeRunFromRecovery,
@@ -390,7 +404,10 @@ export function useRecoveryCommands({
   const cancelRun = useCallback((): void => {
     analytics.reportActionSelectedResult(selectedRecoveryOption, 'succeeded')
     stopRun(runId)
-  }, [runId])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [runId])
 
   const handleResumeAction = (): Promise<RunAction> => {
     if (isAssumeFalsePositiveResumeKind(failedCommand)) {
@@ -410,7 +427,10 @@ export function useRecoveryCommands({
         makeSuccessToast()
       })
     )
-  }, [
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [
     runId,
     resumeRunFromRecovery,
     handleIgnoringErrorKind,
@@ -431,7 +451,10 @@ export function useRecoveryCommands({
     } else {
       return chainRunRecoveryCommands([buildOpenLatchCommand])
     }
-  }, [chainRunRecoveryCommands, unvalidatedFailedCommand])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [chainRunRecoveryCommands, unvalidatedFailedCommand])
 
   const closeLabwareLatch = useCallback((): Promise<CommandData[]> => {
     const buildCloseLatchCommand = buildCloseLatch(unvalidatedFailedCommand)
@@ -442,7 +465,10 @@ export function useRecoveryCommands({
     } else {
       return chainRunRecoveryCommands([buildCloseLatchCommand])
     }
-  }, [chainRunRecoveryCommands, unvalidatedFailedCommand])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [chainRunRecoveryCommands, unvalidatedFailedCommand])
 
   const homeExceptPlungers = useCallback((): Promise<CommandData[]> => {
     return chainRunRecoveryCommands([HOME_EXCEPT_PLUNGERS])
@@ -470,7 +496,10 @@ export function useRecoveryCommands({
     } else {
       return chainRunRecoveryCommands([manualRetrieveCommand])
     }
-  }, [chainRunRecoveryCommands, unvalidatedFailedCommand])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [chainRunRecoveryCommands, unvalidatedFailedCommand])
 
   const manualStore = useCallback((): Promise<CommandData[]> => {
     const manualStoreCommand = buildManualStore(unvalidatedFailedCommand)
@@ -481,7 +510,10 @@ export function useRecoveryCommands({
     } else {
       return chainRunRecoveryCommands([manualStoreCommand])
     }
-  }, [chainRunRecoveryCommands, unvalidatedFailedCommand])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [chainRunRecoveryCommands, unvalidatedFailedCommand])
 
   const moveLabwareWithoutPause = useCallback((): Promise<CommandData[]> => {
     const moveLabwareCmd = buildMoveLabwareWithoutPause(
@@ -494,7 +526,10 @@ export function useRecoveryCommands({
     } else {
       return chainRunRecoveryCommands([moveLabwareCmd])
     }
-  }, [chainRunRecoveryCommands, unvalidatedFailedCommand])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [chainRunRecoveryCommands, unvalidatedFailedCommand])
 
   return {
     resumeRun,

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryTakeover.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryTakeover.ts
@@ -53,7 +53,10 @@ export function useRecoveryTakeover(
     if (isActiveUser && activeId !== thisUserId) {
       setIsActiveUser(false)
     }
-  }, [activeId]) // Not all dependencies added for intended behavior!
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [activeId]) // Not all dependencies added for intended behavior!
 
   // If Error Recovery unrenders and this client is the active user, revoke the client's active user status.
   useEffect(() => {
@@ -62,7 +65,10 @@ export function useRecoveryTakeover(
         clearClientData()
       }
     }
-  }, [isActiveUser])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isActiveUser])
 
   const showTakeover = !(activeId == null || thisUserId === activeId)
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryTakeover.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryTakeover.ts
@@ -49,26 +49,30 @@ export function useRecoveryTakeover(
   const { updateWithIntent, clearClientData } = useUpdateClientDataRecovery()
 
   // Update the client's active user status implicitly if revoked by a different client.
-  useEffect(() => {
-    if (isActiveUser && activeId !== thisUserId) {
-      setIsActiveUser(false)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [activeId]) // Not all dependencies added for intended behavior!
+  useEffect(
+    () => {
+      if (isActiveUser && activeId !== thisUserId) {
+        setIsActiveUser(false)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeId]
+  ) // Not all dependencies added for intended behavior!
 
   // If Error Recovery unrenders and this client is the active user, revoke the client's active user status.
-  useEffect(() => {
-    return () => {
-      if (isActiveUser) {
-        clearClientData()
+  useEffect(
+    () => {
+      return () => {
+        if (isActiveUser) {
+          clearClientData()
+        }
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isActiveUser])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isActiveUser]
+  )
 
   const showTakeover = !(activeId == null || thisUserId === activeId)
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRetainedFailedCommandBySource.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRetainedFailedCommandBySource.ts
@@ -25,28 +25,30 @@ export function useRetainedFailedCommandBySource(
   const [retainedFailedCommand, setRetainedFailedCommand] =
     useState<FailedCommandBySource | null>(null)
 
-  useLayoutEffect(() => {
-    if (failedCommandByRunRecord !== null) {
-      const failedCommandByAnalysis =
-        protocolAnalysis?.commands.find(
-          command => command.key === failedCommandByRunRecord?.key
-        ) ?? null
+  useLayoutEffect(
+    () => {
+      if (failedCommandByRunRecord !== null) {
+        const failedCommandByAnalysis =
+          protocolAnalysis?.commands.find(
+            command => command.key === failedCommandByRunRecord?.key
+          ) ?? null
 
-      if (failedCommandByAnalysis != null) {
-        setRetainedFailedCommand({
-          byRunRecord: failedCommandByRunRecord,
-          byAnalysis: failedCommandByAnalysis,
-        })
+        if (failedCommandByAnalysis != null) {
+          setRetainedFailedCommand({
+            byRunRecord: failedCommandByRunRecord,
+            byAnalysis: failedCommandByAnalysis,
+          })
+        }
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [
-    failedCommandByRunRecord?.key,
-    failedCommandByRunRecord?.error?.errorType,
-    protocolAnalysis?.id,
-  ])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      failedCommandByRunRecord?.key,
+      failedCommandByRunRecord?.error?.errorType,
+      protocolAnalysis?.id,
+    ]
+  )
 
   return retainedFailedCommand
 }

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRetainedFailedCommandBySource.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRetainedFailedCommandBySource.ts
@@ -39,7 +39,10 @@ export function useRetainedFailedCommandBySource(
         })
       }
     }
-  }, [
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [
     failedCommandByRunRecord?.key,
     failedCommandByRunRecord?.error?.errorType,
     protocolAnalysis?.id,

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRouteUpdateActions.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRouteUpdateActions.ts
@@ -103,6 +103,8 @@ export function useRouteUpdateActions(
         resolve()
       })
     },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
 
@@ -131,7 +133,10 @@ export function useRouteUpdateActions(
         resolve()
       }
     })
-  }, [currentRoute, currentStep, isDoorOpen])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [currentRoute, currentStep, isDoorOpen])
 
   const setRobotInMotion = useCallback(
     (inMotion: boolean, robotMovingRoute?: RobotMovingRoute): Promise<void> => {
@@ -162,6 +167,8 @@ export function useRouteUpdateActions(
         resolve()
       })
     },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [currentRoute, currentStep]
   )
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRouteUpdateActions.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRouteUpdateActions.ts
@@ -110,33 +110,35 @@ export function useRouteUpdateActions(
 
   // If the door is permitted on the current step, but the robot is about to move, we need to manually redirect users
   // to the door modal unless the step is specifically a gripper jaw/stacker latch release step.
-  const checkDoorStatus = useCallback((): Promise<void> => {
-    return new Promise((resolve, reject) => {
-      if (
-        isDoorOpen &&
-        !GRIPPER_MOVE_STEPS.includes(currentStep) &&
-        !STACKER_LATCH_STEPS.includes(currentStep)
-      ) {
-        stashedMapRef.current = { route: currentRoute, step: currentStep }
+  const checkDoorStatus = useCallback(
+    (): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        if (
+          isDoorOpen &&
+          !GRIPPER_MOVE_STEPS.includes(currentStep) &&
+          !STACKER_LATCH_STEPS.includes(currentStep)
+        ) {
+          stashedMapRef.current = { route: currentRoute, step: currentStep }
 
-        setRecoveryMap({
-          route: ROBOT_DOOR_OPEN.ROUTE,
-          step: ROBOT_DOOR_OPEN.STEPS.DOOR_OPEN,
-        })
+          setRecoveryMap({
+            route: ROBOT_DOOR_OPEN.ROUTE,
+            step: ROBOT_DOOR_OPEN.STEPS.DOOR_OPEN,
+          })
 
-        reject(
-          new Error(
-            'Cannot perform a command while the door is open. Routing to door open modal.'
+          reject(
+            new Error(
+              'Cannot perform a command while the door is open. Routing to door open modal.'
+            )
           )
-        )
-      } else {
-        resolve()
-      }
-    })
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [currentRoute, currentStep, isDoorOpen])
+        } else {
+          resolve()
+        }
+      })
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [currentRoute, currentStep, isDoorOpen]
+  )
 
   const setRobotInMotion = useCallback(
     (inMotion: boolean, robotMovingRoute?: RobotMovingRoute): Promise<void> => {

--- a/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryDoorOpenSpecial.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryDoorOpenSpecial.tsx
@@ -113,7 +113,10 @@ export function RecoveryDoorOpenSpecial({
         }
       }
     }
-  }, [doorStatusUtils.isDoorOpen])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [doorStatusUtils.isDoorOpen])
 
   return (
     <RecoverySingleColumnContentWrapper>

--- a/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryDoorOpenSpecial.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/shared/RecoveryDoorOpenSpecial.tsx
@@ -84,39 +84,41 @@ export function RecoveryDoorOpenSpecial({
       .then(() => proceedToRouteAndStep(route, step))
   }
 
-  useEffect(() => {
-    if (!doorStatusUtils.isDoorOpen) {
-      switch (selectedRecoveryOption) {
-        case RECOVERY_MAP.MANUAL_REPLACE_AND_RETRY.ROUTE:
-          handleHomeExceptPlungersAndRoute(
-            RECOVERY_MAP.MANUAL_REPLACE_AND_RETRY.ROUTE,
-            RECOVERY_MAP.MANUAL_REPLACE_AND_RETRY.STEPS.MANUAL_REPLACE
-          )
-          break
-        case RECOVERY_MAP.MANUAL_MOVE_AND_SKIP.ROUTE:
-          handleHomeExceptPlungersAndRoute(
-            RECOVERY_MAP.MANUAL_MOVE_AND_SKIP.ROUTE,
-            RECOVERY_MAP.MANUAL_MOVE_AND_SKIP.STEPS.MANUAL_MOVE
-          )
-          break
-        case RECOVERY_MAP.HOME_AND_RETRY.ROUTE:
-          handleHomeAllAndRoute(
-            RECOVERY_MAP.HOME_AND_RETRY.ROUTE,
-            RECOVERY_MAP.HOME_AND_RETRY.STEPS.CONFIRM_RETRY
-          )
-          break
-        default: {
-          console.error(
-            `Unhandled special-cased door open on route ${selectedRecoveryOption}.`
-          )
-          void proceedToRouteAndStep(RECOVERY_MAP.OPTION_SELECTION.ROUTE)
+  useEffect(
+    () => {
+      if (!doorStatusUtils.isDoorOpen) {
+        switch (selectedRecoveryOption) {
+          case RECOVERY_MAP.MANUAL_REPLACE_AND_RETRY.ROUTE:
+            handleHomeExceptPlungersAndRoute(
+              RECOVERY_MAP.MANUAL_REPLACE_AND_RETRY.ROUTE,
+              RECOVERY_MAP.MANUAL_REPLACE_AND_RETRY.STEPS.MANUAL_REPLACE
+            )
+            break
+          case RECOVERY_MAP.MANUAL_MOVE_AND_SKIP.ROUTE:
+            handleHomeExceptPlungersAndRoute(
+              RECOVERY_MAP.MANUAL_MOVE_AND_SKIP.ROUTE,
+              RECOVERY_MAP.MANUAL_MOVE_AND_SKIP.STEPS.MANUAL_MOVE
+            )
+            break
+          case RECOVERY_MAP.HOME_AND_RETRY.ROUTE:
+            handleHomeAllAndRoute(
+              RECOVERY_MAP.HOME_AND_RETRY.ROUTE,
+              RECOVERY_MAP.HOME_AND_RETRY.STEPS.CONFIRM_RETRY
+            )
+            break
+          default: {
+            console.error(
+              `Unhandled special-cased door open on route ${selectedRecoveryOption}.`
+            )
+            void proceedToRouteAndStep(RECOVERY_MAP.OPTION_SELECTION.ROUTE)
+          }
         }
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [doorStatusUtils.isDoorOpen])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [doorStatusUtils.isDoorOpen]
+  )
 
   return (
     <RecoverySingleColumnContentWrapper>

--- a/app/src/organisms/FirmwareUpdateModal/index.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/index.tsx
@@ -87,49 +87,53 @@ export const FirmwareUpdateModal = (
       (i): i is BadGripper | BadPipette => !i.ok && i.subsystem === subsystem
     ) ?? false
 
-  useEffect(() => {
-    setTimeout(() => {
-      if (!updateNeeded) {
-        setFirmwareText(proceedDescription)
-        setTimeout(() => {
-          proceed()
-        }, 2000)
-      } else {
-        updateSubsystem(subsystem)
-      }
-    }, 2000)
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      setTimeout(() => {
+        if (!updateNeeded) {
+          setFirmwareText(proceedDescription)
+          setTimeout(() => {
+            proceed()
+          }, 2000)
+        } else {
+          updateSubsystem(subsystem)
+        }
+      }, 2000)
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
   const { data: updateData } = useSubsystemUpdateQuery(updateId)
   const status = updateData?.data.updateStatus
 
-  useEffect(() => {
-    if ((status != null || updateNeeded) && firmwareText !== description) {
-      setFirmwareText(description)
-    }
-    if (status === 'done') {
-      refetchInstruments()
-        .then(() => {
-          if (instrumentToUpdate?.ok === true) proceed()
-          else {
-            // if the instrument doesn't appear ok when the update is done, wait 10sec and try again
-            setTimeout(() => {
-              proceed()
-            }, 10000)
-          }
-        })
-        .catch(error => {
-          console.error(error.message)
-          // even if the refetch fails, we should proceed as the next screen will handle the error
-          proceed()
-        })
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [status, proceed, refetchInstruments, instrumentToUpdate, updateNeeded])
+  useEffect(
+    () => {
+      if ((status != null || updateNeeded) && firmwareText !== description) {
+        setFirmwareText(description)
+      }
+      if (status === 'done') {
+        refetchInstruments()
+          .then(() => {
+            if (instrumentToUpdate?.ok === true) proceed()
+            else {
+              // if the instrument doesn't appear ok when the update is done, wait 10sec and try again
+              setTimeout(() => {
+                proceed()
+              }, 10000)
+            }
+          })
+          .catch(error => {
+            console.error(error.message)
+            // even if the refetch fails, we should proceed as the next screen will handle the error
+            proceed()
+          })
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [status, proceed, refetchInstruments, instrumentToUpdate, updateNeeded]
+  )
 
   return (
     <Flex css={MODAL_STYLE}>

--- a/app/src/organisms/FirmwareUpdateModal/index.tsx
+++ b/app/src/organisms/FirmwareUpdateModal/index.tsx
@@ -98,7 +98,10 @@ export const FirmwareUpdateModal = (
         updateSubsystem(subsystem)
       }
     }, 2000)
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
   const { data: updateData } = useSubsystemUpdateQuery(updateId)
   const status = updateData?.data.updateStatus
 
@@ -123,7 +126,10 @@ export const FirmwareUpdateModal = (
           proceed()
         })
     }
-  }, [status, proceed, refetchInstruments, instrumentToUpdate, updateNeeded])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [status, proceed, refetchInstruments, instrumentToUpdate, updateNeeded])
 
   return (
     <Flex css={MODAL_STYLE}>

--- a/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
@@ -81,14 +81,16 @@ export const BeforeBeginning = (
     createdMaintenanceRunId,
   } = props
   const { t } = useTranslation(['gripper_wizard_flows', 'shared', 'branded'])
-  useEffect(() => {
-    if (createdMaintenanceRunId == null) {
-      createMaintenanceRun({})
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      if (createdMaintenanceRunId == null) {
+        createMaintenanceRun({})
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   const commandsOnProceed: CreateCommand[] = [
     { commandType: 'home' as const, params: {} },

--- a/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
@@ -85,7 +85,10 @@ export const BeforeBeginning = (
     if (createdMaintenanceRunId == null) {
       createMaintenanceRun({})
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   const commandsOnProceed: CreateCommand[] = [
     { commandType: 'home' as const, params: {} },

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useCompatibleAnalysis.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useCompatibleAnalysis.ts
@@ -57,51 +57,57 @@ export function useCompatibleAnalysis(
     mostRecentAnalysis?.commands ?? []
   )
 
-  useEffect(() => {
-    if (isFlex && mostRecentAnalysis != null && !hasProcessedAnalysis.current) {
-      hasProcessedAnalysis.current = true
-      const runTimeParameterData =
-        runRecord != null ? getRunTimeParameterDataFromRun(runRecord) : {}
-      if (!isLocSeqAnalysisType) {
-        createProtocolAnalysis(
-          {
-            forceReAnalyze: true,
-            protocolKey: protocolId,
-            ...runTimeParameterData,
-          },
-          {
-            onSuccess: res => {
-              if (res != null) {
-                const data = res.data
-                // The last analysis is the most recent.
-                setCompatibleAnalysisId(data[data.length - 1].id as string)
-              }
+  useEffect(
+    () => {
+      if (
+        isFlex &&
+        mostRecentAnalysis != null &&
+        !hasProcessedAnalysis.current
+      ) {
+        hasProcessedAnalysis.current = true
+        const runTimeParameterData =
+          runRecord != null ? getRunTimeParameterDataFromRun(runRecord) : {}
+        if (!isLocSeqAnalysisType) {
+          createProtocolAnalysis(
+            {
+              forceReAnalyze: true,
+              protocolKey: protocolId,
+              ...runTimeParameterData,
             },
-          }
-        )
-      } else {
-        setCompatibleAnalysis(mostRecentAnalysis)
-      }
+            {
+              onSuccess: res => {
+                if (res != null) {
+                  const data = res.data
+                  // The last analysis is the most recent.
+                  setCompatibleAnalysisId(data[data.length - 1].id as string)
+                }
+              },
+            }
+          )
+        } else {
+          setCompatibleAnalysis(mostRecentAnalysis)
+        }
 
-      trackEvent({
-        name: ANALYTICS_LPC_ANALYSIS_KIND,
-        properties: {
-          runId,
-          kind: isLocSeqAnalysisType ? 'newAnalysis' : 'oldAnalysis',
-        },
-      })
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [
-    mostRecentAnalysis,
-    isLocSeqAnalysisType,
-    protocolId,
-    runId,
-    trackEvent,
-    createProtocolAnalysis,
-  ])
+        trackEvent({
+          name: ANALYTICS_LPC_ANALYSIS_KIND,
+          properties: {
+            runId,
+            kind: isLocSeqAnalysisType ? 'newAnalysis' : 'oldAnalysis',
+          },
+        })
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      mostRecentAnalysis,
+      isLocSeqAnalysisType,
+      protocolId,
+      runId,
+      trackEvent,
+      createProtocolAnalysis,
+    ]
+  )
 
   return compatibleAnalysis
 }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useCompatibleAnalysis.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useCompatibleAnalysis.ts
@@ -91,7 +91,10 @@ export function useCompatibleAnalysis(
         },
       })
     }
-  }, [
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [
     mostRecentAnalysis,
     isLocSeqAnalysisType,
     protocolId,

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useHandleClientAppliedOffsets.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useHandleClientAppliedOffsets.ts
@@ -26,28 +26,30 @@ export function useHandleClientAppliedOffsets(
     }
   )
 
-  useEffect(() => {
-    if (isFlex) {
-      if (isThisRunCurrent) {
-        if (clientDataRunId !== thisRunId && clientDataRunId != null) {
-          clearClientData()
-        }
-        // Offsets applied by another user but not locally - mark as applied locally
-        else if (
-          clientDataUserId != null &&
-          clientDataRunId === thisRunId &&
-          thisRunId != null
-        ) {
-          dispatch(appliedOffsetsToRun(thisRunId))
-        }
-      } else {
-        if (clientDataRunId === thisRunId) {
-          clearClientData()
+  useEffect(
+    () => {
+      if (isFlex) {
+        if (isThisRunCurrent) {
+          if (clientDataRunId !== thisRunId && clientDataRunId != null) {
+            clearClientData()
+          }
+          // Offsets applied by another user but not locally - mark as applied locally
+          else if (
+            clientDataUserId != null &&
+            clientDataRunId === thisRunId &&
+            thisRunId != null
+          ) {
+            dispatch(appliedOffsetsToRun(thisRunId))
+          }
+        } else {
+          if (clientDataRunId === thisRunId) {
+            clearClientData()
+          }
         }
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isThisRunCurrent, clientDataRunId, clientDataUserId, thisRunId, isFlex])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isThisRunCurrent, clientDataRunId, clientDataUserId, thisRunId, isFlex]
+  )
 }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useHandleClientAppliedOffsets.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useHandleClientAppliedOffsets.ts
@@ -46,5 +46,8 @@ export function useHandleClientAppliedOffsets(
         }
       }
     }
-  }, [isThisRunCurrent, clientDataRunId, clientDataUserId, thisRunId, isFlex])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isThisRunCurrent, clientDataRunId, clientDataUserId, thisRunId, isFlex])
 }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useInitLPCStore/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useInitLPCStore/index.ts
@@ -91,5 +91,8 @@ export function useInitLPCStore({
 
       dispatch(updateLPC(runId, initialState))
     }
-  }, [isReadyToInit])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isReadyToInit])
 }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useInitLPCStore/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useInitLPCStore/index.ts
@@ -59,40 +59,42 @@ export function useInitLPCStore({
     runRecordOffsets !== undefined
 
   // Initialize the store. This effect should only occur once.
-  useEffect(() => {
-    if (isReadyToInit && isFlex) {
-      const activePipetteId = getActivePipetteId(analysis.pipettes)
+  useEffect(
+    () => {
+      if (isReadyToInit && isFlex) {
+        const activePipetteId = getActivePipetteId(analysis.pipettes)
 
-      const initialState: LPCWizardState = {
-        ...rest,
-        protocolData: analysis,
-        labwareDefs,
-        activePipetteId: activePipetteId ?? 'NO_PIPETTE',
-        protocolName,
-        deckConfig,
-        labwareInfo: {
-          ...rest.labwareInfo,
-          sourcedOffsets: OFFSETS_SOURCE_INITIALIZING,
-          initialRunRecordOffsets: sortRunRecordOffsets(runRecordOffsets),
-          initialDatabaseOffsets: flexStoredOffsets,
-        },
-        steps: {
-          currentStepIndex: 0,
-          totalStepCount: LPC_STEPS.length,
-          all: LPC_STEPS,
-          lastStepIndices: null,
-          currentSubstep: null,
-        },
-        ui: {
-          showDefaultOffsetInfoBanner: true,
-          showSnackbar: null,
-        },
+        const initialState: LPCWizardState = {
+          ...rest,
+          protocolData: analysis,
+          labwareDefs,
+          activePipetteId: activePipetteId ?? 'NO_PIPETTE',
+          protocolName,
+          deckConfig,
+          labwareInfo: {
+            ...rest.labwareInfo,
+            sourcedOffsets: OFFSETS_SOURCE_INITIALIZING,
+            initialRunRecordOffsets: sortRunRecordOffsets(runRecordOffsets),
+            initialDatabaseOffsets: flexStoredOffsets,
+          },
+          steps: {
+            currentStepIndex: 0,
+            totalStepCount: LPC_STEPS.length,
+            all: LPC_STEPS,
+            lastStepIndices: null,
+            currentSubstep: null,
+          },
+          ui: {
+            showDefaultOffsetInfoBanner: true,
+            showSnackbar: null,
+          },
+        }
+
+        dispatch(updateLPC(runId, initialState))
       }
-
-      dispatch(updateLPC(runId, initialState))
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isReadyToInit])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isReadyToInit]
+  )
 }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/index.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/index.ts
@@ -65,11 +65,15 @@ function useFlexLPCLabwareInfo({
         protocolData,
         robotType,
       }),
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [labwareDefs?.length, protocolData?.commands.length, robotType]
   )
 
   const searchLwOffsetsParams = useMemo(
     () => getLPCSearchParams(lwLocationCombos),
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [lwLocationCombos.length]
   )
 

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useUpdateDeckConfig.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useUpdateDeckConfig.ts
@@ -18,5 +18,8 @@ export function useUpdateDeckConfig(
     if (runId != null && deckConfig != null && isFlex) {
       dispatch(updateLPCDeck(runId, deckConfig))
     }
-  }, [deckConfig, runId, isFlex])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [deckConfig, runId, isFlex])
 }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useUpdateDeckConfig.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useUpdateDeckConfig.ts
@@ -14,12 +14,14 @@ export function useUpdateDeckConfig(
 ): void {
   const dispatch = useDispatch()
 
-  useEffect(() => {
-    if (runId != null && deckConfig != null && isFlex) {
-      dispatch(updateLPCDeck(runId, deckConfig))
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [deckConfig, runId, isFlex])
+  useEffect(
+    () => {
+      if (runId != null && deckConfig != null && isFlex) {
+        dispatch(updateLPCDeck(runId, deckConfig))
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [deckConfig, runId, isFlex]
+  )
 }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useUpdateLabware.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useUpdateLabware.ts
@@ -19,5 +19,8 @@ export function useUpdateLabware(
     if (runId != null && maintenanceRunId == null && isFlex) {
       dispatch(updateLPCLabware(runId, labwareInfo.labware))
     }
-  }, [labwareInfo, maintenanceRunId, isFlex, runId])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [labwareInfo, maintenanceRunId, isFlex, runId])
 }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useUpdateLabware.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useUpdateLabware.ts
@@ -15,12 +15,14 @@ export function useUpdateLabware(
 ): void {
   const dispatch = useDispatch()
 
-  useEffect(() => {
-    if (runId != null && maintenanceRunId == null && isFlex) {
-      dispatch(updateLPCLabware(runId, labwareInfo.labware))
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [labwareInfo, maintenanceRunId, isFlex, runId])
+  useEffect(
+    () => {
+      if (runId != null && maintenanceRunId == null && isFlex) {
+        dispatch(updateLPCLabware(runId, labwareInfo.labware))
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [labwareInfo, maintenanceRunId, isFlex, runId]
+  )
 }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
@@ -93,7 +93,10 @@ export function useLPCFlows({
       compatibleRobotAnalysis?.commands ?? []
     )
     return labwareDefsFromCommands
-  }, [compatibleRobotAnalysis?.commands.length])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [compatibleRobotAnalysis?.commands.length])
 
   const {
     labwareInfo,
@@ -150,7 +153,10 @@ export function useLPCFlows({
           setIsLaunching(false)
         })
     }
-  }, [maintenanceRunId])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [maintenanceRunId])
 
   const launchLPC = (): Promise<void> => {
     // Avoid accidentally creating several maintenance runs if a request is ongoing.

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
@@ -88,15 +88,17 @@ export function useLPCFlows({
     ? compatibleFlexAnalysis
     : mostRecentAnalysis
 
-  const labwareDefs = useMemo(() => {
-    const labwareDefsFromCommands = getLabwareDefinitionsFromCommands(
-      compatibleRobotAnalysis?.commands ?? []
-    )
-    return labwareDefsFromCommands
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [compatibleRobotAnalysis?.commands.length])
+  const labwareDefs = useMemo(
+    () => {
+      const labwareDefsFromCommands = getLabwareDefinitionsFromCommands(
+        compatibleRobotAnalysis?.commands ?? []
+      )
+      return labwareDefsFromCommands
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [compatibleRobotAnalysis?.commands.length]
+  )
 
   const {
     labwareInfo,
@@ -136,27 +138,29 @@ export function useLPCFlows({
     useDeleteMaintenanceRunMutation()
 
   // After the maintenance run is created, add labware defs to the maintenance run.
-  useEffect(() => {
-    if (maintenanceRunId != null) {
-      void Promise.all(
-        labwareDefs.map(def => {
-          return createLabwareDefinition({
-            maintenanceRunId,
-            labwareDef: def,
+  useEffect(
+    () => {
+      if (maintenanceRunId != null) {
+        void Promise.all(
+          labwareDefs.map(def => {
+            return createLabwareDefinition({
+              maintenanceRunId,
+              labwareDef: def,
+            })
           })
-        })
-      )
-        .then(() => {
-          setHasCreatedLPCRun(true)
-        })
-        .finally(() => {
-          setIsLaunching(false)
-        })
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [maintenanceRunId])
+        )
+          .then(() => {
+            setHasCreatedLPCRun(true)
+          })
+          .finally(() => {
+            setIsLaunching(false)
+          })
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [maintenanceRunId]
+  )
 
   const launchLPC = (): Promise<void> => {
     // Avoid accidentally creating several maintenance runs if a request is ongoing.

--- a/app/src/organisms/LabwarePositionCheck/LPCWizardFlex.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LPCWizardFlex.tsx
@@ -43,14 +43,16 @@ export function LPCWizardFlex(props: LPCWizardFlexProps): JSX.Element {
   })
 
   // Clean up state on LPC close.
-  useEffect(() => {
-    return () => {
-      dispatch(closeLPC(props.runId))
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      return () => {
+        dispatch(closeLPC(props.runId))
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   const headerCommands = useLPCHeaderCommands({
     ...props,

--- a/app/src/organisms/LabwarePositionCheck/LPCWizardFlex.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LPCWizardFlex.tsx
@@ -47,7 +47,10 @@ export function LPCWizardFlex(props: LPCWizardFlexProps): JSX.Element {
     return () => {
       dispatch(closeLPC(props.runId))
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   const headerCommands = useLPCHeaderCommands({
     ...props,

--- a/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useHandleJog.ts
+++ b/app/src/organisms/LabwarePositionCheck/hooks/useLPCCommands/useHandleJog.ts
@@ -107,6 +107,8 @@ export function useHandleJog({
     }
   }, [pipetteId, maintenanceRunId, createSilentCommand, setErrorMessage])
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedProcessQueue = useCallback(
     debounce(
       () => {

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/index.tsx
@@ -94,7 +94,10 @@ export function CheckLabware(props: CheckLabwareProps): JSX.Element {
     return () => {
       mounted = false
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   const slotOnlyDisplayLocation = getFlexSlotNameOnly(
     selectedLwInfo.offsetLocationDetails,

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/index.tsx
@@ -81,23 +81,25 @@ export function CheckLabware(props: CheckLabwareProps): JSX.Element {
     getVectorDifference(joggedPosition, workingInitialOffset)
   )
 
-  useEffect(() => {
-    //  NOTE: this will perform a "null" jog when the jog controls mount so
-    //  if a user reaches the "confirm exit" modal (unmounting this component)
-    //  and clicks "go back" we are able so initialize the live offset to whatever
-    //  distance they had already jogged before clicking exit.
-    // the `mounted` variable prevents a possible memory leak (see https://legacy.reactjs.org/docs/hooks-effect.html#example-using-hooks-1)
-    let mounted = true
-    if (mounted) {
-      handleJog('x', 1, 0, setJoggedPosition)
-    }
-    return () => {
-      mounted = false
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      //  NOTE: this will perform a "null" jog when the jog controls mount so
+      //  if a user reaches the "confirm exit" modal (unmounting this component)
+      //  and clicks "go back" we are able so initialize the live offset to whatever
+      //  distance they had already jogged before clicking exit.
+      // the `mounted` variable prevents a possible memory leak (see https://legacy.reactjs.org/docs/hooks-effect.html#example-using-hooks-1)
+      let mounted = true
+      if (mounted) {
+        handleJog('x', 1, 0, setJoggedPosition)
+      }
+      return () => {
+        mounted = false
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   const slotOnlyDisplayLocation = getFlexSlotNameOnly(
     selectedLwInfo.offsetLocationDetails,

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/LPCLabwareList.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/LPCLabwareList.tsx
@@ -130,14 +130,16 @@ function LPCLabwareListContent(props: LPCLabwareListContentProps): JSX.Element {
   const isOnDevice = useSelector(getIsOnDevice)
 
   // On the initial render, select the first uri from the list of labware (for desktop app purposes).
-  useLayoutEffect(() => {
-    if (!isOnDevice) {
-      props.setSelectedUri(labwareInfo[0].uri)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useLayoutEffect(
+    () => {
+      if (!isOnDevice) {
+        props.setSelectedUri(labwareInfo[0].uri)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   return (
     <TextListTableContent header={t('select_labware_to_view_data')}>

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/LPCLabwareList.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/LPCLabwareList.tsx
@@ -134,7 +134,10 @@ function LPCLabwareListContent(props: LPCLabwareListContentProps): JSX.Element {
     if (!isOnDevice) {
       props.setSelectedUri(labwareInfo[0].uri)
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   return (
     <TextListTableContent header={t('select_labware_to_view_data')}>

--- a/app/src/organisms/LegacyLabwarePositionCheck/AttachProbe.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/AttachProbe.tsx
@@ -90,25 +90,27 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
 
   const pipetteMount = pipette?.mount
 
-  useEffect(() => {
-    // move into correct position for probe attach on mount
-    chainRunCommands(
-      [
-        {
-          commandType: 'calibration/moveToMaintenancePosition' as const,
-          params: {
-            mount: pipetteMount ?? 'left',
+  useEffect(
+    () => {
+      // move into correct position for probe attach on mount
+      chainRunCommands(
+        [
+          {
+            commandType: 'calibration/moveToMaintenancePosition' as const,
+            params: {
+              mount: pipetteMount ?? 'left',
+            },
           },
-        },
-      ],
-      false
-    ).catch(error => {
-      setFatalError(error.message as string)
-    })
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+        ],
+        false
+      ).catch(error => {
+        setFatalError(error.message as string)
+      })
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   if (pipetteName == null || pipetteMount == null) return null
 

--- a/app/src/organisms/LegacyLabwarePositionCheck/AttachProbe.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/AttachProbe.tsx
@@ -105,7 +105,10 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     ).catch(error => {
       setFatalError(error.message as string)
     })
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   if (pipetteName == null || pipetteMount == null) return null
 

--- a/app/src/organisms/LegacyLabwarePositionCheck/CheckItem.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/CheckItem.tsx
@@ -159,7 +159,10 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
           )
         })
     }
-  }, [moduleId])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [moduleId])
 
   if (pipetteName == null || labwareDef == null || pipetteMount == null)
     return null

--- a/app/src/organisms/LegacyLabwarePositionCheck/CheckItem.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/CheckItem.tsx
@@ -149,20 +149,22 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
       o.initialPosition != null
   )?.initialPosition
 
-  useEffect(() => {
-    if (initialPosition == null && modulePrepCommands.length > 0) {
-      chainRunCommands(modulePrepCommands, false)
-        .then(() => {})
-        .catch((e: Error) => {
-          setFatalError(
-            `CheckItem module prep commands failed with message: ${e?.message}`
-          )
-        })
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [moduleId])
+  useEffect(
+    () => {
+      if (initialPosition == null && modulePrepCommands.length > 0) {
+        chainRunCommands(modulePrepCommands, false)
+          .then(() => {})
+          .catch((e: Error) => {
+            setFatalError(
+              `CheckItem module prep commands failed with message: ${e?.message}`
+            )
+          })
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [moduleId]
+  )
 
   if (pipetteName == null || labwareDef == null || pipetteMount == null)
     return null

--- a/app/src/organisms/LegacyLabwarePositionCheck/DetachProbe.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/DetachProbe.tsx
@@ -79,25 +79,27 @@ export const DetachProbe = (props: DetachProbeProps): JSX.Element | null => {
   }
   const pipetteMount = pipette?.mount
 
-  useEffect(() => {
-    // move into correct position for probe detach on mount
-    chainRunCommands(
-      [
-        {
-          commandType: 'calibration/moveToMaintenancePosition' as const,
-          params: {
-            mount: pipetteMount ?? 'left',
+  useEffect(
+    () => {
+      // move into correct position for probe detach on mount
+      chainRunCommands(
+        [
+          {
+            commandType: 'calibration/moveToMaintenancePosition' as const,
+            params: {
+              mount: pipetteMount ?? 'left',
+            },
           },
-        },
-      ],
-      false
-    ).catch(error => {
-      setFatalError(error.message as string)
-    })
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+        ],
+        false
+      ).catch(error => {
+        setFatalError(error.message as string)
+      })
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   if (pipetteName == null || pipetteMount == null) return null
 

--- a/app/src/organisms/LegacyLabwarePositionCheck/DetachProbe.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/DetachProbe.tsx
@@ -94,7 +94,10 @@ export const DetachProbe = (props: DetachProbeProps): JSX.Element | null => {
     ).catch(error => {
       setFatalError(error.message as string)
     })
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   if (pipetteName == null || pipetteMount == null) return null
 

--- a/app/src/organisms/LegacyLabwarePositionCheck/JogToWell.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/JogToWell.tsx
@@ -89,23 +89,25 @@ export const JogToWell = (props: JogToWellProps): JSX.Element | null => {
     useState<VectorOffset>(initialPosition)
   const isOnDevice = useSelector(getIsOnDevice)
   const [showFullJogControls, setShowFullJogControls] = useState(false)
-  useEffect(() => {
-    //  NOTE: this will perform a "null" jog when the jog controls mount so
-    //  if a user reaches the "confirm exit" modal (unmounting this component)
-    //  and clicks "go back" we are able so initialize the live offset to whatever
-    //  distance they had already jogged before clicking exit.
-    // the `mounted` variable prevents a possible memory leak (see https://legacy.reactjs.org/docs/hooks-effect.html#example-using-hooks-1)
-    let mounted = true
-    if (mounted) {
-      handleJog('x', 1, 0, setJoggedPosition)
-    }
-    return () => {
-      mounted = false
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      //  NOTE: this will perform a "null" jog when the jog controls mount so
+      //  if a user reaches the "confirm exit" modal (unmounting this component)
+      //  and clicks "go back" we are able so initialize the live offset to whatever
+      //  distance they had already jogged before clicking exit.
+      // the `mounted` variable prevents a possible memory leak (see https://legacy.reactjs.org/docs/hooks-effect.html#example-using-hooks-1)
+      let mounted = true
+      if (mounted) {
+        handleJog('x', 1, 0, setJoggedPosition)
+      }
+      return () => {
+        mounted = false
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   let wellsToHighlight: string[] = []
   if (

--- a/app/src/organisms/LegacyLabwarePositionCheck/JogToWell.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/JogToWell.tsx
@@ -102,7 +102,10 @@ export const JogToWell = (props: JogToWellProps): JSX.Element | null => {
     return () => {
       mounted = false
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   let wellsToHighlight: string[] = []
   if (

--- a/app/src/organisms/LocationConflictModal/LocationConflictModal.tsx
+++ b/app/src/organisms/LocationConflictModal/LocationConflictModal.tsx
@@ -112,7 +112,10 @@ export const LocationConflictModal = (
         setShowModuleSelect(true)
       }
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   const isThermocyclerRequired =
     requiredModule === THERMOCYCLER_MODULE_V1 ||

--- a/app/src/organisms/LocationConflictModal/LocationConflictModal.tsx
+++ b/app/src/organisms/LocationConflictModal/LocationConflictModal.tsx
@@ -100,22 +100,24 @@ export const LocationConflictModal = (
 
   // skip past fix conflict screen if D3 can remain the same when you attach
   // a flex stacker module, ie mag block or waste chute only fixture
-  useEffect(() => {
-    if (requiredModule != null && requiredModule === FLEX_STACKER_MODULE_V1) {
-      if (
-        deckConfigurationAtLocationFixtureId != null &&
-        (deckConfigurationAtLocationFixtureId === MAGNETIC_BLOCK_V1_FIXTURE ||
-          WASTE_CHUTE_ONLY_FIXTURES.includes(
-            deckConfigurationAtLocationFixtureId
-          ))
-      ) {
-        setShowModuleSelect(true)
+  useEffect(
+    () => {
+      if (requiredModule != null && requiredModule === FLEX_STACKER_MODULE_V1) {
+        if (
+          deckConfigurationAtLocationFixtureId != null &&
+          (deckConfigurationAtLocationFixtureId === MAGNETIC_BLOCK_V1_FIXTURE ||
+            WASTE_CHUTE_ONLY_FIXTURES.includes(
+              deckConfigurationAtLocationFixtureId
+            ))
+        ) {
+          setShowModuleSelect(true)
+        }
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   const isThermocyclerRequired =
     requiredModule === THERMOCYCLER_MODULE_V1 ||

--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -89,7 +89,10 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
       setSelectedModule(newModules[0])
       sendIdentifyStacker(newModules[0], true)
     }
-  }, [shortCircuitFlow])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [shortCircuitFlow])
 
   // Handler for when there are multiple modules.
   const handleModuleSelected = (serialNumber: string): void => {

--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -84,15 +84,17 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
   }
 
   // Handler for when there is one module
-  useEffect(() => {
-    if (shortCircuitFlow) {
-      setSelectedModule(newModules[0])
-      sendIdentifyStacker(newModules[0], true)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [shortCircuitFlow])
+  useEffect(
+    () => {
+      if (shortCircuitFlow) {
+        setSelectedModule(newModules[0])
+        sendIdentifyStacker(newModules[0], true)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [shortCircuitFlow]
+  )
 
   // Handler for when there are multiple modules.
   const handleModuleSelected = (serialNumber: string): void => {

--- a/app/src/organisms/ModuleWizardFlows/UpdateFirmware.tsx
+++ b/app/src/organisms/ModuleWizardFlows/UpdateFirmware.tsx
@@ -69,84 +69,85 @@ export function UpdateFirmware(props: UpdateFirmwareProps): JSX.Element {
       enabled: requestStatus === SUCCESS && inProgress,
     })?.data?.data ?? []
 
-  useEffect(() => {
-    const matchingModule = attachedModules.find(
-      module => module.serialNumber === moduleSerialNumber
-    )
-    if (matchingModule != null && requestStatus === SUCCESS) {
-      if (moduleRequestTimeoutId != null) {
-        clearTimeout(moduleRequestTimeoutId)
+  useEffect(
+    () => {
+      const matchingModule = attachedModules.find(
+        module => module.serialNumber === moduleSerialNumber
+      )
+      if (matchingModule != null && requestStatus === SUCCESS) {
+        if (moduleRequestTimeoutId != null) {
+          clearTimeout(moduleRequestTimeoutId)
+        }
+        // Update failed
+        if (matchingModule.hasAvailableUpdate) {
+          setIsModuleUpdating(false)
+          setInProgress(false)
+          setErrorMessage(t('firmware_update_failed') as string)
+          if (latestRequestId != null) {
+            dispatch(dismissRequest(latestRequestId))
+          }
+          return
+        }
+        // Update passed
+        setShouldProceed(true)
+        setIsModuleUpdating(false)
+        setInProgress(false)
+        sendIdentifyStacker(matchingModule, true, 'blue')
+        patchModuleAfterUpdate(matchingModule)
+        setTimeout(() => {
+          proceed()
+        }, NO_UPDATE_FOUND_TIMEOUT_MS)
       }
-      // Update failed
-      if (matchingModule.hasAvailableUpdate) {
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [attachedModules, requestStatus, moduleRequestTimeoutId, moduleSerialNumber]
+  )
+
+  useEffect(
+    () => {
+      setCheckingFirmware(true)
+      setTimeout(() => {
+        setCheckingFirmware(false)
+        if (!attachedModule.hasAvailableUpdate) {
+          setIsModuleUpdating(false)
+          setShouldProceed(true)
+          setTimeout(() => {
+            proceed()
+          }, NO_UPDATE_FOUND_TIMEOUT_MS)
+        }
+      }, CHECKING_UPDATE_TIMEOUT_MS)
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
+  useEffect(
+    () => {
+      if (requestStatus === PENDING) {
+        setInProgress(true)
+      } else if (requestStatus === FAILURE) {
         setIsModuleUpdating(false)
         setInProgress(false)
         setErrorMessage(t('firmware_update_failed') as string)
         if (latestRequestId != null) {
           dispatch(dismissRequest(latestRequestId))
         }
-        return
+      } else if (requestStatus === SUCCESS) {
+        // if the request succeeds but the module doesn't come back online within 60 seconds
+        // we should display an error message
+        const timeoutId = setTimeout(() => {
+          setIsModuleUpdating(false)
+          setErrorMessage(t('firmware_update_failed') as string)
+        }, MODULE_TIMEOUT_MS)
+        setModuleRequestTimeoutId(timeoutId)
       }
-      // Update passed
-      setShouldProceed(true)
-      setIsModuleUpdating(false)
-      setInProgress(false)
-      sendIdentifyStacker(matchingModule, true, 'blue')
-      patchModuleAfterUpdate(matchingModule)
-      setTimeout(() => {
-        proceed()
-      }, NO_UPDATE_FOUND_TIMEOUT_MS)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [
-    attachedModules,
-    requestStatus,
-    moduleRequestTimeoutId,
-    moduleSerialNumber,
-  ])
-
-  useEffect(() => {
-    setCheckingFirmware(true)
-    setTimeout(() => {
-      setCheckingFirmware(false)
-      if (!attachedModule.hasAvailableUpdate) {
-        setIsModuleUpdating(false)
-        setShouldProceed(true)
-        setTimeout(() => {
-          proceed()
-        }, NO_UPDATE_FOUND_TIMEOUT_MS)
-      }
-    }, CHECKING_UPDATE_TIMEOUT_MS)
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
-
-  useEffect(() => {
-    if (requestStatus === PENDING) {
-      setInProgress(true)
-    } else if (requestStatus === FAILURE) {
-      setIsModuleUpdating(false)
-      setInProgress(false)
-      setErrorMessage(t('firmware_update_failed') as string)
-      if (latestRequestId != null) {
-        dispatch(dismissRequest(latestRequestId))
-      }
-    } else if (requestStatus === SUCCESS) {
-      // if the request succeeds but the module doesn't come back online within 60 seconds
-      // we should display an error message
-      const timeoutId = setTimeout(() => {
-        setIsModuleUpdating(false)
-        setErrorMessage(t('firmware_update_failed') as string)
-      }, MODULE_TIMEOUT_MS)
-      setModuleRequestTimeoutId(timeoutId)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [requestStatus, setInProgress])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [requestStatus, setInProgress]
+  )
 
   const handleUpdateFirmware = (): void => {
     setIsModuleUpdating(true)

--- a/app/src/organisms/ModuleWizardFlows/UpdateFirmware.tsx
+++ b/app/src/organisms/ModuleWizardFlows/UpdateFirmware.tsx
@@ -97,7 +97,10 @@ export function UpdateFirmware(props: UpdateFirmwareProps): JSX.Element {
         proceed()
       }, NO_UPDATE_FOUND_TIMEOUT_MS)
     }
-  }, [
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [
     attachedModules,
     requestStatus,
     moduleRequestTimeoutId,
@@ -116,7 +119,10 @@ export function UpdateFirmware(props: UpdateFirmwareProps): JSX.Element {
         }, NO_UPDATE_FOUND_TIMEOUT_MS)
       }
     }, CHECKING_UPDATE_TIMEOUT_MS)
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   useEffect(() => {
     if (requestStatus === PENDING) {
@@ -137,7 +143,10 @@ export function UpdateFirmware(props: UpdateFirmwareProps): JSX.Element {
       }, MODULE_TIMEOUT_MS)
       setModuleRequestTimeoutId(timeoutId)
     }
-  }, [requestStatus, setInProgress])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [requestStatus, setInProgress])
 
   const handleUpdateFirmware = (): void => {
     setIsModuleUpdating(true)

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -82,25 +82,32 @@ export function ModuleWizardFlows(
     })?.data?.data ?? []
 
   // build out flow if there is a module passed in at launch
-  useEffect(() => {
-    if (attachedModuleOnLaunch != null) {
-      buildFlowForSelectedModule(attachedModuleOnLaunch)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      if (attachedModuleOnLaunch != null) {
+        buildFlowForSelectedModule(attachedModuleOnLaunch)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   // Close the modal if no new modules are attached
   const newModules = useGetModulesNeedingSetupThatCanCurrentlyBeSetUp()
-  useEffect(() => {
-    if (newModules.length === 0 && wizardFlowBaseProps.attachedModule == null) {
-      handleCleanUpAndClose()
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [newModules, wizardFlowBaseProps])
+  useEffect(
+    () => {
+      if (
+        newModules.length === 0 &&
+        wizardFlowBaseProps.attachedModule == null
+      ) {
+        handleCleanUpAndClose()
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [newModules, wizardFlowBaseProps]
+  )
 
   const doorStatus = useIsDoorOpen(robotName).isDoorOpen
 

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -86,7 +86,10 @@ export function ModuleWizardFlows(
     if (attachedModuleOnLaunch != null) {
       buildFlowForSelectedModule(attachedModuleOnLaunch)
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   // Close the modal if no new modules are attached
   const newModules = useGetModulesNeedingSetupThatCanCurrentlyBeSetUp()
@@ -94,7 +97,10 @@ export function ModuleWizardFlows(
     if (newModules.length === 0 && wizardFlowBaseProps.attachedModule == null) {
       handleCleanUpAndClose()
     }
-  }, [newModules, wizardFlowBaseProps])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [newModules, wizardFlowBaseProps])
 
   const doorStatus = useIsDoorOpen(robotName).isDoorOpen
 

--- a/app/src/organisms/ODD/CameraSettings/CameraControls/ImagePreviewModal.tsx
+++ b/app/src/organisms/ODD/CameraSettings/CameraControls/ImagePreviewModal.tsx
@@ -31,6 +31,8 @@ export function ImagePreviewModal({
       hasExitIcon: true,
       onClick: toggleModal,
     }),
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
 

--- a/app/src/organisms/ODD/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
+++ b/app/src/organisms/ODD/InstrumentMountItem/ProtocolInstrumentMountItem.tsx
@@ -72,6 +72,8 @@ export function ProtocolInstrumentMountItem(
       attachedInstrument?.instrumentType === 'gripper' && attachedInstrument.ok
         ? attachedInstrument
         : null,
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
   const [flowType, setFlowType] = useState<string>(FLOWS.ATTACH)

--- a/app/src/organisms/ODD/NetworkSettings/WifiConnectionDetails.tsx
+++ b/app/src/organisms/ODD/NetworkSettings/WifiConnectionDetails.tsx
@@ -54,12 +54,14 @@ export function WifiConnectionDetails({
   const [showNetworkDetailsModal, setShowNetworkDetailsModal] =
     useState<boolean>(false)
 
-  useEffect(() => {
-    dispatch(fetchStatus(robotName))
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      dispatch(fetchStatus(robotName))
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   return (
     <>

--- a/app/src/organisms/ODD/NetworkSettings/WifiConnectionDetails.tsx
+++ b/app/src/organisms/ODD/NetworkSettings/WifiConnectionDetails.tsx
@@ -56,8 +56,10 @@ export function WifiConnectionDetails({
 
   useEffect(() => {
     dispatch(fetchStatus(robotName))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   return (
     <>

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ChooseCsvFile.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ChooseCsvFile.tsx
@@ -49,6 +49,8 @@ export function ChooseCsvFile({
 }: ChooseCsvFileProps): JSX.Element {
   const { t } = useTranslation('protocol_setup')
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const csvFilesOnUSB = useSelector(getShellUpdateDataFiles) ?? []
   const csvFilesOnRobot = (useAllCsvFilesQuery(protocolId).data?.data ??
     []) as CsvFileData[]

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ChooseNumber.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ChooseNumber.tsx
@@ -38,15 +38,17 @@ export function ChooseNumber({
   // same length as the initial parameter value (as string) when the component mounts
   // so that the delete button operates properly on the exisiting input field value.
   const [prevKeyboardValue, setPrevKeyboardValue] = useState<string>('')
-  useEffect(() => {
-    const arbitraryInput = new Array(paramValue).join('*')
-    // @ts-expect-error keyboard should expose for `setInput` method
-    keyboardRef.current?.setInput(arbitraryInput)
-    setPrevKeyboardValue(arbitraryInput)
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      const arbitraryInput = new Array(paramValue).join('*')
+      // @ts-expect-error keyboard should expose for `setInput` method
+      keyboardRef.current?.setInput(arbitraryInput)
+      setPrevKeyboardValue(arbitraryInput)
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   if (parameter.type !== 'int' && parameter.type !== 'float') {
     console.log(`Incorrect parameter type: ${parameter.type as string}`)

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ChooseNumber.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ChooseNumber.tsx
@@ -43,7 +43,10 @@ export function ChooseNumber({
     // @ts-expect-error keyboard should expose for `setInput` method
     keyboardRef.current?.setInput(arbitraryInput)
     setPrevKeyboardValue(arbitraryInput)
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   if (parameter.type !== 'int' && parameter.type !== 'float') {
     console.log(`Incorrect parameter type: ${parameter.type as string}`)

--- a/app/src/organisms/ODD/RobotSettingsDashboard/LanguageSetting.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/LanguageSetting.tsx
@@ -56,6 +56,8 @@ export function LanguageSetting({
 
   let transactionId = ''
   useEffect(() => {
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     transactionId = uuid()
   }, [])
 

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
@@ -63,22 +63,24 @@ export function ConfirmCancelRunModal({
     })
   }
 
-  useEffect(() => {
-    if (runStatus === RUN_STATUS_STOPPED || isRunFetchError) {
-      trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_ACTION.CANCEL })
-      if (!isActiveRun) {
-        dismissCurrentRun(runId)
-        if (protocolId != null) {
-          navigate(`/protocols/${protocolId}`)
-        } else {
-          navigate('/protocols')
+  useEffect(
+    () => {
+      if (runStatus === RUN_STATUS_STOPPED || isRunFetchError) {
+        trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_ACTION.CANCEL })
+        if (!isActiveRun) {
+          dismissCurrentRun(runId)
+          if (protocolId != null) {
+            navigate(`/protocols/${protocolId}`)
+          } else {
+            navigate('/protocols')
+          }
         }
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [runStatus])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [runStatus]
+  )
 
   return isCanceling || isDismissing ? (
     <CancelingRunModal />

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
@@ -75,7 +75,10 @@ export function ConfirmCancelRunModal({
         }
       }
     }
-  }, [runStatus])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [runStatus])
 
   return isCanceling || isDismissing ? (
     <CancelingRunModal />

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -86,7 +86,10 @@ export const BeforeBeginning = (
     if (createdMaintenanceRunId == null) {
       createMaintenanceRun({})
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
   const pipetteId = attachedPipettes[mount]?.serialNumber
   const isGantryEmpty = getIsGantryEmpty(attachedPipettes)
   const isGantryEmptyFor96ChannelAttachment =

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -82,14 +82,16 @@ export const BeforeBeginning = (
     deckConfig,
   } = props
   const { t } = useTranslation(['pipette_wizard_flows', 'shared'])
-  useEffect(() => {
-    if (createdMaintenanceRunId == null) {
-      createMaintenanceRun({})
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      if (createdMaintenanceRunId == null) {
+        createMaintenanceRun({})
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
   const pipetteId = attachedPipettes[mount]?.serialNumber
   const isGantryEmpty = getIsGantryEmpty(attachedPipettes)
   const isGantryEmptyFor96ChannelAttachment =

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -87,6 +87,8 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
     flowType,
     section: SECTIONS.DETACH_PIPETTE,
   }
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const memoizedAttachedPipettes = useMemo(() => attachedPipettes, [])
   const is96ChannelPipette =
     memoizedAttachedPipettes[mount]?.instrumentName === 'p1000_96' ||

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -74,9 +74,13 @@ export const PipetteWizardFlows = (
   const { t } = useTranslation('pipette_wizard_flows')
   const deckConfig = useNotifyDeckConfigurationQuery()
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const memoizedPipetteInfo = useMemo(() => props.pipetteInfo ?? null, [])
   const isGantryEmpty = useMemo(
     () => attachedPipettes[LEFT] == null && attachedPipettes[RIGHT] == null,
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
 
@@ -97,6 +101,8 @@ export const PipetteWizardFlows = (
             mount,
             deckConfig
           ),
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
   const requiredPipette = memoizedPipetteInfo?.find(
@@ -108,6 +114,8 @@ export const PipetteWizardFlows = (
     pipetteWizardSteps != null ? pipetteWizardSteps.length - 1 : 0
   const currentStep = pipetteWizardSteps?.[currentStepIndex] ?? null
   const [isFetchingPipettes, setIsFetchingPipettes] = useState<boolean>(false)
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const memoizedAttachedPipettes = useMemo(() => attachedPipettes, [])
   const hasCalData =
     memoizedAttachedPipettes[mount]?.data.calibratedOffset?.last_modified !=
@@ -121,6 +129,8 @@ export const PipetteWizardFlows = (
     attachedPipettes: memoizedAttachedPipettes,
     pipetteInfo: memoizedPipetteInfo,
   })
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const memoizedWizardTitle = useMemo(() => wizardTitle, [])
   const [createdMaintenanceRunId, setCreatedMaintenanceRunId] = useState<
     string | null

--- a/app/src/organisms/TakeoverModal/MaintenanceRunTakeover.tsx
+++ b/app/src/organisms/TakeoverModal/MaintenanceRunTakeover.tsx
@@ -50,16 +50,18 @@ export function MaintenanceRunTakeoverModal(
     }
   }
 
-  useEffect(() => {
-    if (currentRunId == null) {
-      setIsLoading(false)
-      setShowConfirmTerminateModal(false)
-      reset()
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [currentRunId])
+  useEffect(
+    () => {
+      if (currentRunId == null) {
+        setIsLoading(false)
+        setShowConfirmTerminateModal(false)
+        reset()
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [currentRunId]
+  )
 
   return (
     <>

--- a/app/src/organisms/TakeoverModal/MaintenanceRunTakeover.tsx
+++ b/app/src/organisms/TakeoverModal/MaintenanceRunTakeover.tsx
@@ -56,7 +56,10 @@ export function MaintenanceRunTakeoverModal(
       setShowConfirmTerminateModal(false)
       reset()
     }
-  }, [currentRunId])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [currentRunId])
 
   return (
     <>

--- a/app/src/organisms/WellSelection/Selection384Wells.tsx
+++ b/app/src/organisms/WellSelection/Selection384Wells.tsx
@@ -264,8 +264,10 @@ function StartingWell({
       selectWells({ A1: null })
     }
     setStartingWellState({ A1: true, A2: false, B1: false, B2: false })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>

--- a/app/src/organisms/WellSelection/Selection384Wells.tsx
+++ b/app/src/organisms/WellSelection/Selection384Wells.tsx
@@ -256,18 +256,20 @@ function StartingWell({
     channels === 8 ? ['A1', 'B1'] : ['A1', 'A2', 'B1', 'B2']
 
   // on mount, select A1 well group for 96-channel
-  useEffect(() => {
-    // deselect all wells on mount; clears well selection when navigating back within quick transfer flow
-    // otherwise, selected wells and lastSelectedIndex pointer will be out of sync
-    deselectWells(wells)
-    if (channels === 96) {
-      selectWells({ A1: null })
-    }
-    setStartingWellState({ A1: true, A2: false, B1: false, B2: false })
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      // deselect all wells on mount; clears well selection when navigating back within quick transfer flow
+      // otherwise, selected wells and lastSelectedIndex pointer will be out of sync
+      deselectWells(wells)
+      if (channels === 96) {
+        selectWells({ A1: null })
+      }
+      setStartingWellState({ A1: true, A2: false, B1: false, B2: false })
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>

--- a/app/src/pages/Desktop/AppSettings/GeneralSettings.tsx
+++ b/app/src/pages/Desktop/AppSettings/GeneralSettings.tsx
@@ -71,6 +71,8 @@ export function GeneralSettings(): JSX.Element {
   const currentLanguageOption = LANGUAGES.find(lng => lng.value === appLanguage)
   let transactionId = ''
   useEffect(() => {
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     transactionId = uuid()
   }, [])
   const handleDropdownClick = (value: string): void => {

--- a/app/src/pages/Desktop/Devices/ProtocolRunDetails/index.tsx
+++ b/app/src/pages/Desktop/Devices/ProtocolRunDetails/index.tsx
@@ -275,7 +275,10 @@ const SetupTab = (props: SetupTabProps): JSX.Element | null => {
     ) {
       navigate(`/devices/${robotName}/protocol-runs/${runId}/setup`)
     }
-  }, [currentRunStatus])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [currentRunStatus])
 
   return (
     <RoundTab

--- a/app/src/pages/Desktop/Devices/ProtocolRunDetails/index.tsx
+++ b/app/src/pages/Desktop/Devices/ProtocolRunDetails/index.tsx
@@ -259,26 +259,28 @@ const SetupTab = (props: SetupTabProps): JSX.Element | null => {
     'not_available_for_a_completed_run'
   )}`
 
-  useEffect(() => {
-    // On the initial render or when a run first begins, navigate to "run preview" if the run has started.
-    if (
-      currentRunStatus !== RUN_STATUS_IDLE &&
-      protocolRunDetailsTab !== 'run-preview' &&
-      protocolRunDetailsTab !== 'camera'
-    ) {
-      navigate(`/devices/${robotName}/protocol-runs/${runId}/run-preview`)
-    }
-    // On initial render or on a clone run, navigate to "run setup" if the run hasn't started.
-    else if (
-      currentRunStatus === RUN_STATUS_IDLE &&
-      protocolRunDetailsTab !== 'setup'
-    ) {
-      navigate(`/devices/${robotName}/protocol-runs/${runId}/setup`)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [currentRunStatus])
+  useEffect(
+    () => {
+      // On the initial render or when a run first begins, navigate to "run preview" if the run has started.
+      if (
+        currentRunStatus !== RUN_STATUS_IDLE &&
+        protocolRunDetailsTab !== 'run-preview' &&
+        protocolRunDetailsTab !== 'camera'
+      ) {
+        navigate(`/devices/${robotName}/protocol-runs/${runId}/run-preview`)
+      }
+      // On initial render or on a clone run, navigate to "run setup" if the run hasn't started.
+      else if (
+        currentRunStatus === RUN_STATUS_IDLE &&
+        protocolRunDetailsTab !== 'setup'
+      ) {
+        navigate(`/devices/${robotName}/protocol-runs/${runId}/setup`)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [currentRunStatus]
+  )
 
   return (
     <RoundTab

--- a/app/src/pages/Desktop/Labware/index.tsx
+++ b/app/src/pages/Desktop/Labware/index.tsx
@@ -130,8 +130,10 @@ export function Labware(): JSX.Element {
         }
       )
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [labwareFailureMessage, newLabwareName])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [labwareFailureMessage, newLabwareName])
 
   return (
     <>

--- a/app/src/pages/Desktop/Labware/index.tsx
+++ b/app/src/pages/Desktop/Labware/index.tsx
@@ -112,28 +112,30 @@ export function Labware(): JSX.Element {
       setShowSortByMenu(false)
     },
   })
-  useEffect(() => {
-    if (labwareFailureMessage != null) {
-      setShowAddLabwareSlideout(false)
-      makeToast(labwareFailureMessage, ERROR_TOAST, {
-        closeButton: true,
-        onClose: clearLabwareFailure,
-      })
-    } else if (newLabwareName != null) {
-      setShowAddLabwareSlideout(false)
-      makeToast(
-        t('imported', { filename: newLabwareName }) as string,
-        SUCCESS_TOAST,
-        {
+  useEffect(
+    () => {
+      if (labwareFailureMessage != null) {
+        setShowAddLabwareSlideout(false)
+        makeToast(labwareFailureMessage, ERROR_TOAST, {
           closeButton: true,
-          onClose: clearLabwareName,
-        }
-      )
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [labwareFailureMessage, newLabwareName])
+          onClose: clearLabwareFailure,
+        })
+      } else if (newLabwareName != null) {
+        setShowAddLabwareSlideout(false)
+        makeToast(
+          t('imported', { filename: newLabwareName }) as string,
+          SUCCESS_TOAST,
+          {
+            closeButton: true,
+            onClose: clearLabwareName,
+          }
+        )
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [labwareFailureMessage, newLabwareName]
+  )
 
   return (
     <>

--- a/app/src/pages/Desktop/LivestreamViewer/hooks/useHlsVideo.ts
+++ b/app/src/pages/Desktop/LivestreamViewer/hooks/useHlsVideo.ts
@@ -44,93 +44,95 @@ export function useHlsVideo(
     }
   }, [error])
 
-  useEffect(() => {
-    if (videoRef.current == null || host == null) {
-      return
-    }
-
-    const video = videoRef.current
-
-    setupHls.current = () => {
-      if (!Hls.isSupported()) {
-        setLivestreamError('HLS streaming not supported in this browser.')
+  useEffect(
+    () => {
+      if (videoRef.current == null || host == null) {
         return
       }
 
-      if (hlsRef.current) {
-        hlsRef.current.destroy()
-      }
+      const video = videoRef.current
 
-      const hls = new Hls({
-        // Disable DVR/back buffer.
-        // Although the scrubber on stream controls will appear to increase
-        // linearly with time (when enabled), past segments are not kept in memory.
-        backBufferLength: 0,
-        // The number of seconds behind the live edge to target playback.
-        // Higher values can cause constant buffering due to unready segments.
-        liveSyncDuration: 2,
-        // If the stream falls more than X seconds behind the live edge,
-        // "catch up" to a segment within X seconds behind the live edge
-        // by skipping segments
-        liveMaxLatencyDuration: 5,
-      })
-
-      hlsRef.current = hls
-
-      hls.loadSource(STREAM_URL(host.hostname))
-      hls.attachMedia(video)
-
-      hls.on(Hls.Events.MANIFEST_PARSED, () => {
-        retryCountRef.current = 0
-        setError(null)
-        video.play().catch(e => {
-          console.error('Auto-play failed:', e)
-          setLivestreamError(
-            'Auto-play failed. Please close and reopen the stream.'
-          )
-        })
-      })
-
-      hls.on(Hls.Events.ERROR, (_, data) => {
-        // `fatal` prevents refetching over-aggressively, ex, when the buffer is temporarily depleted.
-        if (data.fatal && !isTerminalRunStatus(runStatus)) {
-          retryCountRef.current++
-
-          setLivestreamError(
-            `Service unavailable. Retrying (${retryCountRef.current})...`
-          )
-
-          retryTimeoutRef.current = setTimeout(() => {
-            setupHls.current?.()
-          }, RETRY_DELAY_MS)
+      setupHls.current = () => {
+        if (!Hls.isSupported()) {
+          setLivestreamError('HLS streaming not supported in this browser.')
+          return
         }
-      })
 
-      const handleVideoError = (e: ErrorEvent): void => {
-        setLivestreamError(`Video playback error: ${e.message}`)
+        if (hlsRef.current) {
+          hlsRef.current.destroy()
+        }
+
+        const hls = new Hls({
+          // Disable DVR/back buffer.
+          // Although the scrubber on stream controls will appear to increase
+          // linearly with time (when enabled), past segments are not kept in memory.
+          backBufferLength: 0,
+          // The number of seconds behind the live edge to target playback.
+          // Higher values can cause constant buffering due to unready segments.
+          liveSyncDuration: 2,
+          // If the stream falls more than X seconds behind the live edge,
+          // "catch up" to a segment within X seconds behind the live edge
+          // by skipping segments
+          liveMaxLatencyDuration: 5,
+        })
+
+        hlsRef.current = hls
+
+        hls.loadSource(STREAM_URL(host.hostname))
+        hls.attachMedia(video)
+
+        hls.on(Hls.Events.MANIFEST_PARSED, () => {
+          retryCountRef.current = 0
+          setError(null)
+          video.play().catch(e => {
+            console.error('Auto-play failed:', e)
+            setLivestreamError(
+              'Auto-play failed. Please close and reopen the stream.'
+            )
+          })
+        })
+
+        hls.on(Hls.Events.ERROR, (_, data) => {
+          // `fatal` prevents refetching over-aggressively, ex, when the buffer is temporarily depleted.
+          if (data.fatal && !isTerminalRunStatus(runStatus)) {
+            retryCountRef.current++
+
+            setLivestreamError(
+              `Service unavailable. Retrying (${retryCountRef.current})...`
+            )
+
+            retryTimeoutRef.current = setTimeout(() => {
+              setupHls.current?.()
+            }, RETRY_DELAY_MS)
+          }
+        })
+
+        const handleVideoError = (e: ErrorEvent): void => {
+          setLivestreamError(`Video playback error: ${e.message}`)
+        }
+
+        video.addEventListener('error', handleVideoError)
       }
 
-      video.addEventListener('error', handleVideoError)
-    }
+      setupHls.current()
 
-    setupHls.current()
+      return () => {
+        if (retryTimeoutRef.current) {
+          clearTimeout(retryTimeoutRef.current)
+        }
 
-    return () => {
-      if (retryTimeoutRef.current) {
-        clearTimeout(retryTimeoutRef.current)
+        if (hlsRef.current) {
+          hlsRef.current.destroy()
+          hlsRef.current = null
+        }
+
+        retryCountRef.current = 0
       }
-
-      if (hlsRef.current) {
-        hlsRef.current.destroy()
-        hlsRef.current = null
-      }
-
-      retryCountRef.current = 0
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [host, runStatus])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [host, runStatus]
+  )
 
   return { videoRef, videoError: error }
 }

--- a/app/src/pages/Desktop/LivestreamViewer/hooks/useHlsVideo.ts
+++ b/app/src/pages/Desktop/LivestreamViewer/hooks/useHlsVideo.ts
@@ -127,7 +127,10 @@ export function useHlsVideo(
 
       retryCountRef.current = 0
     }
-  }, [host, runStatus])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [host, runStatus])
 
   return { videoRef, videoError: error }
 }

--- a/app/src/pages/ODD/ChooseLanguage/index.tsx
+++ b/app/src/pages/ODD/ChooseLanguage/index.tsx
@@ -33,8 +33,10 @@ export function ChooseLanguage(): JSX.Element {
   useEffect(() => {
     // initialize en-US language on mount
     dispatch(updateConfigValue('language.appLanguage', US_ENGLISH))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   return (
     <Flex

--- a/app/src/pages/ODD/ChooseLanguage/index.tsx
+++ b/app/src/pages/ODD/ChooseLanguage/index.tsx
@@ -30,13 +30,15 @@ export function ChooseLanguage(): JSX.Element {
 
   const appLanguage = useSelector(getAppLanguage)
 
-  useEffect(() => {
-    // initialize en-US language on mount
-    dispatch(updateConfigValue('language.appLanguage', US_ENGLISH))
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      // initialize en-US language on mount
+      dispatch(updateConfigValue('language.appLanguage', US_ENGLISH))
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   return (
     <Flex

--- a/app/src/pages/ODD/InstrumentDetail/index.tsx
+++ b/app/src/pages/ODD/InstrumentDetail/index.tsx
@@ -49,6 +49,8 @@ export const InstrumentDetail = (): JSX.Element => {
   const gripperDisplayName = useGripperDisplayName(
     instrument?.instrumentModel as GripperModel
   )
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const { showDTWiz, disableDTWiz, enableDTWiz } = useDropTipWizardFlows()
   const pipetteModelSpecs =
     instrument != null

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -198,17 +198,19 @@ function PrepareToRun({
       source: SOURCE_RUN_RECORD,
       robotType: robotType,
     })
-  useEffect(() => {
-    if (storageInfo.isImageStorageLow) {
-      reportPhotoAccessUsage({
-        action: 'storageWarning',
-        transactionId: runId,
-      })
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [storageInfo.isImageStorageLow != null])
+  useEffect(
+    () => {
+      if (storageInfo.isImageStorageLow) {
+        reportPhotoAccessUsage({
+          action: 'storageWarning',
+          transactionId: runId,
+        })
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [storageInfo.isImageStorageLow != null]
+  )
   const mostRecentAnalysisSummary = last(protocolRecord?.data.analysisSummaries)
   const [isPollingForCompletedAnalysis, setIsPollingForCompletedAnalysis] =
     useState<boolean>(mostRecentAnalysisSummary?.status !== 'completed')
@@ -856,22 +858,24 @@ export function ProtocolSetup(): JSX.Element {
   })
 
   // The initial app-internal camera state should match the server state.
-  useEffect(() => {
-    if (initialRobotCameraSettings != null) {
-      dispatch(
-        updateCameraUsageSettings({
-          runId,
-          cameraEnabled: initialRobotCameraSettings.cameraEnabled,
-          recoveryEnabled:
-            initialRobotCameraSettings.errorRecoveryCameraEnabled,
-          liveStreamEnabled: initialRobotCameraSettings.liveStreamEnabled,
-        })
-      )
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [initialRobotCameraSettings])
+  useEffect(
+    () => {
+      if (initialRobotCameraSettings != null) {
+        dispatch(
+          updateCameraUsageSettings({
+            runId,
+            cameraEnabled: initialRobotCameraSettings.cameraEnabled,
+            recoveryEnabled:
+              initialRobotCameraSettings.errorRecoveryCameraEnabled,
+            liveStreamEnabled: initialRobotCameraSettings.liveStreamEnabled,
+          })
+        )
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [initialRobotCameraSettings]
+  )
 
   const appCameraSettings = useSelector((state: State) =>
     getCameraUsageState(state, runId)

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -205,7 +205,10 @@ function PrepareToRun({
         transactionId: runId,
       })
     }
-  }, [storageInfo.isImageStorageLow != null])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [storageInfo.isImageStorageLow != null])
   const mostRecentAnalysisSummary = last(protocolRecord?.data.analysisSummaries)
   const [isPollingForCompletedAnalysis, setIsPollingForCompletedAnalysis] =
     useState<boolean>(mostRecentAnalysisSummary?.status !== 'completed')
@@ -865,7 +868,10 @@ export function ProtocolSetup(): JSX.Element {
         })
       )
     }
-  }, [initialRobotCameraSettings])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [initialRobotCameraSettings])
 
   const appCameraSettings = useSelector((state: State) =>
     getCameraUsageState(state, runId)

--- a/app/src/pages/ODD/QuickTransferDetails/index.tsx
+++ b/app/src/pages/ODD/QuickTransferDetails/index.tsx
@@ -95,7 +95,10 @@ const QuickTransferHeader = ({
         name: title,
       },
     })
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   return (
     <Flex

--- a/app/src/pages/ODD/QuickTransferDetails/index.tsx
+++ b/app/src/pages/ODD/QuickTransferDetails/index.tsx
@@ -88,17 +88,19 @@ const QuickTransferHeader = ({
     displayedTitle = truncateString(displayedTitle, 80, 60)
   }
 
-  useEffect(() => {
-    trackEventWithRobotSerial({
-      name: ANALYTICS_QUICK_TRANSFER_DETAILS_PAGE,
-      properties: {
-        name: title,
-      },
-    })
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      trackEventWithRobotSerial({
+        name: ANALYTICS_QUICK_TRANSFER_DETAILS_PAGE,
+        properties: {
+          name: title,
+        },
+      })
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   return (
     <Flex

--- a/app/src/pages/ODD/RobotDashboard/WelcomeModal.tsx
+++ b/app/src/pages/ODD/RobotDashboard/WelcomeModal.tsx
@@ -56,6 +56,8 @@ export function WelcomeModal({
     setShowWelcomeModal(false)
   }
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(startDiscoAnimation, [])
 
   return (

--- a/app/src/pages/ODD/RunSummary/index.tsx
+++ b/app/src/pages/ODD/RunSummary/index.tsx
@@ -137,7 +137,10 @@ export function RunSummary(): JSX.Element {
     if (isRunCurrent && typeof enteredER === 'boolean') {
       reportRecoveredRunResult(runStatus, enteredER)
     }
-  }, [isRunCurrent, enteredER])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isRunCurrent, enteredER])
 
   const { reset, isResetRunLoading } = useRunControls(runId)
   const trackEvent = useTrackEvent()
@@ -242,7 +245,10 @@ export function RunSummary(): JSX.Element {
     ) {
       void determineTipStatus()
     }
-  }, [isRunCurrent, runSummaryNoFixit, isEREnabled])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isRunCurrent, runSummaryNoFixit, isEREnabled])
 
   // TODO(jh, 05-30-24): EXEC-487. Refactor reset() so we can redirect to the setup page, showing the shimmer skeleton instead.
   const runAgain = (): void => {

--- a/app/src/pages/ODD/RunSummary/index.tsx
+++ b/app/src/pages/ODD/RunSummary/index.tsx
@@ -133,14 +133,16 @@ export function RunSummary(): JSX.Element {
   const { reportRecoveredRunResult } = useRecoveryAnalytics()
 
   const enteredER = runRecord?.data.hasEverEnteredErrorRecovery ?? false
-  useEffect(() => {
-    if (isRunCurrent && typeof enteredER === 'boolean') {
-      reportRecoveredRunResult(runStatus, enteredER)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isRunCurrent, enteredER])
+  useEffect(
+    () => {
+      if (isRunCurrent && typeof enteredER === 'boolean') {
+        reportRecoveredRunResult(runStatus, enteredER)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isRunCurrent, enteredER]
+  )
 
   const { reset, isResetRunLoading } = useRunControls(runId)
   const trackEvent = useTrackEvent()
@@ -237,18 +239,20 @@ export function RunSummary(): JSX.Element {
     pageLength: 1,
   })
 
-  useEffect(() => {
-    // Only run tip checking if it wasn't *just* handled during Error Recovery.
-    if (
-      runSummaryNoFixit != null &&
-      !lastRunCommandPromptedErrorRecovery(runSummaryNoFixit, isEREnabled)
-    ) {
-      void determineTipStatus()
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isRunCurrent, runSummaryNoFixit, isEREnabled])
+  useEffect(
+    () => {
+      // Only run tip checking if it wasn't *just* handled during Error Recovery.
+      if (
+        runSummaryNoFixit != null &&
+        !lastRunCommandPromptedErrorRecovery(runSummaryNoFixit, isEREnabled)
+      ) {
+        void determineTipStatus()
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isRunCurrent, runSummaryNoFixit, isEREnabled]
+  )
 
   // TODO(jh, 05-30-24): EXEC-487. Refactor reset() so we can redirect to the setup page, showing the shimmer skeleton instead.
   const runAgain = (): void => {

--- a/app/src/pages/ODD/RunningProtocol/index.tsx
+++ b/app/src/pages/ODD/RunningProtocol/index.tsx
@@ -160,6 +160,8 @@ export function RunningProtocol(): JSX.Element {
       robotSideAnalysis != null
         ? getLabwareDefinitionsFromCommands(robotSideAnalysis.commands)
         : [],
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [isValidRobotSideAnalysis]
   )
 

--- a/app/src/pages/ODD/UpdateRobot/UpdateRobotDuringOnboarding.tsx
+++ b/app/src/pages/ODD/UpdateRobot/UpdateRobotDuringOnboarding.tsx
@@ -58,7 +58,10 @@ export function UpdateRobotDuringOnboarding(): JSX.Element {
     } else {
       return () => {}
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   const [errorString, setErrorString] = useState<string | null>(null)
   const handleSuccessfulUpdate = (): void => {

--- a/app/src/pages/ODD/UpdateRobot/UpdateRobotDuringOnboarding.tsx
+++ b/app/src/pages/ODD/UpdateRobot/UpdateRobotDuringOnboarding.tsx
@@ -47,21 +47,23 @@ export function UpdateRobotDuringOnboarding(): JSX.Element {
     getOnDeviceDisplaySettings
   )
 
-  useEffect(() => {
-    if (robotUpdateType !== 'upgrade') {
-      const checkUpdateTimer = setTimeout(() => {
-        setIsShowCheckingUpdates(false)
-      }, CHECK_UPDATES_DURATION)
-      return () => {
-        clearTimeout(checkUpdateTimer)
+  useEffect(
+    () => {
+      if (robotUpdateType !== 'upgrade') {
+        const checkUpdateTimer = setTimeout(() => {
+          setIsShowCheckingUpdates(false)
+        }, CHECK_UPDATES_DURATION)
+        return () => {
+          clearTimeout(checkUpdateTimer)
+        }
+      } else {
+        return () => {}
       }
-    } else {
-      return () => {}
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   const [errorString, setErrorString] = useState<string | null>(null)
   const handleSuccessfulUpdate = (): void => {

--- a/app/src/redux-resources/analytics/hooks/useRobotAnalyticsData.ts
+++ b/app/src/redux-resources/analytics/hooks/useRobotAnalyticsData.ts
@@ -40,27 +40,29 @@ export function useRobotAnalyticsData(
   }, [dispatch, robotName])
 
   // @ts-expect-error RobotAnalyticsData type needs boolean values should it be boolean | string
-  return useMemo(() => {
-    if (robot != null) {
-      return settings.reduce<RobotAnalyticsData>(
-        (result, setting) => ({
-          ...result,
-          [`${FF_PREFIX}${setting.id}`]: !!(setting?.value ?? false),
-        }),
-        // @ts-expect-error RobotAnalyticsData type needs boolean values should it be boolean | string
-        {
-          robotApiServerVersion: getRobotApiVersion(robot) ?? '',
-          robotSmoothieVersion: getRobotFirmwareVersion(robot) ?? '',
-          robotLeftPipette: pipettes.left?.model ?? '',
-          robotRightPipette: pipettes.right?.model ?? '',
-          robotSerialNumber: serialNumber ?? '',
-        }
-      )
-    }
+  return useMemo(
+    () => {
+      if (robot != null) {
+        return settings.reduce<RobotAnalyticsData>(
+          (result, setting) => ({
+            ...result,
+            [`${FF_PREFIX}${setting.id}`]: !!(setting?.value ?? false),
+          }),
+          // @ts-expect-error RobotAnalyticsData type needs boolean values should it be boolean | string
+          {
+            robotApiServerVersion: getRobotApiVersion(robot) ?? '',
+            robotSmoothieVersion: getRobotFirmwareVersion(robot) ?? '',
+            robotLeftPipette: pipettes.left?.model ?? '',
+            robotRightPipette: pipettes.right?.model ?? '',
+            robotSerialNumber: serialNumber ?? '',
+          }
+        )
+      }
 
-    return null
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [pipettes, robot, settings])
+      return null
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [pipettes, robot, settings]
+  )
 }

--- a/app/src/redux-resources/analytics/hooks/useRobotAnalyticsData.ts
+++ b/app/src/redux-resources/analytics/hooks/useRobotAnalyticsData.ts
@@ -59,5 +59,8 @@ export function useRobotAnalyticsData(
     }
 
     return null
-  }, [pipettes, robot, settings])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [pipettes, robot, settings])
 }

--- a/app/src/redux-resources/runs/hooks/useRequiredSetupStepsInOrder.ts
+++ b/app/src/redux-resources/runs/hooks/useRequiredSetupStepsInOrder.ts
@@ -123,7 +123,10 @@ export function useRequiredSetupStepsInOrder({
         ),
       })
     )
-  }, [runId, dispatch, keyFor(protocolAnalysis), noLwOffsetsInRun])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [runId, dispatch, keyFor(protocolAnalysis), noLwOffsetsInRun])
   return protocolAnalysis == null
     ? {
         orderedSteps: NO_ANALYSIS_STEPS_IN_ORDER,

--- a/app/src/redux-resources/runs/hooks/useRequiredSetupStepsInOrder.ts
+++ b/app/src/redux-resources/runs/hooks/useRequiredSetupStepsInOrder.ts
@@ -104,29 +104,31 @@ export function useRequiredSetupStepsInOrder({
     protocolAnalysis?.labware.length === 0 &&
     protocolAnalysis?.liquids.length === 0
 
-  useEffect(() => {
-    const applicable = keysInOrder(
-      protocolAnalysis,
-      noLwOffsetsInRun,
-      noLabwareOrLiquidsInRun
-    )
-    dispatch(
-      updateRunSetupStepsRequired(runId, {
-        ...ALL_STEPS_IN_ORDER.reduce<
-          UpdateRunSetupStepsRequiredAction['payload']['required']
-        >(
-          (acc, thiskey) => ({
-            ...acc,
-            [thiskey]: applicable.orderedApplicableSteps.includes(thiskey),
-          }),
-          {}
-        ),
-      })
-    )
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [runId, dispatch, keyFor(protocolAnalysis), noLwOffsetsInRun])
+  useEffect(
+    () => {
+      const applicable = keysInOrder(
+        protocolAnalysis,
+        noLwOffsetsInRun,
+        noLabwareOrLiquidsInRun
+      )
+      dispatch(
+        updateRunSetupStepsRequired(runId, {
+          ...ALL_STEPS_IN_ORDER.reduce<
+            UpdateRunSetupStepsRequiredAction['payload']['required']
+          >(
+            (acc, thiskey) => ({
+              ...acc,
+              [thiskey]: applicable.orderedApplicableSteps.includes(thiskey),
+            }),
+            {}
+          ),
+        })
+      )
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [runId, dispatch, keyFor(protocolAnalysis), noLwOffsetsInRun]
+  )
   return protocolAnalysis == null
     ? {
         orderedSteps: NO_ANALYSIS_STEPS_IN_ORDER,

--- a/app/src/resources/dataFiles/useImage.ts
+++ b/app/src/resources/dataFiles/useImage.ts
@@ -13,16 +13,18 @@ export function useImage(imageId: string): string | null {
     { responseType: 'blob' }
   )
 
-  return useMemo(() => {
-    if (data == null) {
-      return null
-    } else {
-      const blob = new Blob([data], { type: MIME_TYPES.IMAGE })
+  return useMemo(
+    () => {
+      if (data == null) {
+        return null
+      } else {
+        const blob = new Blob([data], { type: MIME_TYPES.IMAGE })
 
-      return URL.createObjectURL(blob)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [dataUpdatedAt])
+        return URL.createObjectURL(blob)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dataUpdatedAt]
+  )
 }

--- a/app/src/resources/dataFiles/useImage.ts
+++ b/app/src/resources/dataFiles/useImage.ts
@@ -21,5 +21,8 @@ export function useImage(imageId: string): string | null {
 
       return URL.createObjectURL(blob)
     }
-  }, [dataUpdatedAt])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [dataUpdatedAt])
 }

--- a/app/src/resources/dataFiles/useImageInfo.ts
+++ b/app/src/resources/dataFiles/useImageInfo.ts
@@ -45,6 +45,8 @@ export function useImageInfo(runId: string): UseImagesInfoResult {
       protocolAnalysis != null
         ? getLabwareDefinitionsFromCommands(protocolAnalysis.commands)
         : [],
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [isValidProtocolAnalysis]
   )
   const items = useMemo(() => {

--- a/app/src/resources/useNotifyDataReady.ts
+++ b/app/src/resources/useNotifyDataReady.ts
@@ -97,7 +97,10 @@ export function useNotifyDataReady<TData, TError = Error>({
         })
       }
     }
-  }, [topic, hostname, shouldUseNotifications])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [topic, hostname, shouldUseNotifications])
 
   const onDataEvent = useCallback((data: NotifyResponseData): void => {
     if (data === 'ECONNFAILED' || data === 'ECONNREFUSED') {
@@ -122,7 +125,10 @@ export function useNotifyDataReady<TData, TError = Error>({
         }
       })
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   const notifyOnSettled = useCallback(
     (data: TData | undefined, error: TError | null) => {
@@ -134,6 +140,8 @@ export function useNotifyDataReady<TData, TError = Error>({
       }
       options.onSettled?.(data, error)
     },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [refetch, pendingRefetch, options.onSettled]
   )
 

--- a/app/src/resources/useNotifyDataReady.ts
+++ b/app/src/resources/useNotifyDataReady.ts
@@ -74,61 +74,65 @@ export function useNotifyDataReady<TData, TError = Error>({
     staleTime !== Infinity &&
     !forcePollingFF
 
-  useEffect(() => {
-    if (shouldUseNotifications) {
-      // Always fetch on initial mount to keep latency as low as possible.
-      setRefetch('once')
-      appShellListener({
-        hostname,
-        notifyTopic: topic,
-        callback: onDataEvent,
-      })
-      dispatch(notifySubscribeAction(hostname, topic))
-      seenHostname.current = hostname
-    }
-
-    return () => {
-      if (seenHostname.current != null) {
+  useEffect(
+    () => {
+      if (shouldUseNotifications) {
+        // Always fetch on initial mount to keep latency as low as possible.
+        setRefetch('once')
         appShellListener({
-          hostname: seenHostname.current,
+          hostname,
           notifyTopic: topic,
           callback: onDataEvent,
-          isDismounting: true,
         })
+        dispatch(notifySubscribeAction(hostname, topic))
+        seenHostname.current = hostname
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [topic, hostname, shouldUseNotifications])
 
-  const onDataEvent = useCallback((data: NotifyResponseData): void => {
-    if (data === 'ECONNFAILED' || data === 'ECONNREFUSED') {
-      setHasEncounteredNotificationsError(true)
-      if (data === 'ECONNREFUSED') {
-        doTrackEvent({
-          name: ANALYTICS_NOTIFICATION_PORT_BLOCK_ERROR,
-          properties: {},
+      return () => {
+        if (seenHostname.current != null) {
+          appShellListener({
+            hostname: seenHostname.current,
+            notifyTopic: topic,
+            callback: onDataEvent,
+            isDismounting: true,
+          })
+        }
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [topic, hostname, shouldUseNotifications]
+  )
+
+  const onDataEvent = useCallback(
+    (data: NotifyResponseData): void => {
+      if (data === 'ECONNFAILED' || data === 'ECONNREFUSED') {
+        setHasEncounteredNotificationsError(true)
+        if (data === 'ECONNREFUSED') {
+          doTrackEvent({
+            name: ANALYTICS_NOTIFICATION_PORT_BLOCK_ERROR,
+            properties: {},
+          })
+        }
+      } else if ('refetch' in data || 'unsubscribe' in data) {
+        setRefetch(currentRefetch => {
+          // A refetch is already in progress, mark that we need to do another
+          // one after the current refetch resolves.
+          if (currentRefetch === 'once') {
+            setPendingRefetch(true)
+            return currentRefetch
+          }
+          // No refetch is in progress, start one immediately.
+          else {
+            return 'once'
+          }
         })
       }
-    } else if ('refetch' in data || 'unsubscribe' in data) {
-      setRefetch(currentRefetch => {
-        // A refetch is already in progress, mark that we need to do another
-        // one after the current refetch resolves.
-        if (currentRefetch === 'once') {
-          setPendingRefetch(true)
-          return currentRefetch
-        }
-        // No refetch is in progress, start one immediately.
-        else {
-          return 'once'
-        }
-      })
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   const notifyOnSettled = useCallback(
     (data: TData | undefined, error: TError | null) => {

--- a/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
+++ b/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
@@ -243,7 +243,10 @@ function usePositionChangeReset(
 
     previousInitialRef.current = initialPosition
     previousFinalRef.current = finalPosition
-  }, [initialPosition, finalPosition])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [initialPosition, finalPosition])
 
   const previousInitialRef = useRef(initialPosition)
   const previousFinalRef = useRef(finalPosition)

--- a/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
+++ b/components/src/hardware-sim/Deck/MoveLabwareOnDeck.tsx
@@ -225,28 +225,30 @@ function usePositionChangeReset(
 ): boolean {
   const [shouldReset, setShouldReset] = useState(false)
 
-  useLayoutEffect(() => {
-    if (shouldReset) {
-      setShouldReset(false)
-      return
-    }
+  useLayoutEffect(
+    () => {
+      if (shouldReset) {
+        setShouldReset(false)
+        return
+      }
 
-    const isNewPosition =
-      previousInitialRef.current?.x !== initialPosition.x ||
-      previousInitialRef.current?.y !== initialPosition.y ||
-      previousFinalRef.current?.x !== finalPosition.x ||
-      previousFinalRef.current?.y !== finalPosition.y
+      const isNewPosition =
+        previousInitialRef.current?.x !== initialPosition.x ||
+        previousInitialRef.current?.y !== initialPosition.y ||
+        previousFinalRef.current?.x !== finalPosition.x ||
+        previousFinalRef.current?.y !== finalPosition.y
 
-    if (isNewPosition) {
-      setShouldReset(true)
-    }
+      if (isNewPosition) {
+        setShouldReset(true)
+      }
 
-    previousInitialRef.current = initialPosition
-    previousFinalRef.current = finalPosition
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [initialPosition, finalPosition])
+      previousInitialRef.current = initialPosition
+      previousFinalRef.current = finalPosition
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [initialPosition, finalPosition]
+  )
 
   const previousInitialRef = useRef(initialPosition)
   const previousFinalRef = useRef(finalPosition)

--- a/components/src/hooks/useDrag.ts
+++ b/components/src/hooks/useDrag.ts
@@ -66,8 +66,10 @@ export const useDrag = (position: ElementPosition): UseDragResult => {
       disable()
     }
     return disable
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isEnabled])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isEnabled])
 
   return {
     ref: interactiveRef,

--- a/components/src/hooks/useDrag.ts
+++ b/components/src/hooks/useDrag.ts
@@ -59,17 +59,19 @@ export const useDrag = (position: ElementPosition): UseDragResult => {
     }
   }
 
-  useEffect(() => {
-    if (isEnabled) {
-      enable()
-    } else {
-      disable()
-    }
-    return disable
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isEnabled])
+  useEffect(
+    () => {
+      if (isEnabled) {
+        enable()
+      } else {
+        disable()
+      }
+      return disable
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isEnabled]
+  )
 
   return {
     ref: interactiveRef,

--- a/components/src/hooks/useLongPress.ts
+++ b/components/src/hooks/useLongPress.ts
@@ -61,8 +61,10 @@ export const useLongPress = (): UseLongPressResult => {
       disable()
     }
     return disable
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isEnabled])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isEnabled])
 
   return {
     ref: interactiveRef,

--- a/components/src/hooks/useLongPress.ts
+++ b/components/src/hooks/useLongPress.ts
@@ -54,17 +54,19 @@ export const useLongPress = (): UseLongPressResult => {
     }
   }
 
-  useEffect(() => {
-    if (isEnabled) {
-      enable()
-    } else {
-      disable()
-    }
-    return disable
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isEnabled])
+  useEffect(
+    () => {
+      if (isEnabled) {
+        enable()
+      } else {
+        disable()
+      }
+      return disable
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isEnabled]
+  )
 
   return {
     ref: interactiveRef,

--- a/components/src/hooks/useMountEffect.ts
+++ b/components/src/hooks/useMountEffect.ts
@@ -10,5 +10,7 @@ import type { EffectCallback } from 'react'
  */
 export function useMountEffect(callback: EffectCallback): void {
   // call useEffect with an empty dependency list so it's only called on mount
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(callback, [])
 }

--- a/components/src/hooks/useSwipe.ts
+++ b/components/src/hooks/useSwipe.ts
@@ -66,8 +66,10 @@ export const useSwipe = (): UseSwipeResult => {
       disable()
     }
     return disable
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isEnabled])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isEnabled])
 
   return {
     ref: interactiveRef,

--- a/components/src/hooks/useSwipe.ts
+++ b/components/src/hooks/useSwipe.ts
@@ -59,17 +59,19 @@ export const useSwipe = (): UseSwipeResult => {
     }
   }
 
-  useEffect(() => {
-    if (isEnabled) {
-      enable()
-    } else {
-      disable()
-    }
-    return disable
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isEnabled])
+  useEffect(
+    () => {
+      if (isEnabled) {
+        enable()
+      } else {
+        disable()
+      }
+      return disable
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isEnabled]
+  )
 
   return {
     ref: interactiveRef,

--- a/labware-library/src/labware-creator/index.tsx
+++ b/labware-library/src/labware-creator/index.tsx
@@ -325,6 +325,8 @@ export const LabwareCreator = (props: LabwareCreatorProps): JSX.Element => {
         reader.readAsText(file)
       }
     },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [scrollToForm, proceed, setLastUploaded, setImportError]
   )
 

--- a/opentrons-ai-client/src/OpentronsAI.tsx
+++ b/opentrons-ai-client/src/OpentronsAI.tsx
@@ -64,26 +64,30 @@ function OpentronsAIApp(): JSX.Element | null {
     initializeMixpanel(mixpanelState)
   }
 
-  useEffect(() => {
-    if (!isAuthenticated && !isLoading) {
-      void loginWithRedirect()
-    }
-    if (isAuthenticated) {
-      void fetchAccessToken()
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isAuthenticated, isLoading, loginWithRedirect])
+  useEffect(
+    () => {
+      if (!isAuthenticated && !isLoading) {
+        void loginWithRedirect()
+      }
+      if (isAuthenticated) {
+        void fetchAccessToken()
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isAuthenticated, isLoading, loginWithRedirect]
+  )
 
-  useEffect(() => {
-    if (isAuthenticated) {
-      trackEvent({ name: 'user-login', properties: {} })
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isAuthenticated])
+  useEffect(
+    () => {
+      if (isAuthenticated) {
+        trackEvent({ name: 'user-login', properties: {} })
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isAuthenticated]
+  )
 
   // Sync feature flag changes with Mixpanel analytics state
   useEffect(() => {

--- a/opentrons-ai-client/src/OpentronsAI.tsx
+++ b/opentrons-ai-client/src/OpentronsAI.tsx
@@ -71,13 +71,19 @@ function OpentronsAIApp(): JSX.Element | null {
     if (isAuthenticated) {
       void fetchAccessToken()
     }
-  }, [isAuthenticated, isLoading, loginWithRedirect])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isAuthenticated, isLoading, loginWithRedirect])
 
   useEffect(() => {
     if (isAuthenticated) {
       trackEvent({ name: 'user-login', properties: {} })
     }
-  }, [isAuthenticated])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isAuthenticated])
 
   // Sync feature flag changes with Mixpanel analytics state
   useEffect(() => {

--- a/opentrons-ai-client/src/components/atoms/SendButton/index.tsx
+++ b/opentrons-ai-client/src/components/atoms/SendButton/index.tsx
@@ -28,28 +28,30 @@ export function SendButton({
   const [buttonText, setButtonText] = useState(progressTexts[0])
   const [, setProgressIndex] = useState(0)
 
-  useEffect(() => {
-    if (isLoading) {
-      const interval = setInterval(() => {
-        setProgressIndex(prevIndex => {
-          let newIndex = prevIndex + 1
-          if (newIndex > progressTexts.length - 1) {
-            newIndex = progressTexts.length - 1
-          }
-          return newIndex
-        })
-      }, 10000)
+  useEffect(
+    () => {
+      if (isLoading) {
+        const interval = setInterval(() => {
+          setProgressIndex(prevIndex => {
+            let newIndex = prevIndex + 1
+            if (newIndex > progressTexts.length - 1) {
+              newIndex = progressTexts.length - 1
+            }
+            return newIndex
+          })
+        }, 10000)
 
-      return () => {
-        setProgressIndex(0)
-        setButtonText(progressTexts[0])
-        clearInterval(interval)
+        return () => {
+          setProgressIndex(0)
+          setButtonText(progressTexts[0])
+          clearInterval(interval)
+        }
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isLoading])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isLoading]
+  )
 
   return (
     <button

--- a/opentrons-ai-client/src/components/atoms/SendButton/index.tsx
+++ b/opentrons-ai-client/src/components/atoms/SendButton/index.tsx
@@ -46,7 +46,10 @@ export function SendButton({
         clearInterval(interval)
       }
     }
-  }, [isLoading])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isLoading])
 
   return (
     <button

--- a/opentrons-ai-client/src/components/molecules/FeedbackModal/index.tsx
+++ b/opentrons-ai-client/src/components/molecules/FeedbackModal/index.tsx
@@ -83,7 +83,10 @@ export function FeedbackModal(): JSX.Element {
       }
       setIsSubmitting(false)
     }
-  }, [isSubmitting, isLoading, error, data, feedbackValue])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isSubmitting, isLoading, error, data, feedbackValue])
 
   return (
     <Modal

--- a/opentrons-ai-client/src/components/molecules/FeedbackModal/index.tsx
+++ b/opentrons-ai-client/src/components/molecules/FeedbackModal/index.tsx
@@ -69,24 +69,26 @@ export function FeedbackModal(): JSX.Element {
     await callApi(config as AxiosRequestConfig)
   }
 
-  useEffect(() => {
-    if (isSubmitting && !isLoading) {
-      if (!error && data) {
-        // Success - track event and close modal
-        trackEvent({
-          name: ANALYTICS.FEEDBACK_SENT,
-          properties: {
-            feedback: feedbackValue,
-          },
-        })
-        setShowFeedbackModal(false)
+  useEffect(
+    () => {
+      if (isSubmitting && !isLoading) {
+        if (!error && data) {
+          // Success - track event and close modal
+          trackEvent({
+            name: ANALYTICS.FEEDBACK_SENT,
+            properties: {
+              feedback: feedbackValue,
+            },
+          })
+          setShowFeedbackModal(false)
+        }
+        setIsSubmitting(false)
       }
-      setIsSubmitting(false)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isSubmitting, isLoading, error, data, feedbackValue])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isSubmitting, isLoading, error, data, feedbackValue]
+  )
 
   return (
     <Modal

--- a/opentrons-ai-client/src/components/organisms/InstrumentsSection/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/InstrumentsSection/index.tsx
@@ -101,33 +101,35 @@ export function InstrumentsSection(): JSX.Element | null {
     { name: t('96_channel_1000ul'), value: 'Flex 96-Channel 1000uL pipette' },
   ]
 
-  const pipetteOptions = useMemo(() => {
-    const allPipetteOptions = getAllPipetteNames('maxVolume', 'channels')
-      .filter(name =>
-        (robotType === OPENTRONS_OT2 ? OT2_PIPETTES : OT3_PIPETTES).includes(
-          name
+  const pipetteOptions = useMemo(
+    () => {
+      const allPipetteOptions = getAllPipetteNames('maxVolume', 'channels')
+        .filter(name =>
+          (robotType === OPENTRONS_OT2 ? OT2_PIPETTES : OT3_PIPETTES).includes(
+            name
+          )
         )
-      )
-      .filter(name => {
-        const specs = getPipetteSpecsV2(name)
-        return !specs?.displayName?.includes('GEN1')
-      })
-      .map(name => ({
-        value: name,
-        name: getPipetteSpecsV2(name)?.displayName ?? '',
-      }))
-      .filter(o => {
-        return (
-          o.value !== 'p1000_96' &&
-          o.value !== 'p1000_multi_em_flex' &&
-          o.value !== 'p200_96'
-        )
-      })
-    return [{ name: t('none'), value: NO_PIPETTES }, ...allPipetteOptions]
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [robotType])
+        .filter(name => {
+          const specs = getPipetteSpecsV2(name)
+          return !specs?.displayName?.includes('GEN1')
+        })
+        .map(name => ({
+          value: name,
+          name: getPipetteSpecsV2(name)?.displayName ?? '',
+        }))
+        .filter(o => {
+          return (
+            o.value !== 'p1000_96' &&
+            o.value !== 'p1000_multi_em_flex' &&
+            o.value !== 'p200_96'
+          )
+        })
+      return [{ name: t('none'), value: NO_PIPETTES }, ...allPipetteOptions]
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [robotType]
+  )
 
   return (
     <Flex

--- a/opentrons-ai-client/src/components/organisms/InstrumentsSection/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/InstrumentsSection/index.tsx
@@ -124,7 +124,10 @@ export function InstrumentsSection(): JSX.Element | null {
         )
       })
     return [{ name: t('none'), value: NO_PIPETTES }, ...allPipetteOptions]
-  }, [robotType])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [robotType])
 
   return (
     <Flex

--- a/opentrons-ai-client/src/components/organisms/LabwareModal/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/LabwareModal/index.tsx
@@ -61,34 +61,36 @@ export function LabwareModal({
 
   const defs = getOnlyLatestDefs()
 
-  const labwareByCategory: Record<string, LabwareDefinition[]> = useMemo(() => {
-    const groupedLabware = reduce<
-      LabwareDefByDefURI,
-      Record<string, LabwareDefinition[]>
-    >(
-      defs,
-      (acc, def) => {
-        const category = def.metadata.displayCategory
-        return {
-          ...acc,
-          [category]: [...(acc[category] ?? []), def],
-        }
-      },
-      {}
-    )
-
-    // Sort each category's labware by display name in place
-    for (const category in groupedLabware) {
-      groupedLabware[category].sort((a, b) =>
-        a.metadata.displayName.localeCompare(b.metadata.displayName)
+  const labwareByCategory: Record<string, LabwareDefinition[]> = useMemo(
+    () => {
+      const groupedLabware = reduce<
+        LabwareDefByDefURI,
+        Record<string, LabwareDefinition[]>
+      >(
+        defs,
+        (acc, def) => {
+          const category = def.metadata.displayCategory
+          return {
+            ...acc,
+            [category]: [...(acc[category] ?? []), def],
+          }
+        },
+        {}
       )
-    }
 
-    return groupedLabware
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+      // Sort each category's labware by display name in place
+      for (const category in groupedLabware) {
+        groupedLabware[category].sort((a, b) =>
+          a.metadata.displayName.localeCompare(b.metadata.displayName)
+        )
+      }
+
+      return groupedLabware
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   const populatedCategories: Record<string, boolean> = useMemo(
     () =>
@@ -108,14 +110,16 @@ export function LabwareModal({
     [labwareByCategory, searchTerm]
   )
 
-  useEffect(() => {
-    if (displayLabwareModal) {
-      setSelectedLabwares(labwares.map(lw => lw.labwareURI))
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [displayLabwareModal])
+  useEffect(
+    () => {
+      if (displayLabwareModal) {
+        setSelectedLabwares(labwares.map(lw => lw.labwareURI))
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [displayLabwareModal]
+  )
 
   const handleCategoryClick = (category: string): void => {
     setSelectedCategory(selectedCategory === category ? null : category)

--- a/opentrons-ai-client/src/components/organisms/LabwareModal/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/LabwareModal/index.tsx
@@ -85,7 +85,10 @@ export function LabwareModal({
     }
 
     return groupedLabware
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   const populatedCategories: Record<string, boolean> = useMemo(
     () =>
@@ -100,6 +103,8 @@ export function LabwareModal({
             }
           : acc
       }, {}),
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [labwareByCategory, searchTerm]
   )
 
@@ -107,7 +112,10 @@ export function LabwareModal({
     if (displayLabwareModal) {
       setSelectedLabwares(labwares.map(lw => lw.labwareURI))
     }
-  }, [displayLabwareModal])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [displayLabwareModal])
 
   const handleCategoryClick = (category: string): void => {
     setSelectedCategory(selectedCategory === category ? null : category)

--- a/opentrons-ai-client/src/components/organisms/ProtocolSectionsContainer/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/ProtocolSectionsContainer/index.tsx
@@ -94,7 +94,10 @@ export function ProtocolSectionsContainer(): JSX.Element | null {
 
   useEffect(() => {
     trigger()
-  }, [focusSection])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [focusSection])
 
   function handleSectionClick(stepNumber: number): void {
     currentSection >= stepNumber &&

--- a/opentrons-ai-client/src/components/organisms/ProtocolSectionsContainer/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/ProtocolSectionsContainer/index.tsx
@@ -92,12 +92,14 @@ export function ProtocolSectionsContainer(): JSX.Element | null {
     },
   ]
 
-  useEffect(() => {
-    trigger()
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [focusSection])
+  useEffect(
+    () => {
+      trigger()
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [focusSection]
+  )
 
   function handleSectionClick(stepNumber: number): void {
     currentSection >= stepNumber &&

--- a/opentrons-ai-client/src/pages/Chat/index.tsx
+++ b/opentrons-ai-client/src/pages/Chat/index.tsx
@@ -42,18 +42,20 @@ export function Chat(): JSX.Element | null {
 
   // Redirect to home page if there is no prompt (user has refreshed the page)
   // Exception: Allow direct chat access
-  useEffect(() => {
-    if (
-      updateProtocolChat.prompt === '' &&
-      createProtocolChat.prompt === '' &&
-      !isDirectChatAccess
-    ) {
-      navigate('/')
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      if (
+        updateProtocolChat.prompt === '' &&
+        createProtocolChat.prompt === '' &&
+        !isDirectChatAccess
+      ) {
+        navigate('/')
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   useEffect(() => {
     if (scrollRef.current != null)

--- a/opentrons-ai-client/src/pages/Chat/index.tsx
+++ b/opentrons-ai-client/src/pages/Chat/index.tsx
@@ -50,7 +50,10 @@ export function Chat(): JSX.Element | null {
     ) {
       navigate('/')
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   useEffect(() => {
     if (scrollRef.current != null)

--- a/opentrons-ai-client/src/pages/CreateProtocol/index.tsx
+++ b/opentrons-ai-client/src/pages/CreateProtocol/index.tsx
@@ -126,14 +126,20 @@ export function CreateProtocol(): JSX.Element | null {
     })
     setChatHistoryAtom([])
     setChatData([])
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   useEffect(() => {
     setHeaderWithMeterAtom({
       displayHeaderWithMeter: true,
       progress: calculateProgress(),
     })
-  }, [currentSection])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [currentSection])
 
   useEffect(() => {
     return () => {
@@ -148,7 +154,10 @@ export function CreateProtocol(): JSX.Element | null {
         focusSection: 0,
       })
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   useEffect(() => {
     if (parentRef.current != null) {
@@ -173,7 +182,10 @@ export function CreateProtocol(): JSX.Element | null {
       window.removeEventListener('mousemove', handleMouseMove)
       window.removeEventListener('mouseup', handleMouseUp)
     }
-  }, [isResizing])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isResizing])
 
   function calculateProgress(): number {
     return currentSection > 0 ? currentSection / TOTAL_STEPS : 0

--- a/opentrons-ai-client/src/pages/CreateProtocol/index.tsx
+++ b/opentrons-ai-client/src/pages/CreateProtocol/index.tsx
@@ -101,63 +101,69 @@ export function CreateProtocol(): JSX.Element | null {
   })
 
   // Reset the chat data atom and protocol atoms when navigating to the update protocol page
-  useEffect(() => {
-    setCreateProtocolChatAtom({
-      prompt: '',
-      regenerate: false,
-      scientific_application_type: '',
-      description: '',
-      robots: 'opentrons_flex',
-      mounts: [],
-      flexGripper: false,
-      modules: [],
-      labware: [],
-      liquids: [],
-      steps: [],
-      fake: false,
-    })
-    setUpdateProtocolChatAtom({
-      prompt: '',
-      protocol_text: '',
-      regenerate: false,
-      update_type: 'adapt_python_protocol',
-      update_details: '',
-      fake: false,
-    })
-    setChatHistoryAtom([])
-    setChatData([])
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      setCreateProtocolChatAtom({
+        prompt: '',
+        regenerate: false,
+        scientific_application_type: '',
+        description: '',
+        robots: 'opentrons_flex',
+        mounts: [],
+        flexGripper: false,
+        modules: [],
+        labware: [],
+        liquids: [],
+        steps: [],
+        fake: false,
+      })
+      setUpdateProtocolChatAtom({
+        prompt: '',
+        protocol_text: '',
+        regenerate: false,
+        update_type: 'adapt_python_protocol',
+        update_details: '',
+        fake: false,
+      })
+      setChatHistoryAtom([])
+      setChatData([])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
-  useEffect(() => {
-    setHeaderWithMeterAtom({
-      displayHeaderWithMeter: true,
-      progress: calculateProgress(),
-    })
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [currentSection])
-
-  useEffect(() => {
-    return () => {
+  useEffect(
+    () => {
       setHeaderWithMeterAtom({
-        displayHeaderWithMeter: false,
-        progress: 0,
+        displayHeaderWithMeter: true,
+        progress: calculateProgress(),
       })
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [currentSection]
+  )
 
-      methods.reset()
-      setCreateProtocolAtom({
-        currentSection: 0,
-        focusSection: 0,
-      })
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      return () => {
+        setHeaderWithMeterAtom({
+          displayHeaderWithMeter: false,
+          progress: 0,
+        })
+
+        methods.reset()
+        setCreateProtocolAtom({
+          currentSection: 0,
+          focusSection: 0,
+        })
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   useEffect(() => {
     if (parentRef.current != null) {
@@ -169,23 +175,25 @@ export function CreateProtocol(): JSX.Element | null {
     }
   }, [])
 
-  useEffect(() => {
-    if (isResizing) {
-      window.addEventListener('mousemove', handleMouseMove)
-      window.addEventListener('mouseup', handleMouseUp)
-    } else {
-      window.removeEventListener('mousemove', handleMouseMove)
-      window.removeEventListener('mouseup', handleMouseUp)
-    }
+  useEffect(
+    () => {
+      if (isResizing) {
+        window.addEventListener('mousemove', handleMouseMove)
+        window.addEventListener('mouseup', handleMouseUp)
+      } else {
+        window.removeEventListener('mousemove', handleMouseMove)
+        window.removeEventListener('mouseup', handleMouseUp)
+      }
 
-    return () => {
-      window.removeEventListener('mousemove', handleMouseMove)
-      window.removeEventListener('mouseup', handleMouseUp)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isResizing])
+      return () => {
+        window.removeEventListener('mousemove', handleMouseMove)
+        window.removeEventListener('mouseup', handleMouseUp)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isResizing]
+  )
 
   function calculateProgress(): number {
     return currentSection > 0 ? currentSection / TOTAL_STEPS : 0

--- a/opentrons-ai-client/src/resources/hooks/useInputPromptController.ts
+++ b/opentrons-ai-client/src/resources/hooks/useInputPromptController.ts
@@ -89,42 +89,48 @@ export function useInputPromptController(
     clearFiles,
   } = useAttachFiles()
 
-  useEffect(() => {
-    const prefilledPrompt = isNewProtocol
-      ? createProtocol.prompt
-      : updateProtocol.prompt
+  useEffect(
+    () => {
+      const prefilledPrompt = isNewProtocol
+        ? createProtocol.prompt
+        : updateProtocol.prompt
 
-    if (prefilledPrompt !== '') {
-      setUserPrompt(prefilledPrompt)
-      setSendAutoFilledPrompt(true)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+      if (prefilledPrompt !== '') {
+        setUserPrompt(prefilledPrompt)
+        setSendAutoFilledPrompt(true)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
-  useEffect(() => {
-    if (sendAutoFilledPrompt) {
-      void handleClick(true)
-      setSendAutoFilledPrompt(false)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [sendAutoFilledPrompt])
+  useEffect(
+    () => {
+      if (sendAutoFilledPrompt) {
+        void handleClick(true)
+        setSendAutoFilledPrompt(false)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sendAutoFilledPrompt]
+  )
 
-  useEffect(() => {
-    if (regenerateProtocol.regenerate) {
-      void handleClick(regenerateProtocol.isCreateOrUpdateProtocol, true)
-      setRegenerateProtocol({
-        isCreateOrUpdateProtocol: false,
-        regenerate: false,
-      })
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [regenerateProtocol])
+  useEffect(
+    () => {
+      if (regenerateProtocol.regenerate) {
+        void handleClick(regenerateProtocol.isCreateOrUpdateProtocol, true)
+        setRegenerateProtocol({
+          isCreateOrUpdateProtocol: false,
+          regenerate: false,
+        })
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [regenerateProtocol]
+  )
 
   const prepareValidatedFiles = (
     isUpdateOrCreateRequest: boolean

--- a/opentrons-ai-client/src/resources/hooks/useInputPromptController.ts
+++ b/opentrons-ai-client/src/resources/hooks/useInputPromptController.ts
@@ -98,15 +98,20 @@ export function useInputPromptController(
       setUserPrompt(prefilledPrompt)
       setSendAutoFilledPrompt(true)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   useEffect(() => {
     if (sendAutoFilledPrompt) {
       void handleClick(true)
       setSendAutoFilledPrompt(false)
     }
-  }, [sendAutoFilledPrompt])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [sendAutoFilledPrompt])
 
   useEffect(() => {
     if (regenerateProtocol.regenerate) {
@@ -116,7 +121,10 @@ export function useInputPromptController(
         regenerate: false,
       })
     }
-  }, [regenerateProtocol])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [regenerateProtocol])
 
   const prepareValidatedFiles = (
     isUpdateOrCreateRequest: boolean

--- a/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
+++ b/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
@@ -86,14 +86,16 @@ export function DropdownStepFormField(
     }
   }
 
-  useEffect(() => {
-    if (options.length === 1) {
-      updateValue(options[0].value)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [options.length])
+  useEffect(
+    () => {
+      if (options.length === 1) {
+        updateValue(options[0].value)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [options.length]
+  )
 
   return (
     <Flex padding={padding ?? SPACING.spacing16}>

--- a/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
+++ b/protocol-designer/src/components/molecules/DropdownStepFormField/index.tsx
@@ -90,7 +90,10 @@ export function DropdownStepFormField(
     if (options.length === 1) {
       updateValue(options[0].value)
     }
-  }, [options.length])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [options.length])
 
   return (
     <Flex padding={padding ?? SPACING.spacing16}>

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -115,9 +115,13 @@ export function LabwareStackToolbox({
   }
 
   // select the top labware in the stack if no selected labware ids are provided
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const selectedLabware =
     selectedLabwareIds != null ? selectedLabwareIds : [topDownStackIds[0]]
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (selectedLabware[0] != null) {
       dispatch(openIngredientSelector(selectedLabware[0]))

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -148,7 +148,10 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
       ...getModuleOptions(cutoutId, addressableAreaId, deckDef, fixtures),
     ]
     setAllModuleOptions(moduleOptions)
-  }, [cutoutId, addressableAreaId, existingCutoutFixtureId])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [cutoutId, addressableAreaId, existingCutoutFixtureId])
 
   const modalProps: ModalProps = {
     title: t('add_to_slot', {

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -133,25 +133,27 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
   const [allModuleOptions, setAllModuleOptions] = useState<CutoutConfigMap[][]>(
     []
   )
-  useEffect(() => {
-    const options = [
-      ...getAllFixtureOptions(
-        cutoutId,
-        addressableAreaId,
-        fixtures,
-        existingCutoutFixtureId
-      ),
-      ...getWasteChuteOptions(cutoutId),
-    ]
-    setAllFixtureOptions(options)
-    const moduleOptions = [
-      ...getModuleOptions(cutoutId, addressableAreaId, deckDef, fixtures),
-    ]
-    setAllModuleOptions(moduleOptions)
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [cutoutId, addressableAreaId, existingCutoutFixtureId])
+  useEffect(
+    () => {
+      const options = [
+        ...getAllFixtureOptions(
+          cutoutId,
+          addressableAreaId,
+          fixtures,
+          existingCutoutFixtureId
+        ),
+        ...getWasteChuteOptions(cutoutId),
+      ]
+      setAllFixtureOptions(options)
+      const moduleOptions = [
+        ...getModuleOptions(cutoutId, addressableAreaId, deckDef, fixtures),
+      ]
+      setAllModuleOptions(moduleOptions)
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [cutoutId, addressableAreaId, existingCutoutFixtureId]
+  )
 
   const modalProps: ModalProps = {
     title: t('add_to_slot', {

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/index.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/index.tsx
@@ -118,16 +118,18 @@ export function HardwareConfigurator(
   ]
 
   //  initiate deck config
-  useEffect(() => {
-    dispatch(
-      editDeckConfiguration({
-        deckConfig: updatedDeckConfig as DeckConfiguration,
-      })
-    )
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      dispatch(
+        editDeckConfiguration({
+          deckConfig: updatedDeckConfig as DeckConfiguration,
+        })
+      )
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
   return (
     <HardwareConfiguratorContainer
       modules={modules}

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/index.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/index.tsx
@@ -124,7 +124,10 @@ export function HardwareConfigurator(
         deckConfig: updatedDeckConfig as DeckConfiguration,
       })
     )
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
   return (
     <HardwareConfiguratorContainer
       modules={modules}

--- a/protocol-designer/src/components/organisms/Labware/SelectableLabware.tsx
+++ b/protocol-designer/src/components/organisms/Labware/SelectableLabware.tsx
@@ -200,12 +200,14 @@ export const SelectableLabware = (
 
   // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    updateHighlightedWells({})
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      updateHighlightedWells({})
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   return (
     <SelectionRect

--- a/protocol-designer/src/components/organisms/Labware/SelectableLabware.tsx
+++ b/protocol-designer/src/components/organisms/Labware/SelectableLabware.tsx
@@ -198,9 +198,14 @@ export const SelectableLabware = (
     })
   }
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     updateHighlightedWells({})
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   return (
     <SelectionRect

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -128,11 +128,16 @@ export function SelectLabwareModal(
     ? allCategoriesExpanded
     : userCategoryExpandState
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (!hasNoLabware && error != null) {
       setError(null)
     }
-  }, [hasNoLabware])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [hasNoLabware])
 
   const handleResetLabwareTools = (): void => {
     setUserCategoryExpandState(allCategoriesCollapsed)
@@ -202,6 +207,8 @@ export function SelectLabwareModal(
         parameters.loadName === TIPRACK_LID_LOADNAME
       )
     },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [filterRecommended, filterHeight, getIsLabwareCompatible, moduleType, slot]
   )
 
@@ -228,7 +235,10 @@ export function SelectLabwareModal(
       },
       {}
     )
-  }, [permittedTipracks])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [permittedTipracks])
 
   const filteredLabwareByCategory: Record<string, LabwareInfo[]> = useMemo(
     () =>
@@ -266,6 +276,8 @@ export function SelectLabwareModal(
           ),
         }
       }, {}),
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [labwareByCategory, getIsLabwareFiltered, searchTerm]
   )
 

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -130,14 +130,16 @@ export function SelectLabwareModal(
 
   // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    if (!hasNoLabware && error != null) {
-      setError(null)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [hasNoLabware])
+  useEffect(
+    () => {
+      if (!hasNoLabware && error != null) {
+        setError(null)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [hasNoLabware]
+  )
 
   const handleResetLabwareTools = (): void => {
     setUserCategoryExpandState(allCategoriesCollapsed)
@@ -212,33 +214,35 @@ export function SelectLabwareModal(
     [filterRecommended, filterHeight, getIsLabwareCompatible, moduleType, slot]
   )
 
-  const labwareByCategory = useMemo(() => {
-    return reduce<
-      LabwareDefByDefURI,
-      { [category: string]: LabwareDefinition2[] }
-    >(
-      defs,
-      (acc, def: (typeof defs)[keyof typeof defs]) => {
-        const category: string = def.metadata.displayCategory
-        //  filter out non-permitted tipracks
-        if (
-          category === 'tipRack' &&
-          !permittedTipracks.includes(getLabwareDefURI(def))
-        ) {
-          return acc
-        }
+  const labwareByCategory = useMemo(
+    () => {
+      return reduce<
+        LabwareDefByDefURI,
+        { [category: string]: LabwareDefinition2[] }
+      >(
+        defs,
+        (acc, def: (typeof defs)[keyof typeof defs]) => {
+          const category: string = def.metadata.displayCategory
+          //  filter out non-permitted tipracks
+          if (
+            category === 'tipRack' &&
+            !permittedTipracks.includes(getLabwareDefURI(def))
+          ) {
+            return acc
+          }
 
-        return {
-          ...acc,
-          [category]: [...(acc[category] || []), def],
-        }
-      },
-      {}
-    )
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [permittedTipracks])
+          return {
+            ...acc,
+            [category]: [...(acc[category] || []), def],
+          }
+        },
+        {}
+      )
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [permittedTipracks]
+  )
 
   const filteredLabwareByCategory: Record<string, LabwareInfo[]> = useMemo(
     () =>

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -170,11 +170,16 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
       deckDef,
       pendingCreationStateForHopper,
     })
-  }, [activeDeckSetup, selectedZoomInSlot])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [activeDeckSetup, selectedZoomInSlot])
 
   const createdTopLabwareForSlot = activeLabware[createdStackForSlot[0]]
   const amount = createdStackForSlot?.length ?? 1
   //  initiate the slot's info
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (
       createdTopLabwareForSlot ||
@@ -192,7 +197,10 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         })
       )
     }
-  }, [
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [
     createdAdapterForSlot,
     createdLidForSlot,
     createdTopLabwareForSlot,

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -163,50 +163,54 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
     preSelectedFixture,
     slotPosition,
     isSlotAHopper,
-  } = useMemo(() => {
-    return getSlotInformation({
-      deckSetup: { ...activeDeckSetup, labware: allLabware },
-      slot: selectedZoomInSlot ?? '',
-      deckDef,
-      pendingCreationStateForHopper,
-    })
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [activeDeckSetup, selectedZoomInSlot])
+  } = useMemo(
+    () => {
+      return getSlotInformation({
+        deckSetup: { ...activeDeckSetup, labware: allLabware },
+        slot: selectedZoomInSlot ?? '',
+        deckDef,
+        pendingCreationStateForHopper,
+      })
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeDeckSetup, selectedZoomInSlot]
+  )
 
   const createdTopLabwareForSlot = activeLabware[createdStackForSlot[0]]
   const amount = createdStackForSlot?.length ?? 1
   //  initiate the slot's info
   // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    if (
-      createdTopLabwareForSlot ||
-      createdAdapterForSlot ||
-      createdLidForSlot
-    ) {
-      dispatch(
-        editSlotInfo({
-          labwareDefURI: createdTopLabwareForSlot?.labwareDefURI,
-          adapterDefURI: createdAdapterForSlot?.labwareDefURI,
-          moduleModel: createdModuleForSlot?.model,
-          fixture: preSelectedFixture,
-          lidDefURI: createdLidForSlot?.labwareDefURI,
-          amount,
-        })
-      )
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [
-    createdAdapterForSlot,
-    createdLidForSlot,
-    createdTopLabwareForSlot,
-    amount,
-    selectedZoomInSlot,
-  ])
+  useEffect(
+    () => {
+      if (
+        createdTopLabwareForSlot ||
+        createdAdapterForSlot ||
+        createdLidForSlot
+      ) {
+        dispatch(
+          editSlotInfo({
+            labwareDefURI: createdTopLabwareForSlot?.labwareDefURI,
+            adapterDefURI: createdAdapterForSlot?.labwareDefURI,
+            moduleModel: createdModuleForSlot?.model,
+            fixture: preSelectedFixture,
+            lidDefURI: createdLidForSlot?.labwareDefURI,
+            amount,
+          })
+        )
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      createdAdapterForSlot,
+      createdLidForSlot,
+      createdTopLabwareForSlot,
+      amount,
+      selectedZoomInSlot,
+    ]
+  )
 
   const allModules: ModuleOnDeck[] = values(activeDeckSetup.modules)
   const isMenuListIdForHopper =

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/AdapterControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/AdapterControls.tsx
@@ -112,6 +112,8 @@ export const AdapterControls = (
         draggedItem: monitor.getItem() as DroppedItem,
       }),
     }),
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [swapBlocked, customLabwareDefs]
   )
 

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/LabwareControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/LabwareControls.tsx
@@ -126,17 +126,19 @@ export const LabwareControls = (
 
   // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    if (draggedLabware != null) {
-      setDraggedLabware(draggedLabware?.labwareOnDeck)
-    } else {
-      setHoveredLabware(null)
-      setDraggedLabware(null)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [draggedLabware])
+  useEffect(
+    () => {
+      if (draggedLabware != null) {
+        setDraggedLabware(draggedLabware?.labwareOnDeck)
+      } else {
+        setHoveredLabware(null)
+        setDraggedLabware(null)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [draggedLabware]
+  )
 
   const isBeingDragged =
     draggedLabware?.labwareOnDeck?.stack != null &&

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/LabwareControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/LabwareControls.tsx
@@ -113,13 +113,19 @@ export const LabwareControls = (
         canDrop: monitor.canDrop(),
       }),
     }),
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [labwareOnDeck, swapBlocked]
   )
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     canDropRef.current = canDrop
   }, [canDrop])
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (draggedLabware != null) {
       setDraggedLabware(draggedLabware?.labwareOnDeck)
@@ -127,7 +133,10 @@ export const LabwareControls = (
       setHoveredLabware(null)
       setDraggedLabware(null)
     }
-  }, [draggedLabware])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [draggedLabware])
 
   const isBeingDragged =
     draggedLabware?.labwareOnDeck?.stack != null &&

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/SlotControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/SlotControls.tsx
@@ -137,6 +137,8 @@ export const SlotControls = (props: SlotControlsProps): JSX.Element | null => {
         draggedItem: monitor.getItem() as DroppedItem,
       }),
     }),
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [moduleType, hasTrashAndNotD4, customLabwareDefs]
   )
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DropTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DropTipField.tsx
@@ -69,18 +69,20 @@ export function DropTipField(props: DropTipFieldProps): JSX.Element {
     ({ labwareDefURI }) => labwareDefURI === tiprackDefUri
   )
 
-  useEffect(() => {
-    if (
-      additionalEquipment[String(dropdownItem)] == null &&
-      labwareEntities[String(dropdownItem)] == null &&
-      !isTipDropLocationReturnTip
-    ) {
-      updateValue(null)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [dropdownItem])
+  useEffect(
+    () => {
+      if (
+        additionalEquipment[String(dropdownItem)] == null &&
+        labwareEntities[String(dropdownItem)] == null &&
+        !isTipDropLocationReturnTip
+      ) {
+        updateValue(null)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [dropdownItem]
+  )
 
   return (
     <DropdownStepFormField

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DropTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/DropTipField.tsx
@@ -77,7 +77,10 @@ export function DropTipField(props: DropTipFieldProps): JSX.Element {
     ) {
       updateValue(null)
     }
-  }, [dropdownItem])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [dropdownItem])
 
   return (
     <DropdownStepFormField

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
@@ -200,11 +200,16 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
         )
       : (passThruProps.errorToShow ?? null)
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     if (isPristine && passThruProps.value == null) {
       passThruProps.updateValue(defaultFlowRate)
     }
-  }, [isPristine, passThruProps])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [isPristine, passThruProps])
 
   return (
     <InputStepFormField

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/FlowRateField.tsx
@@ -202,14 +202,16 @@ export function FlowRateField(props: FlowRateFieldProps): JSX.Element {
 
   // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    if (isPristine && passThruProps.value == null) {
-      passThruProps.updateValue(defaultFlowRate)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [isPristine, passThruProps])
+  useEffect(
+    () => {
+      if (isPristine && passThruProps.value == null) {
+        passThruProps.updateValue(defaultFlowRate)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isPristine, passThruProps]
+  )
 
   return (
     <InputStepFormField

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -129,10 +129,15 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
 
   const [hoveredWells, setHoveredWells] = useState<string[] | null>(null)
 
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     setSelectedWells(getSelectedWells())
     setHoveredWells(null)
-  }, [stepType])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [stepType])
 
   const flatSelectedWells = useMemo(() => selectedWells.flat(), [selectedWells])
   const allWellsWithStatus = allWells.reduce<Record<string, number>>(
@@ -178,13 +183,16 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
   const inaccessiblePartialWells = useMemo(() => {
     if (!isPartialNozzle || selectedWells.length === 0) return []
 
-    return getInaccessibleWellsForPartialNozzleRowMap(
+    return     getInaccessibleWellsForPartialNozzleRowMap(
       selectedWells,
       labwareDef.ordering,
       allWellsWithState,
       PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
     )
-  }, [selectedWells, isPartialNozzle, primaryNozzle, labwareDef.ordering])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [selectedWells, isPartialNozzle, primaryNozzle, labwareDef.ordering])
 
   const deckDef = getDeckDefFromRobotType(robotType)
   const slot = getSlotInLocationStack(labware.stack)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -131,13 +131,15 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
 
   // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => {
-    setSelectedWells(getSelectedWells())
-    setHoveredWells(null)
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [stepType])
+  useEffect(
+    () => {
+      setSelectedWells(getSelectedWells())
+      setHoveredWells(null)
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [stepType]
+  )
 
   const flatSelectedWells = useMemo(() => selectedWells.flat(), [selectedWells])
   const allWellsWithStatus = allWells.reduce<Record<string, number>>(
@@ -180,19 +182,21 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
     },
     {}
   )
-  const inaccessiblePartialWells = useMemo(() => {
-    if (!isPartialNozzle || selectedWells.length === 0) return []
+  const inaccessiblePartialWells = useMemo(
+    () => {
+      if (!isPartialNozzle || selectedWells.length === 0) return []
 
-    return     getInaccessibleWellsForPartialNozzleRowMap(
-      selectedWells,
-      labwareDef.ordering,
-      allWellsWithState,
-      PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
-    )
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [selectedWells, isPartialNozzle, primaryNozzle, labwareDef.ordering])
+      return getInaccessibleWellsForPartialNozzleRowMap(
+        selectedWells,
+        labwareDef.ordering,
+        allWellsWithState,
+        PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
+      )
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedWells, isPartialNozzle, primaryNozzle, labwareDef.ordering]
+  )
 
   const deckDef = getDeckDefFromRobotType(robotType)
   const slot = getSlotInLocationStack(labware.stack)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
@@ -56,67 +56,69 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
   const invariantContext = useSelector(getInvariantContext)
   const { labwareEntities } = invariantContext
 
-  return useMemo(() => {
-    if (robotState == null) {
-      return {}
-    }
-    return Object.entries(robotState.labware).reduce<
-      Record<string, Record<string, AccessibilityStatus>>
-    >((acc, [id, { stack }]) => {
-      const { def, labwareDefURI } = labwareEntities[id]
-      const isMatchingTiprackOnDeck =
-        !stack.includes(OFFDECK) &&
-        def.parameters.isTiprack &&
-        labwareDefURI === tiprackUri
-      if (!isMatchingTiprackOnDeck) {
-        return acc
+  return useMemo(
+    () => {
+      if (robotState == null) {
+        return {}
       }
-      const tipState = robotState?.tipState.tipracks[id] ?? null
-      if (tipState == null) {
-        return acc
-      }
-      return {
-        ...acc,
-        [id]: Object.keys(def.wells).reduce((acc, wellName) => {
-          const { isSafe, isComplete } = getIsSafePickupWithinTiprack({
-            tipState,
-            primaryNozzle,
-            channels: pipetteSpecs.channels,
-            nozzleConfiguration: nozzles,
-            wellName,
-            tiprackDef: def,
-            tipsToIgnore: selectedTips.flat(),
-          })
-          const isCollision = !getIsSafePipetteMovement({
-            robotState,
-            invariantContext,
-            pipetteId,
-            labwareId: id,
-            wellTargetName: wellName,
-            primaryNozzle,
-            nozzleConfiguration: nozzles,
-          })
-          const isAccessible = isSafe && isComplete && !isCollision
-          let inaccessibleReason: InaccessibleReason | null = null
-          if (isCollision) {
-            inaccessibleReason = INACCESSIBLE_COLLISION
-          } else if (!isSafe) {
-            inaccessibleReason = INACCESSIBLE_TOO_MANY_PICKUPS
-          } else if (!isComplete) {
-            inaccessibleReason = INACCESSIBLE_INCOMPLETE
-          }
-          return {
-            ...acc,
-            [wellName]: {
-              isAccessible,
-              ...(inaccessibleReason != null ? { inaccessibleReason } : {}),
-            },
-          }
-        }, {}),
-      }
-    }, {})
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [selectedTips])
+      return Object.entries(robotState.labware).reduce<
+        Record<string, Record<string, AccessibilityStatus>>
+      >((acc, [id, { stack }]) => {
+        const { def, labwareDefURI } = labwareEntities[id]
+        const isMatchingTiprackOnDeck =
+          !stack.includes(OFFDECK) &&
+          def.parameters.isTiprack &&
+          labwareDefURI === tiprackUri
+        if (!isMatchingTiprackOnDeck) {
+          return acc
+        }
+        const tipState = robotState?.tipState.tipracks[id] ?? null
+        if (tipState == null) {
+          return acc
+        }
+        return {
+          ...acc,
+          [id]: Object.keys(def.wells).reduce((acc, wellName) => {
+            const { isSafe, isComplete } = getIsSafePickupWithinTiprack({
+              tipState,
+              primaryNozzle,
+              channels: pipetteSpecs.channels,
+              nozzleConfiguration: nozzles,
+              wellName,
+              tiprackDef: def,
+              tipsToIgnore: selectedTips.flat(),
+            })
+            const isCollision = !getIsSafePipetteMovement({
+              robotState,
+              invariantContext,
+              pipetteId,
+              labwareId: id,
+              wellTargetName: wellName,
+              primaryNozzle,
+              nozzleConfiguration: nozzles,
+            })
+            const isAccessible = isSafe && isComplete && !isCollision
+            let inaccessibleReason: InaccessibleReason | null = null
+            if (isCollision) {
+              inaccessibleReason = INACCESSIBLE_COLLISION
+            } else if (!isSafe) {
+              inaccessibleReason = INACCESSIBLE_TOO_MANY_PICKUPS
+            } else if (!isComplete) {
+              inaccessibleReason = INACCESSIBLE_INCOMPLETE
+            }
+            return {
+              ...acc,
+              [wellName]: {
+                isAccessible,
+                ...(inaccessibleReason != null ? { inaccessibleReason } : {}),
+              },
+            }
+          }, {}),
+        }
+      }, {})
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedTips]
+  )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
@@ -115,5 +115,8 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
         }, {}),
       }
     }, {})
-  }, [selectedTips])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [selectedTips])
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/WellSelectionField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/WellSelectionField.tsx
@@ -81,12 +81,14 @@ export const WellSelectionField = (
     }
   }, [nozzleType, updateValue])
 
-  useEffect(() => {
-    setPrimaryWellCount(calculateWellCount)
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [selectedWells])
+  useEffect(
+    () => {
+      setPrimaryWellCount(calculateWellCount)
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedWells]
+  )
 
   const getModalKey = (): string => {
     return `${String(stepId)}${name}${pipetteId || 'noPipette'}${

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/WellSelectionField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/WellSelectionField.tsx
@@ -83,7 +83,10 @@ export const WellSelectionField = (
 
   useEffect(() => {
     setPrimaryWellCount(calculateWellCount)
-  }, [selectedWells])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [selectedWells])
 
   const getModalKey = (): string => {
     return `${String(stepId)}${name}${pipetteId || 'noPipette'}${

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -219,14 +219,16 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
   // state used to determine if user has seen advanced settings page (relevant for presaved forms)
   const [hasSeenAdvancedSettings, setHasSeenAdvancedSettings] =
     useState<boolean>(false)
-  useEffect(() => {
-    if (toolboxStep === 2 && !hasSeenAdvancedSettings) {
-      setHasSeenAdvancedSettings(true)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [toolboxStep])
+  useEffect(
+    () => {
+      if (toolboxStep === 2 && !hasSeenAdvancedSettings) {
+        setHasSeenAdvancedSettings(true)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [toolboxStep]
+  )
   const isConfirmationRequired =
     robotType === FLEX_ROBOT_TYPE &&
     fieldsChangedRequiringConfirmation.length > 0 &&
@@ -275,26 +277,28 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
   )
   const visibleFormErrorsTypes = visibleFormErrors.map(error => error.title)
 
-  useEffect(() => {
-    const dispatchAnalyticsEvent = (
-      eventName: string,
-      eventProperties: FormWarningType[] | string[]
-    ): void => {
-      if (eventProperties.length > 0) {
-        const event: AnalyticsEvent = {
-          name: eventName,
-          properties: { eventProperties },
+  useEffect(
+    () => {
+      const dispatchAnalyticsEvent = (
+        eventName: string,
+        eventProperties: FormWarningType[] | string[]
+      ): void => {
+        if (eventProperties.length > 0) {
+          const event: AnalyticsEvent = {
+            name: eventName,
+            properties: { eventProperties },
+          }
+          dispatch(analyticsEvent(event))
         }
-        dispatch(analyticsEvent(event))
       }
-    }
 
-    dispatchAnalyticsEvent(FORM_WARNINGS_EVENT, visibleFormWarningsTypes)
-    dispatchAnalyticsEvent(FORM_ERRORS_EVENT, visibleFormErrorsTypes)
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [visibleFormWarningsTypes, visibleFormErrorsTypes])
+      dispatchAnalyticsEvent(FORM_WARNINGS_EVENT, visibleFormWarningsTypes)
+      dispatchAnalyticsEvent(FORM_ERRORS_EVENT, visibleFormErrorsTypes)
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [visibleFormWarningsTypes, visibleFormErrorsTypes]
+  )
   const moduleEntities = Object.values(useSelector(getModuleEntities))
   const stackerModules = moduleEntities.filter(moduleEntity => {
     return moduleEntity.type === FLEX_STACKER_MODULE_TYPE

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -223,7 +223,10 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     if (toolboxStep === 2 && !hasSeenAdvancedSettings) {
       setHasSeenAdvancedSettings(true)
     }
-  }, [toolboxStep])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [toolboxStep])
   const isConfirmationRequired =
     robotType === FLEX_ROBOT_TYPE &&
     fieldsChangedRequiringConfirmation.length > 0 &&
@@ -288,7 +291,10 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
 
     dispatchAnalyticsEvent(FORM_WARNINGS_EVENT, visibleFormWarningsTypes)
     dispatchAnalyticsEvent(FORM_ERRORS_EVENT, visibleFormErrorsTypes)
-  }, [visibleFormWarningsTypes, visibleFormErrorsTypes])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [visibleFormWarningsTypes, visibleFormErrorsTypes])
   const moduleEntities = Object.values(useSelector(getModuleEntities))
   const stackerModules = moduleEntities.filter(moduleEntity => {
     return moduleEntity.type === FLEX_STACKER_MODULE_TYPE

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/index.tsx
@@ -59,7 +59,10 @@ export function AbsorbanceReaderTools(props: StepFormProps): JSX.Element {
       return
     }
     isAfterMount.current = true
-  }, [formData.moduleId])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [formData.moduleId])
 
   const lidRadioButton = (
     <RadioButton

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/AbsorbanceReaderTools/index.tsx
@@ -51,18 +51,20 @@ export function AbsorbanceReaderTools(props: StepFormProps): JSX.Element {
 
   // pre-select radio button on module change if compound command (read/initialize)
   // we useRef to avoid changing data from a previously created form
-  useEffect(() => {
-    if (isAfterMount.current) {
-      propsForFields.absorbanceReaderFormType.updateValue(
-        compoundCommandType ?? ABSORBANCE_READER_LID
-      )
-      return
-    }
-    isAfterMount.current = true
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [formData.moduleId])
+  useEffect(
+    () => {
+      if (isAfterMount.current) {
+        propsForFields.absorbanceReaderFormType.updateValue(
+          compoundCommandType ?? ABSORBANCE_READER_LID
+        )
+        return
+      }
+      isAfterMount.current = true
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [formData.moduleId]
+  )
 
   const lidRadioButton = (
     <RadioButton

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
@@ -113,7 +113,10 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
         )
       }
     }
-  }, [fillQuantityLocalState, storedPrimaryEntity?.labwareDefURI])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [fillQuantityLocalState, storedPrimaryEntity?.labwareDefURI])
 
   return (
     <div className={styles.refill_settings_container}>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/RefillSettings.tsx
@@ -88,35 +88,37 @@ export function RefillSettings(props: RefillSettingsProps): JSX.Element {
     storedPrimaryEntity != null && getIsTiprack(storedPrimaryEntity.def)
   // TODO: figure out a way to not need this use Effect. its hard because
   // you can't rely on generating the uuid in the hydrated form
-  useEffect(() => {
-    const newGroupQuantity = Number(fillQuantityLocalState) ?? 1
-    const difference = newGroupQuantity - oldGroupQuantity
-    const valueTooHigh = newGroupQuantity > maxRefillGroupQuantity
-    // Form errors do not have acccess to module state, so this logic is used
-    // to clear out the fillLabwareIds value if the quantity entered is too high
-    // and raise an error.
-    if (valueTooHigh) {
-      propsForFields.fillLabwareIds.updateValue([])
-    } else {
-      if (difference > 0) {
-        const additionalIds = Array.from({ length: difference }, () =>
-          nonNullEntities.map(entity => `${uuid()}:${entity.labwareDefURI}`)
-        ).flat()
-        // ensure we preserve the existing labware IDs, even if a user extensively modifies the quantity up/down
-        propsForFields.fillLabwareIds.updateValue([
-          ...initialLabwareIds,
-          ...additionalIds,
-        ])
-      } else if (difference < 0) {
-        propsForFields.fillLabwareIds.updateValue(
-          initialLabwareIds.slice(0, newGroupQuantity * numEntitiesInGroup)
-        )
+  useEffect(
+    () => {
+      const newGroupQuantity = Number(fillQuantityLocalState) ?? 1
+      const difference = newGroupQuantity - oldGroupQuantity
+      const valueTooHigh = newGroupQuantity > maxRefillGroupQuantity
+      // Form errors do not have acccess to module state, so this logic is used
+      // to clear out the fillLabwareIds value if the quantity entered is too high
+      // and raise an error.
+      if (valueTooHigh) {
+        propsForFields.fillLabwareIds.updateValue([])
+      } else {
+        if (difference > 0) {
+          const additionalIds = Array.from({ length: difference }, () =>
+            nonNullEntities.map(entity => `${uuid()}:${entity.labwareDefURI}`)
+          ).flat()
+          // ensure we preserve the existing labware IDs, even if a user extensively modifies the quantity up/down
+          propsForFields.fillLabwareIds.updateValue([
+            ...initialLabwareIds,
+            ...additionalIds,
+          ])
+        } else if (difference < 0) {
+          propsForFields.fillLabwareIds.updateValue(
+            initialLabwareIds.slice(0, newGroupQuantity * numEntitiesInGroup)
+          )
+        }
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [fillQuantityLocalState, storedPrimaryEntity?.labwareDefURI])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [fillQuantityLocalState, storedPrimaryEntity?.labwareDefURI]
+  )
 
   return (
     <div className={styles.refill_settings_container}>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/index.tsx
@@ -90,7 +90,10 @@ export function FlexStackerTools(props: StepFormProps): JSX.Element {
     if (isFormPresaved && moduleId != null && firstFormTypeOption != null) {
       propsForFields.flexStackerFormType.updateValue(firstFormTypeOption)
     }
-  }, [moduleId])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [moduleId])
 
   const storedLabwareDefinitions = getStoredLabwareDefinitions(
     storedLabwareDetails ?? null,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/FlexStackerTools/index.tsx
@@ -86,14 +86,16 @@ export function FlexStackerTools(props: StepFormProps): JSX.Element {
   })()
 
   // preselect the first form option on mount if the form is presaved
-  useEffect(() => {
-    if (isFormPresaved && moduleId != null && firstFormTypeOption != null) {
-      propsForFields.flexStackerFormType.updateValue(firstFormTypeOption)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [moduleId])
+  useEffect(
+    () => {
+      if (isFormPresaved && moduleId != null && firstFormTypeOption != null) {
+        propsForFields.flexStackerFormType.updateValue(firstFormTypeOption)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [moduleId]
+  )
 
   const storedLabwareDefinitions = getStoredLabwareDefinitions(
     storedLabwareDetails ?? null,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -215,6 +215,8 @@ export const SecondStepsMoveLiquidTools = ({
         pipetteSpecs: pipetteSpec,
         tiprackDef: tiprackDef,
       }),
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       formData.transferVolume,
       formData.disposalVolume_volume,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks/useAssignLiquidClass.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks/useAssignLiquidClass.ts
@@ -153,7 +153,10 @@ export function useAssignLiquidClass(
         updateValue(runningLiquidClass ?? 'none')
       }
     }
-  }, [formData[wellsField], formData[labwareField]])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [formData[wellsField], formData[labwareField]])
 
   return orderedLiquidClassOptions
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks/useAssignLiquidClass.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks/useAssignLiquidClass.ts
@@ -111,52 +111,57 @@ export function useAssignLiquidClass(
   const [orderedLiquidClassOptions, setOrderedLiquidClassOptions] =
     useState<LiquidClassOption[]>(liquidClassOptions)
 
-  useEffect(() => {
-    if (aspirateLabwareLiquids != null) {
-      let runningLiquidClass: string | null = null
-      for (let i = 0; i < allWellsAdjustedForPipette.length; i++) {
-        const well = allWellsAdjustedForPipette[i]
-        const uniqueLiquidClassesInWell = new Set(
-          aspirateLabwareLiquids[well].groupIds.reduce<string[]>((acc, id) => {
-            const liquidClass = liquidEntities[id]?.liquidClass
-            return liquidClass != null ? [...acc, liquidClass] : acc
-          }, [])
-        )
-        if (uniqueLiquidClassesInWell.size > 1) {
-          // well contains more than one liquid class, so break
-          break
-        } else if (uniqueLiquidClassesInWell.size === 0) {
-          // well contains no liquid classes than one liquid class, so continue to next well
-          continue
-        } else {
-          // well contains a single liquid class, so assign
-          const liquidClass = Array.from(uniqueLiquidClassesInWell)[0]
-          if (
-            // liquid class differs from that of a previous well
-            liquidClass !== runningLiquidClass &&
-            runningLiquidClass != null
-          ) {
-            runningLiquidClass = null
+  useEffect(
+    () => {
+      if (aspirateLabwareLiquids != null) {
+        let runningLiquidClass: string | null = null
+        for (let i = 0; i < allWellsAdjustedForPipette.length; i++) {
+          const well = allWellsAdjustedForPipette[i]
+          const uniqueLiquidClassesInWell = new Set(
+            aspirateLabwareLiquids[well].groupIds.reduce<string[]>(
+              (acc, id) => {
+                const liquidClass = liquidEntities[id]?.liquidClass
+                return liquidClass != null ? [...acc, liquidClass] : acc
+              },
+              []
+            )
+          )
+          if (uniqueLiquidClassesInWell.size > 1) {
+            // well contains more than one liquid class, so break
             break
+          } else if (uniqueLiquidClassesInWell.size === 0) {
+            // well contains no liquid classes than one liquid class, so continue to next well
+            continue
           } else {
-            // first single liquid class encountered
-            runningLiquidClass = liquidClass
+            // well contains a single liquid class, so assign
+            const liquidClass = Array.from(uniqueLiquidClassesInWell)[0]
+            if (
+              // liquid class differs from that of a previous well
+              liquidClass !== runningLiquidClass &&
+              runningLiquidClass != null
+            ) {
+              runningLiquidClass = null
+              break
+            } else {
+              // first single liquid class encountered
+              runningLiquidClass = liquidClass
+            }
           }
         }
-      }
-      setOrderedLiquidClassOptions(
-        liquidClassOptions.sort((a, _) =>
-          a.value === (runningLiquidClass ?? 'none') ? -1 : 1
+        setOrderedLiquidClassOptions(
+          liquidClassOptions.sort((a, _) =>
+            a.value === (runningLiquidClass ?? 'none') ? -1 : 1
+          )
         )
-      )
-      if (currentFormIsPresaved || shouldUpdate) {
-        updateValue(runningLiquidClass ?? 'none')
+        if (currentFormIsPresaved || shouldUpdate) {
+          updateValue(runningLiquidClass ?? 'none')
+        }
       }
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [formData[wellsField], formData[labwareField]])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [formData[wellsField], formData[labwareField]]
+  )
 
   return orderedLiquidClassOptions
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerCycle.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerCycle.tsx
@@ -146,7 +146,10 @@ export function ThermocyclerCycle(props: ThermocyclerCycleProps): JSX.Element {
       handleAddCycleStep()
       setIsInEdit(true)
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   const handleAddCycleStep = (): void => {
     const newStepId = uuid()

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerCycle.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerCycle.tsx
@@ -140,16 +140,18 @@ export function ThermocyclerCycle(props: ThermocyclerCycleProps): JSX.Element {
     },
   }
 
-  useEffect(() => {
-    if (orderedCycleStepIds.length === 0) {
-      // prepopulate with blank step on mount if not editing
-      handleAddCycleStep()
-      setIsInEdit(true)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      if (orderedCycleStepIds.length === 0) {
+        // prepopulate with blank step on mount if not editing
+        handleAddCycleStep()
+        setIsInEdit(true)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   const handleAddCycleStep = (): void => {
     const newStepId = uuid()

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
@@ -83,20 +83,22 @@ export function TimelineToolbox({
     }
   }
 
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent): void => {
-      handleKeyDown(e)
-    }
+  useEffect(
+    () => {
+      const onKeyDown = (e: KeyboardEvent): void => {
+        handleKeyDown(e)
+      }
 
-    global.addEventListener('keydown', onKeyDown, false)
+      global.addEventListener('keydown', onKeyDown, false)
 
-    return () => {
-      global.removeEventListener('keydown', onKeyDown, false)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+      return () => {
+        global.removeEventListener('keydown', onKeyDown, false)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
   const handleGoBack = (): void => {
     if (hasTrash) {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
@@ -93,7 +93,10 @@ export function TimelineToolbox({
     return () => {
       global.removeEventListener('keydown', onKeyDown, false)
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   const handleGoBack = (): void => {
     if (hasTrash) {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -173,7 +173,10 @@ export function ProtocolSteps({
     if (selectedStepId != null) {
       handleScrollToTop()
     }
-  }, [selectedStepId])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [selectedStepId])
 
   let header: string = t(activeItem?.id)
   if (currentStep != null) {
@@ -206,7 +209,10 @@ export function ProtocolSteps({
     ) {
       setDeckView(rightString)
     }
-  }, [zoomedInSlot, labware, zoomedInOnOffDeck])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [zoomedInSlot, labware, zoomedInOnOffDeck])
 
   //  zoom out if you select on any step other than starting deck state in the timeline toolbox
   useEffect(() => {
@@ -217,7 +223,10 @@ export function ProtocolSteps({
       dispatch(selectZoomedIntoSlot({ slot: null, cutout: null }))
       setViewBox(initialViewBox)
     }
-  }, [zoomedInSlot, selectedTerminalItemId])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [zoomedInSlot, selectedTerminalItemId])
 
   return (
     <>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/index.tsx
@@ -169,14 +169,16 @@ export function ProtocolSteps({
     }
   }
 
-  useEffect(() => {
-    if (selectedStepId != null) {
-      handleScrollToTop()
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [selectedStepId])
+  useEffect(
+    () => {
+      if (selectedStepId != null) {
+        handleScrollToTop()
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedStepId]
+  )
 
   let header: string = t(activeItem?.id)
   if (currentStep != null) {
@@ -188,45 +190,49 @@ export function ProtocolSteps({
   const zoomedInOnOffDeck =
     zoomedInSlot != null && labware[zoomedInSlot] != null
   //  zoom in already if you are exiting from adding liquids
-  useEffect(() => {
-    if (zoomedInSlot != null && !zoomedInOnOffDeck) {
-      const zoomInSlotPosition = getPositionFromSlotId(
-        zoomedInSlot ?? '',
-        deckDef
-      )
-      if (zoomInSlotPosition != null) {
-        const zoomedInViewBox = zoomInOnCoordinate({
-          x: zoomInSlotPosition[0],
-          y: zoomInSlotPosition[1],
+  useEffect(
+    () => {
+      if (zoomedInSlot != null && !zoomedInOnOffDeck) {
+        const zoomInSlotPosition = getPositionFromSlotId(
+          zoomedInSlot ?? '',
+          deckDef
+        )
+        if (zoomInSlotPosition != null) {
+          const zoomedInViewBox = zoomInOnCoordinate({
+            x: zoomInSlotPosition[0],
+            y: zoomInSlotPosition[1],
 
-          deckDef,
-        })
-        setViewBox(zoomedInViewBox)
+            deckDef,
+          })
+          setViewBox(zoomedInViewBox)
+        }
+      } else if (
+        zoomedInOnOffDeck &&
+        selectedTerminalItemId! === START_TERMINAL_ITEM_ID
+      ) {
+        setDeckView(rightString)
       }
-    } else if (
-      zoomedInOnOffDeck &&
-      selectedTerminalItemId! === START_TERMINAL_ITEM_ID
-    ) {
-      setDeckView(rightString)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [zoomedInSlot, labware, zoomedInOnOffDeck])
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [zoomedInSlot, labware, zoomedInOnOffDeck]
+  )
 
   //  zoom out if you select on any step other than starting deck state in the timeline toolbox
-  useEffect(() => {
-    if (
-      zoomedInSlot != null &&
-      selectedTerminalItemId !== START_TERMINAL_ITEM_ID
-    ) {
-      dispatch(selectZoomedIntoSlot({ slot: null, cutout: null }))
-      setViewBox(initialViewBox)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [zoomedInSlot, selectedTerminalItemId])
+  useEffect(
+    () => {
+      if (
+        zoomedInSlot != null &&
+        selectedTerminalItemId !== START_TERMINAL_ITEM_ID
+      ) {
+        dispatch(selectZoomedIntoSlot({ slot: null, cutout: null }))
+        setViewBox(initialViewBox)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [zoomedInSlot, selectedTerminalItemId]
+  )
 
   return (
     <>

--- a/protocol-designer/src/pages/Designer/index.tsx
+++ b/protocol-designer/src/pages/Designer/index.tsx
@@ -53,30 +53,34 @@ export function Designer(): JSX.Element {
     Object.values(additionalEquipmentOnDeck).length > 1
 
   // only display toast if its a newly made protocol and has hardware
-  useEffect(() => {
-    if (hasHardware && isNewProtocol) {
-      bakeToast(t('add_rest') as string, INFO_TOAST, {
-        heading: t('we_added_hardware'),
-        closeButton: true,
-      })
-      dispatch(generateNewProtocol({ isNewProtocol: false }))
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [])
+  useEffect(
+    () => {
+      if (hasHardware && isNewProtocol) {
+        bakeToast(t('add_rest') as string, INFO_TOAST, {
+          heading: t('we_added_hardware'),
+          closeButton: true,
+        })
+        dispatch(generateNewProtocol({ isNewProtocol: false }))
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
 
-  useEffect(() => {
-    if (fileMetadata?.created == null) {
-      console.warn(
-        'fileMetadata was refreshed while on the designer page, redirecting to landing page'
-      )
-      navigate('/')
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [fileMetadata])
+  useEffect(
+    () => {
+      if (fileMetadata?.created == null) {
+        console.warn(
+          'fileMetadata was refreshed while on the designer page, redirecting to landing page'
+        )
+        navigate('/')
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [fileMetadata]
+  )
 
   const overflowWrapperRef = useOnClickOutside<HTMLDivElement>({
     onClickOutside: () => {

--- a/protocol-designer/src/pages/Designer/index.tsx
+++ b/protocol-designer/src/pages/Designer/index.tsx
@@ -61,7 +61,10 @@ export function Designer(): JSX.Element {
       })
       dispatch(generateNewProtocol({ isNewProtocol: false }))
     }
-  }, [])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [])
 
   useEffect(() => {
     if (fileMetadata?.created == null) {
@@ -70,7 +73,10 @@ export function Designer(): JSX.Element {
       )
       navigate('/')
     }
-  }, [fileMetadata])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [fileMetadata])
 
   const overflowWrapperRef = useOnClickOutside<HTMLDivElement>({
     onClickOutside: () => {

--- a/protocol-designer/src/pages/Hardware/index.tsx
+++ b/protocol-designer/src/pages/Hardware/index.tsx
@@ -46,17 +46,19 @@ export function Hardware(): JSX.Element {
       : t('protocol_overview:untitled_protocol')
 
   //  TODO: remove this when we do the routing refactor
-  useEffect(() => {
-    if (fileMetadata?.created == null) {
-      console.warn(
-        'fileMetadata was refreshed while on the hardware page, redirecting to landing page'
-      )
-      navigate('/')
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [fileMetadata])
+  useEffect(
+    () => {
+      if (fileMetadata?.created == null) {
+        console.warn(
+          'fileMetadata was refreshed while on the hardware page, redirecting to landing page'
+        )
+        navigate('/')
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [fileMetadata]
+  )
 
   return (
     <Flex

--- a/protocol-designer/src/pages/Hardware/index.tsx
+++ b/protocol-designer/src/pages/Hardware/index.tsx
@@ -53,7 +53,10 @@ export function Hardware(): JSX.Element {
       )
       navigate('/')
     }
-  }, [fileMetadata])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [fileMetadata])
 
   return (
     <Flex

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -83,7 +83,10 @@ export function Landing(): JSX.Element {
         }
       )
     }
-  }, [userHasNotSeenAnnouncement, appVersion, hasOptedIn])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [userHasNotSeenAnnouncement, appVersion, hasOptedIn])
 
   useEffect(() => {
     if (metadata?.created != null) {

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -58,35 +58,37 @@ export function Landing(): JSX.Element {
     getLocalStorageItem(localStorageAnnouncementKey) !== announcementKey &&
     hasOptedIn != null
 
-  useEffect(() => {
-    if (
-      userHasNotSeenAnnouncement &&
-      appVersion != null &&
-      hasOptedIn != null
-    ) {
-      const toastId = bakeToast(
-        t('learn_more', { version: _OT_PD_VERSION_ }) as string,
-        INFO_TOAST,
-        {
-          heading: t('updated_protocol_designer'),
-          closeButton: true,
-          linkText: t('view_release_notes'),
-          onClose: () => {
-            setLocalStorageItem(localStorageAnnouncementKey, announcementKey)
-          },
-          onLinkClick: () => {
-            eatToast(toastId)
-            setShowAnnouncementModal(true)
-          },
-          disableTimeout: true,
-          justifyContent: JUSTIFY_CENTER,
-        }
-      )
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [userHasNotSeenAnnouncement, appVersion, hasOptedIn])
+  useEffect(
+    () => {
+      if (
+        userHasNotSeenAnnouncement &&
+        appVersion != null &&
+        hasOptedIn != null
+      ) {
+        const toastId = bakeToast(
+          t('learn_more', { version: _OT_PD_VERSION_ }) as string,
+          INFO_TOAST,
+          {
+            heading: t('updated_protocol_designer'),
+            closeButton: true,
+            linkText: t('view_release_notes'),
+            onClose: () => {
+              setLocalStorageItem(localStorageAnnouncementKey, announcementKey)
+            },
+            onLinkClick: () => {
+              eatToast(toastId)
+              setShowAnnouncementModal(true)
+            },
+            disableTimeout: true,
+            justifyContent: JUSTIFY_CENTER,
+          }
+        )
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [userHasNotSeenAnnouncement, appVersion, hasOptedIn]
+  )
 
   useEffect(() => {
     if (metadata?.created != null) {

--- a/protocol-designer/src/pages/Onboarding/SelectBasics.tsx
+++ b/protocol-designer/src/pages/Onboarding/SelectBasics.tsx
@@ -215,16 +215,18 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
     setValue('hasThermocycler', value)
   }
 
-  useEffect(() => {
-    if (selectedPipetteName != null) {
-      setValue(`pipettesByMount.${mount}.pipetteName`, selectedPipetteName)
-      openPipetteModal(false)
-      setSelectedPipetteName(null)
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [selectedPipetteName])
+  useEffect(
+    () => {
+      if (selectedPipetteName != null) {
+        setValue(`pipettesByMount.${mount}.pipetteName`, selectedPipetteName)
+        openPipetteModal(false)
+        setSelectedPipetteName(null)
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [selectedPipetteName]
+  )
 
   return (
     <>

--- a/protocol-designer/src/pages/Onboarding/SelectBasics.tsx
+++ b/protocol-designer/src/pages/Onboarding/SelectBasics.tsx
@@ -221,7 +221,10 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
       openPipetteModal(false)
       setSelectedPipetteName(null)
     }
-  }, [selectedPipetteName])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [selectedPipetteName])
 
   return (
     <>

--- a/protocol-designer/src/pages/Onboarding/index.tsx
+++ b/protocol-designer/src/pages/Onboarding/index.tsx
@@ -369,16 +369,18 @@ function CreateFileForm(props: CreateFileFormProps): JSX.Element {
 
   // for resetting the onboarding page back to empty and page 1 when you hit "create new"
   //  from the nav bar
-  useEffect(() => {
-    if (location.state?.modalResetKey) {
-      formProps.reset()
-      setCurrentStepIndex(0)
-      dispatch(toggleNewProtocolModal(true))
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [location.state?.modalResetKey])
+  useEffect(
+    () => {
+      if (location.state?.modalResetKey) {
+        formProps.reset()
+        setCurrentStepIndex(0)
+        dispatch(toggleNewProtocolModal(true))
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [location.state?.modalResetKey]
+  )
 
   return (
     <form onSubmit={formProps.handleSubmit(() => {})}>

--- a/protocol-designer/src/pages/Onboarding/index.tsx
+++ b/protocol-designer/src/pages/Onboarding/index.tsx
@@ -375,7 +375,10 @@ function CreateFileForm(props: CreateFileFormProps): JSX.Element {
       setCurrentStepIndex(0)
       dispatch(toggleNewProtocolModal(true))
     }
-  }, [location.state?.modalResetKey])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [location.state?.modalResetKey])
 
   return (
     <form onSubmit={formProps.handleSubmit(() => {})}>

--- a/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
@@ -44,6 +44,8 @@ export function SlotHover(props: SlotHoverProps): JSX.Element | null {
   const { hover, setHover, slotId, slotPosition, robotType } = props
   const deckSetup = useSelector(getInitialDeckSetup)
   const { additionalEquipmentOnDeck, modules } = deckSetup
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const deckDef = useMemo(() => getDeckDefFromRobotType(robotType), [])
   const hasTCOnSlot = Object.values(modules).find(
     module => module.slot === slotId && module.type === THERMOCYCLER_MODULE_TYPE

--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -103,7 +103,10 @@ export function ProtocolOverview(): JSX.Element {
       )
       navigate('/')
     }
-  }, [formValues])
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [formValues])
 
   const {
     modules: modulesOnDeck,

--- a/protocol-designer/src/pages/ProtocolOverview/index.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/index.tsx
@@ -96,17 +96,19 @@ export function ProtocolOverview(): JSX.Element {
   const additionalEquipment = useSelector(getAdditionalEquipmentEntities)
   const liquids = useSelector(getLiquidEntities)
 
-  useEffect(() => {
-    if (formValues?.created == null) {
-      console.log(
-        'formValues was possibly refreshed while on the overview page, redirecting to landing page'
-      )
-      navigate('/')
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [formValues])
+  useEffect(
+    () => {
+      if (formValues?.created == null) {
+        console.log(
+          'formValues was possibly refreshed while on the overview page, redirecting to landing page'
+        )
+        navigate('/')
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [formValues]
+  )
 
   const {
     modules: modulesOnDeck,

--- a/react-api-client/src/runs/useRunQuery.ts
+++ b/react-api-client/src/runs/useRunQuery.ts
@@ -37,24 +37,26 @@ export function useRunQuery<TError = Error>(
 
   // If the run contains an estop error, invalidate the estop query so we get the
   // estop modal as fast as we can
-  useEffect(() => {
-    if (
-      query.data?.data?.current &&
-      some(
-        ((query.data?.data?.errors ?? []) as RunError[]).map(estopInErrorTree)
-      )
-    ) {
-      queryClient.invalidateQueries([host, '/robot/control'])
-    }
-  },
-  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [
-    runId,
-    query.isSuccess,
-    query.data?.data?.current,
-    query.data?.data?.errors,
-  ])
+  useEffect(
+    () => {
+      if (
+        query.data?.data?.current &&
+        some(
+          ((query.data?.data?.errors ?? []) as RunError[]).map(estopInErrorTree)
+        )
+      ) {
+        queryClient.invalidateQueries([host, '/robot/control'])
+      }
+    },
+    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      runId,
+      query.isSuccess,
+      query.data?.data?.current,
+      query.data?.data?.errors,
+    ]
+  )
 
   return query
 }

--- a/react-api-client/src/runs/useRunQuery.ts
+++ b/react-api-client/src/runs/useRunQuery.ts
@@ -46,7 +46,10 @@ export function useRunQuery<TError = Error>(
     ) {
       queryClient.invalidateQueries([host, '/robot/control'])
     }
-  }, [
+  },
+  // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [
     runId,
     query.isSuccess,
     query.data?.data?.current,


### PR DESCRIPTION
## Overview

As discussed in-person:

* The `react-hooks/exhaustive-deps` lint is changed from a warning to an error.
* All ~226 preexisting violations are, for now, ignored via `// eslint-disable-next-line`.

So any new violations will fail CI, and we can incrementally fix the old violations.

## Test Plan and Hands on Testing

None needed, just code review.

## Review requests

Commit a08c5753f0968d12826b95f271ba27eef446c8ee is the config change.

Commit ff5be3d6e3d6c625b316765c4433df36fee191fb adds the `// eslint-disable-next-line` comments. This commit is LLM-generated. Maybe glance through the files changed to see if you're familiar with them and you know how to fix them.

Commit 6847811a622be5d0422e8db970f4e6fe116d515e is just `make format-js`, which is trustworthy. I wouldn't bother looking at it.

## Risk assessment

Low. There should be no behavioral changes here.