### PR TITLE
fix(protocol-designer): add universal lid on custom labware

### DIFF
--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectCustomLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectCustomLabware.tsx
@@ -108,7 +108,7 @@ export function SelectCustomLabware(
                                 labwareDefURI:
                                   selectedLidLabware === universalLid[0]
                                     ? null
-                                    : `opentrons/${universalLid[1].parameters.loadName}/${universalLid[1].version}`,
+                                    : `${universalLid[1].namespace}/${universalLid[1].parameters.loadName}/${universalLid[1].version}`,
                               })
                             )
                           },

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectCustomLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectCustomLabware.tsx
@@ -80,7 +80,6 @@ export function SelectCustomLabware(
               },
               model: FLEX_STACKER_MODULE_V1,
             })
-
             const lidProps: StackingProps | null =
               slot !== 'offDeck' &&
               universalLid != null &&
@@ -109,7 +108,7 @@ export function SelectCustomLabware(
                                 labwareDefURI:
                                   selectedLidLabware === universalLid[0]
                                     ? null
-                                    : uri,
+                                    : `opentrons/${universalLid[1].parameters.loadName}/${universalLid[1].version}`,
                               })
                             )
                           },


### PR DESCRIPTION
closes AUTH_2784

# Overview

add the universal lid uri instead of the parent labware uri

## Test Plan and Hands on Testing

follow the steps in the ticket. basically:
1. download the custom labware from the ticket
2. create a protocol and add the custom labware to the deck
3. add a lid to that custom labwrae
4. see that the lid and custom labware get properly added instead of 2 custom labwares stacked 

## Changelog

change the uri from the parent uri to the universal lid uri

## Risk assessment

low