### PR TITLE
chore(docs): add meta descriptions to documentation pages

### DIFF
--- a/docs/absorbance-plate-reader/docs/additional-info.md
+++ b/docs/absorbance-plate-reader/docs/additional-info.md
@@ -1,5 +1,6 @@
 ---
 title: "Plate Reader: Additional Product Information"
+description: "Warranty, support, app download, and WEEE policy for the plate reader."
 ---
 
 ## Warranty

--- a/docs/absorbance-plate-reader/docs/data.md
+++ b/docs/absorbance-plate-reader/docs/data.md
@@ -1,5 +1,6 @@
 ---
 title: "Plate Reader: Using Data"
+description: "Download plate reader CSV data from the app or use it in Python protocols."
 hide: toc
 ---
 

--- a/docs/absorbance-plate-reader/docs/index.md
+++ b/docs/absorbance-plate-reader/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Absorbance Plate Reader Module Instruction Manual"
+description: "On-deck microplate spectrophotometer for Flex; endpoint and kinetic absorbance reading."
 hide: toc
 ---
 

--- a/docs/absorbance-plate-reader/docs/index.md
+++ b/docs/absorbance-plate-reader/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Absorbance Plate Reader Module Instruction Manual"
-description: "On-deck microplate spectrophotometer for Flex; endpoint and kinetic absorbance reading."
+description: "On-deck microplate spectrophotometer for Flex with endpoint and kinetic absorbance reading."
 hide: toc
 ---
 

--- a/docs/absorbance-plate-reader/docs/installation.md
+++ b/docs/absorbance-plate-reader/docs/installation.md
@@ -1,5 +1,6 @@
 ---
 title: "Plate Reader: Installation"
+description: "Attach the plate reader to a Flex deck slot and connect USB; no calibration needed."
 hide: toc
 ---
 

--- a/docs/absorbance-plate-reader/docs/installation.md
+++ b/docs/absorbance-plate-reader/docs/installation.md
@@ -1,6 +1,6 @@
 ---
 title: "Plate Reader: Installation"
-description: "Attach the plate reader to a Flex deck slot and connect USB; no calibration needed."
+description: "How to attach the plate reader in a deck slot and connect to Opentrons Flex."
 hide: toc
 ---
 

--- a/docs/absorbance-plate-reader/docs/maintenance.md
+++ b/docs/absorbance-plate-reader/docs/maintenance.md
@@ -1,6 +1,6 @@
 ---
 title: "Plate Reader: Maintenance and Cleaning"
-description: "Cleaning procedures and when to contact support; no user-repairable parts."
+description: "Cleaning procedures and when to contact support for the Absorbance Plate Reader."
 hide: toc
 ---
 

--- a/docs/absorbance-plate-reader/docs/maintenance.md
+++ b/docs/absorbance-plate-reader/docs/maintenance.md
@@ -1,5 +1,6 @@
 ---
 title: "Plate Reader: Maintenance and Cleaning"
+description: "Cleaning procedures and when to contact support; no user-repairable parts."
 hide: toc
 ---
 

--- a/docs/absorbance-plate-reader/docs/placement.md
+++ b/docs/absorbance-plate-reader/docs/placement.md
@@ -1,5 +1,6 @@
 ---
 title: "Plate Reader: Deck Placement"
+description: "Compatible Flex deck slots (A3–D3) and caddy mounting for the plate reader."
 hide: toc
 ---
 

--- a/docs/absorbance-plate-reader/docs/product-specs.md
+++ b/docs/absorbance-plate-reader/docs/product-specs.md
@@ -1,5 +1,6 @@
 ---
 title: "Plate Reader: Product Specifications"
+description: "Dimensions, weight, optical specs, and included parts for the plate reader."
 ---
 
 ![Module parts with labels](images/plate-reader-labeled.svg)

--- a/docs/absorbance-plate-reader/docs/safety.md
+++ b/docs/absorbance-plate-reader/docs/safety.md
@@ -1,5 +1,6 @@
 ---
 title: "Plate Reader: Safety Information"
+description: "Safe use, environmental conditions, and compliance for the plate reader."
 ---
 
 Opentrons recommends that you follow the safe use specifications listed in this section and throughout this manual.

--- a/docs/flex/docs/additional-docs.md
+++ b/docs/flex/docs/additional-docs.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Additional Documentation"
+description: "Links to Knowledge Hub, Python API docs, and other Opentrons resources."
 ---
 
 Opentrons maintains additional online documentation for our hardware and software products. You may find these resources valuable as you use Opentrons Flex.

--- a/docs/flex/docs/advanced-operation/command-line.md
+++ b/docs/flex/docs/advanced-operation/command-line.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Command Line Operation Over SSH"
+description: "Connect via SSH and use command-line tools to manage Flex."
 ---
 
 Opentrons Flex gives you command-line access to its operating system through a Secure Shell (SSH) terminal connection. Terminal access lets you:

--- a/docs/flex/docs/advanced-operation/index.md
+++ b/docs/flex/docs/advanced-operation/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Advanced Operations"
+description: "SSH, Jupyter, command-line tools, and log files for advanced users."
 ---
 
 This chapter describes selected features and techniques you might use only under unusual circumstances or for non-standard interactions, such as diagnostics or specialized control that requires knowledge of terminal commands.

--- a/docs/flex/docs/advanced-operation/jupyter-notebook.md
+++ b/docs/flex/docs/advanced-operation/jupyter-notebook.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Jupyter Notebook"
+description: "Use Jupyter on Flex for interactive protocol development and control."
 ---
 
 Flex runs a [Jupyter Notebook](https://jupyter.org/) server on port 48888, which you can connect to with your web browser. Use Jupyter to individually run discrete chunks of Python code, called *cells*. This is a convenient environment for writing and debugging protocols, since you can define different parts of your protocol in different notebook cells, and run a single cell at a time.

--- a/docs/flex/docs/advanced-operation/log-files.md
+++ b/docs/flex/docs/advanced-operation/log-files.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Log Files"
+description: "Where to find and how to use Flex run logs and system logs."
 ---
 
 All Flex robots keep records of their movements and system processes. During normal operation, there's no need to download or examine these files. However, if a failure or malfunction occurs, Opentrons Support may request these files, as they provide detailed information that helps identify and resolve problems with the robot. This article summarizes each log file and explains how to download them using the Opentrons App.

--- a/docs/flex/docs/glossary.md
+++ b/docs/flex/docs/glossary.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Glossary"
+description: "Definitions of terms used in the Flex manual and Opentrons products."
 ---
 
 This appendix defines terms related to Opentrons Flex. It omits industry-standard terms like "labware" unless the term has a special meaning in relation to Flex. For example, the definition for *pipette* describes the narrower meaning that the term has when using Flex, as opposed to any pipette you might find elsewhere in a lab.

--- a/docs/flex/docs/index.md
+++ b/docs/flex/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex Instruction Manual"
+description: "Official instruction manual for the Opentrons Flex liquid handling robot."
 ---
 
 <style>

--- a/docs/flex/docs/installation/first-run.md
+++ b/docs/flex/docs/installation/first-run.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: First Run"
+description: "Power on, connect to network, and complete initial Flex setup."
 ---
 
 Perform basic setup on the touchscreen before connecting any other hardware to your Flex. The robot will guide you through connecting to your lab network, updating to the latest software, and personalizing Flex by giving it a name.

--- a/docs/flex/docs/installation/index.md
+++ b/docs/flex/docs/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Installation and Relocation"
+description: "Prepare your lab, set up the robot, and relocate Flex when needed."
 ---
 
 This chapter describes how to prepare your lab for Opentrons Flex, how to set up the robot, and how to move it if necessary. 

--- a/docs/flex/docs/installation/instruments.md
+++ b/docs/flex/docs/installation/instruments.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Instrument Installation and Calibration"
+description: "Attach pipettes and calibrate using the touchscreen or Opentrons App."
 ---
 
 After initial robot setup, the next step is to attach instruments to the robot and calibrate them.

--- a/docs/flex/docs/installation/relocation.md
+++ b/docs/flex/docs/installation/relocation.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Relocation"
+description: "How to prepare and move Flex for short or long-distance relocation."
 ---
 
 This section provides advice and instructions about how to move your Opentrons Flex robot over short and long distances.

--- a/docs/flex/docs/installation/requirements.md
+++ b/docs/flex/docs/installation/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Installation Requirements"
+description: "Site requirements: placement, power, and environmental conditions for Flex."
 ---
 
 Before setting up Opentrons Flex, make sure that your installation site meets all of the requirements in this section. And follow all of the safety guidance here and throughout the installation instructions.

--- a/docs/flex/docs/installation/unboxing.md
+++ b/docs/flex/docs/installation/unboxing.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Unboxing"
+description: "Step-by-step unboxing, assembly, and initial preparation of your Flex."
 ---
 
 Congratulations! Your Opentrons Flex has arrived and you've prepared a space for it in your lab. Let's open that monster crate, remove the robot, and prepare it for operation. The information in this section provides a parts list and instructions that walk you through the steps required to get the Flex unboxed, set up, and ready for use. We've divided the setup procedure into three parts:

--- a/docs/flex/docs/introduction.md
+++ b/docs/flex/docs/introduction.md
@@ -1,5 +1,6 @@
 ---
 title: 'Opentrons Flex: Introduction'
+description: "Overview of Flex features, manual structure, and how to control the robot."
 ---
 
 Opentrons Flex is a liquid-handling robot designed for high throughput and complex workflows. The Flex robot is the base of a modular system that includes pipettes, a labware gripper, deck fixtures, on-deck modules, and labware — all of which you can swap out yourself. Flex is designed with a touchscreen so you can work with it directly at the lab bench, or you can control it from across your lab with the Opentrons App or our open-source APIs.

--- a/docs/flex/docs/labware/concepts.md
+++ b/docs/flex/docs/labware/concepts.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Labware Concepts"
+description: "Physical labware, verified definitions, and custom labware on Flex."
 ---
 
 Labware encompasses more than just the objects placed on the deck and used in a protocol. For the Opentrons Flex, labware includes:

--- a/docs/flex/docs/labware/definitions.md
+++ b/docs/flex/docs/labware/definitions.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Labware Definitions"
+description: "Labware definitions, Custom Labware Creator, and JSON for custom labware."
 ---
 
 Every labware you use on Flex requires a _labware definition_ that contains all the information Flex needs to work with the labware. This includes information about the physical shape of the labware, how pipettes and the gripper should interact with it, and what the labware should be called on the touchscreen and in the Opentrons App.

--- a/docs/flex/docs/labware/gripper.md
+++ b/docs/flex/docs/labware/gripper.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Labware and the Gripper"
+description: "Gripper-compatible labware and how the gripper moves plates and lids."
 ---
 
 Although Opentrons Flex works with all items in the Labware Library, the Opentrons Flex Gripper is compatible only with labware whose definitions provide information about how they should be picked up and moved around the deck. Currently, the gripper is compatible with the following Opentrons-verified labware: 

--- a/docs/flex/docs/labware/index.md
+++ b/docs/flex/docs/labware/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Labware"
+description: "How Flex uses labware in software and on the deck; concepts and definitions."
 ---
 
 This chapter covers how Opentrons Flex works with labware, both in software and on the robot deck itself.

--- a/docs/flex/docs/labware/index.md
+++ b/docs/flex/docs/labware/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons Flex: Labware"
-description: "How Flex uses labware in software and on the deck; concepts and definitions."
+description: "How Flex uses labware in software and on the deck."
 ---
 
 This chapter covers how Opentrons Flex works with labware, both in software and on the robot deck itself.

--- a/docs/flex/docs/labware/types.md
+++ b/docs/flex/docs/labware/types.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Labware Types"
+description: "Reservoirs, well plates, tube racks, and other labware types for Flex."
 ---
 
 This section covers the different types of labware included in the Opentrons Labware Library for use with Flex. 

--- a/docs/flex/docs/maintenance/cleaning.md
+++ b/docs/flex/docs/maintenance/cleaning.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Cleaning"
+description: "How to clean the Flex frame, deck, and modules; approved solutions."
 ---
 
 Routine cleaning helps keep Flex free of contaminants that can affect your protocols. Cleaning also gives you a chance to inspect the robot for wear and damage. You should review this section for information, instructions, and resources about how to clean your Flex, pipettes, gripper, modules, and other hardware.

--- a/docs/flex/docs/maintenance/cleaning.md
+++ b/docs/flex/docs/maintenance/cleaning.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons Flex: Cleaning"
-description: "How to clean the Flex frame, deck, and modules; approved solutions."
+description: "How to clean the Flex frame, deck, and modules, including approved cleaning solutions."
 ---
 
 Routine cleaning helps keep Flex free of contaminants that can affect your protocols. Cleaning also gives you a chance to inspect the robot for wear and damage. You should review this section for information, instructions, and resources about how to clean your Flex, pipettes, gripper, modules, and other hardware.

--- a/docs/flex/docs/maintenance/index.md
+++ b/docs/flex/docs/maintenance/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Maintenance and Service"
+description: "Routine maintenance, cleaning, and when to contact Opentrons for service."
 ---
 
 This chapter covers how to perform routine maintenance on your Opentrons Flex, and what to do if you require service for a problem. You should be able to perform [cleaning tasks](cleaning.md) yourself, whereas [service and repairs](service.md) should be handled by Opentrons Support.

--- a/docs/flex/docs/maintenance/service.md
+++ b/docs/flex/docs/maintenance/service.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Service"
+description: "Opentrons Care, repairs, preventive maintenance, and service plans."
 ---
 
 Opentrons Flex is designed for years of full-time operation. Unlike cleaning, you should not attempt to service or repair Flex yourself. Opentrons offers multiple levels of service for Flex and related Opentrons hardware, some of which include maintenance and repairs.

--- a/docs/flex/docs/modules/absorbance-plate-reader.md
+++ b/docs/flex/docs/modules/absorbance-plate-reader.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Absorbance Plate Reader"
+description: "Absorbance Plate Reader Module on Flex: on-deck spectrophotometry."
 ---
 
 ![plate reader hero](../images/plate-reader-hero-lid-off.png)

--- a/docs/flex/docs/modules/caddy.md
+++ b/docs/flex/docs/modules/caddy.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Module Caddy System"
+description: "Caddies for deck-mounting modules and below-deck cable routing on Flex."
 ---
 
 Compatible modules are designed to fit into caddies that occupy space below the deck. This system allows labware on top of modules to remain closer to the deck surface, and it also allows for below-deck cable routing so the deck stays tidy during your protocol runs.

--- a/docs/flex/docs/modules/calibration.md
+++ b/docs/flex/docs/modules/calibration.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Module Calibration"
+description: "When and how to calibrate modules on Flex for accurate positioning."
 ---
 
 When you first install a module on Flex, you need to run automated positional calibration. This process is similar to positional calibration for instruments, and ensures that Flex moves to the exact correct locations for optimal protocol performance. During calibration, Flex will move to locations on a module calibration adapter, which looks similar to the calibration squares that are part of removable deck slots.

--- a/docs/flex/docs/modules/heater-shaker.md
+++ b/docs/flex/docs/modules/heater-shaker.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Heater-Shaker Module"
+description: "Heater-Shaker on Flex: heating and orbital shaking; installation and use."
 ---
 
 ![The Heater-Shaker module as seen from the front left. The top of the module has the heating and shaking platform and labware latch. The left side of the module has the power button, USB port, and power port.](../images/heater-shaker-module.png "Heater-Shaker Module")

--- a/docs/flex/docs/modules/heater-shaker.md
+++ b/docs/flex/docs/modules/heater-shaker.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons Flex: Heater-Shaker Module"
-description: "Heater-Shaker on Flex: heating and orbital shaking; installation and use."
+description: "Heater-Shaker on Flex: on-deck heating and orbital shaking."
 ---
 
 ![The Heater-Shaker module as seen from the front left. The top of the module has the heating and shaking platform and labware latch. The left side of the module has the power button, USB port, and power port.](../images/heater-shaker-module.png "Heater-Shaker Module")

--- a/docs/flex/docs/modules/hepa-uv.md
+++ b/docs/flex/docs/modules/hepa-uv.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: HEPA/UV Module"
+description: "HEPA/UV Module on Flex: clean air and UV disinfection; Flex only."
 ---
 
 ![hepa-uv hero](../images/hepa-uv-hero.png)

--- a/docs/flex/docs/modules/hepa-uv.md
+++ b/docs/flex/docs/modules/hepa-uv.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons Flex: HEPA/UV Module"
-description: "HEPA/UV Module on Flex: clean air and UV disinfection; Flex only."
+description: "HEPA/UV Module on Flex: clean air and UV disinfection."
 ---
 
 ![hepa-uv hero](../images/hepa-uv-hero.png)

--- a/docs/flex/docs/modules/index.md
+++ b/docs/flex/docs/modules/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Modules"
+description: "Flex-compatible modules: Heater-Shaker, HEPA/UV, Temperature, Thermocycler, and more."
 ---
 
 Opentrons Flex integrates with several Opentrons hardware modules that add features and capabilities to the robot. Modules can occupy deck slots or are external, frame-mounted components. Flex communicates with and controls most modules via a USB connection.

--- a/docs/flex/docs/modules/index.md
+++ b/docs/flex/docs/modules/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons Flex: Modules"
-description: "Flex-compatible modules: Heater-Shaker, HEPA/UV, Temperature, Thermocycler, and more."
+description: "Flex-compatible modules: Heater-Shaker, HEPA/UV, Temperature Module, Thermocycler, and more."
 ---
 
 Opentrons Flex integrates with several Opentrons hardware modules that add features and capabilities to the robot. Modules can occupy deck slots or are external, frame-mounted components. Flex communicates with and controls most modules via a USB connection.

--- a/docs/flex/docs/modules/magnetic-block.md
+++ b/docs/flex/docs/modules/magnetic-block.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons Flex: Magnetic Block"
-description: "Magnetic Block for bead-based purification on Flex; installation and use."
+description: "Installation and use of the Magnetic Block for bead-based purification on Flex."
 ---
 
 ![The Magnetic Block has an array of 96 high-strength magnets.](../images/magnetic-block.png "Magnetic Block")

--- a/docs/flex/docs/modules/magnetic-block.md
+++ b/docs/flex/docs/modules/magnetic-block.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Magnetic Block"
+description: "Magnetic Block for bead-based purification on Flex; installation and use."
 ---
 
 ![The Magnetic Block has an array of 96 high-strength magnets.](../images/magnetic-block.png "Magnetic Block")

--- a/docs/flex/docs/modules/stacker.md
+++ b/docs/flex/docs/modules/stacker.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Stacker"
+description: "Stacker Module on Flex: high-capacity labware storage and shuttle."
 ---
 
 ![Stacker module image](../images/stacker-module.png)

--- a/docs/flex/docs/modules/temperature.md
+++ b/docs/flex/docs/modules/temperature.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Temperature Module"
+description: "Temperature Module on Flex: 4–95 °C hot and cold plate; installation and use."
 ---
 
 ![The Temperature Module as seen from the top left. The top of the module has the heating and cooling surface and temperature display. The side has the power button, USB port, and power port.](../images/temperature-module.png "Temperature Module")

--- a/docs/flex/docs/modules/thermocycler.md
+++ b/docs/flex/docs/modules/thermocycler.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Thermocycler"
+description: "Thermocycler Module on Flex: on-deck PCR; installation and use."
 ---
 
 ![The Thermocycler as seen from the top right. The lid is open to show the thermal block inside.](../images/thermocycler.png "Thermocycler")

--- a/docs/flex/docs/modules/thermocycler.md
+++ b/docs/flex/docs/modules/thermocycler.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons Flex: Thermocycler"
-description: "Thermocycler Module on Flex: on-deck PCR; installation and use."
+description: "Installation and use of the Thermocycler Module on Flex for on-deck PCR."
 ---
 
 ![The Thermocycler as seen from the top right. The lid is open to show the thermal block inside.](../images/thermocycler.png "Thermocycler")

--- a/docs/flex/docs/open-source.md
+++ b/docs/flex/docs/open-source.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons Flex: Open-Source Software"
-description: "GitHub, releases, contributing, and open-source resources for Flex software."
+description: "GitHub, releases, contributing, and other resources for Flex software."
 ---
 
 Opentrons believes that open-source software and hardware make science

--- a/docs/flex/docs/open-source.md
+++ b/docs/flex/docs/open-source.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Open-Source Software"
+description: "GitHub, releases, contributing, and open-source resources for Flex software."
 ---
 
 Opentrons believes that open-source software and hardware make science

--- a/docs/flex/docs/opentrons-app/camera.md
+++ b/docs/flex/docs/opentrons-app/camera.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Using the Camera"
+description: "Live monitoring, automatic image capture, and downloading protocol images."
 ---
 
 ## Camera features and controls

--- a/docs/flex/docs/opentrons-app/flex-downgrade.md
+++ b/docs/flex/docs/opentrons-app/flex-downgrade.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Software Downgrade"
+description: "Roll back Flex robot software for troubleshooting or compliance."
 ---
 
 Downgrading Flex software should only be done at the direction of Opentrons Support for troubleshooting or software compliance purposes. The instructions in this section take you through the robot software downgrade process.

--- a/docs/flex/docs/opentrons-app/index.md
+++ b/docs/flex/docs/opentrons-app/index.md
@@ -1,5 +1,6 @@
 ---
 title:"Opentrons Flex: Opentrons App"
+description: "Use the Opentrons App to manage Flex, transfer protocols, and control modules."
 ---
 
 You can control and work with Flex using either the on-device [touchscreen](../touchscreen/index.md) or from a computer running the Opentrons App. This chapter describes how to use the Opentrons software to manage your Flex robot, modules, and other app-only features.

--- a/docs/flex/docs/opentrons-app/install.md
+++ b/docs/flex/docs/opentrons-app/install.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: App Installation and Management"
+description: "Download, install, and update the Opentrons App; manage Flex software."
 ---
 
 Start here for step-by-step instructions for downloading, installing, and maintaining the Opentrons App on a computer.

--- a/docs/flex/docs/opentrons-app/install.md
+++ b/docs/flex/docs/opentrons-app/install.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons Flex: App Installation and Management"
-description: "Download, install, and update the Opentrons App; manage Flex software."
+description: "Download, install, and update the Opentrons App."
 ---
 
 Start here for step-by-step instructions for downloading, installing, and maintaining the Opentrons App on a computer.

--- a/docs/flex/docs/opentrons-app/module-control.md
+++ b/docs/flex/docs/opentrons-app/module-control.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Controlling Modules"
+description: "View module status and control temperature, shaking, and other settings."
 ---
 
 ## Module status and controls

--- a/docs/flex/docs/opentrons-app/protocol-transfer.md
+++ b/docs/flex/docs/opentrons-app/protocol-transfer.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Transferring Protocols"
+description: "Import, analyze, and transfer protocols to Flex from your computer."
 ---
 
 Every protocol will begin as a file on your computer, regardless of what method of [protocol development](../protocols/index.md) you use. You need to import the protocol into the Opentrons App and then transfer it to your Flex. When transferring a protocol, you can choose to begin run setup immediately or later.

--- a/docs/flex/docs/preface.md
+++ b/docs/flex/docs/preface.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Preface"
+description: "How to use this manual and where to find setup, safety, and daily use topics."
 ---
 
 Welcome to the instruction manual for the Opentrons Flex liquid handling robot. This manual guides you through just about everything you need to know to set up and use Flex, focusing on topics that are most relevant to everyday users of Flex in a lab environment.

--- a/docs/flex/docs/protocols/designer.md
+++ b/docs/flex/docs/protocols/designer.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Protocol Designer"
+description: "Create protocols visually with Protocol Designer for Flex."
 ---
 
 Protocol Designer is a web-based, no-code tool for developing protocols that run on Opentrons robots, including Opentrons Flex. You can use Protocol Designer to create protocols that:

--- a/docs/flex/docs/protocols/development-service.md
+++ b/docs/flex/docs/protocols/development-service.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Custom Protocol Service"
+description: "Opentrons custom protocol development and on-site or remote support."
 ---
 
 Opentrons provides a [Remote Custom Protocol Development service](https://opentrons.com/instrument-services) for applications not already included in the Protocol Library. As part of the service, Opentrons field applications scientists will:

--- a/docs/flex/docs/protocols/index.md
+++ b/docs/flex/docs/protocols/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Protocol Development"
+description: "Ways to create protocols: Protocol Designer, Python API, OpentronsAI, and services."
 ---
 
 The Opentrons Flex system can run a wide variety of automated protocols, for tasks such as PCR, NGS, ELISA, and many more. There are several ways to get the protocol you need:

--- a/docs/flex/docs/protocols/library.md
+++ b/docs/flex/docs/protocols/library.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Protocol Library"
+description: "Pre-built protocols available for Flex and how to use them."
 ---
 
 The Opentrons Protocol Library hosts protocols authored either by Opentrons itself or by members of the Opentrons community. To find a protocol that fits your target application, use the search field at the top of the [Protocol Library homepage](https://library.opentrons.com).

--- a/docs/flex/docs/protocols/opentrons-ai.md
+++ b/docs/flex/docs/protocols/opentrons-ai.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: OpentronsAI"
+description: "Generate and run protocols using OpentronsAI for Flex."
 ---
 
 [OpentronsAI](https://ai.opentrons.com/) is a web-based tool that uses the Python Protocol API to create, modify, and optimize protocols. Create a free account and take advantage of simple forms and the chat feature to easily create Python protocols that run on the Flex. 

--- a/docs/flex/docs/protocols/ot-2.md
+++ b/docs/flex/docs/protocols/ot-2.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: OT-2 Protocols"
+description: "Running protocols designed for OT-2 on Flex; compatibility and differences."
 ---
 
 There are hundreds of OT-2 protocols in the Protocol Library, and you may have created your own OT-2 protocols for your lab. Opentrons Flex can perform all the basic actions that the OT-2 can, but OT-2 protocols aren't directly compatible with Flex. However, with a little effort, you can adapt an OT-2 protocol so it will run on Flex. This lets you have parity across different Opentrons robots in your lab, or you can extend older protocols to take advantage of new features only offered on Flex.

--- a/docs/flex/docs/protocols/python-api.md
+++ b/docs/flex/docs/protocols/python-api.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Python Protocol API"
+description: "Write Python protocols for Flex using the Opentrons API."
 ---
 
 Writing protocol scripts in Python gives you the most fine-grained control of Opentrons Flex. Version 2 of the Python Protocol API is a single Python package that exposes a wide range of liquid handling features on Opentrons robots. 

--- a/docs/flex/docs/protocols/python-api.md
+++ b/docs/flex/docs/protocols/python-api.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons Flex: Python Protocol API"
-description: "Write Python protocols for Flex using the Opentrons API."
+description: "Write Python protocols for Flex using the Opentrons Python API."
 ---
 
 Writing protocol scripts in Python gives you the most fine-grained control of Opentrons Flex. Version 2 of the Python Protocol API is a single Python package that exposes a wide range of liquid handling features on Opentrons robots. 

--- a/docs/flex/docs/safety-regulatory.md
+++ b/docs/flex/docs/safety-regulatory.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Safety and Regulatory Information"
+description: "Safety symbols, compliance guidelines, and regulatory information for Flex."
 ---
 
 ## Safety information

--- a/docs/flex/docs/support.md
+++ b/docs/flex/docs/support.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Support and Contact Information"
+description: "Contact options for sales, technical support, warranty, and supplies."
 ---
 
 Contact us if you have any questions about the Opentrons Flex liquid handling robot. Opentrons teams are here to help you with:

--- a/docs/flex/docs/system-description/connections.md
+++ b/docs/flex/docs/system-description/connections.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Connections"
+description: "Power, USB, Ethernet, and network connections for the Flex."
 ---
 
 ![Locations of connections on Flex. USB-A ports and covers for cable routing are on either side of the robot. Facing the rear of the robot, on the left are the AUX-1, AUX-2, USB-B and Ethernet ports. On the right are the IEC power inlet and on/off switch.](../images/flex-connections.png "Flex connections")

--- a/docs/flex/docs/system-description/e-stop.md
+++ b/docs/flex/docs/system-description/e-stop.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Emergency Stop Pendant"
+description: "Emergency stop pendant operation and when to use it."
 ---
 
 The *Emergency Stop Pendant (E-stop)* is a dedicated hardware button for quickly stopping robot motion. Opentrons Flex requires a functional, disengaged E-stop to be attached at all times. When you press the stop button, Flex cancels any running protocol or setup workflow as quickly as possible and prevents most robot motion.

--- a/docs/flex/docs/system-description/e-stop.md
+++ b/docs/flex/docs/system-description/e-stop.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons Flex: Emergency Stop Pendant"
-description: "Emergency stop pendant operation and when to use it."
+description: "Emergency Stop Pendant operation and when to use it."
 ---
 
 The *Emergency Stop Pendant (E-stop)* is a dedicated hardware button for quickly stopping robot motion. Opentrons Flex requires a functional, disengaged E-stop to be attached at all times. When you press the stop button, Flex cancels any running protocol or setup workflow as quickly as possible and prevents most robot motion.

--- a/docs/flex/docs/system-description/gripper.md
+++ b/docs/flex/docs/system-description/gripper.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons Flex: Gripper"
-description: "Gripper for moving labware, lids, and adapters on the Flex deck."
+description: "Gripper for moving labware and lids on the Flex deck."
 ---
 
 The *gripper* moves labware throughout the working area and staging area during the execution of protocols. The gripper attaches to the *extension mount*, which is separate from the pipette mounts; the gripper can be used with any pipette configuration. For details on installing the gripper, see [Instrument Installation and Calibration](../installation/instruments.md).

--- a/docs/flex/docs/system-description/gripper.md
+++ b/docs/flex/docs/system-description/gripper.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Gripper"
+description: "Gripper for moving labware, lids, and adapters on the Flex deck."
 ---
 
 The *gripper* moves labware throughout the working area and staging area during the execution of protocols. The gripper attaches to the *extension mount*, which is separate from the pipette mounts; the gripper can be used with any pipette configuration. For details on installing the gripper, see [Instrument Installation and Calibration](../installation/instruments.md).

--- a/docs/flex/docs/system-description/index.md
+++ b/docs/flex/docs/system-description/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: System Description"
+description: "Hardware systems, robot components, and specifications of the Flex."
 ---
 
 This chapter describes the hardware systems of Opentrons Flex, which underlie its core lab automation features. 

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Pipettes"
+description: "Flex pipette types, 96- and 384-channel options, and compatibility."
 ---
 
 Opentrons *pipettes* are configurable devices used to move liquids throughout the working area during the execution of protocols. There are several Opentrons Flex pipettes, which can handle volumes from 1 µL to 1000 µL in 1, 8, or 96 channels:

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons Flex: Pipettes"
-description: "Flex pipette types, 96- and 384-channel options, and compatibility."
+description: "Flex pipette types (1-, 8-, and 96-channel), and compatibility."
 ---
 
 Opentrons *pipettes* are configurable devices used to move liquids throughout the working area during the execution of protocols. There are several Opentrons Flex pipettes, which can handle volumes from 1 µL to 1000 µL in 1, 8, or 96 channels:

--- a/docs/flex/docs/system-description/robot.md
+++ b/docs/flex/docs/system-description/robot.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Robot Components"
+description: "Frame, gantry, deck, working area, and visual indicators of the Flex."
 ---
 
 <figure markdown>

--- a/docs/flex/docs/system-description/specs.md
+++ b/docs/flex/docs/system-description/specs.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: System Specifications"
+description: "Dimensions, weight, deck slots, connectivity, and power specifications."
 ---
 
 ## General specifications

--- a/docs/flex/docs/touchscreen/dashboard.md
+++ b/docs/flex/docs/touchscreen/dashboard.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Touchscreen Dashboard"
+description: "Home screen, status, and quick access to protocols and settings."
 ---
 
 <figure class="screenshot" markdown>

--- a/docs/flex/docs/touchscreen/deck-config.md
+++ b/docs/flex/docs/touchscreen/deck-config.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Deck Configuration"
+description: "Configure deck layout, modules, and labware locations on the touchscreen."
 ---
 
 Deck configuration tells your Flex what fixtures are attached to the deck, in what locations. You need to inform the robot about installed fixtures because they're unpowered attachments. They do not contain electronic or mechanical components that communicate with the robot. Flex won't know what's attached and where it is until you configure deck fixtures via the touchscreen or Opentrons App.

--- a/docs/flex/docs/touchscreen/index.md
+++ b/docs/flex/docs/touchscreen/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Touchscreen"
+description: "On-device touchscreen for running protocols and managing Flex."
 ---
 
 This chapter focuses on operating Flex from its on-device touchscreen. You can use the touchscreen to control Flex whenever the robot is on. If your robot is on and the touchscreen is off, tap it once to wake the screen.

--- a/docs/flex/docs/touchscreen/instruments.md
+++ b/docs/flex/docs/touchscreen/instruments.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Instrument Management"
+description: "View and manage pipettes and modules from the touchscreen."
 ---
 
 The Instruments screen is an interactive list of all instruments that you've connected to your Flex. The list is organized by mount: left pipette mount, right pipette mount, and extension mount.

--- a/docs/flex/docs/touchscreen/protocol-details.md
+++ b/docs/flex/docs/touchscreen/protocol-details.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Protocol Details"
+description: "View protocol steps, labware map, and run history on the touchscreen."
 ---
 
 Tap on any protocol to view its detail screen. This screen displays all of the types of information included in the protocol file, as well as common protocol actions. An indicator at the top left of the screen shows whether the protocol is ready to run, or whether you need to perform additional setup.

--- a/docs/flex/docs/touchscreen/protocol-management.md
+++ b/docs/flex/docs/touchscreen/protocol-management.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Protocol Management"
+description: "Browse, delete, and organize protocols stored on the Flex touchscreen."
 ---
 
 The All Protocols screen is an interactive list of all protocols that you've stored on Opentrons Flex. (Sending a protocol to Flex requires the Opentrons App. See [Transferring Protocols](../opentrons-app/protocol-transfer.md) for more information about that process.)

--- a/docs/flex/docs/touchscreen/protocol-run.md
+++ b/docs/flex/docs/touchscreen/protocol-run.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Protocol Run"
+description: "Start, pause, cancel, and monitor protocol execution on the touchscreen."
 ---
 
 Once everything is set up, begin your run by tapping the play button :material-play-circle: on the "Prepare to run" screen. Flex will begin the protocol and you'll see the Running screen.

--- a/docs/flex/docs/touchscreen/protocol-setup.md
+++ b/docs/flex/docs/touchscreen/protocol-setup.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Protocol Setup"
+description: "Assign robot, configure labware, and prepare to run a protocol on the touchscreen."
 ---
 
 When you start setup for a protocol, you'll see the "Prepare to run" screen, which summarizes all of the requirements for the protocol.

--- a/docs/flex/docs/touchscreen/protocol-setup.md
+++ b/docs/flex/docs/touchscreen/protocol-setup.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons Flex: Protocol Setup"
-description: "Assign robot, configure labware, and prepare to run a protocol on the touchscreen."
+description: "Configure labware and liquids, and prepare to run a protocol on the touchscreen."
 ---
 
 When you start setup for a protocol, you'll see the "Prepare to run" screen, which summarizes all of the requirements for the protocol.

--- a/docs/flex/docs/touchscreen/quick-transfer.md
+++ b/docs/flex/docs/touchscreen/quick-transfer.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Quick Transfer"
+description: "Run a simple liquid transfer from the touchscreen without a full protocol."
 ---
 
 Quick transfer is a touchscreen-only feature that lets you create, save, and run simple procedures that move liquid from a source to a destination, all without creating a protocol or writing code. Available starting in robot software version 8.0.0, this feature is ideal for preparing labware you need to use in other, more complex procedures. For example, you can use quick transfers to:

--- a/docs/flex/docs/touchscreen/settings.md
+++ b/docs/flex/docs/touchscreen/settings.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex: Settings"
+description: "Touchscreen settings for network, display, and robot configuration."
 ---
 
 The Settings screen provides additional controls you can use to customize the behavior of your Flex. Tap a setting to toggle it on or off, or to open another screen that displays related adjustment controls.

--- a/docs/heater-shaker/docs/adapters.md
+++ b/docs/heater-shaker/docs/adapters.md
@@ -1,5 +1,6 @@
 ---
 title: "Heater-Shaker Module: Thermal Adapters"
+description: "Thermal adapter types and supported labware for the Heater-Shaker."
 ---
 
 Aluminum thermal adapters help transfer heat from the Heater-Shaker to attached labware. The module comes with your choice of a universal flat adapter, a PCR well plate adapter, a 96-well flat bottom adapter, or a deep well adapter. You can also purchase additional adapters directly from the [modules section](https://opentrons.com/products/categories/modules) of the Opentrons website.

--- a/docs/heater-shaker/docs/additional-info.md
+++ b/docs/heater-shaker/docs/additional-info.md
@@ -1,5 +1,6 @@
 ---
 title: "Heater-Shaker Module: Additional Product Information"
+description: "Warranty, support, app download, and manufacturer information for the Heater-Shaker."
 ---
 
 ## Warranty

--- a/docs/heater-shaker/docs/compliance.md
+++ b/docs/heater-shaker/docs/compliance.md
@@ -1,5 +1,6 @@
 ---
 title: "Heater-Shaker Module: Safety Information and Regulatory Compliance"
+description: "Environmental conditions, safe use, and regulatory compliance for the Heater-Shaker."
 ---
 
 Opentrons recommends that you follow the safe use specifications listed in this section and throughout this manual.

--- a/docs/heater-shaker/docs/index.md
+++ b/docs/heater-shaker/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Heater-Shaker Module GEN1 Instruction Manual"
+description: "On-deck heating and orbital shaking for Flex and OT-2; 37–95 °C, 200–3000 rpm."
 hide: toc
 ---
 

--- a/docs/heater-shaker/docs/installation-flex.md
+++ b/docs/heater-shaker/docs/installation-flex.md
@@ -1,5 +1,6 @@
 ---
 title: "Heater-Shaker Module: Flex Installation Instructions"
+description: "Attach to caddy, mount on deck, and calibrate the Heater-Shaker on Flex."
 ---
 
 Installing the Heater-Shaker on your robot includes attaching it to the deck and calibrating it for the first time. The instructions here and on the touchscreen will help you get started. The tools you need are included with the module or in the User Kit that came with your Flex.

--- a/docs/heater-shaker/docs/installation-ot2.md
+++ b/docs/heater-shaker/docs/installation-ot2.md
@@ -1,6 +1,6 @@
 ---
 title: "Heater-Shaker Module: OT-2 Installation Instructions"
-description: "Mount, anchor, and connect USB and power for the Heater-Shaker on an OT-2."
+description: "Mount, anchor, and connect USB and power for the Heater-Shaker on OT-2."
 ---
 
 To install the Heater-Shaker on your OT-2:

--- a/docs/heater-shaker/docs/installation-ot2.md
+++ b/docs/heater-shaker/docs/installation-ot2.md
@@ -1,5 +1,6 @@
 ---
 title: "Heater-Shaker Module: OT-2 Installation Instructions"
+description: "Mount, anchor, and connect USB and power for the Heater-Shaker on an OT-2."
 ---
 
 To install the Heater-Shaker on your OT-2:

--- a/docs/heater-shaker/docs/maintenance.md
+++ b/docs/heater-shaker/docs/maintenance.md
@@ -1,6 +1,6 @@
 ---
 title: "Heater-Shaker Module: Maintenance and Cleaning"
-description: "Cleaning procedures and when to contact support; no user servicing."
+description: "Cleaning procedures and when to contact support."
 ---
 
 ## Maintenance

--- a/docs/heater-shaker/docs/maintenance.md
+++ b/docs/heater-shaker/docs/maintenance.md
@@ -1,5 +1,6 @@
 ---
 title: "Heater-Shaker Module: Maintenance and Cleaning"
+description: "Cleaning procedures and when to contact support; no user servicing."
 ---
 
 ## Maintenance

--- a/docs/heater-shaker/docs/pre-installation.md
+++ b/docs/heater-shaker/docs/pre-installation.md
@@ -1,5 +1,6 @@
 ---
 title: "Heater-Shaker Module: Before You Begin"
+description: "Deck placement, Flex caddies, and anchor adjustments before installation."
 ---
 
 Review this section for important information about deck placement, alignment, and anchor adjustments for the Heater-Shaker.

--- a/docs/heater-shaker/docs/product-specs.md
+++ b/docs/heater-shaker/docs/product-specs.md
@@ -1,5 +1,6 @@
 ---
 title: "Heater-Shaker Module: Product Specifications"
+description: "Physical specs, heating and shaking profiles, and included parts for GEN1."
 ---
 
 ![Heater-Shaker with external features labeled](images/hs-with-labels.svg)

--- a/docs/heater-shaker/docs/product-specs.md
+++ b/docs/heater-shaker/docs/product-specs.md
@@ -1,6 +1,6 @@
 ---
 title: "Heater-Shaker Module: Product Specifications"
-description: "Physical specs, heating and shaking profiles, and included parts for GEN1."
+description: "Physical specs, heating and shaking profiles, and included parts."
 ---
 
 ![Heater-Shaker with external features labeled](images/hs-with-labels.svg)

--- a/docs/heater-shaker/docs/software.md
+++ b/docs/heater-shaker/docs/software.md
@@ -1,5 +1,6 @@
 ---
 title: "Heater-Shaker Module: Software Control"
+description: "Control the Heater-Shaker via Protocol Designer, Python API, and the Opentrons App."
 ---
 
 You control the Heater-Shaker through protocols you create in [Opentrons Protocol Designer](https://designer.opentrons.com/) or the [Python API](../python-api/modules/heater-shaker.md). Running these protocols requires version 6.1.0 or newer of the [Opentrons App](https://opentrons.com/ot-app) and robot server.

--- a/docs/hepa-uv/docs/additional-info.md
+++ b/docs/hepa-uv/docs/additional-info.md
@@ -1,5 +1,6 @@
 ---
 title: "HEPA/UV Module: Additional Product Information"
+description: "Warranty, support contact, and manufacturer information for the HEPA/UV Module."
 ---
 
 ## Warranty

--- a/docs/hepa-uv/docs/cleaning.md
+++ b/docs/hepa-uv/docs/cleaning.md
@@ -1,5 +1,6 @@
 ---
 title: "HEPA/UV Module: Cleaning"
+description: "Approved cleaning solutions and procedures for the HEPA/UV Module exterior."
 ---
 
 The following table lists the chemicals you can use to clean the exterior of your HEPA/UV Module. Diluted alcohol and distilled water are our recommended cleaning products, but you can refer to this list for other cleaning options.

--- a/docs/hepa-uv/docs/compliance.md
+++ b/docs/hepa-uv/docs/compliance.md
@@ -1,5 +1,6 @@
 ---
 title: "HEPA/UV Module: Safety Information and Regulatory Compliance"
+description: "Environmental conditions, safe use, and regulatory compliance for the HEPA/UV Module."
 ---
 
 Opentrons recommends that you follow the safe use specifications listed in this section and throughout this manual.

--- a/docs/hepa-uv/docs/hardware-controls.md
+++ b/docs/hepa-uv/docs/hardware-controls.md
@@ -1,5 +1,6 @@
 ---
 title: "HEPA/UV Module: Hardware Controls"
+description: "Fan and UV light buttons, status indicators, and safe operation."
 ---
 
 Separate on/off buttons on the front of the HEPA/UV Module control the fan and UV lights. You can operate these systems simultaneously or independently of each other.

--- a/docs/hepa-uv/docs/hepa-specs.md
+++ b/docs/hepa-uv/docs/hepa-specs.md
@@ -1,5 +1,6 @@
 ---
 title: "HEPA/UV Module: HEPA Specifications"
+description: "Two-stage filtration, H14 HEPA filter, pre-filter, and ISO-5 clean bench standards."
 ---
 
 The Flex HEPA/UV Module uses a two-stage filtration system to purify air pulled into the enclosure. This system includes a reusable pre-filter and a disposable H14 HEPA main filter. The pre-filter traps large particles while the HEPA filter captures up to 99.99% of airborne particulate matter at ≥ 0.3 microns (µm). Vertical air flow from the HEPA filter creates a positive-pressure environment within the enclosure. This air boundary helps protect samples inside the Flex from external contamination. The air cleaning system of the Flex HEPA/UV Module meets ISO-5 clean bench standards.

--- a/docs/hepa-uv/docs/index.md
+++ b/docs/hepa-uv/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: "HEPA/UV Module Instruction Manual"
+description: "Flex clean-air and UV disinfectant module; ISO-5 environment, HEPA and UV-C."
 hide: toc
 ---
 

--- a/docs/hepa-uv/docs/installation.md
+++ b/docs/hepa-uv/docs/installation.md
@@ -1,5 +1,6 @@
 ---
 title: "HEPA/UV Module: Unboxing and Installation"
+description: "Unbox, attach to Flex with clearance requirements, and connect power."
 ---
 
 Ask a lab partner for help with unboxing, lifting, and attaching the module. For tools, you will need scissors and the 2.5 mm hex screwdriver that comes in the Module User Kit.

--- a/docs/hepa-uv/docs/maintenance.md
+++ b/docs/hepa-uv/docs/maintenance.md
@@ -1,5 +1,6 @@
 ---
 title: "HEPA/UV Module: Maintenance"
+description: "UV bulb and filter replacement; when to contact support for service."
 ---
 
 <style>

--- a/docs/hepa-uv/docs/product-specs.md
+++ b/docs/hepa-uv/docs/product-specs.md
@@ -1,5 +1,6 @@
 ---
 title: "HEPA/UV Module: Product Specifications"
+description: "Included parts, dimensions, power, and physical specs for the HEPA/UV Module."
 ---
 
 ![Labeled HEPA/UV Module diagram](images/hepa-features-labeled.png)

--- a/docs/hepa-uv/docs/uv-specs.md
+++ b/docs/hepa-uv/docs/uv-specs.md
@@ -1,5 +1,6 @@
 ---
 title: "HEPA/UV Module: UV Specifications"
+description: "UV-C 254 nm disinfection, safety features, and 15-minute exposure cycle."
 ---
 
 The HEPA/UV Module holds two compact fluorescent UV bulbs. When on, the bulbs emit UV-C at the 254 nm wavelength. At this wavelength, UV-C disinfects by killing or damaging the genetic material found in various microorganisms. After a 15-minute exposure cycle, the ultraviolet light produced is sufficient to achieve log-4 (99.99%) inactivation of commonly targeted microorganisms within the enclosure.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: Opentrons Documentation
+site_description: Documentation for Opentrons liquid handling robots, hardware, and software.
 
 docs_dir: ./shared
 

--- a/docs/ot-2/docs/additional-docs.md
+++ b/docs/ot-2/docs/additional-docs.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Additional Documentation"
+description: "Links to Knowledge Hub, Python API docs, and other Opentrons resources."
 ---
 
 In addition to this manual, Opentrons provides several online resources for our hardware and software products. These resources may be valuable as you use the OT-2.

--- a/docs/ot-2/docs/calibration/index.md
+++ b/docs/ot-2/docs/calibration/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Calibration"
+description: "Deck, tip length, pipette offset, and labware calibration procedures."
 ---
 
 This chapter covers the calibration procedures and software tools you will use to ensure your OT-2 moves around its working area with repeatable accuracy. By mapping the robot's hardware and labware to the deck and gantry-mounted instruments, these procedures help the robot operate with precision during a protocol run.

--- a/docs/ot-2/docs/calibration/jog-controls.md
+++ b/docs/ot-2/docs/calibration/jog-controls.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Jog Controls"
+description: "Use jog controls to align the pipette during calibration and Labware Position Check."
 ---
 
 The Opentrons App displays various _jog controls_ while you perform robot calibrations or run Labware Position Check. These are movement controls that allow you to make fine adjustments along the X, Y, and Z-axes for better alignment with the deck, labware, and modules.

--- a/docs/ot-2/docs/calibration/labware-offsets.md
+++ b/docs/ot-2/docs/calibration/labware-offsets.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Labware Offsets"
+description: "Create and use labware offsets with Labware Position Check for accuracy."
 ---
 
 Labware offsets are fine-tuned positional coordinates that help the OT-2 align a pipette relative to a specific piece of labware used in a protocol. _Labware Position Check_ is the procedure your OT-2 runs to create these offset measurements.

--- a/docs/ot-2/docs/calibration/robot-calibration.md
+++ b/docs/ot-2/docs/calibration/robot-calibration.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Robot Calibration"
+description: "Deck, tip length, and pipette offset calibration steps and when to run them."
 ---
 
 Your OT-2 moves gantry-mounted pipettes in three-dimensional space (left–right, front–back, up–down). To move accurately, the robot needs a precise map of its own hardware relative to a good reference point: the deck. The robot calibration process creates this map.

--- a/docs/ot-2/docs/index.md
+++ b/docs/ot-2/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2 Instruction Manual"
+description: "Official instruction manual for the Opentrons OT-2 liquid handling robot."
 ---
 
 <style>

--- a/docs/ot-2/docs/installation/first-run.md
+++ b/docs/ot-2/docs/installation/first-run.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: First Run"
+description: "Download the app, connect power and Ethernet, and power on the OT-2."
 ---
 
 The OT-2 is powered by an external power supply that converts AC wall current to the 36 VDC used by the robot's internal systems. You control the robot through the Opentrons App and a computer connected using the supplied Ethernet cable and dongle. This section guides you through downloading the Opentrons App, connecting your computer to the OT-2, and connecting the robot to the external power supply.

--- a/docs/ot-2/docs/installation/index.md
+++ b/docs/ot-2/docs/installation/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Installation and Relocation"
+description: "Prepare your lab, set up the robot, and relocate the OT-2 when needed."
 ---
 
 This chapter describes how to prepare your lab for an OT-2, how to set up the robot, and how to move it if necessary.

--- a/docs/ot-2/docs/installation/instruments.md
+++ b/docs/ot-2/docs/installation/instruments.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Instrument Installation and Calibration"
+description: "Attach pipettes to the gantry and run calibration using the Opentrons App."
 ---
 
 After the initial robot setup, your next step is to attach and calibrate a pipette. The OT-2 has two pipette mounts; each can hold a single-channel or multi-channel pipette. The information in this section will help you get started; the Opentrons App provides detailed, illustrated instructions about the attachment and calibration workflows. To begin:

--- a/docs/ot-2/docs/installation/relocation.md
+++ b/docs/ot-2/docs/installation/relocation.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Relocation"
+description: "How to prepare and move the OT-2 for short or long-distance relocation."
 ---
 
 This section provides instructions about how prepare your OT-2 for moving and transportation.

--- a/docs/ot-2/docs/installation/relocation.md
+++ b/docs/ot-2/docs/installation/relocation.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons OT-2: Relocation"
-description: "How to prepare and move the OT-2 for short or long-distance relocation."
+description: "How to prepare and move the OT-2 for short- or long-distance relocation."
 ---
 
 This section provides instructions about how prepare your OT-2 for moving and transportation.

--- a/docs/ot-2/docs/installation/requirements.md
+++ b/docs/ot-2/docs/installation/requirements.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Installation Requirements"
+description: "Site requirements: placement, power, and environmental conditions for the OT-2."
 ---
 
 Before setting up an OT-2, make sure that your installation site meets the requirements described in this section. Also, follow all of the safety guidance here and throughout the installation instructions.

--- a/docs/ot-2/docs/installation/unboxing.md
+++ b/docs/ot-2/docs/installation/unboxing.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Unboxing"
+description: "Step-by-step unboxing, assembly, and initial preparation of your new OT-2."
 ---
 
 Congratulations! Your OT-2 has arrived and you've prepared a space for it in your lab. This section provides instructions to walk you through unboxing, assembling, and preparing the OT-2 for use.

--- a/docs/ot-2/docs/introduction.md
+++ b/docs/ot-2/docs/introduction.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Introduction"
+description: "Overview of the OT-2 robot, manual structure, and how to control it."
 ---
 
 Welcome to the instruction manual for the Opentrons OT-2 liquid handling robot. This manual will help you set up and work with the OT-2.

--- a/docs/ot-2/docs/labware/concepts.md
+++ b/docs/ot-2/docs/labware/concepts.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Labware Concepts"
+description: "Physical labware, Opentrons-verified definitions, and custom labware concepts."
 ---
 
 Labware encompasses more than just the objects placed on the deck and used in a protocol. For the OT-2, labware includes:

--- a/docs/ot-2/docs/labware/definitions.md
+++ b/docs/ot-2/docs/labware/definitions.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Labware Definitions"
+description: "Labware definitions, Custom Labware Creator, and JSON schema for custom labware."
 ---
 
 Every piece of labware you use on an OT-2 requires a _labware definition_. Each definition contains all the information your robot needs to work with a piece of labware. This includes information about the physical shape of the labware, what pipettes can interact with it, and what the labware should be called in the Opentrons App. The OT-2 robot software and the Opentrons App include the labware definitions for everything available in the [Opentrons Labware Library](https://labware.opentrons.com/).

--- a/docs/ot-2/docs/labware/index.md
+++ b/docs/ot-2/docs/labware/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons OT-2: Labware"
-description: "How the OT-2 uses labware in software and on the deck; concepts and definitions."
+description: "How the OT-2 uses labware in software and on the deck."
 ---
 
 This chapter covers how the OT-2 works with labware, both in software and on the robot deck itself.

--- a/docs/ot-2/docs/labware/index.md
+++ b/docs/ot-2/docs/labware/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Labware"
+description: "How the OT-2 uses labware in software and on the deck; concepts and definitions."
 ---
 
 This chapter covers how the OT-2 works with labware, both in software and on the robot deck itself.

--- a/docs/ot-2/docs/labware/types.md
+++ b/docs/ot-2/docs/labware/types.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons OT-2: Labware Types"
-description: "Reservoirs, well plates, tube racks, and other labware types in the Library."
+description: "Reservoirs, well plates, tube racks, and other labware types in the Labware Library."
 ---
 
 This section covers the different types of labware included in the Opentrons Labware Library for use with the OT-2.

--- a/docs/ot-2/docs/labware/types.md
+++ b/docs/ot-2/docs/labware/types.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Labware Types"
+description: "Reservoirs, well plates, tube racks, and other labware types in the Library."
 ---
 
 This section covers the different types of labware included in the Opentrons Labware Library for use with the OT-2.

--- a/docs/ot-2/docs/maintenance/cleaning.md
+++ b/docs/ot-2/docs/maintenance/cleaning.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons OT-2: Cleaning"
-description: "How to clean the OT-2 frame, deck, gantry, and which solutions to use."
+description: "How to clean the OT-2 frame, deck, gantry, and which cleaning solutions to use."
 ---
 
 Routine cleaning helps keep your OT-2 free of contaminants that can affect your protocols. Cleaning also gives you a chance to inspect the robot for wear and damage. Review this section for information and instructions on how to clean your robot.

--- a/docs/ot-2/docs/maintenance/cleaning.md
+++ b/docs/ot-2/docs/maintenance/cleaning.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Cleaning"
+description: "How to clean the OT-2 frame, deck, gantry, and which solutions to use."
 ---
 
 Routine cleaning helps keep your OT-2 free of contaminants that can affect your protocols. Cleaning also gives you a chance to inspect the robot for wear and damage. Review this section for information and instructions on how to clean your robot.

--- a/docs/ot-2/docs/maintenance/index.md
+++ b/docs/ot-2/docs/maintenance/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Maintenance"
+description: "Routine maintenance, cleaning, and when to contact Opentrons for service."
 ---
 
 This chapter covers how to perform routine maintenance on your OT-2, what to do if you require service for a problem, and summarizes the commercial service offerings provided by Opentrons. You should be able to perform the [cleaning tasks](./cleaning.md) described here by yourself, whereas [service and repairs](./services.md) should be handled by Opentrons Support.

--- a/docs/ot-2/docs/maintenance/services.md
+++ b/docs/ot-2/docs/maintenance/services.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Services"
+description: "Opentrons Care and Care Plus service plans, repairs, and preventive maintenance."
 ---
 
 Opentrons offers two levels of service, Opentrons Care and Opentrons Care Plus, both of which include benefits for onboarding, maintenance, and repair. These services are available in the continental United States; Opentrons Care is also available internationally. Both services include:

--- a/docs/ot-2/docs/modules/heater-shaker.md
+++ b/docs/ot-2/docs/modules/heater-shaker.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Heater-Shaker"
+description: "Heater-Shaker Module: on-deck heating and orbital shaking (37–95 °C, 200–3000 rpm)."
 ---
 
 ![Heater-Shaker image](../images/heater-shaker-module.png)

--- a/docs/ot-2/docs/modules/hepa.md
+++ b/docs/ot-2/docs/modules/hepa.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: HEPA Module"
+description: "HEPA Module: positive-pressure clean air for the OT-2 enclosure (OT-2 only)."
 ---
 
 ![OT-2 HEPA Module](../images/ot2-hepa-hero.png)

--- a/docs/ot-2/docs/modules/index.md
+++ b/docs/ot-2/docs/modules/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Modules"
+description: "OT-2-compatible modules: Heater-Shaker, HEPA, Magnetic, Temperature, Thermocycler."
 ---
 
 Modules are a class of deck or externally mounted hardware. You can use an OT-2 with several hardware modules that add features and capabilities to the robot. The OT-2 communicates with and controls most modules through a USB connection.

--- a/docs/ot-2/docs/modules/index.md
+++ b/docs/ot-2/docs/modules/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons OT-2: Modules"
-description: "OT-2-compatible modules: Heater-Shaker, HEPA, Magnetic, Temperature, Thermocycler."
+description: "OT-2-compatible modules: Heater-Shaker, HEPA, Magnetic Module, Temperature Module, Thermocycler."
 ---
 
 Modules are a class of deck or externally mounted hardware. You can use an OT-2 with several hardware modules that add features and capabilities to the robot. The OT-2 communicates with and controls most modules through a USB connection.

--- a/docs/ot-2/docs/modules/magnetic.md
+++ b/docs/ot-2/docs/modules/magnetic.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Magnetic Module"
+description: "Magnetic Module for bead-based purification; discontinued but specifications included."
 ---
 
 ![Magnetic module](../images/magnetic-module.png)

--- a/docs/ot-2/docs/modules/magnetic.md
+++ b/docs/ot-2/docs/modules/magnetic.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons OT-2: Magnetic Module"
-description: "Magnetic Module for bead-based purification; discontinued but specifications included."
+description: "Magnetic Module for bead-based purification on the OT-2."
 ---
 
 ![Magnetic module](../images/magnetic-module.png)

--- a/docs/ot-2/docs/modules/temperature.md
+++ b/docs/ot-2/docs/modules/temperature.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Temperature Module"
+description: "Temperature Module features, thermal blocks, and temperature range (4–95 °C)."
 ---
 
 ![Temperature Module](../images/temperature-module.png)

--- a/docs/ot-2/docs/modules/thermocycler.md
+++ b/docs/ot-2/docs/modules/thermocycler.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Thermocycler"
+description: "On-deck thermocycler for PCR: block and lid temperatures, profiles, and software control."
 ---
 
 ![Thermocycler](../images/thermocycler.png)

--- a/docs/ot-2/docs/open-source.md
+++ b/docs/ot-2/docs/open-source.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Open Source Software"
+description: "How to use Opentrons open-source code, GitHub releases, and contribute."
 ---
 
 Opentrons believes that open-source software and hardware make science better. That's why we make our code available on GitHub and welcome contributions from the open-source community.

--- a/docs/ot-2/docs/opentrons-app/features-summary.md
+++ b/docs/ot-2/docs/opentrons-app/features-summary.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: App Features Summary"
+description: "Protocols, Labware, and Devices tab features and settings in the app."
 ---
 
 You control the OT-2 using the Opentrons App on your computer. This section highlights key features found in the Protocols, Labware, and Devices tabs of the app.

--- a/docs/ot-2/docs/opentrons-app/index.md
+++ b/docs/ot-2/docs/opentrons-app/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Opentrons App"
+description: "Download and use the Opentrons App to run protocols and control the OT-2."
 ---
 
 You operate an OT-2 through the [Opentrons App](https://opentrons.com/ot-app). This chapter describes how to download and use the app to perform fundamental tasks like uploading protocol files, running and managing protocols, controlling hardware, and other features.

--- a/docs/ot-2/docs/opentrons-app/installation.md
+++ b/docs/ot-2/docs/opentrons-app/installation.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons OT-2: Installing the App"
-description: "System requirements, download, and install the Opentrons App on Windows, macOS, or Linux."
+description: "System requirements, download, and installation for the Opentrons App on Windows, macOS, or Linux."
 ---
 
 Start here for step-by-step instructions for downloading, installing, and updating the Opentrons App.

--- a/docs/ot-2/docs/opentrons-app/installation.md
+++ b/docs/ot-2/docs/opentrons-app/installation.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Installing the App"
+description: "System requirements, download, and install the Opentrons App on Windows, macOS, or Linux."
 ---
 
 Start here for step-by-step instructions for downloading, installing, and updating the Opentrons App.

--- a/docs/ot-2/docs/opentrons-app/protocol-import.md
+++ b/docs/ot-2/docs/opentrons-app/protocol-import.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Importing Protocols"
+description: "Upload or import protocol files and understand protocol analysis in the app."
 ---
 
 Regardless of how you create them, every protocol begins as a file on your computer. You must import the protocol into the Opentrons App to transfer it to your OT-2.

--- a/docs/ot-2/docs/opentrons-app/protocol-run.md
+++ b/docs/ot-2/docs/opentrons-app/protocol-run.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Running Protocols"
+description: "Start setup, assign robot, run protocol, and use Run Preview on the OT-2."
 ---
 
 After creating and uploading a protocol, it's time to run it on your OT-2. Follow these instructions to get started.

--- a/docs/ot-2/docs/opentrons-app/protocol-run.md
+++ b/docs/ot-2/docs/opentrons-app/protocol-run.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons OT-2: Running Protocols"
-description: "Start setup, assign robot, run protocol, and use Run Preview on the OT-2."
+description: "Start setup, preview, and run a protocol on the OT-2."
 ---
 
 After creating and uploading a protocol, it's time to run it on your OT-2. Follow these instructions to get started.

--- a/docs/ot-2/docs/pipettes.md
+++ b/docs/ot-2/docs/pipettes.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Pipettes"
+description: "GEN1 and GEN2 pipette types, compatibility, and attachment for the OT-2."
 ---
 
 OT-2 pipettes are a class of gantry-mounted instruments you attach to an Opentrons OT-2 liquid handling robot. They move liquids throughout the working area during protocol execution. For an OT-2, this class of instruments includes single-channel and multi-channel GEN1 and GEN2 pipettes. 

--- a/docs/ot-2/docs/safety-regulatory.md
+++ b/docs/ot-2/docs/safety-regulatory.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Safety and Regulatory Information"
+description: "Safety symbols, compliance guidelines, and regulatory information for the OT-2."
 ---
 
 ## Safety information

--- a/docs/ot-2/docs/support.md
+++ b/docs/ot-2/docs/support.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Product Support and Company Information"
+description: "Contact options for sales, technical support, warranty, and supplies."
 ---
 
 Contact us if you have any questions about the OT-2. Opentrons teams are here to help you with:

--- a/docs/ot-2/docs/system-description/index.md
+++ b/docs/ot-2/docs/system-description/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: System Description"
+description: "Hardware systems, robot components, and specifications of the OT-2."
 ---
 
 This chapter describes the hardware systems and features of the OT-2, which underlie its core lab automation features.

--- a/docs/ot-2/docs/system-description/robot.md
+++ b/docs/ot-2/docs/system-description/robot.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: Robot Components"
+description: "Frame, gantry, deck, working area, and visual indicators of the OT-2."
 ---
 
 ![OT-2 main parts with labels](../images/ot2-features-hero.png)

--- a/docs/ot-2/docs/system-description/specs.md
+++ b/docs/ot-2/docs/system-description/specs.md
@@ -1,6 +1,6 @@
 ---
 title: "Opentrons OT-2: System Specifications"
-description: "Dimensions, weight, deck slots, connectivity, and power specifications."
+description: "Dimensions, weight, deck slots, connectivity, and power specifications of the OT-2."
 ---
 
 <table>

--- a/docs/ot-2/docs/system-description/specs.md
+++ b/docs/ot-2/docs/system-description/specs.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons OT-2: System Specifications"
+description: "Dimensions, weight, deck slots, connectivity, and power specifications."
 ---
 
 <table>

--- a/docs/protocol-designer/docs/about.md
+++ b/docs/protocol-designer/docs/about.md
@@ -1,6 +1,6 @@
 ---
 title: "Protocol Designer: About"
-description: "Four-step workflow: create protocol, starting deck, steps, and export."
+description: "How to use Protocol Designer to build protocols for the Opentrons Flex or OT-2."
 ---
 
 In Protocol Designer, you'll define the hardware, labware, and liquids the robot will use during a protocol. This manual details how to use Protocol Designer to build protocols for the Opentrons Flex or OT-2 in four steps: 

--- a/docs/protocol-designer/docs/about.md
+++ b/docs/protocol-designer/docs/about.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: About"
+description: "Four-step workflow: create protocol, starting deck, steps, and export."
 ---
 
 In Protocol Designer, you'll define the hardware, labware, and liquids the robot will use during a protocol. This manual details how to use Protocol Designer to build protocols for the Opentrons Flex or OT-2 in four steps: 

--- a/docs/protocol-designer/docs/create-protocol/metadata-overview.md
+++ b/docs/protocol-designer/docs/create-protocol/metadata-overview.md
@@ -1,6 +1,6 @@
 ---
 title: "Protocol Designer: Metadata and Overview"
-description: "Protocol title, description, author, and overview summary."
+description: "How to add a protocol title, description, author, and overview."
 ---
 
 ## Protocol metadata

--- a/docs/protocol-designer/docs/create-protocol/metadata-overview.md
+++ b/docs/protocol-designer/docs/create-protocol/metadata-overview.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Metadata and Overview"
+description: "Protocol title, description, author, and overview summary."
 ---
 
 ## Protocol metadata

--- a/docs/protocol-designer/docs/create-protocol/modules-fixtures.md
+++ b/docs/protocol-designer/docs/create-protocol/modules-fixtures.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Modules and Fixtures"
+description: "Add modules and fixtures to the deck; compatibility by robot and slot."
 ---
 
 The second step in building your protocol is to add modules or fixtures to the deck. Click an open slot to add a module, like the Temperature Module, or a fixture like the trash bin. 

--- a/docs/protocol-designer/docs/create-protocol/modules-fixtures.md
+++ b/docs/protocol-designer/docs/create-protocol/modules-fixtures.md
@@ -1,6 +1,6 @@
 ---
 title: "Protocol Designer: Modules and Fixtures"
-description: "Add modules and fixtures to the deck; compatibility by robot and slot."
+description: "Add modules and fixtures to the deck; compatibility varies by robot and slot."
 ---
 
 The second step in building your protocol is to add modules or fixtures to the deck. Click an open slot to add a module, like the Temperature Module, or a fixture like the trash bin. 

--- a/docs/protocol-designer/docs/create-protocol/robot-instruments.md
+++ b/docs/protocol-designer/docs/create-protocol/robot-instruments.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Robot and Instruments"
+description: "Select robot, pipettes, tip racks, and gripper when creating a protocol."
 ---
 
 Click **Create a protocol** on the Protocol Designer homepage or click **Create new** in the header at any time to get started building a protocol. First, select the robot you'll use. You can use Protocol Designer to create protocols that run on either the Opentrons Flex or the OT-2. 

--- a/docs/protocol-designer/docs/edit-steps.md
+++ b/docs/protocol-designer/docs/edit-steps.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Editing Steps"
+description: "Add, reorder, duplicate, and delete steps in the protocol timeline."
 ---
 
 Each step in your protocol appears in the protocol timeline in the order you've added them. After adding steps the robot will perform in your protocol, you can make edits to finalize your protocol. 

--- a/docs/protocol-designer/docs/export-protocol.md
+++ b/docs/protocol-designer/docs/export-protocol.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Export"
+description: "Export protocol as Python and import into the Opentrons App to run."
 ---
 
 When you're finished creating and editing your protocol, click **Back to overview** in the upper left. Review the hardware, labware, liquids, and steps added to your protocol. Then, click **Export protocol** in the upper right. Your protocol will automatically download as a Python (.py) file. 

--- a/docs/protocol-designer/docs/index.md
+++ b/docs/protocol-designer/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer Instruction Manual"
+description: "No-code, web-based tool for creating protocols for Flex and OT-2."
 ---
 
 <img src="images/tm-opentrons-full-blackcolor.png" height=350 width=350>

--- a/docs/protocol-designer/docs/modify-protocol.md
+++ b/docs/protocol-designer/docs/modify-protocol.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Modifying a Protocol"
+description: "Change robot, instruments, deck, or steps in an existing protocol."
 ---
 
 You can upload and edit protocols you've previously made in Protocol Designer. Click **Import** to upload an existing .py or .json file. 

--- a/docs/protocol-designer/docs/starting-deck.md
+++ b/docs/protocol-designer/docs/starting-deck.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Starting Deck"
+description: "Edit deck hardware, labware, and liquids for the start of the protocol."
 ---
 
 Click **Edit protocol** to add and edit hardware, labware, and liquids on the protocol starting deck. 

--- a/docs/protocol-designer/docs/steps/camera.md
+++ b/docs/protocol-designer/docs/steps/camera.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Camera steps"
+description: "Capture images during a protocol run with the robot camera."
 ---
 
 Add a camera step to take a picture of the robot's deck at any point during your protocol. 

--- a/docs/protocol-designer/docs/steps/magnet.md
+++ b/docs/protocol-designer/docs/steps/magnet.md
@@ -1,6 +1,6 @@
 ---
 title: "Protocol Designer: Magnet steps"
-description: "Engage or disengage the Magnetic Module or Block in a protocol."
+description: "Engage or disengage the Magnetic Module or use the Magnetic Block in a protocol."
 ---
 
 Module steps using the Magnetic Module (GEN1 or GEN2, only on the OT-2) appear as magnet steps in the "Add step" menu. When you add a magnet step, the form shows the deck slot the module is on and any labware currently in the module. 

--- a/docs/protocol-designer/docs/steps/magnet.md
+++ b/docs/protocol-designer/docs/steps/magnet.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Magnet steps"
+description: "Engage or disengage the Magnetic Module or Block in a protocol."
 ---
 
 Module steps using the Magnetic Module (GEN1 or GEN2, only on the OT-2) appear as magnet steps in the "Add step" menu. When you add a magnet step, the form shows the deck slot the module is on and any labware currently in the module. 

--- a/docs/protocol-designer/docs/steps/mix.md
+++ b/docs/protocol-designer/docs/steps/mix.md
@@ -1,6 +1,6 @@
 ---
 title: "Protocol Designer: Mix steps"
-description: "Mix liquids in a well; volume, repetitions, and flow rate."
+description: "Mix liquids in a well: volume, repetitions, and flow rate."
 ---
 
 In a mix step, the robot mixes liquid by repeatedly aspirating and dispensing. Mixing occurs in each well you select, one after the other, without moving any liquid between wells. 

--- a/docs/protocol-designer/docs/steps/mix.md
+++ b/docs/protocol-designer/docs/steps/mix.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Mix steps"
+description: "Mix liquids in a well; volume, repetitions, and flow rate."
 ---
 
 In a mix step, the robot mixes liquid by repeatedly aspirating and dispensing. Mixing occurs in each well you select, one after the other, without moving any liquid between wells. 

--- a/docs/protocol-designer/docs/steps/module.md
+++ b/docs/protocol-designer/docs/steps/module.md
@@ -1,6 +1,6 @@
 ---
 title: "Protocol Designer: Module steps"
-description: "Control module actions: temperature, thermocycler, magnet, and more."
+description: "Control module actions: Heater-Shaker, Temperature Module, Thermocycler, and more."
 ---
 
 When you add modules to the robot deck, available module steps appear in the "Add step" menu. Protocol Designer supports the use of the following modules:

--- a/docs/protocol-designer/docs/steps/module.md
+++ b/docs/protocol-designer/docs/steps/module.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Module steps"
+description: "Control module actions: temperature, thermocycler, magnet, and more."
 ---
 
 When you add modules to the robot deck, available module steps appear in the "Add step" menu. Protocol Designer supports the use of the following modules:

--- a/docs/protocol-designer/docs/steps/move.md
+++ b/docs/protocol-designer/docs/steps/move.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Moving Labware"
+description: "Move labware between deck locations with the Flex Gripper."
 ---
 
 Add a move step whenever you need to move labware during a protocol, either with the Flex Gripper or manually. By default, move steps will use a gripper if added in your protocol. Click **Use gripper** in the step form to change your selection. 

--- a/docs/protocol-designer/docs/steps/move.md
+++ b/docs/protocol-designer/docs/steps/move.md
@@ -1,6 +1,6 @@
 ---
 title: "Protocol Designer: Moving Labware"
-description: "Move labware between deck locations with the Flex Gripper."
+description: "Move labware between deck locations with or without the Flex Gripper."
 ---
 
 Add a move step whenever you need to move labware during a protocol, either with the Flex Gripper or manually. By default, move steps will use a gripper if added in your protocol. Click **Use gripper** in the step form to change your selection. 

--- a/docs/protocol-designer/docs/steps/pause.md
+++ b/docs/protocol-designer/docs/steps/pause.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Pause steps"
+description: "Pause the protocol for user confirmation or manual steps."
 ---
 
 You can add a pause step in Protocol Designer to stop your protocol. Three options are available in the form to define the pause and instruct the robot how to resume your protocol. 

--- a/docs/protocol-designer/docs/steps/transfer.md
+++ b/docs/protocol-designer/docs/steps/transfer.md
@@ -1,6 +1,6 @@
 ---
 title: "Protocol Designer: Transfer steps"
-description: "Transfer liquids between wells; single and multi-dispense options."
+description: "Transfer liquids between wells with single- and multi-dispense options."
 ---
 
 Your protocol timeline includes steps the robot will peform in your protocol. To start, the timeline includes the starting and ending deck states. Click **Add Step** in the lower left to add transfer, move, mix, pause, or module-specific steps to your protocol. 

--- a/docs/protocol-designer/docs/steps/transfer.md
+++ b/docs/protocol-designer/docs/steps/transfer.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Transfer steps"
+description: "Transfer liquids between wells; single and multi-dispense options."
 ---
 
 Your protocol timeline includes steps the robot will peform in your protocol. To start, the timeline includes the starting and ending deck states. Click **Add Step** in the lower left to add transfer, move, mix, pause, or module-specific steps to your protocol. 

--- a/docs/protocol-designer/docs/warnings-errors.md
+++ b/docs/protocol-designer/docs/warnings-errors.md
@@ -1,5 +1,6 @@
 ---
 title: "Protocol Designer: Warnings and Errors"
+description: "How to resolve validation warnings and errors before exporting."
 ---
 
 To prevent errors, Protocol Designer displays hints, warnings, and error descriptions as you create a protocol. This section covers types and causes of warnings and errors in Protocol Designer. 

--- a/docs/python-api/docs/adapting-ot2-flex.md
+++ b/docs/python-api/docs/adapting-ot2-flex.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Adapting from OT-2 to Flex"
+description: "Port OT-2 protocols to Flex; deck slots, pipettes, and API differences."
 ---
 
 Python protocols designed to run on the OT-2 can't be directly run on Flex without some modifications. This page describes the minimal steps that you need to take to get OT-2 protocols analyzing and running on Flex.

--- a/docs/python-api/docs/advanced-control/command-line.md
+++ b/docs/python-api/docs/advanced-control/command-line.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Command Line"
+description: "Run and simulate protocols from the command line with opentrons-execute."
 ---
 
 The Python API also lets you perform many actions directly from the command line with `opentrons_execute`.

--- a/docs/python-api/docs/advanced-control/command-line.md
+++ b/docs/python-api/docs/advanced-control/command-line.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API: Command Line"
-description: "Run and simulate protocols from the command line with opentrons-execute."
+description: "Run and simulate protocols from the command line."
 ---
 
 The Python API also lets you perform many actions directly from the command line with `opentrons_execute`.

--- a/docs/python-api/docs/advanced-control/index.md
+++ b/docs/python-api/docs/advanced-control/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Advanced Control"
+description: "Jupyter, command-line, and robot motor control for advanced protocol use."
 ---
 
 The Python Protocol API is primarily designed for creating protocol files that operate your robot and attached hardware and instruments with commands like `transfer_with_liquid_class()`. Advanced control features covered in this section let you control the robot outside of the app or operate individual robot components, like the gantry arm:

--- a/docs/python-api/docs/advanced-control/jupyter.md
+++ b/docs/python-api/docs/advanced-control/jupyter.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Jupyter Notebook"
+description: "Use Jupyter to develop and run protocols interactively on the robot."
 ---
 
 Sometimes it’s more convenient to control your robot outside of the app. For example, you might want to have variables in your code that change based on user input or the contents of a CSV file. Or you might want to only execute part of your protocol at a time, especially when developing or debugging a new protocol.

--- a/docs/python-api/docs/building-block-commands/index.md
+++ b/docs/python-api/docs/building-block-commands/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Building Block Commands"
+description: "Basic commands for tips, liquids, and utilities in Python protocols."
 ---
 
 Building block commands execute some of the most basic actions that your robot can complete. But basic doesn’t mean these commands lack capabilities. They perform important tasks in your protocols. They're also foundational to the [complex commands](../complex-commands/index.md) that help you combine multiple actions into fewer lines of code.

--- a/docs/python-api/docs/complex-commands/index.md
+++ b/docs/python-api/docs/complex-commands/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Complex Commands"
+description: "High-level transfer and distribute commands; sources, order, parameters."
 ---
 
 Complex liquid handling commands combine multiple [building block commands](../building-block-commands/index.md) into a single method call. These commands make it easier to handle larger groups of wells and repeat actions without having to write your own control flow code. They integrate tip-handling behavior and can pick up, use, and drop multiple tips depending on how you want to handle your liquids.

--- a/docs/python-api/docs/complex-commands/index.md
+++ b/docs/python-api/docs/complex-commands/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API: Complex Commands"
-description: "High-level transfer and distribute commands; sources, order, parameters."
+description: "High-level transfer, distribute, and consolidate commands."
 ---
 
 Complex liquid handling commands combine multiple [building block commands](../building-block-commands/index.md) into a single method call. These commands make it easier to handle larger groups of wells and repeat actions without having to write your own control flow code. They integrate tip-handling behavior and can pick up, use, and drop multiple tips depending on how you want to handle your liquids.

--- a/docs/python-api/docs/deck-slots.md
+++ b/docs/python-api/docs/deck-slots.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Deck Slots"
+description: "Deck slot layout and naming for OT-2 and Flex in the Python API."
 ---
 
 <style>

--- a/docs/python-api/docs/examples.md
+++ b/docs/python-api/docs/examples.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Protocol Examples"
+description: "Example protocols for transfers, mixes, and common workflows."
 ---
 
 This page provides simple, ready-made protocols for Flex and OT-2. Feel free to copy and modify these examples to create unique protocols that help automate your laboratory workflows. Also, experimenting with these protocols is another way to build upon the skills you've learned from working through the [tutorial](tutorial.md). Try adding different hardware, labware, and commands to a sample protocol and test its validity after importing it into the Opentrons App.

--- a/docs/python-api/docs/index.md
+++ b/docs/python-api/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Python Protocol API Documentation
-description: "Write Python protocols for Opentrons robots; overview and getting started."
+description: "Write Python protocols for Opentrons liquid handling robots."
 ---
 
 The Opentrons Python Protocol API is a Python framework designed to make it easy to write automated biology lab protocols. Python protocols can control Opentrons Flex and OT-2 robots, their pipettes, and optional hardware modules. We've designed the API to be accessible to anyone with basic Python and wet-lab skills.

--- a/docs/python-api/docs/index.md
+++ b/docs/python-api/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Python Protocol API Documentation
+description: "Write Python protocols for Opentrons robots; overview and getting started."
 ---
 
 The Opentrons Python Protocol API is a Python framework designed to make it easy to write automated biology lab protocols. Python protocols can control Opentrons Flex and OT-2 robots, their pipettes, and optional hardware modules. We've designed the API to be accessible to anyone with basic Python and wet-lab skills.

--- a/docs/python-api/docs/labware.md
+++ b/docs/python-api/docs/labware.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Labware"
+description: "Load and use labware in Python protocols; definitions and custom labware."
 ---
 
 Labware are the durable or consumable items that you work with, reuse, or discard while running a protocol on a Flex or OT-2. Items such as pipette tips, well plates, tubes, and reservoirs are all examples of labware. This section provides a brief overview of default labware, custom labware, and how to use basic labware API methods when creating a protocol for your robot.

--- a/docs/python-api/docs/liquid-class-definitions.md
+++ b/docs/python-api/docs/liquid-class-definitions.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Liquid Class Definitions"
+description: "Reference table of liquid class definitions for the Python API."
 ---
 
 A *liquid class definition* specifies nearly all transfer behavior a Flex pipette will perform during a [`transfer_with_liquid_class()`][opentrons.protocol_api.InstrumentContext.transfer_with_liquid_class], [`distribute_with_liquid_class()`][opentrons.protocol_api.InstrumentContext.distribute_with_liquid_class], or [`consolidate_with_liquid_class()`][opentrons.protocol_api.InstrumentContext.consolidate_with_liquid_class]. Properties, like aspirate flow rate, submerge speed, or dispense position, are required in every liquid class definition.

--- a/docs/python-api/docs/liquid-classes.md
+++ b/docs/python-api/docs/liquid-classes.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Liquid Classes"
+description: "Liquid classes for flow rates and tip handling in the Python API."
 ---
 
 Accounting for properties of liquids in your protocol can increase pipetting accuracy on the Flex. For example, a slower flow rate can improve pipetting for a viscous liquid, and an air gap can prevent a volatile liquid from dripping onto the deck.

--- a/docs/python-api/docs/liquid-classes.md
+++ b/docs/python-api/docs/liquid-classes.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API: Liquid Classes"
-description: "Liquid classes for flow rates and tip handling in the Python API."
+description: "How to use Opentrons-verified and custom liquid clases to increase pipetting accuracy on Flex."
 ---
 
 Accounting for properties of liquids in your protocol can increase pipetting accuracy on the Flex. For example, a slower flow rate can improve pipetting for a viscous liquid, and an air gap can prevent a volatile liquid from dripping onto the deck.

--- a/docs/python-api/docs/modules/absorbance-plate-reader.md
+++ b/docs/python-api/docs/modules/absorbance-plate-reader.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API: Absorbance Plate Reader"
-description: "Read absorbance and kinetic data from the plate reader in Python protocols."
+description: "Initialize and read data from the Absorbance Plate Reader in Python protocols."
 ---
 
 The Absorbance Plate Reader Module is an on-deck microplate spectrophotometer that works with the Flex robot only. The module uses light absorbance to determine sample concentrations in 96-well plates.

--- a/docs/python-api/docs/modules/absorbance-plate-reader.md
+++ b/docs/python-api/docs/modules/absorbance-plate-reader.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Absorbance Plate Reader"
+description: "Read absorbance and kinetic data from the plate reader in Python protocols."
 ---
 
 The Absorbance Plate Reader Module is an on-deck microplate spectrophotometer that works with the Flex robot only. The module uses light absorbance to determine sample concentrations in 96-well plates.

--- a/docs/python-api/docs/modules/heater-shaker.md
+++ b/docs/python-api/docs/modules/heater-shaker.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Heater-Shaker"
+description: "Control the Heater-Shaker: temperature, speed, open/close latch in protocols."
 ---
 
 The Heater-Shaker Module provides on-deck heating and orbital shaking. The module can heat from 37 to 95 °C, and can shake samples from 200 to 3000 rpm.

--- a/docs/python-api/docs/modules/heater-shaker.md
+++ b/docs/python-api/docs/modules/heater-shaker.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API: Heater-Shaker"
-description: "Control the Heater-Shaker: temperature, speed, open/close latch in protocols."
+description: "Control the Heater-Shaker: temperature, speed, and latch position in protocols."
 ---
 
 The Heater-Shaker Module provides on-deck heating and orbital shaking. The module can heat from 37 to 95 °C, and can shake samples from 200 to 3000 rpm.

--- a/docs/python-api/docs/modules/index.md
+++ b/docs/python-api/docs/modules/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Hardware Modules"
+description: "Load and control Temperature, Heater-Shaker, Thermocycler, and other modules."
 ---
 
 Hardware modules are powered and unpowered deck-mounted peripherals. The Flex and OT-2 are aware of deck-mounted powered modules when they're attached via a USB connection and used in an uploaded protocol. The robots do not know about unpowered modules until you use one in a protocol and upload it to the Opentrons App.

--- a/docs/python-api/docs/modules/magnetic-block.md
+++ b/docs/python-api/docs/modules/magnetic-block.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Magnetic Block"
+description: "Control the Flex Magnetic Block: engage and disengage in protocols."
 ---
 
 !!! note "Flex only"

--- a/docs/python-api/docs/modules/magnetic-block.md
+++ b/docs/python-api/docs/modules/magnetic-block.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API: Magnetic Block"
-description: "Control the Flex Magnetic Block: engage and disengage in protocols."
+description: "Use the Magnetic Block with the Flex Gripper in protocols."
 ---
 
 !!! note "Flex only"

--- a/docs/python-api/docs/modules/magnetic-module.md
+++ b/docs/python-api/docs/modules/magnetic-module.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API: Magnetic Module"
-description: "Control the Magnetic Module: engage and disengage height in protocols."
+description: "Control the OT-2 Magnetic Module: engage and disengage height in protocols."
 ---
 
 !!! note "OT-2 only"

--- a/docs/python-api/docs/modules/magnetic-module.md
+++ b/docs/python-api/docs/modules/magnetic-module.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Magnetic Module"
+description: "Control the Magnetic Module: engage and disengage height in protocols."
 ---
 
 !!! note "OT-2 only"

--- a/docs/python-api/docs/modules/multiple-same-type.md
+++ b/docs/python-api/docs/modules/multiple-same-type.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Multiple Modules"
+description: "Load and use multiple modules of the same type in one protocol."
 ---
 
 You can use multiple modules of the same type within a single protocol. The exception is the Thermocycler Module, which has only one supported deck location because of its size. Running protocols with multiple modules of the same type requires version 4.3 or newer of the Opentrons App and robot server.

--- a/docs/python-api/docs/modules/setup.md
+++ b/docs/python-api/docs/modules/setup.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Module Setup"
+description: "Load modules and connect them to the protocol context."
 ---
 
 ## Loading modules onto the deck

--- a/docs/python-api/docs/modules/setup.md
+++ b/docs/python-api/docs/modules/setup.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API: Module Setup"
-description: "Load modules and connect them to the protocol context."
+description: "Load modules and make them available in your protocol."
 ---
 
 ## Loading modules onto the deck

--- a/docs/python-api/docs/modules/temperature-module.md
+++ b/docs/python-api/docs/modules/temperature-module.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Temperature Module"
+description: "Control the Temperature Module: set temperature, wait, and hold in protocols."
 ---
 
 The Temperature Module acts as both a cooling and heating device. It can control the temperature of its deck between 4 °C and 95 °C with a resolution of 1 °C.

--- a/docs/python-api/docs/modules/thermocycler.md
+++ b/docs/python-api/docs/modules/thermocycler.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Thermocycler"
+description: "Control the Thermocycler: lid, block temperature, and profiles in protocols."
 ---
 
 The Thermocycler Module provides on-deck, fully automated thermocycling, and can heat and cool very quickly during operation. The module's block can reach and maintain temperatures between 4 and 99 °C. The module's lid can heat up to 110 °C.

--- a/docs/python-api/docs/moving-labware.md
+++ b/docs/python-api/docs/moving-labware.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Moving Labware"
+description: "Move labware with the Flex Gripper or OT-2 in Python protocols."
 ---
 
 You can move an entire labware (and all of its contents) from one deck slot to another at any point during your protocol. On Flex, you can either use the gripper or move the labware manually. On OT-2, you can only move labware manually, since it doesn't have a gripper instrument.

--- a/docs/python-api/docs/moving-labware.md
+++ b/docs/python-api/docs/moving-labware.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API: Moving Labware"
-description: "Move labware with the Flex Gripper or OT-2 in Python protocols."
+description: "Move labware manually or with the Flex Gripper in Python protocols."
 ---
 
 You can move an entire labware (and all of its contents) from one deck slot to another at any point during your protocol. On Flex, you can either use the gripper or move the labware manually. On OT-2, you can only move labware manually, since it doesn't have a gripper instrument.

--- a/docs/python-api/docs/pipettes/characteristics.md
+++ b/docs/python-api/docs/pipettes/characteristics.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Pipette Characteristics"
+description: "Pipette specs, channels, and volume ranges in the Python API."
 ---
 
 Each Opentrons pipette has different capabilities, which you'll want to take advantage of in your protocols. This page covers some fundamental pipette characteristics.

--- a/docs/python-api/docs/pipettes/index.md
+++ b/docs/python-api/docs/pipettes/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Pipettes"
+description: "Load pipettes and use them for transfers and other liquid handling."
 ---
 
 Opentrons pipettes are configurable devices used to move liquids throughout the working area during the execution of protocols. Flex and OT-2 each have their own pipettes, which are available for use in the Python API.

--- a/docs/python-api/docs/pipettes/loading.md
+++ b/docs/python-api/docs/pipettes/loading.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Loading Pipettes"
+description: "Load single-channel, 8-channel, and 96-channel pipettes in protocols."
 ---
 
 When writing a protocol, you must inform the Protocol API about the pipettes you will be using on your robot. The [`ProtocolContext.load_instrument()`][opentrons.protocol_api.ProtocolContext.load_instrument] function provides this information and returns an [`InstrumentContext`][opentrons.protocol_api.InstrumentContext] object.

--- a/docs/python-api/docs/pipettes/partial-tip-pickup.md
+++ b/docs/python-api/docs/pipettes/partial-tip-pickup.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Partial Tip Pickup"
+description: "Pick up tips with a subset of channels on multi-channel pipettes."
 ---
 
 By default, multi-channel pipettes always use all of their nozzles to pick up tips and handle liquids: an 8-channel pipette picks up 8 tips at once, and a 96-channel pipette picks up 96 tips at once. Partial tip pickup lets you configure a multi-channel pipette to use fewer tips. This expands the liquid handling capabilities of your robot without having to physically switch pipettes, and is especially useful for the Flex 96-Channel Pipette, which occupies both pipette mounts.

--- a/docs/python-api/docs/reference/absorbance-plate-reader.md
+++ b/docs/python-api/docs/reference/absorbance-plate-reader.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API Reference: Absorbance Plate Reader"
+description: "Absorbance Plate Reader Module class reference for the Python API."
 ---
 
 ::: opentrons.protocol_api.AbsorbanceReaderContext

--- a/docs/python-api/docs/reference/execute-simulate.md
+++ b/docs/python-api/docs/reference/execute-simulate.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API Reference: Executing and Simulating"
+description: "Execute and simulate protocols; API for run and simulation control."
 ---
 
 ::: opentrons.execute

--- a/docs/python-api/docs/reference/flex-stacker.md
+++ b/docs/python-api/docs/reference/flex-stacker.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API Reference: Flex Stacker"
+description: "Flex Stacker Module class reference for the Python Protocol API."
 ---
 
 ::: opentrons.protocol_api.FlexStackerContext

--- a/docs/python-api/docs/reference/heater-shaker.md
+++ b/docs/python-api/docs/reference/heater-shaker.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API Reference: Heater-Shaker"
+description: "Heater-Shaker Module class reference for the Python Protocol API."
 ---
 
 ::: opentrons.protocol_api.HeaterShakerContext

--- a/docs/python-api/docs/reference/instruments.md
+++ b/docs/python-api/docs/reference/instruments.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API Reference: Instruments"
+description: "Instrument and pipette API reference for the Python Protocol API."
 ---
 
 ::: opentrons.protocol_api.InstrumentContext

--- a/docs/python-api/docs/reference/labware.md
+++ b/docs/python-api/docs/reference/labware.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API Reference: Labware and Trash"
+description: "Labware and trash container API reference for the Python API."
 ---
 
 ::: opentrons.protocol_api.Labware

--- a/docs/python-api/docs/reference/magnetic-block.md
+++ b/docs/python-api/docs/reference/magnetic-block.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API Reference: Magnetic Block"
-description: "Magnetic Block class reference for the Python Protocol API (Flex)."
+description: "Magnetic Block class reference for the Python Protocol API (Flex only)."
 ---
 
 ::: opentrons.protocol_api.MagneticBlockContext

--- a/docs/python-api/docs/reference/magnetic-block.md
+++ b/docs/python-api/docs/reference/magnetic-block.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API Reference: Magnetic Block"
+description: "Magnetic Block class reference for the Python Protocol API (Flex)."
 ---
 
 ::: opentrons.protocol_api.MagneticBlockContext

--- a/docs/python-api/docs/reference/magnetic-module.md
+++ b/docs/python-api/docs/reference/magnetic-module.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API Reference: Magnetic Module"
-description: "Magnetic Module class reference for the Python Protocol API (OT-2)."
+description: "Magnetic Module class reference for the Python Protocol API (OT-2 only)."
 ---
 
 ::: opentrons.protocol_api.MagneticModuleContext

--- a/docs/python-api/docs/reference/magnetic-module.md
+++ b/docs/python-api/docs/reference/magnetic-module.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API Reference: Magnetic Module"
+description: "Magnetic Module class reference for the Python Protocol API (OT-2)."
 ---
 
 ::: opentrons.protocol_api.MagneticModuleContext

--- a/docs/python-api/docs/reference/protocols.md
+++ b/docs/python-api/docs/reference/protocols.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API Reference: Protocols"
+description: "Protocol context, metadata, and protocol-level API reference."
 ---
 
 ::: opentrons.protocol_api.ProtocolContext

--- a/docs/python-api/docs/reference/temperature-module.md
+++ b/docs/python-api/docs/reference/temperature-module.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API Reference: Temperature Module"
+description: "Temperature Module class reference for the Python Protocol API."
 ---
 
 ::: opentrons.protocol_api.TemperatureModuleContext

--- a/docs/python-api/docs/reference/thermocycler.md
+++ b/docs/python-api/docs/reference/thermocycler.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API Reference: Thermocycler"
+description: "Thermocycler Module class reference for the Python Protocol API."
 ---
 
 ::: opentrons.protocol_api.ThermocyclerContext

--- a/docs/python-api/docs/reference/types.md
+++ b/docs/python-api/docs/reference/types.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API Reference: Useful Types"
-description: "Type definitions and enums used in the Python Protocol API."
+description: "Type definitions used in the Python Protocol API."
 ---
 
 ::: opentrons.types

--- a/docs/python-api/docs/reference/types.md
+++ b/docs/python-api/docs/reference/types.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API Reference: Useful Types"
+description: "Type definitions and enums used in the Python Protocol API."
 ---
 
 ::: opentrons.types

--- a/docs/python-api/docs/reference/wells-liquids.md
+++ b/docs/python-api/docs/reference/wells-liquids.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API Reference: Wells and Liquids"
-description: "Well and liquid handling API reference for the Python Protocol API."
+description: "Well and Liquid class reference for the Python Protocol API."
 ---
 
 ::: opentrons.protocol_api.Well

--- a/docs/python-api/docs/reference/wells-liquids.md
+++ b/docs/python-api/docs/reference/wells-liquids.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API Reference: Wells and Liquids"
+description: "Well and liquid handling API reference for the Python Protocol API."
 ---
 
 ::: opentrons.protocol_api.Well

--- a/docs/python-api/docs/runtime-parameters/choosing.md
+++ b/docs/python-api/docs/runtime-parameters/choosing.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Choosing Runtime Parameters"
+description: "When to use runtime parameters and how to choose parameter types."
 ---
 
 The first decision you need to make when adding parameters to your protocol is "What should be parameterized?" Your goals in adding parameters should be:

--- a/docs/python-api/docs/runtime-parameters/defining.md
+++ b/docs/python-api/docs/runtime-parameters/defining.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API: Defining Runtime Parameters"
-description: "Define parameters with add_parameter; types, defaults, and display."
+description: "Define parameters by type and specify default values."
 ---
 
 To use parameters, you need to define them in [a separate function][the-add_parameters-function] within your protocol. Each parameter definition has two main purposes: to specify acceptable values, and to inform the protocol user what the parameter does.

--- a/docs/python-api/docs/runtime-parameters/defining.md
+++ b/docs/python-api/docs/runtime-parameters/defining.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Defining Runtime Parameters"
+description: "Define parameters with add_parameter; types, defaults, and display."
 ---
 
 To use parameters, you need to define them in [a separate function][the-add_parameters-function] within your protocol. Each parameter definition has two main purposes: to specify acceptable values, and to inform the protocol user what the parameter does.

--- a/docs/python-api/docs/runtime-parameters/index.md
+++ b/docs/python-api/docs/runtime-parameters/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API: Runtime Parameters"
-description: "Add user-editable parameters to protocols; defining and using values."
+description: "Add user-editable parameters to Python protocols."
 ---
 
 Runtime parameters let you define user-customizable variables in your Python protocols. This gives you greater flexibility and puts extra control in the hands of the technician running the protocol — without forcing them to switch between lots of protocol files or write code themselves.

--- a/docs/python-api/docs/runtime-parameters/index.md
+++ b/docs/python-api/docs/runtime-parameters/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Runtime Parameters"
+description: "Add user-editable parameters to protocols; defining and using values."
 ---
 
 Runtime parameters let you define user-customizable variables in your Python protocols. This gives you greater flexibility and puts extra control in the hands of the technician running the protocol — without forcing them to switch between lots of protocol files or write code themselves.

--- a/docs/python-api/docs/runtime-parameters/style.md
+++ b/docs/python-api/docs/runtime-parameters/style.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Runtime Parameter Style"
+description: "Naming and organization best practices for runtime parameters."
 ---
 
 It's important to write clear names and descriptions when you [define parameters](defining.md) in your protocols. Clarity improves the user experience for the technicians who run your protocols. They rely on your parameter names and descriptions to understand how the robot will function when running your protocol.

--- a/docs/python-api/docs/runtime-parameters/use-case-cherrypicking.md
+++ b/docs/python-api/docs/runtime-parameters/use-case-cherrypicking.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Runtime Parameters for Cherrypicking"
+description: "Use parameters to select source and destination wells at runtime."
 ---
 
 A common liquid handling task is *cherrypicking*: pipetting liquid from only certain wells on a source plate and placing them in order on a destination plate. This use case demonstrates how to use a CSV runtime parameter to automate this process and to customize it on every run—without having to modify the Python protocol itself.

--- a/docs/python-api/docs/runtime-parameters/use-case-dry-run.md
+++ b/docs/python-api/docs/runtime-parameters/use-case-dry-run.md
@@ -1,6 +1,6 @@
 ---
 title: "Python API: Runtime Parameters for Dry Runs"
-description: "Add a dry-run option to skip liquid handling or reduce volumes."
+description: "Add a dry-run option to quickly test your protocol."
 ---
 
 When testing out a new protocol, it's common to perform a dry run to watch your robot go through all the steps without actually handling samples or reagents. This use case explores how to add a single Boolean parameter for whether you're performing a dry run.

--- a/docs/python-api/docs/runtime-parameters/use-case-dry-run.md
+++ b/docs/python-api/docs/runtime-parameters/use-case-dry-run.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Runtime Parameters for Dry Runs"
+description: "Add a dry-run option to skip liquid handling or reduce volumes."
 ---
 
 When testing out a new protocol, it's common to perform a dry run to watch your robot go through all the steps without actually handling samples or reagents. This use case explores how to add a single Boolean parameter for whether you're performing a dry run.

--- a/docs/python-api/docs/runtime-parameters/use-case-sample-count.md
+++ b/docs/python-api/docs/runtime-parameters/use-case-sample-count.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Runtime Parameters for Sample Count"
+description: "Use a parameter to let users set the number of samples per run."
 ---
 
 Choosing how many samples to process is important for efficient automation. This use case explores how a single parameter for sample count can have pervasive effects throughout a protocol. The examples are adapted from an actual parameterized protocol for DNA prep. The sample code will use 8-channel pipettes to process 8, 16, 24, or 32 samples.

--- a/docs/python-api/docs/runtime-parameters/using-values.md
+++ b/docs/python-api/docs/runtime-parameters/using-values.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Using Runtime Parameters"
+description: "Read and use runtime parameter values inside your protocol."
 ---
 
 Once you've [defined parameters](defining.md), their values are accessible anywhere within the `run()` function of your protocol.

--- a/docs/python-api/docs/tutorial.md
+++ b/docs/python-api/docs/tutorial.md
@@ -1,5 +1,6 @@
 ---
 title: "Python API: Tutorial"
+description: "Step-by-step tutorial for writing your first Python protocol."
 ---
 
 ## Introduction

--- a/docs/shared/modules/index.md
+++ b/docs/shared/modules/index.md
@@ -1,5 +1,6 @@
 ---
 title: Opentrons Modules
+description: "Overview of Opentrons hardware modules and links to each module manual."
 ---
 
 # Modules

--- a/docs/stacker/docs/additional-info.md
+++ b/docs/stacker/docs/additional-info.md
@@ -1,5 +1,6 @@
 ---
 title: "Flex Stacker: Additional Product Information"
+description: "Warranty, support, app download, and manufacturer information for the Stacker."
 ---
 
 ## Warranty

--- a/docs/stacker/docs/compliance.md
+++ b/docs/stacker/docs/compliance.md
@@ -1,5 +1,6 @@
 ---
 title: "Flex Stacker: Safety and Compliance"
+description: "Safe use guidelines, safety symbols, and regulatory compliance for the Stacker."
 ---
 
 Opentrons recommends that you follow the safe use specifications listed in this section and throughout this manual.

--- a/docs/stacker/docs/index.md
+++ b/docs/stacker/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Opentrons Flex Stacker Instruction Manual"
+description: "High-capacity labware storage and shuttle for Flex; up to four Stackers per robot."
 hide: toc
 ---
 

--- a/docs/stacker/docs/installation.md
+++ b/docs/stacker/docs/installation.md
@@ -1,5 +1,6 @@
 ---
 title: "Flex Stacker: Installation"
+description: "Unbox, replace side panel, attach to Flex, and connect power and data."
 ---
 
 Before you begin, make sure you've read and are familiar with the information provided in the [Pre-Installation Information section](pre-installation.md).

--- a/docs/stacker/docs/loading-labware.md
+++ b/docs/stacker/docs/loading-labware.md
@@ -1,5 +1,6 @@
 ---
 title: "Flex Stacker: Loading Labware"
+description: "How to load and unload labware in the Stacker; one labware type per Stacker."
 ---
 
 ## Loading Labware

--- a/docs/stacker/docs/loading-labware.md
+++ b/docs/stacker/docs/loading-labware.md
@@ -1,6 +1,6 @@
 ---
 title: "Flex Stacker: Loading Labware"
-description: "How to load and unload labware in the Stacker; one labware type per Stacker."
+description: "How to load and unload labware in the Stacker."
 ---
 
 ## Loading Labware

--- a/docs/stacker/docs/maintenance.md
+++ b/docs/stacker/docs/maintenance.md
@@ -1,5 +1,6 @@
 ---
 title: "Flex Stacker: Maintenance and Cleaning"
+description: "Cleaning procedures and when to contact support; no user servicing."
 ---
 
 ## Maintenance

--- a/docs/stacker/docs/maintenance.md
+++ b/docs/stacker/docs/maintenance.md
@@ -1,6 +1,6 @@
 ---
 title: "Flex Stacker: Maintenance and Cleaning"
-description: "Cleaning procedures and when to contact support; no user servicing."
+description: "Cleaning procedures and when to contact support."
 ---
 
 ## Maintenance

--- a/docs/stacker/docs/post-installation.md
+++ b/docs/stacker/docs/post-installation.md
@@ -1,5 +1,6 @@
 ---
 title: "Flex Stacker: Post-installation Procedures"
+description: "Touchscreen setup, firmware, deck mapping, and attaching the shuttle."
 ---
 
 ## Touchscreen Instructions

--- a/docs/stacker/docs/pre-installation.md
+++ b/docs/stacker/docs/pre-installation.md
@@ -1,5 +1,6 @@
 ---
 title: "Flex Stacker: Pre-installation Information"
+description: "Deck placement, column 4 slots, power/data hub, and setup overview."
 ---
 
 Review this section for important information about Stacker placement, deck adapters, the power/data hub, and other components.

--- a/docs/stacker/docs/product-specs.md
+++ b/docs/stacker/docs/product-specs.md
@@ -1,5 +1,6 @@
 ---
 title: "Flex Stacker: Product Specifications"
+description: "Box contents, User Kit parts, physical specs, and capacity for the Stacker."
 ---
 
 ![Stacker with labels identifying main features](images/parts-map4.png)

--- a/docs/temperature-module/docs/additional-info.md
+++ b/docs/temperature-module/docs/additional-info.md
@@ -1,5 +1,6 @@
 ---
 title: "Temperature Module: Additional Product Information"
+description: "Warranty, support, app download, and manufacturer information for the module."
 ---
 
 ## Warranty

--- a/docs/temperature-module/docs/compliance.md
+++ b/docs/temperature-module/docs/compliance.md
@@ -1,5 +1,6 @@
 ---
 title: "Temperature Module: Safety and Compliance"
+description: "Power requirements, environmental conditions, and regulatory compliance."
 ---
 
 Opentrons recommends that you follow the safe use specifications listed in this section and throughout this manual.

--- a/docs/temperature-module/docs/index.md
+++ b/docs/temperature-module/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Temperature Module GEN2 Instruction Manual"
+description: "Hot and cold plate module (4–95 °C) for Flex and OT-2; thermal block adapters."
 hide: toc
 ---
 

--- a/docs/temperature-module/docs/index.md
+++ b/docs/temperature-module/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Temperature Module GEN2 Instruction Manual"
-description: "Hot and cold plate module (4–95 °C) for Flex and OT-2; thermal block adapters."
+description: "Hot and cold plate module (4–95 °C) for Flex and OT-2."
 hide: toc
 ---
 

--- a/docs/temperature-module/docs/installation-flex.md
+++ b/docs/temperature-module/docs/installation-flex.md
@@ -1,5 +1,6 @@
 ---
 title: "Temperature Module: Flex Installation Steps"
+description: "Attach to caddy, mount on deck, and calibrate the Temperature Module on Flex."
 ---
 
 Installing the Temperature Module on your robot includes attaching it to the deck and calibrating it for the first time. The instructions here and on the touchscreen will help you get started. The tools you need are included in the User Kit that came with your Flex.

--- a/docs/temperature-module/docs/installation-ot2.md
+++ b/docs/temperature-module/docs/installation-ot2.md
@@ -1,5 +1,6 @@
 ---
 title: "Temperature Module: OT-2 Attachment Steps"
+description: "Mount the module on the OT-2 deck and connect USB and power."
 hide: toc
 ---
 

--- a/docs/temperature-module/docs/maintenance.md
+++ b/docs/temperature-module/docs/maintenance.md
@@ -1,5 +1,6 @@
 ---
 title: "Temperature Module: Maintenance and Cleaning"
+description: "Cleaning procedures and when to contact support; no user servicing."
 ---
 
 ## Maintenance

--- a/docs/temperature-module/docs/maintenance.md
+++ b/docs/temperature-module/docs/maintenance.md
@@ -1,6 +1,6 @@
 ---
 title: "Temperature Module: Maintenance and Cleaning"
-description: "Cleaning procedures and when to contact support; no user servicing."
+description: "Cleaning procedures and when to contact support."
 ---
 
 ## Maintenance

--- a/docs/temperature-module/docs/pre-installation.md
+++ b/docs/temperature-module/docs/pre-installation.md
@@ -1,5 +1,6 @@
 ---
 title: "Temperature Module: Before You Begin"
+description: "Deck placement, Flex caddies, and anchor adjustments before installation."
 ---
 
 Review this section for important information about deck placement, alignment, and anchor adjustments for the Temperature Module.

--- a/docs/temperature-module/docs/product-specs.md
+++ b/docs/temperature-module/docs/product-specs.md
@@ -1,5 +1,6 @@
 ---
 title: "Temperature Module: Product Specifications"
+description: "Included parts, dimensions, temperature range, and thermal block options."
 ---
 
 ![Temperature module with labels](images/temp-mod-labeled.svg)

--- a/docs/thermocycler/docs/additional-info.md
+++ b/docs/thermocycler/docs/additional-info.md
@@ -1,5 +1,6 @@
 ---
 title: "Thermocycler Module: Additional Product Information"
+description: "Warranty, support, app download, and WEEE policy for the Thermocycler."
 ---
 
 ## Warranty

--- a/docs/thermocycler/docs/compliance.md
+++ b/docs/thermocycler/docs/compliance.md
@@ -1,5 +1,6 @@
 ---
 title: "Thermocycler Module: Safety and Compliance"
+description: "Power requirements, environmental conditions, and regulatory compliance."
 ---
 
 Opentrons recommends that you follow the safe use specifications in this section and throughout this manual.

--- a/docs/thermocycler/docs/index.md
+++ b/docs/thermocycler/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: "Thermocycler Module"
+description: "On-deck thermocycler for PCR; heated lid, 96-well format, Flex and OT-2 compatible."
 hide: toc
 ---
 

--- a/docs/thermocycler/docs/index.md
+++ b/docs/thermocycler/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Thermocycler Module"
-description: "On-deck thermocycler for PCR; heated lid, 96-well format, Flex and OT-2 compatible."
+description: "On-deck 96-well Thermocycler for PCR, compatible with Flex and OT-2."
 hide: toc
 ---
 

--- a/docs/thermocycler/docs/installation-flex.md
+++ b/docs/thermocycler/docs/installation-flex.md
@@ -1,5 +1,6 @@
 ---
 title: "Thermocycler Module: Flex Attachment Steps"
+description: "Attach to caddy, mount on deck, and run first-time calibration on Flex."
 ---
 
 Setting up the Thermocycler on your robot includes attaching it to the deck and running a first-time calibration process. The instructions here and on the touchscreen will help you get started. The tools you need are included in the User Kit that came with your Flex.

--- a/docs/thermocycler/docs/installation-ot2.md
+++ b/docs/thermocycler/docs/installation-ot2.md
@@ -1,5 +1,6 @@
 ---
 title: "Thermocycler Module: OT-2 Attachment Steps"
+description: "Attach exhaust duct, mount on deck, and connect USB and power on OT-2."
 ---
 
 To attach the Thermocycler to your OT-2:

--- a/docs/thermocycler/docs/lid-seals.md
+++ b/docs/thermocycler/docs/lid-seals.md
@@ -1,5 +1,6 @@
 ---
 title: "Thermocycler Module: Lid Seals"
+description: "Disposable auto-sealing lids and reusable GEN2 seals for PCR plates."
 ---
 
 The Thermocycler GEN2 accepts two different plate seals to help protect PCR samples: the disposable [Opentrons Tough PCR Auto-sealing Lid](https://opentrons.com/products/opentrons-flex-tough-auto-sealing-lids-20-count) and the reusable [GEN2 automation seals](https://opentrons.com/products/gen2-thermocycler-seals).

--- a/docs/thermocycler/docs/maintenance.md
+++ b/docs/thermocycler/docs/maintenance.md
@@ -1,6 +1,6 @@
 ---
 title: "Thermocycler Module: Maintenance and Cleaning"
-description: "Cleaning procedures and when to contact support; no user servicing."
+description: "Cleaning procedures and when to contact support."
 ---
 
 ## Maintenance

--- a/docs/thermocycler/docs/maintenance.md
+++ b/docs/thermocycler/docs/maintenance.md
@@ -1,5 +1,6 @@
 ---
 title: "Thermocycler Module: Maintenance and Cleaning"
+description: "Cleaning procedures and when to contact support; no user servicing."
 ---
 
 ## Maintenance

--- a/docs/thermocycler/docs/pre-installation.md
+++ b/docs/thermocycler/docs/pre-installation.md
@@ -1,5 +1,6 @@
 ---
 title: "Thermocycler Module: Before You Begin"
+description: "Deck placement, Flex caddies, OT-2 exhaust duct, and anchor adjustments."
 ---
 
 Review this section for important information about the Thermocycler's deck placement, alignment, and anchor adjustments.

--- a/docs/thermocycler/docs/product-specs.md
+++ b/docs/thermocycler/docs/product-specs.md
@@ -1,5 +1,6 @@
 ---
 title: "Thermocycler Module: Product Specifications"
+description: "Dimensions, temperature profiles, included parts, and physical specs."
 ---
 
 ![Thermocycler with labeled main features](images/specifications.png)


### PR DESCRIPTION
# Overview

Most of our new documentation pages were lacking meta description tags (for social sharing and display in search engine results). This PR adds them.

## Test Plan and Hands on Testing

There is a sandbox, and you can inspect page source to see the meta tags. But probably best to just review the file diff.

## Changelog

- Auto-generated summaries for all pages.
- Hand-edited results.
- Added default description so new pages will never be completely without a description.

## Review requests

good good?

## Risk assessment

v low