### PR TITLE
docs: explain OT2 log files and how to download

### DIFF
--- a/docs/ot-2/docs/opentrons-app/log-files.md
+++ b/docs/ot-2/docs/opentrons-app/log-files.md
@@ -1,0 +1,40 @@
+---
+title: "Opentrons OT-2: Downloading Log Files"
+description: "Lists the different OT-2 log files and how to download them."
+---
+
+All OT-2 robots keep records of their movements and system processes. During normal operation, there's no need to download or examine these files. However, if a failure or malfunction occurs, Opentrons Support may request these files, as they provide detailed information that helps identify and resolve problems with the robot. This article summarizes each log file and explains how to download them using the Opentrons App.
+
+## Understanding OT-2 log files
+
+In an idle state or during a protocol run, your OT-2 writes data to several different log files. Each of these files tracks the activities specific to different parts of the robot and its attachments. The following table summarizes the data captured in each file.
+
+| Log type | Description |
+|----|----|
+| API | The `api.log` records all movement and system activities performed by the robot. |
+| Serial | The `serial.log` records communication between an OT-2 and its attached instruments and modules. |
+| Server | The `server.log` records the HTTP requests (e.g., `GET`, `POST`, `DELETE`) sent and received by the robot server. |
+| Update Server | The `update_server.log` records activity related to robot software system updates. |
+
+The records in these log files can be difficult to interpret and understand but they're valuable for troubleshooting purposes. If you ever need to download the log files, the following instructions will step you through that process.
+
+## Downloading OT-2 log files
+
+Follow these instructions to download the log files from your OT-2:
+
+<div class="instruction-list" markdown>
+
+1. From the Opentrons App, click **Devices** and locate the robot that you want the logs from.
+
+2. For your selected robot, click the three-dot menu ( ⋮ ) and then click **Robot settings**.
+
+3. Click the **Advanced** tab to open the advanced settings page.
+
+4. Click **Download logs**. You’ll be prompted to choose a save location when the log files are ready to download.
+
+    !!!note
+        OT-2 produces a single `.zip` file that contains the logs. The file name includes the robot’s name followed by `_logs.zip`. For example, if your robot is called “Oatie," the log file will be named `Oatie_logs.zip`.
+
+5. _(Optional)_ To read the logs, double-click the downloaded file to decompress it. The individual logs will expand into a new folder in the same location as the downloaded file. Any text editor should be able to open these files.
+
+</div>

--- a/docs/ot-2/mkdocs.yml
+++ b/docs/ot-2/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
       - Installing the App: opentrons-app/installation.md
       - Importing Protocols: opentrons-app/protocol-import.md
       - Running Protocols: opentrons-app/protocol-run.md
+      - Downloading OT-2 Log Files: opentrons-app/log-files.md
       - App Features Summary: opentrons-app/features-summary.md
   - Maintenance:
       - Maintenance: maintenance/index.md


### PR DESCRIPTION
# Overview

This adds a section to the OT-2 manual that explains the log files and how to download these files. This is almost the same text as used in the Flex manual for downloading log files except the OT-2 generates fewer files than Flex. An OT-2 only creates these log files:

- `api.log`
- `serial.log`
- `server.log`
- `update_server.log`

Flex produces CAN bus and touchscreen files that OT-2 does not.

**Sandbox:** https://sandbox.docs.opentrons.com/docs-ot2-log-files/ot-2/opentrons-app/log-files/

RTC-965

## Test Plan and Hands on Testing

Test by trying the instructions.

## Changelog

Adds a new file, `log-files.md`, to the Opentrons App section of the OT-2 manual.

## Review requests

- Compare to Flex

## Risk assessment

Low, docs only, but also important to explain.
