### PR TITLE
fix(app): Fix run setup description responsiveness

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupStep.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupStep.tsx
@@ -57,7 +57,12 @@ export function SetupStep({
             onClick={toggleExpanded}
             gridGap={SPACING.spacing40}
           >
-            <Flex flexDirection={DIRECTION_COLUMN} gap={SPACING.spacing4}>
+            <Flex
+              flexDirection={DIRECTION_COLUMN}
+              gap={SPACING.spacing4}
+              flex="1"
+              minWidth="0"
+            >
               <StyledText
                 color={COLORS.black90}
                 desktopStyle="bodyLargeSemiBold"
@@ -69,6 +74,7 @@ export function SetupStep({
                 desktopStyle="bodyDefaultRegular"
                 color={COLORS.black90}
                 id={`CollapsibleStep_${description}`}
+                css={DESCRIPTION_TEXT_STYLE}
               >
                 {description}
               </StyledText>
@@ -136,8 +142,18 @@ const ACCORDION_STYLE = css`
   }
 `
 
+const DESCRIPTION_TEXT_STYLE = css`
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  white-space: normal;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+`
+
 const RIGHT_CONTENT_CONTAINER_STYLE = css`
   align-items: ${ALIGN_CENTER};
+  flex-shrink: 0;
   text-wrap: ${NO_WRAP};
 `
 

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupStep/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupStep/index.tsx
@@ -1,19 +1,12 @@
-import { css } from 'styled-components'
-
 import {
-  ALIGN_CENTER,
   Btn,
   COLORS,
-  DIRECTION_COLUMN,
-  DIRECTION_ROW,
-  Flex,
   Icon,
-  JUSTIFY_SPACE_BETWEEN,
-  NO_WRAP,
-  SPACING,
   StyledText,
   TYPOGRAPHY,
 } from '@opentrons/components'
+
+import styles from './setupstep.module.css'
 
 import type { ReactNode } from 'react'
 
@@ -44,25 +37,11 @@ export function SetupStep({
   rightElement,
 }: SetupStepProps): JSX.Element {
   return (
-    <Flex flexDirection={DIRECTION_COLUMN}>
+    <div className={styles.container}>
       <Btn textAlign={TYPOGRAPHY.textAlignLeft}>
-        <Flex
-          flexDirection={DIRECTION_ROW}
-          justifyContent={JUSTIFY_SPACE_BETWEEN}
-        >
-          <Flex
-            alignItems={ALIGN_CENTER}
-            justifyContent={JUSTIFY_SPACE_BETWEEN}
-            width="100%"
-            onClick={toggleExpanded}
-            gridGap={SPACING.spacing40}
-          >
-            <Flex
-              flexDirection={DIRECTION_COLUMN}
-              gap={SPACING.spacing4}
-              flex="1"
-              minWidth="0"
-            >
+        <div className={styles.outer_row_container}>
+          <div className={styles.clickable_container} onClick={toggleExpanded}>
+            <div className={styles.title_description_container}>
               <StyledText
                 color={COLORS.black90}
                 desktopStyle="bodyLargeSemiBold"
@@ -74,27 +53,27 @@ export function SetupStep({
                 desktopStyle="bodyDefaultRegular"
                 color={COLORS.black90}
                 id={`CollapsibleStep_${description}`}
-                css={DESCRIPTION_TEXT_STYLE}
+                className={styles.description_text}
               >
                 {description}
               </StyledText>
               {descriptionElement}
-            </Flex>
-            <Flex css={RIGHT_CONTENT_CONTAINER_STYLE}>
+            </div>
+            <div className={styles.right_content_container}>
               {rightElement}
               <Icon
                 color={COLORS.black90}
                 size="1.5rem"
-                css={ACCORDION_STYLE}
+                className={styles.accordion_icon}
                 name={expanded ? 'minus' : 'plus'}
-                margin={SPACING.spacing4}
               />
-            </Flex>
-          </Flex>
-        </Flex>
+            </div>
+          </div>
+        </div>
       </Btn>
       <div
-        css={expanded ? EXPANDED_STYLE : COLLAPSED_STYLE}
+        data-testid={`SetupStep_content_${expanded ? 'expanded' : 'collapsed'}`}
+        className={expanded ? styles.expanded : styles.collapsed}
         onTransitionEnd={e => {
           // HACK:
           // There's some kind of Chromium bug where, when the section expands,
@@ -108,54 +87,9 @@ export function SetupStep({
       >
         {children}
       </div>
-    </Flex>
+    </div>
   )
 }
-
-const EXPANDED_STYLE = css`
-  interpolate-size: allow-keywords;
-  overflow: hidden;
-
-  visibility: visible;
-  height: auto;
-  transition:
-    height 300ms ease-in,
-    visibility 300ms step-start;
-`
-const COLLAPSED_STYLE = css`
-  interpolate-size: allow-keywords;
-  overflow: hidden;
-
-  visibility: hidden;
-  height: 0;
-  transition:
-    height 500ms ease-out,
-    visibility 500ms step-end;
-`
-const ACCORDION_STYLE = css`
-  border-radius: 50%;
-  &:hover {
-    background: ${COLORS.grey30};
-  }
-  &:active {
-    background: ${COLORS.grey35};
-  }
-`
-
-const DESCRIPTION_TEXT_STYLE = css`
-  display: block;
-  width: 100%;
-  max-width: 100%;
-  white-space: normal;
-  word-wrap: break-word;
-  overflow-wrap: break-word;
-`
-
-const RIGHT_CONTENT_CONTAINER_STYLE = css`
-  align-items: ${ALIGN_CENTER};
-  flex-shrink: 0;
-  text-wrap: ${NO_WRAP};
-`
 
 // https://stackoverflow.com/questions/3485365
 function forceRepaint(element: HTMLElement): void {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupStep/setupstep.module.css
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupStep/setupstep.module.css
@@ -1,0 +1,74 @@
+.container {
+  display: flex;
+  flex-direction: column;
+}
+
+.outer_row_container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.clickable_container {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-40);
+}
+
+.title_description_container {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.right_content_container {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--spacing-4);
+  text-wrap: nowrap;
+}
+
+.expanded {
+  overflow: hidden;
+  height: auto;
+  interpolate-size: allow-keywords;
+  transition:
+    height 300ms ease-in,
+    visibility 300ms step-start;
+  visibility: visible;
+}
+
+.collapsed {
+  overflow: hidden;
+  height: 0;
+  interpolate-size: allow-keywords;
+  transition:
+    height 500ms ease-out,
+    visibility 500ms step-end;
+  visibility: hidden;
+}
+
+.accordion_icon {
+  border-radius: 50%;
+}
+
+.accordion_icon:hover {
+  background: var(--grey-30);
+}
+
+.accordion_icon:active {
+  background: var(--grey-35);
+}
+
+.description_text {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  white-space: normal;
+}

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/__tests__/ProtocolRunSetup.test.tsx
@@ -265,6 +265,7 @@ describe('ProtocolRunSetup', () => {
       const robotCalibrationSetup = screen.getByText('Instruments')
       fireEvent.click(robotCalibrationSetup)
       expect(screen.getByText('Mock SetupRobotCalibration')).toBeVisible()
+      expect(screen.getByTestId('SetupStep_content_expanded')).toBeTruthy()
     })
     it('renders robot calibration setup for Flex', () => {
       when(vi.mocked(useIsFlex)).calledWith(ROBOT_NAME).thenReturn(true)
@@ -276,6 +277,7 @@ describe('ProtocolRunSetup', () => {
       const robotCalibrationSetup = screen.getByText('Instruments')
       fireEvent.click(robotCalibrationSetup)
       expect(screen.getByText('Mock SetupRobotCalibration')).toBeVisible()
+      expect(screen.getByTestId('SetupStep_content_expanded')).toBeTruthy()
     })
     it('renders labware and liquid setup', () => {
       render()
@@ -286,6 +288,7 @@ describe('ProtocolRunSetup', () => {
       const labwareSetup = screen.getByText('Labware & Liquids')
       fireEvent.click(labwareSetup)
       expect(screen.getByText('Mock SetupLabware')).toBeVisible()
+      expect(screen.getByTestId('SetupStep_content_expanded')).toBeTruthy()
     })
     it('renders the empty state for modules when no modules in protocol', () => {
       render()
@@ -294,7 +297,9 @@ describe('ProtocolRunSetup', () => {
 
     it('defaults to no step expanded', () => {
       render()
-      expect(screen.getByText('Mock SetupLabware')).not.toBeVisible()
+      expect(screen.getAllByTestId('SetupStep_content_collapsed').length).toBe(
+        3
+      )
     })
 
     it('renders view-only info message if run has started', async () => {
@@ -302,8 +307,9 @@ describe('ProtocolRunSetup', () => {
 
       render()
       await new Promise(resolve => setTimeout(resolve, 1000))
-      expect(screen.getByText('Mock SetupRobotCalibration')).not.toBeVisible()
-      expect(screen.getByText('Mock SetupLabware')).not.toBeVisible()
+      expect(screen.getAllByTestId('SetupStep_content_collapsed').length).toBe(
+        3
+      )
       screen.getByText('Setup is view-only once run has started')
     })
   })


### PR DESCRIPTION
Closes [RQA-5246](https://opentrons.atlassian.net/browse/RQA-5246)

# Overview

This PR is best viewed by commit.

In our `SetupStep` component, we weren't properly wrapping text when the right element's content box impedes on the step description. We add some simple wrapping to fix.

e854e261f8f8e0aed28ae2d804fbe0a5c505d653 - Adds proper text wrapping
a4e777e79112cdba4159019071df371b9129d45f - Migrates `SetupStep` to css modules. Note that we have to update a couple tests to play nicely with css modules, but there are no functional test changes here.

### Current Behavior

https://github.com/user-attachments/assets/7e57d28b-8f93-42eb-9904-2009cb8e51b0

### Fixed Behavior

https://github.com/user-attachments/assets/24834d50-fd76-4394-9482-43b1279e2422

## Test Plan and Hands on Testing

- See videos. Verified no visual regression after migration.

## Changelog

- Fixed setup step description responsiveness on the desktop app when resizing the app window.

## Risk assessment

- very low, all CSS changes


[RQA-5246]: https://opentrons.atlassian.net/browse/RQA-5246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ