### PR TITLE
feat(protocol-designer): add vacuum mode change confirmation modal

### DIFF
--- a/protocol-designer/src/assets/localization/en/modal.json
+++ b/protocol-designer/src/assets/localization/en/modal.json
@@ -352,6 +352,10 @@
   },
   "upload": "Upload",
   "upload_tiprack": "Upload a custom tiprack to select its definition",
+  "vacuum_mode_update": {
+    "body": "Selecting a new vacuum mode type will clear your current profile steps. This action can't be undone.",
+    "title": "Vacuum profile steps will be reset"
+  },
   "well_order": {
     "body": "Change the order in which the robot aspirates from the selected wells",
     "field_label": "Order",

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -315,13 +315,12 @@
         "delete": "Delete",
         "edit": "Edit",
         "errors": {
-          "name": "Enter a valid step name",
           "pumpData": "Enter a valid pressure value",
           "repetitions": "Enter a valid number of cycles",
-          "time": "Enter a valid time"
+          "time": "Enter a valid time",
+          "title": "Enter a valid step title"
         },
         "gauge_pressure": "Gauge pressure",
-        "name": "Name",
         "no_profile_defined": "No profile defined",
         "no_steps_defined": "No steps defined",
         "number_of_cycles": "Number of cycles",
@@ -336,6 +335,7 @@
           "power": "{{power}}% power",
           "pressure": "{{pressure}} mbar"
         },
+        "step_title": "Name",
         "time": "Time",
         "title": "Edit Vacuum profile steps",
         "unsaved_changes": "You have unsaved changes to the profile. Please save or discard them before closing."

--- a/protocol-designer/src/components/organisms/VacuumModeUpdateModal/hooks/__tests__/useVacuumModeUpdate.test.ts
+++ b/protocol-designer/src/components/organisms/VacuumModeUpdateModal/hooks/__tests__/useVacuumModeUpdate.test.ts
@@ -1,0 +1,204 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  VACUUM_MODE_POWER,
+  VACUUM_MODE_PRESSURE,
+} from '@opentrons/step-generation'
+
+import { useVacuumModeUpdate } from '../../hooks/useVacuumModeUpdate'
+
+import type { FormData } from '/protocol-designer/form-types'
+import type { FieldPropsByName } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/types'
+
+const createPropsForFields = (): FieldPropsByName =>
+  ({
+    orderedProfileIds: { updateValue: vi.fn() },
+    profileItemsById: { updateValue: vi.fn() },
+    modeType: { updateValue: vi.fn() },
+  }) as unknown as FieldPropsByName
+
+// helper to create a form data object for a vacuum step with a profile
+const createVacuumFormData = (overrides: Partial<FormData> = {}): FormData =>
+  ({
+    stepType: 'vacuum',
+    id: 'step-1',
+    orderedProfileIds: ['profile-1'],
+    profileItemsById: {
+      'profile-1': {
+        type: 'profileStep',
+        id: 'profile-1',
+        title: 'Step 1',
+        time: '1:00',
+        pumpData: { mode: VACUUM_MODE_PRESSURE, pressureMbar: '100' },
+      },
+    },
+    modeType: VACUUM_MODE_PRESSURE,
+    programType: 'profile',
+    stateType: null,
+    moduleId: 'module-1',
+    ...overrides,
+  }) as FormData
+
+describe('useVacuumModeUpdate', () => {
+  describe('showVacuumModeUpdateModal', () => {
+    it('returns false when step type is not vacuum', () => {
+      const formData = createVacuumFormData({ stepType: 'moveLabware' })
+      const propsForFields = createPropsForFields()
+
+      const { result } = renderHook(() =>
+        useVacuumModeUpdate(formData, propsForFields)
+      )
+
+      expect(result.current.showVacuumModeUpdateModal).toBe(false)
+    })
+
+    it('returns false when vacuum step has no profile (empty orderedProfileIds)', () => {
+      const formData = createVacuumFormData({ orderedProfileIds: [] })
+      const propsForFields = createPropsForFields()
+
+      const { result } = renderHook(() =>
+        useVacuumModeUpdate(formData, propsForFields)
+      )
+
+      expect(result.current.showVacuumModeUpdateModal).toBe(false)
+    })
+
+    it('returns false when saved profile mode matches current form modeType', () => {
+      const formData = createVacuumFormData({ modeType: VACUUM_MODE_PRESSURE })
+      const propsForFields = createPropsForFields()
+
+      const { result } = renderHook(() =>
+        useVacuumModeUpdate(formData, propsForFields)
+      )
+
+      expect(result.current.showVacuumModeUpdateModal).toBe(false)
+    })
+
+    it('returns true when vacuum has profile and modeType differs from saved profile mode', () => {
+      const formData = createVacuumFormData({ modeType: VACUUM_MODE_POWER })
+      const propsForFields = createPropsForFields()
+
+      const { result } = renderHook(() =>
+        useVacuumModeUpdate(formData, propsForFields)
+      )
+
+      expect(result.current.showVacuumModeUpdateModal).toBe(true)
+    })
+
+    it('returns false when saved profile mode cannot be determined (null)', () => {
+      const formData = createVacuumFormData({
+        orderedProfileIds: ['profile-1'],
+        profileItemsById: {},
+        modeType: VACUUM_MODE_POWER,
+      })
+      const propsForFields = createPropsForFields()
+
+      const { result } = renderHook(() =>
+        useVacuumModeUpdate(formData, propsForFields)
+      )
+
+      expect(result.current.showVacuumModeUpdateModal).toBe(false)
+    })
+  })
+
+  describe('handleConfirmVacuumModeUpdate', () => {
+    it('resets profile to defaults and closes modal when vacuum with profile', () => {
+      const formData = createVacuumFormData({ modeType: VACUUM_MODE_POWER })
+      const propsForFields = createPropsForFields()
+
+      const { result } = renderHook(() =>
+        useVacuumModeUpdate(formData, propsForFields)
+      )
+
+      expect(result.current.showVacuumModeUpdateModal).toBe(true)
+      const handleConfirm = (
+        result.current as {
+          handleConfirmVacuumModeUpdate: () => void
+        }
+      ).handleConfirmVacuumModeUpdate
+
+      act(() => {
+        handleConfirm()
+      })
+
+      expect(propsForFields.orderedProfileIds.updateValue).toHaveBeenCalledWith(
+        []
+      )
+      expect(propsForFields.profileItemsById.updateValue).toHaveBeenCalledWith(
+        {}
+      )
+      expect(result.current.showVacuumModeUpdateModal).toBe(false)
+    })
+
+    it('does not expose handleConfirmVacuumModeUpdate when not vacuum with profile', () => {
+      const formData = createVacuumFormData({
+        stepType: 'moveLabware',
+        orderedProfileIds: [],
+      })
+      const propsForFields = createPropsForFields()
+
+      const { result } = renderHook(() =>
+        useVacuumModeUpdate(formData, propsForFields)
+      )
+
+      expect(result.current.showVacuumModeUpdateModal).toBe(false)
+      expect('handleConfirmVacuumModeUpdate' in result.current).toBe(false)
+    })
+  })
+
+  describe('handleCancelVacuumModeUpdate', () => {
+    it('restores saved modeType and closes modal when vacuum with profile', () => {
+      const formData = createVacuumFormData({ modeType: VACUUM_MODE_POWER })
+      const propsForFields = createPropsForFields()
+
+      const { result } = renderHook(() =>
+        useVacuumModeUpdate(formData, propsForFields)
+      )
+
+      expect(result.current.showVacuumModeUpdateModal).toBe(true)
+      const handleCancel = (
+        result.current as {
+          handleCancelVacuumModeUpdate: () => void
+        }
+      ).handleCancelVacuumModeUpdate
+
+      act(() => {
+        handleCancel()
+      })
+
+      expect(propsForFields.modeType.updateValue).toHaveBeenCalledWith(
+        VACUUM_MODE_PRESSURE
+      )
+      expect(result.current.showVacuumModeUpdateModal).toBe(false)
+    })
+
+    it('does not expose handleCancelVacuumModeUpdate when not vacuum with profile', () => {
+      const formData = createVacuumFormData({ stepType: 'moveLabware' })
+      const propsForFields = createPropsForFields()
+
+      const { result } = renderHook(() =>
+        useVacuumModeUpdate(formData, propsForFields)
+      )
+
+      expect(result.current.showVacuumModeUpdateModal).toBe(false)
+      expect('handleCancelVacuumModeUpdate' in result.current).toBe(false)
+    })
+
+    it('does not expose handleCancelVacuumModeUpdate when saved profile mode is null', () => {
+      // firstProfileItem is undefined when profileItemsById is empty, modal never shows
+      const formData = createVacuumFormData({
+        orderedProfileIds: ['profile-1'],
+        profileItemsById: {},
+      })
+      const propsForFields = createPropsForFields()
+
+      const { result } = renderHook(() =>
+        useVacuumModeUpdate(formData, propsForFields)
+      )
+
+      expect(result.current.showVacuumModeUpdateModal).toBe(false)
+      expect('handleCancelVacuumModeUpdate' in result.current).toBe(false)
+    })
+  })
+})

--- a/protocol-designer/src/components/organisms/VacuumModeUpdateModal/hooks/useVacuumModeUpdate.ts
+++ b/protocol-designer/src/components/organisms/VacuumModeUpdateModal/hooks/useVacuumModeUpdate.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+
+import { getDefaultsForStepType } from '/protocol-designer/steplist'
+
+import { getVacuumProfileModeType } from '../utils/getVacuumProfileModeType'
+
+import type { FormData, VacuumProfileItem } from '/protocol-designer/form-types'
+import type { FieldPropsByName } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/types'
+
+export type UseVacuumModeUpdateResult =
+  | {
+      showVacuumModeUpdateModal: true
+      handleConfirmVacuumModeUpdate: () => void
+      handleCancelVacuumModeUpdate: () => void
+    }
+  | {
+      showVacuumModeUpdateModal: false
+    }
+
+export function useVacuumModeUpdate(
+  formData: FormData,
+  propsForFields: FieldPropsByName
+): UseVacuumModeUpdateResult {
+  const [showVacuumModeUpdateModal, setShowVacuumModeUpdateModal] =
+    useState<boolean>(false)
+
+  const isVacuumWithProfile =
+    formData.stepType === 'vacuum' && formData.orderedProfileIds.length > 0
+
+  const firstProfileId = formData.orderedProfileIds?.[0]
+  const firstProfileItem =
+    firstProfileId != null
+      ? formData.profileItemsById?.[firstProfileId]
+      : undefined
+  const savedProfileModeType =
+    firstProfileItem != null
+      ? getVacuumProfileModeType(firstProfileItem as VacuumProfileItem)
+      : null
+
+  const handleConfirmVacuumModeUpdate = (): void => {
+    propsForFields.orderedProfileIds.updateValue(
+      getDefaultsForStepType('vacuum').orderedProfileIds
+    )
+    propsForFields.profileItemsById.updateValue(
+      getDefaultsForStepType('vacuum').profileItemsById
+    )
+    setShowVacuumModeUpdateModal(false)
+  }
+
+  const handleCancelVacuumModeUpdate = (): void => {
+    propsForFields.modeType.updateValue(savedProfileModeType)
+    setShowVacuumModeUpdateModal(false)
+  }
+
+  useEffect(() => {
+    if (
+      isVacuumWithProfile &&
+      savedProfileModeType != null &&
+      savedProfileModeType !== formData.modeType
+    ) {
+      setShowVacuumModeUpdateModal(true)
+    }
+  }, [formData, isVacuumWithProfile, savedProfileModeType])
+
+  return showVacuumModeUpdateModal
+    ? {
+        showVacuumModeUpdateModal,
+        handleConfirmVacuumModeUpdate,
+        handleCancelVacuumModeUpdate,
+      }
+    : { showVacuumModeUpdateModal }
+}

--- a/protocol-designer/src/components/organisms/VacuumModeUpdateModal/index.tsx
+++ b/protocol-designer/src/components/organisms/VacuumModeUpdateModal/index.tsx
@@ -1,0 +1,41 @@
+import { useTranslation } from 'react-i18next'
+
+import {
+  Modal,
+  PrimaryButton,
+  SecondaryButton,
+  StyledText,
+} from '@opentrons/components'
+
+import styles from './vacuummodeupdatemodal.module.css'
+
+interface VacuumModeUpdateModalProps {
+  onConfirm: () => void
+  onClose: () => void
+}
+
+export function VacuumModeUpdateModal(
+  props: VacuumModeUpdateModalProps
+): JSX.Element {
+  const { onConfirm, onClose } = props
+  const { t } = useTranslation(['modal', 'shared'])
+
+  const footer = (
+    <div className={styles.footer}>
+      <SecondaryButton onClick={onClose}>{t('shared:cancel')}</SecondaryButton>
+      <PrimaryButton onClick={onConfirm}>{t('shared:confirm')}</PrimaryButton>
+    </div>
+  )
+  return (
+    <Modal
+      onClose={onClose}
+      title={t('vacuum_mode_update.title')}
+      footer={footer}
+      type="warning"
+    >
+      <StyledText desktopStyle="bodyDefaultRegular">
+        {t('vacuum_mode_update.body')}
+      </StyledText>
+    </Modal>
+  )
+}

--- a/protocol-designer/src/components/organisms/VacuumModeUpdateModal/utils/__tests__/getVacuumProfileModeType.test.ts
+++ b/protocol-designer/src/components/organisms/VacuumModeUpdateModal/utils/__tests__/getVacuumProfileModeType.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { VACUUM_MODE_PRESSURE } from '@opentrons/step-generation'
+
+import { PROFILE_CYCLE, PROFILE_STEP } from '/protocol-designer/form-types'
+
+import { getVacuumProfileModeType } from '../getVacuumProfileModeType'
+
+import type {
+  VacuumProfileCycle,
+  VacuumProfileStep,
+} from '/protocol-designer/form-types'
+
+describe('getVacuumProfileModeType', () => {
+  it('should return the mode type of the first cycle item if the item is a step', () => {
+    const profileItem = {
+      type: PROFILE_STEP,
+      pumpData: { mode: VACUUM_MODE_PRESSURE },
+    } as VacuumProfileStep
+    const result = getVacuumProfileModeType(profileItem)
+    expect(result).toBe(VACUUM_MODE_PRESSURE)
+  })
+
+  it('should return the mode type of the first cycle step if the item is a cycle', () => {
+    const profileItem = {
+      type: PROFILE_CYCLE,
+      orderedProfileStepIds: ['step-1'],
+      profileStepItemsById: {
+        'step-1': {
+          pumpData: { mode: VACUUM_MODE_PRESSURE },
+        },
+      },
+    } as unknown as VacuumProfileCycle
+    const result = getVacuumProfileModeType(profileItem)
+    expect(result).toBe(VACUUM_MODE_PRESSURE)
+  })
+})

--- a/protocol-designer/src/components/organisms/VacuumModeUpdateModal/utils/getVacuumProfileModeType.ts
+++ b/protocol-designer/src/components/organisms/VacuumModeUpdateModal/utils/getVacuumProfileModeType.ts
@@ -1,0 +1,18 @@
+import { PROFILE_STEP } from '/protocol-designer/form-types'
+
+import type {
+  VACUUM_MODE_POWER,
+  VACUUM_MODE_PRESSURE,
+} from '@opentrons/step-generation'
+import type { VacuumProfileItem } from '/protocol-designer/form-types'
+
+export const getVacuumProfileModeType = (
+  profileItem: VacuumProfileItem
+): typeof VACUUM_MODE_PRESSURE | typeof VACUUM_MODE_POWER => {
+  if (profileItem.type === PROFILE_STEP) {
+    return profileItem.pumpData.mode
+  }
+  const firstCycleStep =
+    profileItem.profileStepItemsById[profileItem.orderedProfileStepIds[0]]
+  return firstCycleStep.pumpData.mode
+}

--- a/protocol-designer/src/components/organisms/VacuumModeUpdateModal/vacuummodeupdatemodal.module.css
+++ b/protocol-designer/src/components/organisms/VacuumModeUpdateModal/vacuummodeupdatemodal.module.css
@@ -1,0 +1,6 @@
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 var(--spacing-24) var(--spacing-24);
+  gap: var(--spacing-8);
+}

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -248,22 +248,55 @@ export interface FormData {
 }
 export const PROFILE_CYCLE: 'profileCycle' = 'profileCycle'
 export const PROFILE_STEP: 'profileStep' = 'profileStep'
-export interface ProfileStepItem {
+interface ProfileStepItemBase {
   type: typeof PROFILE_STEP
   id: string
   title: string
+}
+
+// Thermocycler
+// TODO: Rename plain "ProfileX" to "ThermocyclerProfileX"
+export interface ProfileStepItem extends ProfileStepItemBase {
   temperature: string
   durationMinutes: string
   durationSeconds: string
 }
-export interface ProfileCycleItem {
+
+interface ProfileCycleItemBase {
   type: typeof PROFILE_CYCLE
   id: string
-  steps: ProfileStepItem[]
   repetitions: string
 }
-// TODO IMMEDIATELY: ProfileStepItem -> ProfileStep, ProfileCycleItem -> ProfileCycle
+interface ProfileCycleItem extends ProfileCycleItemBase {
+  steps: ProfileStepItem[]
+}
+
 export type ProfileItem = ProfileStepItem | ProfileCycleItem
+
+// Vacuum
+export interface VacuumPressureData {
+  mode: typeof VACUUM_MODE_PRESSURE
+  pressureMbar: string | null
+}
+
+export interface VacuumPowerData {
+  mode: typeof VACUUM_MODE_POWER
+  powerPercent: number
+}
+
+type VacuumPumpData = VacuumPressureData | VacuumPowerData
+
+export interface VacuumProfileStep extends ProfileStepItemBase {
+  time: string
+  pumpData: VacuumPumpData
+}
+
+export type VacuumProfileCycle = ProfileCycleItemBase & {
+  profileStepItemsById: Record<string, VacuumProfileStep>
+  orderedProfileStepIds: string[]
+}
+export type VacuumProfileItem = VacuumProfileStep | VacuumProfileCycle
+
 export type PathOption = 'single' | 'multiAspirate' | 'multiDispense'
 export type WellOrderOption = 'l2r' | 'r2l' | 't2b' | 'b2t'
 export type BlankForm = AnnotationFields & {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -37,6 +37,7 @@ import { FormAlerts } from '/protocol-designer/components/organisms'
 import { AdvancedSettingsUpdateConfirmationModal } from '/protocol-designer/components/organisms/AdvancedSettingsUpdateConfirmationModal'
 import { useKitchen } from '/protocol-designer/components/organisms/Kitchen/useKitchen'
 import { RenameStepModal } from '/protocol-designer/components/organisms/RenameStepModal'
+import { useVacuumModeUpdate } from '/protocol-designer/components/organisms/VacuumModeUpdateModal/hooks/useVacuumModeUpdate'
 import { getFormWarningsForSelectedStep } from '/protocol-designer/dismiss/selectors'
 import {
   getRobotStateTimeline,
@@ -63,6 +64,7 @@ import {
   selectDropdownItem,
 } from '/protocol-designer/ui/steps/actions/actions'
 
+import { VacuumModeUpdateModal } from '../../../../components/organisms/VacuumModeUpdateModal'
 import { useAbsorbanceReaderCommandType } from './hooks'
 import {
   AbsorbanceReaderTools,
@@ -260,6 +262,9 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     showFormErrors,
     currentFormIsPresaved
   )
+
+  const vacuumModeUpdateResult = useVacuumModeUpdate(formData, propsForFields)
+  const { showVacuumModeUpdateModal } = vacuumModeUpdateResult
 
   const [isRename, setIsRename] = useState<boolean>(false)
   const icon = stepIconsByType[formData.stepType]
@@ -508,6 +513,12 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
           }}
         />
       ) : null}
+      {showVacuumModeUpdateModal && (
+        <VacuumModeUpdateModal
+          onConfirm={vacuumModeUpdateResult.handleConfirmVacuumModeUpdate}
+          onClose={vacuumModeUpdateResult.handleCancelVacuumModeUpdate}
+        />
+      )}
       <Toolbox
         height="100%"
         maxHeight={`calc(100vh - ${NAV_BAR_HEIGHT_REM}rem - 2 * ${SPACING.spacing12})`}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx
@@ -37,7 +37,6 @@ import { FormAlerts } from '/protocol-designer/components/organisms'
 import { AdvancedSettingsUpdateConfirmationModal } from '/protocol-designer/components/organisms/AdvancedSettingsUpdateConfirmationModal'
 import { useKitchen } from '/protocol-designer/components/organisms/Kitchen/useKitchen'
 import { RenameStepModal } from '/protocol-designer/components/organisms/RenameStepModal'
-import { useVacuumModeUpdate } from '/protocol-designer/components/organisms/VacuumModeUpdateModal/hooks/useVacuumModeUpdate'
 import { getFormWarningsForSelectedStep } from '/protocol-designer/dismiss/selectors'
 import {
   getRobotStateTimeline,
@@ -64,7 +63,6 @@ import {
   selectDropdownItem,
 } from '/protocol-designer/ui/steps/actions/actions'
 
-import { VacuumModeUpdateModal } from '../../../../components/organisms/VacuumModeUpdateModal'
 import { useAbsorbanceReaderCommandType } from './hooks'
 import {
   AbsorbanceReaderTools,
@@ -262,9 +260,6 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
     showFormErrors,
     currentFormIsPresaved
   )
-
-  const vacuumModeUpdateResult = useVacuumModeUpdate(formData, propsForFields)
-  const { showVacuumModeUpdateModal } = vacuumModeUpdateResult
 
   const [isRename, setIsRename] = useState<boolean>(false)
   const icon = stepIconsByType[formData.stepType]
@@ -513,12 +508,6 @@ export function StepFormToolbox(props: StepFormToolboxProps): JSX.Element {
           }}
         />
       ) : null}
-      {showVacuumModeUpdateModal && (
-        <VacuumModeUpdateModal
-          onConfirm={vacuumModeUpdateResult.handleConfirmVacuumModeUpdate}
-          onClose={vacuumModeUpdateResult.handleCancelVacuumModeUpdate}
-        />
-      )}
       <Toolbox
         height="100%"
         maxHeight={`calc(100vh - ${NAV_BAR_HEIGHT_REM}rem - 2 * ${SPACING.spacing12})`}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumCycle.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumCycle.tsx
@@ -22,11 +22,11 @@ import type {
 } from '@opentrons/step-generation'
 import type {
   PresavedVacuumCycleSavePayload,
-  VacuumCycleBaseProps,
+  PresavedVacuumCycleBaseProps,
 } from './types'
 
-export interface PresavedVacuumCycleProps extends VacuumCycleBaseProps {
-  repetitions: number
+export interface PresavedVacuumCycleProps extends PresavedVacuumCycleBaseProps {
+  repetitions: string
   handleSaveCycle: (data: PresavedVacuumCycleSavePayload) => void
   mode: typeof VACUUM_MODE_PRESSURE | typeof VACUUM_MODE_POWER
   handleAddCycleStep?: (stepId: string) => void
@@ -138,7 +138,7 @@ export function PresavedVacuumCycle(
               value={localRepetitions}
               onChange={e => {
                 setLocalRepetitions(
-                  Number(maskToPositiveInteger(e.currentTarget.value))
+                  maskToPositiveInteger(e.currentTarget.value)
                 )
               }}
               error={

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumCycle.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumCycle.tsx
@@ -21,8 +21,8 @@ import type {
   VACUUM_MODE_PRESSURE,
 } from '@opentrons/step-generation'
 import type {
-  PresavedVacuumCycleSavePayload,
   PresavedVacuumCycleBaseProps,
+  PresavedVacuumCycleSavePayload,
 } from './types'
 
 export interface PresavedVacuumCycleProps extends PresavedVacuumCycleBaseProps {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumStep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumStep.tsx
@@ -26,16 +26,13 @@ import { PresavedVacuumHeader } from './PresavedVacuumHeader'
 import { getStepErrors } from './utils'
 import styles from './vacuumprofile.module.css'
 
-import type {
-  VacuumPumpData,
-  VacuumStepBaseProps,
-  VacuumStepData,
-} from './types'
+import type { VacuumProfileStep } from '/protocol-designer/form-types'
+import type { VacuumPumpData, VacuumStepBaseProps } from './types'
 
 export interface PresavedVacuumStepProps extends VacuumStepBaseProps {
-  onStepChange: (stepId: string, patch: Partial<VacuumStepData>) => void
+  onStepChange: (stepId: string, patch: Partial<VacuumProfileStep>) => void
   /** Not required when nested, since save behavior is handled by parent cycle */
-  onSaveSuccess?: (stepData: VacuumStepData) => void
+  onSaveSuccess?: (stepData: VacuumProfileStep) => void
   /** When true, show validation errors on this step (e.g. when cycle Save is blocked). */
   forceShowErrors?: boolean
 }
@@ -56,10 +53,10 @@ export function PresavedVacuumStep(
   const [showErrors, setShowErrors] = useState<boolean>(false)
   const { t } = useTranslation('protocol_steps')
 
-  const { name, time, pumpData } = stepData
+  const { title, pumpData, time } = stepData
 
   const updateField = (
-    field: 'name' | 'time' | 'pumpData',
+    field: 'title' | 'time' | 'pumpData',
     value: string | Partial<VacuumPumpData>
   ): void => {
     if (field === 'pumpData') {
@@ -121,14 +118,14 @@ export function PresavedVacuumStep(
           <div className={styles.presaved_vacuum_step_form_row}>
             <div className={styles.flex_fill}>
               <InputField
-                title={t('vacuum.controls.profile.name')}
-                value={name}
+                title={t('vacuum.controls.profile.step_title')}
+                value={title}
                 onChange={e => {
-                  updateField('name', e.currentTarget.value)
+                  updateField('title', e.currentTarget.value)
                 }}
                 error={
-                  showValidationErrors && errors.name
-                    ? t('vacuum.controls.profile.errors.name')
+                  showValidationErrors && errors.title
+                    ? t('vacuum.controls.profile.errors.title')
                     : null
                 }
               />

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/SavedVacuumStep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/SavedVacuumStep.tsx
@@ -28,7 +28,7 @@ export function SavedVacuumStep(props: SavedVacuumStepProps): JSX.Element {
     onEdit,
     allowDelete = true,
   } = props
-  const { name, time, pumpData } = stepData
+  const { title, time, pumpData } = stepData
   const { mode } = pumpData
   const { t } = useTranslation('protocol_steps')
   const formattedPumpDetail =
@@ -49,7 +49,7 @@ export function SavedVacuumStep(props: SavedVacuumStepProps): JSX.Element {
       <div className={styles.flex_row_gap_24}>
         <Tag text={displayIndex} type="default" shrinkToContent />
         <StyledText desktopStyle="bodyDefaultRegular">
-          {[name, formattedPumpDetail, time].join(', ')}
+          {[title, formattedPumpDetail, time].join(', ')}
         </StyledText>
       </div>
       <div className={styles.flex_row_gap_8}>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/VacuumProfileModal.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/VacuumProfileModal.tsx
@@ -23,9 +23,9 @@ import type {
   VACUUM_MODE_POWER,
   VACUUM_MODE_PRESSURE,
 } from '@opentrons/step-generation'
-import type { FormData } from '/protocol-designer/form-types'
+import type { FormData, VacuumProfileStep } from '/protocol-designer/form-types'
 import type { FieldPropsByName } from '../../../types'
-import type { ProfileCycleItem, ProfileStepItem, VacuumStepData } from './types'
+import type { VacuumProfileCycleItem, VacuumProfileStepItem } from './types'
 
 export interface VacuumProfileModalProps {
   formData: FormData
@@ -124,13 +124,13 @@ export function VacuumProfileModal(
             {localOrderedProfileItemIds.map((id: string, index: number) => {
               const profileItem = localProfileItemsById[id]
               if (profileItem.type === PROFILE_STEP) {
-                const stepItem = profileItem as ProfileStepItem
+                const stepItem = profileItem as VacuumProfileStepItem
                 return stepItem.isPresaved ? (
                   <PresavedVacuumStep
                     key={id}
                     displayIndex={String(index + 1)}
                     stepData={stepItem}
-                    onSaveSuccess={(stepData: VacuumStepData) => {
+                    onSaveSuccess={(stepData: VacuumProfileStep) => {
                       onSaveSuccess(id, stepData)
                     }}
                     onStepChange={(_stepId, patch) => {
@@ -154,7 +154,7 @@ export function VacuumProfileModal(
                   />
                 )
               } else {
-                const cycleItem = profileItem as ProfileCycleItem
+                const cycleItem = profileItem as VacuumProfileCycleItem
                 return profileItem.isPresaved ? (
                   <PresavedVacuumCycle
                     key={id}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/usePresavedCycleState.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/usePresavedCycleState.ts
@@ -5,17 +5,17 @@ import { uuid } from '/protocol-designer/utils'
 import { PROFILE_STEP } from '../constants'
 import { getDefaultStepData, getInvalidPresavedStepIds } from '../utils'
 
+import type { VacuumProfileStep } from '/protocol-designer/form-types'
 import type {
   PresavedVacuumCycleSavePayload,
-  ProfileStepItem,
-  VacuumStepData,
+  VacuumProfileStepItem,
 } from '../types'
 import type { VacuumMode } from '../utils'
 
 export interface UsePresavedCycleStateArgs {
   orderedProfileStepIds: string[]
-  profileStepItemsById: Record<string, ProfileStepItem>
-  repetitions: number
+  profileStepItemsById: Record<string, VacuumProfileStepItem>
+  repetitions: string
   mode: VacuumMode
   onSaveCycle: (data: PresavedVacuumCycleSavePayload) => void
   handleAddCycleStep?: (stepId: string) => void
@@ -23,17 +23,17 @@ export interface UsePresavedCycleStateArgs {
 
 export function usePresavedCycleState(args: UsePresavedCycleStateArgs): {
   localOrderedProfileStepIds: string[]
-  localProfileStepItemsById: Record<string, ProfileStepItem>
-  localRepetitions: number
-  setLocalRepetitions: (value: number | ((prev: number) => number)) => void
+  localProfileStepItemsById: Record<string, VacuumProfileStepItem>
+  localRepetitions: string
+  setLocalRepetitions: (value: string | ((prev: string) => string)) => void
   showCycleErrors: boolean
   setShowCycleErrors: (value: boolean) => void
   showRepetitionErrors: boolean
   setShowRepetitionErrors: (value: boolean) => void
   isRepetitionError: boolean
   invalidStepIds: string[]
-  defaultStepData: VacuumStepData
-  handleStepChange: (stepId: string, patch: Partial<VacuumStepData>) => void
+  defaultStepData: VacuumProfileStep
+  handleStepChange: (stepId: string, patch: Partial<VacuumProfileStep>) => void
   handleDeleteStep: (stepId: string) => void
   handleEditStep: (stepId: string) => void
   handleAddStep: () => void
@@ -53,14 +53,15 @@ export function usePresavedCycleState(args: UsePresavedCycleStateArgs): {
     string[]
   >(orderedProfileStepIds)
   const [localProfileStepItemsById, setLocalProfileStepItemsById] =
-    useState<Record<string, ProfileStepItem>>(profileStepItemsById)
-  const [localRepetitions, setLocalRepetitions] = useState<number>(repetitions)
+    useState<Record<string, VacuumProfileStepItem>>(profileStepItemsById)
+  const [localRepetitions, setLocalRepetitions] = useState<string>(repetitions)
   const [showCycleErrors, setShowCycleErrors] = useState<boolean>(false)
   const [showRepetitionErrors, setShowRepetitionErrors] =
     useState<boolean>(false)
 
   const defaultStepData = getDefaultStepData(mode)
-  const isRepetitionError = localRepetitions == null || localRepetitions < 1
+  const isRepetitionError =
+    localRepetitions === '' || Number(localRepetitions) < 1
   const invalidStepIds = getInvalidPresavedStepIds(
     localOrderedProfileStepIds,
     localProfileStepItemsById
@@ -69,7 +70,7 @@ export function usePresavedCycleState(args: UsePresavedCycleStateArgs): {
 
   const handleStepChange = (
     stepId: string,
-    patch: Partial<VacuumStepData>
+    patch: Partial<VacuumProfileStep>
   ): void => {
     setLocalProfileStepItemsById(prev => ({
       ...prev,
@@ -106,7 +107,7 @@ export function usePresavedCycleState(args: UsePresavedCycleStateArgs): {
 
   const handleAddStep = (): void => {
     const id = uuid()
-    const newStep: ProfileStepItem = {
+    const newStep: VacuumProfileStepItem = {
       ...defaultStepData,
       id,
       isPresaved: true,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/useVacuumProfileState.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/useVacuumProfileState.ts
@@ -6,34 +6,34 @@ import { getFormattedTime } from '/protocol-designer/utils/getFormattedTime'
 import { PROFILE_CYCLE, PROFILE_STEP } from '../constants'
 import { getDefaultStepData } from '../utils'
 
+import type { VacuumProfileStep } from '/protocol-designer/form-types'
 import type {
   PresavedVacuumCycleSavePayload,
-  ProfileCycleItem,
-  ProfileItem,
-  ProfileStepItem,
-  VacuumStepData,
+  VacuumProfileCycleItem,
+  VacuumProfileItem,
+  VacuumProfileStepItem,
 } from '../types'
 import type { VacuumMode } from '../utils'
 
 export interface UseVacuumProfileStateArgs {
   orderedProfileIds: string[]
-  profileItemsById: Record<string, ProfileItem>
+  profileItemsById: Record<string, VacuumProfileItem>
   mode: VacuumMode
 }
 
 export function useVacuumProfileState(args: UseVacuumProfileStateArgs): {
   orderedProfileItemIds: string[]
-  profileItemsById: Record<string, ProfileItem>
+  profileItemsById: Record<string, VacuumProfileItem>
   addStep: () => void
   addCycle: () => void
   deleteStep: (stepId: string) => void
   deleteCycleStep: (cycleId: string, stepId: string) => void
-  stepChange: (stepId: string, patch: Partial<VacuumStepData>) => void
-  saveStepSuccess: (stepId: string, stepData: VacuumStepData) => void
+  stepChange: (stepId: string, patch: Partial<VacuumProfileStep>) => void
+  saveStepSuccess: (stepId: string, stepData: VacuumProfileStep) => void
   editStep: (stepId: string) => void
   saveCycle: (
     cycleId: string,
-    cycleItem: ProfileCycleItem,
+    cycleItem: VacuumProfileCycleItem,
     data: PresavedVacuumCycleSavePayload
   ) => void
   hasUnsavedPresavedItems: boolean
@@ -42,14 +42,14 @@ export function useVacuumProfileState(args: UseVacuumProfileStateArgs): {
   const [orderedProfileItemIds, setOrderedProfileItemIds] =
     useState<string[]>(orderedProfileIds)
   const [itemsById, setItemsById] =
-    useState<Record<string, ProfileItem>>(profileItemsById)
+    useState<Record<string, VacuumProfileItem>>(profileItemsById)
 
   const defaultStepData = getDefaultStepData(mode)
 
   const addStep = (): void => {
     const id = uuid()
     setOrderedProfileItemIds(prev => [...prev, id])
-    const newStep: ProfileStepItem = {
+    const newStep: VacuumProfileStepItem = {
       ...defaultStepData,
       id,
       isPresaved: true,
@@ -58,7 +58,10 @@ export function useVacuumProfileState(args: UseVacuumProfileStateArgs): {
     setItemsById(prev => ({ ...prev, [id]: newStep }))
   }
 
-  const saveStepSuccess = (stepId: string, stepData: VacuumStepData): void => {
+  const saveStepSuccess = (
+    stepId: string,
+    stepData: VacuumProfileStep
+  ): void => {
     setItemsById(prev => ({
       ...prev,
       [stepId]: {
@@ -69,9 +72,12 @@ export function useVacuumProfileState(args: UseVacuumProfileStateArgs): {
     }))
   }
 
-  const stepChange = (stepId: string, patch: Partial<VacuumStepData>): void => {
+  const stepChange = (
+    stepId: string,
+    patch: Partial<VacuumProfileStep>
+  ): void => {
     setItemsById(prev => {
-      const current = prev[stepId] as ProfileStepItem | undefined
+      const current = prev[stepId] as VacuumProfileStepItem | undefined
       if (current?.type !== PROFILE_STEP) return prev
       return {
         ...prev,
@@ -98,7 +104,7 @@ export function useVacuumProfileState(args: UseVacuumProfileStateArgs): {
 
   const deleteCycleStep = (cycleId: string, stepId: string): void => {
     setItemsById(prev => {
-      const cycleItem = prev[cycleId] as ProfileCycleItem | undefined
+      const cycleItem = prev[cycleId] as VacuumProfileCycleItem | undefined
       if (cycleItem?.type !== PROFILE_CYCLE) return prev
       const nextOrderedIds = cycleItem.orderedProfileStepIds.filter(
         id => id !== stepId
@@ -149,7 +155,7 @@ export function useVacuumProfileState(args: UseVacuumProfileStateArgs): {
         type: PROFILE_CYCLE,
         orderedProfileStepIds: [seedStep.id],
         profileStepItemsById: { [seedStep.id]: seedStep },
-        repetitions: 1,
+        repetitions: '1',
         isPresaved: true,
       },
     }))
@@ -157,7 +163,7 @@ export function useVacuumProfileState(args: UseVacuumProfileStateArgs): {
 
   const saveCycle = (
     cycleId: string,
-    cycleItem: ProfileCycleItem,
+    cycleItem: VacuumProfileCycleItem,
     data: PresavedVacuumCycleSavePayload
   ): void => {
     setItemsById(prev => {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/useVacuumProfileState.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/useVacuumProfileState.ts
@@ -78,7 +78,9 @@ export function useVacuumProfileState(args: UseVacuumProfileStateArgs): {
   ): void => {
     setItemsById(prev => {
       const current = prev[stepId] as VacuumProfileStepItem | undefined
-      if (current?.type !== PROFILE_STEP) return prev
+      if (current?.type !== PROFILE_STEP) {
+        return prev
+      }
       return {
         ...prev,
         [stepId]: {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/types.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/types.ts
@@ -1,73 +1,66 @@
 import type {
-  VACUUM_MODE_POWER,
-  VACUUM_MODE_PRESSURE,
-} from '@opentrons/step-generation'
+  VacuumPowerData,
+  VacuumPressureData,
+  VacuumProfileCycle,
+  VacuumProfileStep,
+} from '/protocol-designer/form-types'
 import type { PROFILE_CYCLE, PROFILE_STEP } from './constants'
-
-export interface VacuumPressureData {
-  mode: typeof VACUUM_MODE_PRESSURE
-  pressureMbar: string | null
-}
-
-export interface VacuumPowerData {
-  mode: typeof VACUUM_MODE_POWER
-  powerPercent: number
-}
 
 export type VacuumPumpData = VacuumPressureData | VacuumPowerData
 
-export interface VacuumStepData<T extends VacuumPumpData = VacuumPumpData> {
-  id: string
-  time: string
-  name: string
-  type: typeof PROFILE_STEP
-  pumpData: T
+export interface ProfileItemBaseProps {
+  isPresaved: boolean
 }
 
+/** Step row props; isPresaved is derived from stepData when stepData is VacuumProfileStepItem. */
 export interface VacuumStepBaseProps {
-  stepData: VacuumStepData
+  stepData: VacuumProfileStep
   displayIndex: string
   onDelete: () => void
   isNested?: boolean
   allowDelete?: boolean
 }
 
-export interface VacuumCycleBaseProps {
+/** Shared props for both saved and presaved cycle components (no isPresaved prop). */
+export interface VacuumCyclePropsBase {
   orderedProfileStepIds: string[]
-  profileStepItemsById: Record<string, ProfileStepItem>
   displayIndex: string
   type: typeof PROFILE_CYCLE
   onDelete: () => void
 }
 
-export interface PresavedVacuumCycleSavePayload {
-  orderedProfileStepIds: string[]
-  profileStepItemsById: Record<string, ProfileStepItem>
-  repetitions: number
+export interface VacuumCycleBaseProps extends VacuumCyclePropsBase {
+  profileStepItemsById: Record<string, VacuumProfileStep>
 }
 
-export interface ProfileStepBaseProps {
-  id: string
-  isPresaved: boolean
+/** Presaved cycle props: steps are VacuumProfileStepItem (include isPresaved). */
+export interface PresavedVacuumCycleBaseProps extends VacuumCyclePropsBase {
+  profileStepItemsById: Record<string, VacuumProfileStepItem>
 }
 
-export interface ProfileStepItem extends VacuumStepData, ProfileStepBaseProps {
+export interface VacuumProfileStepItem
+  extends VacuumProfileStep, ProfileItemBaseProps {
   type: typeof PROFILE_STEP
 }
 
-export interface ProfileCycleItem extends ProfileStepBaseProps {
-  id: string
-  isPresaved: boolean
+export interface PresavedVacuumCycleSavePayload {
   orderedProfileStepIds: string[]
-  profileStepItemsById: Record<string, ProfileStepItem>
-  repetitions: number
+  profileStepItemsById: Record<string, VacuumProfileStepItem>
+  repetitions: string
+}
+
+export interface VacuumProfileCycleItem
+  extends VacuumProfileCycle, ProfileItemBaseProps {
+  orderedProfileStepIds: string[]
+  profileStepItemsById: Record<string, VacuumProfileStepItem>
+  repetitions: string
   type: typeof PROFILE_CYCLE
 }
 
-export type ProfileItem = ProfileStepItem | ProfileCycleItem
+export type VacuumProfileItem = VacuumProfileStepItem | VacuumProfileCycleItem
 
 export interface VacuumStepErrors {
-  name: boolean
+  title: boolean
   time: boolean
   pumpData: boolean
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/utils.ts
@@ -7,20 +7,20 @@ import {
 
 import { PROFILE_STEP } from './constants'
 
+import type { VacuumProfileStep } from '/protocol-designer/form-types'
 import type {
-  ProfileStepItem,
+  VacuumProfileStepItem,
   VacuumPumpData,
-  VacuumStepData,
   VacuumStepErrors,
 } from './types'
 
 export type VacuumMode = typeof VACUUM_MODE_PRESSURE | typeof VACUUM_MODE_POWER
 
-export function getDefaultStepData(mode: VacuumMode): VacuumStepData {
+export function getDefaultStepData(mode: VacuumMode): VacuumProfileStep {
   const baseData = {
     id: '',
     time: '',
-    name: '',
+    title: '',
     type: PROFILE_STEP,
   }
   return mode === VACUUM_MODE_PRESSURE
@@ -31,7 +31,9 @@ export function getDefaultStepData(mode: VacuumMode): VacuumStepData {
     : { ...baseData, pumpData: { mode: VACUUM_MODE_POWER, powerPercent: 1 } }
 }
 
-const getIsNameError = (name: string): boolean => name === ''
+const getIsTitleError = (title: string): boolean => {
+  return title.trim() === ''
+}
 
 const getIsTimeError = (time: string): boolean =>
   time === '' || !/^\d{0,2}(:\d{0,2})?$/.test(time)
@@ -50,22 +52,22 @@ const getIsPumpDataError = (pumpData: VacuumPumpData): boolean => {
   )
 }
 
-export const getStepErrors = (step: VacuumStepData): VacuumStepErrors => {
+export const getStepErrors = (step: VacuumProfileStep): VacuumStepErrors => {
   return {
-    name: getIsNameError(step.name),
+    title: getIsTitleError(step.title),
     time: getIsTimeError(step.time),
     pumpData: getIsPumpDataError(step.pumpData),
   }
 }
 
-export const getIsStepValid = (step: VacuumStepData): boolean => {
+export const getIsStepValid = (step: VacuumProfileStep): boolean => {
   const errors = getStepErrors(step)
   return !Object.values(errors).some(Boolean)
 }
 
 export const getInvalidPresavedStepIds = (
   orderedProfileStepIds: string[],
-  profileStepItemsById: Record<string, ProfileStepItem>
+  profileStepItemsById: Record<string, VacuumProfileStepItem>
 ): string[] => {
   return orderedProfileStepIds.filter(stepId => {
     const step = profileStepItemsById[stepId]

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/index.tsx
@@ -1,3 +1,4 @@
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -5,6 +6,9 @@ import { Divider } from '@opentrons/components'
 import { vacuumModuleStateGetter } from '@opentrons/step-generation'
 
 import { DropdownStepFormField } from '/protocol-designer/components/molecules'
+import { getMainPagePortalEl } from '/protocol-designer/components/organisms'
+import { VacuumModeUpdateModal } from '/protocol-designer/components/organisms/VacuumModeUpdateModal'
+import { useVacuumModeUpdate } from '/protocol-designer/components/organisms/VacuumModeUpdateModal/hooks/useVacuumModeUpdate'
 import { getRobotStateAtActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 import { getVacuumLabwareOptions } from '/protocol-designer/ui/modules/selectors'
 import { hoverSelection } from '/protocol-designer/ui/steps/actions/actions'
@@ -31,25 +35,39 @@ export function VacuumTools(props: VacuumToolsProps): JSX.Element {
     robotState != null
       ? vacuumModuleStateGetter(robotState, formData.moduleId as string)
       : null
+  const vacuumModeUpdateResult = useVacuumModeUpdate(formData, propsForFields)
+  const { showVacuumModeUpdateModal } = vacuumModeUpdateResult
+
   return (
-    <div className={styles.vacuum_tools_container}>
-      <DropdownStepFormField
-        {...propsForFields.moduleId}
-        tooltipContent={null}
-        width="100%"
-        options={vacuumLabwareOptions}
-        title={t('protocol_steps:module')}
-        onEnter={(id: string) => {
-          dispatch(hoverSelection({ id, text: t('select') }))
-        }}
-        onExit={() => {
-          dispatch(hoverSelection({ id: null, text: null }))
-        }}
-      />
-      <Divider marginY="0" />
-      <VacuumModuleState vacuumModuleState={vacuumModuleState} />
-      <Divider marginY="0" />
-      <VacuumControls formData={formData} propsForFields={propsForFields} />
-    </div>
+    <>
+      {createPortal(
+        showVacuumModeUpdateModal ? (
+          <VacuumModeUpdateModal
+            onConfirm={vacuumModeUpdateResult.handleConfirmVacuumModeUpdate}
+            onClose={vacuumModeUpdateResult.handleCancelVacuumModeUpdate}
+          />
+        ) : null,
+        getMainPagePortalEl()
+      )}
+      <div className={styles.vacuum_tools_container}>
+        <DropdownStepFormField
+          {...propsForFields.moduleId}
+          tooltipContent={null}
+          width="100%"
+          options={vacuumLabwareOptions}
+          title={t('protocol_steps:module')}
+          onEnter={(id: string) => {
+            dispatch(hoverSelection({ id, text: t('select') }))
+          }}
+          onExit={() => {
+            dispatch(hoverSelection({ id: null, text: null }))
+          }}
+        />
+        <Divider marginY="0" />
+        <VacuumModuleState vacuumModuleState={vacuumModuleState} />
+        <Divider marginY="0" />
+        <VacuumControls formData={formData} propsForFields={propsForFields} />
+      </div>
+    </>
   )
 }


### PR DESCRIPTION
# Overview

Create new PD component for vacuum mode change modal. This modal shows when a user has saved profile steps relevant to a specific mode type (pressure/power), and the user clicks onto the other mode type. Also implement a refactor for moving vacuum profile types to `protocol-designer/src/form-types.ts`

Closes EXEC-2426

https://github.com/user-attachments/assets/d16a7050-8e57-4639-8b7a-ef3aa774fe34

## Test Plan and Hands on Testing

### Hands on vacuum mode switch

#### Accept mode change
- create a vacuum step
- select "program a vacuum profile" and select either mode type
- build at least one profile step or cycle
- save the profile and click the other mode type
- verify that you are prompted to accept wiping your profile and switching modes
- accept and verify that your profile is cleaned and your new mode is selected

#### Decline mode change
- create a vacuum step
- select "program a vacuum profile" and select either mode type
- build at least one profile step or cycle
- save the profile and click the other mode type
- verify that you are prompted to accept wiping your profile and switching modes
- accept and verify that your profile is maintained and your old mode is re-selected

### Automated testing
- wrote extensive unit tests for all new and updated components

## Changelog

- add `VacuumModeUpdateModal` PD component and wire up in `StepFormToolbox`
- store logic for rendering the above modal in a clean hook
- refactor types from `VacuumProfile/types.ts` to `form-types.ts` for reuse across PD. Update their implementations across `VacuumProfile`
- add unit test

## Review requests

This PR has a large footprint by nature of refactoring vacuum profile types used in `protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile` subdir, so that the types are accessible across the application. These types are refactored and moved to protocol-designer/src/form-types.ts.

The main testing areas are:
1. testing mode switching with a saved profile, as specified in `Test Plan` above
2. smoke testing that the vacuum profile modal works as before (all changes were type updates)

As far as code, I'd love eyes on:
- `protocol-designer/src/components/organisms/VacuumModeUpdateModal`
- `protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepFormToolbox.tsx`

## Risk assessment

low. additive