### PR TITLE
fix(protocol-designer): update default trash location from A3 -> D1

### DIFF
--- a/protocol-designer/src/pages/Onboarding/SelectBasics.tsx
+++ b/protocol-designer/src/pages/Onboarding/SelectBasics.tsx
@@ -32,7 +32,7 @@ import { PipetteInfoItem, SelectPipetteModal } from '../../components/organisms'
 import { WizardBody } from './WizardBody'
 
 import type { PipetteMount, PipetteName } from '@opentrons/shared-data'
-import type { Fixtures } from '../../components/organisms'
+import type { FixtureInfo, Fixtures } from '../../components/organisms'
 import type { Gen, PipetteType, WizardTileProps } from './types'
 
 export function SelectBasics(props: WizardTileProps): JSX.Element {
@@ -130,12 +130,14 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
     setValue('pipettesByMount.right.tiprackDefURI', leftTiprackDefURI)
   }
 
+  const flexTrashFixtureItem: FixtureInfo = {
+    cutoutId: 'cutoutD1',
+    name: 'trashBin',
+    cutoutFixtureId: 'trashBinAdapter',
+  }
+
   const flexTrashFixture: Fixtures = {
-    [uuid()]: {
-      cutoutId: 'cutoutA3',
-      name: 'trashBin',
-      cutoutFixtureId: 'trashBinAdapter',
-    },
+    [uuid()]: flexTrashFixtureItem,
   }
   const ot2TrashFixture: Fixtures = {
     [uuid()]: {
@@ -176,11 +178,7 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
             )
           : {}
 
-      filteredFixtures[uuid()] = {
-        cutoutId: 'cutoutA3',
-        name: 'trashBin',
-        cutoutFixtureId: 'trashBinAdapter',
-      }
+      filteredFixtures[uuid()] = flexTrashFixtureItem
 
       setValue('fixtures', filteredFixtures)
     }


### PR DESCRIPTION
# Overview

In protocol onboarding, moves the default trash location from A3 to D1. This is because the thermocycler can be added only to A1+B1, the waste chute can be added only to D3, and the vacuum module can only be added to A3. Now, if you build a protocol with a trash bin and a vacuum module, you don't need to remove the trash from its default location to add the vacuum module.

Closes EXEC-2448

## Test Plan and Hands on Testing

- create any PD protocol and do _not_ select a waste chute in the basics screen
- continue and verify that the trash is added to cutout D1

## Changelog

- update default trash location in onboarding

## Review requests

see test plan

## Risk assessment

low