### PR TITLE
docs(shared-data): Revise documentation for the `lidOffsets` labware property

### DIFF
--- a/api/src/opentrons/protocol_engine/state/labware_origin_math/stackup_origin_to_labware_origin.py
+++ b/api/src/opentrons/protocol_engine/state/labware_origin_math/stackup_origin_to_labware_origin.py
@@ -1288,7 +1288,7 @@ def _get_tc_lid_gripper_offsets(
         bottom_most_lw_location = stackup_lw_info_top_to_bottom[-1][1]
 
         # This is done as a workaround for some TC geometry inaccuracies.
-        # See PLAT-579 for context.
+        # See EXEC-1267 for context.
         if (
             isinstance(bottom_most_lw_location, ModuleLocation)
             and getattr(underlying_ancestor_definition, "model", None)

--- a/shared-data/labware/schemas/2.json
+++ b/shared-data/labware/schemas/2.json
@@ -710,7 +710,7 @@
         },
         "lidOffsets": {
           "$ref": "#/definitions/pickUpAndDropOffsets",
-          "description": "Additional offsets for gripping this labware, if this labware is a lid. Beware this property's placement: instead of affecting the labware stacked atop this labware, like the rest of the `gripperOffsets` properties, it affects this labware."
+          "description": "An adjustment for when this labware is a lid moving into or out of a Thermocycler. This is a workaround for suspected software bugs in how Thermocycler positions are calculated. This might be ignored once the underlying bugs are fixed. Beware this property's placement: instead of affecting the labware stacked atop this labware, like the rest of the `gripperOffsets` properties, it affects this labware. For historical reasons, `dropOffset` is ignored, and `pickUpOffset` is applied to both the pickup and drop; `dropOffset` should be set to match `pickUpOffset` to avoid confusion."
         },
         "lidDisposalOffsets": {
           "$ref": "#/definitions/pickUpAndDropOffsets",

--- a/shared-data/labware/schemas/3.json
+++ b/shared-data/labware/schemas/3.json
@@ -877,7 +877,7 @@
         },
         "lidOffsets": {
           "$ref": "#/definitions/pickUpAndDropOffsets",
-          "description": "Additional offsets for gripping this labware, if this labware is a lid. Beware this property's placement: instead of affecting the labware stacked atop this labware, like the rest of the `gripperOffsets` properties, it affects this labware."
+          "description": "An adjustment for when this labware is a lid moving into or out of a Thermocycler. This is a workaround for suspected software bugs in how Thermocycler positions are calculated. This might be ignored once the underlying bugs are fixed. Beware this property's placement: instead of affecting the labware stacked atop this labware, like the rest of the `gripperOffsets` properties, it affects this labware. For historical reasons, `dropOffset` is ignored, and `pickUpOffset` is applied to both the pickup and drop; `dropOffset` should be set to match `pickUpOffset` to avoid confusion."
         },
         "lidDisposalOffsets": {
           "$ref": "#/definitions/pickUpAndDropOffsets",


### PR DESCRIPTION
## Overview

This clarifies two points about `gripperOffsets.lidOffsets`:

* It specifically applies to lids being moved *to or from a Thermocycler,* not to lid movements in general.
* Only `pickUpOffset` is applied. `dropOffset` is ignored.

## Details

I documented `lidOffsets` back in #16711, to capture what I read to be its behavior at the time.

At the time, [the code](https://github.com/Opentrons/opentrons/blob/8203e3a63dbac947f355474ee0ac1eaf22b79d97/api/src/opentrons/protocol_engine/state/geometry.py#L1130-L1243) was written roughly like, "if we're moving a labware to/from another labware (i.e. we're moving a lid), **and the underlying labware is in a Thermocycler,** apply `lidOffsets`." That Thermocycler check made sense at the time because our only lid was the Thermocycler auto-sealing lid.

Later, we added more lids, like tip rack lids. The code did not change to apply to those, so we now have a property named `lidOffsets` whose behavior is actually narrower than that.

Separately to all of that, it seems like `pickUpOffset` has always been used in place of `dropOffsets`. [Here's a comment noting this in today's code](https://github.com/Opentrons/opentrons/blob/bad70df5c974edac2ba6b3c68370f904ab449751/api/src/opentrons/protocol_engine/state/labware_origin_math/stackup_origin_to_labware_origin.py#L1298). In the old code, I suspect it was just a bug, but we're committed to that behavior now.

## Test plan

None, unless anyone thinks I should double-check any of this behavior on a robot.

## Review requests

* Double-check my reading of the code that:
  * `lidOffsets` is used for both picking up from, and dropping into, a Thermocycler
  * `lidOffsets` is not used otherwise
  * `pickUpOffset` is used for both the pickup and drop cases
* Do we agree with the recommendation to labware authors that they should set `dropOffset` to match `pickUpOffset`?

## Risk assessment

No risk to changing behavior, but let's be sure about the facts here to avoid introducing further confusion.