### PR TITLE
fix(protocol-designer): consolidate stacks based on shared labware ids

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -65,6 +65,7 @@ import {
 import { getIsAdapterFromDef } from '/protocol-designer/utils'
 
 import { AddStepOverflowButton } from './AddStepOverflowButton'
+import { getConsolidatedStacks } from './utils'
 
 import type { ThunkDispatch } from 'redux-thunk'
 import type { MouseEvent } from 'react'
@@ -112,9 +113,9 @@ export function AddStepButton({
     timeline.length > 0 ? last(timeline)?.robotState : initialTimeline
   const labwareAtLastState = lastTimelineFrame?.labware ?? {}
   const moduleAtLastState = lastTimelineFrame?.modules ?? {}
-  const isLabwarePresentForLiquidHandling = Object.entries(
-    labwareAtLastState
-  ).some(([labwareId, { stack }]) => {
+  const consolidatedStacks = getConsolidatedStacks(labwareAtLastState)
+  const isLabwarePresentForLiquidHandling = consolidatedStacks.some(stack => {
+    const labwareId = stack[0]
     const labwareDef = labwareEntities[labwareId]?.def
     const slot = getSlotInLocationStack(stack)
     const isInaccessible = slot === SYSTEM_LOCATION

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/utils.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/utils.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   capitalizeFirstLetterAfterNumber,
+  getConsolidatedStacks,
   getFillLabwareToDeleteData,
   getShiftSelectedSteps,
 } from '../utils'
@@ -98,7 +99,19 @@ describe('getShiftSelectedSteps', () => {
     ])
   })
 })
-
+describe('getConsolidatedStacks', () => {
+  it('should return an array of stacks with no duplicates', () => {
+    const labwareAtLastState = {
+      labware1: { stack: ['lid', 'labware1', 'slotC1'] },
+      labware2: { stack: ['labware1', 'slotC1'] },
+      labware3: { stack: ['labware3'] },
+    }
+    expect(getConsolidatedStacks(labwareAtLastState)).toStrictEqual([
+      ['lid', 'labware1', 'slotC1'],
+      ['labware3'],
+    ])
+  })
+})
 describe('getFillLabwareToDeleteData', () => {
   const mockModule = {
     id: 'moduleId1',

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/utils.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/utils.test.tsx
@@ -102,13 +102,12 @@ describe('getShiftSelectedSteps', () => {
 describe('getConsolidatedStacks', () => {
   it('should return an array of stacks with no duplicates', () => {
     const labwareAtLastState = {
-      labware1: { stack: ['lid', 'labware1', 'slotC1'] },
-      labware2: { stack: ['labware1', 'slotC1'] },
-      labware3: { stack: ['labware3'] },
+      labware1: { stack: ['labware1', 'C1'] },
+      labware2: { stack: ['labware2', 'labware1', 'C1'] },
+      labware3: { stack: ['labware3', 'labware2', 'labware1', 'C1'] },
     }
     expect(getConsolidatedStacks(labwareAtLastState)).toStrictEqual([
-      ['lid', 'labware1', 'slotC1'],
-      ['labware3'],
+      ['labware3', 'labware2', 'labware1', 'C1'],
     ])
   })
 })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/utils.ts
@@ -181,14 +181,21 @@ export const getConsolidatedStacks = (
   labwareAtLastState: Record<string, LabwareTemporalProperties>
 ): string[][] => {
   const stacks = Object.values(labwareAtLastState).map(labware => labware.stack)
+  // Only returns stacks that are not subsets of other stacks
   return stacks.filter(
     stack =>
       !stacks.some(
-        other =>
-          other !== stack &&
-          other.length > stack.length &&
+        previousStack =>
+          // Skip comparing the stack to itself
+          previousStack !== stack &&
+          // Only consider stacks that are longer than the current stack
+          previousStack.length > stack.length &&
+          // Check if the current stack exists at the end of the longer stack
+          // We align the end of both stacks and compare element-by-element
           stack.every(
-            (item, i) => other[i + (other.length - stack.length)] === item
+            (labware, index) =>
+              previousStack[index + (previousStack.length - stack.length)] ===
+              labware
           )
       )
   )

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/utils.ts
@@ -6,6 +6,7 @@ import { getStepVisibilities } from '/protocol-designer/steplist/utils/getStepVi
 import { convertStepHierarchyToArray } from '/protocol-designer/steplist/utils/stepHierarchy'
 
 import type { MouseEvent } from 'react'
+import type { LabwareTemporalProperties } from '@opentrons/step-generation'
 import type { StepIdType } from '/protocol-designer/form-types'
 import type {
   ModuleOnDeck,
@@ -174,4 +175,21 @@ export const getFillLabwareToDeleteData = (
       ? [...acc, { labwareIds: formData.fillLabwareIds as string[], module }]
       : acc
   }, [])
+}
+
+export const getConsolidatedStacks = (
+  labwareAtLastState: Record<string, LabwareTemporalProperties>
+): string[][] => {
+  const stacks = Object.values(labwareAtLastState).map(labware => labware.stack)
+  return stacks.filter(
+    stack =>
+      !stacks.some(
+        other =>
+          other !== stack &&
+          other.length > stack.length &&
+          stack.every(
+            (item, i) => other[i + (other.length - stack.length)] === item
+          )
+      )
+  )
 }


### PR DESCRIPTION
# Overview

Consolidate labware lists when checking for lids. There were two separate entries for the labware + slot and the same labware + lid. This is fixed by combining lists with shared labware ids. 

This addresses a bug where `Transfer` and `Mix` steps were allowed to be added even when labware had a lid on it. 

## Test Plan and Hands on Testing

- smoke tested adding a labware with a lid and checking steps and adding a labware without a lid and checking available steps.

https://github.com/user-attachments/assets/b68a0fa9-9f3d-4f4f-b6cf-099e27c32248

## Changelog

- added `getConsolidatedStacks` and test to merge stack lists with the same labware id
- adjusted logic in `AddStepButton to filter through new nested list

## Review requests

- Is consolidating here okay? Not sure if lids are added as separate stacks for other reasons so I band aided it here.

## Risk assessment

- low 

Closes AUTH-2772