### PR TITLE
fix(app, protocol-designer, shared-data): include nozzle configuration in determining pipette labware compatibility

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateCompatibleLabwareForPipette.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateCompatibleLabwareForPipette.ts
@@ -1,4 +1,8 @@
-import { getLabwareDefURI, makeWellSetHelpers } from '@opentrons/shared-data'
+import {
+  ALL,
+  getLabwareDefURI,
+  makeWellSetHelpers,
+} from '@opentrons/shared-data'
 
 import { getAllLatestDefs } from '/app/local-resources/labware'
 
@@ -31,7 +35,7 @@ export function generateCompatibleLabwareForPipette(
       } else if (pipetteSpecs.channels === 1) {
         return [...acc, getLabwareDefURI(definition)]
       } else {
-        const isCompatible = canPipetteUseLabware(pipetteSpecs, definition)
+        const isCompatible = canPipetteUseLabware(pipetteSpecs, ALL, definition)
         return isCompatible ? [...acc, getLabwareDefURI(definition)] : acc
       }
     },

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -623,13 +623,14 @@ export type FormErrorChecker = (
 export const incompatibleLabware = (
   fields: HydratedMixFormData
 ): FormError | null => {
-  const { labware, pipette } = fields
+  const { labware, pipette, nozzles } = fields
   if (!labware || !pipette) {
     return null
   }
   //  trashBin and wasteChute cannot mix into a labware
   return !canPipetteUseLabware(
     pipette.spec as PipetteV2Specs,
+    nozzles,
     labware.def as LabwareDefinition2
   )
     ? INCOMPATIBLE_LABWARE
@@ -638,12 +639,13 @@ export const incompatibleLabware = (
 export const incompatibleDispenseLabware = (
   fields: HydratedMoveLiquidFormData
 ): FormError | null => {
-  const { dispense_labware, pipette } = fields
+  const { dispense_labware, pipette, nozzles } = fields
   if (!dispense_labware || !pipette) {
     return null
   }
   return !canPipetteUseLabware(
     pipette.spec as PipetteV2Specs,
+    nozzles,
     'def' in dispense_labware
       ? (dispense_labware.def as LabwareDefinition2)
       : undefined,
@@ -655,13 +657,14 @@ export const incompatibleDispenseLabware = (
 export const incompatibleAspirateLabware = (
   fields: HydratedMoveLiquidFormData
 ): FormError | null => {
-  const { aspirate_labware, pipette } = fields
+  const { aspirate_labware, pipette, nozzles } = fields
   if (!aspirate_labware || !pipette) {
     return null
   }
   //  trashBin and wasteChute cannot aspirate into a labware
   return !canPipetteUseLabware(
     pipette.spec as PipetteV2Specs,
+    nozzles,
     aspirate_labware.def as LabwareDefinition2
   )
     ? INCOMPATIBLE_ASPIRATE_LABWARE

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMix.ts
@@ -43,6 +43,7 @@ const updatePatchOnLabwareChange = (
     wells: getDefaultWells({
       labwareId: appliedPatch.labware,
       pipetteId,
+      nozzleConfiguration: patch.nozzles as NozzleConfigurationStyle,
       labwareEntities,
       pipetteEntities,
     }),
@@ -82,6 +83,7 @@ const updatePatchOnPipetteChannelChange = (
       wells: getDefaultWells({
         labwareId: appliedPatch.labware,
         pipetteId,
+        nozzleConfiguration: patch.nozzles as NozzleConfigurationStyle,
         labwareEntities,
         pipetteEntities,
       }),

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -163,6 +163,7 @@ const updatePatchOnLabwareChange = (
           pipetteId,
           labwareEntities,
           pipetteEntities,
+          nozzleConfiguration: ALL,
         }),
       }
     : {}
@@ -179,6 +180,7 @@ const updatePatchOnLabwareChange = (
           pipetteId,
           labwareEntities,
           pipetteEntities,
+          nozzleConfiguration: ALL,
         }),
       }
     : {}
@@ -540,6 +542,7 @@ const updatePatchOnPipetteChannelChange = (
                 pipetteId,
                 labwareEntities,
                 pipetteEntities,
+                nozzleConfiguration: ALL,
               })
             : getAllWellsFromPrimaryWells(
                 appliedPatch.dispense_wells as string[],

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -40,6 +40,7 @@ import type {
   LabwareDefinition2,
   LiquidHandlingPropertyByVolume,
   MixProperties,
+  NozzleConfigurationStyle,
   PipetteChannels,
   PositionReference,
   RetractAspirate,
@@ -242,9 +243,16 @@ interface GetDefaultWellsArgs {
   pipetteId: string | null | undefined
   labwareEntities: LabwareEntities
   pipetteEntities: PipetteEntities
+  nozzleConfiguration: NozzleConfigurationStyle
 }
 export function getDefaultWells(args: GetDefaultWellsArgs): string[] {
-  const { labwareId, pipetteId, labwareEntities, pipetteEntities } = args
+  const {
+    labwareId,
+    pipetteId,
+    labwareEntities,
+    pipetteEntities,
+    nozzleConfiguration,
+  } = args
   if (
     !labwareId ||
     !labwareEntities[labwareId] ||
@@ -255,6 +263,7 @@ export function getDefaultWells(args: GetDefaultWellsArgs): string[] {
   const labwareDef = labwareEntities[labwareId].def
   const pipetteCanUseLabware = canPipetteUseLabware(
     pipetteEntities[pipetteId].spec,
+    nozzleConfiguration,
     labwareDef
   )
   if (!pipetteCanUseLabware) return []

--- a/shared-data/js/helpers/__tests__/wellSets.test.ts
+++ b/shared-data/js/helpers/__tests__/wellSets.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { get96Channel384WellPlateWells, orderWells } from '..'
+import { ALL, SINGLE } from '../../../command/types'
 import fixture_12_trough from '../../../labware/fixtures/2/fixture_12_trough.json'
 import fixture_96_plate from '../../../labware/fixtures/2/fixture_96_plate.json'
 import fixture_384_plate from '../../../labware/fixtures/2/fixture_384_plate.json'
@@ -204,16 +205,23 @@ describe('canPipetteUseLabware', () => {
     const labwareDef = fixtureOverlappyWellplate
     const pipette = fixtureP10MultiV2Specs
     const pipette96 = fixtureP100096V2Specs
+    const nozzles = ALL
 
-    expect(canPipetteUseLabware(pipette, labwareDef)).toBe(false)
-    expect(canPipetteUseLabware(pipette96, labwareDef)).toBe(false)
+    expect(canPipetteUseLabware(pipette, nozzles, labwareDef)).toBe(false)
+    expect(canPipetteUseLabware(pipette96, nozzles, labwareDef)).toBe(false)
   })
 
   it('returns true when pipette is single channel', () => {
     const labwareDef = fixtureOverlappyWellplate
     const pipette = fixtureP10SingleV2Specs
-
-    expect(canPipetteUseLabware(pipette, labwareDef)).toBe(true)
+    const nozzles = ALL
+    expect(canPipetteUseLabware(pipette, nozzles, labwareDef)).toBe(true)
+  })
+  it('returns true when a multi pipette is using single channel', () => {
+    const labwareDef = fixtureOverlappyWellplate
+    const pipette = fixtureP10MultiV2Specs
+    const nozzles = SINGLE
+    expect(canPipetteUseLabware(pipette, nozzles, labwareDef)).toBe(true)
   })
 })
 

--- a/shared-data/js/helpers/wellSets.ts
+++ b/shared-data/js/helpers/wellSets.ts
@@ -14,8 +14,10 @@
 import uniq from 'lodash/uniq'
 
 import { get96Channel384WellPlateWells, getLabwareDefURI, orderWells } from '.'
+import { SINGLE } from '../../command/types'
 import { getWellNamePerMultiTip } from './getWellNamePerMultiTip'
 
+import type { NozzleConfigurationStyle } from '../../command/types'
 import type {
   ActiveNozzleNumber,
   LabwareDefinition,
@@ -79,6 +81,7 @@ export interface WellSetHelpers {
 
   canPipetteUseLabware: (
     pipetteSpec: PipetteV2Specs,
+    nozzleConfiguration: NozzleConfigurationStyle,
     labwareDef?: LabwareDefinition,
     trashName?: string
   ) => boolean
@@ -227,10 +230,13 @@ export const makeWellSetHelpers = (): WellSetHelpers => {
 
   const canPipetteUseLabware = (
     pipetteSpec: PipetteV2Specs,
+    nozzleConfiguration: NozzleConfigurationStyle,
     labwareDef?: LabwareDefinition,
     trashName?: string
   ): boolean => {
-    if (pipetteSpec.channels === 1 || trashName != null) {
+    const has1ActiveNozzle =
+      pipetteSpec.channels === 1 || nozzleConfiguration === SINGLE
+    if (has1ActiveNozzle || trashName != null) {
       // assume all labware can be used by single-channel
       return true
     }


### PR DESCRIPTION
# Overview

Compatibility between labware and pipettes is done by using the number of pipette channels. In PD, an error occurs if you use single nozzle configuration with tube racks because it is using the pipettes number of channels to determine compatibility. This PR updates logic to use the `nozzleConfiguration`.

## Test Plan and Hands on Testing

Smoke tested with protocol attached in ticket and you are able to transfer and mix liquids in all tube racks in the protocol. Simulated protocol and it works!
[Partial_tip_pickup_test (1).py](https://github.com/user-attachments/files/25803550/Partial_tip_pickup_test.1.py)

https://github.com/user-attachments/assets/748e6138-e82c-4550-9c64-205569ac587b

## Changelog

- included nozzleConfiguration determination of if labware is compatible with pipette

## Review requests

- In quick transfer flow, I defaulted to assuming the nozzleConfiguration was `ALL` - is this correct?
- I also defaulted pd patches to assume nozzleConfiguration was also `ALL` - is this correct?

## Risk assessment

- medium - affects quick transfer 

Closes AUTH-2771