### PR TITLE
test(hardware-testing): Update apiLevel in gravimetric QC protocol

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
@@ -36,7 +36,7 @@ from opentrons.protocol_api._nozzle_layout import NozzleLayout
 from opentrons.protocols.advanced_control.transfers import common as tx_ctl_lib
 
 metadata = {"protocolName": "Gravimetric QC"}
-requirements = {"robotType": "Flex", "apiLevel": "2.27"}
+requirements = {"robotType": "Flex", "apiLevel": "2.28"}
 
 SCALE_SECONDS_TO_TRUE_STABILIZE = 60 * 3
 


### PR DESCRIPTION
## Overview

In #20978, I updated the maximum supported `apiLevel` but forgot to update the `apiLevel` in the gravimetric QC protocol. This caused a test to fail in `chore_release-8.9.0`. For some reason, that test didn't run on #20978 but it is running on #20998...? I don't know.

Anyway, the fix is just to update the `apiLevel` in the protocol.

## Test Plan and Hands on Testing

* [x] Make sure that workflow runs and passes on this PR.

## Review requests

None.

## Risk assessment

Low.