### PR TITLE
chore(protocol-designer, step-generation): Update SW version, PAPI, and PD version to support pd 8.10

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -247,7 +247,7 @@ CUSTOM_LABWARE = json.loads("""{"fixture/fixture_trash/1":{"ordering":[["A1"]],"
             },
           },
         },
-        version: '8.9.0',
+        version: '8.10.0',
         name: 'opentrons/protocol-designer',
       },
       robot: { model: OT2_ROBOT_TYPE },

--- a/protocol-designer/src/load-file/migration/__tests__/index.test.ts
+++ b/protocol-designer/src/load-file/migration/__tests__/index.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { PD_APPLICATION_VERSION } from '@opentrons/step-generation'
+
 import { getMigrationVersionsToRunFromVersion } from '../index'
 
 vi.mock('../../../labware-defs/utils')
@@ -43,6 +45,13 @@ describe('runs appropriate migrations for version', () => {
     const migrationsToRun = getMigrationVersionsToRunFromVersion(
       stubbedMigrationByVersion,
       '8.9.5'
+    )
+    expect(migrationsToRun).toEqual([])
+  })
+  it('returns no migrations if supplied version is equal to PD_APPLICATION_VERSION', () => {
+    const migrationsToRun = getMigrationVersionsToRunFromVersion(
+      stubbedMigrationByVersion,
+      PD_APPLICATION_VERSION
     )
     expect(migrationsToRun).toEqual([])
   })

--- a/protocol-designer/src/load-file/migration/__tests__/index.test.ts
+++ b/protocol-designer/src/load-file/migration/__tests__/index.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { PD_APPLICATION_VERSION } from '@opentrons/step-generation'
 
-import { getMigrationVersionsToRunFromVersion } from '../index'
+import {
+  allMigrationsByVersion,
+  getMigrationVersionsToRunFromVersion,
+} from '../index'
 
 vi.mock('../../../labware-defs/utils')
 describe('runs appropriate migrations for version', () => {
@@ -50,7 +53,7 @@ describe('runs appropriate migrations for version', () => {
   })
   it('returns no migrations if supplied version is equal to PD_APPLICATION_VERSION', () => {
     const migrationsToRun = getMigrationVersionsToRunFromVersion(
-      stubbedMigrationByVersion,
+      allMigrationsByVersion,
       PD_APPLICATION_VERSION
     )
     expect(migrationsToRun).toEqual([])

--- a/protocol-designer/src/load-file/migration/index.ts
+++ b/protocol-designer/src/load-file/migration/index.ts
@@ -49,7 +49,7 @@ export const getMigrationVersionsToRunFromVersion = (
   )
 }
 
-const allMigrationsByVersion: MigrationsByVersion = {
+export const allMigrationsByVersion: MigrationsByVersion = {
   // @ts-expect-error file types are incompatible
   '1.1.0': migrateFileOne,
   // @ts-expect-error file types are incompatible

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -15,7 +15,7 @@ import { cssModuleSideEffect } from './cssModuleSideEffect'
 
 import type { UserConfig } from 'vite'
 
-const REQUIRED_APP_VERSION = '8.8.0' // PD requires this robot stack version or higher
+const REQUIRED_APP_VERSION = '9.0.0' // PD requires this robot stack version or higher
 const { getVersion, generateBuildInfoHtml } = createGitVersionToolkit({
   project: 'protocol-designer',
 })

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -49,8 +49,8 @@ import type {
   WasteChuteEntities,
 } from '../types'
 
-export const PAPI_VERSION = '2.27' // oldest version that we need from api/src/opentrons/protocols/api_support/definitions.py, might not be the actual latest version
-export const PD_APPLICATION_VERSION = '8.9.0' // latest PD version to insert into DESIGNER_APPLICATION blob
+export const PAPI_VERSION = '2.28' // oldest version that we need from api/src/opentrons/protocols/api_support/definitions.py, might not be the actual latest version
+export const PD_APPLICATION_VERSION = '8.10.0' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {
   return ['import json', 'from opentrons import protocol_api, types'].join('\n')


### PR DESCRIPTION
# Overview

Updates SW version to 9.0.0, PAPI version to 2.28, and PD version to 8.10.0 to ensure app support for partial tip functionality

## Test Plan and Hands on Testing

- Added test to ensure if PD version is the most recent, then the file will not go through migrations. Ensured this worked by downgrading `PD_APPLICATION_VERSION` and running the test to make sure it failed:
<img width="1405" height="421" alt="Screenshot 2026-03-23 at 1 30 02 PM" src="https://github.com/user-attachments/assets/a71d613a-071a-4ca9-9b70-8f08f6e99e6c" />

- Uploaded older protocol and ensured it exported with PAPI 2.28
- checked that SW version was updated in protocol metadata

<img width="739" height="463" alt="Screenshot 2026-03-23 at 10 14 22 AM" src="https://github.com/user-attachments/assets/92942d8c-2e17-410c-9d62-9ff812e07157" />


## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment

- medium
closes RQA-5268, RQA-5267