### PR TITLE
feat(ci): Add workflow_dispatch trigger to docs-build-deploy.yaml

### DIFF
--- a/.github/workflows/docs-build-deploy.yaml
+++ b/.github/workflows/docs-build-deploy.yaml
@@ -16,6 +16,7 @@ on:
       - 'staging-mkdocs*'
       - 'MKDOCS*'
       - 'mkdocs*'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.ref_name != 'edge' || github.run_id}}-${{ github.ref_type != 'tag' || github.run_id }}


### PR DESCRIPTION
# Overview

Adding `workflow_dispatch` to our docs build action, so we can trigger a sandbox build manually. This will be useful in cases where we have early-stage drafts of documentation — not even enough to open a draft PR — that we want to share around easily with other members of our team.

## Changelog

+1 line in the workflow file

## Review requests

No downsides to having this, right? And it's implemented properly?

## Risk assessment

v low