### PR TITLE
refactor(app): Update protocol run header run button responsiveness

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/RunHeaderSectionUpper.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/RunHeaderSectionUpper.tsx
@@ -9,7 +9,6 @@ import {
   Box,
   DISPLAY_GRID,
   Flex,
-  JUSTIFY_FLEX_END,
   NO_WRAP,
   SPACING,
   StyledText,
@@ -61,7 +60,7 @@ export function RunHeaderSectionUpper(
           />
         }
       />
-      <Flex justifyContent={JUSTIFY_FLEX_END}>
+      <Flex css={BUTTONS_CONTAINER_STYLE}>
         <Flex gridGap={SPACING.spacing8} alignItems={ALIGN_CENTER}>
           {isCancellableStatus(runStatus) && (
             <AlertPrimaryButton
@@ -85,7 +84,21 @@ export function RunHeaderSectionUpper(
   )
 }
 
+const BUTTONS_CONTAINER_STYLE = css`
+  justify-content: flex-end;
+
+  @media (max-width: 60rem) {
+    justify-content: flex-start;
+  }
+`
+
 const SECTION_STYLE = css`
   display: ${DISPLAY_GRID};
   grid-template-columns: 4fr 3fr 3fr 4fr;
+
+  @media (max-width: 60rem) {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto;
+    row-gap: ${SPACING.spacing16};
+  }
 `

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/RunHeaderSectionUpper/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/RunHeaderSectionUpper/index.tsx
@@ -1,29 +1,19 @@
 import { useTranslation } from 'react-i18next'
-import { css } from 'styled-components'
 
 import { RUN_STATUS_RUNNING } from '@opentrons/api-client'
-import {
-  AlertPrimaryButton,
-  ALIGN_CENTER,
-  BORDERS,
-  Box,
-  DISPLAY_GRID,
-  Flex,
-  NO_WRAP,
-  SPACING,
-  StyledText,
-} from '@opentrons/components'
+import { AlertPrimaryButton, BORDERS, StyledText } from '@opentrons/components'
 
 import { isCancellableStatus } from '/app/local-resources/runs/utils'
 import { RunTimer } from '/app/molecules/RunTimer'
 import { useRunControls } from '/app/organisms/RunTimeControl/hooks'
 import { useRunCreatedAtTimestamp, useRunTimestamps } from '/app/resources/runs'
 
-import { DisplayRunStatus } from '../DisplayRunStatus'
-import { ActionButton } from './ActionButton'
-import { LabeledValue } from './LabeledValue'
+import { DisplayRunStatus } from '../../DisplayRunStatus'
+import { ActionButton } from '../ActionButton'
+import { LabeledValue } from '../LabeledValue'
+import styles from './runheadersectionupper.module.css'
 
-import type { RunHeaderContentProps } from '.'
+import type { RunHeaderContentProps } from '..'
 
 // The upper row of Protocol Run Header.
 export function RunHeaderSectionUpper(
@@ -43,7 +33,7 @@ export function RunHeaderSectionUpper(
   }
 
   return (
-    <Box css={SECTION_STYLE}>
+    <div className={styles.section_container}>
       <LabeledValue label={t('run')} value={createdAtTimestamp} />
       <LabeledValue
         label={t('status')}
@@ -60,8 +50,8 @@ export function RunHeaderSectionUpper(
           />
         }
       />
-      <Flex css={BUTTONS_CONTAINER_STYLE}>
-        <Flex gridGap={SPACING.spacing8} alignItems={ALIGN_CENTER}>
+      <div className={styles.buttons_container}>
+        <div className={styles.buttons_inner}>
           {isCancellableStatus(runStatus) && (
             <AlertPrimaryButton
               borderRadius={BORDERS.borderRadiusFull}
@@ -71,34 +61,14 @@ export function RunHeaderSectionUpper(
               <StyledText
                 oddStyle="bodyTextSemiBold"
                 desktopStyle="bodyDefaultSemiBold"
-                whiteSpace={NO_WRAP}
               >
                 {t('cancel_run')}
               </StyledText>
             </AlertPrimaryButton>
           )}
           <ActionButton {...props}></ActionButton>
-        </Flex>
-      </Flex>
-    </Box>
+        </div>
+      </div>
+    </div>
   )
 }
-
-const BUTTONS_CONTAINER_STYLE = css`
-  justify-content: flex-end;
-
-  @media (max-width: 60rem) {
-    justify-content: flex-start;
-  }
-`
-
-const SECTION_STYLE = css`
-  display: ${DISPLAY_GRID};
-  grid-template-columns: 4fr 3fr 3fr 4fr;
-
-  @media (max-width: 60rem) {
-    grid-template-columns: 1fr 1fr;
-    grid-template-rows: auto auto;
-    row-gap: ${SPACING.spacing16};
-  }
-`

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/RunHeaderSectionUpper/runheadersectionupper.module.css
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/RunHeaderSectionUpper/runheadersectionupper.module.css
@@ -1,0 +1,27 @@
+.section_container {
+  display: grid;
+  grid-template-columns: 4fr 3fr 3fr 4fr;
+}
+
+.buttons_container {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.buttons_inner {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-8);
+}
+
+@media (width <= 960px) {
+  .section_container {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto;
+    row-gap: var(--spacing-16);
+  }
+
+  .buttons_container {
+    justify-content: flex-start;
+  }
+}


### PR DESCRIPTION
Closes [RQA-5246](https://opentrons.atlassian.net/browse/RQA-5246)

# Overview

Best viewed commit-by-commit.

Updates the run header run button responsiveness by collapsing the buttons to a new row along with the run time. There aren't strict design guidelines for this, so the breakpoints and styling is dev discretionary, see ticket. 

a7873330e696707355505a30ad3864bdc34b9048 - The responsiveness fix.
cdfdcd91cd0b73d46f6f52bef09021d09eba2858 - Migration to css modules.

https://github.com/user-attachments/assets/56f8d0f1-fd16-4a0f-9db6-74432587fbf1

## Test Plan and Hands on Testing

- See video

## Changelog

 -Added responsiveness to the desktop app's protocol run header run buttons.


## Risk assessment

- very low, pure css changes


[RQA-5246]: https://opentrons.atlassian.net/browse/RQA-5246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ