### PR TITLE
fix(scripts/eslint-plugin-opentrons): Fix false positives when the monorepo is placed in ~/Desktop

### DIFF
--- a/scripts/eslint-plugin-opentrons/lib/rules/no-imports-across-applications.js
+++ b/scripts/eslint-plugin-opentrons/lib/rules/no-imports-across-applications.js
@@ -25,7 +25,7 @@ function getRelativePath(context) {
   const cwd = context.getCwd()
   const physicalFilename = context.physicalFilename
   const relative = path.relative(cwd, physicalFilename)
-  return path.sep === '\\' ? relative.split(path.sep).join('/') : relative
+  return relative;
 }
 
 module.exports = {

--- a/scripts/eslint-plugin-opentrons/lib/rules/no-imports-across-applications.js
+++ b/scripts/eslint-plugin-opentrons/lib/rules/no-imports-across-applications.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 const UI_PATH_FRAGMENTS = [
   '/organisms/',
   '/molecules/',
@@ -7,11 +9,24 @@ const UI_PATH_FRAGMENTS = [
   '/DesignTokens/',
 ]
 
-const isUI = path =>
+const isUI = pathStr =>
   UI_PATH_FRAGMENTS.reduce(
-    (isUI, pathFragment) => (isUI |= path.includes(pathFragment)),
+    (isUI, pathFragment) => (isUI |= pathStr.includes(pathFragment)),
     false
   )
+
+/**
+ * The path of the file relative to eslint's cwd.
+ *
+ * eslint's cwd is normally the monorepo root, so this should return something like
+ * app/src/.../foo.ts.
+ */
+function getRelativePath(context) {
+  const cwd = context.getCwd()
+  const physicalFilename = context.physicalFilename
+  const relative = path.relative(cwd, physicalFilename)
+  return path.sep === '\\' ? relative.split(path.sep).join('/') : relative
+}
 
 module.exports = {
   meta: {
@@ -30,9 +45,10 @@ module.exports = {
   },
   create: context => ({
     ImportDeclaration: node => {
+      const relativePath = getRelativePath(context)
       if (
-        context.physicalFilename.includes('/ODD/') ||
-        context.physicalFilename.includes('OnDeviceDisplayApp')
+        relativePath.includes('/ODD/') ||
+        relativePath.includes('OnDeviceDisplayApp')
       ) {
         if (node.source.value.includes('/Desktop/')) {
           context.report({
@@ -41,8 +57,8 @@ module.exports = {
           })
         }
       } else if (
-        context.physicalFilename.includes('/Desktop/') ||
-        context.physicalFilename.includes('DesktopApp')
+        relativePath.includes('/Desktop/') ||
+        relativePath.includes('DesktopApp')
       ) {
         if (node.source.value.includes('/ODD/')) {
           context.report({
@@ -50,11 +66,11 @@ module.exports = {
             node,
           })
         }
-      } else if (!isUI(context.physicalFilename)) {
+      } else if (!isUI(relativePath)) {
         if (isUI(node.source.value)) {
           context.report({ messageId: 'avoidImportingUIFromUtils', node })
         }
-      } else if (isUI(context.physicalFilename)) {
+      } else if (isUI(relativePath)) {
         if (node.source.value.includes('/Desktop/')) {
           context.report({ messageId: 'avoidImportingDesktopFromShared', node })
         } else if (node.source.value.includes('/ODD/')) {


### PR DESCRIPTION
## Overview

@koji noticed that our `opentrons/no-imports-across-applications` custom eslint rule was getting applied inconsistently depending on where the monorepo was checked out. For example, this would fail when the monorepo was checked out at ~/Desktop/opentrons, but not if it was checked out at ~/Code/opentrons.

```
yarn eslint --quiet=true --report-unused-disable-directives-severity error --ignore-pattern "node_modules/" ".*.@(js|ts|tsx)" "**/*.@(js|ts|tsx)" app/src/App/SecondaryWindowApp.tsx

14:1  error  Unused eslint-disable directive (no problems were reported from 'opentrons/no-imports-across-applications')
  16:1  error  Unused eslint-disable directive (no problems were reported from 'opentrons/no-imports-across-applications')
  18:1  error  Unused eslint-disable directive (no problems were reported from 'opentrons/no-imports-across-applications')
```

## Test Plan and Hands on Testing

* [x] Proper errors still show up in IDEs
  * [x] When the repo is placed somewhere under ~/Desktop
  * [x] When the repo is placed somewhere else
* [x] Proper errors still show up when running `make lint` on the command line from the monorepo root
  * [x] When the repo is placed somewhere under ~/Desktop
  * [x] When the repo is placed somewhere else
* [x] No spurious errors when the repo is placed under ~/Desktop

## Changelog

Only look at the parts of file paths that are inside the monorepo. So `~/Desktop/opentrons/app/src/App/SecondaryWindowApp.tsx` is not counted as a desktop app file, but `~/Desktop/opentrons/app/src/pages/Desktop/StepDetailViewer` is.

## Review requests

I'm not sure if `cwd` is really the correct thing to use here. Ideally, we'd use something that's more explicitly the "project root" or "monorepo root." But I couldn't find anything like that in the eslint documentation.

## Risk assessment

Low, just affects dev tooling.