### PR TITLE
feat(protocol-designer): wire up Vacuum module in ProtocolOverview hardware

### DIFF
--- a/protocol-designer/src/pages/ProtocolOverview/HardwareInfo.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/HardwareInfo.tsx
@@ -15,11 +15,9 @@ import {
   StyledText,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import {
-  FLEX_ROBOT_TYPE,
-  getModuleDisplayName,
-  THERMOCYCLER_MODULE_TYPE,
-} from '@opentrons/shared-data'
+import { FLEX_ROBOT_TYPE, getModuleDisplayName } from '@opentrons/shared-data'
+
+import { getModuleDisplayLocation } from '/protocol-designer/ui/modules/utils'
 
 import { LINK_BUTTON_STYLE } from '../../components/atoms'
 
@@ -41,7 +39,6 @@ export function HardwareInfo({
   const { t } = useTranslation(['protocol_overview', 'shared'])
   const navigate = useNavigate()
   const isFlex = robotType === FLEX_ROBOT_TYPE
-  const tCSlot = isFlex ? 'A1+B1' : '7,8,10,11'
   const additionalEquipmentLength = Object.keys(additionalEquipment).length
 
   return (
@@ -76,9 +73,7 @@ export function HardwareInfo({
                       desktopStyle="bodyDefaultRegular"
                       color={COLORS.grey60}
                     >
-                      {module.type === THERMOCYCLER_MODULE_TYPE
-                        ? tCSlot
-                        : module.slot}
+                      {getModuleDisplayLocation(module, robotType)}
                     </StyledText>
                   </Flex>
                 }

--- a/protocol-designer/src/ui/modules/__tests__/utils.test.ts
+++ b/protocol-designer/src/ui/modules/__tests__/utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  ABSORBANCE_READER_TYPE,
+  FLEX_ROBOT_TYPE,
+  FLEX_STACKER_MODULE_TYPE,
+  HEATERSHAKER_MODULE_TYPE,
+  MAGNETIC_MODULE_TYPE,
+  OT2_ROBOT_TYPE,
+  TC_MODULE_LOCATION_OT2,
+  TC_MODULE_LOCATION_OT3,
+  TEMPERATURE_MODULE_TYPE,
+  THERMOCYCLER_MODULE_TYPE,
+  VACUUM_MODULE_LOCATION,
+  VACUUM_MODULE_TYPE,
+} from '@opentrons/shared-data'
+
+import { getModuleDisplayLocation } from '../utils'
+
+import type { ModuleOnDeck } from '/protocol-designer/step-forms'
+
+describe('getModuleDisplayLocation', () => {
+  it('returns the correct display location for a vacuum module', () => {
+    const moduleOnDeck = { type: VACUUM_MODULE_TYPE } as ModuleOnDeck
+    const result = getModuleDisplayLocation(moduleOnDeck, OT2_ROBOT_TYPE)
+    expect(result).toEqual(VACUUM_MODULE_LOCATION)
+  })
+  it('returns the correct display location for a thermocycler module on OT-2', () => {
+    const moduleOnDeck = { type: THERMOCYCLER_MODULE_TYPE } as ModuleOnDeck
+    const result = getModuleDisplayLocation(moduleOnDeck, OT2_ROBOT_TYPE)
+    expect(result).toEqual(TC_MODULE_LOCATION_OT2)
+  })
+  it('returns the correct display location for a thermocycler module on Flex', () => {
+    const moduleOnDeck = { type: THERMOCYCLER_MODULE_TYPE } as ModuleOnDeck
+    const result = getModuleDisplayLocation(moduleOnDeck, FLEX_ROBOT_TYPE)
+    expect(result).toEqual(TC_MODULE_LOCATION_OT3)
+  })
+  ;[
+    MAGNETIC_MODULE_TYPE,
+    TEMPERATURE_MODULE_TYPE,
+    HEATERSHAKER_MODULE_TYPE,
+    ABSORBANCE_READER_TYPE,
+    FLEX_STACKER_MODULE_TYPE,
+  ].forEach(type => {
+    it(`returns the slot for ${type}`, () => {
+      const moduleOnDeck = {
+        type,
+        slot: '1',
+      } as ModuleOnDeck
+      const result = getModuleDisplayLocation(moduleOnDeck, OT2_ROBOT_TYPE)
+      expect(result).toEqual('1')
+    })
+  })
+})

--- a/protocol-designer/src/ui/modules/selectors.ts
+++ b/protocol-designer/src/ui/modules/selectors.ts
@@ -11,6 +11,8 @@ import {
   VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
+import { getRobotType } from '/protocol-designer/file-data/selectors'
+
 import { getInitialDeckSetup } from '../../step-forms/selectors'
 import { getDeckSetupForActiveItem } from '../../top-selectors/labware-locations'
 import { getLabwareNicknamesById } from '../labware/selectors'
@@ -47,11 +49,13 @@ export const getMagneticLabwareOptions: Selector<DropdownOption[]> =
   createSelector(
     getInitialDeckSetup,
     getLabwareNicknamesById,
-    (initialDeckSetup, nicknamesById) => {
+    getRobotType,
+    (initialDeckSetup, nicknamesById, robotType) => {
       return getModuleLabwareOptions(
         initialDeckSetup,
         nicknamesById,
-        MAGNETIC_MODULE_TYPE
+        MAGNETIC_MODULE_TYPE,
+        robotType
       )
     }
   )
@@ -61,11 +65,13 @@ export const getTemperatureLabwareOptions: Selector<DropdownOption[]> =
   createSelector(
     getInitialDeckSetup,
     getLabwareNicknamesById,
-    (initialDeckSetup, nicknamesById) => {
+    getRobotType,
+    (initialDeckSetup, nicknamesById, robotType) => {
       const temperatureModuleOptions = getModuleLabwareOptions(
         initialDeckSetup,
         nicknamesById,
-        TEMPERATURE_MODULE_TYPE
+        TEMPERATURE_MODULE_TYPE,
+        robotType
       )
       return temperatureModuleOptions
     }
@@ -76,11 +82,13 @@ export const getHeaterShakerLabwareOptions: Selector<DropdownOption[]> =
   createSelector(
     getInitialDeckSetup,
     getLabwareNicknamesById,
-    (initialDeckSetup, nicknamesById) => {
+    getRobotType,
+    (initialDeckSetup, nicknamesById, robotType) => {
       const heaterShakerModuleOptions = getModuleLabwareOptions(
         initialDeckSetup,
         nicknamesById,
-        HEATERSHAKER_MODULE_TYPE
+        HEATERSHAKER_MODULE_TYPE,
+        robotType
       )
       return heaterShakerModuleOptions
     }
@@ -91,11 +99,13 @@ export const getAbsorbanceReaderLabwareOptions: Selector<DropdownOption[]> =
   createSelector(
     getDeckSetupForActiveItem,
     getLabwareNicknamesById,
-    (deckSetup, nicknamesById) => {
+    getRobotType,
+    (deckSetup, nicknamesById, robotType) => {
       const absorbanceReaderModuleOptions = getModuleLabwareOptions(
         deckSetup,
         nicknamesById,
-        ABSORBANCE_READER_TYPE
+        ABSORBANCE_READER_TYPE,
+        robotType
       )
       return absorbanceReaderModuleOptions
     }
@@ -106,11 +116,13 @@ export const getFlexStackerLabwareOptions: Selector<DropdownOption[]> =
   createSelector(
     getInitialDeckSetup,
     getLabwareNicknamesById,
-    (initialDeckSetup, nicknamesById) => {
+    getRobotType,
+    (initialDeckSetup, nicknamesById, robotType) => {
       const flexStackerModuleOptions = getModuleLabwareOptions(
         initialDeckSetup,
         nicknamesById,
-        FLEX_STACKER_MODULE_TYPE
+        FLEX_STACKER_MODULE_TYPE,
+        robotType
       )
       return flexStackerModuleOptions
     }
@@ -120,11 +132,13 @@ export const getVacuumLabwareOptions: Selector<DropdownOption[]> =
   createSelector(
     getInitialDeckSetup,
     getLabwareNicknamesById,
-    (initialDeckSetup, nicknamesById) => {
+    getRobotType,
+    (initialDeckSetup, nicknamesById, robotType) => {
       const vacuumModuleOptions = getModuleLabwareOptions(
         initialDeckSetup,
         nicknamesById,
-        VACUUM_MODULE_TYPE
+        VACUUM_MODULE_TYPE,
+        robotType
       )
       return vacuumModuleOptions
     }

--- a/protocol-designer/src/ui/modules/utils.ts
+++ b/protocol-designer/src/ui/modules/utils.ts
@@ -2,12 +2,15 @@ import values from 'lodash/values'
 
 import {
   ABSORBANCE_READER_TYPE,
+  FLEX_ROBOT_TYPE,
   FLEX_STACKER_MODULE_TYPE,
   getLabwareDefaultEngageHeight,
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_BLOCK_TYPE,
   MAGNETIC_MODULE_TYPE,
   MAGNETIC_MODULE_V1,
+  TC_MODULE_LOCATION_OT2,
+  TC_MODULE_LOCATION_OT3,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
   VACUUM_MODULE_LOCATION,
@@ -20,7 +23,7 @@ import {
 } from '../../utils'
 
 import type { DropdownOption } from '@opentrons/components'
-import type { ModuleType } from '@opentrons/shared-data'
+import type { ModuleType, RobotType } from '@opentrons/shared-data'
 import type {
   InitialDeckSetup,
   LabwareOnDeck,
@@ -80,10 +83,18 @@ export const getModuleShortNames = (type: ModuleType): string => {
   }
 }
 
-const getModuleDisplayLocation = (moduleOnDeck: ModuleOnDeck): string => {
+export const getModuleDisplayLocation = (
+  moduleOnDeck: ModuleOnDeck,
+  robotType: RobotType
+): string => {
   const { type, slot } = moduleOnDeck
   if (type === VACUUM_MODULE_TYPE) {
     return VACUUM_MODULE_LOCATION
+  }
+  if (type === THERMOCYCLER_MODULE_TYPE) {
+    return robotType === FLEX_ROBOT_TYPE
+      ? TC_MODULE_LOCATION_OT3
+      : TC_MODULE_LOCATION_OT2
   }
   return slot
 }
@@ -91,7 +102,8 @@ const getModuleDisplayLocation = (moduleOnDeck: ModuleOnDeck): string => {
 export function getModuleLabwareOptions(
   initialDeckSetup: InitialDeckSetup,
   nicknamesById: Record<string, string>,
-  type: ModuleType
+  type: ModuleType,
+  robotType: RobotType
 ): DropdownOption[] {
   const labwares = initialDeckSetup.labware
   const modulesOnDeck = getModulesOnDeckByType(initialDeckSetup, type)
@@ -104,7 +116,10 @@ export function getModuleLabwareOptions(
         moduleOnDeck.id,
         Object.values(labwares)
       )
-      const moduleDisplayLocation = getModuleDisplayLocation(moduleOnDeck)
+      const moduleDisplayLocation = getModuleDisplayLocation(
+        moduleOnDeck,
+        robotType
+      )
       if (topMostId != null) {
         return {
           name: nicknamesById[topMostId],


### PR DESCRIPTION
# Overview

Ensures Vacuum module is displayed correctly in hardware section of `ProtocolOverview` page.

Closes EXEC-2399

## Test Plan and Hands on Testing

- create or import a vacuum module protocol
- navigate to protocol overview
- verify that hardware section correctly displays the VM location and display name

<img width="774" height="262" alt="Screenshot 2026-03-18 at 11 28 16 AM" src="https://github.com/user-attachments/assets/8a461967-d279-4439-a70c-5b500db04446" />

## Changelog

- update `getModuleDisplayLocation` util for accommodating any module including vacuum and thermocycler (for Flex or OT-2)
- pass down robotType from selectors calling the above util
- use util in `ProtocolOverview` > `HardwareInfo`

## Review requests

see test plan

## Risk assessment

low