### PR TITLE
feat(api): add SetWasteConfig and GetWasteConfig gcode for vacuum module.

### DIFF
--- a/api/src/opentrons/drivers/vacuum_module/abstract.py
+++ b/api/src/opentrons/drivers/vacuum_module/abstract.py
@@ -1,6 +1,14 @@
 from typing import Optional, Protocol
 
-from .types import LEDColor, LEDPattern, PressureState, PumpState, VacuumModuleInfo
+from .types import (
+    LEDColor,
+    LEDPattern,
+    PressureControlTunings,
+    PressureState,
+    PumpState,
+    VacuumModuleInfo,
+    WasteConfigParameters,
+)
 
 
 class AbstractVacuumModuleDriver(Protocol):
@@ -77,3 +85,39 @@ class AbstractVacuumModuleDriver(Protocol):
     async def set_vent_state(self, state: bool) -> None:
         """Opens/Closes the vent, which release the vacuum in the module chamber."""
         ...
+
+    async def set_pressure_control_tunings(
+        self,
+        kp: Optional[float] = None,
+        ki: Optional[float] = None,
+        kd: Optional[float] = None,
+        overshoot: Optional[float] = None,
+        k_velocity: Optional[float] = None,
+        k_holding: Optional[float] = None,
+        reset: bool = False,
+    ) -> None:
+        """Sets the PID tuning parameters for the pressure control."""
+        ...
+
+    async def get_pressure_control_tunings(self) -> PressureControlTunings:
+        """Get the pressure control pid tunings."""
+        ...
+
+    async def set_waste_configs(
+        self,
+        enable_waste_full_detection: bool,
+        p_window_start: Optional[float] = None,
+        p_window_end: Optional[float] = None,
+        baseline_fast_factor: Optional[float] = None,
+        max_delta_per_tick: Optional[float] = None,
+        max_rise_per_tick: Optional[float] = None,
+        max_cummulative_rise: Optional[float] = None,
+        p_filter_alpha: Optional[float] = None,
+        min_window_time: Optional[float] = None,
+        max_window_time: Optional[float] = None,
+    ) -> None:
+        """Sets the Waste Full detection algorithm parameters"""
+        ...
+
+    async def get_waste_configs(self) -> WasteConfigParameters:
+        """Get the waste full detection configs"""

--- a/api/src/opentrons/drivers/vacuum_module/driver.py
+++ b/api/src/opentrons/drivers/vacuum_module/driver.py
@@ -14,6 +14,7 @@ from .types import (
     PumpState,
     VacuumModuleInfo,
     VentState,
+    WasteConfigParameters,
 )
 from opentrons.drivers.asyncio.communication import AsyncResponseSerialConnection
 
@@ -94,6 +95,27 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
             float(match.group("O")),
             float(match.group("V")),
             float(match.group("H")),
+        )
+
+    @classmethod
+    def parse_get_waste_configs(cls, response: str) -> WasteConfigParameters:
+        """Parse the get waste configs."""
+        pattern = r"E:(?P<E>\d) S:(?P<S>\d.+) P:(?P<P>\d.+) F:(?P<F>\d.+) D:(?P<D>\d.+) R:(?P<R>\d.+) C:(?P<C>\d.+) A:(?P<A>\d.+) M:(?P<M>\d.+) X:(?P<X>\d.+)"
+        _RE = re.compile(rf"^{GCODE.GET_WASTE_CONFIG} {pattern}$")
+        match = _RE.match(response)
+        if not match:
+            raise ValueError(f"Incorrect Response for get waste confis: {response}")
+        return WasteConfigParameters(
+            bool(match.group("E")),
+            float(match.group("S")),
+            float(match.group("P")),
+            float(match.group("F")),
+            float(match.group("D")),
+            float(match.group("R")),
+            float(match.group("C")),
+            float(match.group("A")),
+            float(match.group("M")),
+            float(match.group("X")),
         )
 
     @classmethod
@@ -336,3 +358,50 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
             GCODE.GET_PRESSURE_PID.build_command()
         )
         return self.parse_get_pressure_pid(resp)
+
+    async def set_waste_configs(  # noqa: C901
+        self,
+        enable_waste_full_detection: bool,
+        p_window_start: Optional[float] = None,
+        p_window_end: Optional[float] = None,
+        baseline_fast_factor: Optional[float] = None,
+        max_delta_per_tick: Optional[float] = None,
+        max_rise_per_tick: Optional[float] = None,
+        max_cummulative_rise: Optional[float] = None,
+        p_filter_alpha: Optional[float] = None,
+        min_window_time: Optional[float] = None,
+        max_window_time: Optional[float] = None,
+    ) -> None:
+        """Sets the Waste Full detection algorithm parameters"""
+
+        command = GCODE.SET_WASTE_CONFIG.build_command()
+        if p_window_start is not None:
+            command.add_float("S", p_window_start, GCODE_ROUNDING_PRECISION)
+        if p_window_end is not None:
+            command.add_float("P", p_window_end, GCODE_ROUNDING_PRECISION)
+        if baseline_fast_factor is not None:
+            command.add_float("F", baseline_fast_factor, GCODE_ROUNDING_PRECISION)
+        if max_delta_per_tick is not None:
+            command.add_float("D", max_delta_per_tick, GCODE_ROUNDING_PRECISION)
+        if max_rise_per_tick is not None:
+            command.add_float("R", max_rise_per_tick, GCODE_ROUNDING_PRECISION)
+        if max_cummulative_rise is not None:
+            command.add_float("C", max_cummulative_rise, GCODE_ROUNDING_PRECISION)
+        if p_filter_alpha is not None:
+            command.add_float("A", p_filter_alpha, GCODE_ROUNDING_PRECISION)
+        if min_window_time is not None:
+            command.add_float("M", min_window_time, GCODE_ROUNDING_PRECISION)
+        if max_window_time is not None:
+            command.add_float("X", max_window_time, GCODE_ROUNDING_PRECISION)
+        command.add_int("E", int(enable_waste_full_detection))
+
+        resp = await self._connection.send_command(command)
+        if not re.match(rf"^{GCODE.SET_WASTE_CONFIG}$", resp):
+            raise ValueError(f"Incorrect Response for set waste config: {resp}")
+
+    async def get_waste_configs(self) -> WasteConfigParameters:
+        """Get the waste full detection configs"""
+        resp = await self._connection.send_command(
+            GCODE.GET_WASTE_CONFIG.build_command()
+        )
+        return self.parse_get_waste_configs(resp)

--- a/api/src/opentrons/drivers/vacuum_module/simulator.py
+++ b/api/src/opentrons/drivers/vacuum_module/simulator.py
@@ -5,10 +5,12 @@ from .types import (
     HardwareRevision,
     LEDColor,
     LEDPattern,
+    PressureControlTunings,
     PressureState,
     PumpState,
     VacuumModuleInfo,
     VentState,
+    WasteConfigParameters,
 )
 from opentrons.util.async_helpers import ensure_yield
 
@@ -118,3 +120,40 @@ class SimulatingDriver(AbstractVacuumModuleDriver):
     async def set_vent_state(self, state: bool) -> None:
         """Opens/Closes the vent, which release the vacuum in the module chamber."""
         self.vent_state = VentState(open)
+
+    async def set_pressure_control_tunings(
+        self,
+        kp: Optional[float] = None,
+        ki: Optional[float] = None,
+        kd: Optional[float] = None,
+        overshoot: Optional[float] = None,
+        k_velocity: Optional[float] = None,
+        k_holding: Optional[float] = None,
+        reset: bool = False,
+    ) -> None:
+        """Sets the PID tuning parameters for the pressure control."""
+        pass
+
+    async def get_pressure_control_tunings(self) -> PressureControlTunings:
+        """Get the pressure control pid tunings."""
+        return PressureControlTunings(0, 0, 0, 0, 0, 0)
+
+    async def set_waste_configs(
+        self,
+        enable_waste_full_detection: bool,
+        p_window_start: Optional[float] = None,
+        p_window_end: Optional[float] = None,
+        baseline_fast_factor: Optional[float] = None,
+        max_delta_per_tick: Optional[float] = None,
+        max_rise_per_tick: Optional[float] = None,
+        max_cummulative_rise: Optional[float] = None,
+        p_filter_alpha: Optional[float] = None,
+        min_window_time: Optional[float] = None,
+        max_window_time: Optional[float] = None,
+    ) -> None:
+        """Sets the Waste Full detection algorithm parameters"""
+        pass
+
+    async def get_waste_configs(self) -> WasteConfigParameters:
+        """Get the waste full detection configs"""
+        return WasteConfigParameters(False, 0, 0, 0, 0, 0, 0, 0, 0, 0)

--- a/api/src/opentrons/drivers/vacuum_module/types.py
+++ b/api/src/opentrons/drivers/vacuum_module/types.py
@@ -20,6 +20,8 @@ class GCODE(StrEnum):
     SET_VENT_STATE = "M124"
     SET_PRESSURE_PID = "M125"
     GET_PRESSURE_PID = "M126"
+    SET_WASTE_CONFIG = "M127"
+    GET_WASTE_CONFIG = "M128"
 
     def build_command(self) -> CommandBuilder:
         """Build command."""
@@ -117,6 +119,22 @@ class PressureControlTunings:
     overshoot_error: float
     k_velocity: float
     k_holding: float
+
+
+@dataclass
+class WasteConfigParameters:
+    """Get the waste config parameters"""
+
+    waste_detection_enabled: bool
+    p_window_start: float
+    p_window_end: float
+    baseline_fast_factor: float
+    max_delta_per_tick: float
+    max_rise_per_tick: float
+    max_cummulative_rise: float
+    p_filter_alpha: float
+    min_window_time: float
+    max_window_time: float
 
 
 @dataclass


### PR DESCRIPTION
# Overview

Added SetWasConfig and GetWasteConfig gcodes to set/get the waste full detection configuration. We added a waste detection algorithm with [Opentrons/opentrons-modules#555](https://github.com/Opentrons/opentrons-modules/pull/555) and need to tune or disable this conditionally, so let's expose the configs.

## Test Plan and Hands on Testing
## Changelog

- Added SetWasteConfig M127 to set the waste full detection parameters
- Added GetWasteConfig M128 to get the waste full detection parameters

## Review requests
## Risk assessment