### PR TITLE
fix(hardware-testing): resolve some bugs in the overlap test protocols

### DIFF
--- a/hardware-testing/hardware_testing/protocols/tip_overlap/tip_overlap_8_channel.py
+++ b/hardware-testing/hardware_testing/protocols/tip_overlap/tip_overlap_8_channel.py
@@ -128,8 +128,8 @@ LAYOUT_TO_START: Dict[str, Optional[str]] = {
     "Full": None,
 }
 LAYOUT_TO_END: Dict[str, Optional[str]] = {
-    "SingleA1": "A1",
-    "SingleH1": "H1",
+    "SingleA1": None,
+    "SingleH1": None,
     "H1toG1": "G1",
     "H1toF1": "F1",
     "H1toE1": "E1",

--- a/hardware-testing/hardware_testing/protocols/tip_overlap/tip_overlap_96_channel.py
+++ b/hardware-testing/hardware_testing/protocols/tip_overlap/tip_overlap_96_channel.py
@@ -1,4 +1,4 @@
-"""Protocol to test tip overlap in the 8 channel."""
+"""Protocol to test tip overlap in the 96 channel."""
 from opentrons.protocol_api import ProtocolContext, ParameterContext
 from opentrons.types import Point
 from opentrons.config import IS_ROBOT
@@ -124,8 +124,8 @@ LAYOUT_TO_START: Dict[str, Optional[str]] = {
     "SingleH12": "H12",
     "Column1": "A1",
     "Column12": "A12",
-    "RowA": "A12",
-    "RowH": "H12",
+    "RowA": "A1",
+    "RowH": "H1",
     "Full": None,
 }
 LAYOUT_TO_END: Dict[str, Optional[str]] = {
@@ -133,10 +133,10 @@ LAYOUT_TO_END: Dict[str, Optional[str]] = {
     "SingleH1": None,
     "SingleA12": None,
     "SingleH12": None,
-    "Column1": "H1",
-    "Column12": "H12",
-    "RowA": "A12",
-    "RowH": "H12",
+    "Column1": None,
+    "Column12": None,
+    "RowA": None,
+    "RowH": None,
     "Full": None,
 }
 

--- a/hardware-testing/hardware_testing/protocols/tip_overlap/tip_overlap_96_channel.py
+++ b/hardware-testing/hardware_testing/protocols/tip_overlap/tip_overlap_96_channel.py
@@ -131,8 +131,8 @@ LAYOUT_TO_START: Dict[str, Optional[str]] = {
 LAYOUT_TO_END: Dict[str, Optional[str]] = {
     "SingleA1": None,
     "SingleH1": None,
-    "SingleA12": "A12",
-    "SingleH12": "H12",
+    "SingleA12": None,
+    "SingleH12": None,
     "Column1": "H1",
     "Column12": "H12",
     "RowA": "A12",

--- a/hardware-testing/hardware_testing/protocols/tip_overlap/tip_overlap_96_channel.py
+++ b/hardware-testing/hardware_testing/protocols/tip_overlap/tip_overlap_96_channel.py
@@ -161,13 +161,13 @@ def offset_for_channel(channel: int, layout: str) -> Point:
         return Point(0, 0, 0)
     elif layout in ["Column1", "RowA", "Full"]:
         # channel 0 is the critical point
-        return Point(x=column * 9, y=row * 9, z=0)
+        return Point(x=column * -9, y=row * 9, z=0)
     elif layout in ["Column12"]:
         # channel 11 is the critical point
         return Point(x=0, y=row * 9, z=0)
     elif layout in ["RowH"]:
         # channel 84 is the critical point
-        return Point(x=column * 9, y=0, z=0)
+        return Point(x=column * -9, y=0, z=0)
     else:
         raise RuntimeError("unknown layout")
 
@@ -182,8 +182,11 @@ def run(ctx: ProtocolContext) -> None:
         assert dial is not None, "could not find dial"
     ctx.load_trash_bin("A3")
     tipracks = []
+    adapter: Optional[str] = None
+    if ctx.params.layout == "Full":
+        adapter = "opentrons_flex_96_tiprack_adapter"  # type: ignore [attr-defined]
     for slot in LAYOUT_TO_RACK_SLOTS[ctx.params.layout]:  # type: ignore [attr-defined]
-        tipracks.append(ctx.load_labware(f"opentrons_flex_96_{ctx.params.tip_type}", slot, adapter="opentrons_flex_96_tiprack_adapter"))  # type: ignore [attr-defined]
+        tipracks.append(ctx.load_labware(f"opentrons_flex_96_{ctx.params.tip_type}", slot, adapter=adapter))  # type: ignore [attr-defined]
     pipette = ctx.load_instrument(
         f"flex_96channel_{ctx.params.pipette_volume}", "left", tip_racks=tipracks  # type: ignore [attr-defined]
     )

--- a/hardware-testing/hardware_testing/protocols/tip_overlap/tip_overlap_96_channel.py
+++ b/hardware-testing/hardware_testing/protocols/tip_overlap/tip_overlap_96_channel.py
@@ -183,7 +183,7 @@ def run(ctx: ProtocolContext) -> None:
     ctx.load_trash_bin("A3")
     tipracks = []
     adapter: Optional[str] = None
-    if ctx.params.layout == "Full":
+    if ctx.params.layout == "Full":  # type: ignore [attr-defined]
         adapter = "opentrons_flex_96_tiprack_adapter"  # type: ignore [attr-defined]
     for slot in LAYOUT_TO_RACK_SLOTS[ctx.params.layout]:  # type: ignore [attr-defined]
         tipracks.append(ctx.load_labware(f"opentrons_flex_96_{ctx.params.tip_type}", slot, adapter=adapter))  # type: ignore [attr-defined]

--- a/hardware-testing/hardware_testing/protocols/tip_overlap/tip_overlap_96_channel.py
+++ b/hardware-testing/hardware_testing/protocols/tip_overlap/tip_overlap_96_channel.py
@@ -129,8 +129,8 @@ LAYOUT_TO_START: Dict[str, Optional[str]] = {
     "Full": None,
 }
 LAYOUT_TO_END: Dict[str, Optional[str]] = {
-    "SingleA1": "A1",
-    "SingleH1": "H1",
+    "SingleA1": None,
+    "SingleH1": None,
     "SingleA12": "A12",
     "SingleH12": "H12",
     "Column1": "H1",

--- a/hardware-testing/hardware_testing/protocols/tip_overlap/tip_overlap_single_channel.py
+++ b/hardware-testing/hardware_testing/protocols/tip_overlap/tip_overlap_single_channel.py
@@ -75,7 +75,7 @@ def run(ctx: ProtocolContext) -> None:
     ctx.load_trash_bin("A3")
     tiprack1 = ctx.load_labware(f"opentrons_flex_96_{ctx.params.tip_type}", "C2")  # type: ignore [attr-defined]
     pipette = ctx.load_instrument(
-        f"flex_8channel_{ctx.params.pipette_volume}", "left", tip_racks=[tiprack1]  # type: ignore [attr-defined]
+        f"flex_1channel_{ctx.params.pipette_volume}", "left", tip_racks=[tiprack1]  # type: ignore [attr-defined]
     )
     test_labware = ctx.load_labware("dial_indicator", "C3")
 


### PR DESCRIPTION
# Overview
Couple of cases that didn't work in the 8/96 channel and had the wrong pipette name on the single channel.