### PR TITLE
chore(js): Fix vitest and vitest/coverage-v8 version mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@typescript-eslint/eslint-plugin": "^6.20.0",
     "@typescript-eslint/parser": "^6.20.0",
     "@vitejs/plugin-react": "4.2.0",
-    "@vitest/coverage-v8": "2.1.8",
+    "@vitest/coverage-v8": "2.1.9",
     "ajv": "6.12.3",
     "aws-sdk": "^2.493.0",
     "babel-loader": "^8.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7411,10 +7411,10 @@
     magic-string "^0.27.0"
     react-refresh "^0.14.0"
 
-"@vitest/coverage-v8@2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-2.1.8.tgz#738527e6e79cef5004248452527e272e0df12284"
-  integrity sha512-2Y7BPlKH18mAZYAW1tYByudlCYrQyl5RGvnnDYJKW5tCiO5qg3KSAy3XAxcxKz900a0ZXxWtKrMuZLe3lKBpJw==
+"@vitest/coverage-v8@2.1.9":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz#060bebfe3705c1023bdc220e17fdea4bd9e2b24d"
+  integrity sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==
   dependencies:
     "@ampproject/remapping" "^2.3.0"
     "@bcoe/v8-coverage" "^0.2.3"


### PR DESCRIPTION
# Overview

This updates vitest/coverage-v8 to the same version as vitest, to resolve this warning:

> Loaded  vitest@2.1.9  and  @vitest/coverage-v8@2.1.8 .
> Running mixed versions is not supported and may lead into bugs
> Update your dependencies and make sure the versions match.

## Test Plan and Hands on Testing

* [ ] CI all passes.
* [x] Warning is gone.

## Review requests

None.

## Risk assessment

Low.