### PR TITLE
fix(protocol-designer, step-generation): include waste chute in highest z calculation to prevent collisions

### DIFF
--- a/protocol-designer/src/assets/localization/en/alert.json
+++ b/protocol-designer/src/assets/localization/en/alert.json
@@ -322,7 +322,7 @@
         "title": "Gripper movement with tips attached"
       },
       "POSSIBLE_PIPETTE_COLLISION": {
-        "body": "There is a possibility that the pipette will collide with the adjacent labware or module for partial tip pick up.",
+        "body": "There is a possibility that the pipette will collide with the adjacent labware, modules, or trash fixtures for partial tip pick up.",
         "title": "Pipette collisions likely"
       },
       "REMOVE_96_CHANNEL_TIPRACK_ADAPTER": {

--- a/step-generation/src/utils/__tests__/getIsSafePipetteMovement.test.ts
+++ b/step-generation/src/utils/__tests__/getIsSafePipetteMovement.test.ts
@@ -9,6 +9,7 @@ import {
   fixtureP100096V2Specs,
   fixtureTiprack1000ul,
   fixtureTiprackAdapter,
+  SINGLE,
   TEMPERATURE_MODULE_TYPE,
   TEMPERATURE_MODULE_V2,
 } from '@opentrons/shared-data'
@@ -114,6 +115,38 @@ describe('getIsSafePipetteMovement', () => {
       nozzleConfiguration: ALL,
     })
     expect(result).toEqual(true)
+  })
+  it('returns false when 96ch single tip pick up will overlap with waste chute', () => {
+    const result = getIsSafePipetteMovement({
+      robotState: {
+        ...mockRobotState,
+        pipettes: {
+          ...mockRobotState.pipettes,
+          [mockPipId]: {
+            ...mockRobotState.pipettes[mockPipId],
+            nozzles: SINGLE,
+            primaryNozzle: A1_NOZZLE,
+          },
+        },
+      },
+      invariantContext: {
+        ...mockInvariantProperties,
+        wasteChuteEntities: {
+          id: {
+            id: 'id',
+            location: 'cutoutD3',
+            pythonName: 'waste_chute',
+          },
+        },
+      },
+      pipetteId: mockPipId,
+      labwareId: mockLabwareId,
+      wellLocationOffset: { x: -12, y: -100, z: 20 },
+      wellTargetName: mockWellName,
+      primaryNozzle: A1_NOZZLE,
+      nozzleConfiguration: SINGLE,
+    })
+    expect(result).toEqual(false)
   })
   it('returns false when within pipette extents is false', () => {
     const result = getIsSafePipetteMovement({

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -23,10 +23,7 @@ import {
 } from '@opentrons/shared-data'
 
 import { EMPTY, OT2_TC_SLOTS } from '../constants'
-import {
-  getFullStackFromLabwares,
-  getSlotInLocationStack,
-} from './misc'
+import { getFullStackFromLabwares, getSlotInLocationStack } from './misc'
 
 import type {
   AddressableArea,
@@ -183,9 +180,8 @@ const getHighestZInSlot = (
     const moduleInSlot = Object.keys(modules).find(
       moduleId => modules[moduleId].slot === slotId
     )
-    // TODO(RC, 3/10/2026): wasteChute location is most likely CutoutId but needs better typing to confirm
     const wasteChuteInSlot = Object.values(wasteChuteEntities).find(
-      wasteChute => wasteChute.location as CutoutId === getCutoutIdFromSlot(slotInfo)
+      wasteChute => wasteChute.location === getCutoutIdFromSlot(slotInfo)
     )
     // if slot has waste chute
     if (wasteChuteInSlot) {

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -5,7 +5,6 @@ import {
   COLUMN,
   FLEX_ROBOT_TYPE,
   getAddressableAreaFromSlotId,
-  getCutoutDisplayName,
   getDeckDefFromRobotType,
   getFlexSurroundingSlots,
   getModuleDef,
@@ -24,7 +23,10 @@ import {
 } from '@opentrons/shared-data'
 
 import { EMPTY, OT2_TC_SLOTS } from '../constants'
-import { getFullStackFromLabwares, getSlotInLocationStack } from './misc'
+import {
+  getFullStackFromLabwares,
+  getSlotInLocationStack,
+} from './misc'
 
 import type {
   AddressableArea,
@@ -73,6 +75,16 @@ export interface Point {
   x: number
   y: number
   z?: number
+}
+
+export const getCutoutIdFromSlot = (slotInfo: SlotInfo): CutoutId | null => {
+  if (slotInfo.addressableArea?.areaType === 'slot') {
+    const testCutoutId = `cutoutId${slotInfo.addressableArea?.id}`
+    if (testCutoutId as CutoutId) {
+      return testCutoutId as CutoutId
+    }
+  }
+  return null
 }
 
 // return pipette bounds at a sepcific position
@@ -158,45 +170,49 @@ const getWasteChuteHeightFromDeckDefinition = (
 const getHighestZInSlot = (
   robotState: RobotState,
   invariantContext: InvariantContext,
-  slotId: string,
+  slotInfo: SlotInfo,
   robotType: RobotType
 ): number => {
   const { modules, labware } = robotState
   const { moduleEntities, labwareEntities, wasteChuteEntities } =
     invariantContext
   let totalHeight: number = 0
-  const largestLabwareStack = getFullStackFromLabwares(labware, slotId)
-  const moduleInSlot = Object.keys(modules).find(
-    moduleId => modules[moduleId].slot === slotId
-  )
-  const wasteChuteInSlot = Object.values(wasteChuteEntities).find(
-    wasteChute =>
-      getCutoutDisplayName(wasteChute.location as CutoutId) === slotId
-  )
-  // if slot has waste chute
-  if (wasteChuteInSlot) {
-    totalHeight += getWasteChuteHeightFromDeckDefinition(robotType)
-  }
-  //  if slot has labware, includes labware, adapters, and module
-  if (largestLabwareStack.length > 0) {
-    largestLabwareStack.forEach(item => {
-      if (modules[item] != null) {
-        totalHeight += getModuleHeightFromDeckDefinition(
-          moduleEntities[item].model,
-          robotType
-        )
-      }
-      if (labware[item] != null) {
-        totalHeight += labwareEntities[item].def.dimensions.zDimension
-      }
-    })
-    // if slot only has module
-  } else if (moduleInSlot != null) {
-    totalHeight += getModuleHeightFromDeckDefinition(
-      moduleEntities[moduleInSlot].model,
-      robotType
+  const slotId = slotInfo?.addressableArea?.id
+  if (slotId) {
+    const largestLabwareStack = getFullStackFromLabwares(labware, slotId)
+    const moduleInSlot = Object.keys(modules).find(
+      moduleId => modules[moduleId].slot === slotId
     )
+    // TODO(RC, 3/10/2026): wasteChute location is most likely CutoutId but needs better typing to confirm
+    const wasteChuteInSlot = Object.values(wasteChuteEntities).find(
+      wasteChute => wasteChute.location as CutoutId === getCutoutIdFromSlot(slotInfo)
+    )
+    // if slot has waste chute
+    if (wasteChuteInSlot) {
+      totalHeight += getWasteChuteHeightFromDeckDefinition(robotType)
+    }
+    //  if slot has labware, includes labware, adapters, and module
+    if (largestLabwareStack.length > 0) {
+      largestLabwareStack.forEach(item => {
+        if (modules[item] != null) {
+          totalHeight += getModuleHeightFromDeckDefinition(
+            moduleEntities[item].model,
+            robotType
+          )
+        }
+        if (labware[item] != null) {
+          totalHeight += labwareEntities[item].def.dimensions.zDimension
+        }
+      })
+      // if slot only has module
+    } else if (moduleInSlot != null) {
+      totalHeight += getModuleHeightFromDeckDefinition(
+        moduleEntities[moduleInSlot].model,
+        robotType
+      )
+    }
   }
+
   return totalHeight
 }
 
@@ -249,15 +265,12 @@ const getSlotHasPotentialCollidingObject = (
       ) &&
       pipetteBounds[0].z != null
     ) {
-      const highestZInSurroundingSlot =
-        slot.addressableArea?.id != null
-          ? getHighestZInSlot(
-              robotState,
-              invariantContext,
-              slot.addressableArea.id,
-              robotType
-            )
-          : 0
+      const highestZInSurroundingSlot = getHighestZInSlot(
+        robotState,
+        invariantContext,
+        slot,
+        robotType
+      )
       if (highestZInSurroundingSlot >= pipetteBounds[0]?.z) {
         return true
       }

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -5,6 +5,7 @@ import {
   COLUMN,
   FLEX_ROBOT_TYPE,
   getAddressableAreaFromSlotId,
+  getCutoutDisplayName,
   getDeckDefFromRobotType,
   getFlexSurroundingSlots,
   getModuleDef,
@@ -12,7 +13,6 @@ import {
   getPositionFromSlotId,
   getRobotDefFromRobotType,
   H1_NOZZLE,
-  NINETY_SIX_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
   OT2_ROBOT_TYPE,
   PARTIAL_COLUMN,
   PARTIAL_NOZZLE_MAP,
@@ -20,6 +20,7 @@ import {
   SINGLE,
   THERMOCYCLER_MODULE_TYPE,
   THERMOCYCLER_MODULE_V2,
+  WASTE_CHUTE_FIXTURES,
 } from '@opentrons/shared-data'
 
 import { EMPTY, OT2_TC_SLOTS } from '../constants'
@@ -28,6 +29,7 @@ import { getFullStackFromLabwares, getSlotInLocationStack } from './misc'
 import type {
   AddressableArea,
   CoordinateTuple,
+  CutoutId,
   LabwareDefinition,
   ModuleModel,
   NozzleConfigurationStyle,
@@ -144,15 +146,11 @@ const getModuleHeightFromDeckDefinition = (
 const getWasteChuteHeightFromDeckDefinition = (
   robotType: RobotType
 ): number => {
-  if (robotType === FLEX_ROBOT_TYPE) {
-    const deckDef = getDeckDefFromRobotType(robotType)
-    const wasteChute = Object.values(deckDef.locations.addressableAreas).find(
-      addressableArea =>
-        addressableArea.id === NINETY_SIX_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA
-    )
-    return wasteChute?.offsetFromCutoutFixture[2] ?? 0
-  }
-  return 0
+  const deckDef = getDeckDefFromRobotType(robotType)
+  const wasteChute = Object.values(deckDef.cutoutFixtures).find(cutoutFixture =>
+    WASTE_CHUTE_FIXTURES.includes(cutoutFixture.id)
+  )
+  return wasteChute?.height ?? 0 // returns 0 if no waste chute
 }
 
 //  check the highest Z-point of all items stacked given a deck slot (including modules,
@@ -166,14 +164,17 @@ const getHighestZInSlot = (
   const { modules, labware } = robotState
   const { moduleEntities, labwareEntities, wasteChuteEntities } =
     invariantContext
-
   let totalHeight: number = 0
   const largestLabwareStack = getFullStackFromLabwares(labware, slotId)
   const moduleInSlot = Object.keys(modules).find(
     moduleId => modules[moduleId].slot === slotId
   )
+  const wasteChuteInSlot = Object.values(wasteChuteEntities).find(
+    wasteChute =>
+      getCutoutDisplayName(wasteChute.location as CutoutId) === slotId
+  )
   // if slot has waste chute
-  if (wasteChuteEntities && slotId === 'D3') {
+  if (wasteChuteInSlot) {
     totalHeight += getWasteChuteHeightFromDeckDefinition(robotType)
   }
   //  if slot has labware, includes labware, adapters, and module

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -12,6 +12,7 @@ import {
   getPositionFromSlotId,
   getRobotDefFromRobotType,
   H1_NOZZLE,
+  NINETY_SIX_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
   OT2_ROBOT_TYPE,
   PARTIAL_COLUMN,
   PARTIAL_NOZZLE_MAP,
@@ -140,8 +141,22 @@ const getModuleHeightFromDeckDefinition = (
   return getModuleDef(moduleModel).dimensions.bareOverallHeight
 }
 
+const getWasteChuteHeightFromDeckDefinition = (
+  robotType: RobotType
+): number => {
+  if (robotType === FLEX_ROBOT_TYPE) {
+    const deckDef = getDeckDefFromRobotType(robotType)
+    const wasteChute = Object.values(deckDef.locations.addressableAreas).find(
+      addressableArea =>
+        addressableArea.id === NINETY_SIX_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA
+    )
+    return wasteChute?.offsetFromCutoutFixture[2] ?? 0
+  }
+  return 0
+}
+
 //  check the highest Z-point of all items stacked given a deck slot (including modules,
-//  adapters, and modules on adapters)
+//  adapters, waste chute, and modules on adapters)
 const getHighestZInSlot = (
   robotState: RobotState,
   invariantContext: InvariantContext,
@@ -149,14 +164,18 @@ const getHighestZInSlot = (
   robotType: RobotType
 ): number => {
   const { modules, labware } = robotState
-  const { moduleEntities, labwareEntities } = invariantContext
+  const { moduleEntities, labwareEntities, wasteChuteEntities } =
+    invariantContext
 
   let totalHeight: number = 0
   const largestLabwareStack = getFullStackFromLabwares(labware, slotId)
   const moduleInSlot = Object.keys(modules).find(
     moduleId => modules[moduleId].slot === slotId
   )
-
+  // if slot has waste chute
+  if (wasteChuteEntities && slotId === 'D3') {
+    totalHeight += getWasteChuteHeightFromDeckDefinition(robotType)
+  }
   //  if slot has labware, includes labware, adapters, and module
   if (largestLabwareStack.length > 0) {
     largestLabwareStack.forEach(item => {


### PR DESCRIPTION
# Overview

Check for waste chute in slot to include in highest z calculation.

Previously, collision errors were not being raised when the pipette would collide with the waste chute in the z direction. This fixes it.

## Test Plan and Hands on Testing

Smoke tested with protocol: 
[protocol_with_waste_chute_error.py](https://github.com/user-attachments/files/25774096/protocol_with_waste_chute_error.py)
and ensured error appeared when doing single tip pick up with nozzle A1
<img width="1506" height="767" alt="Screenshot 2026-03-05 at 11 18 45 AM" src="https://github.com/user-attachments/assets/c3dd47b3-aa56-4ae4-aa57-4ab453c57877" />


## Changelog

- use deck definition cutout fixture height to get height of waste chute
- changed WasteChuteEntity type to use WasteEntity instead of TrashEntity so that the location could be typed as a CutoutId rather than a string. This could not be done for the TrashEntity because it is used by the OT-2.

## Risk assessment
medium 
- There may be some protocols that analyzed on pd that no longer do. This is okay, because those protocols would also not analyze on the app.

Closes AUTH-2785
