### PR TITLE
fix(abr-testing): only measure liquid when current height is greater than 1 mm

### DIFF
--- a/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
@@ -523,7 +523,7 @@ def run(protocol: ProtocolContext) -> None:
         liquid_heights = {}
         pip.pick_up_tip()
         for ifp_plate_well in ifp_plate.wells():
-            if ifp_plate_well.current_liquid_height() > 1 :
+            if ifp_plate_well.current_liquid_height() > 1:
                 pip.measure_liquid_height(ifp_plate[ifp_plate_well.well_name])
             height = ifp_plate[ifp_plate_well.well_name].current_liquid_height()
             liquid_heights[ifp_plate_well.well_name] = height

--- a/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
+++ b/abr-testing/abr_testing/protocols/active_protocols/6_Olink_Target_48-96.py
@@ -523,7 +523,7 @@ def run(protocol: ProtocolContext) -> None:
         liquid_heights = {}
         pip.pick_up_tip()
         for ifp_plate_well in ifp_plate.wells():
-            if ifp_plate_well.current_liquid_height() is not None:
+            if ifp_plate_well.current_liquid_height() > 1 :
                 pip.measure_liquid_height(ifp_plate[ifp_plate_well.well_name])
             height = ifp_plate[ifp_plate_well.well_name].current_liquid_height()
             liquid_heights[ifp_plate_well.well_name] = height


### PR DESCRIPTION
# Overview

Adjust ABR6 protocol so that it only attempts to measure liquid when the tracked current height is greater than 1 mm. 

Previously this measured when the current height was not None. Current height is never none since all wells are loaded with liquid. This ensures it will not attempt to measure a near empty well.

## Test Plan and Hands on Testing

- test on ABR robot

## Changelog

List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment

- low