### PR TITLE
feat(components,app): add testid to input field components and remove data-testids

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/RenameRobotSlideout.tsx
@@ -191,7 +191,6 @@ export function RenameRobotSlideout({
             name="newRobotName"
             render={({ field, fieldState }) => (
               <InputField
-                data-testid="rename-robot_input"
                 id="newRobotName"
                 name="newRobotName"
                 type="text"

--- a/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
+++ b/app/src/organisms/ModuleCard/HeaterShakerSlideout.tsx
@@ -145,7 +145,7 @@ export const HeaterShakerSlideout = (
         </LegacyStyledText>
         <form id="HeaterShakerSlideout_submitValue">
           <InputField
-            data-testid={`${String(module.moduleModel)}_setTemp`}
+            title={`${String(module.moduleModel)}_setTemp`}
             id={`${String(module.moduleModel)}_setTemp`}
             units={unit}
             autoFocus
@@ -157,7 +157,7 @@ export const HeaterShakerSlideout = (
             caption={t('module_status_range', {
               min: inputMin,
               max: inputMax,
-              unit: unit,
+              unit,
             })}
             error={errorMessage}
           />

--- a/app/src/organisms/ModuleCard/MagneticModuleSlideout.tsx
+++ b/app/src/organisms/ModuleCard/MagneticModuleSlideout.tsx
@@ -221,7 +221,7 @@ export const MagneticModuleSlideout = (
         </LegacyStyledText>
         <form id="MagneticModuleSlideout_submitValue">
           <InputField
-            data-testid={`${String(module.moduleModel)}`}
+            title={`${String(module.moduleModel)}`}
             id={`${String(module.moduleModel)}`}
             units={info.units}
             value={engageHeightValue}

--- a/app/src/organisms/ModuleCard/TemperatureModuleSlideout.tsx
+++ b/app/src/organisms/ModuleCard/TemperatureModuleSlideout.tsx
@@ -130,7 +130,7 @@ export const TemperatureModuleSlideout = (
         <form id="TemperatureModuleSlideout_submitValue">
           <InputField
             id={`${String(module.moduleModel)}`}
-            data-testid={`${String(module.moduleModel)}`}
+            title={`${String(module.moduleModel)}`}
             units={CELSIUS}
             value={
               temperatureValue != null ? Math.round(temperatureValue) : null

--- a/app/src/organisms/ModuleCard/ThermocyclerModuleSlideout.tsx
+++ b/app/src/organisms/ModuleCard/ThermocyclerModuleSlideout.tsx
@@ -170,9 +170,7 @@ export const ThermocyclerModuleSlideout = (
         </LegacyStyledText>
         <form id="ThermocyclerModuleSlideout_submitValue">
           <InputField
-            data-testid={`${String(module.moduleModel)}_${String(
-              isSecondaryTemp
-            )}`}
+            title={`${String(module.moduleModel)}_${String(isSecondaryTemp)}`}
             id={`${String(module.moduleModel)}_${String(isSecondaryTemp)}`}
             units={CELSIUS}
             value={tempValue != null ? Math.round(tempValue) : null}

--- a/app/src/organisms/ModuleCard/__tests__/HeaterShakerSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/HeaterShakerSlideout.test.tsx
@@ -63,7 +63,9 @@ describe('HeaterShakerSlideout', () => {
     }
     render(props)
     const button = screen.getByRole('button', { name: 'Confirm' })
-    const input = screen.getByTestId('heaterShakerModuleV1_setTemp')
+    const input = screen.getByRole('spinbutton', {
+      name: 'heaterShakerModuleV1_setTemp',
+    })
     fireEvent.change(input, { target: { value: '40' } })
     expect(button).toBeEnabled()
     fireEvent.click(button)
@@ -88,7 +90,9 @@ describe('HeaterShakerSlideout', () => {
     }
     render(props)
     const button = screen.getByLabelText('exit')
-    const input = screen.getByTestId('heaterShakerModuleV1_setTemp')
+    const input = screen.getByRole('spinbutton', {
+      name: 'heaterShakerModuleV1_setTemp',
+    })
     fireEvent.change(input, { target: { value: '40' } })
     fireEvent.click(button)
 

--- a/app/src/organisms/ModuleCard/__tests__/MagneticModuleSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/MagneticModuleSlideout.test.tsx
@@ -85,7 +85,9 @@ describe('MagneticModuleSlideout', () => {
   it('renders the button and it is not clickable until there is something in form field', () => {
     render(props)
     const button = screen.getByRole('button', { name: 'Confirm' })
-    const input = screen.getByTestId('magneticModuleV1')
+    const input = screen.getByRole('spinbutton', {
+      name: 'magneticModuleV1',
+    })
     fireEvent.change(input, { target: { value: '10' } })
     expect(button).toBeEnabled()
     fireEvent.click(button)

--- a/app/src/organisms/ModuleCard/__tests__/TemperatureModuleSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/TemperatureModuleSlideout.test.tsx
@@ -81,7 +81,9 @@ describe('TemperatureModuleSlideout', () => {
     }
     render(props)
     const button = screen.getByRole('button', { name: 'Confirm' })
-    const input = screen.getByTestId('temperatureModuleV2')
+    const input = screen.getByRole('spinbutton', {
+      name: 'temperatureModuleV2',
+    })
     fireEvent.change(input, { target: { value: '20' } })
     expect(button).toBeEnabled()
     fireEvent.click(button)

--- a/app/src/organisms/ModuleCard/__tests__/ThermocyclerModuleSlideout.test.tsx
+++ b/app/src/organisms/ModuleCard/__tests__/ThermocyclerModuleSlideout.test.tsx
@@ -81,7 +81,9 @@ describe('ThermocyclerModuleSlideout', () => {
     }
     render(props)
     const button = screen.getByRole('button', { name: 'Confirm' })
-    const input = screen.getByTestId('thermocyclerModuleV1_false')
+    const input = screen.getByRole('spinbutton', {
+      name: 'thermocyclerModuleV1_false',
+    })
     fireEvent.change(input, { target: { value: '45' } })
     expect(button).toBeEnabled()
     fireEvent.click(button)
@@ -107,7 +109,9 @@ describe('ThermocyclerModuleSlideout', () => {
     }
     render(props)
     const button = screen.getByRole('button', { name: 'Confirm' })
-    const input = screen.getByTestId('thermocyclerModuleV1_true')
+    const input = screen.getByRole('spinbutton', {
+      name: 'thermocyclerModuleV1_true',
+    })
     fireEvent.change(input, { target: { value: '45' } })
     expect(button).toBeEnabled()
     fireEvent.click(button)
@@ -133,7 +137,9 @@ describe('ThermocyclerModuleSlideout', () => {
     }
     render(props)
     const button = screen.getByLabelText('exit')
-    const input = screen.getByTestId('thermocyclerModuleV1_true')
+    const input = screen.getByRole('spinbutton', {
+      name: 'thermocyclerModuleV1_true',
+    })
     fireEvent.change(input, { target: { value: '45' } })
     fireEvent.click(button)
 

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/ChooseNumber.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/ChooseNumber.test.tsx
@@ -76,7 +76,6 @@ describe('ChooseNumber', () => {
       min: -10.2,
     }
     props = { ...props, parameter: mockNegativeFloatNumberParameterData }
-    console.log(mockNegativeFloatNumberParameterData)
     render(props)
     expect(screen.getByRole('button', { name: '.' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '-' })).toBeInTheDocument()

--- a/app/src/pages/ODD/NameRobot/__tests__/NameRobot.test.tsx
+++ b/app/src/pages/ODD/NameRobot/__tests__/NameRobot.test.tsx
@@ -80,7 +80,9 @@ describe('NameRobot', () => {
     fireEvent.click(screen.getByRole('button', { name: 'c' }))
     expect(input).toHaveValue('abc')
     fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
-    await waitFor(() => expect(mockTrackEvent).toHaveBeenCalled())
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenCalled()
+    })
   })
 
   it('should show an error message when tapping confirm without typing anything', async () => {

--- a/components/src/molecules/CustomizeExpandButton/__tests__/CustomizeExpandButton.test.tsx
+++ b/components/src/molecules/CustomizeExpandButton/__tests__/CustomizeExpandButton.test.tsx
@@ -49,7 +49,9 @@ describe('CustomizeExpandButton', () => {
     render(props)
     screen.getByText('mock inputTitle')
     screen.getByText('mock inputCaption')
-    const input = screen.getByTestId('CustomizeExpandButton_inputField')
+    const input = screen.getByRole('spinbutton', {
+      name: 'mock inputTitle',
+    })
     fireEvent.change(input, { target: { value: 4 } })
     expect(props.stackingProps?.onInputFieldChange).toHaveBeenCalled()
   })

--- a/components/src/molecules/CustomizeExpandButton/index.tsx
+++ b/components/src/molecules/CustomizeExpandButton/index.tsx
@@ -120,6 +120,7 @@ export function CustomizeExpandButtonComponent(
               {limit != null && limit > 1 && allowInputField ? (
                 <InputField
                   id="CustomizeExpandButton_inputField"
+                  testId="customize-expand-button-input-field"
                   title={stackingProps.inputTitle}
                   onChange={e => {
                     e.stopPropagation()

--- a/components/src/molecules/InputField/__tests__/InputField.test.tsx
+++ b/components/src/molecules/InputField/__tests__/InputField.test.tsx
@@ -34,7 +34,9 @@ describe('InputField', () => {
 
   it('renders title, caption, units, and input attributes', () => {
     render(props)
-    const input = screen.getByTestId('input-id') as HTMLInputElement
+    const input = screen.getByRole('spinbutton', {
+      name: 'Speed',
+    }) as HTMLInputElement
 
     screen.getByText('Speed')
     screen.getByText('caption')
@@ -51,7 +53,9 @@ describe('InputField', () => {
     props.placeholder = 'placeholder'
 
     render(props)
-    const input = screen.getByTestId('input-id') as HTMLInputElement
+    const input = screen.getByRole('spinbutton', {
+      name: 'Speed',
+    }) as HTMLInputElement
 
     expect(input.value).toBe('')
     expect(input.placeholder).toBe('-')
@@ -59,7 +63,9 @@ describe('InputField', () => {
 
   it('calls onFocus, onBlur, and onChange handlers', () => {
     render(props)
-    const input = screen.getByTestId('input-id')
+    const input = screen.getByRole('spinbutton', {
+      name: 'Speed',
+    })
 
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: '7' } })

--- a/components/src/molecules/InputField/index.tsx
+++ b/components/src/molecules/InputField/index.tsx
@@ -90,6 +90,8 @@ export interface InputFieldProps {
   borderRadius?: string
   /** optional prop to override input field padding */
   padding?: string
+  /** optional props to set data-testid */
+  testId?: string
 }
 
 /**
@@ -119,6 +121,7 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
       hasBackgroundError = false,
       borderRadius,
       padding,
+      testId,
       ...inputProps
     } = props
     const [targetProps, tooltipProps] = useHoverTooltip()
@@ -258,7 +261,7 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
               <StyledInput
                 {...inputProps}
                 id={inputId}
-                data-testid={inputId} //
+                data-testid={testId}
                 value={value}
                 placeholder={placeHolder}
                 onWheel={event => {

--- a/components/src/molecules/InputField/index.tsx
+++ b/components/src/molecules/InputField/index.tsx
@@ -90,7 +90,7 @@ export interface InputFieldProps {
   borderRadius?: string
   /** optional prop to override input field padding */
   padding?: string
-  /** optional props to set data-testid */
+  /** optional props for data-testid */
   testId?: string
 }
 

--- a/components/src/molecules/TouchInputField/__tests__/TouchInputField.test.tsx
+++ b/components/src/molecules/TouchInputField/__tests__/TouchInputField.test.tsx
@@ -34,7 +34,9 @@ describe('TouchInputField', () => {
 
   it('renders label, caption, units, and input attributes', () => {
     render(props)
-    const input = screen.getByTestId('touch-input-id') as HTMLInputElement
+    const input = screen.getByRole('spinbutton', {
+      name: 'Speed',
+    }) as HTMLInputElement
 
     screen.getByText('Speed')
     screen.getByText('caption')
@@ -51,7 +53,9 @@ describe('TouchInputField', () => {
     props.placeholder = 'placeholder'
 
     render(props)
-    const input = screen.getByTestId('touch-input-id') as HTMLInputElement
+    const input = screen.getByRole('spinbutton', {
+      name: 'Speed',
+    }) as HTMLInputElement
 
     expect(input.value).toBe('')
     expect(input.placeholder).toBe('-')
@@ -59,7 +63,7 @@ describe('TouchInputField', () => {
 
   it('calls onFocus, onBlur, and onChange handlers', () => {
     render(props)
-    const input = screen.getByTestId('touch-input-id')
+    const input = screen.getByRole('spinbutton', { name: 'Speed' })
 
     fireEvent.focus(input)
     fireEvent.change(input, { target: { value: '7' } })
@@ -91,9 +95,11 @@ describe('TouchInputField', () => {
     const onClick = vi.fn()
     props.onClick = onClick
     props.disabled = true
+    props.testId = 'touch-input-id'
 
     render(props)
-    fireEvent.click(screen.getByTestId('touch-input-id'))
+    const input = screen.getByRole('spinbutton', { name: 'Speed' })
+    fireEvent.click(input)
 
     expect(onClick).not.toHaveBeenCalled()
   })

--- a/components/src/molecules/TouchInputField/index.tsx
+++ b/components/src/molecules/TouchInputField/index.tsx
@@ -67,6 +67,8 @@ export interface TouchInputFieldProps {
   padding?: string
   /** optional input type */
   type?: 'text' | 'password' | 'number'
+  /** optional props to set data-testid */
+  testId?: string
 }
 
 export const TouchInputField = forwardRef<
@@ -91,6 +93,7 @@ export const TouchInputField = forwardRef<
     borderRadius,
     padding,
     type,
+    testId,
     ...inputProps
   } = props
 
@@ -161,7 +164,7 @@ export const TouchInputField = forwardRef<
             <input
               {...inputProps}
               id={inputId}
-              data-testid={inputId} // ToDo remove or switch to testId
+              data-testid={testId}
               className={clsx(
                 styles.input,
                 size === 'small' ? styles.input_small : styles.input_medium,

--- a/components/src/molecules/TouchInputField/index.tsx
+++ b/components/src/molecules/TouchInputField/index.tsx
@@ -67,7 +67,7 @@ export interface TouchInputFieldProps {
   padding?: string
   /** optional input type */
   type?: 'text' | 'password' | 'number'
-  /** optional props to set data-testid */
+  /** optional props for data-testid */
   testId?: string
 }
 

--- a/e2e-testing/automation/pd_pages/mix_step_form.py
+++ b/e2e-testing/automation/pd_pages/mix_step_form.py
@@ -173,9 +173,9 @@ class MixStepForm(BasePage):
         """Configure mix tip X/Y/Z positions."""
 
         modal = self._modal_area()
-        modal.locator('[data-testid="TipPositionModal_x_custom_input"]').fill(x)
-        modal.locator('[data-testid="TipPositionModal_y_custom_input"]').fill(y)
-        modal.locator('[data-testid="TipPositionModal_z_custom_input"]').fill(z)
+        modal.locator('[data-testid="tip-position-modal-x-custom-input"]').fill(x)
+        modal.locator('[data-testid="tip-position-modal-y-custom-input"]').fill(y)
+        modal.locator('[data-testid="tip-position-modal-z-custom-input"]').fill(z)
 
     def toggle_checkbox(self, index: int = 0) -> None:
         """Toggle a checkbox-like control by index among visible controls."""

--- a/e2e-testing/automation/pd_pages/mix_step_form.py
+++ b/e2e-testing/automation/pd_pages/mix_step_form.py
@@ -321,13 +321,13 @@ class MixStepForm(BasePage):
     def open_blowout_position_modal(self) -> None:
         """Open the blowout position modal."""
 
-        self.page.locator("[data-testid='TipPositionField_blowout_z_offset']").click()
+        self.page.locator("[data-testid='tip-position-field-blowout_z_offset']").click()
 
     def set_blowout_position(self, value: str) -> None:
         """Adjust the blowout Z offset inside the modal."""
 
         modal = self._modal_area()
-        modal.locator('[data-testid="TipPositionModal_custom_input"]').fill(value)
+        modal.locator('[data-testid="tip-position-modal-custom-input"]').fill(value)
 
     def rename_step(self, name: str, notes: str) -> None:
         """Rename the Mix step and set notes."""

--- a/e2e-testing/automation/pd_pages/protocol_editor_page.py
+++ b/e2e-testing/automation/pd_pages/protocol_editor_page.py
@@ -163,8 +163,8 @@ class ProtocolEditorPage(BasePage):
 
         target.click()
         if stacker:
-            self.page.get_by_test_id("CustomizeExpandButton_inputField").click()
-            self.page.get_by_test_id("CustomizeExpandButton_inputField").fill(str(fill_num))
+            self.page.get_by_test_id("customize-expand-button-input-field").click()
+            self.page.get_by_test_id("customize-expand-button-input-field").fill(str(fill_num))
         if lid:
             self._add_lid("Opentrons Flex 96 Tip Rack 50", "CheckboxField_icon")
         self.click_test_id("SelectLabwareModal_confirm")

--- a/e2e-testing/automation/pd_pages/transfer_form.py
+++ b/e2e-testing/automation/pd_pages/transfer_form.py
@@ -180,9 +180,9 @@ class TransferPage(BasePage):
             y: Y coordinate (mm).
             z: Z coordinate (mm).
         """
-        self.page.get_by_test_id("TipPositionModal_x_custom_input").fill(str(xyz[0]))
-        self.page.get_by_test_id("TipPositionModal_y_custom_input").fill(str(xyz[1]))
-        self.page.get_by_test_id("TipPositionModal_z_custom_input").fill(str(xyz[2]))
+        self.page.get_by_test_id("tip-position-modal-x-custom-input").fill(str(xyz[0]))
+        self.page.get_by_test_id("tip-position-modal-x-custom-input").fill(str(xyz[1]))
+        self.page.get_by_test_id("tip-position-modal-x-custom-input").fill(str(xyz[2]))
 
     def tip_position_asp_disp(self, aspirate: bool, xyz: tuple[float, float, float]) -> None:
         """

--- a/protocol-designer/src/components/organisms/TipPositionModal/ZTipPositionModal.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/ZTipPositionModal.tsx
@@ -188,6 +188,7 @@ export function ZTipPositionModal(props: ZTipPositionModalProps): JSX.Element {
             })}
             error={errorText}
             id="TipPositionModal_custom_input"
+            testId="tip-position-modal-custom-input"
             isIndeterminate={value === null && isIndeterminate}
             onChange={handleInputFieldChange}
             units={t('application:units.millimeter')}

--- a/protocol-designer/src/components/organisms/TipPositionModal/index.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/index.tsx
@@ -350,7 +350,7 @@ export function TipPositionModal(
               }
               error={xErrorText}
               id="TipPositionModal_x_custom_input"
-              data-testid="TipPositionModal_x_custom_input"
+              testId="tip-position-modal-x-custom-input"
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 handleChange(e.target.value, setXValue)
               }}
@@ -370,7 +370,7 @@ export function TipPositionModal(
               }
               error={yErrorText}
               id="TipPositionModal_y_custom_input"
-              data-testid="TipPositionModal_y_custom_input"
+              testId="tip-position-modal-y-custom-input"
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 handleChange(e.target.value, setYValue)
               }}
@@ -389,7 +389,7 @@ export function TipPositionModal(
               }
               error={zErrorText}
               id="TipPositionModal_z_custom_input"
-              data-testid="TipPositionModal_z_custom_input"
+              testId="tip-position-modal-z-custom-input"
               isIndeterminate={zValue === null && isIndeterminate}
               onChange={(e: ChangeEvent<HTMLInputElement>) => {
                 handleChange(e.target.value, setZValue)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/BlowoutOffsetField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/BlowoutOffsetField.tsx
@@ -88,6 +88,7 @@ export function BlowoutOffsetField(
           isIndeterminate={isIndeterminate}
           units={t('units.millimeter')}
           id={`TipPositionField_${name}`}
+          testId={`tip-position-field-${name}`}
         />
       </Flex>
     </>


### PR DESCRIPTION
# Overview
add `testId` to input field components and remove `data-testid`s
use `testId` for e2e tests

this is a following PR for https://github.com/Opentrons/opentrons/pull/21006

## Test Plan and Hands on Testing
- make -C app test doesn't show any error

## Changelog
- add `testId` to InputField and TouchInputField
- remove `data-testid` from components that uses InputField

## Review requests

## Risk assessment
low