### PR TITLE
fix(api): permit max of heating/cooling rates for same-target TC temperature transitions

### DIFF
--- a/api/src/opentrons/protocol_engine/state/module_substates/thermocycler_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/thermocycler_module_substate.py
@@ -167,14 +167,24 @@ class ThermocyclerModuleSubState:
             return ramp_rate
 
         if self.target_block_temperature:
-            heating = target_temp > self.get_target_block_temperature()
+            # When new target equals current target, we can't determine whether
+            # heating or cooling will occur without knowing the actual block temp.
+            # Use the max of heating and cooling rates as the limit since it's the most permissive option.
+            if target_temp == self.target_block_temperature:
+                max_ramp_rate = max(MAX_HEATING_RATE, MAX_COOLING_RATE)
+            elif target_temp > self.target_block_temperature:
+                max_ramp_rate = MAX_HEATING_RATE
+            else:
+                max_ramp_rate = MAX_COOLING_RATE
         else:
             # When we're simulating we don't load the TC from live data so there is no default
             # target temperature.
-            heating = target_temp > 20
-        if (heating and ramp_rate > MAX_HEATING_RATE) or (
-            not heating and ramp_rate > MAX_COOLING_RATE
-        ):
+            if target_temp > 20:
+                max_ramp_rate = MAX_HEATING_RATE
+            else:
+                max_ramp_rate = MAX_COOLING_RATE
+
+        if ramp_rate > max_ramp_rate:
             raise InvalidRampRateError(
                 f"Thermocycler ramp rate cannot exceed {MAX_HEATING_RATE}°C/s"
                 f" while heating or {MAX_COOLING_RATE}°C/s when cooling."

--- a/api/tests/opentrons/protocol_engine/state/test_module_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_module_view_old.py
@@ -48,6 +48,10 @@ from opentrons.protocol_engine.state.module_substates import (
     ThermocyclerModuleId,
     ThermocyclerModuleSubState,
 )
+from opentrons.protocol_engine.state.module_substates.thermocycler_module_substate import (
+    MAX_COOLING_RATE,
+    MAX_HEATING_RATE,
+)
 from opentrons.protocol_engine.state.modules import (
     HardwareModule,
     ModuleState,
@@ -66,9 +70,7 @@ from opentrons.protocol_engine.types import (
     ModuleOffsetData,
     PotentialCutoutFixture,
 )
-from opentrons.protocols.api_support.deck_type import (
-    STANDARD_OT3_DECK,
-)
+from opentrons.protocols.api_support.deck_type import STANDARD_OT3_DECK
 from opentrons.types import DeckSlotName, MountType, Point
 
 
@@ -1718,6 +1720,57 @@ def test_thermocycler_validate_ramp_rate(
     # must be positive.
     with pytest.raises(errors.InvalidRampRateError):
         subject.validate_ramp_rate(ramp_rate=-0.1, target_temp=0)
+
+
+@pytest.fixture
+def module_view_with_thermocycler_target_set(
+    thermocycler_v1_def: ModuleDefinition,
+) -> ModuleView:
+    """Get a module state view with a loaded thermocycler that has a target temp set."""
+    return make_module_view(
+        slot_by_module_id={"module-id": DeckSlotName.SLOT_1},
+        hardware_by_module_id={
+            "module-id": HardwareModule(
+                serial_number="serial-number",
+                definition=thermocycler_v1_def,
+            )
+        },
+        substate_by_module_id={
+            "module-id": ThermocyclerModuleSubState(
+                module_id=ThermocyclerModuleId("module-id"),
+                target_block_temperature=75.0,
+                target_lid_temperature=None,
+                is_lid_open=False,
+            )
+        },
+    )
+
+
+def test_thermocycler_validate_ramp_rate_same_target(
+    module_view_with_thermocycler_target_set: ModuleView,
+) -> None:
+    """It should allow up to the max of MAX_HEATING_RATE and MAX_COOLING_RATE when new target equals current target."""
+    subject = module_view_with_thermocycler_target_set.get_thermocycler_module_substate(
+        "module-id"
+    )
+
+    result = subject.validate_ramp_rate(ramp_rate=3.0, target_temp=75.0)
+    assert result == 3.0
+
+    result = subject.validate_ramp_rate(ramp_rate=MAX_HEATING_RATE, target_temp=75.0)
+    assert result == MAX_HEATING_RATE
+
+    with pytest.raises(errors.InvalidRampRateError):
+        subject.validate_ramp_rate(ramp_rate=MAX_HEATING_RATE + 0.1, target_temp=75.0)
+
+    result = subject.validate_ramp_rate(ramp_rate=4.0, target_temp=80.0)
+    assert result == 4.0
+
+    with pytest.raises(errors.InvalidRampRateError):
+        subject.validate_ramp_rate(ramp_rate=MAX_COOLING_RATE + 0.1, target_temp=50.0)
+
+    result = subject.validate_ramp_rate(ramp_rate=1.5, target_temp=50.0)
+    assert result == 1.5
 
 
 @pytest.mark.parametrize("input_temperature", [36.999, 110.001])


### PR DESCRIPTION
Closes [RESC-552](https://opentrons.atlassian.net/browse/RESC-552)

# Overview

When we set `set_block_temperature()` for a TC more than once in a protocol, we determine whether we need to heat or cool by comparing the new target block temperature to the previous target block temperature. The existing logic works well unless the new target block temperature is equivalent to the old target block temperature, in which case PE marks this as a "cooling" case, and if `set_block_temperature()` contains a `ramp_rate` that isn't permissible for cooling, (ex., 4.0°C/s), we throw an error, which is confusing for end users.

Whenever we `set_block_temperature()` to the same temperature as the previous invocation of `set_block_temperature()`, let's permit a `ramp_rate` that is the maximum of our max heating/cooling values.

## Test Plan and Hands on Testing

- Below is a minimal protocol that reproduces the issue and validates the fix. Ran via simulation and on a robot:

```
from opentrons import protocol_api

metadata = {
    "protocolName": "Ramp Rate Bug Reproduction",
}

requirements = {
    "robotType": "Flex",
    "apiLevel": "2.29",
}

def run(protocol: protocol_api.ProtocolContext):
    thermocycler = protocol.load_module("thermocyclerModuleV2")

    thermocycler.set_block_temperature(temperature=75, hold_time_seconds=10)

    actual_temp = thermocycler.block_temperature
    target_temp = thermocycler.block_target_temperature

    protocol.comment(f"Actual block temp: {actual_temp}")
    protocol.comment(f"Block target temp: {target_temp}")

    thermocycler.set_block_temperature(
        temperature=75,
        ramp_rate=3.0,
        hold_time_seconds=10,
    )

```

## Changelog

- Fixed a bug in which setting a thermocycler's block temperature to the same target value as the previous attempt with a value greater than the max cooling rate but less than the max heating rate was not permitted.

## Risk assessment

- relatively low - new logic handles only the case where old target equals new target

[RESC-552]: https://opentrons.atlassian.net/browse/RESC-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ