### PR TITLE
feat(components, protocol-designer): add vacuum profile to PD step form

### DIFF
--- a/components/src/atoms/Slider/index.tsx
+++ b/components/src/atoms/Slider/index.tsx
@@ -15,6 +15,8 @@ interface SliderProps {
   label?: string
   /** Optional color for the unfilled (right) track. Defaults to blue-20. */
   backgroundColor?: string
+  /** Gap between label and slider: "large" (8px) or "small" (4px). Defaults to "large". */
+  type?: 'small' | 'large'
 }
 
 export function Slider({
@@ -22,6 +24,7 @@ export function Slider({
   label,
   adjustValue,
   backgroundColor,
+  type = 'large',
 }: SliderProps): JSX.Element {
   const style: CSSProperties & Record<string, string> = {
     '--value-percent': `${value}%`,
@@ -30,7 +33,11 @@ export function Slider({
     }),
   }
   return (
-    <div className={styles.slider_container}>
+    <div
+      className={clsx(styles.slider_container, {
+        [styles.slider_container_small]: type === 'small',
+      })}
+    >
       <div
         className={clsx(styles.slider_text_container_label, {
           [styles.slider_text_container_no_label]: label == null,
@@ -45,18 +52,19 @@ export function Slider({
           {value}%
         </StyledText>
       </div>
-      <input
-        type="range"
-        min="1"
-        max="100"
-        value={value}
-        onChange={e => {
-          adjustValue(Number(e.target.value))
-        }}
-        className={styles.slider}
-        style={style}
-        aria-label={label}
-      />
+      <div className={styles.slider_track_wrapper} style={style}>
+        <input
+          type="range"
+          min="1"
+          max="100"
+          value={value}
+          onChange={e => {
+            adjustValue(Number(e.target.value))
+          }}
+          className={styles.slider}
+          aria-label={label}
+        />
+      </div>
     </div>
   )
 }

--- a/components/src/atoms/Slider/slider.module.css
+++ b/components/src/atoms/Slider/slider.module.css
@@ -5,6 +5,10 @@
   gap: var(--spacing-8);
 }
 
+.slider_container_small {
+  gap: var(--spacing-4);
+}
+
 .slider_text_container_label {
   display: flex;
   flex-direction: row;
@@ -13,6 +17,10 @@
 
 .slider_text_container_no_label {
   justify-content: flex-end;
+}
+
+.slider_track_wrapper {
+  width: 100%;
 }
 
 .slider {

--- a/components/src/atoms/Slider/slider.stories.tsx
+++ b/components/src/atoms/Slider/slider.stories.tsx
@@ -1,9 +1,4 @@
-import {
-  ALIGN_CENTER,
-  Flex,
-  JUSTIFY_CENTER,
-  SPACING,
-} from '@opentrons/components'
+import { ALIGN_CENTER, Flex, JUSTIFY_CENTER } from '@opentrons/components'
 
 import { Slider } from './index'
 
@@ -15,7 +10,6 @@ const meta: Meta<typeof Slider> = {
   decorators: [
     Story => (
       <Flex
-        marginTop={SPACING.spacing16}
         width="20rem"
         height="22rem"
         justifyContent={JUSTIFY_CENTER}

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -306,6 +306,40 @@
         "profile": "Program a Vacuum profile",
         "state": "Change Vacuum state"
       },
+      "profile": {
+        "add_cycle": "Add cycle",
+        "add_cycle_step": "Add a cycle step",
+        "add_step": "Add step",
+        "cancel": "Cancel",
+        "cycle": "Cycle",
+        "delete": "Delete",
+        "edit": "Edit",
+        "errors": {
+          "name": "Enter a valid step name",
+          "pumpData": "Enter a valid pressure value",
+          "repetitions": "Enter a valid number of cycles",
+          "time": "Enter a valid time"
+        },
+        "gauge_pressure": "Gauge pressure",
+        "name": "Name",
+        "no_profile_defined": "No profile defined",
+        "no_steps_defined": "No steps defined",
+        "number_of_cycles": "Number of cycles",
+        "profile_steps": "Profile steps",
+        "profile_defined_single": "{{numSteps}} profile step defined",
+        "profile_defined_multiple": "{{numSteps}} profile steps defined",
+        "pump_power": "Pump power",
+        "repetitions": "Number of cycles",
+        "save": "Save",
+        "step": "Step",
+        "step_detail": {
+          "power": "{{power}}% power",
+          "pressure": "{{pressure}} mbar"
+        },
+        "time": "Time",
+        "title": "Edit Vacuum profile steps",
+        "unsaved_changes": "You have unsaved changes to the profile. Please save or discard them before closing."
+      },
       "state": {
         "label": "Select the state to change",
         "options": {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/EndingHoldField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/EndingHoldField.tsx
@@ -27,7 +27,7 @@ export function EndingHoldField(
   }
 
   return (
-    <div className={styles.ending_hold_section} style={{ width: '100%' }}>
+    <div className={styles.ending_hold_section}>
       <StyledText desktopStyle="bodyDefaultSemiBold">
         {t('vacuum.controls.ending_hold_vent.title')}
       </StyledText>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/EndingHoldField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/EndingHoldField.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 
 import { Check, COLORS, StyledText } from '@opentrons/components'
+import { VACUUM_PROGRAM_STATE } from '@opentrons/step-generation'
 
 import styles from './vacuumtools.module.css'
 
@@ -18,12 +19,15 @@ export function EndingHoldField(
   const { formData, propsForFields } = props
   const { t } = useTranslation('protocol_steps')
 
-  if (formData.pumpDurationCheckbox !== true) {
+  if (
+    formData.programType === VACUUM_PROGRAM_STATE &&
+    formData.pumpDurationCheckbox !== true
+  ) {
     return null
   }
 
   return (
-    <div className={styles.ending_hold_section}>
+    <div className={styles.ending_hold_section} style={{ width: '100%' }}>
       <StyledText desktopStyle="bodyDefaultSemiBold">
         {t('vacuum.controls.ending_hold_vent.title')}
       </StyledText>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumControls.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumControls.tsx
@@ -1,7 +1,16 @@
+import { Fragment, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
-import { Divider } from '@opentrons/components'
+import {
+  DIRECTION_COLUMN,
+  Divider,
+  Flex,
+  ListButton,
+  SPACING,
+  StyledText,
+} from '@opentrons/components'
 import {
   VACUUM_MODE_POWER,
   VACUUM_MODE_PRESSURE,
@@ -14,12 +23,16 @@ import {
   vacuumModuleStateGetter,
 } from '@opentrons/step-generation'
 
+import { getMainPagePortalEl } from '/protocol-designer/components/organisms'
 import { getRobotStateAtActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 
+import { EndingHoldField } from './EndingHoldField'
 import { VacuumControlsGroup } from './VacuumControlsGroup'
+import { VacuumProfileModal } from './VacuumProfile/VacuumProfileModal'
 import { VacuumPumpControls } from './VacuumPumpControls'
 import styles from './vacuumtools.module.css'
 
+import type { ReactNode } from 'react'
 import type { FormData } from '/protocol-designer/form-types'
 import type { FieldPropsByName } from '../../types'
 
@@ -30,6 +43,7 @@ interface VacuumControlsProps {
 export function VacuumControls(props: VacuumControlsProps): JSX.Element {
   const { t } = useTranslation('protocol_steps')
   const { formData, propsForFields } = props
+  const [showProfileModal, setShowProfileModal] = useState<boolean>(false)
   const { moduleId } = formData
   const robotState = useSelector(getRobotStateAtActiveItem)
   const vacuumModuleState =
@@ -63,80 +77,157 @@ export function VacuumControls(props: VacuumControlsProps): JSX.Element {
       ? VACUUM_VENT_SET_CLOSED
       : VACUUM_VENT_SET_OPEN
 
-  return (
-    <div className={styles.vacuum_controls_root}>
-      {/* State / Profile selection */}
+  const sections: ReactNode[] = []
+
+  // 1. State / Profile selection (always)
+  sections.push(
+    <VacuumControlsGroup
+      key="program-type"
+      title={t('vacuum.controls.label')}
+      options={[
+        {
+          label: t('vacuum.controls.options.state'),
+          value: VACUUM_PROGRAM_STATE,
+        },
+        {
+          label: t('vacuum.controls.options.profile'),
+          value: VACUUM_PROGRAM_PROFILE,
+        },
+      ]}
+      selectedValue={formData.programType}
+      onChange={handleProgramTypeChange}
+    />
+  )
+
+  // 2. Pump / Vent selection (when State program)
+  if (formData.programType === VACUUM_PROGRAM_STATE) {
+    sections.push(
       <VacuumControlsGroup
-        title={t('vacuum.controls.label')}
+        key="state-type"
+        title={t('vacuum.controls.state.label')}
         options={[
           {
-            label: t('vacuum.controls.options.state'),
-            value: VACUUM_PROGRAM_STATE,
+            label: t('vacuum.controls.state.options.pump'),
+            value: VACUUM_STATE_PUMP,
           },
           {
-            label: t('vacuum.controls.options.profile'),
-            value: VACUUM_PROGRAM_PROFILE,
+            label: t(`vacuum.controls.state.options.vent.${ventToSwitch}`),
+            value: ventToSwitch,
           },
         ]}
-        selectedValue={formData.programType}
-        onChange={handleProgramTypeChange}
+        selectedValue={formData.stateType}
+        onChange={handleStateTypeChange}
       />
-      {formData.programType != null && <Divider marginY="0" />}
-      {formData.programType === VACUUM_PROGRAM_STATE && (
-        <>
-          {/* Pump / Vent selection */}
-          <VacuumControlsGroup
-            title={t('vacuum.controls.state.label')}
-            options={[
-              {
-                label: t('vacuum.controls.state.options.pump'),
-                value: VACUUM_STATE_PUMP,
-              },
-              {
-                label: t(`vacuum.controls.state.options.vent.${ventToSwitch}`),
-                value: ventToSwitch,
-              },
-            ]}
-            selectedValue={formData.stateType}
-            onChange={handleStateTypeChange}
-          />
-          {formData.stateType === VACUUM_STATE_PUMP && <Divider marginY="0" />}
-          {/* Pressure / Power selection */}
-          {formData.stateType === VACUUM_STATE_PUMP && (
-            <VacuumControlsGroup
-              title={t('vacuum.controls.mode.label')}
-              options={[
-                {
-                  label: t('vacuum.controls.mode.options.pressure.label'),
-                  value: VACUUM_MODE_PRESSURE,
-                  description: t(
-                    'vacuum.controls.mode.options.pressure.description'
-                  ),
-                },
-                {
-                  label: t('vacuum.controls.mode.options.power.label'),
-                  value: VACUUM_MODE_POWER,
-                  description: t(
-                    'vacuum.controls.mode.options.power.description'
-                  ),
-                },
-              ]}
-              selectedValue={formData.modeType}
-              onChange={handleModeTypeChange}
-              titleTooltip={t('vacuum.controls.mode.tooltip')}
-            />
-          )}
-          {formData.modeType != null && <Divider marginY="0" />}
-          {formData.stateType === VACUUM_STATE_PUMP && (
-            <VacuumPumpControls
-              formData={formData}
-              propsForFields={propsForFields}
-            />
-          )}
-        </>
-      )}
-      {formData.programType === VACUUM_PROGRAM_PROFILE &&
-        'TODO: ADD PROFILE CONTENT'}
+    )
+  }
+
+  // 4. Pressure / Power mode selection (when Pump state or Profile program)
+  if (
+    formData.stateType === VACUUM_STATE_PUMP ||
+    formData.programType === VACUUM_PROGRAM_PROFILE
+  ) {
+    sections.push(
+      <VacuumControlsGroup
+        key="mode-type"
+        title={t('vacuum.controls.mode.label')}
+        options={[
+          {
+            label: t('vacuum.controls.mode.options.pressure.label'),
+            value: VACUUM_MODE_PRESSURE,
+            description: t('vacuum.controls.mode.options.pressure.description'),
+          },
+          {
+            label: t('vacuum.controls.mode.options.power.label'),
+            value: VACUUM_MODE_POWER,
+            description: t('vacuum.controls.mode.options.power.description'),
+          },
+        ]}
+        selectedValue={formData.modeType}
+        onChange={handleModeTypeChange}
+        titleTooltip={t('vacuum.controls.mode.tooltip')}
+      />
+    )
+  }
+
+  // 3. Pump controls (when State + Pump)
+  if (
+    formData.programType === VACUUM_PROGRAM_STATE &&
+    formData.stateType === VACUUM_STATE_PUMP
+  ) {
+    sections.push(
+      <VacuumPumpControls
+        key="pump-controls"
+        formData={formData}
+        propsForFields={propsForFields}
+      />
+    )
+  }
+
+  // 5. Profile steps (when Profile program + mode selected)
+  if (
+    formData.programType === VACUUM_PROGRAM_PROFILE &&
+    formData.modeType != null
+  ) {
+    const numSavedStepsInProfile = formData.orderedProfileIds.length
+    sections.push(
+      <Flex
+        key="profile-steps"
+        flexDirection={DIRECTION_COLUMN}
+        gridGap={SPACING.spacing12}
+        paddingX={SPACING.spacing16}
+      >
+        <StyledText desktopStyle="bodyDefaultSemiBold">
+          {t('vacuum.controls.profile.profile_steps')}
+        </StyledText>
+        <ListButton
+          type="noActive"
+          onClick={() => {
+            setShowProfileModal(true)
+          }}
+          padding={SPACING.spacing12}
+        >
+          <StyledText desktopStyle="bodyDefaultRegular">
+            {numSavedStepsInProfile > 0
+              ? t(
+                  `vacuum.controls.profile.profile_defined_${numSavedStepsInProfile > 1 ? 'multiple' : 'single'}`,
+                  {
+                    numSteps: numSavedStepsInProfile,
+                  }
+                )
+              : t('vacuum.controls.profile.no_profile_defined')}
+          </StyledText>
+        </ListButton>
+      </Flex>
+    )
+    sections.push(
+      <Flex key="ending-hold" paddingX={SPACING.spacing16}>
+        <EndingHoldField formData={formData} propsForFields={propsForFields} />
+      </Flex>
+    )
+  }
+
+  return (
+    <div className={styles.vacuum_controls_root}>
+      {sections.map((section, index) => (
+        <Fragment key={index}>
+          {index > 0 && <Divider marginY="0" />}
+          {section}
+        </Fragment>
+      ))}
+      {showProfileModal &&
+        formData.modeType != null &&
+        // Safety check. in practice, modeType can not be null here
+        createPortal(
+          <VacuumProfileModal
+            formData={formData}
+            propsForFields={propsForFields}
+            mode={formData.modeType}
+            onClose={() => {
+              setShowProfileModal(false)
+            }}
+          />,
+          getMainPagePortalEl()
+        )}
     </div>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumControls.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumControls.tsx
@@ -79,7 +79,7 @@ export function VacuumControls(props: VacuumControlsProps): JSX.Element {
 
   const sections: ReactNode[] = []
 
-  // 1. State / Profile selection (always)
+  // State / Profile
   sections.push(
     <VacuumControlsGroup
       key="program-type"
@@ -99,7 +99,7 @@ export function VacuumControls(props: VacuumControlsProps): JSX.Element {
     />
   )
 
-  // 2. Pump / Vent selection (when State program)
+  // Pump / Vent
   if (formData.programType === VACUUM_PROGRAM_STATE) {
     sections.push(
       <VacuumControlsGroup
@@ -121,7 +121,7 @@ export function VacuumControls(props: VacuumControlsProps): JSX.Element {
     )
   }
 
-  // 4. Pressure / Power mode selection (when Pump state or Profile program)
+  // Pressure / Power
   if (
     formData.stateType === VACUUM_STATE_PUMP ||
     formData.programType === VACUUM_PROGRAM_PROFILE
@@ -149,7 +149,7 @@ export function VacuumControls(props: VacuumControlsProps): JSX.Element {
     )
   }
 
-  // 3. Pump controls (when State + Pump)
+  // Pump controls
   if (
     formData.programType === VACUUM_PROGRAM_STATE &&
     formData.stateType === VACUUM_STATE_PUMP
@@ -163,7 +163,7 @@ export function VacuumControls(props: VacuumControlsProps): JSX.Element {
     )
   }
 
-  // 5. Profile steps (when Profile program + mode selected)
+  // Profile steps
   if (
     formData.programType === VACUUM_PROGRAM_PROFILE &&
     formData.modeType != null

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumCycle.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumCycle.tsx
@@ -7,7 +7,6 @@ import {
   ListItem,
 } from '@opentrons/components'
 
-import { useKitchen } from '/protocol-designer/components/organisms/Kitchen/useKitchen'
 import { maskToPositiveInteger } from '/protocol-designer/steplist/fieldLevel/processing'
 
 import { PROFILE_CYCLE } from './constants'
@@ -47,7 +46,6 @@ export function PresavedVacuumCycle(
     mode,
   } = props
   const { t } = useTranslation('protocol_steps')
-  const { makeSnackbar } = useKitchen()
 
   const {
     localOrderedProfileStepIds,
@@ -70,9 +68,6 @@ export function PresavedVacuumCycle(
     repetitions,
     mode,
     onSaveCycle: handleSaveCycle,
-    onRepetitionsError: () => {
-      makeSnackbar(t('vacuum.controls.profile.repetitions_error') as string)
-    },
     handleAddCycleStep,
   })
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumCycle.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumCycle.tsx
@@ -1,0 +1,161 @@
+import { useTranslation } from 'react-i18next'
+
+import {
+  BasicButton,
+  DIRECTION_COLUMN,
+  InputField,
+  ListItem,
+} from '@opentrons/components'
+
+import { useKitchen } from '/protocol-designer/components/organisms/Kitchen/useKitchen'
+import { maskToPositiveInteger } from '/protocol-designer/steplist/fieldLevel/processing'
+
+import { PROFILE_CYCLE } from './constants'
+import { usePresavedCycleState } from './hooks/usePresavedCycleState'
+import { PresavedVacuumHeader } from './PresavedVacuumHeader'
+import { PresavedVacuumStep } from './PresavedVacuumStep'
+import { SavedVacuumStep } from './SavedVacuumStep'
+import styles from './vacuumprofile.module.css'
+
+import type {
+  VACUUM_MODE_POWER,
+  VACUUM_MODE_PRESSURE,
+} from '@opentrons/step-generation'
+import type {
+  PresavedVacuumCycleSavePayload,
+  VacuumCycleBaseProps,
+} from './types'
+
+export interface PresavedVacuumCycleProps extends VacuumCycleBaseProps {
+  repetitions: number
+  handleSaveCycle: (data: PresavedVacuumCycleSavePayload) => void
+  handleAddCycleStep?: (stepId: string) => void
+  mode?: typeof VACUUM_MODE_PRESSURE | typeof VACUUM_MODE_POWER
+}
+
+export function PresavedVacuumCycle(
+  props: PresavedVacuumCycleProps
+): JSX.Element {
+  const {
+    orderedProfileStepIds,
+    profileStepItemsById,
+    repetitions,
+    displayIndex,
+    onDelete,
+    handleSaveCycle,
+    handleAddCycleStep,
+    mode,
+  } = props
+  const { t } = useTranslation('protocol_steps')
+  const { makeSnackbar } = useKitchen()
+
+  const {
+    localOrderedProfileStepIds,
+    localProfileStepItemsById,
+    localRepetitions,
+    setLocalRepetitions,
+    showCycleErrors,
+    showRepetitionErrors,
+    isRepetitionError,
+    invalidStepIds,
+    handleStepChange,
+    handleDeleteStep,
+    handleEditStep,
+    handleAddStep,
+    saveCycle: onSaveCycle,
+    allowDeleteStep,
+  } = usePresavedCycleState({
+    orderedProfileStepIds,
+    profileStepItemsById,
+    repetitions,
+    mode,
+    onSaveCycle: handleSaveCycle,
+    onRepetitionsError: () => {
+      makeSnackbar(t('vacuum.controls.profile.repetitions_error') as string)
+    },
+    handleAddCycleStep,
+  })
+
+  return (
+    <ListItem
+      type="default"
+      className={styles.presaved_vacuum_cycle_container}
+      flexDirection={DIRECTION_COLUMN}
+      padding={0}
+    >
+      <div className={styles.presaved_vacuum_cycle_content}>
+        <PresavedVacuumHeader
+          displayIndex={displayIndex}
+          variant={PROFILE_CYCLE}
+          onDelete={onDelete}
+          onSave={onSaveCycle}
+        />
+        <div className={styles.presaved_content}>
+          <ListItem type="default" padding={0}>
+            <div className={styles.cycle_steps_list}>
+              {localOrderedProfileStepIds.map(
+                (stepId: string, stepIndex: number) => {
+                  const stepData = localProfileStepItemsById[stepId]
+                  if (stepData == null) return null
+                  const { id } = stepData
+                  return stepData.isPresaved ? (
+                    <PresavedVacuumStep
+                      key={id}
+                      displayIndex={`${displayIndex}.${stepIndex + 1}`}
+                      stepData={stepData}
+                      onSaveSuccess={() => {}}
+                      onDelete={() => {
+                        handleDeleteStep(id)
+                      }}
+                      onStepChange={handleStepChange}
+                      isNested
+                      allowDelete={allowDeleteStep}
+                      forceShowErrors={
+                        showCycleErrors && invalidStepIds.includes(id)
+                      }
+                    />
+                  ) : (
+                    <SavedVacuumStep
+                      key={id}
+                      displayIndex={`${displayIndex}.${stepIndex + 1}`}
+                      stepData={stepData}
+                      onDelete={() => {
+                        handleDeleteStep(id)
+                      }}
+                      onEdit={() => {
+                        handleEditStep(id)
+                      }}
+                      isNested
+                      allowDelete={allowDeleteStep}
+                    />
+                  )
+                }
+              )}
+              <div className={styles.presaved_vacuum_cycle_add_step_row}>
+                <BasicButton onClick={handleAddStep}>
+                  {t('vacuum.controls.profile.add_cycle_step')}
+                </BasicButton>{' '}
+              </div>
+            </div>
+          </ListItem>
+          <div className={styles.flex_fill}>
+            <InputField
+              title={t('vacuum.controls.profile.repetitions')}
+              value={localRepetitions}
+              onChange={e => {
+                setLocalRepetitions(
+                  Number(maskToPositiveInteger(e.currentTarget.value))
+                )
+              }}
+              error={
+                showRepetitionErrors && isRepetitionError
+                  ? t('vacuum.controls.profile.errors.repetitions')
+                  : null
+              }
+            />
+          </div>
+        </div>
+      </div>
+    </ListItem>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumCycle.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumCycle.tsx
@@ -28,8 +28,8 @@ import type {
 export interface PresavedVacuumCycleProps extends VacuumCycleBaseProps {
   repetitions: number
   handleSaveCycle: (data: PresavedVacuumCycleSavePayload) => void
+  mode: typeof VACUUM_MODE_PRESSURE | typeof VACUUM_MODE_POWER
   handleAddCycleStep?: (stepId: string) => void
-  mode?: typeof VACUUM_MODE_PRESSURE | typeof VACUUM_MODE_POWER
 }
 
 export function PresavedVacuumCycle(
@@ -98,7 +98,6 @@ export function PresavedVacuumCycle(
                       key={id}
                       displayIndex={`${displayIndex}.${stepIndex + 1}`}
                       stepData={stepData}
-                      onSaveSuccess={() => {}}
                       onDelete={() => {
                         handleDeleteStep(id)
                       }}
@@ -129,7 +128,7 @@ export function PresavedVacuumCycle(
               <div className={styles.presaved_vacuum_cycle_add_step_row}>
                 <BasicButton onClick={handleAddStep}>
                   {t('vacuum.controls.profile.add_cycle_step')}
-                </BasicButton>{' '}
+                </BasicButton>
               </div>
             </div>
           </ListItem>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumHeader.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumHeader.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next'
+
+import {
+  BasicButton,
+  StyledText,
+  Tag,
+  TertiaryButton,
+} from '@opentrons/components'
+
+import { PROFILE_STEP } from './constants'
+import styles from './vacuumprofile.module.css'
+
+import type { PROFILE_CYCLE } from './constants'
+
+export interface PresavedVacuumHeaderProps {
+  displayIndex: string
+  variant: typeof PROFILE_STEP | typeof PROFILE_CYCLE
+  onDelete: () => void
+  onSave: () => void
+  showActions?: boolean
+}
+
+export function PresavedVacuumHeader(
+  props: PresavedVacuumHeaderProps
+): JSX.Element {
+  const { displayIndex, variant, onDelete, onSave, showActions = true } = props
+  const { t } = useTranslation('protocol_steps')
+
+  return (
+    <div className={styles.presaved_vacuum_header}>
+      <div className={styles.flex_row_gap_24}>
+        <Tag text={displayIndex} type="default" shrinkToContent />
+        <StyledText desktopStyle="bodyDefaultRegular">
+          {t(
+            `vacuum.controls.profile.${variant === PROFILE_STEP ? 'step' : 'cycle'}`
+          )}
+        </StyledText>
+      </div>
+      {showActions && (
+        <div className={styles.flex_row_gap_8}>
+          <BasicButton onClick={onDelete} underLine>
+            {t('vacuum.controls.profile.delete')}
+          </BasicButton>
+          <TertiaryButton buttonType="primary" onClick={onSave}>
+            {t('vacuum.controls.profile.save')}
+          </TertiaryButton>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumStep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumStep.tsx
@@ -1,0 +1,194 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import {
+  COLORS,
+  Icon,
+  InputField,
+  ListItem,
+  Slider,
+} from '@opentrons/components'
+import {
+  VACUUM_MAX_PRESSURE_MBAR,
+  VACUUM_MIN_PRESSURE_MBAR,
+  VACUUM_MODE_POWER,
+  VACUUM_MODE_PRESSURE,
+} from '@opentrons/step-generation'
+
+import {
+  maskToSignedDecimal,
+  maskToTimeMMSS,
+} from '/protocol-designer/steplist/fieldLevel/processing'
+
+import { PROFILE_STEP } from './constants'
+import { PresavedVacuumHeader } from './PresavedVacuumHeader'
+import { getFormattedTime, getStepErrors } from './utils'
+import styles from './vacuumprofile.module.css'
+
+import type {
+  VacuumPumpData,
+  VacuumStepBaseProps,
+  VacuumStepData,
+} from './types'
+
+export interface PresavedVacuumStepProps extends VacuumStepBaseProps {
+  onSaveSuccess: (stepData: VacuumStepData) => void
+  onStepChange: (stepId: string, patch: Partial<VacuumStepData>) => void
+  /** When true, show validation errors on this step (e.g. when cycle Save is blocked). */
+  forceShowErrors?: boolean
+}
+
+export function PresavedVacuumStep(
+  props: PresavedVacuumStepProps
+): JSX.Element {
+  const {
+    stepData,
+    displayIndex,
+    onSaveSuccess,
+    onDelete,
+    isNested,
+    onStepChange,
+    allowDelete = true,
+    forceShowErrors = false,
+  } = props
+  const [showErrors, setShowErrors] = useState<boolean>(false)
+  const { t } = useTranslation('protocol_steps')
+
+  const { name, time, pumpData } = stepData
+
+  const updateField = (
+    field: 'name' | 'time' | 'pumpData',
+    value: string | Partial<VacuumPumpData>
+  ): void => {
+    if (field === 'pumpData') {
+      const patch = value as Partial<VacuumPumpData>
+      const nextPumpData: VacuumPumpData =
+        stepData.pumpData.mode === VACUUM_MODE_PRESSURE
+          ? {
+              mode: VACUUM_MODE_PRESSURE,
+              pressureMbar:
+                'pressureMbar' in patch && patch.pressureMbar !== undefined
+                  ? patch.pressureMbar
+                  : stepData.pumpData.pressureMbar,
+            }
+          : {
+              mode: VACUUM_MODE_POWER,
+              powerPercent:
+                'powerPercent' in patch && patch.powerPercent !== undefined
+                  ? patch.powerPercent
+                  : stepData.pumpData.powerPercent,
+            }
+      onStepChange(stepData.id, { pumpData: nextPumpData })
+    } else {
+      onStepChange(stepData.id, { [field]: value })
+    }
+  }
+
+  const errors = getStepErrors(stepData)
+  const showValidationErrors = showErrors || forceShowErrors
+
+  const handleSave = (): void => {
+    if (Object.values(errors).some(error => error)) {
+      setShowErrors(true)
+      return
+    }
+    const formattedTime = getFormattedTime(time)
+    onSaveSuccess({
+      ...stepData,
+      time: formattedTime,
+    })
+  }
+
+  return (
+    <ListItem
+      type="default"
+      backgroundColor={isNested ? COLORS.grey10 : COLORS.grey20}
+      padding={0}
+    >
+      <div className={styles.presaved_vacuum_step_content}>
+        {!isNested && (
+          <PresavedVacuumHeader
+            displayIndex={displayIndex}
+            variant={PROFILE_STEP}
+            onDelete={onDelete}
+            onSave={handleSave}
+            showActions={allowDelete}
+          />
+        )}
+        <div className={styles.presaved_content}>
+          <div className={styles.presaved_vacuum_step_form_row}>
+            <div className={styles.flex_fill}>
+              <InputField
+                title={t('vacuum.controls.profile.name')}
+                value={name}
+                onChange={e => {
+                  updateField('name', e.currentTarget.value)
+                }}
+                error={
+                  showValidationErrors && errors.name
+                    ? t('vacuum.controls.profile.errors.name')
+                    : null
+                }
+              />
+            </div>
+            <div className={styles.flex_fill}>
+              {pumpData.mode === VACUUM_MODE_PRESSURE ? (
+                <InputField
+                  title={t('vacuum.controls.profile.gauge_pressure')}
+                  value={pumpData.pressureMbar}
+                  caption={t('vacuum.controls.mode.pressure.caption', {
+                    min: VACUUM_MIN_PRESSURE_MBAR,
+                    max: VACUUM_MAX_PRESSURE_MBAR,
+                  })}
+                  onChange={e => {
+                    const maskedPressure = maskToSignedDecimal(
+                      e.currentTarget.value
+                    )
+                    updateField('pumpData', { pressureMbar: maskedPressure })
+                  }}
+                  units={t('application:units.millibar')}
+                  error={
+                    showValidationErrors && errors.pumpData
+                      ? t('vacuum.controls.profile.errors.pumpData')
+                      : null
+                  }
+                />
+              ) : (
+                <Slider
+                  value={pumpData.powerPercent}
+                  label={t('vacuum.controls.profile.pump_power')}
+                  adjustValue={value => {
+                    updateField('pumpData', { powerPercent: value })
+                  }}
+                  backgroundColor={COLORS.grey35}
+                  type="small"
+                />
+              )}
+            </div>
+            <div className={styles.flex_fill}>
+              <InputField
+                title={t('vacuum.controls.profile.time')}
+                value={time}
+                onChange={e => {
+                  const maskedTime = maskToTimeMMSS(e.currentTarget.value)
+                  updateField('time', maskedTime)
+                }}
+                units={t('application:units.time')}
+                error={
+                  showValidationErrors && errors.time
+                    ? t('vacuum.controls.profile.errors.time')
+                    : null
+                }
+              />
+            </div>
+            {isNested && allowDelete ? (
+              <div className={styles.delete_button} onClick={onDelete}>
+                <Icon name="close" size="1.5rem" />
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </ListItem>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumStep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumStep.tsx
@@ -32,8 +32,9 @@ import type {
 } from './types'
 
 export interface PresavedVacuumStepProps extends VacuumStepBaseProps {
-  onSaveSuccess: (stepData: VacuumStepData) => void
   onStepChange: (stepId: string, patch: Partial<VacuumStepData>) => void
+  /** Not required when nested, since save behavior is handled by parent cycle */
+  onSaveSuccess?: (stepData: VacuumStepData) => void
   /** When true, show validation errors on this step (e.g. when cycle Save is blocked). */
   forceShowErrors?: boolean
 }
@@ -93,7 +94,7 @@ export function PresavedVacuumStep(
       return
     }
     const formattedTime = getFormattedTime(time)
-    onSaveSuccess({
+    onSaveSuccess?.({
       ...stepData,
       time: formattedTime,
     })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/SavedVacuumCycle.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/SavedVacuumCycle.tsx
@@ -61,7 +61,9 @@ export function SavedVacuumCycle(props: SavedVacuumCycleProps): JSX.Element {
           <div className={styles.cycle_steps_list}>
             {orderedProfileStepIds.map((stepId: string, stepIndex: number) => {
               const stepData = profileStepItemsById[stepId]
-              if (stepData == null) return null
+              if (stepData == null) {
+                return null
+              }
               const { id } = stepData
               return (
                 <SavedVacuumStep

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/SavedVacuumCycle.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/SavedVacuumCycle.tsx
@@ -1,0 +1,87 @@
+import { useTranslation } from 'react-i18next'
+
+import {
+  BasicButton,
+  Icon,
+  ListItem,
+  StyledText,
+  Tag,
+} from '@opentrons/components'
+
+import { SavedVacuumStep } from './SavedVacuumStep'
+import styles from './vacuumprofile.module.css'
+
+import type { VacuumCycleBaseProps } from './types'
+
+export interface SavedVacuumCycleProps extends VacuumCycleBaseProps {
+  cycleId: string
+  onEdit: (cycleId: string) => void
+  onDeleteStep: (stepId: string) => void
+}
+
+export function SavedVacuumCycle(props: SavedVacuumCycleProps): JSX.Element {
+  const {
+    orderedProfileStepIds,
+    profileStepItemsById,
+    displayIndex,
+    cycleId,
+    onEdit,
+    onDelete,
+    onDeleteStep,
+  } = props
+  const { t } = useTranslation('protocol_steps')
+
+  return (
+    <ListItem type="default" padding={0}>
+      <div className={styles.saved_vacuum_cycle_content}>
+        <div className={styles.saved_vacuum_cycle_header}>
+          <div className={styles.saved_vacuum_cycle_header_row}>
+            <div className={styles.flex_row_gap_24}>
+              <Tag text={displayIndex} type="default" shrinkToContent />
+              <StyledText desktopStyle="bodyDefaultRegular">
+                {t('vacuum.controls.profile.cycle')}
+              </StyledText>
+            </div>
+            <div className={styles.flex_row_gap_8}>
+              <BasicButton
+                onClick={() => {
+                  onEdit(cycleId)
+                }}
+                underLine
+              >
+                {t('vacuum.controls.profile.edit')}
+              </BasicButton>
+              <div className={styles.delete_button} onClick={onDelete}>
+                <Icon name="close" size="1.5rem" />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className={styles.saved_vacuum_cycle_steps_container}>
+          <div className={styles.cycle_steps_list}>
+            {orderedProfileStepIds.map((stepId: string, stepIndex: number) => {
+              const stepData = profileStepItemsById[stepId]
+              if (stepData == null) return null
+              const { id } = stepData
+              return (
+                <SavedVacuumStep
+                  key={id}
+                  displayIndex={`${displayIndex}.${stepIndex + 1}`}
+                  stepData={stepData}
+                  onDelete={() => {
+                    onDeleteStep(id)
+                  }}
+                  onEdit={() => {
+                    onEdit(cycleId)
+                  }}
+                  isNested
+                  allowDelete={orderedProfileStepIds.length > 1}
+                />
+              )
+            })}
+          </div>
+        </div>
+      </div>
+    </ListItem>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/SavedVacuumStep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/SavedVacuumStep.tsx
@@ -1,0 +1,74 @@
+import { useTranslation } from 'react-i18next'
+
+import {
+  BasicButton,
+  COLORS,
+  Icon,
+  ListItem,
+  SPACING,
+  StyledText,
+  Tag,
+} from '@opentrons/components'
+import { VACUUM_MODE_PRESSURE } from '@opentrons/step-generation'
+
+import styles from './vacuumprofile.module.css'
+
+import type { VacuumStepBaseProps } from './types'
+
+export interface SavedVacuumStepProps extends VacuumStepBaseProps {
+  onEdit: (id: string) => void
+}
+
+export function SavedVacuumStep(props: SavedVacuumStepProps): JSX.Element {
+  const {
+    stepData,
+    displayIndex,
+    isNested,
+    onDelete,
+    onEdit,
+    allowDelete = true,
+  } = props
+  const { name, time, pumpData } = stepData
+  const { mode } = pumpData
+  const { t } = useTranslation('protocol_steps')
+  const formattedPumpDetail =
+    mode === VACUUM_MODE_PRESSURE
+      ? t('vacuum.controls.profile.step_detail.pressure', {
+          pressure: pumpData.pressureMbar,
+        })
+      : t('vacuum.controls.profile.step_detail.power', {
+          power: pumpData.powerPercent,
+        })
+  return (
+    <ListItem
+      type="default"
+      padding={SPACING.spacing12}
+      backgroundColor={isNested ? COLORS.grey10 : COLORS.grey20}
+      className={styles.saved_vacuum_step_row}
+    >
+      <div className={styles.flex_row_gap_24}>
+        <Tag text={displayIndex} type="default" shrinkToContent />
+        <StyledText desktopStyle="bodyDefaultRegular">
+          {[name, formattedPumpDetail, time].join(', ')}
+        </StyledText>
+      </div>
+      <div className={styles.flex_row_gap_8}>
+        {!isNested && (
+          <BasicButton
+            onClick={() => {
+              onEdit(stepData.id)
+            }}
+            underLine
+          >
+            {t('vacuum.controls.profile.edit')}
+          </BasicButton>
+        )}
+        {allowDelete && (
+          <div className={styles.delete_button} onClick={onDelete}>
+            <Icon name="close" size="1.5rem" />
+          </div>
+        )}
+      </div>
+    </ListItem>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/VacuumProfileModal.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/VacuumProfileModal.tsx
@@ -1,0 +1,198 @@
+import { useTranslation } from 'react-i18next'
+
+import {
+  EmptySelectorButton,
+  InfoScreen,
+  Modal,
+  PrimaryButton,
+  SecondaryButton,
+  SPACING,
+} from '@opentrons/components'
+
+import { useKitchen } from '/protocol-designer/components/organisms/Kitchen/useKitchen'
+
+import { PROFILE_CYCLE, PROFILE_STEP } from './constants'
+import { useVacuumProfileState } from './hooks/useVacuumProfileState'
+import { PresavedVacuumCycle } from './PresavedVacuumCycle'
+import { PresavedVacuumStep } from './PresavedVacuumStep'
+import { SavedVacuumCycle } from './SavedVacuumCycle'
+import { SavedVacuumStep } from './SavedVacuumStep'
+import styles from './vacuumprofile.module.css'
+
+import type {
+  VACUUM_MODE_POWER,
+  VACUUM_MODE_PRESSURE,
+} from '@opentrons/step-generation'
+import type { FormData } from '/protocol-designer/form-types'
+import type { FieldPropsByName } from '../../../types'
+import type { ProfileCycleItem, ProfileStepItem, VacuumStepData } from './types'
+
+export interface VacuumProfileModalProps {
+  formData: FormData
+  propsForFields: FieldPropsByName
+  mode: typeof VACUUM_MODE_PRESSURE | typeof VACUUM_MODE_POWER
+  onClose: () => void
+}
+
+export function VacuumProfileModal(
+  props: VacuumProfileModalProps
+): JSX.Element {
+  const { formData, propsForFields, mode, onClose } = props
+  const { orderedProfileIds, profileItemsById } = formData
+  const { t } = useTranslation('protocol_steps')
+  const { makeSnackbar } = useKitchen()
+
+  const {
+    orderedProfileItemIds: localOrderedProfileItemIds,
+    profileItemsById: localProfileItemsById,
+    addStep: handleAddStep,
+    addCycle: handleAddCycle,
+    deleteStep: handleDeleteStep,
+    deleteCycleStep: handleDeleteCycleStep,
+    stepChange: handleStepChange,
+    saveStepSuccess: onSaveSuccess,
+    editStep: handleEditStep,
+    saveCycle: handleSaveCycle,
+    hasUnsavedPresavedItems,
+  } = useVacuumProfileState({
+    orderedProfileIds,
+    profileItemsById,
+    mode,
+  })
+
+  const handleSaveModal = (): void => {
+    if (localOrderedProfileItemIds.length === 0) {
+      makeSnackbar(t('vacuum.controls.profile.no_steps_defined') as string)
+      return
+    }
+    if (hasUnsavedPresavedItems) {
+      makeSnackbar(t('vacuum.controls.profile.unsaved_changes') as string)
+      return
+    }
+    propsForFields.profileItemsById.updateValue(localProfileItemsById)
+    propsForFields.orderedProfileIds.updateValue(localOrderedProfileItemIds)
+    onClose()
+  }
+
+  const footer = (
+    <div className={styles.vacuum_profile_modal_footer}>
+      <SecondaryButton onClick={onClose}>
+        {t('vacuum.controls.profile.cancel')}
+      </SecondaryButton>
+      <PrimaryButton onClick={handleSaveModal}>
+        {t('vacuum.controls.profile.save')}
+      </PrimaryButton>
+    </div>
+  )
+
+  return (
+    <Modal
+      title={t('vacuum.controls.profile.title')}
+      width="45rem"
+      maxHeight="45rem"
+      childrenPadding={SPACING.spacing24}
+      onClose={onClose}
+      marginLeft="0"
+      footer={footer}
+    >
+      <div className={styles.vacuum_profile_modal_body}>
+        <div className={styles.vacuum_profile_modal_actions}>
+          <div className={styles.empty_selector_button_container}>
+            <EmptySelectorButton
+              text={t('vacuum.controls.profile.add_step')}
+              textAlignment="left"
+              iconName="plus"
+              onClick={handleAddStep}
+            />
+          </div>
+          <div className={styles.empty_selector_button_container}>
+            <EmptySelectorButton
+              text={t('vacuum.controls.profile.add_cycle')}
+              textAlignment="left"
+              iconName="plus"
+              onClick={handleAddCycle}
+            />
+          </div>
+        </div>
+        {localOrderedProfileItemIds.length === 0 ? (
+          <InfoScreen
+            content={t('vacuum.controls.profile.no_steps_defined')}
+            height="27.625rem"
+          />
+        ) : (
+          <div className={styles.vacuum_profile_modal_list}>
+            {localOrderedProfileItemIds.map((id: string, index: number) => {
+              const profileItem = localProfileItemsById[id]
+              if (profileItem.type === PROFILE_STEP) {
+                const stepItem = profileItem as ProfileStepItem
+                return stepItem.isPresaved ? (
+                  <PresavedVacuumStep
+                    key={id}
+                    displayIndex={String(index + 1)}
+                    stepData={stepItem}
+                    onSaveSuccess={(stepData: VacuumStepData) => {
+                      onSaveSuccess(id, stepData)
+                    }}
+                    onStepChange={(_stepId, patch) => {
+                      handleStepChange(id, patch)
+                    }}
+                    onDelete={() => {
+                      handleDeleteStep(id)
+                    }}
+                  />
+                ) : (
+                  <SavedVacuumStep
+                    key={id}
+                    displayIndex={String(index + 1)}
+                    stepData={stepItem}
+                    onDelete={() => {
+                      handleDeleteStep(id)
+                    }}
+                    onEdit={() => {
+                      handleEditStep(id)
+                    }}
+                  />
+                )
+              } else {
+                const cycleItem = profileItem as ProfileCycleItem
+                return profileItem.isPresaved ? (
+                  <PresavedVacuumCycle
+                    key={id}
+                    displayIndex={String(index + 1)}
+                    orderedProfileStepIds={cycleItem.orderedProfileStepIds}
+                    profileStepItemsById={cycleItem.profileStepItemsById}
+                    repetitions={cycleItem.repetitions}
+                    onDelete={() => {
+                      handleDeleteStep(id)
+                    }}
+                    handleSaveCycle={data => {
+                      handleSaveCycle(id, cycleItem, data)
+                    }}
+                    type={PROFILE_CYCLE}
+                    mode={mode}
+                  />
+                ) : (
+                  <SavedVacuumCycle
+                    key={id}
+                    cycleId={id}
+                    displayIndex={String(index + 1)}
+                    orderedProfileStepIds={cycleItem.orderedProfileStepIds}
+                    profileStepItemsById={cycleItem.profileStepItemsById}
+                    onEdit={handleEditStep}
+                    onDeleteStep={stepId => {
+                      handleDeleteCycleStep(id, stepId)
+                    }}
+                    type={PROFILE_CYCLE}
+                    onDelete={() => {
+                      handleDeleteStep(id)
+                    }}
+                  />
+                )
+              }
+            })}
+          </div>
+        )}
+      </div>
+    </Modal>
+  )
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/constants.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/constants.ts
@@ -1,0 +1,2 @@
+export const PROFILE_STEP: 'profileStep' = 'profileStep'
+export const PROFILE_CYCLE: 'profileCycle' = 'profileCycle'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/usePresavedCycleState.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/usePresavedCycleState.ts
@@ -16,7 +16,7 @@ export interface UsePresavedCycleStateArgs {
   orderedProfileStepIds: string[]
   profileStepItemsById: Record<string, ProfileStepItem>
   repetitions: number
-  mode: VacuumMode | undefined
+  mode: VacuumMode
   onSaveCycle: (data: PresavedVacuumCycleSavePayload) => void
   handleAddCycleStep?: (stepId: string) => void
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/usePresavedCycleState.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/usePresavedCycleState.ts
@@ -1,0 +1,163 @@
+import { useState } from 'react'
+
+import { uuid } from '/protocol-designer/utils'
+
+import { PROFILE_STEP } from '../constants'
+import { getDefaultStepData, getInvalidPresavedStepIds } from '../utils'
+
+import type {
+  PresavedVacuumCycleSavePayload,
+  ProfileStepItem,
+  VacuumStepData,
+} from '../types'
+import type { VacuumMode } from '../utils'
+
+export interface UsePresavedCycleStateArgs {
+  orderedProfileStepIds: string[]
+  profileStepItemsById: Record<string, ProfileStepItem>
+  repetitions: number
+  mode: VacuumMode | undefined
+  onSaveCycle: (data: PresavedVacuumCycleSavePayload) => void
+  onRepetitionsError?: () => void
+  handleAddCycleStep?: (stepId: string) => void
+}
+
+export function usePresavedCycleState(args: UsePresavedCycleStateArgs): {
+  localOrderedProfileStepIds: string[]
+  localProfileStepItemsById: Record<string, ProfileStepItem>
+  localRepetitions: number
+  setLocalRepetitions: (value: number | ((prev: number) => number)) => void
+  showCycleErrors: boolean
+  setShowCycleErrors: (value: boolean) => void
+  showRepetitionErrors: boolean
+  setShowRepetitionErrors: (value: boolean) => void
+  isRepetitionError: boolean
+  invalidStepIds: string[]
+  defaultStepData: VacuumStepData
+  handleStepChange: (stepId: string, patch: Partial<VacuumStepData>) => void
+  handleDeleteStep: (stepId: string) => void
+  handleEditStep: (stepId: string) => void
+  handleAddStep: () => void
+  saveCycle: () => void
+  allowDeleteStep: boolean
+} {
+  const {
+    orderedProfileStepIds,
+    profileStepItemsById,
+    repetitions,
+    mode,
+    onSaveCycle,
+    onRepetitionsError,
+    handleAddCycleStep,
+  } = args
+
+  const [localOrderedProfileStepIds, setLocalOrderedProfileStepIds] = useState<
+    string[]
+  >(orderedProfileStepIds)
+  const [localProfileStepItemsById, setLocalProfileStepItemsById] =
+    useState<Record<string, ProfileStepItem>>(profileStepItemsById)
+  const [localRepetitions, setLocalRepetitions] = useState<number>(repetitions)
+  const [showCycleErrors, setShowCycleErrors] = useState<boolean>(false)
+  const [showRepetitionErrors, setShowRepetitionErrors] =
+    useState<boolean>(false)
+
+  const defaultStepData = getDefaultStepData(mode)
+  const isRepetitionError = localRepetitions == null || localRepetitions < 1
+  const invalidStepIds = getInvalidPresavedStepIds(
+    localOrderedProfileStepIds,
+    localProfileStepItemsById
+  )
+  const allowDeleteStep = localOrderedProfileStepIds.length > 1
+
+  const handleStepChange = (
+    stepId: string,
+    patch: Partial<VacuumStepData>
+  ): void => {
+    setLocalProfileStepItemsById(prev => ({
+      ...prev,
+      [stepId]: {
+        ...prev[stepId],
+        ...patch,
+        type: PROFILE_STEP,
+      },
+    }))
+  }
+
+  const handleDeleteStep = (stepId: string): void => {
+    setLocalOrderedProfileStepIds(prev => prev.filter(id => id !== stepId))
+    setLocalProfileStepItemsById(prev =>
+      Object.entries(prev).reduce((acc, [key, value]) => {
+        if (key === stepId) {
+          return acc
+        }
+        return { ...acc, [key]: value }
+      }, {})
+    )
+    handleAddCycleStep?.(stepId)
+  }
+
+  const handleEditStep = (stepId: string): void => {
+    setLocalProfileStepItemsById(prev => ({
+      ...prev,
+      [stepId]: {
+        ...prev[stepId],
+        isPresaved: true,
+      },
+    }))
+  }
+
+  const handleAddStep = (): void => {
+    const id = uuid()
+    const newStep: ProfileStepItem = {
+      ...defaultStepData,
+      id,
+      isPresaved: true,
+      type: PROFILE_STEP,
+    }
+    setLocalOrderedProfileStepIds(prev => [...prev, id])
+    setLocalProfileStepItemsById(prev => ({
+      ...prev,
+      [id]: newStep,
+    }))
+    handleAddCycleStep?.(id)
+  }
+
+  const saveCycle = (): void => {
+    if (invalidStepIds.length > 0) {
+      setShowCycleErrors(true)
+      return
+    }
+    if (isRepetitionError) {
+      setShowRepetitionErrors(true)
+      onRepetitionsError?.()
+      return
+    }
+    setShowCycleErrors(false)
+    setShowRepetitionErrors(false)
+    onSaveCycle({
+      orderedProfileStepIds: localOrderedProfileStepIds,
+      profileStepItemsById: localProfileStepItemsById,
+      repetitions: localRepetitions,
+    })
+  }
+
+  return {
+    localOrderedProfileStepIds,
+    localProfileStepItemsById,
+    localRepetitions,
+    setLocalRepetitions,
+    showCycleErrors,
+    setShowCycleErrors,
+    showRepetitionErrors,
+    setShowRepetitionErrors,
+    isRepetitionError,
+    invalidStepIds,
+    defaultStepData,
+    handleStepChange,
+    handleDeleteStep,
+    handleEditStep,
+    handleAddStep,
+    saveCycle,
+    allowDeleteStep,
+  }
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/usePresavedCycleState.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/usePresavedCycleState.ts
@@ -18,7 +18,6 @@ export interface UsePresavedCycleStateArgs {
   repetitions: number
   mode: VacuumMode | undefined
   onSaveCycle: (data: PresavedVacuumCycleSavePayload) => void
-  onRepetitionsError?: () => void
   handleAddCycleStep?: (stepId: string) => void
 }
 
@@ -47,7 +46,6 @@ export function usePresavedCycleState(args: UsePresavedCycleStateArgs): {
     repetitions,
     mode,
     onSaveCycle,
-    onRepetitionsError,
     handleAddCycleStep,
   } = args
 
@@ -129,7 +127,6 @@ export function usePresavedCycleState(args: UsePresavedCycleStateArgs): {
     }
     if (isRepetitionError) {
       setShowRepetitionErrors(true)
-      onRepetitionsError?.()
       return
     }
     setShowCycleErrors(false)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/useVacuumProfileState.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/useVacuumProfileState.ts
@@ -1,0 +1,191 @@
+import { useState } from 'react'
+
+import { uuid } from '/protocol-designer/utils'
+
+import { PROFILE_CYCLE, PROFILE_STEP } from '../constants'
+import { getDefaultStepData } from '../utils'
+
+import type {
+  PresavedVacuumCycleSavePayload,
+  ProfileCycleItem,
+  ProfileItem,
+  ProfileStepItem,
+  VacuumStepData,
+} from '../types'
+import type { VacuumMode } from '../utils'
+
+export interface UseVacuumProfileStateArgs {
+  orderedProfileIds: string[]
+  profileItemsById: Record<string, ProfileItem>
+  mode: VacuumMode
+}
+
+export function useVacuumProfileState(args: UseVacuumProfileStateArgs): {
+  orderedProfileItemIds: string[]
+  profileItemsById: Record<string, ProfileItem>
+  addStep: () => void
+  addCycle: () => void
+  deleteStep: (stepId: string) => void
+  deleteCycleStep: (cycleId: string, stepId: string) => void
+  stepChange: (stepId: string, patch: Partial<VacuumStepData>) => void
+  saveStepSuccess: (stepId: string, stepData: VacuumStepData) => void
+  editStep: (stepId: string) => void
+  saveCycle: (
+    cycleId: string,
+    cycleItem: ProfileCycleItem,
+    data: PresavedVacuumCycleSavePayload
+  ) => void
+  hasUnsavedPresavedItems: boolean
+} {
+  const { orderedProfileIds, profileItemsById, mode } = args
+  const [orderedProfileItemIds, setOrderedProfileItemIds] =
+    useState<string[]>(orderedProfileIds)
+  const [itemsById, setItemsById] =
+    useState<Record<string, ProfileItem>>(profileItemsById)
+
+  const defaultStepData = getDefaultStepData(mode)
+
+  const addStep = (): void => {
+    const id = uuid()
+    setOrderedProfileItemIds(prev => [...prev, id])
+    const newStep: ProfileStepItem = {
+      ...defaultStepData,
+      id,
+      isPresaved: true,
+      type: PROFILE_STEP,
+    }
+    setItemsById(prev => ({ ...prev, [id]: newStep }))
+  }
+
+  const saveStepSuccess = (stepId: string, stepData: VacuumStepData): void => {
+    setItemsById(prev => ({
+      ...prev,
+      [stepId]: {
+        ...prev[stepId],
+        ...stepData,
+        isPresaved: false,
+      },
+    }))
+  }
+
+  const stepChange = (stepId: string, patch: Partial<VacuumStepData>): void => {
+    setItemsById(prev => {
+      const current = prev[stepId] as ProfileStepItem | undefined
+      if (current?.type !== PROFILE_STEP) return prev
+      return {
+        ...prev,
+        [stepId]: {
+          ...current,
+          ...patch,
+          type: PROFILE_STEP,
+        },
+      }
+    })
+  }
+
+  const deleteStep = (stepId: string): void => {
+    setOrderedProfileItemIds(prev => prev.filter(id => id !== stepId))
+    setItemsById(prev => {
+      return Object.entries(prev).reduce((acc, [key, value]) => {
+        if (key === stepId) {
+          return acc
+        }
+        return { ...acc, [key]: value }
+      }, {})
+    })
+  }
+
+  const deleteCycleStep = (cycleId: string, stepId: string): void => {
+    setItemsById(prev => {
+      const cycleItem = prev[cycleId] as ProfileCycleItem | undefined
+      if (cycleItem?.type !== PROFILE_CYCLE) return prev
+      const nextOrderedIds = cycleItem.orderedProfileStepIds.filter(
+        id => id !== stepId
+      )
+      const nextStepItemsById = Object.entries(
+        cycleItem.profileStepItemsById
+      ).reduce((acc, [key, value]) => {
+        if (key === stepId) {
+          return acc
+        }
+        return { ...acc, [key]: value }
+      }, {})
+      return {
+        ...prev,
+        [cycleId]: {
+          ...cycleItem,
+          orderedProfileStepIds: nextOrderedIds,
+          profileStepItemsById: nextStepItemsById,
+        },
+      }
+    })
+  }
+
+  const editStep = (stepId: string): void => {
+    setItemsById(prev => ({
+      ...prev,
+      [stepId]: {
+        ...prev[stepId],
+        isPresaved: true,
+      },
+    }))
+  }
+
+  const addCycle = (): void => {
+    const cycleId = uuid()
+    const seedStep = {
+      ...defaultStepData,
+      id: uuid(),
+      isPresaved: true,
+      type: PROFILE_STEP,
+    }
+    setOrderedProfileItemIds(prev => [...prev, cycleId])
+    setItemsById(prev => ({
+      ...prev,
+      [cycleId]: {
+        ...seedStep,
+        id: cycleId,
+        type: PROFILE_CYCLE,
+        orderedProfileStepIds: [seedStep.id],
+        profileStepItemsById: { [seedStep.id]: seedStep },
+        repetitions: 1,
+        isPresaved: true,
+      },
+    }))
+  }
+
+  const saveCycle = (
+    cycleId: string,
+    cycleItem: ProfileCycleItem,
+    data: PresavedVacuumCycleSavePayload
+  ): void => {
+    setItemsById(prev => ({
+      ...prev,
+      [cycleId]: {
+        ...cycleItem,
+        orderedProfileStepIds: data.orderedProfileStepIds,
+        profileStepItemsById: data.profileStepItemsById,
+        repetitions: data.repetitions,
+        isPresaved: false,
+      },
+    }))
+  }
+
+  const hasUnsavedPresavedItems = Object.values(itemsById).some(
+    item => item.isPresaved
+  )
+
+  return {
+    orderedProfileItemIds,
+    profileItemsById: itemsById,
+    addStep,
+    addCycle,
+    deleteStep,
+    deleteCycleStep,
+    stepChange,
+    saveStepSuccess,
+    editStep,
+    saveCycle,
+    hasUnsavedPresavedItems,
+  }
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/useVacuumProfileState.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/useVacuumProfileState.ts
@@ -3,7 +3,7 @@ import { useState } from 'react'
 import { uuid } from '/protocol-designer/utils'
 
 import { PROFILE_CYCLE, PROFILE_STEP } from '../constants'
-import { getDefaultStepData } from '../utils'
+import { getDefaultStepData, getFormattedTime } from '../utils'
 
 import type {
   PresavedVacuumCycleSavePayload,
@@ -159,16 +159,30 @@ export function useVacuumProfileState(args: UseVacuumProfileStateArgs): {
     cycleItem: ProfileCycleItem,
     data: PresavedVacuumCycleSavePayload
   ): void => {
-    setItemsById(prev => ({
-      ...prev,
-      [cycleId]: {
-        ...cycleItem,
-        orderedProfileStepIds: data.orderedProfileStepIds,
-        profileStepItemsById: data.profileStepItemsById,
-        repetitions: data.repetitions,
-        isPresaved: false,
-      },
-    }))
+    setItemsById(prev => {
+      // ensure all cycle items have formatted time when saving cycle
+      const updatedProfileStepItemsById = Object.entries(
+        data.profileStepItemsById
+      ).reduce((acc, [key, value]) => {
+        return {
+          ...acc,
+          [key]: {
+            ...value,
+            time: getFormattedTime(value.time),
+          },
+        }
+      }, {})
+      return {
+        ...prev,
+        [cycleId]: {
+          ...cycleItem,
+          orderedProfileStepIds: data.orderedProfileStepIds,
+          profileStepItemsById: updatedProfileStepItemsById,
+          repetitions: data.repetitions,
+          isPresaved: false,
+        },
+      }
+    })
   }
 
   const hasUnsavedPresavedItems = Object.values(itemsById).some(

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/types.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/types.ts
@@ -1,0 +1,73 @@
+import type {
+  VACUUM_MODE_POWER,
+  VACUUM_MODE_PRESSURE,
+} from '@opentrons/step-generation'
+import type { PROFILE_CYCLE, PROFILE_STEP } from './constants'
+
+export interface VacuumPressureData {
+  mode: typeof VACUUM_MODE_PRESSURE
+  pressureMbar: string | null
+}
+
+export interface VacuumPowerData {
+  mode: typeof VACUUM_MODE_POWER
+  powerPercent: number
+}
+
+export type VacuumPumpData = VacuumPressureData | VacuumPowerData
+
+export interface VacuumStepData<T extends VacuumPumpData = VacuumPumpData> {
+  id: string
+  time: string
+  name: string
+  type: typeof PROFILE_STEP
+  pumpData: T
+}
+
+export interface VacuumStepBaseProps {
+  stepData: VacuumStepData
+  displayIndex: string
+  onDelete: () => void
+  isNested?: boolean
+  allowDelete?: boolean
+}
+
+export interface VacuumCycleBaseProps {
+  orderedProfileStepIds: string[]
+  profileStepItemsById: Record<string, ProfileStepItem>
+  displayIndex: string
+  type: typeof PROFILE_CYCLE
+  onDelete: () => void
+}
+
+export interface PresavedVacuumCycleSavePayload {
+  orderedProfileStepIds: string[]
+  profileStepItemsById: Record<string, ProfileStepItem>
+  repetitions: number
+}
+
+export interface ProfileStepBaseProps {
+  id: string
+  isPresaved: boolean
+}
+
+export interface ProfileStepItem extends VacuumStepData, ProfileStepBaseProps {
+  type: typeof PROFILE_STEP
+}
+
+export interface ProfileCycleItem extends ProfileStepBaseProps {
+  id: string
+  isPresaved: boolean
+  orderedProfileStepIds: string[]
+  profileStepItemsById: Record<string, ProfileStepItem>
+  repetitions: number
+  type: typeof PROFILE_CYCLE
+}
+
+export type ProfileItem = ProfileStepItem | ProfileCycleItem
+
+export interface VacuumStepErrors {
+  name: boolean
+  time: boolean
+  pumpData: boolean
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/utils.ts
@@ -16,9 +16,7 @@ import type {
 
 export type VacuumMode = typeof VACUUM_MODE_PRESSURE | typeof VACUUM_MODE_POWER
 
-export function getDefaultStepData(
-  mode: VacuumMode | undefined
-): VacuumStepData {
+export function getDefaultStepData(mode: VacuumMode): VacuumStepData {
   const baseData = {
     id: '',
     time: '',

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/utils.ts
@@ -1,0 +1,82 @@
+import {
+  VACUUM_MAX_PRESSURE_MBAR,
+  VACUUM_MIN_PRESSURE_MBAR,
+  VACUUM_MODE_POWER,
+  VACUUM_MODE_PRESSURE,
+} from '@opentrons/step-generation'
+
+import { PROFILE_STEP } from './constants'
+
+import type {
+  ProfileStepItem,
+  VacuumPumpData,
+  VacuumStepData,
+  VacuumStepErrors,
+} from './types'
+
+export type VacuumMode = typeof VACUUM_MODE_PRESSURE | typeof VACUUM_MODE_POWER
+
+export function getDefaultStepData(
+  mode: VacuumMode | undefined
+): VacuumStepData {
+  const baseData = {
+    id: '',
+    time: '',
+    name: '',
+    type: PROFILE_STEP,
+  }
+  return mode === VACUUM_MODE_PRESSURE
+    ? {
+        ...baseData,
+        pumpData: { mode: VACUUM_MODE_PRESSURE, pressureMbar: null },
+      }
+    : { ...baseData, pumpData: { mode: VACUUM_MODE_POWER, powerPercent: 1 } }
+}
+
+const getIsNameError = (name: string): boolean => name === ''
+
+const getIsTimeError = (time: string): boolean =>
+  time === '' || !/^\d{0,2}(:\d{0,2})?$/.test(time)
+
+const getIsPumpDataError = (pumpData: VacuumPumpData): boolean => {
+  if (pumpData.mode === VACUUM_MODE_POWER) {
+    return false
+  }
+  const { pressureMbar: rawPressureMbar } = pumpData
+  const pressureMbar = rawPressureMbar ? Number(rawPressureMbar) : null
+  return (
+    pumpData.mode === VACUUM_MODE_PRESSURE &&
+    (pressureMbar === null ||
+      pressureMbar < VACUUM_MIN_PRESSURE_MBAR ||
+      pressureMbar > VACUUM_MAX_PRESSURE_MBAR)
+  )
+}
+
+export const getStepErrors = (step: VacuumStepData): VacuumStepErrors => {
+  return {
+    name: getIsNameError(step.name),
+    time: getIsTimeError(step.time),
+    pumpData: getIsPumpDataError(step.pumpData),
+  }
+}
+
+export const getIsStepValid = (step: VacuumStepData): boolean => {
+  const errors = getStepErrors(step)
+  return !Object.values(errors).some(Boolean)
+}
+
+export const getInvalidPresavedStepIds = (
+  orderedProfileStepIds: string[],
+  profileStepItemsById: Record<string, ProfileStepItem>
+): string[] => {
+  return orderedProfileStepIds.filter(stepId => {
+    const step = profileStepItemsById[stepId]
+    return step?.isPresaved === true && !getIsStepValid(step)
+  })
+}
+
+export const getFormattedTime = (time: string): string => {
+  const [minutes, rawSeconds] = time.split(':')
+  const seconds = rawSeconds ? Number(rawSeconds) : 0
+  return `${minutes.padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/vacuumprofile.module.css
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/vacuumprofile.module.css
@@ -1,9 +1,9 @@
 .saved_vacuum_step_row {
-  width: 100%;
   display: flex;
+  width: 100%;
   flex-direction: row;
-  justify-content: space-between;
   align-items: center;
+  justify-content: space-between;
 }
 
 .presaved_vacuum_cycle_container {
@@ -11,51 +11,51 @@
 }
 
 .presaved_vacuum_cycle_content {
-  width: 100%;
   display: flex;
+  width: 100%;
   flex-direction: column;
 }
 
 .presaved_content {
   display: flex;
-  flex-direction: column;
-  gap: var(--spacing-8);
-  padding: var(--spacing-12);
   box-sizing: border-box;
+  flex-direction: column;
+  padding: var(--spacing-12);
+  gap: var(--spacing-8);
 }
 
 .saved_vacuum_cycle_content {
-  width: 100%;
   display: flex;
+  width: 100%;
   flex-direction: column;
 }
 
 .saved_vacuum_cycle_header {
-  padding: var(--spacing-12);
   box-sizing: border-box;
+  padding: var(--spacing-12);
 }
 
 .saved_vacuum_cycle_header_row {
   display: flex;
+  width: 100%;
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
-  width: 100%;
 }
 
 .saved_vacuum_cycle_steps_container {
+  box-sizing: border-box;
   padding: var(--spacing-12) var(--spacing-12) var(--spacing-12)
     var(--spacing-60);
-  box-sizing: border-box;
 }
 
 .delete_button {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  align-self: center;
   width: 2rem;
   height: 2rem;
+  align-items: center;
+  align-self: center;
+  justify-content: center;
   border-radius: 50%;
   background-color: transparent;
   cursor: pointer;
@@ -70,62 +70,62 @@
 }
 
 .presaved_vacuum_step_content {
+  display: flex;
   width: 100%;
   min-width: 0;
-  display: flex;
   flex-direction: column;
 }
 
 .presaved_vacuum_step_form_row {
   display: flex;
-  flex-direction: row;
-  gap: var(--spacing-12);
-  align-items: flex-start;
-  min-width: 0;
   overflow: hidden;
+  min-width: 0;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: var(--spacing-12);
 }
 
 .cycle_steps_list {
   display: flex;
-  flex-direction: column;
-  gap: var(--spacing-4);
   width: 100%;
   min-width: 0;
+  flex-direction: column;
+  gap: var(--spacing-4);
 }
 
 .flex_row_gap_8 {
   display: flex;
   flex-direction: row;
-  gap: var(--spacing-8);
   align-items: center;
+  gap: var(--spacing-8);
 }
 
 .flex_row_gap_24 {
   display: flex;
   flex-direction: row;
-  gap: var(--spacing-24);
   align-items: center;
+  gap: var(--spacing-24);
 }
 
 /* Header and content sections each own their 12px padding; no gap between them */
 .presaved_vacuum_header {
-  padding: var(--spacing-12);
   display: flex;
-  flex-direction: row;
-  justify-content: space-between;
   width: 100%;
   box-sizing: border-box;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: var(--spacing-12);
 }
 
 .flex_fill {
-  flex: 1;
-  min-width: 0;
   overflow: hidden;
+  min-width: 0;
+  flex: 1;
 }
 
 .presaved_vacuum_cycle_add_step_row {
-  width: 100%;
   display: flex;
+  width: 100%;
   justify-content: flex-end;
 }
 
@@ -136,24 +136,24 @@
 .vacuum_profile_modal_actions {
   display: flex;
   flex-direction: row;
-  gap: var(--spacing-8);
   justify-content: flex-end;
+  gap: var(--spacing-8);
 }
 
 .vacuum_profile_modal_footer {
   display: flex;
   flex-direction: row;
-  justify-content: flex-end;
   align-self: flex-end;
-  gap: var(--spacing-8);
+  justify-content: flex-end;
   padding: var(--spacing-24);
+  gap: var(--spacing-8);
 }
 
 .vacuum_profile_modal_body {
   display: flex;
-  flex-direction: column;
-  min-height: 100%;
   height: 100%;
+  min-height: 100%;
+  flex-direction: column;
   gap: var(--spacing-24);
 }
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/vacuumprofile.module.css
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/vacuumprofile.module.css
@@ -1,0 +1,164 @@
+.saved_vacuum_step_row {
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.presaved_vacuum_cycle_container {
+  width: 100%;
+}
+
+.presaved_vacuum_cycle_content {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.presaved_content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-8);
+  padding: var(--spacing-12);
+  box-sizing: border-box;
+}
+
+.saved_vacuum_cycle_content {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.saved_vacuum_cycle_header {
+  padding: var(--spacing-12);
+  box-sizing: border-box;
+}
+
+.saved_vacuum_cycle_header_row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.saved_vacuum_cycle_steps_container {
+  padding: var(--spacing-12) var(--spacing-12) var(--spacing-12)
+    var(--spacing-60);
+  box-sizing: border-box;
+}
+
+.delete_button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  align-self: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background-color: transparent;
+  cursor: pointer;
+}
+
+.delete_button:hover {
+  background-color: var(--grey-35);
+}
+
+.delete_button:active {
+  background-color: var(--grey-40);
+}
+
+.presaved_vacuum_step_content {
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.presaved_vacuum_step_form_row {
+  display: flex;
+  flex-direction: row;
+  gap: var(--spacing-12);
+  align-items: flex-start;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.cycle_steps_list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+  width: 100%;
+  min-width: 0;
+}
+
+.flex_row_gap_8 {
+  display: flex;
+  flex-direction: row;
+  gap: var(--spacing-8);
+  align-items: center;
+}
+
+.flex_row_gap_24 {
+  display: flex;
+  flex-direction: row;
+  gap: var(--spacing-24);
+  align-items: center;
+}
+
+/* Header and content sections each own their 12px padding; no gap between them */
+.presaved_vacuum_header {
+  padding: var(--spacing-12);
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.flex_fill {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.presaved_vacuum_cycle_add_step_row {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.empty_selector_button_container {
+  width: max-content;
+}
+
+.vacuum_profile_modal_actions {
+  display: flex;
+  flex-direction: row;
+  gap: var(--spacing-8);
+  justify-content: flex-end;
+}
+
+.vacuum_profile_modal_footer {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-self: flex-end;
+  gap: var(--spacing-8);
+  padding: var(--spacing-24);
+}
+
+.vacuum_profile_modal_body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  height: 100%;
+  gap: var(--spacing-24);
+}
+
+.vacuum_profile_modal_list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/vacuumtools.module.css
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/vacuumtools.module.css
@@ -91,6 +91,7 @@
 /* Ending hold vent (shown when pump duration is enabled) */
 .ending_hold_section {
   display: flex;
+  width: 100%;
   flex-direction: column;
   gap: var(--spacing-8);
 }

--- a/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
+++ b/protocol-designer/src/steplist/formLevel/getDefaultsForStepType.ts
@@ -273,6 +273,8 @@ export function getDefaultsForStepType(
         pumpDurationCheckbox: null,
         pumpDurationTime: null,
         endingHoldVentCheckbox: null,
+        orderedProfileIds: [],
+        profileItemsById: {},
       }
     default:
       return {}

--- a/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
+++ b/protocol-designer/src/steplist/formLevel/test/getDefaultsForStepType.test.ts
@@ -258,6 +258,8 @@ describe('getDefaultsForStepType', () => {
         programType: null,
         stateType: null,
         modeType: null,
+        orderedProfileIds: [],
+        profileItemsById: {},
         pressureMbar: null,
         powerPercent: null,
         pumpDurationCheckbox: null,


### PR DESCRIPTION
# Overview

This PR builds the full UI for creating a vacuum module profile in a PD VM stepform. It also refactors the shared `Slider` component for correct layout in the modal.

Adds **Vacuum Profile** support to the Protocol Designer vacuum step. A user can program this profile in a vacuum profile modal to define an ordered list of profile items (steps and/or cycles). Each step requires name, pressure or power, and duration; cycles require repetitions and nested steps. The modal protects against saving the modal with unsaved profile items. It also handles errors for step inputs:
- name required
- pressure required, must be within range (placeholder min/max constants for now as hardware specs are finalized)
- time must match format

Also, cycles must have a non-zero integer for number of repetitions.

Closes EXEC-2425

https://github.com/user-attachments/assets/55926902-eb22-42ec-abfe-3d00a0646c3f


## Test Plan and Hands on Testing

NOTE— unit tests are to be added in a followup to limit the already large footprint of this PR. See this subtask: EXEC-2422

- Create or import a vacuum module protocol and open or program a vacuum step
- Select "Program a vacuum profile" and select pressure or power
- Select the list button under "Profile steps" to open the vacuum profile modal
- Ensure you can successfully create and delete vacuum steps and cycles. Bad step inputs should be protected by errors upon saving. Attempting to save the overall modal with steps open for editing should prompt a snackbar to that effect.
- Once the form is in a good state, save and verify that the step form list button specifies the number of profile items
- Verify that reopening the modal respects the saved profile

## Changelog

### Protocol Designer
  - New program type option: **Profile** (in addition to State). When Profile is selected, user selects mode (Pressure/Power) then can open the Vacuum Profile modal to define steps and cycles.
  - New **Vacuum Profile** modal: add Step or Cycle; presaved steps/cycles are editable inline (name, pressure/power, time; cycles: repetitions and nested steps); Save converts to saved; saved items are read-only with Edit/Delete.
  - New form fields: `orderedProfileIds`, `profileItemsById`; defaults added in `getDefaultsForStepType` for vacuum step.
  - New localization keys under `vacuum.controls.profile.*` and `vacuum.controls.ending_hold_vent`.
- New components: VacuumProfile
  - created the following components to be used in the VacuumProfile: `VacuumProfileModal`, `PresavedVacuumHeader`, `PresavedVacuumStep`, `PresavedVacuumCycle`, `SavedVacuumStep`, `SavedVacuumCycle`.
  - Hooks for managing profile/cycle state: `useVacuumProfileState`, `usePresavedCycleState`; types and utils for steps/cycles, validation, and default data.
  - new CSS module for all new components' CSS classes

### Components
- updated `Slider` styles to accommodate a more compact version as specified in the modal designs (smaller padding between label and slider input bar)

## Review requests

Please follow test plan. Designs are complex, and I hold responsibility for auditing all new components and that they match designs, so please focus on functionality.

## Risk assessment

Low. Large footprint, but mostly additive.