### PR TITLE
test(server-utils): Add tests for the auth-server client

### DIFF
--- a/server-utils/server_utils/auth/resource_server/__init__.py
+++ b/server-utils/server_utils/auth/resource_server/__init__.py
@@ -1,1 +1,5 @@
-"""Utilities for resource servers to enforce access controls on protected resources."""
+"""Utilities for OAuth 2 resource servers.
+
+A "resource server," in OAuth 2 terminology, is basically any server that has resources
+(endpoints) that need to be protected behind access control, with user logins and such.
+"""

--- a/server-utils/tests/auth/resource_server/test_auth_server.py
+++ b/server-utils/tests/auth/resource_server/test_auth_server.py
@@ -91,9 +91,9 @@ async def mock_server(
         if mock_server_type == "unix_domain_socket":
             socket_path = tmp_path_factory.mktemp("mock") / "sock"
 
-            site = aiohttp.web.UnixSite(runner, socket_path)
-            await site.start()
-            exit_stack.push_async_callback(site.stop)
+            unix_site = aiohttp.web.UnixSite(runner, socket_path)
+            await unix_site.start()
+            exit_stack.push_async_callback(unix_site.stop)
 
             client = await exit_stack.enter_async_context(
                 LocalHTTPClient(auth_server_uds=str(socket_path))
@@ -102,9 +102,9 @@ async def mock_server(
             yield (app_mock, client)
 
         else:  # mock_server_type == "tcp"
-            site = aiohttp.web.TCPSite(runner, host="localhost", port=0)
-            await site.start()
-            exit_stack.push_async_callback(site.stop)
+            tcp_site = aiohttp.web.TCPSite(runner, host="localhost", port=0)
+            await tcp_site.start()
+            exit_stack.push_async_callback(tcp_site.stop)
 
             port = runner.addresses[0][1]
             url = f"http://localhost:{port}"

--- a/server-utils/tests/auth/resource_server/test_auth_server.py
+++ b/server-utils/tests/auth/resource_server/test_auth_server.py
@@ -1,0 +1,158 @@
+"""Tests for our client of auth-server's HTTP API."""
+
+from __future__ import annotations
+
+from contextlib import AsyncExitStack
+from typing import AsyncGenerator, Final
+
+import aiohttp.web
+import pytest
+
+from server_utils.auth.resource_server.auth_server import (
+    CLIENT_ID,
+    SETTINGS_ENDPOINT_PATH,
+    TOKEN_INTROSPECTION_ENDPOINT_PATH,
+    AuthSettingsResponse,
+    AuthSettingsResponseData,
+    LocalHTTPClient,
+    TokenIntrospectionResponse,
+)
+
+
+class AppMock:
+    """A fake AIOHTTP app to test the client against.
+
+    This should mirror the HTTP API of our real auth-server.
+    """
+
+    introspect_response: object
+    """How the server should respond to requests to its token introspection endpoint.
+
+    A JSON-serializable object.
+    """
+
+    introspect_requests: list[object]
+    """When the server receives a request to its token introspection endpoint,
+    it records the request body here.
+    """
+
+    settings_response: object
+    """How the server should respond to requests to its settings endpoint.
+
+    A JSON-serializable object.
+    """
+
+    app: Final[aiohttp.web.Application]
+
+    def __init__(self) -> None:
+        self.settings_response = {}
+        self.introspect_response = {}
+        self.introspect_requests = []
+
+        app = aiohttp.web.Application()
+        app.router.add_get(f"/{SETTINGS_ENDPOINT_PATH}", self._get_settings)
+        app.router.add_post(
+            f"/{TOKEN_INTROSPECTION_ENDPOINT_PATH}", self._post_introspect
+        )
+        self.app = app
+
+    async def _get_settings(
+        self, _request: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
+        return aiohttp.web.json_response(data=self.settings_response)
+
+    async def _post_introspect(
+        self, request: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
+        body = await request.post()
+        self.introspect_requests.append(dict(body))
+        return aiohttp.web.json_response(self.introspect_response)
+
+
+@pytest.fixture(params=["unix_domain_socket", "tcp"])
+async def mock_server(
+    request: pytest.FixtureRequest,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> AsyncGenerator[tuple[AppMock, LocalHTTPClient], None]:
+    """Return a fake server, and a real client pointed at that fake server.
+
+    Parametrized over two connection types: Unix domain socket, and TCP.
+    """
+    async with AsyncExitStack() as exit_stack:
+        app_mock = AppMock()
+
+        runner = aiohttp.web.AppRunner(app_mock.app)
+
+        await runner.setup()
+        exit_stack.push_async_callback(runner.cleanup)
+
+        mock_server_type = request.param
+
+        if mock_server_type == "unix_domain_socket":
+            socket_path = tmp_path_factory.mktemp("mock") / "sock"
+
+            site = aiohttp.web.UnixSite(runner, socket_path)
+            await site.start()
+            exit_stack.push_async_callback(site.stop)
+
+            client = await exit_stack.enter_async_context(
+                LocalHTTPClient(auth_server_uds=str(socket_path))
+            )
+
+            yield (app_mock, client)
+
+        else:  # mock_server_type == "tcp"
+            site = aiohttp.web.TCPSite(runner, host="localhost", port=0)
+            await site.start()
+            exit_stack.push_async_callback(site.stop)
+
+            port = runner.addresses[0][1]
+            url = f"http://localhost:{port}"
+
+            client = await exit_stack.enter_async_context(
+                LocalHTTPClient(auth_server_url=url)
+            )
+
+            yield (app_mock, client)
+
+
+async def test_settings(mock_server: tuple[AppMock, LocalHTTPClient]) -> None:
+    """Test that the client can retrieve auth settings."""
+    app_mock, client = mock_server
+
+    app_mock.settings_response = {"data": {"accessControlEnabled": False}}
+    settings_result = await client.get_auth_settings()
+    assert settings_result == AuthSettingsResponse(
+        data=AuthSettingsResponseData(accessControlEnabled=False)
+    )
+
+    app_mock.settings_response = {"data": {"accessControlEnabled": True}}
+    settings_result = await client.get_auth_settings()
+    assert settings_result == AuthSettingsResponse(
+        data=AuthSettingsResponseData(accessControlEnabled=True)
+    )
+
+
+async def test_token_introspection(
+    mock_server: tuple[AppMock, LocalHTTPClient],
+) -> None:
+    """Test that the client can send a well-formed token introspection request and retrieve the response."""
+    app_mock, client = mock_server
+
+    app_mock.introspect_response = {"active": False}
+    introspect_response = await client.introspect_token("test-token")
+    assert introspect_response == TokenIntrospectionResponse(active=False, scope="")
+    assert app_mock.introspect_requests == [
+        {"token": "test-token", "client_id": CLIENT_ID}
+    ]
+
+    app_mock.introspect_requests.clear()
+
+    app_mock.introspect_response = {"active": True, "scope": "mama_mia papa_pia"}
+    introspect_response = await client.introspect_token("test-token")
+    assert introspect_response == TokenIntrospectionResponse(
+        active=True, scope="mama_mia papa_pia"
+    )
+    assert app_mock.introspect_requests == [
+        {"token": "test-token", "client_id": CLIENT_ID}
+    ]


### PR DESCRIPTION
## Overview

This improves test coverage for some new code in the guts of access control mode.

## Details

auth-server can run in two ways: on a TCP socket, which is good for general compatibility with dev tools on dev machines; or on a Unix domain socket, which is good for efficiency when running on an actual robot.

Our other servers talk to auth-server via a client, `LocalHTTPClient`. `LocalHTTPClient` needs to support both connection types. The Unix domain socket half of that has turned out to be surprisingly bug-prone. See e.g. 83a69e481d72b90ff0c1048191c3a9b850b46b3e, https://github.com/Opentrons/oe-core/pull/293, and https://github.com/aio-libs/aiohttp/issues/11324.

To mitigate that, this PR adds an "integration-ish" test for `LocalHTTPClient`. The client talks to a fake server, but over a real TCP or Unix-socket connection.

The fake server is written in aiohttp, as opposed to fastapi+uvicorn. aiohttp strikes me as having more mature support for running the server in the background of our tests, without needing to own the entire event loop.

## Test Plan and Hands on Testing

Just CI.

## Review requests

OK with my weird aiohttp-based mock server?

## Risk assessment

No risk.