### PR TITLE
chore: Fix `make push-ot3` failing on key-server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,10 +179,10 @@ push-ot3:
 	$(if $(host),@echo "Pushing to $(host)",$(error host variable required))
 	$(MAKE) -C $(SHARED_DATA_DIR) push-no-restart-ot3
 	$(MAKE) -C $(HARDWARE_DIR) push-no-restart-ot3
-	$(MAKE) -C $(KEY_SERVER_DIR) push-no-restart-ot3
 	$(MAKE) -C $(API_DIR) push-no-restart-ot3
 	$(MAKE) -C $(SERVER_UTILS_DIR) push-ot3
 	$(MAKE) -C $(AUTH_SERVER_DIR) push-ot3
+	$(MAKE) -C $(KEY_SERVER_DIR) push-ot3
 	$(MAKE) -C $(ROBOT_SERVER_DIR) push-ot3
 	$(MAKE) -C $(SYSTEM_SERVER_DIR) push-ot3
 	$(MAKE) -C $(UPDATE_SERVER_DIR) push-ot3


### PR DESCRIPTION
## Overview

`make push-ot3` tries to call `make -C key-server push-no-restart-ot3`, which doesn't exist. This makes it use `make -C key-server push-ot3`, instead.

## Test Plan and Hands on Testing

* [ ] `make push-ot3` works now.

## Review requests

None.

## Risk assessment

Low.