### PR TITLE
feat: create and wire up dependent fields update for vacuum form

### DIFF
--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateVacuum.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateVacuum.ts
@@ -1,0 +1,88 @@
+import pick from 'lodash/pick'
+
+import { getDefaultsForStepType } from '../getDefaultsForStepType'
+import { chainPatchUpdaters, fieldHasChanged } from './utils'
+
+import type { FormData, StepFieldName } from '../../../form-types'
+import type { FormPatch } from '../../actions/types'
+
+const getDefaultFields = (...fields: StepFieldName[]): FormPatch =>
+  pick(getDefaultsForStepType('vacuum'), fields)
+
+const updatePatchOnVacuumProgramType = (
+  patch: FormPatch,
+  rawForm: FormData
+): FormPatch => {
+  if (
+    rawForm.programType != null &&
+    fieldHasChanged(rawForm, patch, 'programType')
+  ) {
+    return {
+      ...patch,
+      ...getDefaultFields(
+        'stateType',
+        'modeType',
+        'pressureMbar',
+        'powerPercent',
+        'pumpDurationCheckbox',
+        'pumpDurationTime',
+        'endingHoldVentCheckbox',
+        'orderedProfileIds',
+        'profileItemsById'
+      ),
+    }
+  }
+  return patch
+}
+
+const updatePatchOnVacuumStateType = (
+  patch: FormPatch,
+  rawForm: FormData
+): FormPatch => {
+  if (
+    rawForm.stateType != null &&
+    fieldHasChanged(rawForm, patch, 'stateType')
+  ) {
+    return {
+      ...patch,
+      ...getDefaultFields(
+        'modeType',
+        'pressureMbar',
+        'powerPercent',
+        'pumpDurationCheckbox',
+        'pumpDurationTime',
+        'endingHoldVentCheckbox'
+      ),
+    }
+  }
+  return patch
+}
+
+const updatePatchOnVacuumModeType = (
+  patch: FormPatch,
+  rawForm: FormData
+): FormPatch => {
+  if (rawForm.modeType != null && fieldHasChanged(rawForm, patch, 'modeType')) {
+    return {
+      ...patch,
+      ...getDefaultFields(
+        'pressureMbar',
+        'powerPercent',
+        'pumpDurationCheckbox',
+        'pumpDurationTime'
+      ),
+    }
+  }
+  return patch
+}
+
+export const dependentFieldsUpdateVacuum = (
+  originalPatch: FormPatch,
+  rawForm: FormData
+): FormPatch => {
+  return chainPatchUpdaters(originalPatch, [
+    chainPatch => updatePatchOnVacuumProgramType(chainPatch, rawForm),
+    chainPatch => updatePatchOnVacuumStateType(chainPatch, rawForm),
+    chainPatch => updatePatchOnVacuumModeType(chainPatch, rawForm),
+  ])
+}

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/index.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/index.ts
@@ -7,6 +7,7 @@ import { dependentFieldsUpdateMoveLiquid } from './dependentFieldsUpdateMoveLiqu
 import { dependentFieldsUpdatePause } from './dependentFieldsUpdatePause'
 import { dependentFieldsUpdateTemperature } from './dependentFieldsUpdateTemperature'
 import { dependentFieldsUpdateThermocycler } from './dependentFieldsUpdateThermocycler'
+import { dependentFieldsUpdateVacuum } from './dependentFieldsUpdateVacuum'
 
 import type {
   LabwareEntities,
@@ -90,6 +91,9 @@ export function handleFormChange(
     )
     return { ...patch, ...dependentFieldsPatch }
   }
-
+  if (rawForm.stepType === 'vacuum') {
+    const dependentFieldsPatch = dependentFieldsUpdateVacuum(patch, rawForm)
+    return { ...patch, ...dependentFieldsPatch }
+  }
   return patch
 }

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/test/vacuum.test.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/test/vacuum.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+
+import { dependentFieldsUpdateVacuum } from '../dependentFieldsUpdateVacuum'
+
+import type { FormData } from '/protocol-designer/form-types'
+
+const formData: FormData = {
+  stepType: 'vacuum',
+  id: 'vacuum-step-1',
+  moduleId: 'vacuum-module-1',
+  programType: 'profile',
+  stateType: 'pump',
+  modeType: 'pressure',
+  pressureMbar: 100,
+  powerPercent: 50,
+  pumpDurationCheckbox: true,
+  pumpDurationTime: '1:00',
+  endingHoldVentCheckbox: true,
+  orderedProfileIds: ['1'],
+  profileItemsById: {
+    '1': {
+      type: 'profileStep',
+      id: '1',
+      title: 'Step 1',
+      time: '1:00',
+      pumpData: { mode: 'pressure', pressureMbar: 100 },
+    },
+  },
+}
+
+describe('dependentFieldsUpdateVacuum', () => {
+  it('should update the patch on program type', () => {
+    expect(
+      dependentFieldsUpdateVacuum({ programType: 'state' }, formData)
+    ).toEqual({
+      programType: 'state',
+      stateType: null,
+      modeType: null,
+      pressureMbar: null,
+      powerPercent: null,
+      pumpDurationCheckbox: null,
+      pumpDurationTime: null,
+      endingHoldVentCheckbox: null,
+      orderedProfileIds: [],
+      profileItemsById: {},
+    })
+  })
+
+  it('should update the patch on state type', () => {
+    expect(
+      dependentFieldsUpdateVacuum({ stateType: 'vent' }, formData)
+    ).toEqual({
+      stateType: 'vent',
+      modeType: null,
+      pressureMbar: null,
+      powerPercent: null,
+      pumpDurationCheckbox: null,
+      pumpDurationTime: null,
+      endingHoldVentCheckbox: null,
+    })
+  })
+
+  it('should update the patch on mode type', () => {
+    expect(
+      dependentFieldsUpdateVacuum({ modeType: 'power' }, formData)
+    ).toEqual({
+      modeType: 'power',
+      pressureMbar: null,
+      powerPercent: null,
+      pumpDurationCheckbox: null,
+      pumpDurationTime: null,
+    })
+  })
+})


### PR DESCRIPTION
# Overview

Add `dependFieldsUpdateVacuum` updater function to correctly update affected vacuum module form fields. This behavior is required for updates of:
- `programType`
- `stateType`
- `modeType`

Closes EXEC-2447

## Test Plan and Hands on Testing

### Hands on
General smoke testing. Imported a vacuum form and verify that changing program (profile/state), state type (pump/vent), and mode type (pressure/power) wipes downstream fields. 

### Automated testing
Added unit test suite for all patch updaters

## Changelog

- create `dependentFieldsUpdateVacuum`
- wire up in `handleFormChange/index.ts`
- add unit tests

## Review requests

see test plan

## Risk assessment

low