### PR TITLE
feat(app-shell): migrate flex protocols to `protocols-10.0-plus`

### DIFF
--- a/app-shell/src/protocol-storage/__tests__/file-system.test.ts
+++ b/app-shell/src/protocol-storage/__tests__/file-system.test.ts
@@ -10,6 +10,8 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { analyzeProtocolSource } from '../../protocol-analysis'
 import {
   addProtocolFile,
+  FLEX_PROTOCOLS_DIRECTORY_NAME,
+  isFlexProtocol,
   parseProtocolDirs,
   PROTOCOLS_DIRECTORY_NAME,
   PROTOCOLS_DIRECTORY_PATH,
@@ -52,6 +54,43 @@ describe('protocol storage directory utilities', () => {
       return expect(PROTOCOLS_DIRECTORY_PATH).toEqual(
         path.join('__mock-app-path__', PROTOCOLS_DIRECTORY_NAME)
       )
+    })
+
+    it('uses flex-protocols as FLEX_PROTOCOLS_DIRECTORY_NAME', () => {
+      expect(FLEX_PROTOCOLS_DIRECTORY_NAME).toBe('flex-protocols')
+    })
+  })
+
+  describe('isFlexProtocol', () => {
+    it('returns true when analysis has robotType OT-3 Standard', async () => {
+      const protocolDir = makeEmptyDir()
+      await fs.mkdir(path.join(protocolDir, 'src'))
+      await fs.mkdir(path.join(protocolDir, 'analysis'))
+      await fs.writeFile(path.join(protocolDir, 'src', 'main.py'), '')
+      await fs.writeJson(
+        path.join(protocolDir, 'analysis', '1234567890.json'),
+        { robotType: 'OT-3 Standard' }
+      )
+      expect(await isFlexProtocol(protocolDir)).toBe(true)
+    })
+
+    it('returns false when analysis has robotType OT-2 Standard', async () => {
+      const protocolDir = makeEmptyDir()
+      await fs.mkdir(path.join(protocolDir, 'src'))
+      await fs.mkdir(path.join(protocolDir, 'analysis'))
+      await fs.writeFile(path.join(protocolDir, 'src', 'main.py'), '')
+      await fs.writeJson(
+        path.join(protocolDir, 'analysis', '1234567890.json'),
+        { robotType: 'OT-2 Standard' }
+      )
+      expect(await isFlexProtocol(protocolDir)).toBe(false)
+    })
+
+    it('returns false when analysis directory is missing', async () => {
+      const protocolDir = makeEmptyDir()
+      await fs.mkdir(path.join(protocolDir, 'src'))
+      await fs.writeFile(path.join(protocolDir, 'src', 'main.py'), '')
+      expect(await isFlexProtocol(protocolDir)).toBe(false)
     })
   })
 

--- a/app-shell/src/protocol-storage/__tests__/file-system.test.ts
+++ b/app-shell/src/protocol-storage/__tests__/file-system.test.ts
@@ -4,25 +4,24 @@ import path from 'path'
 import Electron from 'electron'
 import fs from 'fs-extra'
 import tempy from 'tempy'
-import { v4 as uuidv4 } from 'uuid'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { analyzeProtocolSource } from '../../protocol-analysis'
 import {
   addProtocolFile,
-  FLEX_PROTOCOLS_DIRECTORY_NAME,
-  isFlexProtocol,
+  NOT_OT2_PROTOCOLS_DIRECTORY_NAME,
   parseProtocolDirs,
   PROTOCOLS_DIRECTORY_NAME,
   PROTOCOLS_DIRECTORY_PATH,
   readDirectoriesWithinDirectory,
   readFilesWithinDirectory,
   removeProtocolByKey,
+  shouldMigrateToNotOt2Directory,
 } from '../file-system'
 
-// vi.mock('uuid')
-vi.mock('uuid', () => ({
-  v4: vi.fn(),
+vi.mock('uuid/v4', () => ({
+  __esModule: true,
+  default: vi.fn(),
 }))
 vi.mock('electron')
 vi.mock('electron-store')
@@ -56,12 +55,12 @@ describe('protocol storage directory utilities', () => {
       )
     })
 
-    it('uses flex-protocols as FLEX_PROTOCOLS_DIRECTORY_NAME', () => {
-      expect(FLEX_PROTOCOLS_DIRECTORY_NAME).toBe('flex-protocols')
+    it('uses protocols-10.0-plus as NOT_OT2_PROTOCOLS_DIRECTORY_NAME', () => {
+      expect(NOT_OT2_PROTOCOLS_DIRECTORY_NAME).toBe('protocols-10.0-plus')
     })
   })
 
-  describe('isFlexProtocol', () => {
+  describe('shouldMigrateToNotOt2Directory', () => {
     it('returns true when analysis has robotType OT-3 Standard', async () => {
       const protocolDir = makeEmptyDir()
       await fs.mkdir(path.join(protocolDir, 'src'))
@@ -71,7 +70,7 @@ describe('protocol storage directory utilities', () => {
         path.join(protocolDir, 'analysis', '1234567890.json'),
         { robotType: 'OT-3 Standard' }
       )
-      expect(await isFlexProtocol(protocolDir)).toBe(true)
+      expect(await shouldMigrateToNotOt2Directory(protocolDir)).toBe(true)
     })
 
     it('returns false when analysis has robotType OT-2 Standard', async () => {
@@ -83,14 +82,26 @@ describe('protocol storage directory utilities', () => {
         path.join(protocolDir, 'analysis', '1234567890.json'),
         { robotType: 'OT-2 Standard' }
       )
-      expect(await isFlexProtocol(protocolDir)).toBe(false)
+      expect(await shouldMigrateToNotOt2Directory(protocolDir)).toBe(false)
     })
 
-    it('returns false when analysis directory is missing', async () => {
+    it('returns true when analysis directory is missing (migrate by default)', async () => {
       const protocolDir = makeEmptyDir()
       await fs.mkdir(path.join(protocolDir, 'src'))
       await fs.writeFile(path.join(protocolDir, 'src', 'main.py'), '')
-      expect(await isFlexProtocol(protocolDir)).toBe(false)
+      expect(await shouldMigrateToNotOt2Directory(protocolDir)).toBe(true)
+    })
+
+    it('returns true when analysis has no robotType (migrate by default)', async () => {
+      const protocolDir = makeEmptyDir()
+      await fs.mkdir(path.join(protocolDir, 'src'))
+      await fs.mkdir(path.join(protocolDir, 'analysis'))
+      await fs.writeFile(path.join(protocolDir, 'src', 'main.py'), '')
+      await fs.writeJson(
+        path.join(protocolDir, 'analysis', '1234567890.json'),
+        { metadata: {} }
+      )
+      expect(await shouldMigrateToNotOt2Directory(protocolDir)).toBe(true)
     })
   })
 
@@ -216,35 +227,28 @@ describe('protocol storage directory utilities', () => {
   })
 
   describe('addProtocolFile', () => {
-    it('writes a protocol file to a new directory', () => {
-      let count = 0
-      vi.mocked(uuidv4).mockImplementation(() => {
-        const nextId = `${count}abc123`
-        count = count + 1
-        return nextId
-      })
+    it('writes a protocol file to a new directory', async () => {
+      const { default: uuid } = await import('uuid/v4')
+      vi.mocked(uuid).mockReturnValue('0abc123')
       const sourceDir = makeEmptyDir()
       const destDir = makeEmptyDir()
       const sourceName = path.join(sourceDir, 'source.py')
       const expectedProtocolDirPath = path.join(destDir, '0abc123')
 
-      return fs
-        .writeFile(sourceName, 'file contents')
-        .then(() => addProtocolFile(sourceName, destDir))
-        .then(() => readDirectoriesWithinDirectory(destDir))
-        .then(dirPaths => parseProtocolDirs(dirPaths))
-        .then(dirs => {
-          expect(dirs).toEqual([
-            {
-              dirPath: expectedProtocolDirPath,
-              srcFilePaths: [
-                path.join(expectedProtocolDirPath, 'src', 'source.py'),
-              ],
-              analysisFilePaths: [],
-              modified: expect.any(Number),
-            },
-          ])
-        })
+      await fs.writeFile(sourceName, 'file contents')
+      await addProtocolFile(sourceName, destDir)
+      const dirPaths = await readDirectoriesWithinDirectory(destDir)
+      const dirs = await parseProtocolDirs(dirPaths)
+      expect(dirs).toEqual([
+        {
+          dirPath: expectedProtocolDirPath,
+          srcFilePaths: [
+            path.join(expectedProtocolDirPath, 'src', 'source.py'),
+          ],
+          analysisFilePaths: [],
+          modified: expect.any(Number),
+        },
+      ])
     })
   })
 

--- a/app-shell/src/protocol-storage/__tests__/protocol-storage.test.ts
+++ b/app-shell/src/protocol-storage/__tests__/protocol-storage.test.ts
@@ -14,6 +14,15 @@ import { PROTOCOLS_DIRECTORY_NAME } from '../file-system'
 
 vi.mock('electron-store')
 vi.mock('../../log')
+vi.mock('../../config', () => ({
+  getConfig: vi.fn((path?: string) => {
+    if (path === 'devInternal') {
+      return {}
+    } else {
+      return undefined
+    }
+  }),
+}))
 
 describe('protocol storage directory utilities', () => {
   let protocolsDir: string

--- a/app-shell/src/protocol-storage/file-system.ts
+++ b/app-shell/src/protocol-storage/file-system.ts
@@ -1,9 +1,9 @@
 import path from 'path'
 import { app, shell } from 'electron'
 import fs from 'fs-extra'
-import { v4 as uuidv4 } from 'uuid'
+import uuid from 'uuid/v4'
 
-import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { analyzeProtocolSource } from '../protocol-analysis'
 
@@ -35,15 +35,19 @@ export const PROTOCOLS_DIRECTORY_PATH = path.join(
   app.getPath('userData'),
   PROTOCOLS_DIRECTORY_NAME
 )
-export const FLEX_PROTOCOLS_DIRECTORY_NAME = 'flex-protocols'
-export const FLEX_PROTOCOLS_DIRECTORY_PATH = path.join(
+
+export const NOT_OT2_PROTOCOLS_DIRECTORY_NAME = 'protocols-10.0-plus'
+export const NOT_OT2_PROTOCOLS_DIRECTORY_PATH = path.join(
   app.getPath('userData'),
-  FLEX_PROTOCOLS_DIRECTORY_NAME
+  NOT_OT2_PROTOCOLS_DIRECTORY_NAME
 )
 export const PROTOCOL_SRC_DIRECTORY_NAME = 'src'
 export const PROTOCOL_ANALYSIS_DIRECTORY_NAME = 'analysis'
 
-export async function isFlexProtocol(
+// Returns true if the protocol should be migrated to the not-OT-2 directory.
+// Migrate by default; exclude only when analysis explicitly says OT-2 Standard.
+// Covers protocols with no analysis, failed analysis, etc.
+export async function shouldMigrateToNotOt2Directory(
   protocolDirPath: string
 ): Promise<boolean> {
   try {
@@ -53,7 +57,7 @@ export async function isFlexProtocol(
     )
     const stat = await fs.stat(analysisDirPath)
     if (!stat.isDirectory()) {
-      return false
+      return true
     }
 
     const analysisFiles = await readFilesWithinDirectory(analysisDirPath)
@@ -61,7 +65,7 @@ export async function isFlexProtocol(
       p => path.extname(p).toLowerCase() === '.json'
     )
     if (jsonFiles.length === 0) {
-      return false
+      return true
     }
 
     const withTimestamps = jsonFiles
@@ -71,13 +75,14 @@ export async function isFlexProtocol(
     const mostRecentPath = withTimestamps[0]?.path
 
     if (mostRecentPath == null) {
-      return false
+      return true
     }
 
     const analysis = await fs.readJson(mostRecentPath)
-    return analysis?.robotType === FLEX_ROBOT_TYPE
+
+    return analysis?.robotType !== OT2_ROBOT_TYPE
   } catch {
-    return false
+    return true
   }
 }
 
@@ -97,18 +102,12 @@ export function readDirectoriesWithinDirectory(dir: string): Promise<string[]> {
   })
 }
 
-const VALID_PROTOCOL_FILE_EXTENSIONS = ['.py', '.json']
 export function readFilesWithinDirectory(dir: string): Promise<string[]> {
   const getAbsolutePath = (e: Dirent): string => path.join(dir, e.name)
 
-  const isValidProtocolFile = (e: Dirent): boolean => {
-    const extension = path.extname(e.name).toLowerCase()
-    return e.isFile() && VALID_PROTOCOL_FILE_EXTENSIONS.includes(extension)
-  }
-
   return fs.readdir(dir, { withFileTypes: true }).then((entries: Dirent[]) => {
     const protocolDirPaths = entries
-      .filter(isValidProtocolFile)
+      .filter(e => e.isFile())
       .map(getAbsolutePath)
 
     return protocolDirPaths
@@ -159,7 +158,7 @@ export function addProtocolFile(
   mainFileSourcePath: string,
   protocolsDirPath: string
 ): Promise<string> {
-  const protocolKey = uuidv4()
+  const protocolKey = uuid()
   const protocolDirPath = path.join(protocolsDirPath, protocolKey as string)
 
   const srcDirPath = path.join(protocolDirPath, PROTOCOL_SRC_DIRECTORY_NAME)
@@ -210,14 +209,7 @@ export function analyzeProtocolByKey(
     PROTOCOL_ANALYSIS_DIRECTORY_NAME
   )
   const destFilePath = makeAnalysisFilePath(analysisDirPath)
-  return readFilesWithinDirectory(srcDirPath).then(dirsContainingProtocol => {
-    if (dirsContainingProtocol.length === 0) {
-      throw new Error(
-        `No valid protocol files (.py, .json) found in directory: ${srcDirPath}`
-      )
-    }
-    return analyzeProtocolSource(dirsContainingProtocol[0], destFilePath)
-  })
+  return analyzeProtocolSource(srcDirPath, destFilePath)
 }
 
 export function viewProtocolSourceFolder(

--- a/app-shell/src/protocol-storage/file-system.ts
+++ b/app-shell/src/protocol-storage/file-system.ts
@@ -3,6 +3,8 @@ import { app, shell } from 'electron'
 import fs from 'fs-extra'
 import { v4 as uuidv4 } from 'uuid'
 
+import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+
 import { analyzeProtocolSource } from '../protocol-analysis'
 
 import type { Dirent } from 'fs'
@@ -33,8 +35,51 @@ export const PROTOCOLS_DIRECTORY_PATH = path.join(
   app.getPath('userData'),
   PROTOCOLS_DIRECTORY_NAME
 )
+export const FLEX_PROTOCOLS_DIRECTORY_NAME = 'flex-protocols'
+export const FLEX_PROTOCOLS_DIRECTORY_PATH = path.join(
+  app.getPath('userData'),
+  FLEX_PROTOCOLS_DIRECTORY_NAME
+)
 export const PROTOCOL_SRC_DIRECTORY_NAME = 'src'
 export const PROTOCOL_ANALYSIS_DIRECTORY_NAME = 'analysis'
+
+export async function isFlexProtocol(
+  protocolDirPath: string
+): Promise<boolean> {
+  try {
+    const analysisDirPath = path.join(
+      protocolDirPath,
+      PROTOCOL_ANALYSIS_DIRECTORY_NAME
+    )
+    const stat = await fs.stat(analysisDirPath)
+    if (!stat.isDirectory()) {
+      return false
+    }
+
+    const analysisFiles = await readFilesWithinDirectory(analysisDirPath)
+    const jsonFiles = analysisFiles.filter(
+      p => path.extname(p).toLowerCase() === '.json'
+    )
+    if (jsonFiles.length === 0) {
+      return false
+    }
+
+    const withTimestamps = jsonFiles
+      .map(p => ({ path: p, ts: Number(path.basename(p, path.extname(p))) }))
+      .filter(({ ts }) => Number.isFinite(ts))
+      .sort((a, b) => b.ts - a.ts)
+    const mostRecentPath = withTimestamps[0]?.path
+
+    if (mostRecentPath == null) {
+      return false
+    }
+
+    const analysis = await fs.readJson(mostRecentPath)
+    return analysis?.robotType === FLEX_ROBOT_TYPE
+  } catch {
+    return false
+  }
+}
 
 function makeAnalysisFilePath(analysisDirPath: string): string {
   return path.join(analysisDirPath, `${new Date().getTime()}.json`)

--- a/app-shell/src/protocol-storage/index.ts
+++ b/app-shell/src/protocol-storage/index.ts
@@ -2,6 +2,7 @@ import path from 'path'
 import { shell } from 'electron'
 import fse from 'fs-extra'
 
+import { getConfig } from '../config'
 import {
   analyzeProtocol,
   analyzeProtocolFailure,
@@ -29,6 +30,25 @@ import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 import type { Action, Dispatch } from '../types'
 
 const ensureDir: (dir: string) => Promise<void> = fse.ensureDir
+
+function getIgnoreOT2App(): boolean {
+  const devInternal = getConfig('devInternal') ?? {}
+  return devInternal.ignoreOT2App ?? false
+}
+
+let protocolsDirectoryPath: string | null = null
+
+// Returns the protocols directory path. Set once at initialization based on
+// `ignoreOT2App` feature flag. Does not change during app lifecycle.
+function getProtocolsDirectoryPath(): string {
+  if (protocolsDirectoryPath == null) {
+    protocolsDirectoryPath = getIgnoreOT2App()
+      ? FileSystem.FLEX_PROTOCOLS_DIRECTORY_PATH
+      : FileSystem.PROTOCOLS_DIRECTORY_PATH
+  }
+
+  return protocolsDirectoryPath
+}
 
 export const getUnixTimeFromAnalysisPath = (analysisPath: string): number =>
   Number(path.basename(analysisPath, path.extname(analysisPath)))
@@ -110,55 +130,111 @@ export function preParityMigrateProtocolsFrom(
   }
 }
 
+// If ignoreOT2App is enabled and flex-protocols does not exist,
+// copy only Flex protocols from protocols to flex-protocols.
+async function migrateFlexProtocolsToFlexDirectory(): Promise<void> {
+  if (!getIgnoreOT2App()) {
+    return
+  }
+
+  try {
+    const destStat = await fse.stat(FileSystem.FLEX_PROTOCOLS_DIRECTORY_PATH)
+    if (destStat.isDirectory()) {
+      return
+    }
+  } catch {
+    // flex-protocols doesn't exist, proceed with migration
+  }
+
+  try {
+    await ensureDir(FileSystem.FLEX_PROTOCOLS_DIRECTORY_PATH)
+    const protocolDirPaths = await FileSystem.readDirectoriesWithinDirectory(
+      FileSystem.PROTOCOLS_DIRECTORY_PATH
+    )
+
+    for (const dirPath of protocolDirPaths) {
+      const isFlex = await FileSystem.isFlexProtocol(dirPath)
+      if (isFlex) {
+        const protocolKey = path.parse(dirPath).base
+        const destPath = path.join(
+          FileSystem.FLEX_PROTOCOLS_DIRECTORY_PATH,
+          protocolKey
+        )
+        await fse.copy(dirPath, destPath, { overwrite: false })
+      }
+    }
+    console.log(
+      `Flex protocol migration to ${FileSystem.FLEX_PROTOCOLS_DIRECTORY_NAME} complete.`
+    )
+  } catch (e) {
+    console.log(
+      `Error migrating Flex protocols to ${FileSystem.FLEX_PROTOCOLS_DIRECTORY_NAME}: ${e}`
+    )
+  }
+}
+
+function storedProtocolDirToProtocolData(storedProtocolDir: {
+  dirPath: string
+  modified: number
+  srcFilePaths: string[]
+  analysisFilePaths: string[]
+}): {
+  protocolKey: string
+  modified: number
+  srcFileNames: string[]
+  srcFiles: Buffer[]
+  mostRecentAnalysis: ProtocolAnalysisOutput | null
+} {
+  const mostRecentAnalysisFilePath = storedProtocolDir.analysisFilePaths.reduce<
+    string | null
+  >((acc, analysisFilePath) => {
+    if (acc !== null) {
+      if (
+        getUnixTimeFromAnalysisPath(analysisFilePath) >
+        getUnixTimeFromAnalysisPath(acc)
+      ) {
+        return analysisFilePath
+      }
+      return acc
+    }
+    return analysisFilePath
+  }, null)
+  const mostRecentAnalysis =
+    mostRecentAnalysisFilePath != null
+      ? (getParsedAnalysisFromPath(mostRecentAnalysisFilePath) ?? null)
+      : null
+
+  return {
+    protocolKey: path.parse(storedProtocolDir.dirPath).base,
+    modified: storedProtocolDir.modified,
+    srcFileNames: storedProtocolDir.srcFilePaths.map(
+      filePath => path.parse(filePath).base
+    ),
+    srcFiles: storedProtocolDir.srcFilePaths.map(srcFilePath => {
+      const buffer = fse.readFileSync(srcFilePath)
+      return Buffer.from(buffer, buffer.byteOffset, buffer.byteLength)
+    }),
+    mostRecentAnalysis,
+  }
+}
+
 export const fetchProtocols = (
   dispatch: Dispatch,
   source: ListSource
 ): Promise<void> => {
   return ensureDir(FileSystem.PROTOCOLS_DIRECTORY_PATH)
     .then(() => migrateProtocolsFromTempDirectory())
-    .then(() =>
-      FileSystem.readDirectoriesWithinDirectory(
-        FileSystem.PROTOCOLS_DIRECTORY_PATH
-      )
-    )
+    .then(() => migrateFlexProtocolsToFlexDirectory())
+    .then(() => {
+      const protocolsDir = getProtocolsDirectoryPath()
+      return FileSystem.readDirectoriesWithinDirectory(protocolsDir)
+    })
     .then(FileSystem.parseProtocolDirs)
     .then(storedProtocols => {
-      const storedProtocolsData = storedProtocols.map(storedProtocolDir => {
-        const mostRecentAnalysisFilePath =
-          storedProtocolDir.analysisFilePaths.reduce<string | null>(
-            (acc, analysisFilePath) => {
-              if (acc !== null) {
-                if (
-                  getUnixTimeFromAnalysisPath(analysisFilePath) >
-                  getUnixTimeFromAnalysisPath(acc)
-                ) {
-                  return analysisFilePath
-                }
-                return acc
-              }
-              return analysisFilePath
-            },
-            null
-          )
-        const mostRecentAnalysis =
-          mostRecentAnalysisFilePath != null
-            ? (getParsedAnalysisFromPath(mostRecentAnalysisFilePath) ?? null)
-            : null
-
-        return {
-          protocolKey: path.parse(storedProtocolDir.dirPath).base,
-          modified: storedProtocolDir.modified,
-          srcFileNames: storedProtocolDir.srcFilePaths.map(
-            filePath => path.parse(filePath).base
-          ),
-          srcFiles: storedProtocolDir.srcFilePaths.map(srcFilePath => {
-            const buffer = fse.readFileSync(srcFilePath)
-            return Buffer.from(buffer, buffer.byteOffset, buffer.byteLength)
-          }),
-          mostRecentAnalysis,
-        }
-      })
-      dispatch(updateProtocolList(storedProtocolsData, source))
+      const protocolDataList = storedProtocols.map(
+        storedProtocolDirToProtocolData
+      )
+      dispatch(updateProtocolList(protocolDataList, source))
     })
     .catch((error: Error) => {
       dispatch(updateProtocolListFailure(error.message, source))
@@ -171,25 +247,27 @@ export function registerProtocolStorage(dispatch: Dispatch): Dispatch {
       case FETCH_PROTOCOLS:
       case UI_INITIALIZED: {
         const source = action.type === FETCH_PROTOCOLS ? POLL : INITIAL
-        fetchProtocols(dispatch, source)
+        void fetchProtocols(dispatch, source)
         break
       }
 
       case ADD_PROTOCOL: {
-        FileSystem.addProtocolFile(
+        const protocolsDir = getProtocolsDirectoryPath()
+        void FileSystem.addProtocolFile(
           action.payload.protocolFilePath,
-          FileSystem.PROTOCOLS_DIRECTORY_PATH
+          protocolsDir
         ).then(protocolKey => {
-          fetchProtocols(dispatch, PROTOCOL_ADDITION)
+          void fetchProtocols(dispatch, PROTOCOL_ADDITION)
           dispatch(analyzeProtocol(protocolKey))
         })
         break
       }
 
       case ANALYZE_PROTOCOL: {
-        FileSystem.analyzeProtocolByKey(
+        const protocolsDir = getProtocolsDirectoryPath()
+        void FileSystem.analyzeProtocolByKey(
           action.payload.protocolKey,
-          FileSystem.PROTOCOLS_DIRECTORY_PATH
+          protocolsDir
         )
           .then(() => {
             dispatch(analyzeProtocolSuccess(action.payload.protocolKey))
@@ -202,23 +280,25 @@ export function registerProtocolStorage(dispatch: Dispatch): Dispatch {
       }
 
       case REMOVE_PROTOCOL: {
-        FileSystem.removeProtocolByKey(
+        const protocolsDir = getProtocolsDirectoryPath()
+        void FileSystem.removeProtocolByKey(
           action.payload.protocolKey,
-          FileSystem.PROTOCOLS_DIRECTORY_PATH
+          protocolsDir
         ).then(() => fetchProtocols(dispatch, PROTOCOL_ADDITION))
         break
       }
 
       case VIEW_PROTOCOL_SOURCE_FOLDER: {
+        const protocolsDir = getProtocolsDirectoryPath()
         FileSystem.viewProtocolSourceFolder(
           action.payload.protocolKey,
-          FileSystem.PROTOCOLS_DIRECTORY_PATH
+          protocolsDir
         )
         break
       }
 
       case OPEN_PROTOCOL_DIRECTORY: {
-        shell.openPath(FileSystem.PROTOCOLS_DIRECTORY_PATH)
+        void shell.openPath(getProtocolsDirectoryPath())
         break
       }
     }

--- a/app-shell/src/protocol-storage/index.ts
+++ b/app-shell/src/protocol-storage/index.ts
@@ -43,7 +43,7 @@ let protocolsDirectoryPath: string | null = null
 function getProtocolsDirectoryPath(): string {
   if (protocolsDirectoryPath == null) {
     protocolsDirectoryPath = getIgnoreOT2App()
-      ? FileSystem.FLEX_PROTOCOLS_DIRECTORY_PATH
+      ? FileSystem.NOT_OT2_PROTOCOLS_DIRECTORY_PATH
       : FileSystem.PROTOCOLS_DIRECTORY_PATH
   }
 
@@ -130,45 +130,43 @@ export function preParityMigrateProtocolsFrom(
   }
 }
 
-// If ignoreOT2App is enabled and flex-protocols does not exist,
-// copy only Flex protocols from protocols to flex-protocols.
-async function migrateFlexProtocolsToFlexDirectory(): Promise<void> {
-  if (!getIgnoreOT2App()) {
-    return
-  }
+// If ignoreOT2App is enabled and the not-OT-2 directory does not exist,
+// copy protocols from protocols to protocols-10.0-plus. Exclude only
+// protocols that explicitly are OT-2 protocols.
+async function migrateProtocolsToNotOt2Directory(): Promise<void> {
+  if (!getIgnoreOT2App()) return
 
   try {
-    const destStat = await fse.stat(FileSystem.FLEX_PROTOCOLS_DIRECTORY_PATH)
-    if (destStat.isDirectory()) {
-      return
-    }
+    const destStat = await fse.stat(FileSystem.NOT_OT2_PROTOCOLS_DIRECTORY_PATH)
+    if (destStat.isDirectory()) return
   } catch {
-    // flex-protocols doesn't exist, proceed with migration
+    // the "not-OT-2 directory" doesn't exist, proceed with migration
   }
 
   try {
-    await ensureDir(FileSystem.FLEX_PROTOCOLS_DIRECTORY_PATH)
+    await ensureDir(FileSystem.NOT_OT2_PROTOCOLS_DIRECTORY_PATH)
     const protocolDirPaths = await FileSystem.readDirectoriesWithinDirectory(
       FileSystem.PROTOCOLS_DIRECTORY_PATH
     )
 
     for (const dirPath of protocolDirPaths) {
-      const isFlex = await FileSystem.isFlexProtocol(dirPath)
-      if (isFlex) {
+      const shouldMigrate =
+        await FileSystem.shouldMigrateToNotOt2Directory(dirPath)
+      if (shouldMigrate) {
         const protocolKey = path.parse(dirPath).base
         const destPath = path.join(
-          FileSystem.FLEX_PROTOCOLS_DIRECTORY_PATH,
+          FileSystem.NOT_OT2_PROTOCOLS_DIRECTORY_PATH,
           protocolKey
         )
         await fse.copy(dirPath, destPath, { overwrite: false })
       }
     }
     console.log(
-      `Flex protocol migration to ${FileSystem.FLEX_PROTOCOLS_DIRECTORY_NAME} complete.`
+      `Protocol migration to ${FileSystem.NOT_OT2_PROTOCOLS_DIRECTORY_NAME} complete.`
     )
   } catch (e) {
     console.log(
-      `Error migrating Flex protocols to ${FileSystem.FLEX_PROTOCOLS_DIRECTORY_NAME}: ${e}`
+      `Error migrating protocols to ${FileSystem.NOT_OT2_PROTOCOLS_DIRECTORY_NAME}: ${e}`
     )
   }
 }
@@ -224,7 +222,7 @@ export const fetchProtocols = (
 ): Promise<void> => {
   return ensureDir(FileSystem.PROTOCOLS_DIRECTORY_PATH)
     .then(() => migrateProtocolsFromTempDirectory())
-    .then(() => migrateFlexProtocolsToFlexDirectory())
+    .then(() => migrateProtocolsToNotOt2Directory())
     .then(() => {
       const protocolsDir = getProtocolsDirectoryPath()
       return FileSystem.readDirectoriesWithinDirectory(protocolsDir)


### PR DESCRIPTION
Closes [EXEC-2364](https://opentrons.atlassian.net/browse/EXEC-2364)

# Overview

On desktop app launch, we copy non OT-2 protocols to a new `protocols-10.0-plus` directory if the directory does not already exist and the `ignoreOT2App` feature flag is enabled, following a similar pattern as outlined in [this PR](https://github.com/Opentrons/opentrons-ot2/pull/10). The desktop app will only display protocols present in `protocols-10.0-plus`, effectively filtering out OT-2 protocols.

NOTE: To prevent a lot of temporary and complex logic that would otherwise be required to keep protocol directories in sync, the migration logic is as follows:

- The `ignoreOT2App` FF must be enabled and the app must be fully restarted for the `protocols-10.0-plus` directory to be created and for any migrations to occur.
- Protocol directories are effectively isolated after the `protocols-10.0-plus` directory is created: no further persistence syncing occurs. Any new protocols/analyses are confined only to their respective directory reflected by the state of the feature flag at the time the protocol/analysis is created. Practically, any protocol uploaded while the FF is disabled will not be present in the list of available protocols when the FF is enabled and vice versa.

<img width="916" height="439" alt="Screenshot 2026-03-09 at 11 27 08 AM" src="https://github.com/user-attachments/assets/21fadc1e-0e7a-42d6-93f4-c84068876875" />

<img width="1021" height="768" alt="Screenshot 2026-03-09 at 11 27 20 AM" src="https://github.com/user-attachments/assets/16cf1af9-1ea4-4ff0-8d73-2fa60cdc315c" />

## Test Plan and Hands on Testing

- See images.
- Verified toggling the feature flag works as expected.

## Changelog

- Non-OT-2 protocols are copied to `protocols-10.0-plus` on startup.

## Risk assessment

- high. This PR touches core protocol functionality but hopefully does so in a relatively straightforward manner.


[EXEC-2364]: https://opentrons.atlassian.net/browse/EXEC-2364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ