### PR TITLE
test(system-server,auth-server): Test access control coverage

### DIFF
--- a/auth-server/tests/test_access_control_coverage.py
+++ b/auth-server/tests/test_access_control_coverage.py
@@ -6,20 +6,15 @@ import pytest
 
 from server_utils.testing_utils.get_declared_security import get_declared_security
 
-from robot_server.app_setup import app
+from auth_server.app import app
 
 # Endpoints that are deliberately missing access control for some reason.
 IGNORED_ENDPOINTS: set[tuple[str, str]] = {
-    # /clientData is purely client-to-client communication, not actual robot control.
-    ("post", "/clientData"),
-    ("put", "/clientData"),
-    ("delete", "/clientData"),
-    ("put", "/clientData/{key}"),
-    ("delete", "/clientData/{key}"),
-    # This is spiritually a GET endpoint. It doesn't actually control or modify anything.
-    ("post", "/labwareOffsets/searches"),
-    # Protocol analyses are just disposable simulations.
-    ("post", "/protocols/{protocolId}/analyses"),
+    # Leaving /introspect open seems relatively harmless and might help with debugging.
+    ("post", "/auth/oauth2/introspect"),
+    # /token is how an unauthenticated client authenticates,
+    # so it itself can't be protected behind access control.
+    ("post", "/auth/oauth2/token"),
 }
 
 

--- a/server-utils/server_utils/testing_utils/__init__.py
+++ b/server-utils/server_utils/testing_utils/__init__.py
@@ -1,0 +1,11 @@
+"""Shared utilities for servers to use in their automated tests.
+
+Not to be confused with the automated tests covering `server_utils` itself,
+which are in the local `tests/` directory.
+
+These should not be used in any production code.
+
+For packaging simplicity, these utils are unfortunately still shipped to robots as part
+of the `server_utils` package, despite not being used on robots. These utils should
+therefore be careful not to import any dev-only dependencies such as pytest.
+"""

--- a/server-utils/server_utils/testing_utils/get_declared_security.py
+++ b/server-utils/server_utils/testing_utils/get_declared_security.py
@@ -1,0 +1,91 @@
+# noqa: D100
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+def get_declared_security(openapi: dict[str, Any]) -> dict[tuple[str, str], bool]:
+    """Return which endpoints in a server are protected with access control.
+
+    Limitations:
+        This is intended to help find basic omissions, like if we outright forgot to add
+        access control to an endpoint. It can't check that the access control was
+        actually implemented correctly. It works based on what the server says
+        about itself in its OpenAPI document, which is not necessarily the truth.
+
+    Params:
+        openapi: The OpenAPI document to extract information from,
+        e.g. as returned by `FastAPI.openapi()`.
+
+    Returns:
+        A dict where the keys are `(method, path)` tuples, and the values are whether
+        that endpoint has any kind of security declared. For example,
+        `{("get", "/health"): False}`.
+    """
+    validated_openapi = _OpenAPI.model_validate(openapi)
+    return {
+        (method, path): _operation_has_security(operation)
+        for path, path_item in validated_openapi.paths.items()
+        for method, operation in path_item.items()
+    }
+
+
+def _operation_has_security(operation: _Operation) -> bool:
+    # Is there at least one security scheme that has a non-empty list of scopes?
+    for security_requirement in operation.security or []:
+        for scope_list in security_requirement.values():
+            if scope_list:
+                return True
+    return False
+
+
+class _OpenAPI(BaseModel):
+    """A barebones model for parsing an OpenAPI document, just enough for our purposes.
+
+    FastAPI provides more complete models, but they seem buggy. e.g. there are nested
+    objects that the type checker thinks should be Pydantic models but are actually
+    dicts at run time.
+
+    Example:
+    ```
+    {
+      "paths": {
+        "/foo": {
+          "get": {...}
+          "post": {...}
+        },
+        "/bar": {
+          "patch": {...}
+        }
+      }
+    }
+    ```
+    """
+
+    paths: dict[str, dict[str, _Operation]]
+
+
+class _Operation(BaseModel):
+    """Details describing a single operation, for example the details of `GET /health`.
+
+    Example:
+    ```
+    {
+      "security": [
+        {
+          "securitySchemeA": ["scope1", "scope2"],
+          "securitySchemeB": ["scope3", "scope4"]
+        },
+        {
+          "securitySchemeC": ["scope5", "scope6"],
+          "securitySchemeD": ["scope7", "scope8"]
+        }
+      ]
+    }
+    ```
+    """
+
+    security: list[dict[str, list[str]]] | None = None

--- a/system-server/tests/test_access_control_coverage.py
+++ b/system-server/tests/test_access_control_coverage.py
@@ -6,20 +6,14 @@ import pytest
 
 from server_utils.testing_utils.get_declared_security import get_declared_security
 
-from robot_server.app_setup import app
+from system_server.app_setup import app
 
 # Endpoints that are deliberately missing access control for some reason.
 IGNORED_ENDPOINTS: set[tuple[str, str]] = {
-    # /clientData is purely client-to-client communication, not actual robot control.
-    ("post", "/clientData"),
-    ("put", "/clientData"),
-    ("delete", "/clientData"),
-    ("put", "/clientData/{key}"),
-    ("delete", "/clientData/{key}"),
-    # This is spiritually a GET endpoint. It doesn't actually control or modify anything.
-    ("post", "/labwareOffsets/searches"),
-    # Protocol analyses are just disposable simulations.
-    ("post", "/protocols/{protocolId}/analyses"),
+    # /system/authorize and /system/register are legacy endpoints that need to remain
+    # accessible without authentication for compatibility reasons.
+    ("post", "/system/authorize"),
+    ("post", "/system/register"),
 }
 
 


### PR DESCRIPTION
## Overview

In https://github.com/Opentrons/opentrons/pull/21010, I added a test to robot-server that'll fail if we add a new `POST`/`PUT`/`PATCH`/`DELETE` endpoint, and we forget to add access control to it.

This PR copies that test into system-server and auth-server.

This skips update-server because it's not in FastAPI and so I didn't have an easy way to implement the check. And this skips key-server, because it isn't exposed outside of robots, so it won't have any HTTP-level access control.

## Test Plan and Hands on Testing

None needed.

## Review requests

For deduplication reasons, I'm adding a _test-only_ util to `server_utils`, which is a bit weird. Are we OK with this?

## Risk assessment

No risk.