### PR TITLE
feat(key-server): Create, load, and store TLS CAs

### DIFF
--- a/key-server/key_server/tls/__init__.py
+++ b/key-server/key_server/tls/__init__.py
@@ -1,0 +1,1 @@
+"""Package for managing TLS keys."""

--- a/key-server/key_server/tls/ca_manager.py
+++ b/key-server/key_server/tls/ca_manager.py
@@ -1,0 +1,419 @@
+"""Code for managing TLS CAs."""
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Final, Iterable, Iterator
+
+from cryptography import x509
+from cryptography.exceptions import UnsupportedAlgorithm
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+LOG = logging.getLogger(__name__)
+
+
+@dataclass
+class X509Pair:
+    """Store a CA cert/key pair."""
+
+    keypath: Path
+    certpath: Path
+    key: ec.EllipticCurvePrivateKey
+    cert: x509.Certificate
+
+
+# these are the x509 cert details that are the same for all of our CA certs
+
+# our CA style: no intermediate CAs (we rotate these pretty frequently, and wouldn't be storing them
+# anywhere different)
+_OT_CA_BASIC_CONSTRAINTS = x509.BasicConstraints(ca=True, path_length=0)
+# standard ca KU
+_OT_CA_KU = x509.KeyUsage(
+    digital_signature=True,  # required for any signature
+    content_commitment=False,
+    key_encipherment=False,
+    data_encipherment=False,
+    key_agreement=False,
+    key_cert_sign=True,
+    crl_sign=True,  # we don't use CRLs, at least not yet, but browsers may choke without this
+    encipher_only=False,
+    decipher_only=False,
+)
+# our ca name field
+_NAME = _ISSUER = x509.Name(
+    [
+        x509.NameAttribute(x509.NameOID.COUNTRY_NAME, "US"),
+        x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, "New York"),
+        x509.NameAttribute(x509.NameOID.LOCALITY_NAME, "New York"),
+        x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, "Opentrons"),
+        x509.NameAttribute(x509.NameOID.COMMON_NAME, "Opentrons Flex TLS CA"),
+    ]
+)
+
+_CA_NAME_PATTERN: Final = re.compile(
+    r"^ot-robot-tls-ca-(\d{4}-\d{2}-\d{2})\.(pem|cer)$"
+)
+
+
+def _safe_del(path: Path, kind: str) -> None:
+    try:
+        path.unlink()
+    except Exception:
+        LOG.exception(f"Failed to delete {kind} {str(path)}")
+
+
+def _load_key(maybe_key: Path) -> ec.EllipticCurvePrivateKey | None:
+    """Load a prospective private key from a path.
+
+    This function upholds the internal requirements we set on a key to make sure we don't
+    accidentally load the wrong thing, or indeed load the wrong thing in the future. This needs
+    to be an elliptic curve key that's properly loadable, and if it's anything else we won't load it
+    and will delete the file (so be careful calling this in an iterdir()).
+    """
+    try:
+        key_bytes = maybe_key.read_bytes()
+    except Exception:
+        LOG.exception(f"Failed to read key bytes from {str(maybe_key)}")
+        return None
+    try:
+        key = serialization.load_pem_private_key(key_bytes, password=None)
+    except ValueError:
+        LOG.exception(f"Failed to parse key from {str(maybe_key)}: invalid")
+        return None
+    except TypeError:
+        LOG.exception(f"Failed to load key from {str(maybe_key)}: requires password")
+        return None
+    except UnsupportedAlgorithm:
+        LOG.exception(
+            f"Failed to load key from {str(maybe_key)}: unsupported algorithm"
+        )
+        return None
+    except Exception:
+        LOG.exception(f"Failed to load key from {str(maybe_key)}")
+        return None
+    if not isinstance(key, ec.EllipticCurvePrivateKey):
+        LOG.exception(
+            f"Failed to load key from {str(maybe_key)}: wrong key type ({type(key)})"
+        )
+        return None
+    return key
+
+
+def _load_cert(maybe_cert: Path) -> x509.Certificate | None:
+    """Load a prospective x509 cert from a path.
+
+    If the cert can't be loaded, returns None and deletes the malformed file.
+    """
+    try:
+        cert_bytes = maybe_cert.read_bytes()
+    except Exception:
+        LOG.exception(f"Failed to read CA cert bytes from {str(maybe_cert)}")
+        return None
+    try:
+        cert = x509.load_der_x509_certificate(cert_bytes)
+    except ValueError:
+        LOG.exception(f"Failed to parse x509 cert from {str(maybe_cert)}")
+        return None
+    return cert
+
+
+def _load_ca_cert(maybe_cert: Path) -> x509.Certificate | None:  # noqa: C901
+    """Load a prospective OT CA cert from a path.
+
+    This is like _load_cert but checks to see if this is one of our CA certs as well as being a valid cert in general.
+    """
+    cert = _load_cert(maybe_cert)
+    if cert is None:
+        return None
+    # if a cert doesn't have valid extensions, it's not one of ours
+    try:
+        extensions = cert.extensions
+    except x509.DuplicateExtension:
+        LOG.exception(
+            f"Failed to parse x509 cert from {str(maybe_cert)}: duplicate extension"
+        )
+        return None
+    except x509.UnsupportedGeneralNameType:
+        LOG.exception(
+            f"Failed to parse x509 cert from {str(maybe_cert)}: unsupported extension name"
+        )
+        return None
+    # if a cert doesn't have BasicConstraints, it can't be a ca since that's where that flag lives
+    try:
+        basics = extensions.get_extension_for_class(x509.BasicConstraints)
+    except x509.ExtensionNotFound:
+        LOG.exception(
+            f"Failed to parse x509 cert from {str(maybe_cert)}: no BasicConstraints in cert"
+        )
+        return None
+    # if the cert isn't actually a ca, that's bad too
+    if not basics.value.ca or basics.value.path_length != 0:
+        LOG.exception(f"Failed to parse CA cert from {str(maybe_cert)}: not a CA")
+        return None
+    try:
+        key_usage = extensions.get_extension_for_class(x509.KeyUsage)
+    except x509.ExtensionNotFound:
+        LOG.exception(
+            f"Failed to parse x509 cert from {str(maybe_cert)}: no KeyUsage in cert"
+        )
+        return None
+    if not key_usage.value.digital_signature or not key_usage.value.key_cert_sign:
+        LOG.error(
+            f"Failed to parse x509 cert from {str(maybe_cert)}: bad KeyUsage in cert"
+        )
+        return None
+    # if the cert doesn't have our static details, we can't have that
+    if cert.subject != _NAME:
+        LOG.error(
+            f"Failed to parse Opentrons Flex CA cert from {str(maybe_cert)}: wrong subject {cert.subject}"
+        )
+        return None
+    if cert.issuer != _NAME:
+        LOG.error(
+            f"Failed to parse Opentrons Flex CA cert from {str(maybe_cert)}: wrong issuer {cert.issuer}"
+        )
+        return None
+    if not isinstance(cert.public_key(), ec.EllipticCurvePublicKey):
+        LOG.error(
+            f"Failed to parse Opentrons Flex CA cert from {str(maybe_cert)}: wrong key type {type(cert.public_key())}"
+        )
+        return None
+    return cert
+
+
+def _keys_from_dir(key_dir: Path) -> Iterator[tuple[Path, ec.EllipticCurvePrivateKey]]:
+    """Load all the keys that match our CA key format from the specified path."""
+    for maybe_key in key_dir.iterdir():
+        if _CA_NAME_PATTERN.match(maybe_key.name):
+            key = _load_key(maybe_key)
+            if key:
+                yield (maybe_key, key)
+            else:
+                _safe_del(maybe_key, "bad CA private key")
+
+
+def _ca_certs_from_dir(ca_cert_dir: Path) -> Iterator[tuple[Path, x509.Certificate]]:
+    """Load all the keys that match our CA cert format from the specified path.
+
+    If any cert that is named like one of our CAs is not one of our CAs, delete it.
+    """
+    for maybe_cert in ca_cert_dir.iterdir():
+        if _CA_NAME_PATTERN.match(maybe_cert.name):
+            # loading the cert requires that it be a valid x509 cert in DER
+            cert = _load_ca_cert(maybe_cert)
+            if cert:
+                yield (maybe_cert, cert)
+            else:
+                _safe_del(maybe_cert, "bad CA cert")
+
+
+def _match_keys_and_certs(
+    keys: Iterable[tuple[Path, ec.EllipticCurvePrivateKey]],
+    certs: Iterable[tuple[Path, x509.Certificate]],
+) -> Iterator[X509Pair]:
+    cert_set = set(certs)
+    for keypath, key in keys:
+        pubkey = key.public_key()
+        for certpath, cert in cert_set:
+            if cert.public_key() == pubkey:
+                yield X509Pair(keypath=keypath, key=key, certpath=certpath, cert=cert)
+                cert_set.remove((certpath, cert))
+                break
+        else:
+            LOG.info(f"No matching cert for key {str(keypath)}")
+    LOG.info(f"{len(cert_set)} certs remain unmatched")
+
+
+def _remove_certpair(pair: X509Pair) -> None:
+    try:
+        pair.keypath.unlink()
+    except OSError:
+        LOG.exception(f"Failed to remove key {str(pair.keypath)}")
+    try:
+        pair.certpath.unlink()
+    except OSError:
+        LOG.exception(f"Failed to remove cert {str(pair.certpath)}")
+
+
+def _remove_certs(
+    certlist: list[X509Pair], predicate: Callable[[X509Pair], bool], reason: str
+) -> list[X509Pair]:
+    """Remove certs from a list if they match a predicate. The predicate is called exactly once for each candidate."""
+    invalid = [cert for cert in certlist if predicate(cert)]
+    valid = [cert for cert in certlist if cert not in invalid]
+    LOG.info(
+        f"Invalid {len(invalid)} certs for {reason} leaving {len(valid)} certs (removed: {', '.join([_fingerprint(cert.cert) for cert in invalid])})"
+    )
+    for cert in invalid:
+        _remove_certpair(cert)
+    return valid
+
+
+def _fingerprint(cert: x509.Certificate) -> str:
+    return cert.fingerprint(hashes.SHA256()).hex()
+
+
+def _create_ca(key_dir: Path, ca_cert_dir: Path, now: datetime) -> X509Pair:
+    """Make a new CA pair."""
+    expiry = now + timedelta(days=365, hours=1)
+    key = ec.generate_private_key(ec.SECP256R1())
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(_NAME)
+        .issuer_name(_ISSUER)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now)
+        .not_valid_after(expiry)
+        .add_extension(_OT_CA_BASIC_CONSTRAINTS, critical=True)
+        .add_extension(_OT_CA_KU, critical=True)
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(key.public_key()), critical=False
+        )
+        .sign(key, hashes.SHA256())
+    )
+    LOG.info(f"Created CA {_fingerprint(cert)}")
+    pair = X509Pair(
+        keypath=key_dir / f"ot-robot-tls-ca-{expiry.strftime('%Y-%m-%d')}.pem",
+        certpath=ca_cert_dir / f"ot-robot-tls-ca-{expiry.strftime('%Y-%m-%d')}.cer",
+        key=key,
+        cert=cert,
+    )
+    if not key_dir.exists():
+        try:
+            key_dir.mkdir(parents=True)
+        except OSError:
+            LOG.warning(
+                f"Key directory {str(key_dir)} could not be created! Keys will not be saved"
+            )
+    elif not key_dir.is_dir():
+        LOG.warning(
+            f"Key directory {str(key_dir)} is not a directory! Keys will not be saved"
+        )
+    try:
+        pair.keypath.write_bytes(
+            key.private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            )
+        )
+        LOG.info(f"Wrote key for {_fingerprint(pair.cert)} to {str(pair.keypath)}")
+    except OSError:
+        LOG.error(
+            f"Could not write key for {_fingerprint(pair.cert)} to {str(pair.keypath)}, CA will be lost on server shutdown"
+        )
+    if not ca_cert_dir.exists():
+        try:
+            ca_cert_dir.mkdir(parents=True)
+        except OSError:
+            LOG.warning(
+                f"CA cert directory {str(ca_cert_dir)} could not be created! Certs will not be saved"
+            )
+    elif not ca_cert_dir.is_dir():
+        LOG.warning(
+            f"CA cert directory {str(ca_cert_dir)} is not a directory! Certs will not be saved"
+        )
+    try:
+        pair.certpath.write_bytes(cert.public_bytes(serialization.Encoding.DER))
+        LOG.info(f"Wrote cert for {_fingerprint(pair.cert)} to {str(pair.certpath)}")
+    except OSError:
+        LOG.error(
+            f"Could not write cert for {_fingerprint(pair.cert)} to {str(pair.certpath)}, CA will be lost on server shutdown"
+        )
+    return pair
+
+
+class TLSCAManager:
+    """Class that manages TLS CAs.
+
+    This is a mix of code that reads and manages data from the filesystem and code that keeps state in its
+    attributes. It manages
+    - CA generation, expiry, and management
+    - CA cert export
+    """
+
+    def __init__(self, key_dir: Path, ca_cert_dir: Path) -> None:
+        """Build the object. Scans the given directories to set up the first set of CAs."""
+        self._key_dir = key_dir
+        self._ca_cert_dir = ca_cert_dir
+
+        try:
+            pairs = list(
+                _match_keys_and_certs(
+                    _keys_from_dir(key_dir), _ca_certs_from_dir(ca_cert_dir)
+                )
+            )
+        except OSError:
+            # if at least one of these directories doesn't exist or isn't readable, we have no certs
+            pairs = []
+
+        now = datetime.now(timezone.utc)
+        # remove any certificates that have expired
+        valid = _remove_certs(
+            pairs, lambda pair: pair.cert.not_valid_after_utc < now, "no longer valid"
+        )
+        # we should never have more CAs than 2 (a current and a next). if we do, we need to delete some.
+        # unfortunately, this leaves us open to something else creating some certs that replace whatever
+        # we were using before reboot, but if someone can do that to the filesystem there's not much we
+        # can do - this is better understood as bug robustness.
+        valid = sorted(valid, key=lambda pair: pair.cert.not_valid_after_utc)
+        # delete in order
+        # - any that are not yet valid
+        if len(valid) > 2:
+            valid = _remove_certs(
+                valid,
+                lambda pair: pair.cert.not_valid_before_utc > now,
+                "not yet valid",
+            )
+
+        # - the furthest-in-the-future expiring ones
+        if len(valid) > 2:
+            valid = _remove_certs(
+                valid,
+                lambda pair: valid.index(pair) >= 2,
+                "furthest-in-the-future",
+            )
+
+        # if there are still two CAs, that's allowed - the sooner-to-expire one is current and the
+        # later-to-expire one is next. If there's just one, that's fine too - it's current, and there's no
+        # next. If there are none, we need to make one.
+        if len(valid) == 2:
+            self._current_ca = valid[0]
+            LOG.info(
+                f"Loaded {_fingerprint(self._current_ca.cert)} ({self._current_ca.cert.not_valid_before_utc}-{self._current_ca.cert.not_valid_after_utc}) as current CA"
+            )
+            self._next_ca: X509Pair | None = valid[1]
+            LOG.info(
+                f"Loaded {_fingerprint(self._next_ca.cert)} ({self._next_ca.cert.not_valid_before_utc}-{self._next_ca.cert.not_valid_after_utc}) as next CA"
+            )
+        elif len(valid) == 1:
+            self._current_ca = valid[0]
+            LOG.info(
+                f"Loaded {_fingerprint(self._current_ca.cert)} ({self._current_ca.cert.not_valid_before_utc}-{self._current_ca.cert.not_valid_after_utc}) as current CA"
+            )
+            self._next_ca = None
+            LOG.info("Found no next CA to load")
+        else:
+            LOG.info("Found no CAs to load, creating")
+            self._current_ca = _create_ca(key_dir, ca_cert_dir, now)
+            LOG.info(
+                f"Created {_fingerprint(self._current_ca.cert)} ({self._current_ca.cert.not_valid_before_utc}-{self._current_ca.cert.not_valid_after_utc}) as current CA"
+            )
+            self._next_ca = None
+
+        # if we don't have a next CA and our current expires in <90 days (ish), make a next one
+        if (
+            self._current_ca.cert.not_valid_after_utc < (now + timedelta(days=3 * 30))
+            and not self._next_ca
+        ):
+            LOG.info(
+                f"Current CA expires at {self._current_ca.cert.not_valid_after_utc} which is less than 3 months from {now} and we have no next CA, creating"
+            )
+            self._next_ca = _create_ca(key_dir, ca_cert_dir, now)
+            LOG.info(
+                f"Created {_fingerprint(self._next_ca.cert)} ({self._next_ca.cert.not_valid_before_utc}-{self._next_ca.cert.not_valid_after_utc}) as next CA"
+            )

--- a/key-server/key_server/tls/ca_manager.py
+++ b/key-server/key_server/tls/ca_manager.py
@@ -70,8 +70,7 @@ def _load_key(maybe_key: Path) -> ec.EllipticCurvePrivateKey | None:
 
     This function upholds the internal requirements we set on a key to make sure we don't
     accidentally load the wrong thing, or indeed load the wrong thing in the future. This needs
-    to be an elliptic curve key that's properly loadable, and if it's anything else we won't load it
-    and will delete the file (so be careful calling this in an iterdir()).
+    to be an elliptic curve key that's properly loadable, and if it's anything else we won't load it.
     """
     try:
         key_bytes = maybe_key.read_bytes()
@@ -105,7 +104,7 @@ def _load_key(maybe_key: Path) -> ec.EllipticCurvePrivateKey | None:
 def _load_cert(maybe_cert: Path) -> x509.Certificate | None:
     """Load a prospective x509 cert from a path.
 
-    If the cert can't be loaded, returns None and deletes the malformed file.
+    If the cert can't be loaded, returns None.
     """
     try:
         cert_bytes = maybe_cert.read_bytes()
@@ -185,7 +184,10 @@ def _load_ca_cert(maybe_cert: Path) -> x509.Certificate | None:  # noqa: C901
 
 
 def _keys_from_dir(key_dir: Path) -> Iterator[tuple[Path, ec.EllipticCurvePrivateKey]]:
-    """Load all the keys that match our CA key format from the specified path."""
+    """Load all the keys that match our CA key format from the specified path.
+
+    If any key that is named like one of our CAs is not one of our CAs, delete it.
+    """
     for maybe_key in key_dir.iterdir():
         if _CA_NAME_PATTERN.match(maybe_key.name):
             key = _load_key(maybe_key)

--- a/key-server/pyproject.toml
+++ b/key-server/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "pydantic-settings==2.4.0",
     "typing-extensions>=4.0.0,<5",
     "uvicorn==0.27.0.post1",
+    "cryptography==42.0.5"
 ]
 
 [tool.uv.dependency-groups]
@@ -29,6 +30,7 @@ robot = [
     "pydantic-settings==2.4.0",
     "typing-extensions>=4.0.0,<5",
     "uvicorn==0.27.0.post1",
+    "cryptography==42.0.5"
 ]
 dev = [
     "ruff==0.14.10",

--- a/key-server/tests/tls/test_ca_manager.py
+++ b/key-server/tests/tls/test_ca_manager.py
@@ -1,0 +1,500 @@
+import random
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from shutil import rmtree
+from typing import Any, Callable, Iterator, Literal
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
+
+from key_server.tls import ca_manager
+
+
+def test_load_key_handles_unreadable_file(
+    caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """It should fail if the key cannot be loaded."""
+    assert ca_manager._load_key(tmp_path / "some-key.pem") is None
+    assert "Failed to read key bytes" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "key_contents,failure_log",
+    [
+        pytest.param(random.randbytes(1024), ": invalid", id="random-contents"),
+        pytest.param(
+            ec.generate_private_key(ec.SECP256R1()).private_bytes(
+                serialization.Encoding.DER,
+                serialization.PrivateFormat.TraditionalOpenSSL,
+                serialization.NoEncryption(),
+            ),
+            ": invalid",
+            id="der-format",
+        ),
+        pytest.param(
+            ec.generate_private_key(ec.SECP256R1()).private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.BestAvailableEncryption(password=b"oh no"),
+            ),
+            "requires password",
+            id="requires-password",
+        ),
+        pytest.param(
+            rsa.generate_private_key(
+                public_exponent=65537, key_size=2048
+            ).private_bytes(
+                serialization.Encoding.PEM,
+                serialization.PrivateFormat.PKCS8,
+                serialization.NoEncryption(),
+            ),
+            "wrong key type",
+            id="wrong-key-type",
+        ),
+    ],
+)
+def test_load_key_requires_key_characteristics(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+    key_contents: bytes,
+    failure_log: str,
+) -> None:
+    """It should require our key characteristics."""
+    keyfile = tmp_path / "key.pem"
+    keyfile.write_bytes(key_contents)
+    assert ca_manager._load_key(keyfile) is None
+    assert failure_log in caplog.text
+
+
+def test_load_key_loads_key(tmp_path: Path) -> None:
+    """It should correctly load a valid key."""
+    keyfile = tmp_path / "key.pem"
+    key = ec.generate_private_key(ec.SECP256R1())
+    keyfile.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+    loaded_key = ca_manager._load_key(keyfile)
+    assert loaded_key
+    # surprisingly hard to compare the keys as python objects, but this works (the private number
+    # is unique to the key)
+    assert (
+        loaded_key.private_numbers().private_value
+        == key.private_numbers().private_value
+    ), "loaded keys do not match"
+
+
+def test_load_cert_handles_unreadable_file(
+    caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
+    """It should fail if the cert file cannot be read."""
+    assert ca_manager._load_ca_cert(tmp_path / "some-cert.der") is None
+    assert "Failed to read CA cert bytes" in caplog.text
+
+
+def _build_cert(
+    with_bc: bool = True,
+    with_ca: bool = True,
+    with_name: Literal["valid", "invalid"] = "valid",
+    with_issuer: Literal["valid", "invalid"] = "valid",
+    with_keyusage: Literal["valid", "invalid", False] = "valid",
+    with_key: Literal["valid", "invalid"] = "valid",
+) -> x509.Certificate:
+    if with_key == "valid":
+        key: ec.EllipticCurvePrivateKey | rsa.RSAPrivateKey = ec.generate_private_key(
+            ec.SECP256R1()
+        )
+    else:
+        key = rsa.generate_private_key(65537, key_size=2048)
+
+    builder = (
+        x509.CertificateBuilder()
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.now())
+        .not_valid_after(datetime.now() + timedelta(seconds=1))
+    )
+    if with_bc:
+        builder = builder.add_extension(
+            x509.BasicConstraints(ca=with_ca, path_length=0 if with_ca else None),
+            critical=True,
+        )
+    if with_name == "valid":
+        builder = builder.subject_name(ca_manager._NAME)
+    else:
+        builder = builder.subject_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(x509.NameOID.COUNTRY_NAME, "ZA"),
+                    x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, "uh oh"),
+                    x509.NameAttribute(x509.NameOID.LOCALITY_NAME, "nope"),
+                    x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, "O"),
+                    x509.NameAttribute(x509.NameOID.COMMON_NAME, "who knows"),
+                ]
+            )
+        )
+    if with_issuer == "valid":
+        builder = builder.issuer_name(ca_manager._ISSUER)
+    else:
+        builder = builder.issuer_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(x509.NameOID.COUNTRY_NAME, "ZA"),
+                    x509.NameAttribute(x509.NameOID.STATE_OR_PROVINCE_NAME, "uh oh"),
+                    x509.NameAttribute(x509.NameOID.LOCALITY_NAME, "nope"),
+                    x509.NameAttribute(x509.NameOID.ORGANIZATION_NAME, "O"),
+                    x509.NameAttribute(x509.NameOID.COMMON_NAME, "who knows"),
+                ]
+            )
+        )
+    if with_keyusage == "valid":
+        builder = builder.add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+    elif with_keyusage == "invalid":
+        builder = builder.add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=False,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+
+    return builder.sign(key, hashes.SHA256())
+
+
+@pytest.mark.parametrize(
+    "file_contents,reason",
+    [
+        pytest.param(
+            random.randbytes(1024), "Failed to parse x509 cert", id="random-bytes"
+        ),
+        pytest.param(
+            _build_cert().public_bytes(serialization.Encoding.PEM),
+            "Failed to parse x509 cert",
+            id="pem-encoded",
+        ),
+        pytest.param(
+            ec.generate_private_key(ec.SECP256R1())
+            .public_key()
+            .public_bytes(
+                serialization.Encoding.DER,
+                serialization.PublicFormat.SubjectPublicKeyInfo,
+            ),
+            "Failed to parse x509 cert",
+            id="not-cert",
+        ),
+        pytest.param(
+            _build_cert(with_bc=False).public_bytes(serialization.Encoding.DER),
+            "no BasicConstraints in cert",
+            id="no-basic-constrains",
+        ),
+        pytest.param(
+            _build_cert(with_ca=False).public_bytes(serialization.Encoding.DER),
+            "not a CA",
+            id="not-a-ca",
+        ),
+        pytest.param(
+            _build_cert(with_name="invalid").public_bytes(serialization.Encoding.DER),
+            "wrong subject",
+            id="wrong-name",
+        ),
+        pytest.param(
+            _build_cert(with_issuer="invalid").public_bytes(serialization.Encoding.DER),
+            "wrong issuer",
+            id="wrong-issuer",
+        ),
+        pytest.param(
+            _build_cert(with_keyusage="invalid").public_bytes(
+                serialization.Encoding.DER
+            ),
+            "bad KeyUsage in cert",
+            id="wrong-keyusage",
+        ),
+        pytest.param(
+            _build_cert(with_keyusage=False).public_bytes(serialization.Encoding.DER),
+            "no KeyUsage in cert",
+            id="no-keyusage",
+        ),
+        pytest.param(
+            _build_cert(with_key="invalid").public_bytes(serialization.Encoding.DER),
+            "wrong key type",
+            id="wrong-key-type",
+        ),
+    ],
+)
+def test_load_cert_handles_invalid_bytes(
+    caplog: pytest.LogCaptureFixture, tmp_path: Path, file_contents: bytes, reason: str
+) -> None:
+    """It should handle loading something that isn't a DER-encoded cert."""
+    cert_path = tmp_path / "cert.cer"
+    cert_path.write_bytes(file_contents)
+    assert ca_manager._load_ca_cert(cert_path) is None
+    assert reason in caplog.text
+
+
+def test_load_create_ca_cert_roundtrips(tmp_path: Path) -> None:
+    """It should be able to load its own saved keys."""
+    key_dir = tmp_path / "keys"
+    ca_dir = tmp_path / "ca"
+    key_dir.mkdir()
+    ca_dir.mkdir()
+    now = datetime.now(timezone.utc)
+    pair = ca_manager._create_ca(key_dir, ca_dir, now)
+    assert ca_manager._load_ca_cert(pair.certpath) == pair.cert
+
+
+def test_match_keys_and_certs() -> None:
+    """It should match up various keys and certificates."""
+    matched_originals: list[ca_manager.X509Pair] = []
+    for idx in range(3):
+        key = ec.generate_private_key(ec.SECP256R1())
+        cert = (
+            x509.CertificateBuilder()
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now())
+            .not_valid_after(datetime.now() + timedelta(seconds=1))
+            .subject_name(ca_manager._NAME)
+            .issuer_name(ca_manager._ISSUER)
+            .sign(key, hashes.SHA256())
+        )
+        matched_originals.append(
+            ca_manager.X509Pair(
+                cert=cert,
+                key=key,
+                keypath=Path(f"/matched/key/{idx}"),
+                certpath=Path(f"/matched/cert/{idx}"),
+            )
+        )
+    solo_keys = [
+        (Path(f"/solo/key/{idx}"), ec.generate_private_key(ec.SECP256R1()))
+        for idx in range(2)
+    ]
+    keys_to_dump = [ec.generate_private_key(ec.SECP256R1()) for idx in range(2)]
+    solo_certs = [
+        (
+            Path(f"/solo/cert/{idx}"),
+            x509.CertificateBuilder()
+            .public_key(key.public_key())
+            .serial_number(x509.random_serial_number())
+            .not_valid_before(datetime.now())
+            .not_valid_after(datetime.now() + timedelta(seconds=1))
+            .subject_name(ca_manager._NAME)
+            .issuer_name(ca_manager._ISSUER)
+            .sign(key, hashes.SHA256()),
+        )
+        for idx, key in enumerate(keys_to_dump)
+    ]
+    keys = [(el.keypath, el.key) for el in matched_originals] + solo_keys
+    random.shuffle(keys)
+    certs = [(el.certpath, el.cert) for el in matched_originals] + solo_certs
+    random.shuffle(certs)
+    matched_outputs = list(ca_manager._match_keys_and_certs(keys, certs))
+    # we should ignore the unmatched certs and keys
+    assert len(matched_outputs) == 3
+
+    sorted_matched_originals = sorted(
+        matched_originals, key=lambda pair: pair.cert.serial_number
+    )
+    sorted_matched_outputs = sorted(
+        matched_outputs, key=lambda pair: pair.cert.serial_number
+    )
+    # they should be the correct certs and keys
+    for original, output in zip(sorted_matched_originals, sorted_matched_outputs):
+        assert original.cert.fingerprint(hashes.SHA256()) == output.cert.fingerprint(
+            hashes.SHA256()
+        )
+        assert original.certpath == output.certpath
+        assert (
+            original.key.private_numbers().private_value
+            == output.key.private_numbers().private_value
+        )
+        assert original.keypath == output.keypath
+
+
+@pytest.mark.parametrize(
+    "prep_fs,key_subdir,cert_subdir,log_pattern",
+    [
+        pytest.param(
+            lambda tmp_path: (tmp_path / "key_dir").touch(),
+            Path("key_dir"),
+            Path("ca_cert_dir"),
+            r"Key directory .* is not a directory",
+            id="key-dir-is-file",
+        ),
+        pytest.param(
+            lambda tmp_path: (tmp_path / "ca_cert_dir").touch(),
+            Path("key_dir"),
+            Path("ca_cert_dir"),
+            r"CA cert directory .* is not a directory",
+            id="ca-dir-is-file",
+        ),
+        pytest.param(
+            lambda tmp_path: (tmp_path / "key_intermediate").touch(),
+            Path("key_intermediate") / "key_dir",
+            Path("ca_cert_dir"),
+            r"Key directory .* could not be created",
+            id="key-dir-not-created",
+        ),
+        pytest.param(
+            lambda tmp_path: (tmp_path / "ca_intermediate").touch(),
+            Path("key_dir"),
+            Path("ca_intermediate") / "ca_cert_dir",
+            r"CA cert directory .* could not be created",
+            id="ca-cert-dir-not-created",
+        ),
+        pytest.param(
+            lambda tmp_path: (tmp_path / "key_dir").mkdir(mode=0o000),
+            Path("key_dir"),
+            Path("ca_cert_dir"),
+            r"Could not write key",
+            id="key-not-writable",
+        ),
+        pytest.param(
+            lambda tmp_path: (tmp_path / "ca_cert_dir").mkdir(mode=0o000),
+            Path("key_dir"),
+            Path("ca_cert_dir"),
+            r"Could not write cert for",
+            id="cert-not-writable",
+        ),
+    ],
+)
+def test_create_ca_handles_fs_issues(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    prep_fs: Callable[[Path], Any],
+    key_subdir: Path,
+    cert_subdir: Path,
+    log_pattern: str,
+) -> None:
+    """It should deal with various filesystem vagaries and still create a cert pair."""
+    # note that this test causes a lot of warnings because it does some deep fs
+    # manipulation.
+    prep_fs(tmp_path)
+    pair = ca_manager._create_ca(
+        tmp_path / key_subdir, tmp_path / cert_subdir, datetime.now()
+    )
+    assert pair.key.public_key() == pair.cert.public_key()
+    assert re.search(log_pattern, caplog.text)
+
+
+@pytest.fixture
+def key_dir(tmp_path: Path) -> Iterator[Path]:
+    """Key directory for the CA manager."""
+    key_dir = tmp_path / "key_dir"
+    yield key_dir
+    rmtree(key_dir)
+
+
+@pytest.fixture
+def ca_cert_dir(tmp_path: Path) -> Iterator[Path]:
+    """Cert directory for the CA manager."""
+    ca_dir = tmp_path / "ca_certs"
+    yield ca_dir
+    rmtree(ca_dir)
+
+
+def test_init_limits_to_two_certs(key_dir: Path, ca_cert_dir: Path) -> None:
+    """It should use multiple criteria to limit itself to two valid CAs."""
+    not_yet_valid = ca_manager._create_ca(
+        key_dir, ca_cert_dir, datetime.now() + timedelta(days=1)
+    )
+    already_invalid = ca_manager._create_ca(
+        key_dir, ca_cert_dir, datetime.now() - timedelta(days=365 * 10)
+    )
+    current = ca_manager._create_ca(
+        key_dir, ca_cert_dir, datetime.now() - timedelta(days=30 * 6)
+    )
+    next = ca_manager._create_ca(
+        key_dir, ca_cert_dir, datetime.now() - timedelta(days=30 * 3)
+    )
+    should_delete = [
+        ca_manager._create_ca(
+            key_dir, ca_cert_dir, datetime.now() - timedelta(days=10)
+        ),
+        ca_manager._create_ca(key_dir, ca_cert_dir, datetime.now() - timedelta(days=5)),
+    ]
+    subject = ca_manager.TLSCAManager(key_dir, ca_cert_dir)
+
+    assert subject._current_ca.certpath == current.certpath
+    assert subject._current_ca.cert.fingerprint(
+        hashes.SHA256()
+    ) == current.cert.fingerprint(hashes.SHA256())
+    assert subject._next_ca
+    assert subject._next_ca.certpath == next.certpath
+    assert subject._next_ca.cert.fingerprint(hashes.SHA256()) == next.cert.fingerprint(
+        hashes.SHA256()
+    )
+    assert current.certpath.exists()
+    assert current.keypath.exists()
+    assert next.certpath.exists()
+    assert next.keypath.exists()
+    assert not not_yet_valid.certpath.exists()
+    assert not not_yet_valid.keypath.exists()
+    assert not already_invalid.certpath.exists()
+    assert not already_invalid.keypath.exists()
+    for sd in should_delete:
+        assert not sd.certpath.exists()
+        assert not sd.keypath.exists()
+
+
+def test_does_not_create_next_ca(key_dir: Path, ca_cert_dir: Path) -> None:
+    """If it finds only one CA and it expires in more than 3 months it should not create a next."""
+    current = ca_manager._create_ca(
+        key_dir, ca_cert_dir, datetime.now() - timedelta(days=1)
+    )
+    subject = ca_manager.TLSCAManager(key_dir, ca_cert_dir)
+    assert subject._current_ca.cert == current.cert
+    assert subject._next_ca is None
+
+
+def dt_isclose(a: datetime, b: datetime) -> bool:
+    return (a > b - timedelta(minutes=1)) and (a < b + timedelta(minutes=1))
+
+
+def test_creates_next_ca(key_dir: Path, ca_cert_dir: Path) -> None:
+    """If it finds only one CA and it expires in less than 3 months it should create a next."""
+    nowish = datetime.now(timezone.utc)
+    current = ca_manager._create_ca(key_dir, ca_cert_dir, nowish - timedelta(days=350))
+    subject = ca_manager.TLSCAManager(key_dir, ca_cert_dir)
+    assert subject._current_ca.cert == current.cert
+    assert subject._next_ca is not None
+
+    assert dt_isclose(
+        subject._next_ca.cert.not_valid_after_utc, nowish + timedelta(days=365, hours=1)
+    )
+
+
+def test_creates_current_ca(key_dir: Path, ca_cert_dir: Path) -> None:
+    """If it finds no CAs, it should make a current one and not a next one."""
+    subject = ca_manager.TLSCAManager(key_dir, ca_cert_dir)
+    assert dt_isclose(
+        subject._current_ca.cert.not_valid_after_utc,
+        datetime.now(timezone.utc) + timedelta(days=365, hours=1),
+    )
+    assert subject._next_ca is None

--- a/key-server/uv.lock
+++ b/key-server/uv.lock
@@ -172,6 +172,63 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -331,6 +388,40 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/96/38086d58a181aac86d503dfa9c47eb20715a79c3e3acbdf786e92e5c09a8/coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932", size = 224148, upload-time = "2026-02-09T12:58:58.645Z" },
     { url = "https://files.pythonhosted.org/packages/ce/72/8d10abd3740a0beb98c305e0c3faf454366221c0f37a8bcf8f60020bb65a/coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b", size = 222172, upload-time = "2026-02-09T12:59:00.396Z" },
     { url = "https://files.pythonhosted.org/packages/0d/4a/331fe2caf6799d591109bb9c08083080f6de90a823695d412a935622abb2/coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0", size = 211242, upload-time = "2026-02-09T12:59:02.032Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "42.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/9e/a55763a32d340d7b06d045753c186b690e7d88780cafce5f88cb931536be/cryptography-42.0.5.tar.gz", hash = "sha256:6fe07eec95dfd477eb9530aef5bead34fec819b3aaf6c5bd6d20565da607bfe1", size = 671025, upload-time = "2024-02-24T01:17:48.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/f1/fd98e6e79242d9aeaf6a5d49639a7e85f05741575af14d3f4a1d477f572e/cryptography-42.0.5-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:a30596bae9403a342c978fb47d9b0ee277699fa53bbafad14706af51fe543d16", size = 5883181, upload-time = "2024-02-24T01:17:24.437Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/f9/27dda069a9f9bfda7c75305e222d904cc2445acf5eab5c696ade57d36f1b/cryptography-42.0.5-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b7ffe927ee6531c78f81aa17e684e2ff617daeba7f189f911065b2ea2d526dec", size = 3106715, upload-time = "2024-02-24T01:16:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/61b2364f2a4d3668d933531bc30d012b9b2de1e534df4805678471287d57/cryptography-42.0.5-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2424ff4c4ac7f6b8177b53c17ed5d8fa74ae5955656867f5a8affaca36a27abb", size = 4376731, upload-time = "2024-02-24T01:17:03.742Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/0b/14509319a1b49858425553d2fb3808579cfdfe98c1d71a3f046c1b4e0108/cryptography-42.0.5-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:329906dcc7b20ff3cad13c069a78124ed8247adcac44b10bea1130e36caae0b4", size = 4568288, upload-time = "2024-02-24T01:16:43.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/50/9185cca136596448d9cc595ae22a9bd4412ad35d812550c37c1390d54673/cryptography-42.0.5-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b03c2ae5d2f0fc05f9a2c0c997e1bc18c8229f392234e8a0194f202169ccd278", size = 4362222, upload-time = "2024-02-24T01:16:33.882Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f7/d3c83c79947cc6807e6acd3b2d9a1cbd312042777bc7eec50c869913df79/cryptography-42.0.5-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:f8837fe1d6ac4a8052a9a8ddab256bc006242696f03368a4009be7ee3075cdb7", size = 4578380, upload-time = "2024-02-24T01:17:21.958Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/61/67e090a41c70ee526bd5121b1ccabab85c727574332d03326baaedea962d/cryptography-42.0.5-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:0270572b8bd2c833c3981724b8ee9747b3ec96f699a9665470018594301439ee", size = 4475683, upload-time = "2024-02-24T01:16:11.726Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3d/c3c21e3afaf43bacccc3ebf61d1a0d47cef6e2607dbba01662f6f9d8fc40/cryptography-42.0.5-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:b8cac287fafc4ad485b8a9b67d0ee80c66bf3574f655d3b97ef2e1082360faf1", size = 4651973, upload-time = "2024-02-24T01:16:57.816Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/b1/127ecb373d02db85a7a7de5093d7ac7b7714b8907d631f0591e8f002998d/cryptography-42.0.5-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:16a48c23a62a2f4a285699dba2e4ff2d1cff3115b9df052cdd976a18856d8e3d", size = 4448866, upload-time = "2024-02-24T01:17:28.106Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9c/821ef6144daf80360cf6093520bf07eec7c793103ed4b1bf3fa17d2b55d8/cryptography-42.0.5-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2bce03af1ce5a5567ab89bd90d11e7bbdff56b8af3acbbec1faded8f44cb06da", size = 4652546, upload-time = "2024-02-24T01:16:37.085Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7f/1c6bb9ef3c4e5e2a438ab2b7ac85af52a9aa9a9a9a326b89e1b25659b598/cryptography-42.0.5-cp37-abi3-win32.whl", hash = "sha256:b6cd2203306b63e41acdf39aa93b86fb566049aeb6dc489b70e34bcd07adca74", size = 2431140, upload-time = "2024-02-24T01:16:48.931Z" },
+    { url = "https://files.pythonhosted.org/packages/36/33/ed48350d38a6a151dd3cf1850a5966b86c5752212ddaaceb44e65bf412e5/cryptography-42.0.5-cp37-abi3-win_amd64.whl", hash = "sha256:98d8dc6d012b82287f2c3d26ce1d2dd130ec200c8679b6213b3c73c08b2b7940", size = 2890092, upload-time = "2024-02-24T01:17:35.583Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/4d/f7c14c7a49e35df829e04d451a57b843208be7442c8e087250c195775be1/cryptography-42.0.5-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:5e6275c09d2badf57aea3afa80d975444f4be8d3bc58f7f80d2a484c6f9485c8", size = 5881247, upload-time = "2024-02-24T01:16:54.4Z" },
+    { url = "https://files.pythonhosted.org/packages/50/26/248cd8b6809635ed412159791c0d3869d8ec9dfdc57d428d500a14d425b7/cryptography-42.0.5-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4985a790f921508f36f81831817cbc03b102d643b5fcb81cd33df3fa291a1a1", size = 4376966, upload-time = "2024-02-24T01:16:19.43Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/057f9d7a5364c86ccb6a4bd4e5c58920dcb66532be0cc21da3f9c7617ec3/cryptography-42.0.5-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7cde5f38e614f55e28d831754e8a3bacf9ace5d1566235e39d91b35502d6936e", size = 4567683, upload-time = "2024-02-24T01:16:14.285Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/1d/62a2324882c0db89f64358dadfb95cae024ee3ba9fde3d5fd4d2f58af9f5/cryptography-42.0.5-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:7367d7b2eca6513681127ebad53b2582911d1736dc2ffc19f2c3ae49997496bc", size = 4363579, upload-time = "2024-02-24T01:17:38.512Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c8/c0962598c43d3cff2c9d6ac66d0c612bdfb1975be8d87b8889960cf8c81d/cryptography-42.0.5-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:cd2030f6650c089aeb304cf093f3244d34745ce0cfcc39f20c6fbfe030102e2a", size = 4578653, upload-time = "2024-02-24T01:17:16.343Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f6/630eb71f246208103ffee754b8375b6b334eeedb28620b3ae57be815eeeb/cryptography-42.0.5-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a2913c5375154b6ef2e91c10b5720ea6e21007412f6437504ffea2109b5a33d7", size = 4476954, upload-time = "2024-02-24T01:16:07.717Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bc/b6c691c960b5dcd54c5444e73af7f826e62af965ba59b6d7e9928b6489a2/cryptography-42.0.5-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:c41fb5e6a5fe9ebcd58ca3abfeb51dffb5d83d6775405305bfa8715b76521922", size = 4650638, upload-time = "2024-02-24T01:16:16.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/40/c7cb9d6819b90640ffc3c4028b28f46edc525feaeaa0d98ea23e843d446d/cryptography-42.0.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3eaafe47ec0d0ffcc9349e1708be2aaea4c6dd4978d76bf6eb0cb2c13636c6fc", size = 4450500, upload-time = "2024-02-24T01:17:06.895Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/2e/9f2c49bd6a18d46c05ec098b040e7d4599c61f50ced40a39adfae3f68306/cryptography-42.0.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1b95b98b0d2af784078fa69f637135e3c317091b615cd0905f8b8a087e86fa30", size = 4651722, upload-time = "2024-02-24T01:16:31.501Z" },
+    { url = "https://files.pythonhosted.org/packages/93/56/2d8d8903513185743bc6f763797fcba1718093190943735aa2ce8f3f0328/cryptography-42.0.5-cp39-abi3-win32.whl", hash = "sha256:1f71c10d1e88467126f0efd484bd44bca5e14c664ec2ede64c32f20875c0d413", size = 2431150, upload-time = "2024-02-24T01:17:33.35Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/14/13acd84f2a8303d9410ba2e24534a9d90c2817583636a91c4f314224768d/cryptography-42.0.5-cp39-abi3-win_amd64.whl", hash = "sha256:a011a644f6d7d03736214d38832e030d8268bcff4a41f728e6030325fea3e400", size = 2891129, upload-time = "2024-02-24T01:16:22.758Z" },
 ]
 
 [[package]]
@@ -610,6 +701,7 @@ wheels = [
 name = "key-server"
 source = { editable = "." }
 dependencies = [
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -635,6 +727,7 @@ dev = [
     { name = "types-requests" },
 ]
 robot = [
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -645,6 +738,7 @@ robot = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cryptography", specifier = "==42.0.5" },
     { name = "fastapi", specifier = "==0.100.0" },
     { name = "pydantic", specifier = "==2.11.7" },
     { name = "pydantic-settings", specifier = "==2.4.0" },
@@ -670,6 +764,7 @@ dev = [
     { name = "types-requests", marker = "python_full_version >= '3.11'", specifier = "==2.27.1" },
 ]
 robot = [
+    { name = "cryptography", specifier = "==42.0.5" },
     { name = "fastapi", specifier = "==0.100.0" },
     { name = "pydantic", specifier = "==2.11.7" },
     { name = "pydantic-settings", specifier = "==2.4.0" },
@@ -1009,6 +1104,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719", size = 207796, upload-time = "2021-11-04T17:17:01.377Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f6/f0/10642828a8dfb741e5f3fbaac830550a518a775c7fff6f04a007259b0548/py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378", size = 98708, upload-time = "2021-11-04T17:17:00.152Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The key server manages the CAs that create our TLS certificates. This
commit adds creation of those CAs and initial loading of pre-existing
ones.

We're going to use "CA" as metonymy for an x509 cert that is capable of
signing other x509 certs, i.e. it has ca=True in its BasicConstraints
and key_cert_sign=True in its KeyUsage. These come (in this case) with
their private keys, since this module is going to be capable of using
the certs to sign certificate signing requests (which will probably be
from another module).

We create and store those CAs in, eventually, the secure volume. That
means that we're not encrypting the keys for the CAs at this time. I
don't think this creates any holes because how would you get to the keys
in the first place, but I'm open to being surprised and if we want to we
can actually use the caam for these keys too.

An important fact about x509 certificates and especially CAs is that
they have an expiry. This is pretty useful for setting a limit to how
long a leaked key is useful for, but more to the point most software
that parses CAs will require that the CA expire eventually, so we have
to do it too. That means we need an expiry strategy. We want our expiry
to be long enough that we don't have to deal with it often, but ideally
short enough that we'll see it before we forget about it. These CAs
expire after 1 year.

Since we're doing expiry we need a rolling key strategy. The way that
works is that we'll have _unrelated_ CAs that we roll between - they're
not cross-signed or signed by a higher authority, since there isn't
really one. This isn't how you'd do it for a big trust tree, but we
don't really have one of those - the robot is the only client of its own
CA, and the CA certs are only accessible from the robot itself. So the
robot generates a new CA 3 months before the old CA expires; the new CA
will be accessible (in plaintext) via HTTPS, and clients should poll that url and
download the new CA when it's available. Because they're downloading it
via an HTTPS connection that was authenticated by the old CA, it's safe
to trust without further work, even though it's not cross-signed. If we
did require cross-signing, then these certificates would grow over time,
and we don't really want to deal with that.

Also, we need cryptography.

## Review requests
- is this comprehensible?
- do you agree that storing the keys on the secure volume is enough, or should we add passwords to them that are stored in the caam?

## testing
- [x] run this on a robot and check that the certs get created