### PR TITLE
fix(protocol-designer): add stub to avoid react-color icon issues

### DIFF
--- a/protocol-designer/src/icon-stub.tsx
+++ b/protocol-designer/src/icon-stub.tsx
@@ -1,6 +1,10 @@
+/* eslint-disable import/no-default-export */
 // This will be removed when replacing react-color
 // icon-stub.tsx
-import React from 'react'
+import type { JSX } from 'react'
 
-const IconStub = () => null
+export function IconStub(): JSX.Element | null {
+  return null
+}
+
 export default IconStub

--- a/protocol-designer/src/icon-stub.tsx
+++ b/protocol-designer/src/icon-stub.tsx
@@ -1,0 +1,6 @@
+// This will be removed when replacing react-color
+// icon-stub.tsx
+import React from 'react'
+
+const IconStub = () => null
+export default IconStub

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -194,6 +194,14 @@ export default defineConfig(async (): Promise<UserConfig> => {
       // For unknown reasons, PD whitescreens on launch unless we have this.
       dedupe: ['tslib'],
       alias: {
+        '@icons/material/CheckIcon': path.resolve(
+          __dirname,
+          './src/icon-stub.tsx'
+        ),
+        '@icons/material/UnfoldMoreHorizontalIcon': path.resolve(
+          __dirname,
+          './src/icon-stub.tsx'
+        ),
         // todo(mm, 2025-10-27): These cross-project aliases cause trouble like
         // files being processed with the wrong config (the config from the
         // consuming project vs. the config from the source project).


### PR DESCRIPTION

# Overview
add stub to avoid react-color icon issues.
react-color hasn't been updated more than 3 years. I'm planing to replace `react-color` with `@uiw/react-color`
https://github.com/Opentrons/opentrons/pull/20980

however, before replacing the package, i have to fix `date-fns` issue on protocol-designer and app.


## Test Plan and Hands on Testing
- make -C protocol-designer dev

## Changelog
- add stub file for icons

## Review requests

## Risk assessment
low