### PR TITLE
fix(app): remove ODD "capture image" button

### DIFF
--- a/app/src/organisms/ODD/RunningProtocol/ImageGalleryList/__tests__/ImageGalleryList.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ImageGalleryList/__tests__/ImageGalleryList.test.tsx
@@ -1,5 +1,4 @@
 import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { RUN_STATUS_IDLE, RUN_STATUS_RUNNING } from '@opentrons/api-client'
@@ -102,12 +101,6 @@ describe('ImageGalleryList', () => {
     screen.getByText('MOCK_GALLERY_LIST_ITEM_2024-01-01 11:00:00')
   })
 
-  it('renders image capture floating action button', () => {
-    render(mockProps)
-
-    screen.getByText('Image capture')
-  })
-
   it('renders with running status', () => {
     const runningProps = { ...mockProps, runStatus: RUN_STATUS_RUNNING }
     render(runningProps)
@@ -116,14 +109,6 @@ describe('ImageGalleryList', () => {
       runningProps,
       {}
     )
-  })
-
-  it('calls image capture button onClick handler', async () => {
-    const user = userEvent.setup()
-    render(mockProps)
-
-    const captureButton = screen.getByText('Image capture')
-    await user.click(captureButton)
   })
 
   it('renders no images copy when no images are present', () => {

--- a/app/src/organisms/ODD/RunningProtocol/ImageGalleryList/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ImageGalleryList/index.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from 'react-i18next'
 
 import { ListTable, StyledText } from '@opentrons/components'
 
-import { FloatingActionButton } from '/app/atoms/buttons'
 import { OddInfoScreen } from '/app/molecules/ODDInfoScreen'
 import { GalleryListItem } from '/app/organisms/ODD/RunningProtocol/ImageGalleryList/GalleryListItem'
 import { ProtocolPlayPauseHeader } from '/app/organisms/ODD/RunningProtocol/shared/ProtocolPlayPauseHeader'
@@ -30,7 +29,6 @@ export interface ImageGalleryListProps {
 }
 
 export function ImageGalleryList(props: ImageGalleryListProps): JSX.Element {
-  const { t } = useTranslation('run_details')
   const { runId, protocolAnalysis, robotType, allRunDefs } = props
 
   const { items } = useImageInfo(runId)
@@ -51,11 +49,6 @@ export function ImageGalleryList(props: ImageGalleryListProps): JSX.Element {
           <NoImagesAvailable />
         )}
       </div>
-      <FloatingActionButton
-        buttonText={t('image_capture')}
-        iconName="camera"
-        onClick={() => null}
-      />
     </div>
   )
 }


### PR DESCRIPTION
Closes [RQA-5253](https://opentrons.atlassian.net/browse/RQA-5253)

# Overview

Whoops, For the second round of camera work, the "capture images during a protocol run" feature was cut from scope, however, the UI that supports this feature on the ODD was not removed when we removed the feature flag. This PR simply removes the no-oping "Image capture" button on the ODD.

### Current Behavior

<img width="960" height="558" alt="Screenshot 2026-03-17 at 12 10 28 PM" src="https://github.com/user-attachments/assets/e4ad9c68-20fd-4b10-8474-3443cdcda0f3" />

### Fixed Behavior

<img width="961" height="568" alt="Screenshot 2026-03-17 at 12 14 38 PM" src="https://github.com/user-attachments/assets/0348155a-feba-44cc-b8a4-41de9774ebd3" />

## Test Plan and Hands on Testing

- See image.

## Changelog

- Removed the "Image capture" button on the ODD that appears during a protocol run.

## Risk assessment

- very very low, just removing placeholder UI


[RQA-5253]: https://opentrons.atlassian.net/browse/RQA-5253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ