### PR TITLE
feat(shared-data): add nozzle offset quirks for reservoirs with sub-wells

### DIFF
--- a/shared-data/js/__tests__/labwareDefQuirks.test.ts
+++ b/shared-data/js/__tests__/labwareDefQuirks.test.ts
@@ -17,6 +17,8 @@ const EXPECTED_VALID_QUIRKS = [
   'stackingOnly',
   'noLabwarePositionCheck',
   'disableGeometryBasedGripCheck',
+  'offsetPipetteFor96GridSubwells',
+  'offsetPipetteFor12GridSubwells',
 ]
 
 describe('check quirks for all labware defs', () => {

--- a/shared-data/labware/definitions/2/agilent_1_reservoir_290ml/2.json
+++ b/shared-data/labware/definitions/2/agilent_1_reservoir_290ml/2.json
@@ -42,7 +42,11 @@
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "agilent_1_reservoir_290ml",
-    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"]
+    "quirks": [
+      "centerMultichannelOnWells",
+      "touchTipDisabled",
+      "offsetPipetteFor96GridSubwells"
+    ]
   },
   "namespace": "opentrons",
   "version": 2,

--- a/shared-data/labware/definitions/2/agilent_1_reservoir_290ml/3.json
+++ b/shared-data/labware/definitions/2/agilent_1_reservoir_290ml/3.json
@@ -42,7 +42,11 @@
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "agilent_1_reservoir_290ml",
-    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"]
+    "quirks": [
+      "centerMultichannelOnWells",
+      "touchTipDisabled",
+      "offsetPipetteFor96GridSubwells"
+    ]
   },
   "namespace": "opentrons",
   "version": 3,

--- a/shared-data/labware/definitions/2/agilent_1_reservoir_290ml/4.json
+++ b/shared-data/labware/definitions/2/agilent_1_reservoir_290ml/4.json
@@ -42,7 +42,11 @@
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "agilent_1_reservoir_290ml",
-    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"]
+    "quirks": [
+      "centerMultichannelOnWells",
+      "touchTipDisabled",
+      "offsetPipetteFor96GridSubwells"
+    ]
   },
   "namespace": "opentrons",
   "version": 4,

--- a/shared-data/labware/definitions/2/nest_1_reservoir_195ml/3.json
+++ b/shared-data/labware/definitions/2/nest_1_reservoir_195ml/3.json
@@ -43,7 +43,11 @@
     "format": "trough",
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
-    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"],
+    "quirks": [
+      "centerMultichannelOnWells",
+      "touchTipDisabled",
+      "offsetPipetteFor96GridSubwells"
+    ],
     "loadName": "nest_1_reservoir_195ml"
   },
   "namespace": "opentrons",

--- a/shared-data/labware/definitions/2/nest_1_reservoir_195ml/4.json
+++ b/shared-data/labware/definitions/2/nest_1_reservoir_195ml/4.json
@@ -43,7 +43,11 @@
     "format": "trough",
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
-    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"],
+    "quirks": [
+      "centerMultichannelOnWells",
+      "touchTipDisabled",
+      "offsetPipetteFor96GridSubwells"
+    ],
     "loadName": "nest_1_reservoir_195ml"
   },
   "namespace": "opentrons",

--- a/shared-data/labware/definitions/2/nest_1_reservoir_290ml/2.json
+++ b/shared-data/labware/definitions/2/nest_1_reservoir_290ml/2.json
@@ -41,7 +41,11 @@
     "format": "trough",
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
-    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"],
+    "quirks": [
+      "centerMultichannelOnWells",
+      "touchTipDisabled",
+      "offsetPipetteFor12GridSubwells"
+    ],
     "loadName": "nest_1_reservoir_290ml"
   },
   "namespace": "opentrons",

--- a/shared-data/labware/definitions/2/opentrons_tough_12_reservoir_22ml/1.json
+++ b/shared-data/labware/definitions/2/opentrons_tough_12_reservoir_22ml/1.json
@@ -190,7 +190,11 @@
     "format": "trough",
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
-    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"],
+    "quirks": [
+      "centerMultichannelOnWells",
+      "touchTipDisabled",
+      "offsetPipetteFor96GridSubwells"
+    ],
     "loadName": "opentrons_tough_12_reservoir_22ml"
   },
   "namespace": "opentrons",

--- a/shared-data/labware/definitions/2/opentrons_tough_1_reservoir_300ml/1.json
+++ b/shared-data/labware/definitions/2/opentrons_tough_1_reservoir_300ml/1.json
@@ -44,7 +44,11 @@
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "opentrons_tough_1_reservoir_300ml",
-    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"]
+    "quirks": [
+      "centerMultichannelOnWells",
+      "touchTipDisabled",
+      "offsetPipetteFor96GridSubwells"
+    ]
   },
   "namespace": "opentrons",
   "version": 1,

--- a/shared-data/labware/definitions/2/usascientific_12_reservoir_22ml/2.json
+++ b/shared-data/labware/definitions/2/usascientific_12_reservoir_22ml/2.json
@@ -32,7 +32,11 @@
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "usascientific_12_reservoir_22ml",
-    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"]
+    "quirks": [
+      "centerMultichannelOnWells",
+      "touchTipDisabled",
+      "offsetPipetteFor96GridSubwells"
+    ]
   },
   "wells": {
     "A1": {

--- a/shared-data/labware/definitions/2/usascientific_12_reservoir_22ml/3.json
+++ b/shared-data/labware/definitions/2/usascientific_12_reservoir_22ml/3.json
@@ -32,7 +32,11 @@
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "usascientific_12_reservoir_22ml",
-    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"]
+    "quirks": [
+      "centerMultichannelOnWells",
+      "touchTipDisabled",
+      "offsetPipetteFor96GridSubwells"
+    ]
   },
   "wells": {
     "A1": {

--- a/shared-data/labware/definitions/2/usascientific_12_reservoir_22ml/4.json
+++ b/shared-data/labware/definitions/2/usascientific_12_reservoir_22ml/4.json
@@ -32,7 +32,11 @@
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "usascientific_12_reservoir_22ml",
-    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"]
+    "quirks": [
+      "centerMultichannelOnWells",
+      "touchTipDisabled",
+      "offsetPipetteFor96GridSubwells"
+    ]
   },
   "wells": {
     "A1": {


### PR DESCRIPTION
## Overview
In [RABR-880](https://opentrons.atlassian.net/browse/RABR-880), we encountered the issue that had _sort of_ been solved by [this commit](https://github.com/Opentrons/opentrons/pull/19317/), where we look at the combination of the pipette configuration and subwell status of a well (determined by the presence of a labware quirk), and in the event where we needed to, move the nozzle into the middle of the subwell we’re pipetting into. 

It turns out, we haven’t actually added this quirk in production code to any of our labware definitions, and have avoided seeing this issue pop up again because we were restricting the minimum nozzle height to be above any sub-wells. 

This pr just adds those quirks to the appropriate labware definitions

## Note
The agilent 290mL reservoir has 8 “v”-shaped sub-wells arranged vertically; we don’t already have a quirk written for this. However, filing it under the 96-grid quirk allows us to fully fix any issues that might come up with this labware, it just comes packaged with moving an odd-column-number nozzle configuration (single tip for example) a little to the left unnecessarily. 

[RABR-880]: https://opentrons.atlassian.net/browse/RABR-880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ