### PR TITLE
fix(protocol-designer): Fix Thermocycler profiles getting corrupted on re-import

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -247,7 +247,7 @@ CUSTOM_LABWARE = json.loads("""{"fixture/fixture_trash/1":{"ordering":[["A1"]],"
             },
           },
         },
-        version: '8.8.0',
+        version: '8.9.0',
         name: 'opentrons/protocol-designer',
       },
       robot: { model: OT2_ROBOT_TYPE },

--- a/protocol-designer/src/load-file/migration/8_9_0.ts
+++ b/protocol-designer/src/load-file/migration/8_9_0.ts
@@ -60,10 +60,26 @@ export const migrateFile = (
  * v8.9.0-shaped, except that designerApplication.version was incorrectly set to '8.8.0'.
  * This function detects such files.
  */
-export function isBroken890Export(appData: ProtocolFile<PDMetadata>): boolean {
-  if (appData.designerApplication?.version === '8.8.0') {
+export function isBroken890Export(
+  // This is `unknown` so this is safe to call on potentially ancient or invalid files,
+  // where we can't assume much about their structure.
+  appData: unknown
+): boolean {
+  // Inspect .designerApplication.version if it exists,
+  // paranoically accounting for unknown input file shapes.
+  const isDeclared880 =
+    typeof appData === 'object' &&
+    appData != null &&
+    'designerApplication' in appData &&
+    typeof appData.designerApplication === 'object' &&
+    appData.designerApplication != null &&
+    'version' in appData.designerApplication &&
+    appData.designerApplication.version === '8.8.0'
+
+  if (isDeclared880) {
+    const trustedAppData = appData as ProtocolFile<PDMetadata>
     const savedStepForms = Object.values(
-      appData.designerApplication?.data?.savedStepForms ?? {}
+      trustedAppData.designerApplication?.data?.savedStepForms ?? {}
     )
     const fileContains890Structures = savedStepForms.some(
       savedStepForm =>

--- a/protocol-designer/src/load-file/migration/8_9_0.ts
+++ b/protocol-designer/src/load-file/migration/8_9_0.ts
@@ -55,6 +55,27 @@ export const migrateFile = (
     return draft
   })
 
+/**
+ * v8.9.0 released with a bug where it would export a file that was mostly correctly
+ * v8.9.0-shaped, except that designerApplication.version was incorrectly set to '8.8.0'.
+ * This function detects such files.
+ */
+export function isBroken890Export(appData: ProtocolFile<PDMetadata>): boolean {
+  if (appData.designerApplication?.version === '8.8.0') {
+    const savedStepForms = Object.values(
+      appData.designerApplication?.data?.savedStepForms ?? {}
+    )
+    const fileContains890Structures = savedStepForms.some(
+      savedStepForm =>
+        savedStepForm.stepType === 'pause' &&
+        savedStepForm.pauseAction === 'untilThermocyclerProfileComplete'
+    )
+    return fileContains890Structures
+  } else {
+    return false
+  }
+}
+
 function migrateForm(originalForm: FormData): FormData[] {
   if (isThermocyclerProfileForm(originalForm)) {
     return migrateThermocyclerProfileForm(originalForm)

--- a/protocol-designer/src/load-file/migration/__tests__/8_9_0.test.ts
+++ b/protocol-designer/src/load-file/migration/__tests__/8_9_0.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { migrateFile } from '../8_9_0'
+import { isBroken890Export, migrateFile } from '../8_9_0'
 
 import type { ProtocolFile } from '@opentrons/shared-data'
 import type { PDMetadata } from '/protocol-designer/file-types'
@@ -125,6 +125,7 @@ describe('v8.9.0 migration', () => {
           setStateStep,
         ].map(step => [step.id, step])
       ),
+      version: '8.8.0',
     })
 
     const result = migrateFile(input)
@@ -233,20 +234,108 @@ describe('v8.9.0 migration', () => {
   })
 })
 
-/** Create a mock protocol file with the given commands. */
+describe('isBroken890Export', () => {
+  const v880TCProfile: LegacyFormData = {
+    id: 'v880-tc-profile',
+    stepName: 'profile step name',
+    stepDetails: 'profile step details',
+    stepType: 'thermocycler',
+    thermocyclerFormType: 'thermocyclerProfile',
+    moduleId: 'thermocycler-module-id',
+    blockIsActive: false,
+    blockTargetTemp: null,
+    lidIsActive: false,
+    lidTargetTemp: null,
+    lidOpen: false,
+    orderedProfileItems: [],
+    profileItemsById: {},
+    profileTargetLidTemp: '40',
+    profileVolume: '10',
+    blockIsActiveHold: true,
+    blockTargetTempHold: '123',
+    lidIsActiveHold: true,
+    lidTargetTempHold: '456',
+    lidOpenHold: true,
+  }
+
+  const v890TCProfileStart: FormData = {
+    id: 'v890-tc-profile',
+    stepName: 'profile step name',
+    stepDetails: 'profile step details',
+    stepType: 'thermocycler',
+    thermocyclerFormType: 'thermocyclerProfile',
+    moduleId: 'thermocycler-module-id',
+    blockIsActive: false,
+    blockTargetTemp: null,
+    lidIsActive: false,
+    lidTargetTemp: null,
+    lidOpen: false,
+    orderedProfileItems: [],
+    profileItemsById: {},
+    profileTargetLidTemp: '40',
+    profileVolume: '10',
+  }
+
+  const v890TCProfilePause: FormData = {
+    id: 'v890-tc-profile-pause',
+    stepType: 'pause',
+    stepName: 'pause',
+    stepDetails: '',
+    pauseAction: 'untilThermocyclerProfileComplete',
+    moduleId: 'thermocycler-module-id',
+  }
+
+  it('should return false for v8.8.0-labeled files with v8.8.0 contents', () => {
+    const file = createFile({
+      version: '8.8.0',
+      orderedStepIds: [v880TCProfile.id],
+      savedStepForms: { [v880TCProfile.id]: v880TCProfile },
+    })
+    expect(isBroken890Export(file)).toStrictEqual(false)
+  })
+
+  it('should return true for v8.8.0-labeled files with v8.9.0 contents', () => {
+    const file = createFile({
+      version: '8.8.0',
+      orderedStepIds: [v890TCProfileStart.id, v890TCProfilePause.id],
+      savedStepForms: {
+        [v890TCProfileStart.id]: v890TCProfileStart,
+        [v890TCProfilePause.id]: v890TCProfilePause,
+      },
+    })
+    expect(isBroken890Export(file)).toStrictEqual(true)
+  })
+
+  it('should return false for v8.9.0-labeled files with v8.9.0 contents', () => {
+    const file = createFile({
+      version: '8.9.0',
+      orderedStepIds: [v890TCProfileStart.id, v890TCProfilePause.id],
+      savedStepForms: {
+        [v890TCProfileStart.id]: v890TCProfileStart,
+        [v890TCProfilePause.id]: v890TCProfilePause,
+      },
+    })
+    expect(isBroken890Export(file)).toStrictEqual(false)
+  })
+})
+
+/** Create a mock protocol file with the given commands and version.. */
 function createFile({
   orderedStepIds,
   savedStepForms,
-}: Pick<
-  PDMetadata,
-  'orderedStepIds' | 'savedStepForms'
->): ProtocolFile<PDMetadata> {
+  version,
+}: {
+  orderedStepIds: PDMetadata['orderedStepIds']
+  savedStepForms: PDMetadata['savedStepForms']
+  version: NonNullable<ProtocolFile['designerApplication']>['version']
+}): ProtocolFile<PDMetadata> {
   return {
     designerApplication: {
       data: {
         orderedStepIds,
         savedStepForms,
       },
+      ...(version != null && { version }),
     },
   } as any
 }

--- a/protocol-designer/src/load-file/migration/__tests__/8_9_0.test.ts
+++ b/protocol-designer/src/load-file/migration/__tests__/8_9_0.test.ts
@@ -237,20 +237,25 @@ describe('v8.9.0 migration', () => {
 describe('isBroken890Export', () => {
   const v880TCProfile: LegacyFormData = {
     id: 'v880-tc-profile',
+    stepType: 'thermocycler',
     stepName: 'profile step name',
     stepDetails: 'profile step details',
-    stepType: 'thermocycler',
+
     thermocyclerFormType: 'thermocyclerProfile',
+
     moduleId: 'thermocycler-module-id',
+
     blockIsActive: false,
     blockTargetTemp: null,
     lidIsActive: false,
     lidTargetTemp: null,
     lidOpen: false,
+
     orderedProfileItems: [],
     profileItemsById: {},
     profileTargetLidTemp: '40',
     profileVolume: '10',
+
     blockIsActiveHold: true,
     blockTargetTempHold: '123',
     lidIsActiveHold: true,
@@ -260,16 +265,20 @@ describe('isBroken890Export', () => {
 
   const v890TCProfileStart: FormData = {
     id: 'v890-tc-profile',
+    stepType: 'thermocycler',
     stepName: 'profile step name',
     stepDetails: 'profile step details',
-    stepType: 'thermocycler',
+
     thermocyclerFormType: 'thermocyclerProfile',
+
     moduleId: 'thermocycler-module-id',
+
     blockIsActive: false,
     blockTargetTemp: null,
     lidIsActive: false,
     lidTargetTemp: null,
     lidOpen: false,
+
     orderedProfileItems: [],
     profileItemsById: {},
     profileTargetLidTemp: '40',
@@ -281,6 +290,7 @@ describe('isBroken890Export', () => {
     stepType: 'pause',
     stepName: 'pause',
     stepDetails: '',
+
     pauseAction: 'untilThermocyclerProfileComplete',
     moduleId: 'thermocycler-module-id',
   }
@@ -319,7 +329,7 @@ describe('isBroken890Export', () => {
   })
 })
 
-/** Create a mock protocol file with the given commands and version.. */
+/** Create a mock protocol file with the given commands and version. */
 function createFile({
   orderedStepIds,
   savedStepForms,

--- a/protocol-designer/src/load-file/migration/index.ts
+++ b/protocol-designer/src/load-file/migration/index.ts
@@ -20,7 +20,7 @@ import { migrateFile as migrateFileEightFiveFive } from './8_5_5'
 import { migrateFile as migrateFileEightSix } from './8_6_0'
 import { migrateFile as migrateFileEightSeven } from './8_7_0'
 import { migrateFile as migrateFileEightEight } from './8_8_0'
-import { migrateFile as migrateFileEightNine } from './8_9_0'
+import { isBroken890Export, migrateFile as migrateFileEightNine } from './8_9_0'
 
 import type {
   PDProtocolFile,
@@ -93,15 +93,26 @@ export const migration = (
 } => {
   const designerApplication =
     file.designerApplication || file['designer-application'] || file
+
   // NOTE: default exists because any protocol that doesn't include the application version
   // key will be treated as the oldest migrateable version ('1.0.0')
   const applicationVersion: string =
     designerApplication.applicationVersion ||
     designerApplication.version ||
     OLDEST_MIGRATEABLE_VERSION
+
+  // v8.9.0 released with a bug where it would export files that were mostly correctly
+  // v8.9.0-shaped, except that their version was incorrectly declared as '8.8.0'. If
+  // we're dealing with such a file, we need to treat it as v8.9.0, to avoid running
+  // the v8.8.0->v8.9.0 migration on a file that's already effectively v8.9.0. That
+  // migration is not idempotent.
+  const empiricalApplicationVersion = isBroken890Export(file)
+    ? '8.9.0'
+    : applicationVersion
+
   const migrationVersionsToRun = getMigrationVersionsToRunFromVersion(
     allMigrationsByVersion,
-    applicationVersion
+    empiricalApplicationVersion
   )
   const migratedFile = flow(
     migrationVersionsToRun.map(version => allMigrationsByVersion[version])

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -50,7 +50,7 @@ import type {
 } from '../types'
 
 export const PAPI_VERSION = '2.27' // oldest version that we need from api/src/opentrons/protocols/api_support/definitions.py, might not be the actual latest version
-export const PD_APPLICATION_VERSION = '8.8.0' // latest PD version to insert into DESIGNER_APPLICATION blob
+export const PD_APPLICATION_VERSION = '8.9.0' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {
   return ['import json', 'from opentrons import protocol_api, types'].join('\n')


### PR DESCRIPTION
## Overview

Closes: AUTH-2822

## Details

When PD exports a v8.9.0 file, it was incorrectly labeling it as v8.8.0. So, when the user imported the file later, PD would try running the v8.8.0->v8.9.0 migration on it. Because the file was already actually v8.9.0, this would screw up its list of commands, particularly Thermocycler profiles.

My fix here is: before running any migrations, we read the commands to detect this "quasi-v8.9.0" case. If we detect that case, we call the file "already v8.9.0," thereby skipping the v8.8.0->v8.9.0 migration.

## Test Plan and Hands on Testing

* [x] The user protocols attached to the ticket and Slack thread should now import without errors.
* [x] Creating a Thermocycler profile protocol from scratch, exporting it, and reimporting it should now work without errors.
* [x] Older protocols should continue to be importable without errors.

## Review requests

Does this approach of detecting a broken file and patching the version seem fundamentally OK?

## Risk assessment

Medium. As always, migration code is sketchy.