### PR TITLE
fix(app): highlight correct well in protocol visualization

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/LabwareOnDeck.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/LabwareOnDeck.tsx
@@ -47,10 +47,10 @@ export function LabwareOnDeck(props: LabwareOnDeckProps): JSX.Element {
       ? pipetteTemporalProperties[1].wellName
       : null
 
-  const wellName = activeWellName ?? 'A1'
-
   const wellGroup: WellGroup =
-    labwareDef.wells[wellName] != null ? { [wellName]: null } : {}
+    activeWellName != null && labwareDef.wells[activeWellName] != null
+      ? { [activeWellName]: null }
+      : {}
 
   const allWellContentsForActiveItem = getAllWellContentsAtFrame(
     liquidState,


### PR DESCRIPTION
# Overview

A regression introduced in #20896 was causing the viz deck map to highlight every A1 well of every labware on every step.

That was due to setting `const wellName = activeWellName ?? 'A1'`

This small fix corrects that logic so only active wells are highlighted, and A1 does not become a "default" value for highlighting.

Before
<img width="3936" height="2334" alt="Screenshot 2026-03-17 at 2 56 33 PM" src="https://github.com/user-attachments/assets/2bf62ecd-94f8-4fb9-a2e4-9baaf8f4e980" />

After
<img width="3936" height="2334" alt="Screenshot 2026-03-17 at 2 56 21 PM" src="https://github.com/user-attachments/assets/e012df3f-05da-4dda-8376-cb974be657ab" />

## Test Plan and Hands on Testing

- Inspected several protocols in viz
- Automated tests

## Changelog

- Remove the default value in favor of overtly checking `labwareDef.wells[activeWellName] != null`

## Review requests

This is an LLM diagnosis and fix, but the logic seems correct to me. However, let's make sure that:
- This is in fact logically correct, not just superficially correct
- This logic is limited to the viz deck map and won't have knock-on effects anywhere else

## Risk assessment

low. we should be only fixing an erroneous calculation and undoing a regression.