### PR TITLE
refactor(api, hardware-testing, docs): Bump PAPI v2.28 to v2.29

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7583faec7c][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_return_tip_error].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7583faec7c][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_return_tip_error].json
@@ -4916,7 +4916,7 @@
   "errors": [
     {
       "createdAt": "TIMESTAMP",
-      "detail": "UnexpectedProtocolError [line 146]: Error 4000 GENERAL_ERROR (UnexpectedProtocolError): Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.28.",
+      "detail": "UnexpectedProtocolError [line 146]: Error 4000 GENERAL_ERROR (UnexpectedProtocolError): Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.29.",
       "errorCode": "4000",
       "errorInfo": {},
       "errorType": "ExceptionInProtocolError",
@@ -4925,7 +4925,7 @@
       "wrappedErrors": [
         {
           "createdAt": "TIMESTAMP",
-          "detail": "Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.28.",
+          "detail": "Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.29.",
           "errorCode": "4000",
           "errorInfo": {},
           "errorType": "UnexpectedProtocolError",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8b07e799f6][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_drop_tip_with_location].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8b07e799f6][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_drop_tip_with_location].json
@@ -3764,7 +3764,7 @@
   "errors": [
     {
       "createdAt": "TIMESTAMP",
-      "detail": "UnexpectedProtocolError [line 184]: Error 4000 GENERAL_ERROR (UnexpectedProtocolError): Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.28.",
+      "detail": "UnexpectedProtocolError [line 184]: Error 4000 GENERAL_ERROR (UnexpectedProtocolError): Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.29.",
       "errorCode": "4000",
       "errorInfo": {},
       "errorType": "ExceptionInProtocolError",
@@ -3773,7 +3773,7 @@
       "wrappedErrors": [
         {
           "createdAt": "TIMESTAMP",
-          "detail": "Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.28.",
+          "detail": "Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.29.",
           "errorCode": "4000",
           "errorInfo": {},
           "errorType": "UnexpectedProtocolError",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[afd5d372a9][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_return_tip_error].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[afd5d372a9][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_return_tip_error].json
@@ -3764,7 +3764,7 @@
   "errors": [
     {
       "createdAt": "TIMESTAMP",
-      "detail": "UnexpectedProtocolError [line 180]: Error 4000 GENERAL_ERROR (UnexpectedProtocolError): Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.28.",
+      "detail": "UnexpectedProtocolError [line 180]: Error 4000 GENERAL_ERROR (UnexpectedProtocolError): Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.29.",
       "errorCode": "4000",
       "errorInfo": {},
       "errorType": "ExceptionInProtocolError",
@@ -3773,7 +3773,7 @@
       "wrappedErrors": [
         {
           "createdAt": "TIMESTAMP",
-          "detail": "Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.28.",
+          "detail": "Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.29.",
           "errorCode": "4000",
           "errorInfo": {},
           "errorType": "UnexpectedProtocolError",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b0ce7dde5d][Flex_X_v2_16_P1000_96_TC_PartialTipPickupTryToReturnTip].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b0ce7dde5d][Flex_X_v2_16_P1000_96_TC_PartialTipPickupTryToReturnTip].json
@@ -3704,7 +3704,7 @@
   "errors": [
     {
       "createdAt": "TIMESTAMP",
-      "detail": "UnexpectedProtocolError [line 22]: Error 4000 GENERAL_ERROR (UnexpectedProtocolError): Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.28.",
+      "detail": "UnexpectedProtocolError [line 22]: Error 4000 GENERAL_ERROR (UnexpectedProtocolError): Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.29.",
       "errorCode": "4000",
       "errorInfo": {},
       "errorType": "ExceptionInProtocolError",
@@ -3713,7 +3713,7 @@
       "wrappedErrors": [
         {
           "createdAt": "TIMESTAMP",
-          "detail": "Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.28.",
+          "detail": "Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.29.",
           "errorCode": "4000",
           "errorInfo": {},
           "errorType": "UnexpectedProtocolError",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b79134ab8a][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_drop_tip_with_location].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b79134ab8a][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_drop_tip_with_location].json
@@ -4916,7 +4916,7 @@
   "errors": [
     {
       "createdAt": "TIMESTAMP",
-      "detail": "UnexpectedProtocolError [line 150]: Error 4000 GENERAL_ERROR (UnexpectedProtocolError): Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.28.",
+      "detail": "UnexpectedProtocolError [line 150]: Error 4000 GENERAL_ERROR (UnexpectedProtocolError): Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.29.",
       "errorCode": "4000",
       "errorInfo": {},
       "errorType": "ExceptionInProtocolError",
@@ -4925,7 +4925,7 @@
       "wrappedErrors": [
         {
           "createdAt": "TIMESTAMP",
-          "detail": "Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.28.",
+          "detail": "Cannot return tip to a tip rack while the pipette is configured for partial tip before API version 2.29.",
           "errorCode": "4000",
           "errorInfo": {},
           "errorType": "UnexpectedProtocolError",

--- a/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
+++ b/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
@@ -144,7 +144,7 @@ DEFAULT_LABWARE_VERSIONS: DefaultLabwareVersions = {
         "usascientific_12_reservoir_22ml": 4,
         "usascientific_96_wellplate_2.4ml_deep": 4,
     },
-    APIVersion(2, 28): {
+    APIVersion(2, 29): {
         "black_96_well_microtiter_plate_lid": 2,
         "corning_96_wellplate_360ul_lid": 2,
         "corning_falcon_384_wellplate_130ul_flat_lid": 2,

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -597,9 +597,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             increment: Customize the movement "distance" of the pipette to press harder.
             prep_after: Not used by this core, pipette preparation will always happen.
         """
-        assert presses is None and increment is None, (
-            "Tip pick-up with custom presses or increment deprecated"
-        )
+        assert (
+            presses is None and increment is None
+        ), "Tip pick-up with custom presses or increment deprecated"
 
         well_name = well_core.get_name()
         labware_id = well_core.labware_id
@@ -1252,10 +1252,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             assert (
                 # We make sure to set these nozzles in the calling function
                 # if using QUADRANT or PARTIAL_COLUMN. Asserting only for type verification here.
-                front_right_nozzle is not None and back_left_nozzle is not None
-            ), (
-                f"Both front right and back left nozzles are required for {style} configuration."
-            )
+                front_right_nozzle is not None
+                and back_left_nozzle is not None
+            ), f"Both front right and back left nozzles are required for {style} configuration."
             configuration_model = QuadrantNozzleLayoutConfiguration(
                 primaryNozzle=cast(PRIMARY_NOZZLE_LITERAL, primary_nozzle),
                 frontRightNozzle=front_right_nozzle,
@@ -2163,7 +2162,7 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             )
         )
         if volume_for_pipette_mode_configuration is not None and (
-            self._protocol_core.api_version < APIVersion(2, 28)
+            self._protocol_core.api_version < APIVersion(2, 29)
             or self._engine_client.state.pipettes.get_will_volume_mode_change(
                 self._pipette_id, volume_for_pipette_mode_configuration
             )

--- a/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/pipette_movement_conflict.py
@@ -29,7 +29,7 @@ from opentrons.protocol_engine.types import (
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.types import DeckSlotName, Point, StagingSlotName
 
-_PARTIAL_TIP_RETURN_VERSION_GATE = APIVersion(2, 28)
+_PARTIAL_TIP_RETURN_VERSION_GATE = APIVersion(2, 29)
 
 
 class PartialTipMovementNotAllowedError(MotionPlanningFailureError):

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_labware_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_labware_core.py
@@ -161,7 +161,7 @@ class LegacyLabwareCore(AbstractLabware[LegacyWellCore]):
                 well.set_has_tip(True)
 
     def set_empty(self) -> None:
-        assert False, "set_empty only supported in API version 2.28 & later"
+        assert False, "set_empty only supported in API version 2.29 & later"
 
     def get_next_tip(
         self,

--- a/api/src/opentrons/protocol_api/instrument_context.py
+++ b/api/src/opentrons/protocol_api/instrument_context.py
@@ -1077,7 +1077,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 *Changed in version 2.16*: Accepts `TrashBin` and `WasteChute` values.
             flow_rate: The absolute flow rate in µL/s.
 
-                *New in version 2.28*
+                *New in version 2.29*
 
         Raises:
             RuntimeError: If no location is specified and the location cache is `None`.
@@ -1090,10 +1090,10 @@ class InstrumentContext(publisher.CommandPublisher):
             InstrumentContext: This instance.
         """
         if flow_rate is not None:
-            if self.api_version < APIVersion(2, 28):
+            if self.api_version < APIVersion(2, 29):
                 raise APIVersionError(
                     api_element="flow_rate",
-                    until_version="2.28",
+                    until_version="2.29",
                     current_version=f"{self.api_version}",
                 )
         else:
@@ -1216,7 +1216,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         Raises:
             UnexpectedTipRemovalError: If no tip is attached to the pipette.
-            RuntimeError: 
+            RuntimeError:
                 - If no location is specified and the location cache is `None`.
                     This should happen if `touch_tip()` is called without first calling a
                     method that takes a location, like
@@ -1230,7 +1230,7 @@ class InstrumentContext(publisher.CommandPublisher):
 
         *Changed in version 2.24:* Added the `mm_from_edge` parameter.
 
-        *Changed in version 2.28:*
+        *Changed in version 2.29:*
             The API will raise an error if touching tip on a labware with the `touchTipDisabled` quirk, like reservoirs or well plates with large wells.
         """
         if not self._core.has_tip():
@@ -1271,7 +1271,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 )
 
         if "touchTipDisabled" in parent_labware.quirks:
-            if self.api_version < APIVersion(2, 28):
+            if self.api_version < APIVersion(2, 29):
                 _log.info(f"Ignoring touch tip on labware {well}")
                 return self
             raise RuntimeError(
@@ -1743,7 +1743,7 @@ class InstrumentContext(publisher.CommandPublisher):
         the same as specifying [`TrashBin.top()`][opentrons.protocol_api.TrashBin.top],
         which is a fixed position.
 
-        Starting in API version 2.28, you can manually control whether ``drop_tip()`` varies
+        Starting in API version 2.29, you can manually control whether ``drop_tip()`` varies
         the drop location with ``alternate_drop_location``.
 
         Args:
@@ -1764,7 +1764,7 @@ class InstrumentContext(publisher.CommandPublisher):
                 ``location`` is ``None``, and drop the tip to a fixed position when
                 ``location`` is specified.
 
-                *New in version 2.28*
+                *New in version 2.29*
         Returns:
             This instance.
         """

--- a/api/src/opentrons/protocol_api/labware.py
+++ b/api/src/opentrons/protocol_api/labware.py
@@ -1376,7 +1376,7 @@ class Labware:
         """
         self._core.reset_tips()
 
-    @requires_version(2, 28)
+    @requires_version(2, 29)
     def set_empty(self) -> None:
         """Mark a tip rack as completely empty of tips.
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -7,6 +7,9 @@ from opentrons_shared_data.errors.exceptions import CommandPreconditionViolated
 from opentrons_shared_data.labware.types import LabwareDefinition
 from opentrons_shared_data.module.types import ModuleModel, ModuleType
 
+from . import (
+    validation,
+)  # isort: skip  # Imported after other protocol_api imports to avoid circular import
 from .core.common import (
     AbsorbanceReaderCore,
     FlexStackerCore,
@@ -42,7 +45,6 @@ from opentrons.protocols.api_support.util import (
     requires_version,
 )
 
-from . import validation  # isort: skip  # Imported after other protocol_api imports to avoid circular import
 from .tasks import Task  # isort: skip
 
 _MAGNETIC_MODULE_HEIGHT_PARAM_REMOVED_IN = APIVersion(2, 14)
@@ -118,9 +120,9 @@ class ModuleContext(CommandPublisher):
             "`ModuleContext.load_labware_object` is an internal, deprecated method. Use `ModuleContext.load_labware` or `load_labware_by_definition` instead."
         )
 
-        assert labware.parent == self._core.geometry, (
-            "Labware is not configured with this module as its parent"
-        )
+        assert (
+            labware.parent == self._core.geometry
+        ), "Labware is not configured with this module as its parent"
 
         return self._core.geometry.add_labware(labware)
 
@@ -709,8 +711,8 @@ class ThermocyclerContext(ModuleContext):
                 2.27 and newer, the API will first attempt to use the liquid tracking in labware, then default to 25 µL if the protocol lacks probed or loaded
                 liquid information.
 
-                *Changed in version 2.28:* Use the optional `ramp_rate` parameter to control how quickly 
-                the block heats or cools. 
+                *Changed in version 2.29:* Use the optional `ramp_rate` parameter to control how quickly
+                the block heats or cools.
 
         !!! note
             If `hold_time_minutes` and `hold_time_seconds` are not specified,
@@ -722,7 +724,7 @@ class ThermocyclerContext(ModuleContext):
         )
         if self._api_version >= APIVersion(2, 27) and block_max_volume is None:
             block_max_volume = self._get_current_labware_max_vol()
-        if self._api_version < APIVersion(2, 28) and ramp_rate:
+        if self._api_version < APIVersion(2, 29) and ramp_rate:
             # because the argument was always there but didn't work, continue to swallow this arg on
             # old api versions.
             ramp_rate = None
@@ -763,13 +765,13 @@ class ThermocyclerContext(ModuleContext):
         2.27 and newer, the API will first attempt to use the liquid tracking in labware, then default to 25 µL if the protocol lacks probed or loaded
         liquid information.
 
-        *Changed in version 2.28:* Use the optional `ramp_rate` parameter to control how quickly 
-        the block heats or cools. 
+        *Changed in version 2.29:* Use the optional `ramp_rate` parameter to control how quickly
+        the block heats or cools.
         """
 
         if block_max_volume is None:
             block_max_volume = self._get_current_labware_max_vol()
-        if self._api_version < APIVersion(2, 28) and ramp_rate:
+        if self._api_version < APIVersion(2, 29) and ramp_rate:
             # because the argument was always there but didn't work, continue to swallow this arg on
             # old api versions.
             ramp_rate = None
@@ -1858,7 +1860,7 @@ class VacuumModuleContext(ModuleContext):
     _core: VacuumModuleCore
 
     @property
-    @requires_version(2, 28)
+    @requires_version(2, 29)
     def serial_number(self) -> str:
         """Get the module's unique hardware serial number."""
         return self._core.get_serial_number()

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -359,9 +359,9 @@ class GeometryView:
         calibrated_slot_column = self.get_slot_column(calibrated_slot)
         current_slot_column = self.get_slot_column(module_location.slotName)
         # make sure that we have valid colums since we cant have modules in the middle of the deck
-        assert set([calibrated_slot_column, current_slot_column]).issubset({1, 3}), (
-            f"Module calibration offset is an invalid slot {calibrated_slot}"
-        )
+        assert set([calibrated_slot_column, current_slot_column]).issubset(
+            {1, 3}
+        ), f"Module calibration offset is an invalid slot {calibrated_slot}"
 
         # Check if the module has moved from one side of the deck to the other
         if calibrated_slot_column != current_slot_column:
@@ -781,10 +781,10 @@ class GeometryView:
         This makes sure that the well location has an appropriate origin & offset
         if one is not already set previously.
 
-        In API levels before 2.28, we did not support dropping tips in a tip rack
+        In API levels before 2.29, we did not support dropping tips in a tip rack
         while in a partial configuration. The boolean variable `api_version_allows_partial_return_tip`
         will be set to False if called by a protocol API layer and the API level is both below
-        v2.28 and the pipette is partially configured.
+        v2.29 and the pipette is partially configured.
         """
         if (
             not api_version_allows_partial_return_tip
@@ -792,7 +792,7 @@ class GeometryView:
         ):
             raise errors.UnexpectedProtocolError(
                 "Cannot return tip to a tip rack while the pipette is"
-                " configured for partial tip before API version 2.28."
+                " configured for partial tip before API version 2.29."
             )
         if well_location.origin != DropTipWellOrigin.DEFAULT:
             return WellLocation(
@@ -1222,7 +1222,9 @@ class GeometryView:
                                     self._config.robot_type
                                 )
                             )
-                        ][0],
+                        ][
+                            0
+                        ],
                     )
                 return [(middle_slot_center.x, middle_slot_center.y)]
         return []
@@ -1276,9 +1278,9 @@ class GeometryView:
             return 4
         row_col_name = slot_name.to_ot3_equivalent()
         slot_name_match = WELL_NAME_PATTERN.match(row_col_name.value)
-        assert slot_name_match is not None, (
-            f"Slot name {row_col_name} did not match required pattern; please check labware location."
-        )
+        assert (
+            slot_name_match is not None
+        ), f"Slot name {row_col_name} did not match required pattern; please check labware location."
 
         row_name, column_name = slot_name_match.group(1, 2)
         return int(column_name)
@@ -1862,12 +1864,12 @@ class GeometryView:
         # this function is only called by
         # HardwarePipetteHandler::aspirate/dispense while_tracking, and shouldn't
         # be reached in the case of a simulated liquid_probe
-        assert not isinstance(initial_handling_height, SimulatedProbeResult), (
-            "Initial handling height got SimulatedProbeResult"
-        )
-        assert not isinstance(final_height, SimulatedProbeResult), (
-            "final height is SimulatedProbeResult"
-        )
+        assert not isinstance(
+            initial_handling_height, SimulatedProbeResult
+        ), "Initial handling height got SimulatedProbeResult"
+        assert not isinstance(
+            final_height, SimulatedProbeResult
+        ), "final height is SimulatedProbeResult"
         return final_height - initial_handling_height
 
     def get_well_offset_adjustment(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -359,9 +359,9 @@ class GeometryView:
         calibrated_slot_column = self.get_slot_column(calibrated_slot)
         current_slot_column = self.get_slot_column(module_location.slotName)
         # make sure that we have valid colums since we cant have modules in the middle of the deck
-        assert set([calibrated_slot_column, current_slot_column]).issubset(
-            {1, 3}
-        ), f"Module calibration offset is an invalid slot {calibrated_slot}"
+        assert set([calibrated_slot_column, current_slot_column]).issubset({1, 3}), (
+            f"Module calibration offset is an invalid slot {calibrated_slot}"
+        )
 
         # Check if the module has moved from one side of the deck to the other
         if calibrated_slot_column != current_slot_column:
@@ -1222,9 +1222,7 @@ class GeometryView:
                                     self._config.robot_type
                                 )
                             )
-                        ][
-                            0
-                        ],
+                        ][0],
                     )
                 return [(middle_slot_center.x, middle_slot_center.y)]
         return []
@@ -1278,9 +1276,9 @@ class GeometryView:
             return 4
         row_col_name = slot_name.to_ot3_equivalent()
         slot_name_match = WELL_NAME_PATTERN.match(row_col_name.value)
-        assert (
-            slot_name_match is not None
-        ), f"Slot name {row_col_name} did not match required pattern; please check labware location."
+        assert slot_name_match is not None, (
+            f"Slot name {row_col_name} did not match required pattern; please check labware location."
+        )
 
         row_name, column_name = slot_name_match.group(1, 2)
         return int(column_name)
@@ -1864,12 +1862,12 @@ class GeometryView:
         # this function is only called by
         # HardwarePipetteHandler::aspirate/dispense while_tracking, and shouldn't
         # be reached in the case of a simulated liquid_probe
-        assert not isinstance(
-            initial_handling_height, SimulatedProbeResult
-        ), "Initial handling height got SimulatedProbeResult"
-        assert not isinstance(
-            final_height, SimulatedProbeResult
-        ), "final height is SimulatedProbeResult"
+        assert not isinstance(initial_handling_height, SimulatedProbeResult), (
+            "Initial handling height got SimulatedProbeResult"
+        )
+        assert not isinstance(final_height, SimulatedProbeResult), (
+            "final height is SimulatedProbeResult"
+        )
         return final_height - initial_handling_height
 
     def get_well_offset_adjustment(

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 28)
+MAX_SUPPORTED_VERSION = APIVersion(2, 29)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -1283,13 +1283,13 @@ def test_valid_96_pipette_movement_for_tiprack_and_adapter(
         ("OT-3 Standard", DeckType.OT3_STANDARD),
     ],
 )
-@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 28)))
+@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 29)))
 def test_check_safe_for_pipette_movement_partial_tip_version_gate_above(
     decoy: Decoy,
     mock_state_view: StateView,
     api_version: APIVersion,
 ) -> None:
-    """It should pass when location is a well and API version is at or over 2.28."""
+    """It should pass when location is a well and API version is at or over 2.29."""
     decoy.when(
         mock_state_view.pipettes.get_is_partially_configured("pipette-id")
     ).then_return(True)
@@ -1436,14 +1436,14 @@ def test_check_safe_for_pipette_movement_partial_tip_version_gate_above(
     ],
 )
 @pytest.mark.parametrize(
-    "api_version", versions_below(APIVersion(2, 28), flex_only=True)
+    "api_version", versions_below(APIVersion(2, 29), flex_only=True)
 )
 def test_check_safe_for_pipette_movement_partial_tip_version_gate_below(
     decoy: Decoy,
     mock_state_view: StateView,
     api_version: APIVersion,
 ) -> None:
-    """It should pass when location is a well and API version is below 2.28."""
+    """It should pass when location is a well and API version is below 2.29."""
     decoy.when(
         mock_state_view.pipettes.get_is_partially_configured("pipette-id")
     ).then_return(True)

--- a/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_instrument_core.py
@@ -2335,8 +2335,8 @@ def test_aspirate_liquid_class_using_volume_config_below_2_28(
     assert result == [LiquidAndAirGapPair(air_gap=222, liquid=111)]
 
 
-@pytest.mark.parametrize("version", versions_at_or_above(APIVersion(2, 28)))
-def test_aspirate_liquid_class_using_volume_config_2_28_and_above(
+@pytest.mark.parametrize("version", versions_at_or_above(APIVersion(2, 29)))
+def test_aspirate_liquid_class_using_volume_config_2_29_and_above(
     decoy: Decoy,
     mock_engine_client: EngineClient,
     subject: InstrumentCore,
@@ -2464,8 +2464,8 @@ def test_aspirate_liquid_class_using_volume_config_2_28_and_above(
     assert result == [LiquidAndAirGapPair(air_gap=222, liquid=111)]
 
 
-@pytest.mark.parametrize("version", versions_at_or_above(APIVersion(2, 28)))
-def test_aspirate_liquid_class_2_28_and_above_skips_configure_volume(
+@pytest.mark.parametrize("version", versions_at_or_above(APIVersion(2, 29)))
+def test_aspirate_liquid_class_2_29_and_above_skips_configure_volume(
     decoy: Decoy,
     mock_engine_client: EngineClient,
     subject: InstrumentCore,

--- a/api/tests/opentrons/protocol_api/test_instrument_context.py
+++ b/api/tests/opentrons/protocol_api/test_instrument_context.py
@@ -1147,7 +1147,7 @@ def test_drop_tip_to_trash(
 
 
 @pytest.mark.parametrize(
-    "api_version", [APIVersion(2, 15), APIVersion(2, 18), APIVersion(2, 28)]
+    "api_version", [APIVersion(2, 15), APIVersion(2, 18), APIVersion(2, 29)]
 )
 def test_drop_tip_to_randomized_trash_location(
     decoy: Decoy,
@@ -1175,7 +1175,7 @@ def test_drop_tip_to_randomized_trash_location(
 
 @pytest.mark.parametrize(
     ["api_version", "alternate_drop"],
-    [(APIVersion(2, 17), True), (APIVersion(2, 18), False), (APIVersion(2, 28), False)],
+    [(APIVersion(2, 17), True), (APIVersion(2, 18), False), (APIVersion(2, 29), False)],
 )
 def test_drop_tip_in_trash_bin(
     decoy: Decoy,
@@ -1200,7 +1200,7 @@ def test_drop_tip_in_trash_bin(
 
 @pytest.mark.parametrize(
     ["api_version", "alternate_drop"],
-    [(APIVersion(2, 17), True), (APIVersion(2, 18), False), (APIVersion(2, 28), False)],
+    [(APIVersion(2, 17), True), (APIVersion(2, 18), False), (APIVersion(2, 29), False)],
 )
 def test_drop_tip_in_waste_chute(
     decoy: Decoy,
@@ -1223,7 +1223,7 @@ def test_drop_tip_in_waste_chute(
     )
 
 
-@pytest.mark.parametrize("api_version", [APIVersion(2, 28)])
+@pytest.mark.parametrize("api_version", [APIVersion(2, 29)])
 def test_drop_tip_alternate_position_explicitly(
     decoy: Decoy,
     mock_instrument_core: InstrumentCore,
@@ -1741,7 +1741,7 @@ def test_touch_tip_raises_if_trash_last_location(
         subject.touch_tip()
 
 
-@pytest.mark.parametrize("api_version", versions_below(APIVersion(2, 28), False))
+@pytest.mark.parametrize("api_version", versions_below(APIVersion(2, 29), False))
 def test_touch_tip_noops_for_older_api_if_labware_is_untouchable(
     decoy: Decoy,
     mock_instrument_core: InstrumentCore,
@@ -1768,14 +1768,14 @@ def test_touch_tip_noops_for_older_api_if_labware_is_untouchable(
     )
 
 
-@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 28)))
+@pytest.mark.parametrize("api_version", versions_at_or_above(APIVersion(2, 29)))
 def test_touch_tip_raises_if_labware_is_untouchable(
     decoy: Decoy,
     mock_instrument_core: InstrumentCore,
     subject: InstrumentContext,
     mock_protocol_core: ProtocolCore,
 ) -> None:
-    """It should raise if the labware has quirk 'touchTipDisabled' for API v2.28 & above."""
+    """It should raise if the labware has quirk 'touchTipDisabled' for API v2.29 & above."""
     mock_well = decoy.mock(cls=Well)
     decoy.when(mock_instrument_core.has_tip()).then_return(True)
     decoy.when(mock_well.parent.quirks).then_return(["touchTipDisabled"])

--- a/api/tests/opentrons/protocol_api/test_thermocycler_context.py
+++ b/api/tests/opentrons/protocol_api/test_thermocycler_context.py
@@ -782,7 +782,7 @@ def test_deactivate(
 
 
 @pytest.mark.parametrize(
-    "this_api_version,ramp_rate", [(APIVersion(2, 27), None), (APIVersion(2, 28), 3.0)]
+    "this_api_version,ramp_rate", [(APIVersion(2, 27), None), (APIVersion(2, 29), 3.0)]
 )
 def test_ramp_rate_(
     decoy: Decoy,
@@ -792,7 +792,7 @@ def test_ramp_rate_(
     this_api_version: APIVersion,
     ramp_rate: Optional[float],
 ) -> None:
-    """It should delete the ramp rate argument on pre 2.28 versions."""
+    """It should delete the ramp rate argument on pre 2.29 versions."""
     subject._api_version = this_api_version
     decoy.when(
         mock_validation.ensure_hold_time_seconds(seconds=None, minutes=None)

--- a/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
+++ b/api/tests/opentrons/protocol_api_integration/test_liquid_classes.py
@@ -117,7 +117,7 @@ def test_custom_liquid_class_w_multi_dispense_creation_and_property_fetching(
 
 @pytest.mark.ot3_only
 @pytest.mark.parametrize(
-    "simulated_protocol_context", [("2.28", "Flex")], indirect=True
+    "simulated_protocol_context", [("2.29", "Flex")], indirect=True
 )
 def test_adding_blowout_position_to_liquid_classes(
     simulated_protocol_context: ProtocolContext,

--- a/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
+++ b/api/tests/opentrons/protocols/advanced_control/transfers/test_transfer_liquid_utils.py
@@ -622,7 +622,7 @@ def test_blowout_location_for_trash(
     trash = TrashBin(
         location=DeckSlotName.SLOT_A1,
         addressable_area_name="moveableTrashD3",
-        api_version=APIVersion(2, 28),
+        api_version=APIVersion(2, 29),
         engine_client=engine_client,
     )
     decoy.when(

--- a/docs/python-api/docs/building-block-commands/liquids.md
+++ b/docs/python-api/docs/building-block-commands/liquids.md
@@ -329,7 +329,7 @@ pipette.blow_out(pipette.trash_container)
 
 *Changed in version 2.16:* Added support for `TrashBin` and `WasteChute` locations.
 
-*Changed in version 2.28:* Use the optional `flow_rate` argument to specify an absolute flow rate for blowing out the pipette.
+*Changed in version 2.29:* Use the optional `flow_rate` argument to specify an absolute flow rate for blowing out the pipette.
 
 ## Touch tip { #touch-tip-building-block }
 
@@ -340,7 +340,7 @@ pipette.touch_tip()
 ```
 
 !!! note
-    Calling [`touch_tip()`][opentrons.protocol_api.InstrumentContext.touch_tip] moves the pipette across the well. In large spaces like reservoirs, trash containers, and 6- or 24-well plates, this can cause large, rapid pipette movements. Beginning in API version 2.28, the API will raise an error if your protocol specifies a `touch_tip()` in labware like the examples listed above.
+    Calling [`touch_tip()`][opentrons.protocol_api.InstrumentContext.touch_tip] moves the pipette across the well. In large spaces like reservoirs, trash containers, and 6- or 24-well plates, this can cause large, rapid pipette movements. Beginning in API version 2.29, the API will raise an error if your protocol specifies a `touch_tip()` in labware like the examples listed above.
 
 ### Touch location
 

--- a/docs/python-api/docs/building-block-commands/pipette-tips.md
+++ b/docs/python-api/docs/building-block-commands/pipette-tips.md
@@ -109,7 +109,7 @@ pipette.drop_tip(chute)  # drops tip in waste chute
 
 *New in version 2.16*
 
-The API automatically varies the tip drop location in the default trash container, or when you haven't specified a `location`, to help keep tips from piling up. Beginning with API version 2.28, you can add the optional `alternate_drop_location` argument to control the tip drop location in a specified `location`:
+The API automatically varies the tip drop location in the default trash container, or when you haven't specified a `location`, to help keep tips from piling up. Beginning with API version 2.29, you can add the optional `alternate_drop_location` argument to control the tip drop location in a specified `location`:
 
 ```python
 trash = protocol_context.load_trash_bin("A3")
@@ -124,7 +124,7 @@ pipette.drop_tip(
     location=secondary_trash,
     alternate_drop_location=True)
 ```
-*New in version 2.28*
+*New in version 2.29*
 
 In the example above, the pipette drops each tip in a slightly different location in the `secondary_trash`.  
 
@@ -138,7 +138,7 @@ pipette.return_tip()
 
 *New in version 2.0*
 
-Beginning with API version 2.28, you can return tips with a pipette that's configured to use [partial tip pickup](../pipettes/partial-tip-pickup.md). 
+Beginning with API version 2.29, you can return tips with a pipette that's configured to use [partial tip pickup](../pipettes/partial-tip-pickup.md). 
 
 When you return tips to their original position in the tip rack, you'll need to consider which tips, if any, you plan to pick up and use again. For example, a 96-channel pipette in column configuration can't reach column 2 unless column 1 is completely empty. When you call [`pick_up_tip()`][opentrons.protocol_api.InstrumentContext.pick_up_tip] again, the robot won't be able to access unused tips in column 2.
 
@@ -161,7 +161,7 @@ pipette.pick_up_tip()
 pipette.drop_tip(tiprack_1["A1"])
 ```
 
-*New in version 2.28*
+*New in version 2.29*
 
 In the example above, the pipette uses automatic tip tracking to pick up the next available tip in its assigned tip rack. Then, it drops the attached tip in well A1 of the empty `tiprack_1`.
 

--- a/docs/python-api/docs/liquid-classes.md
+++ b/docs/python-api/docs/liquid-classes.md
@@ -388,4 +388,4 @@ You'll need to define values for all required properties in your new liquid clas
 The example above also defines some optional properties, like a mix and a blowout, in a custom liquid class. See [the liquid class schema](https://github.com/Opentrons/opentrons/blob/edge/shared-data/liquid-class/schemas/1.json) for a complete list of properties.
 
 !!! note
-The [`ProtocolContext.get_liquid_class()`][opentrons.protocol_api.ProtocolContext.get_liquid_class] method only accepts Opentrons-verified liquid classes, like `glycerol_50`. You'll need to use [`ProtocolContext.define_liquid_class()`][opentrons.protocol_api.ProtocolContext.define_liquid_class] in each Flex protocol that uses a custom liquid class.
+    The [`ProtocolContext.get_liquid_class()`][opentrons.protocol_api.ProtocolContext.get_liquid_class] method only accepts Opentrons-verified liquid classes, like `glycerol_50`. You'll need to use [`ProtocolContext.define_liquid_class()`][opentrons.protocol_api.ProtocolContext.define_liquid_class] in each Flex protocol that uses a custom liquid class.

--- a/docs/python-api/docs/liquid-classes.md
+++ b/docs/python-api/docs/liquid-classes.md
@@ -1,5 +1,5 @@
 ---
-title: "Python API: Liquid Classes"
+title: 'Python API: Liquid Classes'
 ---
 
 Accounting for properties of liquids in your protocol can increase pipetting accuracy on the Flex. For example, a slower flow rate can improve pipetting for a viscous liquid, and an air gap can prevent a volatile liquid from dripping onto the deck.
@@ -11,10 +11,10 @@ This page covers the properties of Opentrons-verified liquid classes, how to use
 Opentrons-verified liquid classes are based on the properties of common liquids: water, ethanol, and glycerol.
 
 | Opentrons-verified liquid class | Description              | Load name {width="25%"} |
-|---------------------------------|--------------------------|---------------|
-| Aqueous                        | Based on deionized water | `water`       |
-| Volatile                       | Based on 80% ethanol     | `ethanol_80`  |
-| Viscous                        | Based on 50% glycerol    | `glycerol_50` |
+| ------------------------------- | ------------------------ | ----------------------- |
+| Aqueous                         | Based on deionized water | `water`                 |
+| Volatile                        | Based on 80% ethanol     | `ethanol_80`            |
+| Viscous                         | Based on 50% glycerol    | `glycerol_50`           |
 
 Use an Opentrons-verified liquid class in your transfers to automatically apply optimized behavior. For example, choosing the `glycerol_50` liquid class changes properties, like flow rate, to accurately transfer viscous liquid.
 
@@ -191,7 +191,8 @@ def run(protocol: protocol_api.ProtocolContext):
     # select liquid class to use in your protocol
     viscous_liquid = protocol.get_liquid_class(name="glycerol_50")
 ```
-*New in version 2.24*
+
+_New in version 2.24_
 
 Next, use the [`InstrumentContext.transfer_with_liquid_class()`][opentrons.protocol_api.InstrumentContext.transfer_with_liquid_class] method to transfer an aqueous, volatile, or viscous liquid defined in a Flex protocol. This method requires the stored set of properties defined earlier, `viscous_liquid`, instead of the `glycerol_50` load name. It accepts additional arguments that let you specify your liquid, volume, source and destination wells, tip handling preferences, and trash location.
 
@@ -210,7 +211,8 @@ pipette.transfer_with_liquid_class(
    trash_location=trash,
 )
 ```
-*New in version 2.24*
+
+_New in version 2.24_
 
 Here, the `glycerol_50` viscous liquid class definition accounts for all other transfer behavior, like flow rate, whether or not to add an air gap or delay, and submerge and retract speeds. For each aspirate, the pipette:
 
@@ -232,7 +234,7 @@ And for each dispense, the pipette:
 In many cases, the liquid class definition represents fine-tuned changes optimized for each liquid class. If you instead used the same pipette to transfer 50 µL of the volatile `liquid_2`, transfer behavior would include:
 
 - Submerging into and retracting from the volatile `liquid_2` at 100 mm/sec.
-- Adding larger air gaps after aspirating *and* dispensing to prevent dripping onto the deck.
+- Adding larger air gaps after aspirating _and_ dispensing to prevent dripping onto the deck.
 - Aspirating and dispensing at 30 µL/sec with a larger correction by volume.
 - Pushing out a larger volume of air to ensure all liquid leaves the tip.
 
@@ -251,9 +253,9 @@ custom_water_properties = custom_water.get_for(pipette, tiprack)
 
 Here, you can also use the optional `version` parameter to specify which version of the liquid class definition you’d like to customize. If unspecified, the API loads the latest version.
 
-*New in version 2.24*
+_New in version 2.24_
 
-*Changed in version 2.26:* The `version` parameter lets you apply a previous liquid class definition version.
+_Changed in version 2.26:_ The `version` parameter lets you apply a previous liquid class definition version.
 
 Next, edit individual liquid class properties based on your Flex pipette and tip combination.
 
@@ -269,7 +271,7 @@ custom_water_properties.aspirate.flow_rate_by_volume.set_for_volume = [(20.0, 30
 custom_water_properties.aspirate.retract.delay.enabled = True
 custom_water_properties.aspirate.retract.delay.duration = 1.0
 
-# edit aspirate tip position 
+# edit aspirate tip position
 custom_water_properties.aspirate.aspirate_position = {
     "position_reference": "well-top",
     "offset": {"x": 1, "y": 2, "z": 3}
@@ -277,9 +279,10 @@ custom_water_properties.aspirate.aspirate_position = {
 # use aspirate tip position to set dispense tip position
 custom_water_properties.dispense.dispense_position = custom_water_properties.aspirate.aspirate_position
 ```
-*New in version 2.24*
 
-*Changed in version 2.28*: Edit tip position for an aspirate, dispense, or blowout in a single line, and use one tip position to set another.
+_New in version 2.24_
+
+_Changed in version 2.29_: Edit tip position for an aspirate, dispense, or blowout in a single line, and use one tip position to set another.
 
 Then, complete your transfers with the modified `custom_water` liquid class.
 
@@ -302,8 +305,8 @@ custom_liquid_class_properties = {
                 "delay": {"enabled": False},
                 "flow_rate_by_volume": [(10.0, 40.0), (20.0, 30.0)],
                 "mix": {
-                    "enabled": True, 
-                    "repetitions": 1, 
+                    "enabled": True,
+                    "repetitions": 1,
                     "volume": 50,
                 },
                 "pre_wet": True,
@@ -339,8 +342,8 @@ custom_liquid_class_properties = {
                 "retract": {
                     "air_gap_by_volume": [(5.0, 3.0), (10.0, 4.0)],
                     "blowout": {
-                        "enabled": True, 
-                        "location": "destination", 
+                        "enabled": True,
+                        "location": "destination",
                         "flowRate": 50,
                     },
                     "delay": {"enabled": False},
@@ -376,13 +379,13 @@ custom_viscous = protocol.define_liquid_class(
 )
 ```
 
-*New in version 2.24*
+_New in version 2.24_
 
-*Changed in version 2.28*: Add ability to control where and when the pipette blows out excess liquid.
+_Changed in version 2.29_: Add ability to control where and when the pipette blows out excess liquid.
 
 You'll need to define values for all required properties in your new liquid class, like submerging before aspirating or after dispensing, speeds and flow rates, and position offsets. See the Opentrons-verified [liquid class properties](https://github.com/Opentrons/opentrons/tree/edge/shared-data/liquid-class/definitions/1) for examples.
 
 The example above also defines some optional properties, like a mix and a blowout, in a custom liquid class. See [the liquid class schema](https://github.com/Opentrons/opentrons/blob/edge/shared-data/liquid-class/schemas/1.json) for a complete list of properties.
 
 !!! note
-    The [`ProtocolContext.get_liquid_class()`][opentrons.protocol_api.ProtocolContext.get_liquid_class] method only accepts Opentrons-verified liquid classes, like `glycerol_50`. You'll need to use [`ProtocolContext.define_liquid_class()`][opentrons.protocol_api.ProtocolContext.define_liquid_class] in each Flex protocol that uses a custom liquid class.
+The [`ProtocolContext.get_liquid_class()`][opentrons.protocol_api.ProtocolContext.get_liquid_class] method only accepts Opentrons-verified liquid classes, like `glycerol_50`. You'll need to use [`ProtocolContext.define_liquid_class()`][opentrons.protocol_api.ProtocolContext.define_liquid_class] in each Flex protocol that uses a custom liquid class.

--- a/docs/python-api/docs/modules/thermocycler.md
+++ b/docs/python-api/docs/modules/thermocycler.md
@@ -157,7 +157,7 @@ In some protocols, your samples might require a slower ramp speed. Use the optio
 
 Here, the Thermocycler Module will cool the block to 4 °C at a rate of 1 °C/second. 
 
-*New in version 2.28*
+*New in version 2.29*
 
 ### Block max volume
 The Thermocycler's block temperature controller varies its behavior based on the amount of liquid in the wells of its labware. Accurately specifying the liquid volume allows the Thermocycler to more precisely control the temperature of the samples. You should set the `block_max_volume` parameter to the amount of liquid in the *fullest* well, measured in µL. If not specified, the Thermocycler will assume samples of 25 µL.

--- a/docs/python-api/docs/versioning.md
+++ b/docs/python-api/docs/versioning.md
@@ -68,7 +68,7 @@ This table lists the correspondence between Protocol API versions and robot soft
 
 | API Version | Introduced in Robot Software |
 |-------------|------------------------------|
-| 2.28        | 9.0.0                        |
+| 2.29        | 9.0.0                        |
 | 2.27        | 8.8.0                        |
 | 2.26        | 8.7.0                        |
 | 2.25        | 8.6.0                        |
@@ -101,7 +101,7 @@ This table lists the correspondence between Protocol API versions and robot soft
 
 ## Changes in API versions
 
-### Version 2.28
+### Version 2.29
 
 - Return tips to the tip rack with a pipette that's configured to use [partial tip pickup](pipettes/partial-tip-pickup.md).
 - Adds additional tools to customize pipette blowouts: 
@@ -110,7 +110,7 @@ This table lists the correspondence between Protocol API versions and robot soft
 - Simplifies [customizing liquid class](liquid-classes.md#customizing-liquid-classes) tip positions, including aspirate, dispense, and blowout positions.
 - Control how quickly the Thermocycler Module's block heats or cools with the [`set_block_temperature()`][opentrons.protocol_api.ThermocyclerContext.set_block_temperature] and [`start_set_block_temperature()`][opentrons.protocol_api.ThermocyclerContext.start_set_block_temperature] methods' optional `ramp_rate` parameter.
 - Use the [`drop_tip()`][opentrons.protocol_api.InstrumentContext.drop_tip] method's optional `alternate_drop_location` argument to vary the tip drop location in a waste container, preventing tips from piling up in a single location.
-- In protocols using API version 2.28, the API raises an error when calling [`touch_tip()`][opentrons.protocol_api.InstrumentContext.touch_tip] in large spaces, like reservoirs and large well plates.
+- In protocols using API version 2.29, the API raises an error when calling [`touch_tip()`][opentrons.protocol_api.InstrumentContext.touch_tip] in large spaces, like reservoirs and large well plates.
 
 ### Version 2.27
 

--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
@@ -37,7 +37,7 @@ from opentrons.protocol_api._nozzle_layout import NozzleLayout
 from opentrons.protocols.advanced_control.transfers import common as tx_ctl_lib
 
 metadata = {"protocolName": "Gravimetric QC"}
-requirements = {"robotType": "Flex", "apiLevel": "2.28"}
+requirements = {"robotType": "Flex", "apiLevel": "2.29"}
 
 SCALE_SECONDS_TO_TRUE_STABILIZE = 60 * 3
 


### PR DESCRIPTION
# Overview

Because `chore_release-8.9.0` will implement PAPI v2.28 for liquid class reasons, we'll need to bump PAPI changes in the `chore_release-9.0.0` branch to v2.29. Each commit touches a different namespace of the repo.

## Changelog

- Bumped PAPI v2.28 to v2.29

## Review requests

Please do a quick look over of your respective code to ensure it looks ok. 

@ecormany / @emilyburghardt I went ahead and updated all doc references that contain `2.28` to `2.29`, but I'm happy to revert this commit if you'd rather be responsible for it in a different PR.

## Risk assessment

should be low, just an API bump refactor
