### PR TITLE
refactor(app): improve the process of recent run protocols filter

### DIFF
--- a/app/src/pages/ODD/RobotDashboard/index.tsx
+++ b/app/src/pages/ODD/RobotDashboard/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
@@ -38,17 +38,22 @@ export function RobotDashboard(): JSX.Element {
     unfinishedUnboxingFlowRoute !== null
   )
 
-  const recentRunsOfUniqueProtocols = (allRunsQueryData?.data ?? [])
-    .reduceRight<RunData[]>((acc, run) => {
-      if (
-        acc.some(collectedRun => collectedRun.protocolId === run.protocolId)
-      ) {
-        return acc
-      } else {
-        return [...acc, run]
-      }
-    }, [])
-    .slice(0, MAXIMUM_RECENT_RUN_PROTOCOLS)
+  const recentRunsOfUniqueProtocols = useMemo(() => {
+    const runs = allRunsQueryData?.data ?? []
+    const seenProtocolIds = new Set<string>()
+    const result: RunData[] = []
+    for (let i = runs.length - 1; i >= 0; i--) {
+      const run = runs[i]
+      if (seenProtocolIds.has(run.protocolId!)) continue
+
+      seenProtocolIds.add(run.protocolId!)
+      result.push(run)
+
+      if (result.length === MAXIMUM_RECENT_RUN_PROTOCOLS) break
+    }
+
+    return result
+  }, [allRunsQueryData?.data])
 
   let contents: JSX.Element = <EmptyRecentRun />
   // GET runs query will error with 503 if database is initializing


### PR DESCRIPTION


# Overview
when i checked code to verify a question from Felix, i noticed this.
the current implementation is O(n^2). this pr improves that with `useMemo`.

## Test Plan and Hands on Testing
- push this branch to a Flex
check the dashboard shows the same protocols that are listed before pushing this branch


## Changelog


## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment
low

