### PR TITLE
fix(auth-server): Fix refresh tokens being usable as access tokens

### DIFF
--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -280,19 +280,35 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         request: oauthlib.common.Request,
     ) -> dict[str, int | str | list[str]] | None:
         """Return information about an access or refresh token (if it exists)."""
-        found_token = self.__token_store.find_active_access_token(
+        found_access_token = self.__token_store.find_active_access_token(
             token, now=_now()
-        ) or self.__token_store.find_active_refresh_token(token, now=_now())
-        if found_token:
+        )
+        found_refresh_token = self.__token_store.find_active_refresh_token(
+            token, now=_now()
+        )
+
+        found_token_type, found_token = (
+            ("access", found_access_token)
+            if found_access_token
+            else ("refresh", found_refresh_token)
+            if found_refresh_token
+            else (None, None)
+        )
+
+        if found_token_type is None or found_token is None:
+            return None
+        else:
             # Values defined by:
             # https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
             return {
-                "active": True,  # Always true because find_active_*_token() won't return inactive tokens.
+                # Only access tokens should work for accessing a protected resource, not
+                # refresh tokens. RFC7662 doesn't specify exactly how that distinction
+                # should be made. Here, we're doing it by calling refresh
+                # tokens "inactive."
+                "active": found_token_type == "access",
                 "scope": serialize_scopes(found_token.scopes),
                 "username": found_token.username,
             }
-        else:
-            return None
 
 
 @dataclass

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -280,34 +280,22 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         request: oauthlib.common.Request,
     ) -> dict[str, int | str | list[str]] | None:
         """Return information about an access or refresh token (if it exists)."""
+        # Note: It's important that we return non-None only when the token is both
+        # (1) currently active, and (2) an access token, as opposed to a refresh token.
+        # oauthlib sets `"active": True` on any non-None response, and our resource
+        # servers interpret that as meaning "this is a currently valid access token".
         found_access_token = self.__token_store.find_active_access_token(
             token, now=_now()
         )
-        found_refresh_token = self.__token_store.find_active_refresh_token(
-            token, now=_now()
-        )
-
-        found_token_type, found_token = (
-            ("access", found_access_token)
-            if found_access_token
-            else ("refresh", found_refresh_token)
-            if found_refresh_token
-            else (None, None)
-        )
-
-        if found_token_type is None or found_token is None:
+        if found_access_token is None:
             return None
         else:
             # Values defined by:
             # https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
             return {
-                # Only access tokens should work for accessing a protected resource, not
-                # refresh tokens. RFC7662 doesn't specify exactly how that distinction
-                # should be made. Here, we're doing it by calling refresh
-                # tokens "inactive."
-                "active": found_token_type == "access",
-                "scope": serialize_scopes(found_token.scopes),
-                "username": found_token.username,
+                "scope": serialize_scopes(found_access_token.scopes),
+                "username": found_access_token.username,
+                # "active": True is set implicitly by oauthlib.
             }
 
 

--- a/auth-server/tests/integration/test_oauth_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_oauth_flows.tavern.yaml
@@ -53,8 +53,8 @@ stages:
       status_code: 200
       json:
         active: false
-        username: test_admin
-        scope: *returned_scope
+      strict:
+        - json:off
 
   - name: Exchange the refresh token for a new access token and refresh token
     request:
@@ -102,9 +102,8 @@ stages:
       status_code: 200
       json:
         active: false
-        username: test_admin
-        scope: *returned_scope
-
+      strict:
+        - json:off
 ---
 test_name: Getting a token should fail if the request asks for scopes beyond what the user is authorized for
 

--- a/auth-server/tests/integration/test_oauth_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_oauth_flows.tavern.yaml
@@ -42,7 +42,7 @@ stages:
         username: test_admin
         scope: *returned_scope
 
-  - name: Introspect the refresh token and confirm it is found but inactive (only access tokens are active)
+  - name: Introspect the refresh token and confirm it's inactive (only access tokens are active)
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/introspect'
@@ -91,7 +91,7 @@ stages:
         username: test_admin
         scope: *returned_scope
 
-  - name: Introspect the new refresh token and confirm it is found but inactive (only access tokens are active)
+  - name: Introspect the new refresh token and confirm it's inactive (only access tokens are active)
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/introspect'

--- a/auth-server/tests/integration/test_oauth_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_oauth_flows.tavern.yaml
@@ -42,7 +42,7 @@ stages:
         username: test_admin
         scope: *returned_scope
 
-  - name: Introspect the refresh token to confirm that it's active
+  - name: Introspect the refresh token and confirm it is found but inactive (only access tokens are active)
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/introspect'
@@ -52,7 +52,7 @@ stages:
     response:
       status_code: 200
       json:
-        active: true
+        active: false
         username: test_admin
         scope: *returned_scope
 
@@ -91,7 +91,7 @@ stages:
         username: test_admin
         scope: *returned_scope
 
-  - name: Introspect the new refresh token to confirm that it's active
+  - name: Introspect the new refresh token and confirm it is found but inactive (only access tokens are active)
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/introspect'
@@ -101,7 +101,7 @@ stages:
     response:
       status_code: 200
       json:
-        active: true
+        active: false
         username: test_admin
         scope: *returned_scope
 


### PR DESCRIPTION
## Overview

This closes EXEC-2372. See there for background.

## Test Plan and Hands on Testing

I'm satisfied with the included Tavern testing.

## Changelog

The `/auth/oauth2/introspect` endpoint now returns `"active": false` when given a refresh token, instead of `"active": true`.

In oauthlib, it turns out that the only way to do this is to not return any token information *at all.* If we explicitly return something with `"active": false`, it just gets [overridden](https://github.com/oauthlib/oauthlib/blob/a4689bedd616597f7fc4d5b0a7070f64a0d5feff/oauthlib/oauth2/rfc6749/endpoints/introspect.py#L76-L80)...?!

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment

Low. We're covered by Tavern tests.