### PR TITLE
 chore(ci): Use repo variables for non-sensitive config

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -316,7 +316,7 @@ jobs:
           WINDOWS_CSC_FILEPATH: "D:\\opentrons_labworks_inc.crt"
           CSC_LINK: ${{ secrets.OT_APP_CSC_MACOS_V2 }}
           CSC_KEY_PASSWORD: ${{ secrets.OT_APP_CSC_KEY_MACOS_V2 }}
-          APPLE_ID: ${{ secrets.OT_APP_APPLE_ID_V2 }}
+          APPLE_ID: ${{ vars.OT_APP_APPLE_ID_V2 }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.OT_APP_APPLE_ID_PASSWORD_V2 }}
           APPLE_TEAM_ID: ${{ secrets.OT_APP_APPLE_TEAM_ID_V2 }}
           HOST_PYTHON: python

--- a/.github/workflows/odd-memory-usage-test.yaml
+++ b/.github/workflows/odd-memory-usage-test.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Run memory analysis
         uses: ./.github/actions/odd-resource-analysis
         with:
-          mixpanel-user: ${{ secrets.MIXPANEL_INGEST_USER }}
+          mixpanel-user: ${{ vars.MIXPANEL_INGEST_USER }}
           mixpanel-secret: ${{ secrets.MIXPANEL_INGEST_SECRET }}
           mixpanel-project-id: ${{ secrets.OT_MIXPANEL_PROJECT_ID }}
           previous-version-count: '2'

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -112,8 +112,8 @@ jobs:
           OT_PD_SENTRY_DEV_DSN: ${{ secrets.OT_PD_SENTRY_DEV_DSN }}
           # Used by @sentry/vite-plugin (sourcemap upload is gated by OT_PD_SENTRY_PLUGIN_UPLOAD).
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
           # Only meaningful for tagged releases; empty string is treated as absent.
           SENTRY_RELEASE: ${{ github.ref_type == 'tag' && steps.version.outputs.number || '' }}
           # Opt-in CI sourcemap upload via the Vite plugin (staging/prod tagged releases only).
@@ -126,8 +126,8 @@ jobs:
         uses: getsentry/action-release@5657c9e888b4e2cc85f4d29143ea4131fde4a73a # v3.6.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         with:
           release: ${{ steps.version.outputs.number }}
           set_commits: auto
@@ -204,8 +204,8 @@ jobs:
         uses: getsentry/action-release@5657c9e888b4e2cc85f4d29143ea4131fde4a73a # v3.6.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
         with:
           release: ${{ steps.version.outputs.number }}
           finalize: true

--- a/.github/workflows/pd-test-build-deploy.yaml
+++ b/.github/workflows/pd-test-build-deploy.yaml
@@ -108,7 +108,7 @@ jobs:
           NODE_OPTIONS: '--max-old-space-size=5120'
           OT_PD_MIXPANEL_ID: ${{ secrets.OT_PD_MIXPANEL_ID }}
           OT_PD_MIXPANEL_DEV_ID: ${{ secrets.OT_PD_MIXPANEL_DEV_ID }}
-          OT_PD_SENTRY_DSN: ${{ secrets.OT_PD_SENTRY_DSN }}
+          OT_PD_SENTRY_DSN: ${{ vars.OT_PD_SENTRY_DSN }}
           OT_PD_SENTRY_DEV_DSN: ${{ secrets.OT_PD_SENTRY_DEV_DSN }}
           # Used by @sentry/vite-plugin (sourcemap upload is gated by OT_PD_SENTRY_PLUGIN_UPLOAD).
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}


### PR DESCRIPTION
 chore(ci): Use repo variables for non-sensitive config

Summary:

* Use GitHub Actions variables instead of secrets for: SENTRY_ORG, SENTRY_PROJECT, MIXPANEL_INGEST_USER, OT_APP_APPLE_ID_V2.
* Updated workflows: pd-test-build-deploy.yaml, app-test-build-deploy.yaml, odd-memory-usage-test.yaml.
* These values are not highly sensitive; variables allow default values and clearer visibility in the UI. Add the same names under Settings → Actions → Variables and remove the corresponding secrets once variables are in place.