### PR TITLE
fix(protocol-designer, shared-data, step-generation): always nick name top non-lid labware in a stack

### DIFF
--- a/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/__tests__/LabwareCardOverflowMenu.test.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/__tests__/LabwareCardOverflowMenu.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { fixture96Plate } from '@opentrons/shared-data'
+import { fixture96Plate, fixtureLid } from '@opentrons/shared-data'
 
 import { renderWithProviders } from '/protocol-designer/__testing-utils__'
 import { i18n } from '/protocol-designer/assets/localization'
@@ -49,7 +49,7 @@ describe('LabwareCardOverflowMenu', () => {
   beforeEach(() => {
     props = {
       setShowOverflowMenu: vi.fn(),
-      labwareIds: ['mockLabwareId'],
+      labwareIds: ['labId3'],
     }
     vi.mocked(EditNickNameModal).mockReturnValue(
       <div>mock EditNickNameModal</div>
@@ -57,11 +57,18 @@ describe('LabwareCardOverflowMenu', () => {
     vi.mocked(getSavedStepForms).mockReturnValue({})
     vi.mocked(getDeckSetupForActiveItem).mockReturnValue({
       labware: {
-        mockLabwareId: {
-          id: 'mockLabwareId',
-          def: fixture96Plate as LabwareDefinition2,
-          stack: ['mockLabwareId', 'A1'],
+        labId3: {
+          stack: ['labId3', 'D2'],
+          id: 'labId3',
           labwareDefURI: 'mockUri',
+          def: fixture96Plate as LabwareDefinition2,
+          pythonName: 'mockPythonName',
+        },
+        lid1: {
+          stack: ['lid1', 'labId3', 'D2'],
+          id: 'lid1',
+          labwareDefURI: 'mockUri',
+          def: fixtureLid as LabwareDefinition2,
           pythonName: 'mockPythonName',
         },
       },
@@ -89,5 +96,16 @@ describe('LabwareCardOverflowMenu', () => {
     render(props)
     fireEvent.click(screen.getByText('Delete labware'))
     screen.getByText('mock ConfirmDeleteEntityInUseModal')
+  })
+
+  it('nicknames the labware, not the lid', () => {
+    render(props)
+    fireEvent.click(screen.getByRole('button', { name: 'Rename labware' }))
+    expect(EditNickNameModal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        labwareId: 'labId3',
+      }),
+      {}
+    )
   })
 })

--- a/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/index.tsx
@@ -91,8 +91,7 @@ export function LabwareCardOverflowMenu(
   const fullStack = getFullStackFromLabwares(
     deckSetupLabware,
     slotName,
-    topLabwareId,
-    true
+    topLabwareId
   )
   const moduleId = getModuleIdFromStack(fullStack, deckSetupModules)
   const moduleType = moduleId != null ? deckSetupModules[moduleId].type : null

--- a/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/index.tsx
@@ -80,7 +80,13 @@ export function LabwareCardOverflowMenu(
       }
     },
   })
-  const topLabwareId = labwareIds[0]
+  const stackOnlyHasLids =
+    labwareIds.filter(
+      id =>
+        id !== lidId && !deckSetup.labware[id].def.allowedRoles?.includes('lid')
+    ).length === 0
+
+  const topLabwareId = labwareIds.filter(id => id !== lidId)[0]
   const isAdapter =
     deckSetupLabware[topLabwareId].def.allowedRoles?.includes('adapter')
   const slotName = getSlotInLocationStack(deckSetupLabware[topLabwareId].stack)
@@ -105,6 +111,7 @@ export function LabwareCardOverflowMenu(
   const disallowNickname =
     isAdapter ||
     deckSetupLabware[topLabwareId].def.parameters.isTiprack ||
+    stackOnlyHasLids ||
     deckSetupLabware[topLabwareId].def.parameters.quirks?.includes(
       'tiprackAdapterFor96Channel'
     ) ||

--- a/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCardOverflowMenu/index.tsx
@@ -43,6 +43,7 @@ import { COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE } from '/protocol-designer/
 
 import { getStackerModuleStateFromSlot } from '../AssignLiquidsModal/utils'
 import { LabwareNotCompatibleModal } from '../LabwareNotCompatibleModal'
+import { getAllLabwareWithoutLids } from '../utils'
 
 import type { Dispatch, MouseEvent, SetStateAction } from 'react'
 import type { HopperLocationMapKey } from '@opentrons/step-generation'
@@ -81,10 +82,7 @@ export function LabwareCardOverflowMenu(
     },
   })
   const stackOnlyHasLids =
-    labwareIds.filter(
-      id =>
-        id !== lidId && !deckSetup.labware[id].def.allowedRoles?.includes('lid')
-    ).length === 0
+    getAllLabwareWithoutLids(deckSetup, labwareIds).length === 0
 
   const topLabwareId = labwareIds.filter(id => id !== lidId)[0]
   const isAdapter =
@@ -93,7 +91,8 @@ export function LabwareCardOverflowMenu(
   const fullStack = getFullStackFromLabwares(
     deckSetupLabware,
     slotName,
-    topLabwareId
+    topLabwareId,
+    true
   )
   const moduleId = getModuleIdFromStack(fullStack, deckSetupModules)
   const moduleType = moduleId != null ? deckSetupModules[moduleId].type : null

--- a/protocol-designer/src/components/organisms/utils.ts
+++ b/protocol-designer/src/components/organisms/utils.ts
@@ -26,6 +26,22 @@ import type {
 } from '/protocol-designer/step-forms'
 import type * as wellContentsSelectors from '/protocol-designer/top-selectors/well-contents'
 
+export const getAllLabwareWithoutLids = (
+  deckSetup: AllTemporalPropertiesForTimelineFrame,
+  labwareIds?: string[]
+): string[] => {
+  const labwareOnDeck = deckSetup.labware
+  if (labwareIds) {
+    return labwareIds.filter(
+      id => !labwareOnDeck[id].def.allowedRoles?.includes('lid')
+    )
+  }
+  const allLabwareIds = Object.keys(labwareOnDeck)
+  return allLabwareIds.filter(
+    id => !labwareOnDeck[id].def.allowedRoles?.includes('lid')
+  )
+}
+
 export const getSlotsWithCollisions = (
   deckDef: DeckDefinition,
   allModules: ModuleOnDeck[]

--- a/protocol-designer/src/components/organisms/utils.ts
+++ b/protocol-designer/src/components/organisms/utils.ts
@@ -28,16 +28,10 @@ import type * as wellContentsSelectors from '/protocol-designer/top-selectors/we
 
 export const getAllLabwareWithoutLids = (
   deckSetup: AllTemporalPropertiesForTimelineFrame,
-  labwareIds?: string[]
+  labwareIds: string[]
 ): string[] => {
   const labwareOnDeck = deckSetup.labware
-  if (labwareIds) {
-    return labwareIds.filter(
-      id => !labwareOnDeck[id].def.allowedRoles?.includes('lid')
-    )
-  }
-  const allLabwareIds = Object.keys(labwareOnDeck)
-  return allLabwareIds.filter(
+  return labwareIds.filter(
     id => !labwareOnDeck[id].def.allowedRoles?.includes('lid')
   )
 }

--- a/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
@@ -112,7 +112,10 @@ export function SlotOverflowMenu(
   const { makeSnackbar } = useKitchen()
 
   const { labware: deckSetupLabware, modules: deckSetupModules } = deckSetup
-  const allLabwareNotLids = getAllLabwareWithoutLids(deckSetup)
+  const allLabwareNotLids = getAllLabwareWithoutLids(
+    deckSetup,
+    Object.keys(deckSetupLabware)
+  )
   const topLabwareThatIsNotALid = deckSetupLabware[allLabwareNotLids[0]]
   const isOffDeckLocation = deckSetupLabware[location] != null
 

--- a/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
@@ -111,7 +111,10 @@ export function SlotOverflowMenu(
   const { makeSnackbar } = useKitchen()
 
   const { labware: deckSetupLabware, modules: deckSetupModules } = deckSetup
-
+  const allLabwareNotLids = Object.values(deckSetupLabware).filter(
+    lbw => !lbw.def.allowedRoles?.includes('lid')
+  )
+  const topLabwareThatIsNotALid = allLabwareNotLids[0]
   const isOffDeckLocation = deckSetupLabware[location] != null
 
   const fullStackOnSlot = getFullStackFromLabwares(deckSetupLabware, location)
@@ -210,7 +213,7 @@ export function SlotOverflowMenu(
       : TOP_SLOT_Y_POSITION_2_BUTTONS
   }
 
-  let nickNameId = topLabwareOnSlot?.id
+  let nickNameId = topLabwareThatIsNotALid?.id
   if (isOffDeckLocation) {
     nickNameId = location
   }

--- a/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
@@ -29,6 +29,7 @@ import {
   ConfirmDeleteEntityInUseModal,
   ConfirmDeleteStagingAreaModal,
   EditNickNameModal,
+  getAllLabwareWithoutLids,
 } from '../../../components/organisms'
 import { useKitchen } from '../../../components/organisms/Kitchen/useKitchen'
 import { getRobotType } from '../../../file-data/selectors'
@@ -111,10 +112,8 @@ export function SlotOverflowMenu(
   const { makeSnackbar } = useKitchen()
 
   const { labware: deckSetupLabware, modules: deckSetupModules } = deckSetup
-  const allLabwareNotLids = Object.values(deckSetupLabware).filter(
-    lbw => !lbw.def.allowedRoles?.includes('lid')
-  )
-  const topLabwareThatIsNotALid = allLabwareNotLids[0]
+  const allLabwareNotLids = getAllLabwareWithoutLids(deckSetup)
+  const topLabwareThatIsNotALid = deckSetupLabware[allLabwareNotLids[0]]
   const isOffDeckLocation = deckSetupLabware[location] != null
 
   const fullStackOnSlot = getFullStackFromLabwares(deckSetupLabware, location)

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SlotOverflowMenu.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/SlotOverflowMenu.test.tsx
@@ -11,6 +11,7 @@ import { i18n } from '/protocol-designer/assets/localization'
 import {
   ConfirmDeleteEntityInUseModal,
   EditNickNameModal,
+  getAllLabwareWithoutLids,
 } from '/protocol-designer/components/organisms'
 import { useKitchen } from '/protocol-designer/components/organisms/Kitchen/useKitchen'
 import {
@@ -40,6 +41,7 @@ vi.mock('/protocol-designer/components/organisms')
 vi.mock('/protocol-designer/file-data/selectors')
 vi.mock('/protocol-designer/labware-ingred/utils')
 vi.mock('/protocol-designer/components/organisms/Kitchen/useKitchen')
+
 vi.mock('react-router-dom', async importOriginal => {
   const actual = await importOriginal<NavigateFunction>()
   return {
@@ -103,6 +105,7 @@ describe('SlotOverflowMenu', () => {
         },
       },
     })
+    vi.mocked(getAllLabwareWithoutLids).mockReturnValue(['labId'])
     vi.mocked(EditNickNameModal).mockReturnValue(
       <div>mock EditNickNameModal</div>
     )

--- a/shared-data/js/labware.ts
+++ b/shared-data/js/labware.ts
@@ -7,6 +7,7 @@ import fixture384Plate from '../labware/fixtures/2/fixture_384_plate.json'
 import fixtureCalibrationBlock from '../labware/fixtures/2/fixture_calibration_block.json'
 import fixtureTiprack1000ul from '../labware/fixtures/2/fixture_flex_96_tiprack_1000ul.json'
 import fixtureTiprackAdapter from '../labware/fixtures/2/fixture_flex_96_tiprack_adapter.json'
+import fixtureLid from '../labware/fixtures/2/fixture_lid.json'
 import fixtureTiprack10ul from '../labware/fixtures/2/fixture_tiprack_10_ul.json'
 import fixtureTiprack300ul from '../labware/fixtures/2/fixture_tiprack_300_ul.json'
 import fixtureTrash from '../labware/fixtures/2/fixture_trash.json'
@@ -208,6 +209,7 @@ export {
   labwareImages,
   labwareSchemaV2,
   labwareSchemaV3,
+  fixtureLid,
   fixture96Plate,
   fixture12Trough,
   fixture24Tuberack,

--- a/shared-data/labware/fixtures/2/fixture_lid.json
+++ b/shared-data/labware/fixtures/2/fixture_lid.json
@@ -1,0 +1,97 @@
+{
+  "allowedRoles": ["labware", "lid"],
+  "ordering": [],
+  "brand": {
+    "brand": "generic"
+  },
+  "metadata": {
+    "displayName": "Lid Fixture",
+    "displayCategory": "lid",
+    "displayVolumeUnits": "µL",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.76,
+    "yDimension": 85.48,
+    "zDimension": 9.2
+  },
+  "wells": {},
+  "groups": [
+    {
+      "metadata": {},
+      "wells": []
+    }
+  ],
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "parameters": {
+    "format": "irregular",
+    "quirks": [],
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "isDeckSlotCompatible": false,
+    "loadName": "fixture_lid"
+  },
+  "namespace": "fixture",
+  "version": 2,
+  "schemaVersion": 2,
+  "stackingOffsetWithLabware": {
+    "default": {
+      "x": 0,
+      "y": 0,
+      "z": 7.1
+    },
+    "opentrons_96_wellplate_200ul_pcr_full_skirt": {
+      "x": 0,
+      "y": 0,
+      "z": 6.1
+    },
+    "protocol_engine_lid_stack_object": {
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "opentrons_tough_universal_lid": {
+      "x": 0,
+      "y": 0,
+      "z": 1
+    },
+    "opentrons_flex_deck_riser": {
+      "x": 0,
+      "y": 0,
+      "z": 34
+    }
+  },
+  "stackLimit": 5,
+  "gripForce": 10,
+  "gripHeightFromLabwareBottom": 5.5,
+  "gripperOffsets": {
+    "default": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 3
+      }
+    },
+    "lidDisposalOffsets": {
+      "pickUpOffset": {
+        "x": 0,
+        "y": 0,
+        "z": 0
+      },
+      "dropOffset": {
+        "x": 0,
+        "y": 5.0,
+        "z": 50.0
+      }
+    }
+  }
+}

--- a/shared-data/labware/fixtures/2/index.ts
+++ b/shared-data/labware/fixtures/2/index.ts
@@ -8,6 +8,7 @@ import fixture_corning_96_wellplate_360_flat from './fixture_corning_96_wellplat
 import fixture_flex_96_tiprack_1000ul from './fixture_flex_96_tiprack_1000ul.json'
 import fixture_flex_96_tiprack_adapter from './fixture_flex_96_tiprack_adapter.json'
 import fixture_irregular_example_1 from './fixture_irregular_example_1.json'
+import fixture_lid from './fixture_lid.json'
 import fixture_overlappy_wellplate from './fixture_overlappy_wellplate.json'
 import fixture_regular_example_1 from './fixture_regular_example_1.json'
 import fixture_regular_example_2 from './fixture_regular_example_2.json'
@@ -18,6 +19,7 @@ import fixture_trash from './fixture_trash.json'
 import fixture_universal_flat_bottom_adapter from './fixture_universal_flat_bottom_adapter.json'
 
 export {
+  fixture_lid,
   fixture_12_trough_v2,
   fixture_12_trough,
   fixture_24_tuberack,

--- a/step-generation/src/utils/__tests__/misc.test.ts
+++ b/step-generation/src/utils/__tests__/misc.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@opentrons/shared-data'
 
 import {
+  getFullStackFromLabwares,
   getIsRetractSafeForAirGap,
   getTransferPlanAndReferenceVolumes,
 } from '../misc'
@@ -435,5 +436,21 @@ describe('getIsRetractSafeForAirGap', () => {
     vi.mocked(getMmFromBottom).mockReturnValue(11)
     const result = getIsRetractSafeForAirGap(args)
     expect(result).toBe(false)
+  })
+})
+
+describe('getFullStackFromLabwares', () => {
+  it('return the top stack of labwares', () => {
+    const labware = {
+      labwareId1: {
+        stack: ['labwareId1', 'D3'],
+      },
+      labwareId2: {
+        stack: ['labwareId2', 'labwareId1', 'D3'],
+      },
+    }
+    const slot = 'D3'
+    const largestStack = getFullStackFromLabwares(labware, slot)
+    expect(largestStack).toEqual(['labwareId2', 'labwareId1', 'D3'])
   })
 })

--- a/step-generation/src/utils/__tests__/misc.test.ts
+++ b/step-generation/src/utils/__tests__/misc.test.ts
@@ -450,7 +450,12 @@ describe('getFullStackFromLabwares', () => {
       },
     }
     const slot = 'D3'
-    const largestStack = getFullStackFromLabwares(labware, slot)
+    const largestStack = getFullStackFromLabwares(
+      labware,
+      slot,
+      undefined,
+      true
+    )
     expect(largestStack).toEqual(['labwareId2', 'labwareId1', 'D3'])
   })
 })

--- a/step-generation/src/utils/__tests__/misc.test.ts
+++ b/step-generation/src/utils/__tests__/misc.test.ts
@@ -450,12 +450,7 @@ describe('getFullStackFromLabwares', () => {
       },
     }
     const slot = 'D3'
-    const largestStack = getFullStackFromLabwares(
-      labware,
-      slot,
-      undefined,
-      true
-    )
+    const largestStack = getFullStackFromLabwares(labware, slot, undefined)
     expect(largestStack).toEqual(['labwareId2', 'labwareId1', 'D3'])
   })
 })

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -1055,8 +1055,7 @@ export const getFullStackFromLabwares = (
     [labwareId: string]: LabwareTemporalProperties
   },
   slot: string,
-  offDeckOverrideId?: string,
-  returnLargestStack?: boolean
+  offDeckOverrideId?: string
 ): string[] => {
   if (slot === 'offDeck' && offDeckOverrideId == null) {
     console.error(
@@ -1074,15 +1073,11 @@ export const getFullStackFromLabwares = (
       (offDeckOverrideId == null || lw.stack.includes(offDeckOverrideId)) &&
       lw.stack.includes(HOPPER_STACKER_LOCATION) === isOnHopper
   )
-  const index = returnLargestStack ? -1 : 0
+  if (isOnHopper) {
+    return labwareStack.reverse()[0].stack ?? []
+  }
   return (
-    labwareStack
-      .sort(
-        returnLargestStack
-          ? (a, b) => a.stack.length - b.stack.length
-          : (a, b) => b.stack.length - a.stack.length
-      )
-      .at(index)?.stack ?? []
+    labwareStack.sort((a, b) => b.stack.length - a.stack.length)[0]?.stack ?? []
   )
 }
 

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -1048,7 +1048,7 @@ export const getModuleIdFromRobotStateStack = (
  * @param labware - The labware object containing all labware entities
  * @param slot - The slot to get the full stack from
  * @param offDeckOverrideId - Labware ID for an offDeck stack
- * @returns The full stack from the labware object
+ * @returns The top full stack from the labware object
  */
 export const getFullStackFromLabwares = (
   labware: {
@@ -1075,7 +1075,8 @@ export const getFullStackFromLabwares = (
           (offDeckOverrideId == null || lw.stack.includes(offDeckOverrideId)) &&
           lw.stack.includes(HOPPER_STACKER_LOCATION) === isOnHopper
       )
-      .sort((a, b) => b.stack.length - a.stack.length)[0]?.stack ?? []
+      .sort((a, b) => a.stack.length - b.stack.length)
+      .at(-1)?.stack ?? []
   )
 }
 

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -1055,7 +1055,8 @@ export const getFullStackFromLabwares = (
     [labwareId: string]: LabwareTemporalProperties
   },
   slot: string,
-  offDeckOverrideId?: string
+  offDeckOverrideId?: string,
+  returnLargestStack?: boolean
 ): string[] => {
   if (slot === 'offDeck' && offDeckOverrideId == null) {
     console.error(
@@ -1067,16 +1068,21 @@ export const getFullStackFromLabwares = (
   const mappedLocation = isOnHopper
     ? FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
     : slot
+  const labwareStack = Object.values(labware).filter(
+    lw =>
+      lw.stack.includes(mappedLocation) &&
+      (offDeckOverrideId == null || lw.stack.includes(offDeckOverrideId)) &&
+      lw.stack.includes(HOPPER_STACKER_LOCATION) === isOnHopper
+  )
+  const index = returnLargestStack ? -1 : 0
   return (
-    Object.values(labware)
-      .filter(
-        lw =>
-          lw.stack.includes(mappedLocation) &&
-          (offDeckOverrideId == null || lw.stack.includes(offDeckOverrideId)) &&
-          lw.stack.includes(HOPPER_STACKER_LOCATION) === isOnHopper
+    labwareStack
+      .sort(
+        returnLargestStack
+          ? (a, b) => a.stack.length - b.stack.length
+          : (a, b) => b.stack.length - a.stack.length
       )
-      .sort((a, b) => a.stack.length - b.stack.length)
-      .at(-1)?.stack ?? []
+      .at(index)?.stack ?? []
   )
 }
 


### PR DESCRIPTION
# Overview

Prevent nicknaming of lids and always nick names the top most non-lid labware in a stack

## Test Plan and Hands on Testing

- smoke tested by adjusting protocol attached in the bug ticket

[lid smoke test.py](https://github.com/user-attachments/files/25939459/lid.smoke.test.py)

https://github.com/user-attachments/assets/37cd3380-5432-45d5-ad03-4dd2e227e664

## Changelog

- added lid fixture object for unit tests
- filter out lids from labwareList before getting the topLabwareId to pass into `EditNickNameModal`
- adjusted `getFullStackFromLabwares` to return the largest stack at the end of the list of stacks to ensure the top labware in a stacker is what gets renamed.

## Review requests

- should I make a new `getFullStackFromLabwares` util or is this fine since all unit tests pass?

## Risk assessment

- High: adjusts widely used util for getting stack object

Closes AUTH-2770