### PR TITLE
fix(shared-data): T20 overlaps updates fix

### DIFF
--- a/shared-data/pipette/definitions/2/general/eight_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/general/eight_channel/p50/3_5.json
@@ -59,9 +59,9 @@
             "speed": 10,
             "tipOverlaps": {
               "v0": {
-                "default": 10.5,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.48,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.48
+                "default": 10.38,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.38,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.38
               }
             }
           }
@@ -94,9 +94,9 @@
             "speed": 10,
             "tipOverlaps": {
               "v0": {
-                "default": 10.06,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.06,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.06
+                "default": 10.36,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.36,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.36
               }
             }
           }
@@ -116,9 +116,9 @@
               },
               "v1": {
                 "default": 9.24,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.74,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.78,
                 "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 9.24,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.74,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.78,
                 "opentrons/opentrons_flex_96_tiprack_50ul/1": 9.24
               }
             }
@@ -139,9 +139,9 @@
               },
               "v1": {
                 "default": 9.2,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.5,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.58,
                 "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 9.2,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.5,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.58,
                 "opentrons/opentrons_flex_96_tiprack_50ul/1": 9.2
               }
             }
@@ -162,9 +162,9 @@
               },
               "v1": {
                 "default": 9.2,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.7,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.78,
                 "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 9.2,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.7,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.78,
                 "opentrons/opentrons_flex_96_tiprack_50ul/1": 9.2
               }
             }
@@ -185,9 +185,9 @@
               },
               "v1": {
                 "default": 9.2,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.65,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.73,
                 "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 9.2,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.65,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.73,
                 "opentrons/opentrons_flex_96_tiprack_50ul/1": 9.2
               }
             }
@@ -208,9 +208,9 @@
               },
               "v1": {
                 "default": 9.2,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.2,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.66,
                 "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 9.5,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.2,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.66,
                 "opentrons/opentrons_flex_96_tiprack_50ul/1": 9.5
               }
             }
@@ -231,9 +231,9 @@
               },
               "v1": {
                 "default": 9.13,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.43,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.68,
                 "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 9.13,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.43,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.68,
                 "opentrons/opentrons_flex_96_tiprack_50ul/1": 9.13
               }
             }

--- a/shared-data/pipette/definitions/2/general/ninety_six_channel/p200/3_2.json
+++ b/shared-data/pipette/definitions/2/general/ninety_six_channel/p200/3_2.json
@@ -67,12 +67,7 @@
             "speed": 5.5,
             "tipOverlaps": {
               "v0": {
-                "default": 10.5,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.5,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.5
-              },
-              "v1": {
-                "default": 9.52,
+                "default": 9.76,
                 "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.76,
                 "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.76
               }
@@ -138,10 +133,10 @@
               "v1": {
                 "default": 9.884,
                 "opentrons/opentrons_flex_96_filtertiprack_200ul/1": 10.077,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.792,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.246,
                 "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 10.092,
                 "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.077,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.792,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.246,
                 "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.092
               }
             }
@@ -152,14 +147,9 @@
             "speed": 10,
             "tipOverlaps": {
               "v0": {
-                "default": 10.5,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.5,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.5
-              },
-              "v1": {
-                "default": 9.884,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.021,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.021
+                "default": 10.246,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.246,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.246
               }
             }
           },
@@ -216,10 +206,10 @@
               "v1": {
                 "default": 9.884,
                 "opentrons/opentrons_flex_96_filtertiprack_200ul/1": 9.979,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.455,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.118,
                 "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 9.857,
                 "opentrons/opentrons_flex_96_tiprack_200ul/1": 9.979,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.455,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.118,
                 "opentrons/opentrons_flex_96_tiprack_50ul/1": 9.875
               }
             }
@@ -230,14 +220,9 @@
             "speed": 10,
             "tipOverlaps": {
               "v0": {
-                "default": 10.5,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.5,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.5
-              },
-              "v1": {
-                "default": 9.884,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.884,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.884
+                "default": 10.118,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.118,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.118
               }
             }
           },
@@ -294,10 +279,10 @@
               "v1": {
                 "default": 9.884,
                 "opentrons/opentrons_flex_96_filtertiprack_200ul/1": 10.132,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.78,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.168,
                 "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 10.132,
                 "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.138,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.78,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.168,
                 "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.138
               }
             }
@@ -308,14 +293,9 @@
             "speed": 10,
             "tipOverlaps": {
               "v0": {
-                "default": 10.5,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.5,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.5
-              },
-              "v1": {
-                "default": 9.884,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.138,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.138
+                "default": 10.168,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.168,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.168
               }
             }
           },
@@ -372,10 +352,10 @@
               "v1": {
                 "default": 9.884,
                 "opentrons/opentrons_flex_96_filtertiprack_200ul/1": 10.09,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.68,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.193,
                 "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 10.007,
                 "opentrons/opentrons_flex_96_tiprack_200ul/1": 10.09,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.68,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.193,
                 "opentrons/opentrons_flex_96_tiprack_50ul/1": 10.007
               }
             }
@@ -386,14 +366,9 @@
             "speed": 10,
             "tipOverlaps": {
               "v0": {
-                "default": 10.5,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.5,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.5
-              },
-              "v1": {
-                "default": 9.884,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.007,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.007
+                "default": 10.193,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.193,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.193
               }
             }
           },
@@ -456,10 +431,10 @@
               "v3": {
                 "default": 9.491,
                 "opentrons/opentrons_flex_96_filtertiprack_200ul/1": 9.552,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.7,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.729,
                 "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 9.491,
                 "opentrons/opentrons_flex_96_tiprack_200ul/1": 9.552,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.7,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.729,
                 "opentrons/opentrons_flex_96_tiprack_50ul/1": 9.491
               }
             }
@@ -470,18 +445,9 @@
             "speed": 10,
             "tipOverlaps": {
               "v0": {
-                "default": 10.5,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.5,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.5
-              },
-              "v1": {
-                "default": 10.5,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.16
-              },
-              "v3": {
-                "default": 9.491,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.491,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.491
+                "default": 9.729,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.729,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.729
               }
             }
           },
@@ -552,10 +518,10 @@
               "v3": {
                 "default": 9.562,
                 "opentrons/opentrons_flex_96_filtertiprack_200ul/1": 9.562,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.771,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.801,
                 "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 9.491,
                 "opentrons/opentrons_flex_96_tiprack_200ul/1": 9.562,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.771,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.801,
                 "opentrons/opentrons_flex_96_tiprack_50ul/1": 9.491
               }
             }
@@ -566,18 +532,9 @@
             "speed": 10,
             "tipOverlaps": {
               "v0": {
-                "default": 10.5,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 10.5,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.5
-              },
-              "v1": {
-                "default": 10.5,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 10.16
-              },
-              "v3": {
-                "default": 9.491,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.491,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.491
+                "default": 9.801,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.801,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.801
               }
             }
           },
@@ -640,9 +597,9 @@
                 "default": 9.275,
                 "opentrons/opentrons_flex_96_filstertiprack_50ul/1": 9.155,
                 "opentrons/opentrons_flex_96_filtertiprack_200ul/1": 9.275,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.25,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.52,
                 "opentrons/opentrons_flex_96_tiprack_200ul/1": 9.275,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.25,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.52,
                 "opentrons/opentrons_flex_96_tiprack_50ul/1": 9.155
               }
             }
@@ -662,10 +619,10 @@
               "v1": {
                 "default": 9.407,
                 "opentrons/opentrons_flex_96_filtertiprack_200ul/1": 9.407,
-                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.027,
+                "opentrons/opentrons_flex_96_filtertiprack_20ul/1": 9.5,
                 "opentrons/opentrons_flex_96_filtertiprack_50ul/1": 9.132,
                 "opentrons/opentrons_flex_96_tiprack_200ul/1": 9.407,
-                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.027,
+                "opentrons/opentrons_flex_96_tiprack_20ul/1": 9.5,
                 "opentrons/opentrons_flex_96_tiprack_50ul/1": 9.132
               }
             }


### PR DESCRIPTION
# Overview
The fix that made partial tip overlap values to be correctly applied were reverted in the branch of 9.0 and the hardware testing team was using an alpha with that fix reverted. This means that the math for the 20tips was being applied to the wrong numbers in partial tip configurations.