### PR TITLE
test(python): Auto-select ports through pytest-asyncio

### DIFF
--- a/auth-server/tests/conftest.py
+++ b/auth-server/tests/conftest.py
@@ -10,9 +10,9 @@ _INTEGRATION_SERVER_STARTUP_TIMEOUT_S = 30
 
 
 @pytest.fixture
-def run_server() -> Generator[DevServer, None, None]:
+def run_server(unused_tcp_port: int) -> Generator[DevServer, None, None]:
     """Run a dev server as a fixture scoped to the test."""
-    with DevServer() as dev_server:
+    with DevServer(port=unused_tcp_port) as dev_server:
         dev_server.start()
         base_url = f"http://localhost:{dev_server.port}"
         _wait_until_ready(base_url)

--- a/auth-server/tests/dev_server.py
+++ b/auth-server/tests/dev_server.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import random
 import signal
 import subprocess
 import sys
@@ -11,11 +10,9 @@ from typing import Optional
 class DevServer:
     """An instance of the server, running as a background process."""
 
-    def __init__(self, port: int | None = None) -> None:
+    def __init__(self, port: int) -> None:
         """Initialize a dev server."""
-        self.port: int = (
-            port if port is not None else random.randrange(2**15 + 2**14, 2**16 - 1)
-        )
+        self.port: int = port
 
     def __enter__(self) -> DevServer:
         return self

--- a/key-server/tests/conftest.py
+++ b/key-server/tests/conftest.py
@@ -10,9 +10,9 @@ _INTEGRATION_SERVER_STARTUP_TIMEOUT_S = 30
 
 
 @pytest.fixture
-def run_server() -> Generator[DevServer, None, None]:
+def run_server(unused_tcp_port: int) -> Generator[DevServer, None, None]:
     """Run a dev server as a fixture scoped to the test."""
-    with DevServer() as dev_server:
+    with DevServer(port=unused_tcp_port) as dev_server:
         dev_server.start()
         base_url = f"http://localhost:{dev_server.port}"
         _wait_until_ready(base_url)

--- a/key-server/tests/dev_server.py
+++ b/key-server/tests/dev_server.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import random
 import signal
 import subprocess
 import sys
@@ -11,11 +10,9 @@ from typing import Optional
 class DevServer:
     """An instance of the server, running as a background process."""
 
-    def __init__(self, port: int | None = None) -> None:
+    def __init__(self, port: int) -> None:
         """Initialize a dev server."""
-        self.port: int = (
-            port if port is not None else random.randrange(2**15 + 2**14, 2**16 - 1)
-        )
+        self.port: int = port
 
     def __enter__(self) -> DevServer:
         return self

--- a/robot-server/tests/integration/conftest.py
+++ b/robot-server/tests/integration/conftest.py
@@ -3,7 +3,7 @@ import contextlib
 import json
 import time
 from pathlib import Path
-from typing import Any, Dict, Generator
+from typing import Any, Callable, Dict, Generator
 
 import pytest
 import requests
@@ -19,8 +19,6 @@ from robot_server.versioning import API_VERSION_HEADER, LATEST_API_VERSION_HEADE
 
 _SESSION_SERVER_SCHEME = "http://"
 _SESSION_SERVER_HOST = "localhost"
-_OT2_SESSION_SERVER_PORT = "31950"
-_OT3_SESSION_SERVER_PORT = "31960"
 _INTEGRATION_SERVER_STARTUP_TIMEOUT_S = 30
 
 
@@ -62,12 +60,16 @@ def ot3_server_base_url(_ot3_session_server: str) -> Generator[str, None, None]:
 
 
 @pytest.fixture(scope="session")
-def _ot2_session_server(server_temp_directory: str) -> Generator[str, None, None]:
-    base_url = (
-        f"{_SESSION_SERVER_SCHEME}{_SESSION_SERVER_HOST}:{_OT2_SESSION_SERVER_PORT}"
-    )
+def _ot2_session_server(
+    server_temp_directory: str,
+    # We need unused_tcp_port_factory instead of unused_tcp_port to avoid a ScopeMismatch
+    # error, since it's function-scoped and we're session-scoped.
+    unused_tcp_port_factory: Callable[[], int],
+) -> Generator[str, None, None]:
+    port = unused_tcp_port_factory()
+    base_url = f"{_SESSION_SERVER_SCHEME}{_SESSION_SERVER_HOST}:{port}"
     with DevServer(
-        port=_OT2_SESSION_SERVER_PORT,
+        port=str(port),
         ot_api_config_dir=Path(server_temp_directory),
     ) as dev_server:
         dev_server.start()
@@ -76,12 +78,16 @@ def _ot2_session_server(server_temp_directory: str) -> Generator[str, None, None
 
 
 @pytest.fixture(scope="session")
-def _ot3_session_server(server_temp_directory: str) -> Generator[str, None, None]:
-    base_url = (
-        f"{_SESSION_SERVER_SCHEME}{_SESSION_SERVER_HOST}:{_OT3_SESSION_SERVER_PORT}"
-    )
+def _ot3_session_server(
+    server_temp_directory: str,
+    # We need unused_tcp_port_factory instead of unused_tcp_port to avoid a ScopeMismatch
+    # error, since it's function-scoped and we're session-scoped.
+    unused_tcp_port_factory: Callable[[], int],
+) -> Generator[str, None, None]:
+    port = unused_tcp_port_factory()
+    base_url = f"{_SESSION_SERVER_SCHEME}{_SESSION_SERVER_HOST}:{port}"
     with DevServer(
-        port=_OT3_SESSION_SERVER_PORT,
+        port=str(port),
         is_ot3=True,
         ot_api_config_dir=Path(server_temp_directory),
     ) as dev_server:

--- a/robot-server/tests/integration/http_api/runs/test_deck_slot_standardization.py
+++ b/robot-server/tests/integration/http_api/runs/test_deck_slot_standardization.py
@@ -3,7 +3,6 @@ from typing import AsyncGenerator
 import pytest
 from pytest_lazy_fixtures import lf
 
-from ...conftest import _OT3_SESSION_SERVER_PORT
 from ...robot_client import RobotClient
 
 
@@ -17,16 +16,18 @@ async def robot_client(base_url: str) -> AsyncGenerator[RobotClient, None]:
 @pytest.mark.parametrize(
     (
         "base_url",
+        "is_ot3",
         "input_slot_1",
         "input_slot_2",
         "standardized_slot_1",
         "standardized_slot_2",
     ),
     [
-        (lf("ot2_server_base_url"), "1", "2", "1", "2"),
-        (lf("ot2_server_base_url"), "D1", "D2", "1", "2"),
+        (lf("ot2_server_base_url"), False, "1", "2", "1", "2"),
+        (lf("ot2_server_base_url"), False, "D1", "D2", "1", "2"),
         pytest.param(
             lf("ot3_server_base_url"),
+            True,
             "1",
             "2",
             "D1",
@@ -35,6 +36,7 @@ async def robot_client(base_url: str) -> AsyncGenerator[RobotClient, None]:
         ),
         pytest.param(
             lf("ot3_server_base_url"),
+            True,
             "D1",
             "D2",
             "D1",
@@ -45,6 +47,7 @@ async def robot_client(base_url: str) -> AsyncGenerator[RobotClient, None]:
 )
 async def test_deck_slot_standardization(
     robot_client: RobotClient,
+    is_ot3: bool,
     input_slot_1: str,
     input_slot_2: str,
     standardized_slot_1: str,
@@ -78,7 +81,7 @@ async def test_deck_slot_standardization(
         {"cutoutFixtureId": "singleRightSlot", "cutoutId": "cutoutC3"},
         {"cutoutFixtureId": "singleRightSlot", "cutoutId": "cutoutD3"},
     ]
-    if _OT3_SESSION_SERVER_PORT in robot_client.base_url:
+    if is_ot3:
         await robot_client.put_deck_configuration(
             req_body={"data": {"cutoutFixtures": deck_configuration_request}}
         )

--- a/system-server/tests/conftest.py
+++ b/system-server/tests/conftest.py
@@ -40,9 +40,9 @@ def sql_engine(tmpdir: Path) -> Generator[SQLEngine, None, None]:
 
 
 @pytest.fixture
-def run_server() -> Generator[DevServer, None, None]:
+def run_server(unused_tcp_port: int) -> Generator[DevServer, None, None]:
     """Run the system server as a subprocess."""
-    with DevServer() as dev_server:
+    with DevServer(port=unused_tcp_port) as dev_server:
         print("Starting server")
         dev_server.start()
         base_url = f"http://localhost:{dev_server.port}"

--- a/system-server/tests/dev_server.py
+++ b/system-server/tests/dev_server.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import random
 import signal
 import subprocess
 import sys
@@ -11,18 +10,16 @@ from types import TracebackType
 
 class DevServer:
     def __init__(
-        self, port: int | None = None, persistence_directory: Path | None = None
+        self, port: int, persistence_directory: Path | None = None
     ) -> None:
-        """Initialize a dev server."""
+        """Initialize a dev server with the given port."""
         self.server_temp_directory: str = tempfile.mkdtemp()
         self.persistence_directory: Path = (
             persistence_directory
             if persistence_directory is not None
             else Path(tempfile.mkdtemp())
         )
-        self.port: int = (
-            port if port is not None else random.randrange(2**15 + 2**14, 2**16 - 1)
-        )
+        self.port: int = port
 
     def __enter__(self) -> DevServer:
         return self


### PR DESCRIPTION
## Overview

This tries to resolve a source of flakiness in our Python integration tests.

## Details

The integration tests in auth-server, key-server, robot-server, and system-server run instances of the server on localhost on a random port. The random port occasionally collides with something else, causing a spurious test failure.

This PR changes things to use pytest-asyncio's [unused_tcp_port](https://pytest-asyncio.readthedocs.io/en/stable/reference/fixtures/index.html#unused-tcp-port) fixture instead. The fixture works by [acquiring a random port from the OS and immediately releasing it](https://github.com/pytest-dev/pytest-asyncio/blob/dbacf7b378efee687eee1912ef9c1603eed11368/pytest_asyncio/plugin.py#L844-L848), relying on the fact that it will probably be a long time before the OS reuses it. This is a hack, but it's probably a more battle-tested hack?

The right solution is either:

* Use Unix sockets instead of TCP sockets. But it looks annoying to get Tavern to work with those.
* Get the servers to internally bind to an OS-chosen port, and then output that port over a Unix socket. But this feels a bit Rube Goldberg, and it also looks kind of sketchy to implement with Uvicorn.

## Test Plan and Hands on Testing

* [x] Try a few test runs locally and in CI and make sure they consistently pass.

## Review requests

None.

## Risk assessment

Low.