### PR TITLE
fix(app): block ODD confirm camera preferences if the camera is disabled but required

### DIFF
--- a/app/src/assets/localization/en/protocol_setup.json
+++ b/app/src/assets/localization/en/protocol_setup.json
@@ -48,6 +48,7 @@
   "camera": "Camera",
   "camera_disabled": "Camera disabled",
   "camera_enabled": "Camera enabled",
+  "camera_required": "Camera is required to run this protocol",
   "camera_settings": "camera settings",
   "camera_setup_step_description": "Review camera preferences for this protocol run.",
   "camera_setup_step_title": "Camera",

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupCamera/__tests__/ProtocolSetupCamera.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupCamera/__tests__/ProtocolSetupCamera.test.tsx
@@ -7,6 +7,7 @@ import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { ODDBackButton } from '/app/molecules/ODDBackButton'
 import { CameraSettings } from '/app/organisms/ODD/CameraSettings'
+import { useToaster } from '/app/organisms/ToasterOven'
 import { getCameraUsageState } from '/app/redux/protocol-runs'
 
 import { ProtocolSetupCamera } from '..'
@@ -18,6 +19,7 @@ vi.mock('/app/organisms/ODD/CameraSettings')
 vi.mock('/app/molecules/ODDBackButton')
 vi.mock('/app/redux/protocol-runs')
 vi.mock('@opentrons/react-api-client')
+vi.mock('/app/organisms/ToasterOven')
 
 const render = (props: ProtocolSetupCameraProps) => {
   return renderWithProviders(<ProtocolSetupCamera {...props} />, {
@@ -28,9 +30,16 @@ const render = (props: ProtocolSetupCameraProps) => {
 describe('ProtocolSetupCamera', () => {
   let mockProps: ProtocolSetupCameraProps
   let mockConfirmCamera: Mock
+  let mockMakeSnackbar: Mock
 
   beforeEach(() => {
     mockConfirmCamera = vi.fn()
+    mockMakeSnackbar = vi.fn()
+    vi.mocked(useToaster).mockReturnValue({
+      makeSnackbar: mockMakeSnackbar,
+      makeToast: vi.fn(),
+      eatToast: vi.fn(),
+    })
     mockProps = {
       runId: 'MOCK-RUN-ID',
       isCameraRequired: true,
@@ -102,5 +111,58 @@ describe('ProtocolSetupCamera', () => {
     render(propsWithConfirmed)
 
     expect(screen.queryByText('Confirm preferences')).not.toBeInTheDocument()
+  })
+
+  describe('when camera is disabled and required', () => {
+    beforeEach(() => {
+      vi.mocked(getCameraUsageState).mockReturnValue({
+        enabled: false,
+        recoveryEnabled: false,
+        liveStreamEnabled: false,
+      })
+    })
+
+    it('blocks confirmation and shows snackbar when confirm is clicked', () => {
+      render(mockProps)
+
+      const confirmButton = screen.getByText('Confirm preferences')
+      fireEvent.click(confirmButton)
+
+      expect(mockMakeSnackbar).toHaveBeenCalledWith(
+        'Camera is required to run this protocol',
+        3000
+      )
+      expect(mockConfirmCamera).not.toHaveBeenCalled()
+    })
+
+    it('passes isCameraRequired to CameraSettings for required notification', () => {
+      render(mockProps)
+
+      expect(vi.mocked(CameraSettings)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isCameraRequired: true,
+        }),
+        {}
+      )
+    })
+  })
+
+  it('allows confirmation when camera is disabled but not required', () => {
+    vi.mocked(getCameraUsageState).mockReturnValue({
+      enabled: false,
+      recoveryEnabled: false,
+      liveStreamEnabled: false,
+    })
+    const propsWithCameraNotRequired = {
+      ...mockProps,
+      isCameraRequired: false,
+    }
+    render(propsWithCameraNotRequired)
+
+    const confirmButton = screen.getByText('Confirm preferences')
+    fireEvent.click(confirmButton)
+
+    expect(mockConfirmCamera).toHaveBeenCalledTimes(1)
+    expect(mockMakeSnackbar).not.toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupCamera/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupCamera/index.tsx
@@ -71,36 +71,40 @@ export function ProtocolSetupCamera(
   }
 
   const onConfirmPreferences = (): void => {
-    setIsConfirmPending(true)
+    if (!cameraEnabled && props.isCameraRequired) {
+      makeSnackbar(t('camera_required') as string, TOAST_DURATION_MS)
+    } else {
+      setIsConfirmPending(true)
 
-    addCameraSettingsToRun(
-      {
-        runId,
-        settings: {
-          cameraEnabled,
-          liveStreamEnabled,
-          errorRecoveryCameraEnabled: recoveryEnabled,
+      addCameraSettingsToRun(
+        {
+          runId,
+          settings: {
+            cameraEnabled,
+            liveStreamEnabled,
+            errorRecoveryCameraEnabled: recoveryEnabled,
+          },
         },
-      },
-      {
-        onSuccess: confirmCameraSettings,
-        onError: () => {
-          // This request only fails if the camera is not connected to the robot.
-          // We only want to surface the error if a user expects the camera to be enabled.
-          if (cameraEnabled) {
-            makeSnackbar(
-              t('error_confirming_camera') as string,
-              TOAST_DURATION_MS
-            )
-          } else {
-            confirmCameraSettings()
-          }
-        },
-        onSettled: () => {
-          setIsConfirmPending(false)
-        },
-      }
-    )
+        {
+          onSuccess: confirmCameraSettings,
+          onError: () => {
+            // This request only fails if the camera is not connected to the robot.
+            // We only want to surface the error if a user expects the camera to be enabled.
+            if (cameraEnabled) {
+              makeSnackbar(
+                t('error_confirming_camera') as string,
+                TOAST_DURATION_MS
+              )
+            } else {
+              confirmCameraSettings()
+            }
+          },
+          onSettled: () => {
+            setIsConfirmPending(false)
+          },
+        }
+      )
+    }
   }
 
   return (


### PR DESCRIPTION
Closes [RQA-5244](https://opentrons.atlassian.net/browse/RQA-5244)

# Overview

If the camera is currently disabled but required to run the protocol, we shouldn't allow the user to confirm camera preferences with the camera disabled. We do this in the desktop app correctly, but do not currently support that behavior on the ODD.

To fix, we simply check for this condition and then display a snackbar reminding users to enable the camera before confirming preferences. 

![IMG_7719](https://github.com/user-attachments/assets/b06c08c4-1879-4bbc-ab04-a71c9fa01597)

## Test Plan and Hands on Testing

- See image.
- Verified that the ODD still correctly blocks users from starting the run at other ODD protocol entry points.

## Changelog

- Users cannot confirm camera preferences on the ODD if the camera is disabled but required for the protocol run.

## Risk assessment

- low - this logic mirrors the desktop app logic and is orthogonal to existing behavior.


[RQA-5244]: https://opentrons.atlassian.net/browse/RQA-5244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ