### PR TITLE
chore(python): Fix formatting not being checked

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -61,6 +61,10 @@ clean_all_cmd = $(clean_cmd) dist
 
 plot_type ?=
 
+files_to_typecheck := src tests integration_testing
+files_to_lint := src tests integration_testing docs/v2/example_protocols
+files_to_format := src tests integration_testing docs/v2/example_protocols
+
 .PHONY: all
 all: clean wheel
 
@@ -133,13 +137,14 @@ test-ot2:
 
 .PHONY: lint
 lint:
-	$(python) -m mypy src tests integration_testing
-	$(ruff) check src tests integration_testing docs/v2/example_protocols
+	$(python) -m mypy $(files_to_typecheck)
+	$(ruff) check $(files_to_lint)
+	$(ruff) format --check $(files_to_format)
 
 .PHONY: format
 format:
-	$(ruff) format src tests integration_testing docs/v2/example_protocols
-	$(ruff) check --select I --fix src tests integration_testing docs/v2/example_protocols
+	$(ruff) format $(files_to_format)
+	$(ruff) check --select I --fix $(files_to_format)
 
 docs/build/html/v%: docs/v%
 	$(sphinx_build) -b html -d docs/build/doctrees -n $< $@

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -152,7 +152,7 @@ convention = "google"
 [tool.ruff.lint.mccabe]
 max-complexity = 9
 [tool.ruff.format]
-exclude = ["docs/v2/example_protocols/*"]
+exclude = ["docs/v2/example_protocols/*", "src/opentrons/_version.py"]
 [tool.ruff.lint.isort]
 known-first-party = ["opentrons_shared_data", "opentrons_hardware"]
 known-local-folder = ["opentrons"]

--- a/api/src/opentrons/protocol_api/core/engine/instrument.py
+++ b/api/src/opentrons/protocol_api/core/engine/instrument.py
@@ -612,9 +612,9 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             increment: Customize the movement "distance" of the pipette to press harder.
             prep_after: Not used by this core, pipette preparation will always happen.
         """
-        assert (
-            presses is None and increment is None
-        ), "Tip pick-up with custom presses or increment deprecated"
+        assert presses is None and increment is None, (
+            "Tip pick-up with custom presses or increment deprecated"
+        )
 
         well_name = well_core.get_name()
         labware_id = well_core.labware_id
@@ -1285,9 +1285,10 @@ class InstrumentCore(AbstractInstrument[WellCore, LabwareCore]):
             assert (
                 # We make sure to set these nozzles in the calling function
                 # if using QUADRANT or PARTIAL_COLUMN. Asserting only for type verification here.
-                front_right_nozzle is not None
-                and back_left_nozzle is not None
-            ), f"Both front right and back left nozzles are required for {style} configuration."
+                front_right_nozzle is not None and back_left_nozzle is not None
+            ), (
+                f"Both front right and back left nozzles are required for {style} configuration."
+            )
             configuration_model = QuadrantNozzleLayoutConfiguration(
                 primaryNozzle=cast(PRIMARY_NOZZLE_LITERAL, primary_nozzle),
                 frontRightNozzle=front_right_nozzle,

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -121,9 +121,9 @@ class ModuleContext(CommandPublisher):
             "`ModuleContext.load_labware_object` is an internal, deprecated method. Use `ModuleContext.load_labware` or `load_labware_by_definition` instead."
         )
 
-        assert (
-            labware.parent == self._core.geometry
-        ), "Labware is not configured with this module as its parent"
+        assert labware.parent == self._core.geometry, (
+            "Labware is not configured with this module as its parent"
+        )
 
         return self._core.geometry.add_labware(labware)
 

--- a/auth-server/Makefile
+++ b/auth-server/Makefile
@@ -90,6 +90,7 @@ test-cov:
 lint:
 	$(python) -m mypy $(SRC_PATH) $(TESTS_PATH)
 	$(ruff) check .
+	$(ruff) format --check .
 
 .PHONY: format
 format:

--- a/auth-server/pyproject.toml
+++ b/auth-server/pyproject.toml
@@ -73,6 +73,9 @@ convention = "google"
 [tool.ruff.lint.mccabe]
 max-complexity = 9
 
+[tool.ruff.format]
+exclude = ["auth_server/_version.py"]
+
 # uv: global settings and dependency tweaks
 [tool.uv]
 # Provide static metadata so uv can resolve systemd-python without building its sdist on

--- a/g-code-testing/Makefile
+++ b/g-code-testing/Makefile
@@ -15,6 +15,8 @@ test_opts ?=  --cov=g_code_parsing --cov-report term-missing:skip-covered --cov-
 tests_to_typecheck := \
 	tests/g_code_parsing
 
+files_to_check := g_code_parsing tests cli.py
+
 # Defined separately than the clean target so the wheel file doesn’t have to
 # depend on a PHONY target
 clean_cmd = $(SHX) rm -rf build dist .coverage coverage.xml '*.egg-info' '**/__pycache__' '**/*.pyc' '**/.mypy_cache'
@@ -68,12 +70,13 @@ test-g-code-omega:
 .PHONY: lint
 lint: lint-other
 	$(python) -m mypy g_code_parsing $(tests_to_typecheck)
-	$(ruff) check g_code_parsing tests cli.py
+	$(ruff) check $(files_to_check)
+	$(ruff) format --check $(files_to_check)
 
 .PHONY: format
 format: format-other
-	$(ruff) format g_code_parsing tests cli.py
-	$(ruff) check --select I --fix g_code_parsing tests cli.py
+	$(ruff) format $(files_to_check)
+	$(ruff) check --select I --fix $(files_to_check)
 
 .PHONY: get-g-code-configurations
 get-g-code-configurations:

--- a/g-code-testing/pyproject.toml
+++ b/g-code-testing/pyproject.toml
@@ -55,6 +55,9 @@ known-first-party = ["opentrons", "opentrons_shared_data"]
 "g_code_parsing/_version.py" = ["I"]
 "cli.py" = ["T201"]
 
+[tool.ruff.format]
+exclude = ["g_code_parsing/_version.py"]
+
 # uv: global settings and dependency tweaks
 [tool.uv]
 # Provide static metadata so uv can resolve systemd-python without building its sdist on

--- a/hardware/Makefile
+++ b/hardware/Makefile
@@ -27,6 +27,8 @@ tests ?= tests
 cov_opts ?= --cov=opentrons_hardware --cov-report term-missing:skip-covered --cov-report xml:coverage.xml
 test_opts ?=
 
+files_to_check := opentrons_hardware tests
+
 # These variables must be overridden when make deploy or make deploy-staging is run
 # to set the auth details for pypi
 pypi_username ?=
@@ -127,13 +129,14 @@ test-with-opentrons-sock-emulator: test-with-emulator
 
 .PHONY: lint
 lint:
-	$(python) -m mypy opentrons_hardware tests
-	$(ruff) check opentrons_hardware tests
+	$(python) -m mypy $(files_to_check)
+	$(ruff) check $(files_to_check)
+	$(ruff) format --check $(files_to_check)
 
 .PHONY: format
 format:
-	$(ruff) format opentrons_hardware tests
-	$(ruff) check --select I --fix opentrons_hardware tests
+	$(ruff) format $(files_to_check)
+	$(ruff) check --select I --fix $(files_to_check)
 
 # launch hardware controller in dev mode
 .PHONY: dev

--- a/hardware/pyproject.toml
+++ b/hardware/pyproject.toml
@@ -67,6 +67,9 @@ known-local-folder = ["opentrons_hardware"]
 "opentrons_hardware/_version.py" = ["I"]
 "opentrons_hardware/scripts/*" = ["T201"]
 
+[tool.ruff.format]
+exclude = ["opentrons_hardware/_version.py"]
+
 [tool.hatch.metadata.hooks.dependency-coversion]
 override-versions-of=['opentrons_shared_data']
 

--- a/key-server/Makefile
+++ b/key-server/Makefile
@@ -90,6 +90,7 @@ test-cov:
 lint:
 	$(python) -m mypy $(SRC_PATH) $(TESTS_PATH)
 	$(ruff) check .
+	$(ruff) format --check .
 
 .PHONY: format
 format:

--- a/key-server/pyproject.toml
+++ b/key-server/pyproject.toml
@@ -64,6 +64,9 @@ convention = "google"
 [tool.ruff.lint.mccabe]
 max-complexity = 9
 
+[tool.ruff.format]
+exclude = ["key_server/_version.py"]
+
 # uv: global settings and dependency tweaks
 [tool.uv]
 # Provide static metadata so uv can resolve systemd-python without building its sdist on

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -124,6 +124,7 @@ test-fast:
 lint:
 	$(python) -m mypy $(SRC_PATH) $(SCRIPTS_PATH) $(TESTS_PATH)
 	$(ruff) check .
+	$(ruff) format --check .
 
 .PHONY: format
 format:

--- a/robot-server/pyproject.toml
+++ b/robot-server/pyproject.toml
@@ -105,7 +105,7 @@ convention = "google"
 [tool.ruff.lint.mccabe]
 max-complexity = 9
 [tool.ruff.format]
-exclude = ["tests/integration/persistence_snapshots"]
+exclude = ["tests/integration/persistence_snapshots", "robot_server/_version.py"]
 
 # uv: global settings and dependency tweaks
 [tool.uv]

--- a/robot-server/tests/file_provider/test_provider.py
+++ b/robot-server/tests/file_provider/test_provider.py
@@ -1,4 +1,5 @@
 """Test the file provider."""
+
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import Mock
@@ -110,7 +111,7 @@ async def test_write_new_file(subject: FileProviderExecutor) -> None:
     )
     file_info = await subject.write_file_cb(file_data)
 
-    #make sure it appends a csv to the filename if there's not one
+    # make sure it appends a csv to the filename if there's not one
     assert file_info.path.endswith("file.csv")
 
     cmd_metadata = UserDefinedCSVCmdFileNameMetadata(
@@ -146,8 +147,8 @@ async def test_append(subject: FileProviderExecutor) -> None:
     # Do the first write
     first_file_info = await subject.write_file_cb(file_data)
 
-    subject._data_files_store.insert.assert_called_once_with(first_file_info) # type: ignore[attr-defined]
-    subject._data_files_store.insert.reset_mock() # type: ignore[attr-defined]
+    subject._data_files_store.insert.assert_called_once_with(first_file_info)  # type: ignore[attr-defined]
+    subject._data_files_store.insert.reset_mock()  # type: ignore[attr-defined]
 
     with open(first_file_info.path, "r") as output:
         first_call_lines = output.readlines()
@@ -170,7 +171,7 @@ async def test_append(subject: FileProviderExecutor) -> None:
     second_file_info = await subject.write_file_cb(file_data)
 
     # Should not be inserted a second time
-    subject._data_files_store.insert.assert_not_called() # type: ignore[attr-defined]
+    subject._data_files_store.insert.assert_not_called()  # type: ignore[attr-defined]
 
     # All of this should be the same
     assert first_file_info.id == second_file_info.id

--- a/scripts/static-deploy/Makefile
+++ b/scripts/static-deploy/Makefile
@@ -12,6 +12,7 @@ format:
 
 lint:
 	uv run ruff check
+	uv run ruff format --check
 
 test:
 	uv run pytest tests/ -v

--- a/server-utils/Makefile
+++ b/server-utils/Makefile
@@ -95,6 +95,7 @@ test-cov:
 lint:
 	$(python) -m mypy $(SRC_PATH) $(tests)
 	$(ruff) check .
+	$(ruff) format --check .
 
 .PHONY: format
 format:

--- a/server-utils/pyproject.toml
+++ b/server-utils/pyproject.toml
@@ -60,6 +60,9 @@ max-complexity = 9
 [tool.ruff.lint.isort]
 known-local-folder = ["server_utils"]
 
+[tool.ruff.format]
+exclude = ["server_utils/_version.py"]
+
 # uv: global settings and dependency tweaks
 [tool.uv]
 # Provide static metadata so uv can resolve systemd-python without building its sdist on

--- a/server-utils/server_utils/auth/scopes.py
+++ b/server-utils/server_utils/auth/scopes.py
@@ -29,10 +29,7 @@ class Scope(enum.Enum):
         "Restart the robot.",
     )
 
-    ROBOT_SETTINGS_WRITE = (
-        "robot_settings.write",
-        "Edit general robot settings."
-    )
+    ROBOT_SETTINGS_WRITE = ("robot_settings.write", "Edit general robot settings.")
 
     RUNS_WRITE = (
         "runs.write",

--- a/shared-data/Makefile-python.mk
+++ b/shared-data/Makefile-python.mk
@@ -41,6 +41,8 @@ gripper_sources = $(wildcard gripper/definitions/*.json) $(wildcard gripper/sche
 
 json_sources = $(deck_sources) $(labware_sources) $(module_sources) $(pipette_sources) $(protocol_sources) $(gripper_sources)
 
+files_to_check := python/opentrons_shared_data python_tests tools
+
 tests ?= python_tests
 
 twine_auth_args := --username $(pypi_username) --password $(pypi_password)
@@ -99,13 +101,14 @@ sdist: $(py_sources) $(json_sources)
 
 .PHONY: lint
 lint: $(py_sources)
-	$(python) -m mypy python/opentrons_shared_data python_tests tools
-	$(ruff) check python/opentrons_shared_data python_tests tools
+	$(python) -m mypy $(files_to_check)
+	$(ruff) check $(files_to_check)
+	$(ruff) format --check $(files_to_check)
 
 .PHONY: format
 format:
-	$(ruff) format python/opentrons_shared_data python_tests tools
-	$(ruff) check --select I --fix python/opentrons_shared_data python_tests tools
+	$(ruff) format $(files_to_check)
+	$(ruff) check --select I --fix $(files_to_check)
 
 .PHONY: push-no-restart
 push-no-restart: wheel

--- a/shared-data/pyproject.toml
+++ b/shared-data/pyproject.toml
@@ -94,6 +94,8 @@ max-complexity = 9
 [tool.ruff.lint.isort]
 known-local-folder = ["opentrons_shared_data"]
 
+[tool.ruff.format]
+exclude = ["python/opentrons_shared_data/_version.py"]
 
 [tool.hatch.build.hooks.vcs-tunable]
 version-file="python/opentrons_shared_data/_version.py"

--- a/system-server/Makefile
+++ b/system-server/Makefile
@@ -26,6 +26,9 @@ version_file = $(call python_get_git_version,system-server,$(project_rs_default)
 # specified test
 tests ?= tests
 test_opts ?=
+
+files_to_check := system_server tests
+
 # Host key location for robot
 ssh_key ?= $(default_ssh_key)
 # Other SSH args for robot
@@ -66,13 +69,14 @@ test:
 
 .PHONY: lint
 lint:
-	$(python) -m mypy system_server tests
-	$(ruff) check system_server tests
+	$(python) -m mypy $(files_to_check)
+	$(ruff) check $(files_to_check)
+	$(ruff) format --check $(files_to_check)
 
 .PHONY: format
 format:
-	$(ruff) format system_server tests
-	$(ruff) check --select I --fix system_server tests
+	$(ruff) format $(files_to_check)
+	$(ruff) check --select I --fix $(files_to_check)
 
 .PHONY: wheel
 wheel: export OPENTRONS_PROJECT=$(PROJECT)

--- a/system-server/pyproject.toml
+++ b/system-server/pyproject.toml
@@ -89,6 +89,9 @@ max-complexity = 9
 known-first-party = ["opentrons", "opentrons_shared_data", "server_utils"]
 known-local-folder = ["system_server"]
 
+[tool.ruff.format]
+exclude = ["system_server/_version.py"]
+
 [tool.hatch.build.hooks.vcs-tunable]
 version-file="system_server/_version.py"
 tag-pattern='v(?P<version>.*)'

--- a/system-server/tests/dev_server.py
+++ b/system-server/tests/dev_server.py
@@ -9,9 +9,7 @@ from types import TracebackType
 
 
 class DevServer:
-    def __init__(
-        self, port: int, persistence_directory: Path | None = None
-    ) -> None:
+    def __init__(self, port: int, persistence_directory: Path | None = None) -> None:
         """Initialize a dev server with the given port."""
         self.server_temp_directory: str = tempfile.mkdtemp()
         self.persistence_directory: Path = (

--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -12,6 +12,9 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 port ?= 34000
 tests ?= tests
 test_opts ?=
+
+files_to_check := otupdate tests
+
 wheel_file = $(call python_get_wheelname,update-server,$(project_rs_default),otupdate)
 # Find the branch, sha, version that will be used to update the VERSION.json file
 version_file = $(call python_get_git_version,update-server,$(project_rs_default),update-server)
@@ -64,13 +67,14 @@ test:
 
 .PHONY: lint
 lint:
-	$(python) -m mypy otupdate tests
-	$(ruff) check otupdate tests
+	$(python) -m mypy $(files_to_check)
+	$(ruff) check $(files_to_check)
+	$(ruff) format --check $(files_to_check)
 
 .PHONY: format
 format:
-	$(ruff) format otupdate tests
-	$(ruff) check --select I --fix otupdate tests
+	$(ruff) format $(files_to_check)
+	$(ruff) check --select I --fix $(files_to_check)
 
 .PHONY: wheel
 wheel: export OPENTRONS_PROJECT=$(PROJECT)

--- a/update-server/pyproject.toml
+++ b/update-server/pyproject.toml
@@ -69,6 +69,9 @@ known-first-party = ["server_utils"]
 "buildroot_upload.py" = ["T201"]
 "oe_upload.py" = ["T201"]
 
+[tool.ruff.format]
+exclude = ["otupdate/_version.py"]
+
 [tool.hatch.build.hooks.vcs-tunable]
 version-file="otupdate/_version.py"
 tag-pattern='v(?P<version>.*)'

--- a/usb-bridge/Makefile
+++ b/usb-bridge/Makefile
@@ -18,6 +18,9 @@ PATH := $(shell cd .. && yarn bin):$(PATH)
 # specified test
 tests ?= tests
 test_opts ?=
+
+files_to_check := ot3usb tests
+
 wheel_file = $(call python_get_wheelname,usb-bridge,$(project_rs_default),ot3usb)
 
 # Find the branch, sha, version that will be used to update the VERSION.json file
@@ -62,13 +65,14 @@ test:
 
 .PHONY: lint
 lint:
-	$(python) -m mypy ot3usb tests
-	$(ruff) check ot3usb tests
+	$(python) -m mypy $(files_to_check)
+	$(ruff) check $(files_to_check)
+	$(ruff) format --check $(files_to_check)
 
 .PHONY: format
 format:
-	$(ruff) format ot3usb tests
-	$(ruff) check --select I --fix ot3usb tests
+	$(ruff) format $(files_to_check)
+	$(ruff) check --select I --fix $(files_to_check)
 
 .PHONY: wheel
 wheel: export OPENTRONS_PROJECT=$(project_rs_default)

--- a/usb-bridge/pyproject.toml
+++ b/usb-bridge/pyproject.toml
@@ -63,6 +63,9 @@ max-complexity = 9
 known-first-party = ["opentrons", "opentrons_hardware", "opentrons_shared_data", "robot_server" ]
 known-local-folder = ["usb_bridge"]
 
+[tool.ruff.format]
+exclude = ["ot3usb/_version.py"]
+
 [tool.hatch.build.hooks.vcs-tunable]
 version-file = "ot3usb/_version.py"
 tag-pattern = 'v(?P<version>.*)'


### PR DESCRIPTION
## Overview

It turns out that since our switch to Ruff, we have simply not been enforcing Python formatting. `make lint` runs `ruff check`, but to check formatting, we have to run a separate command on top of that, `ruff format --check`.

This PR:

* Adds that command to all Python projects that are using Ruff.
* Excludes the autogenerated `_version.py` files from formatting, just as we exclude them from linting.
* Runs `make format-py` to fix all outstanding violations.

This is via LLM.

## Test Plan and Hands on Testing

* [x] `make lint` in a Python project now fails if there are formatting violations
* [x] `make format` fixes it

## Review requests

None.

## Risk assessment

Low, just dev tooling.