### PR TITLE
fix(app): modify TouchInputField props to allow users to use an external keyboard

### DIFF
--- a/app/src/organisms/ODD/NetworkSettings/SetWifiSsid.tsx
+++ b/app/src/organisms/ODD/NetworkSettings/SetWifiSsid.tsx
@@ -48,6 +48,7 @@ export function SetWifiSsid({
           {t('enter_network_name')}
         </LegacyStyledText>
         <TouchInputField
+          autoFocus
           aria-label="wifi_ssid"
           value={inputSsid}
           id="wifiSsid"
@@ -59,7 +60,6 @@ export function SetWifiSsid({
           onBlur={e => {
             e.target.focus()
           }}
-          autoFocus
         />
       </Flex>
       <Flex width="100%" position={POSITION_FIXED} left="0" bottom="0">

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ChooseNumber.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ChooseNumber.tsx
@@ -145,12 +145,11 @@ export function ChooseNumber({
               e.target.focus()
             }}
             onChange={e => {
-              const updatedValue =
-                parameter.type === 'int'
-                  ? Math.round(e.target.valueAsNumber)
-                  : e.target.valueAsNumber
+              const inputValue = Number(e.target.value as string)
+              const modifiedValue =
+                parameter.type === 'int' ? Math.round(inputValue) : inputValue
               setParamValue(
-                Number.isNaN(updatedValue) ? '' : String(updatedValue)
+                Number.isNaN(modifiedValue) ? '' : String(modifiedValue)
               )
             }}
           />

--- a/app/src/organisms/ODD/QuickTransferFlow/NameQuickTransfer.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/NameQuickTransfer.tsx
@@ -65,11 +65,15 @@ export function NameQuickTransfer(props: NameQuickTransferProps): JSX.Element {
           width="100%"
         >
           <TouchInputField
+            autoFocus
             type="text"
             value={name}
             textAlign={TYPOGRAPHY.textAlignCenter}
             onBlur={e => {
               e.target.focus()
+            }}
+            onChange={e => {
+              setName(e.target.value as string)
             }}
           />
           <StyledText

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/AirGap.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/AirGap.tsx
@@ -203,13 +203,16 @@ export function AirGap(props: AirGapProps): JSX.Element {
             marginTop={SPACING.spacing68}
           >
             <TouchInputField
+              autoFocus
               type="number"
               value={volume}
               label={t('air_gap_volume_µL')}
               error={volumeError}
-              readOnly
               onBlur={e => {
                 e.target.focus()
+              }}
+              onChange={e => {
+                setVolume(Number(e.target.value))
               }}
             />
           </Flex>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/BlowOut.tsx
@@ -396,13 +396,16 @@ export function BlowOut(props: BlowOutProps): JSX.Element {
             marginTop={SPACING.spacing68}
           >
             <TouchInputField
+              autoFocus
               type="text"
               value={String(speed ?? '')}
               label={t('blow_out_speed')}
               error={speedError}
-              readOnly
               onBlur={e => {
                 e.target.focus()
+              }}
+              onChange={e => {
+                handleFlowRateChange(e.target.value as string)
               }}
             />
           </Flex>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Condition.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Condition.tsx
@@ -185,13 +185,16 @@ export function Condition(props: DelayProps): JSX.Element {
             marginTop={SPACING.spacing68}
           >
             <TouchInputField
+              autoFocus
               type="number"
               value={conditionVolume}
               label={t('condition_volume')}
               error={volumeError}
-              readOnly
               onBlur={e => {
                 e.target.focus()
+              }}
+              onChange={e => {
+                setConditionVolume(Number(e.target.value))
               }}
             />
             <StyledText oddStyle="bodyTextRegular" color={COLORS.grey60}>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Delay.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Delay.tsx
@@ -194,13 +194,16 @@ export function Delay(props: DelayProps): JSX.Element {
             marginTop={SPACING.spacing68}
           >
             <TouchInputField
+              autoFocus
               type="number"
               value={delayDuration}
               error={durationError}
               label={t('delay_duration_s')}
-              readOnly
               onBlur={e => {
                 e.target.focus()
+              }}
+              onChange={e => {
+                setDelayDuration(Number(e.target.value))
               }}
             />
           </Flex>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/DisposalVolume.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/DisposalVolume.tsx
@@ -242,12 +242,15 @@ export function DisposalVolume(props: DisposalVolumeProps): JSX.Element {
             marginTop={SPACING.spacing68}
           >
             <TouchInputField
+              autoFocus
               type="text"
               value={String(volume ?? '')}
               label={t('disposal_volume_µL')}
-              readOnly
               onBlur={e => {
                 e.target.focus()
+              }}
+              onChange={e => {
+                handleVolumeChange(e.target.value as string)
               }}
             />
           </Flex>
@@ -313,13 +316,16 @@ export function DisposalVolume(props: DisposalVolumeProps): JSX.Element {
             marginTop={SPACING.spacing68}
           >
             <TouchInputField
+              autoFocus
               type="text"
               value={String(flowRate ?? '')}
               label={t('blowout_flow_rate_µL')}
               error={flowRateError}
-              readOnly
               onBlur={e => {
                 e.target.focus()
+              }}
+              onChange={e => {
+                handleFlowRateChange(e.target.value as string)
               }}
             />
             <StyledText oddStyle="bodyTextRegular" color={COLORS.grey60}>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/FlowRate.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/FlowRate.tsx
@@ -138,13 +138,16 @@ export function FlowRateEntry(props: FlowRateEntryProps): JSX.Element {
           marginTop={SPACING.spacing68}
         >
           <TouchInputField
+            autoFocus
             type="number"
             value={flowRate}
             label={textEntryCopy}
             error={error}
-            readOnly
             onBlur={e => {
               e.target.focus()
+            }}
+            onChange={e => {
+              setFlowRate(Number(e.target.value))
             }}
           />
         </Flex>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Mix.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Mix.tsx
@@ -219,13 +219,16 @@ export function Mix(props: MixProps): JSX.Element {
             marginTop={SPACING.spacing68}
           >
             <TouchInputField
+              autoFocus
               type="number"
               value={mixVolume}
               label={t('mix_volume_µL')}
               error={volumeError}
-              readOnly
               onBlur={e => {
                 e.target.focus()
+              }}
+              onChange={e => {
+                setMixVolume(Number(e.target.value))
               }}
             />
           </Flex>
@@ -263,13 +266,16 @@ export function Mix(props: MixProps): JSX.Element {
             marginTop={SPACING.spacing68}
           >
             <TouchInputField
+              autoFocus
               type="number"
               value={mixReps}
               error={repititionError}
               label={t('mix_repetitions')}
-              readOnly
               onBlur={e => {
                 e.target.focus()
+              }}
+              onChange={e => {
+                setMixReps(Number(e.target.value))
               }}
             />
           </Flex>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PipettePath.tsx
@@ -203,13 +203,16 @@ export function PipettePath(props: PipettePathProps): JSX.Element {
             marginTop={SPACING.spacing68}
           >
             <TouchInputField
+              autoFocus
               type="number"
               value={disposalVolume}
               label={t('disposal_volume_µL')}
               error={volumeError}
-              readOnly
               onBlur={e => {
                 e.target.focus()
+              }}
+              onChange={e => {
+                setDisposalVolume(Number(e.target.value))
               }}
             />
           </Flex>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PushOut.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/PushOut.tsx
@@ -176,13 +176,16 @@ export function PushOut(props: PushOutProps): JSX.Element {
             marginTop={SPACING.spacing68}
           >
             <TouchInputField
+              autoFocus
               type="number"
               value={volume}
               error={volumeError}
               label={t('push_out_volume')}
-              readOnly
               onBlur={e => {
                 e.target.focus()
+              }}
+              onChange={e => {
+                setVolume(Number(e.target.value))
               }}
             />
           </Flex>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Retract.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Retract.tsx
@@ -282,12 +282,15 @@ function RetractSettingComponent({
               : t('withdraw_tip_from_liquid_dispense')}
           </StyledText>
           <TouchInputField
+            autoFocus
             type="number"
             value={speed}
             label={t('speed')}
-            readOnly
             onBlur={e => {
               e.target.focus()
+            }}
+            onChange={e => {
+              handleSpeedChange(e.target.value as string)
             }}
           />
         </Flex>
@@ -320,12 +323,15 @@ function RetractSettingComponent({
           marginTop={SPACING.spacing68}
         >
           <TouchInputField
+            autoFocus
             type="number"
             value={delayDuration}
             label={t('delay_duration_s')}
-            readOnly
             onBlur={e => {
               e.target.focus()
+            }}
+            onChange={e => {
+              handleDelayDurationChange(e.target.value as string)
             }}
           />
         </Flex>
@@ -361,11 +367,17 @@ function RetractSettingComponent({
           marginTop={SPACING.spacing68}
         >
           <TouchInputField
+            autoFocus
             type="text"
             value={position}
             error={positionError}
             label={positionText}
-            readOnly
+            onBlur={e => {
+              e.target.focus()
+            }}
+            onChange={e => {
+              handlePositionChange(e.target.value as string)
+            }}
           />
           {positionError == null ? (
             <StyledText oddStyle="bodyTextRegular" color={COLORS.grey60}>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Submerge.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/Submerge.tsx
@@ -282,12 +282,15 @@ function SubmergeSettingComponent({
             {t(`submerge_${kind}_description`)}
           </StyledText>
           <TouchInputField
+            autoFocus
             type="number"
             value={speed}
             label={t('speed')}
-            readOnly
             onBlur={e => {
               e.target.focus()
+            }}
+            onChange={e => {
+              handleSpeedChange(e.target.value as string)
             }}
           />
         </Flex>
@@ -320,12 +323,15 @@ function SubmergeSettingComponent({
           marginTop={SPACING.spacing68}
         >
           <TouchInputField
+            autoFocus
             type="number"
             value={delayDuration}
             label={t('delay_duration_s')}
-            readOnly
             onBlur={e => {
               e.target.focus()
+            }}
+            onChange={e => {
+              handleDelayDurationChange(e.target.value as string)
             }}
           />
         </Flex>
@@ -362,13 +368,16 @@ function SubmergeSettingComponent({
           marginTop={SPACING.spacing68}
         >
           <TouchInputField
+            autoFocus
             type="text"
             value={position}
             error={positionError}
             label={positionText}
-            readOnly
             onBlur={e => {
               e.target.focus()
+            }}
+            onChange={e => {
+              handlePositionChange(e.target.value as string)
             }}
           />
           {positionError == null ? (

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TipPosition.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TipPosition.tsx
@@ -130,13 +130,16 @@ export function TipPositionEntry(props: TipPositionEntryProps): JSX.Element {
           marginTop={SPACING.spacing68}
         >
           <TouchInputField
+            autoFocus
             type="text"
             value={tipPosition}
             label={textEntryCopy}
             error={error}
-            readOnly
             onBlur={e => {
               e.target.focus()
+            }}
+            onChange={e => {
+              setTipPosition(Number(e.target.value))
             }}
           />
         </Flex>

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/TouchTip.tsx
@@ -235,12 +235,15 @@ export function TouchTip(props: TouchTipProps): JSX.Element {
             marginTop={SPACING.spacing68}
           >
             <TouchInputField
+              autoFocus
               type="text"
               value={String(speed ?? '')}
               label={t('speed')}
-              readOnly
               onBlur={e => {
                 e.target.focus()
+              }}
+              onChange={e => {
+                handleSpeedChange(e.target.value as string)
               }}
             />
           </Flex>
@@ -278,13 +281,16 @@ export function TouchTip(props: TouchTipProps): JSX.Element {
             marginTop={SPACING.spacing68}
           >
             <TouchInputField
+              autoFocus
               type="text"
               value={String(position ?? '')}
               label={t('touch_tip_position_mm')}
               error={positionError}
-              readOnly
               onBlur={e => {
                 e.target.focus()
+              }}
+              onChange={e => {
+                setPosition(e.target.value as string)
               }}
             />
             <StyledText oddStyle="bodyTextRegular" color={COLORS.grey60}>

--- a/app/src/organisms/ODD/QuickTransferFlow/VolumeEntry.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/VolumeEntry.tsx
@@ -51,6 +51,10 @@ export function VolumeEntry(props: VolumeEntryProps): JSX.Element {
 
   const volumeAsNumber = Number(volume)
 
+  const handleVolumeChange = (input: string): void => {
+    setVolume(input)
+  }
+
   const handleClickNext = (): void => {
     // the button will be disabled if this values is null
     if (volumeAsNumber != null) {
@@ -105,13 +109,16 @@ export function VolumeEntry(props: VolumeEntryProps): JSX.Element {
           marginTop={SPACING.spacing68}
         >
           <TouchInputField
+            autoFocus
             type="text"
             value={volume}
             label={textEntryCopy}
             error={error}
-            readOnly
             onBlur={e => {
               e.target.focus()
+            }}
+            onChange={e => {
+              setVolume(e.target.value as string)
             }}
           />
         </Flex>
@@ -123,9 +130,7 @@ export function VolumeEntry(props: VolumeEntryProps): JSX.Element {
         >
           <NumericalKeyboard
             keyboardRef={keyboardRef}
-            onChange={e => {
-              setVolume(e)
-            }}
+            onChange={handleVolumeChange}
           />
         </Flex>
       </Flex>

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/AirGap.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/AirGap.test.tsx
@@ -96,12 +96,13 @@ describe('AirGap', () => {
     fireEvent.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Air gap volume (µL)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: null,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -128,12 +129,13 @@ describe('AirGap', () => {
     fireEvent.click(screen.getByText('0'))
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Air gap volume (µL)',
         error: 'Value must be between 0 to 195',
-        readOnly: true,
         type: 'number',
         value: 200,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -158,12 +160,13 @@ describe('AirGap', () => {
     fireEvent.click(numButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Air gap volume (µL)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: 0,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -186,12 +189,13 @@ describe('AirGap', () => {
     fireEvent.click(numButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Air gap volume (µL)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: 0,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -212,12 +216,13 @@ describe('AirGap', () => {
     fireEvent.click(numButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Air gap volume (µL)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: 0,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -250,12 +255,13 @@ describe('AirGap', () => {
     fireEvent.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Air gap volume (µL)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: 4,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -276,12 +282,13 @@ describe('AirGap', () => {
     fireEvent.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Air gap volume (µL)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: 16,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Delay.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Delay.test.tsx
@@ -102,12 +102,13 @@ describe('Delay', () => {
     fireEvent.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Delay duration (seconds)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: null,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -133,12 +134,13 @@ describe('Delay', () => {
     fireEvent.click(oneButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Delay duration (seconds)',
         error: 'Value must be between 0.1 to 9999999999',
-        readOnly: true,
         type: 'number',
         value: 0,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -179,12 +181,13 @@ describe('Delay', () => {
     fireEvent.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Delay duration (seconds)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: 15,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -206,12 +209,13 @@ describe('Delay', () => {
     fireEvent.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Delay duration (seconds)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: 20,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/FlowRate.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/FlowRate.test.tsx
@@ -94,12 +94,13 @@ describe('FlowRate', () => {
     screen.getByTestId('ChildNavigation_Primary_Button')
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Aspirate flow rate (µL/s)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: 35,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -117,12 +118,13 @@ describe('FlowRate', () => {
     screen.getByText('Dispense flow rate')
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Dispense flow rate (µL/s)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: 62,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -135,12 +137,13 @@ describe('FlowRate', () => {
     fireEvent.click(deleteBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Aspirate flow rate (µL/s)',
         error: 'Value must be between 1 to 92',
-        readOnly: true,
         type: 'number',
         value: 0,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Mix.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Mix.test.tsx
@@ -102,12 +102,13 @@ describe('Mix', () => {
     fireEvent.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Mix volume (µL)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: null,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -133,12 +134,13 @@ describe('Mix', () => {
     fireEvent.click(oneButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Mix volume (µL)',
         error: 'Value must be between 1 to 200',
-        readOnly: true,
         type: 'number',
         value: 0,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -160,12 +162,13 @@ describe('Mix', () => {
     fireEvent.click(zeroButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Mix repetitions',
         error: 'Value must be between 1 to 999',
-        readOnly: true,
         type: 'number',
         value: 0,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -207,24 +210,26 @@ describe('Mix', () => {
     fireEvent.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Mix volume (µL)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: 15,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
     fireEvent.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Mix repetitions',
         error: null,
-        readOnly: true,
         type: 'number',
         value: 55,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -247,24 +252,26 @@ describe('Mix', () => {
     fireEvent.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Mix volume (µL)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: 18,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
     fireEvent.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Mix repetitions',
         error: null,
-        readOnly: true,
         type: 'number',
         value: 2,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/PipettePath.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/PipettePath.test.tsx
@@ -172,12 +172,13 @@ describe('PipettePath', () => {
 
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Disposal volume (µL)',
         error: null,
-        readOnly: true,
         type: 'number',
         value: 20,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -204,12 +205,13 @@ describe('PipettePath', () => {
     fireEvent.click(oneButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Disposal volume (µL)',
         error: 'Value must be between 1 to 160',
-        readOnly: true,
         type: 'number',
         value: 201,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TipPosition.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TipPosition.test.tsx
@@ -91,12 +91,13 @@ describe('TipPosition', () => {
     screen.getByTestId('ChildNavigation_Primary_Button')
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Distance from bottom of well (mm)',
         error: null,
-        readOnly: true,
         type: 'text',
         value: 10,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -114,12 +115,13 @@ describe('TipPosition', () => {
     screen.getByText('Dispense tip position')
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Distance from bottom of well (mm)',
         error: null,
-        readOnly: true,
         type: 'text',
         value: 75,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -132,12 +134,13 @@ describe('TipPosition', () => {
     fireEvent.click(deleteBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Distance from bottom of well (mm)',
         error: 'Value must be between 1 to 52',
-        readOnly: true,
         type: 'text',
         value: 0,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -156,12 +159,13 @@ describe('TipPosition', () => {
     fireEvent.click(deleteBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Distance from bottom of well (mm)',
         error: 'Value must be between 1 to 202',
-        readOnly: true,
         type: 'text',
         value: 0,
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TouchTip.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TouchTip.test.tsx
@@ -116,7 +116,6 @@ describe('TouchTip', () => {
       expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',
         error: null,
-        readOnly: true,
         type: 'text',
         value: '',
         onBlur: expect.any(Function),
@@ -154,7 +153,6 @@ describe('TouchTip', () => {
       expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',
         error: 'Value must be between -25 to 0',
-        readOnly: true,
         type: 'text',
         value: '-98',
         onBlur: expect.any(Function),
@@ -184,7 +182,6 @@ describe('TouchTip', () => {
       expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',
         error: 'Value must be between -100 to 0',
-        readOnly: true,
         type: 'text',
         value: '1',
         onBlur: expect.any(Function),
@@ -230,7 +227,6 @@ describe('TouchTip', () => {
       expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',
         error: null,
-        readOnly: true,
         type: 'text',
         value: '-25',
         onBlur: expect.any(Function),
@@ -258,7 +254,6 @@ describe('TouchTip', () => {
       expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',
         error: null,
-        readOnly: true,
         type: 'text',
         value: '-8',
         onBlur: expect.any(Function),

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/VolumeEntry.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/VolumeEntry.test.tsx
@@ -74,12 +74,13 @@ describe('VolumeEntry', () => {
     screen.getByText('Set transfer volume')
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Volume per well (µL)',
         error: null,
-        readOnly: true,
         type: 'text',
         value: '',
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -98,12 +99,13 @@ describe('VolumeEntry', () => {
     screen.getByText('Set dispense volume')
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Dispense volume per well (µL)',
         error: null,
-        readOnly: true,
         type: 'text',
         value: '',
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -122,12 +124,13 @@ describe('VolumeEntry', () => {
     screen.getByText('Set aspirate volume')
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Aspirate volume per well (µL)',
         error: null,
-        readOnly: true,
         type: 'text',
         value: '',
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )
@@ -164,12 +167,13 @@ describe('VolumeEntry', () => {
     expect(continueBtn).toBeDisabled()
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
+        autoFocus: true,
         label: 'Aspirate volume per well (µL)',
         error: 'Value must be between 5 to 50',
-        readOnly: true,
         type: 'text',
         value: '90',
         onBlur: expect.any(Function),
+        onChange: expect.any(Function),
       },
       {}
     )

--- a/app/src/pages/ODD/NameRobot/index.tsx
+++ b/app/src/pages/ODD/NameRobot/index.tsx
@@ -264,6 +264,7 @@ export function NameRobot(): JSX.Element {
                 name="newRobotName"
                 render={({ field, fieldState }) => (
                   <TouchInputField
+                    autoFocus
                     data-testid="name-robot_input"
                     id="newRobotName"
                     name="newRobotName"
@@ -273,6 +274,10 @@ export function NameRobot(): JSX.Element {
                     textAlign={TYPOGRAPHY.textAlignCenter}
                     onBlur={e => {
                       e.target.focus()
+                    }}
+                    onChange={e => {
+                      field.onChange(e)
+                      setNewName(e.target.value as string)
                     }}
                   />
                 )}

--- a/components/src/molecules/TouchInputField/TouchInputField.stories.tsx
+++ b/components/src/molecules/TouchInputField/TouchInputField.stories.tsx
@@ -51,7 +51,7 @@ function TouchInputFieldWithErrorStory(
   return (
     <div style={{ flexDirection: DIRECTION_COLUMN, gap: SPACING.spacing4 }}>
       <TouchInputFieldComponent
-        autoFocus 
+        autoFocus
         {...args}
         value={value}
         onChange={(e: ChangeEvent<HTMLInputElement>) => {

--- a/components/src/molecules/TouchInputField/TouchInputField.stories.tsx
+++ b/components/src/molecules/TouchInputField/TouchInputField.stories.tsx
@@ -31,6 +31,7 @@ function TouchInputFieldStory(
   return (
     <div style={{ flexDirection: DIRECTION_COLUMN, gap: SPACING.spacing4 }}>
       <TouchInputFieldComponent
+        autoFocus
         {...args}
         value={value}
         onChange={(e: ChangeEvent<HTMLInputElement>) => {
@@ -50,6 +51,7 @@ function TouchInputFieldWithErrorStory(
   return (
     <div style={{ flexDirection: DIRECTION_COLUMN, gap: SPACING.spacing4 }}>
       <TouchInputFieldComponent
+        autoFocus 
         {...args}
         value={value}
         onChange={(e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION




# Overview
add onChange + autoFocus  and remove `readOnly` to modify TouchInputField props to allow users to use an external keyboard

close EXEC-2302


## Test Plan and Hands on Testing
- push this branch to Flex
- https://opentrons.atlassian.net/wiki/spaces/PER/pages/5835129224/External+Keyboard+Support#Screens-that-support-an-external-keyboard

## Changelog
- update components that consume `TouchInputField`

## Review requests


## Risk assessment
low
