### PR TITLE
feat(protocol-designer): add vacuum module feature flag to PD

### DIFF
--- a/protocol-designer/src/assets/localization/en/feature_flags.json
+++ b/protocol-designer/src/assets/localization/en/feature_flags.json
@@ -42,5 +42,9 @@
   "OT_PD_ENABLE_ADDITIONAL_PARTIAL_TIP_SELECTION": {
     "title": "Enable additional partial tip selection",
     "description": "Enables use of other pipette nozzles and return"
+  },
+  "OT_PD_ENABLE_VACUUM_MODULE": {
+    "title": "Enable vacuum module use",
+    "description": "Enables use of vacuum modules in Protocol Designer protocols"
   }
 }

--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -40,6 +40,8 @@ const initialFlags: Flags = {
   OT_PD_ENABLE_ADDITIONAL_PARTIAL_TIP_SELECTION:
     _FF_ENV_VARS_.OT_PD_ENABLE_ADDITIONAL_PARTIAL_TIP_SELECTION === '1' ||
     false,
+  OT_PD_ENABLE_VACUUM_MODULE:
+    _FF_ENV_VARS_.OT_PD_ENABLE_VACUUM_MODULE === '1' || false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -52,3 +52,7 @@ export const getEnableAdditionalPartialTipSelection: Selector<boolean> =
     getFeatureFlagData,
     flags => flags.OT_PD_ENABLE_ADDITIONAL_PARTIAL_TIP_SELECTION ?? false
   )
+export const getEnableVacuumModule: Selector<boolean> = createSelector(
+  getFeatureFlagData,
+  flags => flags.OT_PD_ENABLE_VACUUM_MODULE ?? false
+)

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -50,6 +50,7 @@ export type FlagTypes =
   | 'OT_PD_ENABLE_BY_VOLUME_BUILDER'
   | 'OT_PD_ENABLE_CAMERA_SUPPORT'
   | 'OT_PD_ENABLE_ADDITIONAL_PARTIAL_TIP_SELECTION'
+  | 'OT_PD_ENABLE_VACUUM_MODULE'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [
   'OT_PD_DISABLE_MODULE_RESTRICTIONS',


### PR DESCRIPTION
# Overview

Adds dev feature flag for enabling vacuum module in PD

Closes EXEC-2402

## Test Plan and Hands on Testing

** ensure prerelease mode is enabled
- open PD
- select settings (top right gear icon)
- scroll down and verify that new vacuum module feature flag is present

## Changelog

add and wire up new vacuum module feature flag in PD

## Review requests

see test plan

## Risk assessment

low