### PR TITLE
fix(shared-data): Remove extraneous offsets causing the gripper to crash into the deck

### DIFF
--- a/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
+++ b/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
@@ -144,6 +144,11 @@ DEFAULT_LABWARE_VERSIONS: DefaultLabwareVersions = {
         "usascientific_12_reservoir_22ml": 4,
         "usascientific_96_wellplate_2.4ml_deep": 4,
     },
+    APIVersion(2, 28): {
+        "black_96_well_microtiter_plate_lid": 2,
+        "corning_96_wellplate_360ul_lid": 2,
+        "corning_falcon_384_wellplate_130ul_flat_lid": 2,
+    },
 }
 
 

--- a/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
+++ b/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
@@ -148,6 +148,7 @@ DEFAULT_LABWARE_VERSIONS: DefaultLabwareVersions = {
         "black_96_well_microtiter_plate_lid": 2,
         "corning_96_wellplate_360ul_lid": 2,
         "corning_falcon_384_wellplate_130ul_flat_lid": 2,
+        "ibidi_96_square_well_plate_300ul_lid": 2,
     },
 }
 

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 27)
+MAX_SUPPORTED_VERSION = APIVersion(2, 28)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)

--- a/shared-data/labware/definitions/2/black_96_well_microtiter_plate_lid/2.json
+++ b/shared-data/labware/definitions/2/black_96_well_microtiter_plate_lid/2.json
@@ -1,0 +1,110 @@
+{
+  "allowedRoles": ["labware", "lid"],
+  "ordering": [],
+  "brand": {
+    "brand": "greiner",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "Black 96-well Microtiter Plate Lid",
+    "displayCategory": "lid",
+    "displayVolumeUnits": "\u00b5L",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.5,
+    "yDimension": 85,
+    "zDimension": 10
+  },
+  "wells": {},
+  "groups": [
+    {
+      "metadata": {},
+      "wells": []
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "parameters": {
+    "format": "irregular",
+    "quirks": ["stackingMaxFive"],
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "black_96_well_microtiter_plate_lid"
+  },
+  "namespace": "opentrons",
+  "version": 2,
+  "schemaVersion": 2,
+  "stackingOffsetWithLabware": {
+    "milliplex_r_96_well_microtiter_plate": {
+      "x": 0,
+      "y": 0,
+      "z": 7.4
+    },
+    "black_96_well_microtiter_plate_lid": {
+      "x": 0,
+      "y": 0,
+      "z": 1
+    },
+    "opentrons_flex_deck_riser": {
+      "x": 0,
+      "y": 0,
+      "z": 34
+    },
+    "protocol_engine_lid_stack_object": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  "stackLimit": 5,
+  "compatibleParentLabware": [
+    "protocol_engine_lid_stack_object",
+    "opentrons_flex_deck_riser",
+    "milliplex_r_96_well_microtiter_plate",
+    "black_96_well_microtiter_plate_lid"
+  ],
+  "gripForce": 10,
+  "gripHeightFromLabwareBottom": 7,
+  "gripperOffsets": {
+    "default": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 0,
+        "z": -5
+      }
+    },
+    "lidOffsets": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": -5
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 0,
+        "z": -5
+      }
+    },
+    "lidDisposalOffsets": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 5.0,
+        "z": 50.0
+      }
+    }
+  }
+}

--- a/shared-data/labware/definitions/2/black_96_well_microtiter_plate_lid/2.json
+++ b/shared-data/labware/definitions/2/black_96_well_microtiter_plate_lid/2.json
@@ -82,18 +82,6 @@
         "z": -5
       }
     },
-    "lidOffsets": {
-      "pickUpOffset": {
-        "x": 0,
-        "y": 0,
-        "z": -5
-      },
-      "dropOffset": {
-        "x": 0,
-        "y": 0,
-        "z": -5
-      }
-    },
     "lidDisposalOffsets": {
       "pickUpOffset": {
         "x": 0,

--- a/shared-data/labware/definitions/2/black_96_well_microtiter_plate_lid/2.json
+++ b/shared-data/labware/definitions/2/black_96_well_microtiter_plate_lid/2.json
@@ -70,18 +70,6 @@
   "gripForce": 10,
   "gripHeightFromLabwareBottom": 7,
   "gripperOffsets": {
-    "default": {
-      "pickUpOffset": {
-        "x": 0,
-        "y": 0,
-        "z": 0
-      },
-      "dropOffset": {
-        "x": 0,
-        "y": 0,
-        "z": -5
-      }
-    },
     "lidDisposalOffsets": {
       "pickUpOffset": {
         "x": 0,

--- a/shared-data/labware/definitions/2/corning_96_wellplate_360ul_lid/2.json
+++ b/shared-data/labware/definitions/2/corning_96_wellplate_360ul_lid/2.json
@@ -1,0 +1,117 @@
+{
+  "allowedRoles": ["labware", "lid"],
+  "ordering": [],
+  "brand": {
+    "brand": "Corning",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "Corning 96 Wellplate 360ul Lid",
+    "displayCategory": "lid",
+    "displayVolumeUnits": "\u00b5L",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127,
+    "yDimension": 85,
+    "zDimension": 10
+  },
+  "wells": {},
+  "groups": [
+    {
+      "metadata": {},
+      "wells": []
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "parameters": {
+    "format": "irregular",
+    "quirks": ["stackingMaxFive"],
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "corning_96_wellplate_360ul_lid"
+  },
+  "namespace": "opentrons",
+  "version": 2,
+  "schemaVersion": 2,
+  "stackingOffsetWithModule": {
+    "thermocyclerModuleV2": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  "stackingOffsetWithLabware": {
+    "corning_96_wellplate_360ul_flat": {
+      "x": 0,
+      "y": 0,
+      "z": 6.5
+    },
+    "corning_96_wellplate_360ul_lid": {
+      "x": 0,
+      "y": 0,
+      "z": 1
+    },
+    "opentrons_flex_deck_riser": {
+      "x": 0,
+      "y": 0,
+      "z": 34
+    },
+    "protocol_engine_lid_stack_object": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  "stackLimit": 5,
+  "compatibleParentLabware": [
+    "protocol_engine_lid_stack_object",
+    "opentrons_flex_deck_riser",
+    "corning_96_wellplate_360ul_flat",
+    "corning_96_wellplate_360ul_lid"
+  ],
+  "gripForce": 10,
+  "gripHeightFromLabwareBottom": 7,
+  "gripperOffsets": {
+    "default": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 0,
+        "z": -6
+      }
+    },
+    "lidOffsets": {
+      "pickUpOffset": {
+        "x": 0.5,
+        "y": 0,
+        "z": -5
+      },
+      "dropOffset": {
+        "x": 0.5,
+        "y": 0,
+        "z": -1
+      }
+    },
+    "lidDisposalOffsets": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 5.0,
+        "z": 50.0
+      }
+    }
+  }
+}

--- a/shared-data/labware/definitions/2/corning_96_wellplate_360ul_lid/2.json
+++ b/shared-data/labware/definitions/2/corning_96_wellplate_360ul_lid/2.json
@@ -77,18 +77,6 @@
   "gripForce": 10,
   "gripHeightFromLabwareBottom": 7,
   "gripperOffsets": {
-    "default": {
-      "pickUpOffset": {
-        "x": 0,
-        "y": 0,
-        "z": 0
-      },
-      "dropOffset": {
-        "x": 0,
-        "y": 0,
-        "z": -6
-      }
-    },
     "lidDisposalOffsets": {
       "pickUpOffset": {
         "x": 0,

--- a/shared-data/labware/definitions/2/corning_96_wellplate_360ul_lid/2.json
+++ b/shared-data/labware/definitions/2/corning_96_wellplate_360ul_lid/2.json
@@ -89,18 +89,6 @@
         "z": -6
       }
     },
-    "lidOffsets": {
-      "pickUpOffset": {
-        "x": 0.5,
-        "y": 0,
-        "z": -5
-      },
-      "dropOffset": {
-        "x": 0.5,
-        "y": 0,
-        "z": -1
-      }
-    },
     "lidDisposalOffsets": {
       "pickUpOffset": {
         "x": 0,

--- a/shared-data/labware/definitions/2/corning_falcon_384_wellplate_130ul_flat_lid/2.json
+++ b/shared-data/labware/definitions/2/corning_falcon_384_wellplate_130ul_flat_lid/2.json
@@ -1,0 +1,118 @@
+{
+  "allowedRoles": ["labware", "lid"],
+  "ordering": [],
+  "brand": {
+    "brand": "Corning",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "Corning Falcon 384 Well Microtest Plate 130 µL Lid",
+    "displayCategory": "lid",
+    "displayVolumeUnits": "\u00b5L",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127,
+    "yDimension": 84.8,
+    "zDimension": 6.85
+  },
+  "wells": {},
+  "groups": [
+    {
+      "metadata": {},
+      "wells": []
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "parameters": {
+    "format": "irregular",
+    "quirks": [],
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "corning_falcon_384_wellplate_130ul_flat_lid"
+  },
+  "namespace": "opentrons",
+  "version": 2,
+  "schemaVersion": 2,
+  "stackingOffsetWithModule": {
+    "thermocyclerModuleV2": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  "stackingOffsetWithLabware": {
+    "corning_falcon_384_wellplate_130ul_flat": {
+      "x": 0,
+      "y": 0,
+      "z": 2.1
+    },
+    "corning_falcon_384_wellplate_130ul_flat_lid": {
+      "x": 0,
+      "y": 0,
+      "z": 5.9
+    },
+    "opentrons_flex_deck_riser": {
+      "x": 0,
+      "y": 0,
+      "z": 28
+    },
+    "protocol_engine_lid_stack_object": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  "stackLimit": 5,
+  "compatibleParentLabware": [
+    "protocol_engine_lid_stack_object",
+    "opentrons_flex_deck_riser",
+    "corning_falcon_384_wellplate_130ul_flat",
+    "corning_falcon_384_wellplate_130ul_flat_lid",
+    "opentrons_universal_flat_adapter"
+  ],
+  "gripForce": 10,
+  "gripHeightFromLabwareBottom": 7,
+  "gripperOffsets": {
+    "default": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 0,
+        "z": -6
+      }
+    },
+    "lidOffsets": {
+      "pickUpOffset": {
+        "x": 0.5,
+        "y": 0,
+        "z": -5
+      },
+      "dropOffset": {
+        "x": 0.5,
+        "y": 0,
+        "z": -1
+      }
+    },
+    "lidDisposalOffsets": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 5.0,
+        "z": 50.0
+      }
+    }
+  }
+}

--- a/shared-data/labware/definitions/2/corning_falcon_384_wellplate_130ul_flat_lid/2.json
+++ b/shared-data/labware/definitions/2/corning_falcon_384_wellplate_130ul_flat_lid/2.json
@@ -78,18 +78,6 @@
   "gripForce": 10,
   "gripHeightFromLabwareBottom": 7,
   "gripperOffsets": {
-    "default": {
-      "pickUpOffset": {
-        "x": 0,
-        "y": 0,
-        "z": 0
-      },
-      "dropOffset": {
-        "x": 0,
-        "y": 0,
-        "z": -6
-      }
-    },
     "lidDisposalOffsets": {
       "pickUpOffset": {
         "x": 0,

--- a/shared-data/labware/definitions/2/corning_falcon_384_wellplate_130ul_flat_lid/2.json
+++ b/shared-data/labware/definitions/2/corning_falcon_384_wellplate_130ul_flat_lid/2.json
@@ -90,18 +90,6 @@
         "z": -6
       }
     },
-    "lidOffsets": {
-      "pickUpOffset": {
-        "x": 0.5,
-        "y": 0,
-        "z": -5
-      },
-      "dropOffset": {
-        "x": 0.5,
-        "y": 0,
-        "z": -1
-      }
-    },
     "lidDisposalOffsets": {
       "pickUpOffset": {
         "x": 0,

--- a/shared-data/labware/definitions/2/ibidi_96_square_well_plate_300ul_lid/2.json
+++ b/shared-data/labware/definitions/2/ibidi_96_square_well_plate_300ul_lid/2.json
@@ -82,18 +82,6 @@
         "z": -6
       }
     },
-    "lidOffsets": {
-      "pickUpOffset": {
-        "x": 0.5,
-        "y": 0,
-        "z": -5
-      },
-      "dropOffset": {
-        "x": 0.5,
-        "y": 0,
-        "z": -1
-      }
-    },
     "lidDisposalOffsets": {
       "pickUpOffset": {
         "x": 0,

--- a/shared-data/labware/definitions/2/ibidi_96_square_well_plate_300ul_lid/2.json
+++ b/shared-data/labware/definitions/2/ibidi_96_square_well_plate_300ul_lid/2.json
@@ -70,18 +70,6 @@
   "gripForce": 10,
   "gripHeightFromLabwareBottom": 5,
   "gripperOffsets": {
-    "default": {
-      "pickUpOffset": {
-        "x": 0,
-        "y": 0,
-        "z": 0
-      },
-      "dropOffset": {
-        "x": 0,
-        "y": 0,
-        "z": -6
-      }
-    },
     "lidDisposalOffsets": {
       "pickUpOffset": {
         "x": 0,

--- a/shared-data/labware/definitions/2/ibidi_96_square_well_plate_300ul_lid/2.json
+++ b/shared-data/labware/definitions/2/ibidi_96_square_well_plate_300ul_lid/2.json
@@ -1,0 +1,110 @@
+{
+  "allowedRoles": ["labware", "lid"],
+  "ordering": [],
+  "brand": {
+    "brand": "ibidi",
+    "brandId": []
+  },
+  "metadata": {
+    "displayName": "ibidi 96 Square Well Flat Bottom Plate 300 µL Lid",
+    "displayCategory": "lid",
+    "displayVolumeUnits": "\u00b5L",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127,
+    "yDimension": 84.5,
+    "zDimension": 6.95
+  },
+  "wells": {},
+  "groups": [
+    {
+      "metadata": {},
+      "wells": []
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "parameters": {
+    "format": "irregular",
+    "quirks": ["stackingMaxFive"],
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "ibidi_96_square_well_plate_300ul_lid"
+  },
+  "namespace": "opentrons",
+  "version": 2,
+  "schemaVersion": 2,
+  "stackingOffsetWithLabware": {
+    "ibidi_96_square_well_plate_300ul_lid": {
+      "x": 0,
+      "y": 0,
+      "z": 1.2
+    },
+    "ibidi_96_square_well_plate_300ul": {
+      "x": 0,
+      "y": 0,
+      "z": 4.75
+    },
+    "opentrons_flex_deck_riser": {
+      "x": 0,
+      "y": 0,
+      "z": 34
+    },
+    "protocol_engine_lid_stack_object": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    }
+  },
+  "stackLimit": 5,
+  "compatibleParentLabware": [
+    "protocol_engine_lid_stack_object",
+    "opentrons_flex_deck_riser",
+    "ibidi_96_square_well_plate_300ul",
+    "ibidi_96_square_well_plate_300ul_lid"
+  ],
+  "gripForce": 10,
+  "gripHeightFromLabwareBottom": 5,
+  "gripperOffsets": {
+    "default": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 0,
+        "z": -6
+      }
+    },
+    "lidOffsets": {
+      "pickUpOffset": {
+        "x": 0.5,
+        "y": 0,
+        "z": -5
+      },
+      "dropOffset": {
+        "x": 0.5,
+        "y": 0,
+        "z": -1
+      }
+    },
+    "lidDisposalOffsets": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 5.0,
+        "z": 50.0
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview

This addresses RESC-548.

## Details

### Primary fix: delete `gripperOffsets.default` (commit 3c3405d362eb2ffcb04ff18c37eb1ffe7f54cb43)

These labware definitions were specifying `gripperOffsets.default` values like `"z": -5`. (I assume to "overpress" the  labware so it fits firmly in the slot?) For other labware, that might be OK. But these labware are very short, so if the gripper lowers by even a few extra mm, it will hit the deck.

| Labware definition | gripHeightFromLabwareBottom | Gripper-to-deck clearance with zero overpress |
|--------------------|-----------------------------|--------------------------------------|
| `black_96_well_microtiter_plate_lid` | 7 | 3 |
| `corning_96_wellplate_360ul_lid` | 7 | 3 |
| `corning_falcon_384_wellplate_130ul_flat_lid` | 7 | 3 |
| `ibidi_96_square_well_plate_300ul_lid` | 5 | 1 |

There are two possibilities for how this passed testing in the first place:

* Maybe we didn't test this labware moving into or out of a bare deck slots. Maybe we always tested it on top of a plate.
* There's a separate bug, EXEC-1989, that causes `gripperOffsets.default` to be applied inconsistently depending on how the lid is loaded. Maybe the test protocol happened to load the lid in the way that makes it not apply.

Here are the options that I see:

* Zero out the overpress.
* Some combination of reducing the overpress, and raising the `gripHeightFromLabwareBottom` to give the gripper more clearance.
* Just tell users that they can't put these labware in bare deck slots. They need to use a deck slot riser.
* Attempt some kind of software solution to dynamically allow the overpress if the lid is on top of something and the gripper will have clearance, but clamp it if the lid is on a bare deck slot and the gripper won't have clearance.

In this PR, I've zeroed out the overpress, because it seems like it'll be the simplest thing, *if it works.*

### Secondary improvement: delete `gripperOffsets.lidOffsets` (commit 922232cbffd4ef7e7272aaa12fd4d8a0869233d2)

Since we're introducing new versions of these labware, now's a good time to delete the `lidOffsets` fields for clarity. I don't think they were doing anything.

`lidOffsets` appears to be Thermocycler-specific (see #20976 for details). Since all of these lids fit on labware that are physically incompatible with the Thermocycler (see the table below), I don't see any way it could have been used.

| Lid | Fits on (plate) |
|-----|------------------|
| [black_96_well_microtiter_plate_lid](https://labware.opentrons.com/#/?loadName=black_96_well_microtiter_plate_lid) | [milliplex_r_96_well_microtiter_plate](https://labware.opentrons.com/#/?loadName=milliplex_r_96_well_microtiter_plate) |
| [corning_96_wellplate_360ul_lid](https://labware.opentrons.com/#/?loadName=corning_96_wellplate_360ul_lid) | [corning_96_wellplate_360ul_flat](https://labware.opentrons.com/#/?loadName=corning_96_wellplate_360ul_flat) |
| [corning_falcon_384_wellplate_130ul_flat_lid](https://labware.opentrons.com/#/?loadName=corning_falcon_384_wellplate_130ul_flat_lid) | [corning_falcon_384_wellplate_130ul_flat](https://labware.opentrons.com/#/?loadName=corning_falcon_384_wellplate_130ul_flat) |
| [ibidi_96_square_well_plate_300ul_lid](https://labware.opentrons.com/#/?loadName=ibidi_96_square_well_plate_300ul_lid) | [ibidi_96_square_well_plate_300ul](https://labware.opentrons.com/#/?loadName=ibidi_96_square_well_plate_300ul) |

I haven't been able to test this with the real labware because I'm not sure where to find it.

## Review requests

Do we agree that zeroing out the overpress is the correct solution here, compared to the other options, listed above?

## Test Plan and Hands on Testing

On all 4 of the lids mentioned above, this should no longer cause a gripper crash, and it should still deposit the lid in the deck slot "firmly enough."

Make sure you have a good gripper calibration!

```python
requirements = {
    "apiLevel": "2.28",
    "robotType": "Flex"
}

def run(protocol):
    protocol.load_lid_stack("black_96_well_microtiter_plate_lid", 'A1', 1)
    protocol.load_lid_stack("corning_96_wellplate_360ul_lid", "B1", 1)
    protocol.load_lid_stack("corning_falcon_384_wellplate_130ul_flat_lid", "C1", 1)
    protocol.load_lid_stack("ibidi_96_square_well_plate_300ul_lid", "D1", 1)

    for _ in range(10):
         protocol.move_lid("A1", "A2", use_gripper=True)
         protocol.move_lid("A2", "A1", use_gripper=True)

         protocol.move_lid("B1", "B2", use_gripper=True)
         protocol.move_lid("B2", "B1", use_gripper=True)

         protocol.move_lid("C1", "C2", use_gripper=True)
         protocol.move_lid("C2", "C1", use_gripper=True)

         protocol.move_lid("D1", "D2", use_gripper=True)
         protocol.move_lid("D2", "D1", use_gripper=True)
```

I've so far only tested this with `corning_falcon_384_wellplate_130ul_flat_lid`.

I'm not sure if this needs any further testing beyond that. I would imagine that a deck slot is the most difficult place to drop a lid, because of the springs, so if having zero overpress works in a deck slot, it should also work everywhere else, right?

## Risk assessment

High. Even if zeroing out the overpress is necessary for placing the lid in a bare deck slot, it might make moving the lid less reliable when it's going on top of another labware.
