### PR TITLE
fix(abr-testing): install slack-sdk on individual push of abr folder

### DIFF
--- a/abr-testing/Makefile
+++ b/abr-testing/Makefile
@@ -1,7 +1,9 @@
+
 include ../scripts/push.mk
 include ../scripts/python.mk
 
 SHX := npx shx
+slack_sdk_version := 3.39.0
 
 package_name = abr_testing
 package_version = $(call python_package_version,abr-testing,$(project_rs_default))
@@ -73,6 +75,10 @@ test:
 .PHONY: push-no-restart-ot3
 push-no-restart-ot3: wheel Pipfile.lock
 	$(call push-python,$(host),$(ssh_key),$(ssh_opts),dist/$(wheel_file),/opt/opentrons-robot-server/)
+	ssh $(ssh_helper_ot3) root@$(host) \
+		'set -e; mount -o remount,rw /; pip3 config --global unset install.root; \
+		pip3 install --upgrade --ignore-installed -t /opt/opentrons-robot-server/ "slack-sdk==$(slack_sdk_version)"; \
+		pip3 config --global set install.root /var/user-packages; mount -o remount,ro /'
 
 .PHONY: push-ot3
 push-ot3: push-no-restart-ot3

--- a/abr-testing/pyproject.toml
+++ b/abr-testing/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 classifiers = [
     "Private :: Do Not Upload"  # Prevent uploading to PyPI.
 ]
-dependencies = []
+dependencies = ["slack-sdk==3.39.0"]
 dynamic = ["version"]
 
 [project.urls]


### PR DESCRIPTION
Originally, we didn't install slack-sdk which caused unclear error messages, now we don't have to install it manually enabling us to easily push the abr folder to any robot.

[RABR-887
](https://opentrons.atlassian.net/browse/RABR-926)
# Overview

Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.

## Test Plan and Hands on Testing

I already pushed it to a robot with and without slack-sdk and it resolves the issue 
## Changelog
updated make file when pushing abr-testing folder to a single robot. 
## Review requests
Is there are a more elegant way to say "install this python package" 

## Risk assessment
- low 