### PR TITLE
feat(protocol-designer): add vacuum module step form errors

### DIFF
--- a/protocol-designer/src/components/organisms/StepSummary/VacuumSummary.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/VacuumSummary.tsx
@@ -7,8 +7,6 @@ import {
   VACUUM_STATE_PUMP,
 } from '@opentrons/step-generation'
 
-import { getFormattedTime } from '/protocol-designer/utils/getFormattedTime'
-
 import { StyledTrans } from './StyledTrans'
 
 import type { FormData } from '/protocol-designer/form-types'
@@ -29,8 +27,6 @@ export function VacuumSummary(props: {
     orderedProfileIds,
   } = currentStep
   const { t } = useTranslation('protocol_steps')
-  const formattedTime =
-    pumpDurationTime != null ? getFormattedTime(pumpDurationTime as string) : ''
   if (
     programType === VACUUM_PROGRAM_STATE &&
     stateType !== null &&
@@ -64,7 +60,7 @@ export function VacuumSummary(props: {
               ),
             },
             {
-              text: formattedTime,
+              text: pumpDurationTime,
               iconName: 'timer',
             },
             {

--- a/protocol-designer/src/components/organisms/StepSummary/__tests__/VacuumSummary.test.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/__tests__/VacuumSummary.test.tsx
@@ -103,7 +103,7 @@ describe('VacuumSummary', () => {
         modeType: VACUUM_MODE_POWER,
         powerPercent: 50,
         pumpDurationCheckbox: true,
-        pumpDurationTime: '5:30',
+        pumpDurationTime: '05:30',
         endingHoldVentCheckbox: true,
       })
       expect(screen.getByText(/Set pump power to/)).toBeInTheDocument()
@@ -121,7 +121,7 @@ describe('VacuumSummary', () => {
         modeType: VACUUM_MODE_POWER,
         powerPercent: 80,
         pumpDurationCheckbox: true,
-        pumpDurationTime: '1:00',
+        pumpDurationTime: '01:00',
         endingHoldVentCheckbox: false,
       })
       expect(screen.getByText(/Set pump power to/)).toBeInTheDocument()
@@ -139,7 +139,7 @@ describe('VacuumSummary', () => {
         modeType: VACUUM_MODE_PRESSURE,
         pressureMbar: 100,
         pumpDurationCheckbox: true,
-        pumpDurationTime: '2:45',
+        pumpDurationTime: '02:45',
         endingHoldVentCheckbox: true,
       })
       expect(screen.getByText(/Set gauge pressure to/)).toBeInTheDocument()

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumControls.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumControls.tsx
@@ -39,10 +39,11 @@ import type { FieldPropsByName } from '../../types'
 interface VacuumControlsProps {
   formData: FormData
   propsForFields: FieldPropsByName
+  showFormErrors: boolean
 }
 export function VacuumControls(props: VacuumControlsProps): JSX.Element {
   const { t } = useTranslation('protocol_steps')
-  const { formData, propsForFields } = props
+  const { formData, propsForFields, showFormErrors } = props
   const [showProfileModal, setShowProfileModal] = useState<boolean>(false)
   const { moduleId } = formData
   const robotState = useSelector(getRobotStateAtActiveItem)
@@ -180,7 +181,12 @@ export function VacuumControls(props: VacuumControlsProps): JSX.Element {
           {t('vacuum.controls.profile.profile_steps')}
         </StyledText>
         <ListButton
-          type="noActive"
+          type={
+            showFormErrors &&
+            propsForFields.orderedProfileIds.errorToShow != null
+              ? 'error'
+              : 'noActive'
+          }
           onClick={() => {
             setShowProfileModal(true)
           }}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumStep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/PresavedVacuumStep.tsx
@@ -17,9 +17,8 @@ import {
 
 import {
   maskToSignedDecimal,
-  maskToTimeMMSS,
+  maskToTimeWithPlaceholders,
 } from '/protocol-designer/steplist/fieldLevel/processing'
-import { getFormattedTime } from '/protocol-designer/utils/getFormattedTime'
 
 import { PROFILE_STEP } from './constants'
 import { PresavedVacuumHeader } from './PresavedVacuumHeader'
@@ -94,11 +93,7 @@ export function PresavedVacuumStep(
       setShowErrors(true)
       return
     }
-    const formattedTime = getFormattedTime(time)
-    onSaveSuccess?.({
-      ...stepData,
-      time: formattedTime,
-    })
+    onSaveSuccess?.(stepData)
   }
 
   return (
@@ -172,7 +167,10 @@ export function PresavedVacuumStep(
                 title={t('vacuum.controls.profile.time')}
                 value={time}
                 onChange={e => {
-                  const maskedTime = maskToTimeMMSS(e.currentTarget.value)
+                  const maskedTime = maskToTimeWithPlaceholders(
+                    e.currentTarget.value,
+                    'mmss'
+                  )
                   updateField('time', maskedTime)
                 }}
                 units={t('application:units.time')}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/useVacuumProfileState.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/hooks/useVacuumProfileState.ts
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 
 import { uuid } from '/protocol-designer/utils'
-import { getFormattedTime } from '/protocol-designer/utils/getFormattedTime'
 
 import { PROFILE_CYCLE, PROFILE_STEP } from '../constants'
 import { getDefaultStepData } from '../utils'
@@ -161,24 +160,12 @@ export function useVacuumProfileState(args: UseVacuumProfileStateArgs): {
     data: PresavedVacuumCycleSavePayload
   ): void => {
     setItemsById(prev => {
-      // ensure all cycle items have formatted time when saving cycle
-      const updatedProfileStepItemsById = Object.entries(
-        data.profileStepItemsById
-      ).reduce((acc, [key, value]) => {
-        return {
-          ...acc,
-          [key]: {
-            ...value,
-            time: getFormattedTime(value.time),
-          },
-        }
-      }, {})
       return {
         ...prev,
         [cycleId]: {
           ...cycleItem,
           orderedProfileStepIds: data.orderedProfileStepIds,
-          profileStepItemsById: updatedProfileStepItemsById,
+          profileStepItemsById: data.profileStepItemsById,
           repetitions: data.repetitions,
           isPresaved: false,
         },

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/index.tsx
@@ -19,10 +19,11 @@ import type { FieldPropsByName } from '../../types'
 interface VacuumToolsProps {
   formData: FormData
   propsForFields: FieldPropsByName
+  showFormErrors: boolean
 }
 
 export function VacuumTools(props: VacuumToolsProps): JSX.Element {
-  const { formData, propsForFields } = props
+  const { formData, propsForFields, showFormErrors } = props
   const dispatch = useDispatch()
   const { t } = useTranslation(['form', 'protocol_steps'])
   const vacuumLabwareOptions = useSelector(getVacuumLabwareOptions)
@@ -49,7 +50,11 @@ export function VacuumTools(props: VacuumToolsProps): JSX.Element {
       <Divider marginY="0" />
       <VacuumModuleState vacuumModuleState={vacuumModuleState} />
       <Divider marginY="0" />
-      <VacuumControls formData={formData} propsForFields={propsForFields} />
+      <VacuumControls
+        formData={formData}
+        propsForFields={propsForFields}
+        showFormErrors={showFormErrors}
+      />
     </div>
   )
 }

--- a/protocol-designer/src/steplist/fieldLevel/index.ts
+++ b/protocol-designer/src/steplist/fieldLevel/index.ts
@@ -8,7 +8,7 @@ import {
   maskToInteger,
   maskToSignedDecimal,
   maskToTime,
-  maskToTimeMMSS,
+  maskToTimeWithPlaceholders,
   numberOrNull,
   onlyPositiveNumbers,
   trimDecimals,
@@ -445,7 +445,7 @@ const stepFieldHelperMap = {
     castValue: numberOrNull,
   }),
   pumpDurationTime: stepFieldHelpers({
-    maskValue: composeMaskers(maskToTimeMMSS),
+    maskValue: composeMaskers(maskToTimeWithPlaceholders),
   }),
   pressureMbar: stepFieldHelpers({
     maskValue: composeMaskers(maskToSignedDecimal),

--- a/protocol-designer/src/steplist/fieldLevel/processing.ts
+++ b/protocol-designer/src/steplist/fieldLevel/processing.ts
@@ -31,22 +31,27 @@ export const maskToTime = (rawValue: unknown): string => {
       : String(rawValue)
   return rawTimeValue
 }
-export const maskToTimeMMSS = (rawValue: unknown): string => {
+/**
+ * Masks input as MM:SS, building up from the right as the user types.
+ * Digits are right-aligned and padded with leading zeros.
+ * e.g. '' → '', '3' → '00:03', '34' → '00:34', '342' → '03:42', '3421' → '34:21'
+ */
+export const maskToTimeWithPlaceholders = (
+  rawValue: unknown,
+  mode: 'mmss' | 'hhmmss' = 'mmss'
+): string => {
   if (rawValue == null || rawValue === '') {
     return ''
   }
 
   const value = typeof rawValue === 'string' ? rawValue : String(rawValue)
+  const digits = value.replace(/\D/g, '').slice(-(mode === 'mmss' ? 4 : 6))
+  if (digits.length === 0) {
+    return ''
+  }
 
-  // remove invalid characters
-  const sanitized = value.replace(/[^\d:]/g, '')
-
-  // allow only one colon
-  const parts = sanitized.split(':')
-  const minutes = parts[0].slice(0, 2)
-  const seconds = parts[1]?.slice(0, 2)
-
-  return seconds != null ? `${minutes}:${seconds}` : minutes
+  const padded = digits.padStart(4, '0')
+  return `${padded.slice(0, 2)}:${padded.slice(2)}`
 }
 export const maskToSignedDecimal = (rawValue: unknown): string => {
   if (rawValue == null || rawValue === '') {

--- a/protocol-designer/src/steplist/fieldLevel/processing.ts
+++ b/protocol-designer/src/steplist/fieldLevel/processing.ts
@@ -34,7 +34,7 @@ export const maskToTime = (rawValue: unknown): string => {
 /**
  * Masks input as MM:SS, building up from the right as the user types.
  * Digits are right-aligned and padded with leading zeros.
- * e.g. '' → '', '3' → '00:03', '34' → '00:34', '342' → '03:42', '3421' → '34:21'
+ * e.g. '' -> '', '3' -> '00:03', '34' -> '00:34', '342' -> '03:42', '3421' -> '34:21'
  */
 export const maskToTimeWithPlaceholders = (
   rawValue: unknown,

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -4,7 +4,15 @@ import {
   MAGNETIC_MODULE_V1,
   MAGNETIC_MODULE_V2,
 } from '@opentrons/shared-data'
-import { MANUAL } from '@opentrons/step-generation'
+import {
+  MANUAL,
+  VACUUM_MAX_PRESSURE_MBAR,
+  VACUUM_MIN_PRESSURE_MBAR,
+  VACUUM_MODE_PRESSURE,
+  VACUUM_PROGRAM_PROFILE,
+  VACUUM_PROGRAM_STATE,
+  VACUUM_STATE_PUMP,
+} from '@opentrons/step-generation'
 
 import {
   ABSORBANCE_READER_INITIALIZE,
@@ -54,6 +62,7 @@ import type {
   HydratedPauseFormData,
   HydratedTemperatureFormData,
   HydratedThermocyclerFormData,
+  HydratedVacuumFormData,
   LabwareOrAdditionalEquipmentEntity,
   StepFieldName,
 } from '../../form-types'
@@ -610,6 +619,36 @@ const TIPS_SELECTED_REQUIRED: FormError = {
   dependentFields: ['tips_selected', 'tip_tracking'],
   location: ['form', 'field'],
   page: 3,
+}
+const VACUUM_PROGRAM_REQUIRED: FormError = {
+  title: 'Select vacuum controls',
+  dependentFields: ['programType'],
+  location: ['form'],
+}
+const VACUUM_STATE_REQUIRED: FormError = {
+  title: 'Select vacuum state',
+  dependentFields: ['stateType'],
+  location: ['form'],
+}
+const VACUUM_MODE_REQUIRED: FormError = {
+  title: 'Select vacuum mode type',
+  dependentFields: ['modeType'],
+  location: ['form'],
+}
+const GAUGE_PRESSURE_REQUIRED: FormError = {
+  title: 'Enter a valid gauge pressure value',
+  dependentFields: ['pressureMbar'],
+  location: ['field'],
+}
+const VACUUM_DURATION_REQUIRED: FormError = {
+  title: 'Enter a valid duration',
+  dependentFields: ['pumpDurationTime'],
+  location: ['field'],
+}
+const VACUUM_PROFILE_REQUIRED: FormError = {
+  title: 'Select vacuum profile',
+  dependentFields: ['orderedProfileIds', 'profileItemsById'],
+  location: ['field'],
 }
 export type FormErrorChecker = (
   arg: HydratedFormData,
@@ -1531,6 +1570,65 @@ export const tipSelectionRequired = (
   return tip_tracking === MANUAL &&
     (tips_selected == null || tips_selected?.length === 0)
     ? TIPS_SELECTED_REQUIRED
+    : null
+}
+
+export const vacuumProgramRequired = (
+  fields: HydratedVacuumFormData
+): FormError | null => {
+  const { programType } = fields
+  return programType == null ? VACUUM_PROGRAM_REQUIRED : null
+}
+
+export const vacuumStateRequired = (
+  fields: HydratedVacuumFormData
+): FormError | null => {
+  const { programType, stateType } = fields
+  return programType === VACUUM_PROGRAM_STATE && stateType == null
+    ? VACUUM_STATE_REQUIRED
+    : null
+}
+
+export const vacuumModeRequired = (
+  fields: HydratedVacuumFormData
+): FormError | null => {
+  const { modeType } = fields
+  return modeType == null ? VACUUM_MODE_REQUIRED : null
+}
+
+export const vacuumProfileRequired = (
+  fields: HydratedVacuumFormData
+): FormError | null => {
+  const { programType, orderedProfileIds } = fields
+  return programType === VACUUM_PROGRAM_PROFILE &&
+    orderedProfileIds.length === 0
+    ? VACUUM_PROFILE_REQUIRED
+    : null
+}
+
+export const gaugePressureRequired = (
+  fields: HydratedVacuumFormData
+): FormError | null => {
+  const { programType, stateType, modeType, pressureMbar } = fields
+  return programType === VACUUM_PROGRAM_STATE &&
+    stateType === VACUUM_STATE_PUMP &&
+    modeType === VACUUM_MODE_PRESSURE &&
+    (pressureMbar == null ||
+      pressureMbar < VACUUM_MIN_PRESSURE_MBAR ||
+      pressureMbar > VACUUM_MAX_PRESSURE_MBAR)
+    ? GAUGE_PRESSURE_REQUIRED
+    : null
+}
+export const vacuumDurationRequired = (
+  fields: HydratedVacuumFormData
+): FormError | null => {
+  const { programType, stateType, pumpDurationCheckbox, pumpDurationTime } =
+    fields
+  return programType === VACUUM_PROGRAM_STATE &&
+    stateType === VACUUM_STATE_PUMP &&
+    pumpDurationCheckbox === true &&
+    !pumpDurationTime
+    ? VACUUM_DURATION_REQUIRED
     : null
 }
 

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -34,6 +34,7 @@ import {
   engageHeightRequired,
   fileNameRequired,
   fillQuantityOutOfRange,
+  gaugePressureRequired,
   incompatibleAspirateLabware,
   incompatibleDispenseLabware,
   incompatibleLabware,
@@ -71,6 +72,11 @@ import {
   tiprackRequired,
   tipSelectionRequired,
   transferVolumeMin,
+  vacuumDurationRequired,
+  vacuumModeRequired,
+  vacuumProfileRequired,
+  vacuumProgramRequired,
+  vacuumStateRequired,
   volumeRequired,
   volumeTooHigh,
   wavelengthOutOfRange,
@@ -291,7 +297,14 @@ const stepFormHelperMap: {
     getErrors: composeErrors(fillQuantityOutOfRange, moduleIdRequired),
   },
   vacuum: {
-    getErrors: composeErrors(),
+    getErrors: composeErrors(
+      vacuumProgramRequired,
+      vacuumStateRequired,
+      vacuumModeRequired,
+      gaugePressureRequired,
+      vacuumDurationRequired,
+      vacuumProfileRequired
+    ),
   },
 }
 


### PR DESCRIPTION
# Overview

Creates and wires up all vacuum for errors. Also refactors the masking logic for time input fields, such that no transformation should be necessary when saving a profile or the step form.

Closes EXEC-2419

## Test Plan and Hands on Testing

Smoke test saving a vacuum form with bad input fields (radio buttons not selected, empty input fields, profile without steps)

## Changelog

- create and wire up vacuum step form errors
- update time masking processing util to avoid the need for time transformation

## Review requests

see test plan

## Risk assessment

low