### PR TITLE
fix(app): unifying the behavior of TouchInputField

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/NameQuickTransfer.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/NameQuickTransfer.tsx
@@ -68,6 +68,9 @@ export function NameQuickTransfer(props: NameQuickTransferProps): JSX.Element {
             type="text"
             value={name}
             textAlign={TYPOGRAPHY.textAlignCenter}
+            onBlur={e => {
+              e.target.focus()
+            }}
           />
           <StyledText
             oddStyle="bodyTextRegular"

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/AirGap.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/AirGap.tsx
@@ -208,6 +208,9 @@ export function AirGap(props: AirGapProps): JSX.Element {
               label={t('air_gap_volume_µL')}
               error={volumeError}
               readOnly
+              onBlur={e => {
+                e.target.focus()
+              }}
             />
           </Flex>
           <Flex

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
@@ -401,6 +401,9 @@ export function BlowOut(props: BlowOutProps): JSX.Element {
               label={t('blow_out_speed')}
               error={speedError}
               readOnly
+              onBlur={e => {
+                e.target.focus()
+              }}
             />
           </Flex>
           <Flex

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Condition.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Condition.tsx
@@ -190,6 +190,9 @@ export function Condition(props: DelayProps): JSX.Element {
               label={t('condition_volume')}
               error={volumeError}
               readOnly
+              onBlur={e => {
+                e.target.focus()
+              }}
             />
             <StyledText oddStyle="bodyTextRegular" color={COLORS.grey60}>
               {t('condition_max_volume', { max: maxConditioningVolume })}

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Delay.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Delay.tsx
@@ -199,6 +199,9 @@ export function Delay(props: DelayProps): JSX.Element {
               error={durationError}
               label={t('delay_duration_s')}
               readOnly
+              onBlur={e => {
+                e.target.focus()
+              }}
             />
           </Flex>
           <Flex

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/DisposalVolume.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/DisposalVolume.tsx
@@ -246,6 +246,9 @@ export function DisposalVolume(props: DisposalVolumeProps): JSX.Element {
               value={String(volume ?? '')}
               label={t('disposal_volume_µL')}
               readOnly
+              onBlur={e => {
+                e.target.focus()
+              }}
             />
           </Flex>
           <Flex
@@ -315,6 +318,9 @@ export function DisposalVolume(props: DisposalVolumeProps): JSX.Element {
               label={t('blowout_flow_rate_µL')}
               error={flowRateError}
               readOnly
+              onBlur={e => {
+                e.target.focus()
+              }}
             />
             <StyledText oddStyle="bodyTextRegular" color={COLORS.grey60}>
               {t('disposal_volume_flow_rate', {

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/FlowRate.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/FlowRate.tsx
@@ -143,6 +143,9 @@ export function FlowRateEntry(props: FlowRateEntryProps): JSX.Element {
             label={textEntryCopy}
             error={error}
             readOnly
+            onBlur={e => {
+              e.target.focus()
+            }}
           />
         </Flex>
         <Flex

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Mix.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Mix.tsx
@@ -224,6 +224,9 @@ export function Mix(props: MixProps): JSX.Element {
               label={t('mix_volume_µL')}
               error={volumeError}
               readOnly
+              onBlur={e => {
+                e.target.focus()
+              }}
             />
           </Flex>
           <Flex
@@ -265,6 +268,9 @@ export function Mix(props: MixProps): JSX.Element {
               error={repititionError}
               label={t('mix_repetitions')}
               readOnly
+              onBlur={e => {
+                e.target.focus()
+              }}
             />
           </Flex>
           <Flex

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
@@ -208,6 +208,9 @@ export function PipettePath(props: PipettePathProps): JSX.Element {
               label={t('disposal_volume_µL')}
               error={volumeError}
               readOnly
+              onBlur={e => {
+                e.target.focus()
+              }}
             />
           </Flex>
           <Flex

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PushOut.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PushOut.tsx
@@ -181,6 +181,9 @@ export function PushOut(props: PushOutProps): JSX.Element {
               error={volumeError}
               label={t('push_out_volume')}
               readOnly
+              onBlur={e => {
+                e.target.focus()
+              }}
             />
           </Flex>
           <Flex

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Retract.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Retract.tsx
@@ -286,6 +286,9 @@ function RetractSettingComponent({
             value={speed}
             label={t('speed')}
             readOnly
+            onBlur={e => {
+              e.target.focus()
+            }}
           />
         </Flex>
         <Flex
@@ -321,6 +324,9 @@ function RetractSettingComponent({
             value={delayDuration}
             label={t('delay_duration_s')}
             readOnly
+            onBlur={e => {
+              e.target.focus()
+            }}
           />
         </Flex>
         <Flex

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Submerge.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Submerge.tsx
@@ -286,6 +286,9 @@ function SubmergeSettingComponent({
             value={speed}
             label={t('speed')}
             readOnly
+            onBlur={e => {
+              e.target.focus()
+            }}
           />
         </Flex>
         <Flex
@@ -321,6 +324,9 @@ function SubmergeSettingComponent({
             value={delayDuration}
             label={t('delay_duration_s')}
             readOnly
+            onBlur={e => {
+              e.target.focus()
+            }}
           />
         </Flex>
         <Flex
@@ -361,6 +367,9 @@ function SubmergeSettingComponent({
             error={positionError}
             label={positionText}
             readOnly
+            onBlur={e => {
+              e.target.focus()
+            }}
           />
           {positionError == null ? (
             <StyledText oddStyle="bodyTextRegular" color={COLORS.grey60}>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TipPosition.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TipPosition.tsx
@@ -135,6 +135,9 @@ export function TipPositionEntry(props: TipPositionEntryProps): JSX.Element {
             label={textEntryCopy}
             error={error}
             readOnly
+            onBlur={e => {
+              e.target.focus()
+            }}
           />
         </Flex>
         <Flex

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
@@ -239,6 +239,9 @@ export function TouchTip(props: TouchTipProps): JSX.Element {
               value={String(speed ?? '')}
               label={t('speed')}
               readOnly
+              onBlur={e => {
+                e.target.focus()
+              }}
             />
           </Flex>
           <Flex
@@ -280,6 +283,9 @@ export function TouchTip(props: TouchTipProps): JSX.Element {
               label={t('touch_tip_position_mm')}
               error={positionError}
               readOnly
+              onBlur={e => {
+                e.target.focus()
+              }}
             />
             <StyledText oddStyle="bodyTextRegular" color={COLORS.grey60}>
               {t('touch_tip_from_top', {

--- a/app/src/organisms/ODD/QuickTransferFlow/VolumeEntry.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/VolumeEntry.tsx
@@ -110,6 +110,9 @@ export function VolumeEntry(props: VolumeEntryProps): JSX.Element {
             label={textEntryCopy}
             error={error}
             readOnly
+            onBlur={e => {
+              e.target.focus()
+            }}
           />
         </Flex>
         <Flex

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/AirGap.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/AirGap.test.tsx
@@ -101,6 +101,7 @@ describe('AirGap', () => {
         readOnly: true,
         type: 'number',
         value: null,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -132,6 +133,7 @@ describe('AirGap', () => {
         readOnly: true,
         type: 'number',
         value: 200,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -161,6 +163,7 @@ describe('AirGap', () => {
         readOnly: true,
         type: 'number',
         value: 0,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -188,6 +191,7 @@ describe('AirGap', () => {
         readOnly: true,
         type: 'number',
         value: 0,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -213,6 +217,7 @@ describe('AirGap', () => {
         readOnly: true,
         type: 'number',
         value: 0,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -250,6 +255,7 @@ describe('AirGap', () => {
         readOnly: true,
         type: 'number',
         value: 4,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -275,6 +281,7 @@ describe('AirGap', () => {
         readOnly: true,
         type: 'number',
         value: 16,
+        onBlur: expect.any(Function),
       },
       {}
     )

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Delay.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Delay.test.tsx
@@ -107,6 +107,7 @@ describe('Delay', () => {
         readOnly: true,
         type: 'number',
         value: null,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -137,6 +138,7 @@ describe('Delay', () => {
         readOnly: true,
         type: 'number',
         value: 0,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -182,6 +184,7 @@ describe('Delay', () => {
         readOnly: true,
         type: 'number',
         value: 15,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -208,6 +211,7 @@ describe('Delay', () => {
         readOnly: true,
         type: 'number',
         value: 20,
+        onBlur: expect.any(Function),
       },
       {}
     )

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/FlowRate.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/FlowRate.test.tsx
@@ -99,6 +99,7 @@ describe('FlowRate', () => {
         readOnly: true,
         type: 'number',
         value: 35,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -121,6 +122,7 @@ describe('FlowRate', () => {
         readOnly: true,
         type: 'number',
         value: 62,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -138,6 +140,7 @@ describe('FlowRate', () => {
         readOnly: true,
         type: 'number',
         value: 0,
+        onBlur: expect.any(Function),
       },
       {}
     )

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Mix.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Mix.test.tsx
@@ -107,6 +107,7 @@ describe('Mix', () => {
         readOnly: true,
         type: 'number',
         value: null,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -137,6 +138,7 @@ describe('Mix', () => {
         readOnly: true,
         type: 'number',
         value: 0,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -163,6 +165,7 @@ describe('Mix', () => {
         readOnly: true,
         type: 'number',
         value: 0,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -209,6 +212,7 @@ describe('Mix', () => {
         readOnly: true,
         type: 'number',
         value: 15,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -220,6 +224,7 @@ describe('Mix', () => {
         readOnly: true,
         type: 'number',
         value: 55,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -247,6 +252,7 @@ describe('Mix', () => {
         readOnly: true,
         type: 'number',
         value: 18,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -258,6 +264,7 @@ describe('Mix', () => {
         readOnly: true,
         type: 'number',
         value: 2,
+        onBlur: expect.any(Function),
       },
       {}
     )

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/PipettePath.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/PipettePath.test.tsx
@@ -177,6 +177,7 @@ describe('PipettePath', () => {
         readOnly: true,
         type: 'number',
         value: 20,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -208,6 +209,7 @@ describe('PipettePath', () => {
         readOnly: true,
         type: 'number',
         value: 201,
+        onBlur: expect.any(Function),
       },
       {}
     )

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TipPosition.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TipPosition.test.tsx
@@ -96,6 +96,7 @@ describe('TipPosition', () => {
         readOnly: true,
         type: 'text',
         value: 10,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -118,6 +119,7 @@ describe('TipPosition', () => {
         readOnly: true,
         type: 'text',
         value: 75,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -135,6 +137,7 @@ describe('TipPosition', () => {
         readOnly: true,
         type: 'text',
         value: 0,
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -158,6 +161,7 @@ describe('TipPosition', () => {
         readOnly: true,
         type: 'text',
         value: 0,
+        onBlur: expect.any(Function),
       },
       {}
     )

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TouchTip.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TouchTip.test.tsx
@@ -112,14 +112,15 @@ describe('TouchTip', () => {
     fireEvent.click(continueBtn)
     fireEvent.click(screen.getByText('1'))
     fireEvent.click(continueBtn)
-    expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
-      {
+    expect(vi.mocked(TouchInputField)).toHaveBeenLastCalledWith(
+      expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',
         error: null,
         readOnly: true,
         type: 'text',
         value: '',
-      },
+        onBlur: expect.any(Function),
+      }),
       {}
     )
   })
@@ -149,14 +150,15 @@ describe('TouchTip', () => {
     fireEvent.click(numButton)
     const secondNumButton = screen.getByText('8')
     fireEvent.click(secondNumButton)
-    expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
-      {
+    expect(vi.mocked(TouchInputField)).toHaveBeenLastCalledWith(
+      expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',
         error: 'Value must be between -25 to 0',
         readOnly: true,
         type: 'text',
         value: '-98',
-      },
+        onBlur: expect.any(Function),
+      }),
       {}
     )
     const saveBtn = screen.getByTestId('ChildNavigation_Primary_Button')
@@ -178,14 +180,15 @@ describe('TouchTip', () => {
     fireEvent.click(continueBtn)
     const numButton = screen.getByText('1')
     fireEvent.click(numButton)
-    expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
-      {
+    expect(vi.mocked(TouchInputField)).toHaveBeenLastCalledWith(
+      expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',
         error: 'Value must be between -100 to 0',
         readOnly: true,
         type: 'text',
         value: '1',
-      },
+        onBlur: expect.any(Function),
+      }),
       {}
     )
     const saveBtn = screen.getByTestId('ChildNavigation_Primary_Button')
@@ -223,14 +226,15 @@ describe('TouchTip', () => {
     const numButton = screen.getByText('0')
     fireEvent.click(numButton)
     fireEvent.click(continueBtn)
-    expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
-      {
+    expect(vi.mocked(TouchInputField)).toHaveBeenLastCalledWith(
+      expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',
         error: null,
         readOnly: true,
         type: 'text',
         value: '-25',
-      },
+        onBlur: expect.any(Function),
+      }),
       {}
     )
   })
@@ -250,14 +254,15 @@ describe('TouchTip', () => {
     const numButton = screen.getByText('0')
     fireEvent.click(numButton)
     fireEvent.click(continueBtn)
-    expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
-      {
+    expect(vi.mocked(TouchInputField)).toHaveBeenLastCalledWith(
+      expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',
         error: null,
         readOnly: true,
         type: 'text',
         value: '-8',
-      },
+        onBlur: expect.any(Function),
+      }),
       {}
     )
   })

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/VolumeEntry.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/VolumeEntry.test.tsx
@@ -79,6 +79,7 @@ describe('VolumeEntry', () => {
         readOnly: true,
         type: 'text',
         value: '',
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -102,6 +103,7 @@ describe('VolumeEntry', () => {
         readOnly: true,
         type: 'text',
         value: '',
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -125,6 +127,7 @@ describe('VolumeEntry', () => {
         readOnly: true,
         type: 'text',
         value: '',
+        onBlur: expect.any(Function),
       },
       {}
     )
@@ -166,6 +169,7 @@ describe('VolumeEntry', () => {
         readOnly: true,
         type: 'text',
         value: '90',
+        onBlur: expect.any(Function),
       },
       {}
     )


### PR DESCRIPTION
# Overview
Unifying the behavior of TouchInputField
TouchField is showing the blue outline when a user is filling the value

RTP input screen, RobotName screen, and Wifi screens are aligned with the above behavior

close EXEC-2304

## Test Plan and Hands on Testing
- push this pr
- create a Quick Transfer 
TouchInputField in each screen shows the blue outline when filling the value

## Changelog


## Review requests


## Risk assessment
low
