### PR TITLE
feat(api,robot-server): add offsets to analyses

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[004ebb2b82][OT2_S_v2_11_P10S_P300M_MM_TC1_TM_Swift].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[004ebb2b82][OT2_S_v2_11_P10S_P300M_MM_TC1_TM_Swift].json
@@ -16510,6 +16510,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[010f0c3a8d][OT2_S_v2_11_PL_IDT-xGen-EZ-24x-for-OT2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[010f0c3a8d][OT2_S_v2_11_PL_IDT-xGen-EZ-24x-for-OT2].json
@@ -9680,6 +9680,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[011481812b][OT2_S_v2_7_P20S_None_Walkthrough].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[011481812b][OT2_S_v2_7_P20S_None_Walkthrough].json
@@ -4934,6 +4934,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0160301f8a][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_200_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0160301f8a][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_200_filter].json
@@ -12252,6 +12252,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0161fbd0a6][Flex_S_2_15_MPL_langone_ribo_pt1_ramp].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0161fbd0a6][Flex_S_2_15_MPL_langone_ribo_pt1_ramp].json
@@ -31554,6 +31554,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[017ba6956c][Flex_S_v2_24_P1000_8ch_200ulTips_None_HappyPath_all3_liquid].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[017ba6956c][Flex_S_v2_24_P1000_8ch_200ulTips_None_HappyPath_all3_liquid].json
@@ -34350,6 +34350,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0190369ce5][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_DeckConfiguration1NoFixtures].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0190369ce5][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_DeckConfiguration1NoFixtures].json
@@ -11388,6 +11388,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0256665840][OT2_S_v2_16_P300M_P20S_aspirateDispenseMix0Volume].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0256665840][OT2_S_v2_16_P300M_P20S_aspirateDispenseMix0Volume].json
@@ -2955,6 +2955,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0317363f95][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_distribute_liquid_Override_200_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0317363f95][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_distribute_liquid_Override_200_filter].json
@@ -8679,6 +8679,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0330dc472b][OT2_S_v2_20_P50_touch_tip].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0330dc472b][OT2_S_v2_20_P50_touch_tip].json
@@ -1661,6 +1661,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[041ad55e7b][OT2_S_v2_15_P300M_P20S_HS_TC_TM_dispense_changes].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[041ad55e7b][OT2_S_v2_15_P300M_P20S_HS_TC_TM_dispense_changes].json
@@ -3164,6 +3164,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[057de2035d][OT2_S_v2_19_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[057de2035d][OT2_S_v2_19_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -18253,6 +18253,46 @@
       "offsetId": "UUID"
     }
   ],
+  "labwareOffsets": [
+    {
+      "createdAt": "TIMESTAMP",
+      "definitionUri": "opentrons/nest_12_reservoir_15ml/1",
+      "id": "UUID",
+      "location": {
+        "slotName": "3"
+      },
+      "locationSequence": [
+        {
+          "addressableAreaName": "3",
+          "kind": "onAddressableArea"
+        }
+      ],
+      "vector": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 10.0
+      }
+    },
+    {
+      "createdAt": "TIMESTAMP",
+      "definitionUri": "opentrons/nest_12_reservoir_15ml/1",
+      "id": "UUID",
+      "location": {
+        "slotName": "2"
+      },
+      "locationSequence": [
+        {
+          "addressableAreaName": "2",
+          "kind": "onAddressableArea"
+        }
+      ],
+      "vector": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 10.0
+      }
+    }
+  ],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0602eebc82][OT2_S_v2_13_PL_transient_transfection_of_HeLacells_Protocol_2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0602eebc82][OT2_S_v2_13_PL_transient_transfection_of_HeLacells_Protocol_2].json
@@ -9125,6 +9125,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[06b25301ac][Flex_S_v2_20_8_TipsDontMatchWells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[06b25301ac][Flex_S_v2_20_8_TipsDontMatchWells].json
@@ -2443,6 +2443,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0903a95825][Flex_S_v2_19_QIASeq_FX_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0903a95825][Flex_S_v2_19_QIASeq_FX_48x].json
@@ -66246,6 +66246,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[09676b9f7e][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_south_west].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[09676b9f7e][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_south_west].json
@@ -1506,6 +1506,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[09ba51132a][OT2_S_v2_14_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[09ba51132a][OT2_S_v2_14_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
@@ -58,6 +58,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0a1735c6a6][Flex_S_v2_24_P1000M_Alex_tip_strategy_with_lc].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0a1735c6a6][Flex_S_v2_24_P1000M_Alex_tip_strategy_with_lc].json
@@ -19791,6 +19791,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0a9ef592c8][Flex_S_v2_18_Illumina_DNA_Prep_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0a9ef592c8][Flex_S_v2_18_Illumina_DNA_Prep_48x].json
@@ -49600,6 +49600,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0affe60373][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_maximum].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0affe60373][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_maximum].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0b10dab37d][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_50_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0b10dab37d][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_50_filter].json
@@ -20740,6 +20740,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0b42cfc151][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_north_row].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0b42cfc151][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_north_row].json
@@ -1506,6 +1506,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0babad786f][Flex_S_v2_16_PL_Zymo_Quick-RNA_Flex_96-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0babad786f][Flex_S_v2_16_PL_Zymo_Quick-RNA_Flex_96-Cells].json
@@ -49625,6 +49625,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0bb7d18726][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_consolidate_liquid_Override_200].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0bb7d18726][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_consolidate_liquid_Override_200].json
@@ -11841,6 +11841,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0bb99055d8][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_transfer_liquid_Override_50_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0bb99055d8][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_transfer_liquid_Override_50_filter].json
@@ -9290,6 +9290,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0c4ae179bb][OT2_S_v2_15_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0c4ae179bb][OT2_S_v2_15_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -16485,6 +16485,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0cbde10c37][OT2_S_v2_18_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0cbde10c37][OT2_S_v2_18_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -18253,6 +18253,46 @@
       "offsetId": "UUID"
     }
   ],
+  "labwareOffsets": [
+    {
+      "createdAt": "TIMESTAMP",
+      "definitionUri": "opentrons/nest_12_reservoir_15ml/1",
+      "id": "UUID",
+      "location": {
+        "slotName": "3"
+      },
+      "locationSequence": [
+        {
+          "addressableAreaName": "3",
+          "kind": "onAddressableArea"
+        }
+      ],
+      "vector": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 10.0
+      }
+    },
+    {
+      "createdAt": "TIMESTAMP",
+      "definitionUri": "opentrons/nest_12_reservoir_15ml/1",
+      "id": "UUID",
+      "location": {
+        "slotName": "2"
+      },
+      "locationSequence": [
+        {
+          "addressableAreaName": "2",
+          "kind": "onAddressableArea"
+        }
+      ],
+      "vector": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 10.0
+      }
+    }
+  ],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0dad703b86][Flex_S_v2_18_PL_QIAseq-FX-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0dad703b86][Flex_S_v2_18_PL_QIAseq-FX-48x].json
@@ -71281,6 +71281,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0e29cceb48][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_200_exceeds].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0e29cceb48][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_200_exceeds].json
@@ -81648,6 +81648,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0ea9d4ab9b][Flex_S_2_16_MPL_sample_dilution_with_96_channel_pipette].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0ea9d4ab9b][Flex_S_2_16_MPL_sample_dilution_with_96_channel_pipette].json
@@ -1308,6 +1308,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0eb87cc9d7][OT2_S_v2_15_PL_3e0bef].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[0eb87cc9d7][OT2_S_v2_15_PL_3e0bef].json
@@ -24481,6 +24481,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[10583ea444][Flex_S_v2_18_PL_QIAseq-Targeted-DNA-Pro-8x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[10583ea444][Flex_S_v2_18_PL_QIAseq-Targeted-DNA-Pro-8x].json
@@ -94322,6 +94322,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[109b7ad1f0][Flex_S_v2_20_96_None_ROW_HappyPath].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[109b7ad1f0][Flex_S_v2_20_96_None_ROW_HappyPath].json
@@ -6308,6 +6308,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[109e77ecb1][Flex_S_v2_18_PL_imac-by-ni-nta-magnetic-agarose-beads-on-flex].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[109e77ecb1][Flex_S_v2_18_PL_imac-by-ni-nta-magnetic-agarose-beads-on-flex].json
@@ -56948,6 +56948,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[10b36ea8cf][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_50].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[10b36ea8cf][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_50].json
@@ -20740,6 +20740,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[10c2386b92][Flex_S_v2_20_96_AllCorners].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[10c2386b92][Flex_S_v2_20_96_AllCorners].json
@@ -34335,6 +34335,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[12233269bc][Flex_S_v2_20_PL_evercode-whole-transcriptomeWT-kit-Parse-Biosciences-protocol2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[12233269bc][Flex_S_v2_20_PL_evercode-whole-transcriptomeWT-kit-Parse-Biosciences-protocol2].json
@@ -38049,6 +38049,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1231f17ee7][Flex_S_v2_24_P50_8ch_P50_tracking].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1231f17ee7][Flex_S_v2_24_P50_8ch_P50_tracking].json
@@ -9976,6 +9976,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[12494feef2][Flex_S_2_16_MPL_QIAseq_FX_24x_Normalizer_Workflow_B].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[12494feef2][Flex_S_2_16_MPL_QIAseq_FX_24x_Normalizer_Workflow_B].json
@@ -76996,6 +76996,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[130a7364bd][Flex_S_v2_18_PL_bca_protein_assay].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[130a7364bd][Flex_S_v2_18_PL_bca_protein_assay].json
@@ -41292,6 +41292,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[134037b2aa][OT2_X_v6_P300M_P20S_HS_MM_TM_TC_AllMods].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[134037b2aa][OT2_X_v6_P300M_P20S_HS_MM_TM_TC_AllMods].json
@@ -7594,6 +7594,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13c4a34603][Flex_S_v2_20_PL_cherry].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13c4a34603][Flex_S_v2_20_PL_cherry].json
@@ -50,6 +50,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13cc2361a9][Flex_S_v2_25_P50_P200_stacker_all_parts].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13cc2361a9][Flex_S_v2_25_P50_P200_stacker_all_parts].json
@@ -91905,6 +91905,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13e5a9c68b][Flex_S_v2_20_P8X1000_P50_LLD].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13e5a9c68b][Flex_S_v2_20_P8X1000_P50_LLD].json
@@ -6283,6 +6283,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13f7ecad1f][Flex_S_2_7_concurrent_modules_demo].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13f7ecad1f][Flex_S_2_7_concurrent_modules_demo].json
@@ -1309,6 +1309,7 @@
   "errors": [],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13fce6146d][Flex_S_v2_24_96_Live_SingleTip_NIR-RQA-4089].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13fce6146d][Flex_S_v2_24_96_Live_SingleTip_NIR-RQA-4089].json
@@ -8455,6 +8455,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1458004a84][Flex_S_v2_20_96_Reservoir].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1458004a84][Flex_S_v2_20_96_Reservoir].json
@@ -1898,6 +1898,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[149d9c9812][Flex_S_v2_18_PL_Illumina-DNA-Prep-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[149d9c9812][Flex_S_v2_18_PL_Illumina-DNA-Prep-48x].json
@@ -51934,6 +51934,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[14d01ac9fc][Flex_S_v2_24_P1000S_PD_happy].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[14d01ac9fc][Flex_S_v2_24_P1000S_PD_happy].json
@@ -19791,6 +19791,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[15e725b9f6][Flex_S_2_17_MPL_cherrypicking_csv_airgap].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[15e725b9f6][Flex_S_2_17_MPL_cherrypicking_csv_airgap].json
@@ -28373,6 +28373,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[160f3e77e4][OT2_S_v2_9_PL_macherey-nagel-nucleomag-virus].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[160f3e77e4][OT2_S_v2_9_PL_macherey-nagel-nucleomag-virus].json
@@ -76656,6 +76656,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1656293bfe][Flex_S_2_15_MPL_NiNTA_Flex_96well_final].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1656293bfe][Flex_S_2_15_MPL_NiNTA_Flex_96well_final].json
@@ -56956,6 +56956,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[17a4e8ece0][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_1000_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[17a4e8ece0][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_1000_filter].json
@@ -76624,6 +76624,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[180cffe1e4][Flex_S_v2_18_PL_Twist-EF-2_0].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[180cffe1e4][Flex_S_v2_18_PL_Twist-EF-2_0].json
@@ -30666,6 +30666,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[19022a0ab8][Flex_S_2_16_MPL_microBioID_beads_touchtip].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[19022a0ab8][Flex_S_2_16_MPL_microBioID_beads_touchtip].json
@@ -34996,6 +34996,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[196ec488f7][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_west].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[196ec488f7][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_west].json
@@ -1506,6 +1506,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[19ffa9c839][OT2_X_v2_16_None_None_HS_HeaterShakerConflictWithTrashBin2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[19ffa9c839][OT2_X_v2_16_None_None_HS_HeaterShakerConflictWithTrashBin2].json
@@ -75,6 +75,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1b02ecac28][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_50_filter_exceeds].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1b02ecac28][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_50_filter_exceeds].json
@@ -13795,6 +13795,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1baf3666f4][Flex_X_v2_18_Illumina_Stranded_total_RNA_Ribo_Zero].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1baf3666f4][Flex_X_v2_18_Illumina_Stranded_total_RNA_Ribo_Zero].json
@@ -39476,6 +39476,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1c19a2055c][OT2_S_v2_4_P300M_None_MM_TM_Zymo].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1c19a2055c][OT2_S_v2_4_P300M_None_MM_TM_Zymo].json
@@ -81628,6 +81628,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1c5eb55b4b][OT2_S_v2_4_PL_sci-macherey-nagel-nucleomag].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1c5eb55b4b][OT2_S_v2_4_PL_sci-macherey-nagel-nucleomag].json
@@ -19407,6 +19407,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1e5825a070][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_minimum].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1e5825a070][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_minimum].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[20048cb3d1][OT2_S_v2_9_PL_macherey-nagel-nucleomag-size-select].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[20048cb3d1][OT2_S_v2_9_PL_macherey-nagel-nucleomag-size-select].json
@@ -45134,6 +45134,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[203e156a44][Flex_S_2_16_MPL_SamplePrep_MS_Digest_Flex_upto96].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[203e156a44][Flex_S_2_16_MPL_SamplePrep_MS_Digest_Flex_upto96].json
@@ -65237,6 +65237,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[205b590d97][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_distribute_liquid_Override_1000].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[205b590d97][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_distribute_liquid_Override_1000].json
@@ -8679,6 +8679,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[21168793ea][Flex_S_v2_16_PL_invitrogen_elisa_targetcapture].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[21168793ea][Flex_S_v2_16_PL_invitrogen_elisa_targetcapture].json
@@ -25997,6 +25997,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[21eaee0bbe][OT2_S_v2_13_PL_Magazorb_DNA_OT2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[21eaee0bbe][OT2_S_v2_13_PL_Magazorb_DNA_OT2].json
@@ -63,6 +63,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[22286b71e3][Flex_S_2_7_96_partial_select_tips].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[22286b71e3][Flex_S_2_7_96_partial_select_tips].json
@@ -10487,6 +10487,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2296026a1c][Flex_S_v2_18_PL_IDT-xGen-EZ-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2296026a1c][Flex_S_v2_18_PL_IDT-xGen-EZ-48x].json
@@ -62736,6 +62736,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[238912ff51][Flex_S_v2_18_KAPA_Library_Quant].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[238912ff51][Flex_S_v2_18_KAPA_Library_Quant].json
@@ -31576,6 +31576,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[24a6b167a7][OT2_X_v2_18_None_None_NoRTPdisplay_name].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[24a6b167a7][OT2_X_v2_18_None_None_NoRTPdisplay_name].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[255d014c70][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_mix_collision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[255d014c70][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_mix_collision].json
@@ -2766,6 +2766,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[26d6478878][Flex_S_2_17_MPL_sigdx_part2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[26d6478878][Flex_S_2_17_MPL_sigdx_part2].json
@@ -47165,6 +47165,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2781e8aa2a][Flex_S_v2_24_P1000S_Alex_tip_strategy_with_lc].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2781e8aa2a][Flex_S_v2_24_P1000S_Alex_tip_strategy_with_lc].json
@@ -19791,6 +19791,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2791b57a2c][Flex_S_v2_24_P50_P1000_HappyPath_alter_lc].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2791b57a2c][Flex_S_v2_24_P50_P1000_HappyPath_alter_lc].json
@@ -9147,6 +9147,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[29795b699e][Flex_X_v2_16_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[29795b699e][Flex_X_v2_16_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots].json
@@ -75,6 +75,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[29d240bc4b][OT2_S_v2_15_PL_dna_transfection_up_to_4].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[29d240bc4b][OT2_S_v2_15_PL_dna_transfection_up_to_4].json
@@ -39346,6 +39346,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[29e143f047][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_distribute_destination_collision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[29e143f047][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_distribute_destination_collision].json
@@ -3967,6 +3967,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[29eec5a85a][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_transfer_source_collision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[29eec5a85a][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_transfer_source_collision].json
@@ -3931,6 +3931,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2a7790ba1a][Flex_S_2_15_MPL_customizable_serial_dilution_upload].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2a7790ba1a][Flex_S_2_15_MPL_customizable_serial_dilution_upload].json
@@ -10452,6 +10452,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2a9760aa21][Flex_S_2_16_MPL_MagMax_RNA_Cells_Flex_multi].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2a9760aa21][Flex_S_2_16_MPL_MagMax_RNA_Cells_Flex_multi].json
@@ -21032,6 +21032,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2aceb4fe25][Flex_S_v2_18_PL_Illumina-Stranded_total_RNA_Ribo-Zero].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2aceb4fe25][Flex_S_v2_18_PL_Illumina-Stranded_total_RNA_Ribo-Zero].json
@@ -59739,6 +59739,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2afc9dd12f][Flex_S_2_16_MPL_SamplePrep_MS_Cleanup_Flex_upto96].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2afc9dd12f][Flex_S_2_16_MPL_SamplePrep_MS_Cleanup_Flex_upto96].json
@@ -50353,6 +50353,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b7fcb5b23][Flex_S_v2_18_P1000_96_TipTrackingBug].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b7fcb5b23][Flex_S_v2_18_P1000_96_TipTrackingBug].json
@@ -4276,6 +4276,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -14946,6 +14946,46 @@
       "location": "offDeck"
     }
   ],
+  "labwareOffsets": [
+    {
+      "createdAt": "TIMESTAMP",
+      "definitionUri": "opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
+      "id": "UUID",
+      "location": {
+        "slotName": "C2"
+      },
+      "locationSequence": [
+        {
+          "addressableAreaName": "C2",
+          "kind": "onAddressableArea"
+        }
+      ],
+      "vector": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 10.0
+      }
+    },
+    {
+      "createdAt": "TIMESTAMP",
+      "definitionUri": "opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2",
+      "id": "UUID",
+      "location": {
+        "slotName": "D2"
+      },
+      "locationSequence": [
+        {
+          "addressableAreaName": "D2",
+          "kind": "onAddressableArea"
+        }
+      ],
+      "vector": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 10.0
+      }
+    }
+  ],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2cc8efae68][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_east_column].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2cc8efae68][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_east_column].json
@@ -1506,6 +1506,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2d549941fa][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_distribute_liquid_Override_200].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2d549941fa][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_distribute_liquid_Override_200].json
@@ -11787,6 +11787,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2d58622ea7][Flex_S_2_16_MPL_Zymo_Magbead_DNA_Cells_Flex_96_channel].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2d58622ea7][Flex_S_2_16_MPL_Zymo_Magbead_DNA_Cells_Flex_96_channel].json
@@ -41002,6 +41002,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2eaf98de6a][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_TriggerPrepareForMountMovement].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2eaf98de6a][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_TriggerPrepareForMountMovement].json
@@ -26421,6 +26421,7 @@
       "location": "wasteChuteLocation"
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[30c05024e8][Flex_S_v2_20_96_None_SINGLE_4Corners50ul].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[30c05024e8][Flex_S_v2_20_96_None_SINGLE_4Corners50ul].json
@@ -3034,6 +3034,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[31d1aec819][Flex_S_v2_20_96_None_SINGLE_HappyPathNorthSide].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[31d1aec819][Flex_S_v2_20_96_None_SINGLE_HappyPathNorthSide].json
@@ -9502,6 +9502,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[322ceafe84][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_1000_filter_exceeds].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[322ceafe84][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_1000_filter_exceeds].json
@@ -79138,6 +79138,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3251c6e175][OT2_S_v2_2_P300S_None_MM1_MM2_EngageMagHeightFromBase].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3251c6e175][OT2_S_v2_2_P300S_None_MM1_MM2_EngageMagHeightFromBase].json
@@ -1392,6 +1392,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3308d71521][OT2_S_v2_10_PL_opentrons_logo].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3308d71521][OT2_S_v2_10_PL_opentrons_logo].json
@@ -5369,6 +5369,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[330ee3be81][Flex_S_v2_24_96_Live_SingleTip_SLAM_FRONT_NIR].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[330ee3be81][Flex_S_v2_24_96_Live_SingleTip_SLAM_FRONT_NIR].json
@@ -3357,6 +3357,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3341cad92f][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_distribute_liquid_Override_1000_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3341cad92f][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_distribute_liquid_Override_1000_filter].json
@@ -9273,6 +9273,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[33db294a9b][Flex_X_v2_18_NO_PIPETTES_DescriptionTooLongRTP].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[33db294a9b][Flex_X_v2_18_NO_PIPETTES_DescriptionTooLongRTP].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[34f32336bc][Flex_X_v2_21_plate_reader_wrong_plate2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[34f32336bc][Flex_X_v2_21_plate_reader_wrong_plate2].json
@@ -2530,6 +2530,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[35f3c73b42][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_consolidate_liquid_Override_200_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[35f3c73b42][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_consolidate_liquid_Override_200_filter].json
@@ -8597,6 +8597,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[376765183a0][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_bottom_left_edge].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[376765183a0][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_bottom_left_edge].json
@@ -1261,6 +1261,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[376765183a1][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_bottom_left_edge].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[376765183a1][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_bottom_left_edge].json
@@ -1261,6 +1261,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[37ce360fa4][OT2_S_v2_20_P20M_PARTIAL_COLUMN_Overhang].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[37ce360fa4][OT2_S_v2_20_P20M_PARTIAL_COLUMN_Overhang].json
@@ -2749,6 +2749,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[387177996b][Flex_S_v2_18_PL_peptide_cleanup_lcms].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[387177996b][Flex_S_v2_18_PL_peptide_cleanup_lcms].json
@@ -50353,6 +50353,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[38b5298c77][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultOutOfRangeRTP_Override_default_less_than_minimum].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[38b5298c77][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultOutOfRangeRTP_Override_default_less_than_minimum].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[38b7ac4410][OT2_S_v2_10_PL_swift-2s-turbo-pt1].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[38b7ac4410][OT2_S_v2_10_PL_swift-2s-turbo-pt1].json
@@ -9119,6 +9119,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[39191e3573][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_south_row].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[39191e3573][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_south_row].json
@@ -1506,6 +1506,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[39286f107b][Flex_S_v2_24_P50_8ch_None_HappyPath_all3_liquid_exceeds].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[39286f107b][Flex_S_v2_24_P50_8ch_None_HappyPath_all3_liquid_exceeds].json
@@ -51620,6 +51620,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3a469bddf5][Flex_S_2_15_MPL_Normalization_with_PCR].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3a469bddf5][Flex_S_2_15_MPL_Normalization_with_PCR].json
@@ -8852,6 +8852,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3cec61dfd9][Flex_S_v2_19_KAPA_Library_Quant].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3cec61dfd9][Flex_S_v2_19_KAPA_Library_Quant].json
@@ -31576,6 +31576,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3cf6a3778e][Flex_S_v2_18_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3cf6a3778e][Flex_S_v2_18_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -15988,6 +15988,46 @@
       }
     }
   ],
+  "labwareOffsets": [
+    {
+      "createdAt": "TIMESTAMP",
+      "definitionUri": "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
+      "id": "UUID",
+      "location": {
+        "slotName": "C2"
+      },
+      "locationSequence": [
+        {
+          "addressableAreaName": "C2",
+          "kind": "onAddressableArea"
+        }
+      ],
+      "vector": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 10.0
+      }
+    },
+    {
+      "createdAt": "TIMESTAMP",
+      "definitionUri": "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
+      "id": "UUID",
+      "location": {
+        "slotName": "D2"
+      },
+      "locationSequence": [
+        {
+          "addressableAreaName": "D2",
+          "kind": "onAddressableArea"
+        }
+      ],
+      "vector": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 10.0
+      }
+    }
+  ],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3d6408144f][Flex_S_v2_16_PL_Magmax_RNA_Flex_Multi-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3d6408144f][Flex_S_v2_16_PL_Magmax_RNA_Flex_Multi-Cells].json
@@ -21032,6 +21032,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3e0d221183][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_200_under].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3e0d221183][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_200_under].json
@@ -15377,6 +15377,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3fcd82209d][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_50_under].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[3fcd82209d][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_50_under].json
@@ -15712,6 +15712,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4101d3312d][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_distribute_liquid_Override_50_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4101d3312d][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_distribute_liquid_Override_50_filter].json
@@ -11823,6 +11823,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4148613317][Flex_S_v2_19_ligseq].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4148613317][Flex_S_v2_19_ligseq].json
@@ -22663,6 +22663,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[42dbb496e4][Flex_S_v2_18_PL_protein_digest_lcms].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[42dbb496e4][Flex_S_v2_18_PL_protein_digest_lcms].json
@@ -65237,6 +65237,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[434bdb8ecc][OT2_S_2_7_concurrent_modules_for_ot2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[434bdb8ecc][OT2_S_2_7_concurrent_modules_for_ot2].json
@@ -5994,6 +5994,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4389e3ab18][OT2_X_v6_P20S_None_SimpleTransfer].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4389e3ab18][OT2_X_v6_P20S_None_SimpleTransfer].json
@@ -1925,6 +1925,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[43918caf53][Flex_S_v2_18_PL_immunoprecipitation-by-dynabeads-on-flex-reagents-in-15-ml-tubes].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[43918caf53][Flex_S_v2_18_PL_immunoprecipitation-by-dynabeads-on-flex-reagents-in-15-ml-tubes].json
@@ -59453,6 +59453,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[43d2b3290b][Flex_S_2_16_MPL_Zymo_Quick_RNA_Cells_Flex_96_Channel].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[43d2b3290b][Flex_S_2_16_MPL_Zymo_Quick_RNA_Cells_Flex_96_Channel].json
@@ -49625,6 +49625,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4420d0fb0d][Flex_S_v2_18_PL_pacbio-hifi-prep].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4420d0fb0d][Flex_S_v2_18_PL_pacbio-hifi-prep].json
@@ -49163,6 +49163,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4458220422][OT2_S_v2_18_NO_PIPETTES_GoldenRTP_OT2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4458220422][OT2_S_v2_18_NO_PIPETTES_GoldenRTP_OT2].json
@@ -294,6 +294,7 @@
   "errors": [],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[463830e283][OT2_S_v2_9_PL_macherey-nagel-nucleomag-dna-food].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[463830e283][OT2_S_v2_9_PL_macherey-nagel-nucleomag-dna-food].json
@@ -104961,6 +104961,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[47faf6c3ae][OT2_S_v2_12_PL_6d901d].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[47faf6c3ae][OT2_S_v2_12_PL_6d901d].json
@@ -5124,6 +5124,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[48cfb44146][Flex_S_v2_21_PL_protein_quant].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[48cfb44146][Flex_S_v2_21_PL_protein_quant].json
@@ -43582,6 +43582,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[48d2ab1037][Flex_S_2_16_MPL_Takara_InFusionSnapAssembly_Flex].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[48d2ab1037][Flex_S_2_16_MPL_Takara_InFusionSnapAssembly_Flex].json
@@ -16310,6 +16310,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[48ef489108][Flex_S_v2_24_P1000_8ch_1000ulTips_None_HappyPath_all3_liquid].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[48ef489108][Flex_S_v2_24_P1000_8ch_1000ulTips_None_HappyPath_all3_liquid].json
@@ -34350,6 +34350,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[49404e7e31][OT2_S_v2_11_PL_sci-phytip-protein-A].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[49404e7e31][OT2_S_v2_11_PL_sci-phytip-protein-A].json
@@ -14143,6 +14143,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4a82419f1f][OT2_S_v2_16_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4a82419f1f][OT2_S_v2_16_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -16839,6 +16839,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4b35ef8c0e][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_50_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4b35ef8c0e][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_50_filter].json
@@ -77905,6 +77905,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4b9e0f93d9][OT2_S_v2_20_8_None_PARTIAL_COLUMN_HappyPathMixedTipRacks].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4b9e0f93d9][OT2_S_v2_20_8_None_PARTIAL_COLUMN_HappyPathMixedTipRacks].json
@@ -19778,6 +19778,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4cb705bdbf][Flex_X_v2_16_NO_PIPETTES_MM_MagneticModuleInFlexProtocol].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4cb705bdbf][Flex_X_v2_16_NO_PIPETTES_MM_MagneticModuleInFlexProtocol].json
@@ -102,6 +102,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4e5cd7e906][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_50_exceeds].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4e5cd7e906][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_50_exceeds].json
@@ -13795,6 +13795,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4ea9d66206][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_eight_partial_column_no_end].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4ea9d66206][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_eight_partial_column_no_end].json
@@ -1258,6 +1258,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4f50c02c81][Flex_S_v2_19_AMPure_XP_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4f50c02c81][Flex_S_v2_19_AMPure_XP_48x].json
@@ -27677,6 +27677,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4fadc166c0][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_variable_name].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4fadc166c0][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_variable_name].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4ff0682094][Flex_S_v2_18_PL_QIAseq-FX-Normalizer-Workflow-B-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[4ff0682094][Flex_S_v2_18_PL_QIAseq-FX-Normalizer-Workflow-B-48x].json
@@ -80236,6 +80236,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[51a761307d][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultOutOfRangeRTP_Override_default_greater_than_maximum].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[51a761307d][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultOutOfRangeRTP_Override_default_greater_than_maximum].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[51fc977577][OT2_S_v6_P300M_P20S_MixTransferManyLiquids].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[51fc977577][OT2_S_v6_P300M_P20S_MixTransferManyLiquids].json
@@ -6182,6 +6182,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[53db9bf516][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_left].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[53db9bf516][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_left].json
@@ -1301,6 +1301,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[545597b9fd][OT2_S_v2_13_PL_sci-lucif-assay2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[545597b9fd][OT2_S_v2_13_PL_sci-lucif-assay2].json
@@ -14400,6 +14400,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[549cc904ac][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_c3_right_edge].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[549cc904ac][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_c3_right_edge].json
@@ -1263,6 +1263,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[54b0b509cd][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_eight_partial_column_no_end].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[54b0b509cd][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_eight_partial_column_no_end].json
@@ -2420,6 +2420,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[54f717cfd1][OT2_S_v2_16_P300S_None_verifyNoFloatingPointErrorInPipetting].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[54f717cfd1][OT2_S_v2_16_P300S_None_verifyNoFloatingPointErrorInPipetting].json
@@ -1919,6 +1919,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[552e4bfb25][OT2_S_v2_13_PL_transient_transfection_of_HeLacells_Protocol_1].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[552e4bfb25][OT2_S_v2_13_PL_transient_transfection_of_HeLacells_Protocol_1].json
@@ -3266,6 +3266,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[555b2fff00][Flex_S_v2_19_Illumina_DNA_Prep_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[555b2fff00][Flex_S_v2_19_Illumina_DNA_Prep_48x].json
@@ -49600,6 +49600,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[55d9fd0f78][Flex_S_2_16_MPL_Zymo_Quick_RNA_Cells_Flex_multi].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[55d9fd0f78][Flex_S_2_16_MPL_Zymo_Quick_RNA_Cells_Flex_multi].json
@@ -23708,6 +23708,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[565fe12cbd][Flex_S_2_18_MPL_96_ch_demo_rtp].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[565fe12cbd][Flex_S_2_18_MPL_96_ch_demo_rtp].json
@@ -17602,6 +17602,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[56c0c2e8fc][OT2_S_v2_9_PL_macherey-nagel-nucleomag-tissue].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[56c0c2e8fc][OT2_S_v2_9_PL_macherey-nagel-nucleomag-tissue].json
@@ -91047,6 +91047,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5827810f4a][Flex_S_v2_16_PL_HDQ_DNA_Flex_96-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5827810f4a][Flex_S_v2_16_PL_HDQ_DNA_Flex_96-Cells].json
@@ -35070,6 +35070,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[58750bf5fb][Flex_X_v2_16_NO_PIPETTES_TrashBinInStagingAreaCol4].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[58750bf5fb][Flex_X_v2_16_NO_PIPETTES_TrashBinInStagingAreaCol4].json
@@ -54,6 +54,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[58f4fdb80f][Flex_S_2_18_MPL_96_ch_demo_rtp_with_hs].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[58f4fdb80f][Flex_S_2_18_MPL_96_ch_demo_rtp_with_hs].json
@@ -17510,6 +17510,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[59b00713a7][Flex_S_v2_18_ligseq].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[59b00713a7][Flex_S_v2_18_ligseq].json
@@ -22663,6 +22663,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5a248d53c7][OT2_S_v2_9_PL_macherey-nagel-nucleomag-rna].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5a248d53c7][OT2_S_v2_9_PL_macherey-nagel-nucleomag-rna].json
@@ -143859,6 +143859,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5cdd930bc8][OT2_S_v2_9_PL_sci-neb-next-ultra].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5cdd930bc8][OT2_S_v2_9_PL_sci-neb-next-ultra].json
@@ -44897,6 +44897,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5e70330181][Flex_S_v2_16_PL_invitrogen_elisa_signaldevelopment].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5e70330181][Flex_S_v2_16_PL_invitrogen_elisa_signaldevelopment].json
@@ -45578,6 +45578,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5e958b7c98][Flex_X_v2_16_P300MGen2_None_OT2PipetteInFlexProtocol].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5e958b7c98][Flex_X_v2_16_P300MGen2_None_OT2PipetteInFlexProtocol].json
@@ -1270,6 +1270,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5edb9b4de3][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_ninety_six_partial_column_2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5edb9b4de3][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_ninety_six_partial_column_2].json
@@ -1258,6 +1258,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5f50127d90][OT2_S_v2_4_PL_sci-mag-bind-blood-tissue-kit].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5f50127d90][OT2_S_v2_4_PL_sci-mag-bind-blood-tissue-kit].json
@@ -21769,6 +21769,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[60015c6e65][OT2_X_v2_18_None_None_duplicateRTPVariableName].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[60015c6e65][OT2_X_v2_18_None_None_duplicateRTPVariableName].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[604023f7f1][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInStagingAreaCol3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[604023f7f1][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInStagingAreaCol3].json
@@ -210,6 +210,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[60c1d39463][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_int_default_no_matching_choices].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[60c1d39463][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_int_default_no_matching_choices].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[60ea56b776][OT2_S_v2_9_PL_macherey-nagel-nucleomag-clean-up].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[60ea56b776][OT2_S_v2_9_PL_macherey-nagel-nucleomag-clean-up].json
@@ -62889,6 +62889,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6122c72996][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_ninety_six_partial_column_1].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6122c72996][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_ninety_six_partial_column_1].json
@@ -1258,6 +1258,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6126498df7][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInStagingAreaCol4].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6126498df7][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInStagingAreaCol4].json
@@ -54,6 +54,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[61619d5498][Flex_S_v2_18_NO_PIPETTES_GoldenRTP].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[61619d5498][Flex_S_v2_18_NO_PIPETTES_GoldenRTP].json
@@ -294,6 +294,7 @@
   "errors": [],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[62c7329ba7][Flex_S_2_18_MPL_KAPA_Library_Quant_48_v8].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[62c7329ba7][Flex_S_2_18_MPL_KAPA_Library_Quant_48_v8].json
@@ -31576,6 +31576,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[62d011fe90][Flex_S_2_16_MPL_M_N_Nucleomag_DNA_Flex_multi].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[62d011fe90][Flex_S_2_16_MPL_M_N_Nucleomag_DNA_Flex_multi].json
@@ -16169,6 +16169,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6484e4f4e6][Flex_S_v2_16_PL_immunoprecipitation-by-dynabeads-on-flex-96ch].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6484e4f4e6][Flex_S_v2_16_PL_immunoprecipitation-by-dynabeads-on-flex-96ch].json
@@ -22561,6 +22561,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[657905d518][Flex_S_v2_19_PL_customizable_serial_dilution_flex].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[657905d518][Flex_S_v2_19_PL_customizable_serial_dilution_flex].json
@@ -53147,6 +53147,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[675d2c2562][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_south_east].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[675d2c2562][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_south_east].json
@@ -1508,6 +1508,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[67f0eaa4b1][OT2_S_v2_2_PL_pcr_prep_part_1].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[67f0eaa4b1][OT2_S_v2_2_PL_pcr_prep_part_1].json
@@ -4076,6 +4076,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[683a0d9cbd][Flex_S_v2_15_PL_seqwell-expressplex-library-prep].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[683a0d9cbd][Flex_S_v2_15_PL_seqwell-expressplex-library-prep].json
@@ -13125,6 +13125,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[68614da0b3][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_east].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[68614da0b3][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_east].json
@@ -1508,6 +1508,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6a1d5a5b10][Flex_S_v2_18_PL_MN_RNA_Flex_Multi].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6a1d5a5b10][Flex_S_v2_18_PL_MN_RNA_Flex_Multi].json
@@ -21329,6 +21329,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6ad5590adf][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_unit].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6ad5590adf][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_unit].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6b8f269aec][Flex_S_v2_18_PL_immunoprecipitation-by-dynabeads-on-flex].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6b8f269aec][Flex_S_v2_18_PL_immunoprecipitation-by-dynabeads-on-flex].json
@@ -44791,6 +44791,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6b969e303d][Flex_S_v2_24_96_Live_SingleTip_SLAM_BACK_NIR].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6b969e303d][Flex_S_v2_24_96_Live_SingleTip_SLAM_BACK_NIR].json
@@ -3357,6 +3357,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6c0587a400][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_50_under].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6c0587a400][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_50_under].json
@@ -77905,6 +77905,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6c20d6c570][Flex_S_v2_20_96_None_COLUMN_HappyPath].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6c20d6c570][Flex_S_v2_20_96_None_COLUMN_HappyPath].json
@@ -6308,6 +6308,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6c599fcf11][Flex_S_v2_18_PL_Illumina-DNA-Prep-96x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6c599fcf11][Flex_S_v2_18_PL_Illumina-DNA-Prep-96x].json
@@ -141786,6 +141786,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6cee20a957][OT2_S_v2_12_NO_PIPETTES_Python310SyntaxRobotAnalysisOnlyError].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6cee20a957][OT2_S_v2_12_NO_PIPETTES_Python310SyntaxRobotAnalysisOnlyError].json
@@ -93,6 +93,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6cfce0dd81][OT2_S_v2_16_PL_takara_infusion_assembly_ot2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6cfce0dd81][OT2_S_v2_16_PL_takara_infusion_assembly_ot2].json
@@ -11366,6 +11366,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e2f6f10c5][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_consolidate_destination_collision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e2f6f10c5][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_consolidate_destination_collision].json
@@ -4001,6 +4001,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e34343cfc][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TM_MagMaxRNAExtraction].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e34343cfc][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TM_MagMaxRNAExtraction].json
@@ -59023,6 +59023,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e5128f107][OT2_X_v2_16_None_None_HS_HeaterShakerConflictWithTrashBin1].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e5128f107][OT2_X_v2_16_None_None_HS_HeaterShakerConflictWithTrashBin1].json
@@ -75,6 +75,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e744cbb48][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_str_default_no_matching_choices].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e744cbb48][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_str_default_no_matching_choices].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e90094352][Flex_S_v2_18_PL_ligseq].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6e90094352][Flex_S_v2_18_PL_ligseq].json
@@ -22663,6 +22663,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6f246e1cd8][Flex_S_2_18_P1000M_P50M_GRIP_HS_TM_MB_TC_IlluminaDNAEnrichmentV4].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6f246e1cd8][Flex_S_2_18_P1000M_P50M_GRIP_HS_TM_MB_TC_IlluminaDNAEnrichmentV4].json
@@ -62029,6 +62029,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6f3e297a11][OT2_S_v2_3_P300S_None_MM1_MM2_TM_Mix].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6f3e297a11][OT2_S_v2_3_P300S_None_MM1_MM2_TM_Mix].json
@@ -2787,6 +2787,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6f84e60cb0][OT2_S_v2_16_P300M_P20S_HS_TC_TM_aspirateDispenseMix0Volume].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6f84e60cb0][OT2_S_v2_16_P300M_P20S_HS_TC_TM_aspirateDispenseMix0Volume].json
@@ -2887,6 +2887,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[718c468b7d][Flex_X_v2_21_plate_reader_no_close_lid].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[718c468b7d][Flex_X_v2_21_plate_reader_no_close_lid].json
@@ -2596,6 +2596,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7286bdbef8][Flex_S_2_15_MPL_ExpressPlex_96_final].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7286bdbef8][Flex_S_2_15_MPL_ExpressPlex_96_final].json
@@ -13125,6 +13125,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[733c9cdf62][Flex_S_v2_20_8_None_PARTIAL_COLUMN_HappyPath].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[733c9cdf62][Flex_S_v2_20_8_None_PARTIAL_COLUMN_HappyPath].json
@@ -4992,6 +4992,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7344fbabd6][OT2_S_v2_13_PL_sci-lucif-assay4].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7344fbabd6][OT2_S_v2_13_PL_sci-lucif-assay4].json
@@ -17981,6 +17981,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7583faec7c][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_return_tip_error].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7583faec7c][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_return_tip_error].json
@@ -4971,6 +4971,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[76f2753ce0][Flex_S_v2_20_1000M_Simple].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[76f2753ce0][Flex_S_v2_20_1000M_Simple].json
@@ -4583,6 +4583,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[77fecf1fc2][Flex_X_v2_20_P50_LPD_wet_tip_scenarios].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[77fecf1fc2][Flex_X_v2_20_P50_LPD_wet_tip_scenarios].json
@@ -4175,6 +4175,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[78af64e315][OT2_S_v2_13_PL_sci-lucif-assay1].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[78af64e315][OT2_S_v2_13_PL_sci-lucif-assay1].json
@@ -7675,6 +7675,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[79e61426a2][Flex_S_v2_18_AMPure_XP_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[79e61426a2][Flex_S_v2_18_AMPure_XP_48x].json
@@ -27677,6 +27677,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[79ef0c5304][OT2_S_v2_13_PL_Quick-RNA_OT2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[79ef0c5304][OT2_S_v2_13_PL_Quick-RNA_OT2].json
@@ -63,6 +63,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7b70c7c961][Flex_S_v2_19_PL_MN_DNA_Flex_Multi-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7b70c7c961][Flex_S_v2_19_PL_MN_DNA_Flex_Multi-Cells].json
@@ -42946,6 +42946,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7ba40057e4][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_1000_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7ba40057e4][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_1000_filter].json
@@ -15094,6 +15094,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7bc49deea3][Flex_S_2_18_MPL_BCApeptideassay].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7bc49deea3][Flex_S_2_18_MPL_BCApeptideassay].json
@@ -26170,6 +26170,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7cabb5741a][OT2_S_v2_12_PL_normalization].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7cabb5741a][OT2_S_v2_12_PL_normalization].json
@@ -6433,6 +6433,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7d06568bfe][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_choice_display_name].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7d06568bfe][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_choice_display_name].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7d16d5dbf0][Flex_X_v2_21_tc_lids_wrong_target].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7d16d5dbf0][Flex_X_v2_21_tc_lids_wrong_target].json
@@ -2632,6 +2632,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7d4f5e2cfb][OT2_S_v2_13_PL_HDQ_DNA_OT2-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7d4f5e2cfb][OT2_S_v2_13_PL_HDQ_DNA_OT2-Cells].json
@@ -63,6 +63,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7dc5a7804d][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_200_filter_exceeds].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7dc5a7804d][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_200_filter_exceeds].json
@@ -13767,6 +13767,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7e382de818][OT2_S_v2_20_P300M_PARTIAL_COLUMN_Overhang].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7e382de818][OT2_S_v2_20_P300M_PARTIAL_COLUMN_Overhang].json
@@ -2987,6 +2987,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7e7a90041b][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_west_column].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7e7a90041b][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_west_column].json
@@ -1508,6 +1508,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7eb42ae11d][OT2_S_v2_11_PL_customizable_serial_dilution_ot2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7eb42ae11d][OT2_S_v2_11_PL_customizable_serial_dilution_ot2].json
@@ -43993,6 +43993,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7f2ef0eaff][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_float_default_no_matching_choices].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7f2ef0eaff][Flex_X_v2_18_NO_PIPETTES_Overrides_DefaultChoiceNoMatchChoice_Override_float_default_no_matching_choices].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7fba7321ed][OT2_S_v2_4_PL_sci-omegabiotek-extraction-fa].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7fba7321ed][OT2_S_v2_4_PL_sci-omegabiotek-extraction-fa].json
@@ -171781,6 +171781,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7fddaecb11][Flex_S_v2_20_8_PARTIAL_COLUMN_Overhang].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[7fddaecb11][Flex_S_v2_20_8_PARTIAL_COLUMN_Overhang].json
@@ -5427,6 +5427,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[80daf57f21][Flex_S_v2_24_P1000_8ch_200ulTips_None_HappyPath_all3_liquid_exceeds].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[80daf57f21][Flex_S_v2_24_P1000_8ch_200ulTips_None_HappyPath_all3_liquid_exceeds].json
@@ -51566,6 +51566,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8203c1173d][Flex_S_2_18_MPL_Nanopore_Genomic_Ligation_v5_Final].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8203c1173d][Flex_S_2_18_MPL_Nanopore_Genomic_Ligation_v5_Final].json
@@ -22663,6 +22663,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[82105239d6][Flex_S_v2_16_PL_Zymo_Magbead_DNA_Flex_96-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[82105239d6][Flex_S_v2_16_PL_Zymo_Magbead_DNA_Flex_96-Cells].json
@@ -40960,6 +40960,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[829c44a2c2][Flex_S_v2_24_96_Live_Column_NIR].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[829c44a2c2][Flex_S_v2_24_96_Live_Column_NIR].json
@@ -18269,6 +18269,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[82e9853b34][Flex_X_v2_16_NO_PIPETTES_TrashBinInCol2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[82e9853b34][Flex_X_v2_16_NO_PIPETTES_TrashBinInCol2].json
@@ -54,6 +54,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[83bde2a1d4][OT2_S_v2_9_PL_macherey-nagel-nucleomag-dna-microbiome].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[83bde2a1d4][OT2_S_v2_9_PL_macherey-nagel-nucleomag-dna-microbiome].json
@@ -119544,6 +119544,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8455adcea9][OT2_S_v2_12_P300M_P20S_FailOnRun].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8455adcea9][OT2_S_v2_12_P300M_P20S_FailOnRun].json
@@ -2683,6 +2683,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8492208771][Flex_S_v2_24_P50_8ch_None_HappyPath_all3_liquid].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8492208771][Flex_S_v2_24_P50_8ch_None_HappyPath_all3_liquid].json
@@ -53459,6 +53459,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[84a82c5bfd][Flex_S_v2_21_PL_bca_ms].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[84a82c5bfd][Flex_S_v2_21_PL_bca_ms].json
@@ -43582,6 +43582,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[84f684cbc4][Flex_S_v2_18_IDT_xGen_EZ_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[84f684cbc4][Flex_S_v2_18_IDT_xGen_EZ_48x].json
@@ -59598,6 +59598,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8543b2a5aa][OT2_S_v2_4_PL_sci-omegabiotek-magbind-total-rna-96].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8543b2a5aa][OT2_S_v2_4_PL_sci-omegabiotek-magbind-total-rna-96].json
@@ -32402,6 +32402,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[86137c784e][Flex_S_v2_20_PL_quickr_1].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[86137c784e][Flex_S_v2_20_PL_quickr_1].json
@@ -15163,6 +15163,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[86e5d6be52][OT2_S_v2_20_P300M_Simple].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[86e5d6be52][OT2_S_v2_20_P300M_Simple].json
@@ -4814,6 +4814,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[874fdce8c5][Flex_S_v2_18_PL_QIAseq-Targeted-DNA-Pro-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[874fdce8c5][Flex_S_v2_18_PL_QIAseq-Targeted-DNA-Pro-48x].json
@@ -48516,6 +48516,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[87c1ba0c84][Flex_X_v2_16_P1000_96_TC_PartialTipPickupSingle].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[87c1ba0c84][Flex_X_v2_16_P1000_96_TC_PartialTipPickupSingle].json
@@ -3636,6 +3636,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[88095b83cd][Flex_S_2_15_MPL_langone_pt2_ribo].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[88095b83cd][Flex_S_2_15_MPL_langone_pt2_ribo].json
@@ -29711,6 +29711,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8860ee702c][OT2_S_v2_14_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8860ee702c][OT2_S_v2_14_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -13524,6 +13524,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[88d6e7fc09][OT2_S_v2_13_PL_MagneSil_RNA_OT2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[88d6e7fc09][OT2_S_v2_13_PL_MagneSil_RNA_OT2].json
@@ -29956,6 +29956,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8943a6d1a0][OT2_S_v2_15_PL_cell_seeding_up_to_4].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8943a6d1a0][OT2_S_v2_15_PL_cell_seeding_up_to_4].json
@@ -21778,6 +21778,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[89a255db0b][OT2_X_v2_18_None_None_StrRTPwith_unit].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[89a255db0b][OT2_X_v2_18_None_None_StrRTPwith_unit].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[89a8226c4e][Flex_X_v2_16_P1000_96_TC_PartialTipPickupThermocyclerLidConflict].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[89a8226c4e][Flex_X_v2_16_P1000_96_TC_PartialTipPickupThermocyclerLidConflict].json
@@ -4960,6 +4960,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8a0c8e9261][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_200].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8a0c8e9261][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_200].json
@@ -12252,6 +12252,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8a663305c4][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_south].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8a663305c4][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_south].json
@@ -1506,6 +1506,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8a9e245f62][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_200_exceeds].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8a9e245f62][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_200_exceeds].json
@@ -13767,6 +13767,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8b07e799f6][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_drop_tip_with_location].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8b07e799f6][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_drop_tip_with_location].json
@@ -3811,6 +3811,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8bf96873a4][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_transfer_liquid_Override_1000].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8bf96873a4][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_transfer_liquid_Override_1000].json
@@ -7997,6 +7997,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8c903758e0][Flex_S_v2_20_PL_easypep_digest_tmt].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8c903758e0][Flex_S_v2_20_PL_easypep_digest_tmt].json
@@ -44229,6 +44229,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8d5007afc0][Flex_S_2_15_MPL_ExpressPlex_Pooling_Final].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8d5007afc0][Flex_S_2_15_MPL_ExpressPlex_Pooling_Final].json
@@ -36707,6 +36707,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8d7ad02701][Flex_S_2_17_MPL_EM_seq_48Samples_AllSteps_Edits_150].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8d7ad02701][Flex_S_2_17_MPL_EM_seq_48Samples_AllSteps_Edits_150].json
@@ -50076,6 +50076,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8db2d761e2][Flex_S_v2_20_8_None_SINGLE_TubeRackCollision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8db2d761e2][Flex_S_v2_20_8_None_SINGLE_TubeRackCollision].json
@@ -1769,6 +1769,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8e63842620][Flex_S_v2_18_PL_QIAseq-miRNA-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8e63842620][Flex_S_v2_18_PL_QIAseq-miRNA-48x].json
@@ -62719,6 +62719,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8e722ad718][OT2_S_v2_3_PL_cherrypicking].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8e722ad718][OT2_S_v2_3_PL_cherrypicking].json
@@ -10363,6 +10363,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8fcfd2ced0][Flex_S_v2_16_P1000_96_TC_PartialTipPickupColumn].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8fcfd2ced0][Flex_S_v2_16_P1000_96_TC_PartialTipPickupColumn].json
@@ -3772,6 +3772,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9109c5e897][Flex_S_v2_20_96_LLD].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9109c5e897][Flex_S_v2_20_96_LLD].json
@@ -4120,6 +4120,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[915f33283e][Flex_S_v2_21_PL_protein_quant_normal].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[915f33283e][Flex_S_v2_21_PL_protein_quant_normal].json
@@ -25264,6 +25264,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[92358b6367][Flex_S_v2_24_P50_PAPI_Changes].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[92358b6367][Flex_S_v2_24_P50_PAPI_Changes].json
@@ -6216,6 +6216,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[926d619a02][Flex_S_PD_8_4_2_Illumina_DNA_Prep_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[926d619a02][Flex_S_PD_8_4_2_Illumina_DNA_Prep_48x].json
@@ -22163,6 +22163,7 @@
       "location": "offDeck"
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[92dad6cad1][Flex_S_2_15_MPL_NiNTA_Flex_96well_PlatePrep_final].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[92dad6cad1][Flex_S_2_15_MPL_NiNTA_Flex_96well_PlatePrep_final].json
@@ -17777,6 +17777,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[92edff4f2e][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_1000].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[92edff4f2e][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_1000].json
@@ -79138,6 +79138,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[92f51e3237][Flex_S_2_16_MPL_BacteriaInoculation_Flex_6plates].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[92f51e3237][Flex_S_2_16_MPL_BacteriaInoculation_Flex_6plates].json
@@ -42734,6 +42734,7 @@
       "location": "offDeck"
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[93b724671e][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_right].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[93b724671e][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_right].json
@@ -2493,6 +2493,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[94913d2988][OT2_S_v3_P300SGen1_None_Gen1PipetteSimple].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[94913d2988][OT2_S_v3_P300SGen1_None_Gen1PipetteSimple].json
@@ -6523,6 +6523,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[94cd467de4][Flex_X_v2_19_Illumina_Stranded_total_RNA_Ribo_Zero].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[94cd467de4][Flex_X_v2_19_Illumina_Stranded_total_RNA_Ribo_Zero].json
@@ -39476,6 +39476,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[94d4526c55][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_1000_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[94d4526c55][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_1000_filter].json
@@ -12256,6 +12256,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[94e2c0cb14][Flex_S_v2_16_PL_MN_DNA_Flex_96-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[94e2c0cb14][Flex_S_v2_16_PL_MN_DNA_Flex_96-Cells].json
@@ -36217,6 +36217,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[95da6fbef2][Flex_S_2_15_P1000M_GRIP_HS_TM_MB_OmegaHDQDNAExtractionBacteria].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[95da6fbef2][Flex_S_2_15_P1000M_GRIP_HS_TM_MB_OmegaHDQDNAExtractionBacteria].json
@@ -32317,6 +32317,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9618a6623c][OT2_X_v2_11_P300S_TC1_TC2_ThermocyclerMoamError].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9618a6623c][OT2_X_v2_11_P300S_TC1_TC2_ThermocyclerMoamError].json
@@ -2701,6 +2701,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9640622079][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_1000_filter_exceeds].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9640622079][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_1000_filter_exceeds].json
@@ -13771,6 +13771,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[96daaa8fbf][OT2_S_v2_9_PL_macherey-nagel-nucleomag-pathogen].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[96daaa8fbf][OT2_S_v2_9_PL_macherey-nagel-nucleomag-pathogen].json
@@ -96891,6 +96891,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[98e1c5ded7][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_50_filter_under].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[98e1c5ded7][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_50_filter_under].json
@@ -15712,6 +15712,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[99c15c6c62][Flex_S_v2_21_tc_lids_happy_path].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[99c15c6c62][Flex_S_v2_21_tc_lids_happy_path].json
@@ -2447,6 +2447,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9a4ca27521][OT2_S_v2_13_PL_sci-lucif-assay3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9a4ca27521][OT2_S_v2_13_PL_sci-lucif-assay3].json
@@ -15485,6 +15485,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9ae03c8481][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_1000_exceeds].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9ae03c8481][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_1000_exceeds].json
@@ -13771,6 +13771,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9c1234c6f1][OT2_S_v2_2_PL_pcr_prep_part_2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9c1234c6f1][OT2_S_v2_2_PL_pcr_prep_part_2].json
@@ -10206,6 +10206,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9c65032c02][Flex_S_2_15_MPL_Dynabeads_IP_Flex_96well_RIT_final].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9c65032c02][Flex_S_2_15_MPL_Dynabeads_IP_Flex_96well_RIT_final].json
@@ -53607,6 +53607,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9d4246b8ea][Flex_S_v2_16_PL_HDQ_DNA_Flex_Multi-Bacteria].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9d4246b8ea][Flex_S_v2_16_PL_HDQ_DNA_Flex_Multi-Bacteria].json
@@ -20684,6 +20684,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9dda567b8b][Flex_S_v2_16_PL_Zymo_Quick-RNA_Flex_Multi-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9dda567b8b][Flex_S_v2_16_PL_Zymo_Quick-RNA_Flex_Multi-Cells].json
@@ -23708,6 +23708,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9e3f4e8fc6][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_consolidate_liquid_Override_50_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9e3f4e8fc6][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_consolidate_liquid_Override_50_filter].json
@@ -11877,6 +11877,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9e56ee92f6][Flex_X_v2_16_P1000_96_GRIP_DropLabwareIntoTrashBin].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9e56ee92f6][Flex_X_v2_16_P1000_96_GRIP_DropLabwareIntoTrashBin].json
@@ -1469,6 +1469,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9fefecf4bf][Flex_S_v2_18_PL_kapahyperplus].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[9fefecf4bf][Flex_S_v2_18_PL_kapahyperplus].json
@@ -29609,6 +29609,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a01a35c14a][Flex_X_v2_16_NO_PIPETTES_TrashBinInStagingAreaCol3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a01a35c14a][Flex_X_v2_16_NO_PIPETTES_TrashBinInStagingAreaCol3].json
@@ -166,6 +166,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a05a9a63c1][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_200_filter_under].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a05a9a63c1][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_200_filter_under].json
@@ -15684,6 +15684,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a06502b2dc][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_description].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a06502b2dc][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_description].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a08c261369][Flex_S_v2_16_P1000_96_GRIP_DeckConfiguration1NoModulesNoFixtures].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a08c261369][Flex_S_v2_16_P1000_96_GRIP_DeckConfiguration1NoModulesNoFixtures].json
@@ -9900,6 +9900,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a0b755a1a1][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_north_west].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a0b755a1a1][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_north_west].json
@@ -1506,6 +1506,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a14eb3247c][Flex_S_v2_20_PL_easypep_cleanup].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a14eb3247c][Flex_S_v2_20_PL_easypep_cleanup].json
@@ -22959,6 +22959,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a1733fd0ea][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_200].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a1733fd0ea][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_200].json
@@ -77877,6 +77877,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a181c1ff39][OT2_S_v2_13_PL_cell_viability_and_cytotoxicity_assay_A549_cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a181c1ff39][OT2_S_v2_13_PL_cell_viability_and_cytotoxicity_assay_A549_cells].json
@@ -14701,6 +14701,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a1bf8f0c17][Flex_S_2_18_MPL_Bradford_proteinassay].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a1bf8f0c17][Flex_S_2_18_MPL_Bradford_proteinassay].json
@@ -19207,6 +19207,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a1d73ee800][Flex_S_v2_24_P50_8ch_P50_tracking_liquid].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a1d73ee800][Flex_S_v2_24_P50_8ch_P50_tracking_liquid].json
@@ -13366,6 +13366,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a21ae61169][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_transfer_liquid_Override_1000_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a21ae61169][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_transfer_liquid_Override_1000_filter].json
@@ -9254,6 +9254,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a2ad8a3607][OT2_S_v2_20_P20M_Simple].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a2ad8a3607][OT2_S_v2_20_P20M_Simple].json
@@ -4608,6 +4608,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a2f48a280e][OT2_S_PD_8_4_2_smoketest].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a2f48a280e][OT2_S_PD_8_4_2_smoketest].json
@@ -12926,6 +12926,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a3dfca7f0c][Flex_S_v2_19_Illumina_DNA_PCR_Free].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a3dfca7f0c][Flex_S_v2_19_Illumina_DNA_PCR_Free].json
@@ -27214,6 +27214,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a437534569][Flex_S_v2_19_kapahyperplus].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a437534569][Flex_S_v2_19_kapahyperplus].json
@@ -29609,6 +29609,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a569ad4977][Flex_S_2_16_MPL_Flex_Protein_Digestion_Protocol].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a569ad4977][Flex_S_2_16_MPL_Flex_Protein_Digestion_Protocol].json
@@ -12028,6 +12028,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a5ba8297e3][Flex_X_v2_21_plate_reader_no_trash].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a5ba8297e3][Flex_X_v2_21_plate_reader_no_trash].json
@@ -2561,6 +2561,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a61a631b38][Flex_X_v2_15_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a61a631b38][Flex_X_v2_15_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots].json
@@ -84,6 +84,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a66d700ed6][OT2_S_v2_13_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a66d700ed6][OT2_S_v2_13_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -13184,6 +13184,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a73432d867][Flex_S_v2_18_PL_bradford_protein_assay].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a73432d867][Flex_S_v2_18_PL_bradford_protein_assay].json
@@ -34423,6 +34423,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a750f8a161][Flex_S_v2_18_PL_QIAseq-Normalizer-Workflow-A-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a750f8a161][Flex_S_v2_18_PL_QIAseq-Normalizer-Workflow-A-48x].json
@@ -48065,6 +48065,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a77050a24d][Flex_S_v2_16_PL_HDQ_DNA_Flex_96-Bacteria].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a77050a24d][Flex_S_v2_16_PL_HDQ_DNA_Flex_96-Bacteria].json
@@ -46237,6 +46237,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a8528e52b4][Flex_S_v2_20_96_None_SINGLE_HappyPathSouthSide].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a8528e52b4][Flex_S_v2_20_96_None_SINGLE_HappyPathSouthSide].json
@@ -9502,6 +9502,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a94f22054f][Flex_S_v2_18_kapahyperplus].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a94f22054f][Flex_S_v2_18_kapahyperplus].json
@@ -29609,6 +29609,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a9557d762c][Flex_X_v2_16_NO_PIPETTES_AccessToFixedTrashProp].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[a9557d762c][Flex_X_v2_16_NO_PIPETTES_AccessToFixedTrashProp].json
@@ -54,6 +54,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ac886d7768][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TC_TM_IDTXgen96Part1to3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ac886d7768][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TC_TM_IDTXgen96Part1to3].json
@@ -22482,6 +22482,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[acefe91275][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_left].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[acefe91275][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_left].json
@@ -2463,6 +2463,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad247e5f7c][Flex_S_2_16_MPL_Omega_HDQ_DNA_Bacteria_Flex_multi].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad247e5f7c][Flex_S_2_16_MPL_Omega_HDQ_DNA_Bacteria_Flex_multi].json
@@ -20684,6 +20684,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad627dcedf][OT2_S_v6_P300M_P20S_HS_Smoke620release].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad627dcedf][OT2_S_v6_P300M_P20S_HS_Smoke620release].json
@@ -9151,6 +9151,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad9184067d][Flex_X_v2_18_NO_PIPETTES_ReservedWord].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad9184067d][Flex_X_v2_18_NO_PIPETTES_ReservedWord].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad957852f3][OT2_S_v2_4_PL_sci-promega-magnesil-total-rna-mini-isolation-system].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ad957852f3][OT2_S_v2_4_PL_sci-promega-magnesil-total-rna-mini-isolation-system].json
@@ -145888,6 +145888,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[adc0621263][Flex_X_v2_16_P1000_96_TC_pipetteCollisionWithThermocyclerLid].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[adc0621263][Flex_X_v2_16_P1000_96_TC_pipetteCollisionWithThermocyclerLid].json
@@ -6242,6 +6242,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[aee7ffcf1d][OT2_S_v2_13_PL_HDQ_DNA_OT2-Saliva].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[aee7ffcf1d][OT2_S_v2_13_PL_HDQ_DNA_OT2-Saliva].json
@@ -63,6 +63,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[af9dcf184f][Flex_S_2_7_p1000_dynamic_demo].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[af9dcf184f][Flex_S_2_7_p1000_dynamic_demo].json
@@ -4842,6 +4842,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[afd5d372a9][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_return_tip_error].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[afd5d372a9][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_return_tip_error].json
@@ -3811,6 +3811,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b04d5232c1][Flex_S_2_7_96_channel_select_tips].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b04d5232c1][Flex_S_2_7_96_channel_select_tips].json
@@ -10916,6 +10916,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b0ce7dde5d][Flex_X_v2_16_P1000_96_TC_PartialTipPickupTryToReturnTip].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b0ce7dde5d][Flex_X_v2_16_P1000_96_TC_PartialTipPickupTryToReturnTip].json
@@ -3751,6 +3751,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b175e7d807][OT2_S_v2_12_PL_6d901d-2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b175e7d807][OT2_S_v2_12_PL_6d901d-2].json
@@ -7713,6 +7713,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b2b1925b81][Flex_S_2_7_P200_96_GRIP_HS_MB_TC_TM_SmokeTestWith2Stackers].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b2b1925b81][Flex_S_2_7_P200_96_GRIP_HS_MB_TC_TM_SmokeTestWith2Stackers].json
@@ -24585,6 +24585,46 @@
       }
     }
   ],
+  "labwareOffsets": [
+    {
+      "createdAt": "TIMESTAMP",
+      "definitionUri": "opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/4",
+      "id": "UUID",
+      "location": {
+        "slotName": "C2"
+      },
+      "locationSequence": [
+        {
+          "addressableAreaName": "C2",
+          "kind": "onAddressableArea"
+        }
+      ],
+      "vector": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 10.0
+      }
+    },
+    {
+      "createdAt": "TIMESTAMP",
+      "definitionUri": "opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/4",
+      "id": "UUID",
+      "location": {
+        "slotName": "D2"
+      },
+      "locationSequence": [
+        {
+          "addressableAreaName": "D2",
+          "kind": "onAddressableArea"
+        }
+      ],
+      "vector": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 10.0
+      }
+    }
+  ],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b3d58bf433][Flex_S_v2_20_PL_protein_normal].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b3d58bf433][Flex_S_v2_20_PL_protein_normal].json
@@ -50,6 +50,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b3dc4bb2a5][Flex_S_2_18_MPL_Hyperplus_tiptracking_V4_final].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b3dc4bb2a5][Flex_S_2_18_MPL_Hyperplus_tiptracking_V4_final].json
@@ -29609,6 +29609,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b4f07bfb7c][Flex_X_v2_17_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b4f07bfb7c][Flex_X_v2_17_NO_PIPETTES_TC_verifyThermocyclerLoadedSlots].json
@@ -75,6 +75,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b539ac9025][Flex_S_2_16_MPL_Omega_HDQ_DNA_Cells_Flex_96_channel].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b539ac9025][Flex_S_2_16_MPL_Omega_HDQ_DNA_Cells_Flex_96_channel].json
@@ -35070,6 +35070,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b694b0a20e][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_transfer_liquid_Override_50].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b694b0a20e][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_transfer_liquid_Override_50].json
@@ -8033,6 +8033,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b776da6c41][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_1000].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b776da6c41][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_1000].json
@@ -12256,6 +12256,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b79134ab8a][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_drop_tip_with_location].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b79134ab8a][OT2_X_v2_20_8_Overrides_InvalidConfigs_Override_drop_tip_with_location].json
@@ -4971,6 +4971,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b806f07be9][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_choice_value].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b806f07be9][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_choice_value].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b856a4edaa][Flex_S_v2_20_PL_evercode-whole-transcriptomeWT-kit-Parse-Biosciences-protocol3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b856a4edaa][Flex_S_v2_20_PL_evercode-whole-transcriptomeWT-kit-Parse-Biosciences-protocol3].json
@@ -126422,6 +126422,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b87f2818a2][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_consolidate_liquid_Override_50].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b87f2818a2][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_consolidate_liquid_Override_50].json
@@ -8633,6 +8633,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b9b15682f9][OT2_S_v2_12_PL_sci-amplex-red].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b9b15682f9][OT2_S_v2_12_PL_sci-amplex-red].json
@@ -32018,6 +32018,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b9c04c58f9][Flex_S_2_16_MPL_MagMax_RNA_Cells_Flex_96_Channel].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b9c04c58f9][Flex_S_2_16_MPL_MagMax_RNA_Cells_Flex_96_Channel].json
@@ -41518,6 +41518,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ba14bd77a8][Flex_X_v2_21_plate_reader_bad_slot].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ba14bd77a8][Flex_X_v2_21_plate_reader_bad_slot].json
@@ -2514,6 +2514,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ba4123c2b6][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_50_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ba4123c2b6][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_50_filter].json
@@ -12280,6 +12280,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[baf79d9b4a][Flex_S_v2_15_P1000S_None_SimpleNormalizeLongRight].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[baf79d9b4a][Flex_S_v2_15_P1000S_None_SimpleNormalizeLongRight].json
@@ -126510,6 +126510,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bb52c0482f][Flex_S_v2_24_P1000_8ch_50ulTips_None_HappyPath_all3_liquid_exceeds].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bb52c0482f][Flex_S_v2_24_P1000_8ch_50ulTips_None_HappyPath_all3_liquid_exceeds].json
@@ -50688,6 +50688,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bb91ddef8c][OT2_S_v2_9_PL_sci-idt-normalase].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bb91ddef8c][OT2_S_v2_9_PL_sci-idt-normalase].json
@@ -6783,6 +6783,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bbcc80454d][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_50].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bbcc80454d][Flex_S_v2_24_96_HappyPath_Overrides_transfer_liquid_Override_50].json
@@ -12280,6 +12280,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bc049301c1][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_transfer_destination_collision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bc049301c1][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_transfer_destination_collision].json
@@ -3967,6 +3967,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bdb03e312b][Flex_S_2_24_P1000S_keep_last_tip_check].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bdb03e312b][Flex_S_2_24_P1000S_keep_last_tip_check].json
@@ -7170,6 +7170,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bdf8e68050][OT2_S_v2_9_PL_KAPA-HyperPrep-Kit-for-OT2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[bdf8e68050][OT2_S_v2_9_PL_KAPA-HyperPrep-Kit-for-OT2].json
@@ -29138,6 +29138,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c0435f08da][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_north].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c0435f08da][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_north].json
@@ -1506,6 +1506,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c064d0de2c][OT2_S_v6_P1000S_None_SimpleTransfer].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c064d0de2c][OT2_S_v6_P1000S_None_SimpleTransfer].json
@@ -2029,6 +2029,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c15790917f][Flex_S_v2_20_PL_evercode-whole-transcriptomeWT-kit-Parse-Biosciences-protocol1].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c15790917f][Flex_S_v2_20_PL_evercode-whole-transcriptomeWT-kit-Parse-Biosciences-protocol1].json
@@ -98191,6 +98191,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c195291f84][OT2_S_v2_17_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c195291f84][OT2_S_v2_17_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
@@ -49,6 +49,7 @@
   "errors": [],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c1f9c0f021][Flex_S_v2_24_P50_P1000_HappyPath_tips_liquid].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c1f9c0f021][Flex_S_v2_24_P50_P1000_HappyPath_tips_liquid].json
@@ -115751,6 +115751,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c22ff78471][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_1000_under].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c22ff78471][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_1000_under].json
@@ -75894,6 +75894,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3098303ad][OT2_S_v2_15_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3098303ad][OT2_S_v2_15_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
@@ -58,6 +58,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c343dfb5a0][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_bottom_right_edge].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c343dfb5a0][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_bottom_right_edge].json
@@ -1263,6 +1263,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3b37eae0f][Flex_S_v2_25_P200_stacker_2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3b37eae0f][Flex_S_v2_25_P200_stacker_2].json
@@ -57952,6 +57952,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c41d4198c8][Flex_S_2_18_MPL_Illumina_DNA_Prep_48x_v8].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c41d4198c8][Flex_S_2_18_MPL_Illumina_DNA_Prep_48x_v8].json
@@ -52060,6 +52060,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c4b93f248d][Flex_S_2_16_MPL_Zymo_Magbead_DNA_Cells_Flex_multi].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c4b93f248d][Flex_S_2_16_MPL_Zymo_Magbead_DNA_Cells_Flex_multi].json
@@ -17935,6 +17935,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c509a33600][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_200].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c509a33600][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_200].json
@@ -20712,6 +20712,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c6a3e46457][Flex_S_v2_24_96_Live_SingleTip_All_NIR].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c6a3e46457][Flex_S_v2_24_96_Live_SingleTip_All_NIR].json
@@ -19045,6 +19045,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c745e5824a][Flex_S_v2_16_P1000_96_GRIP_DeckConfiguration1NoModules].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c745e5824a][Flex_S_v2_16_P1000_96_GRIP_DeckConfiguration1NoModules].json
@@ -12865,6 +12865,7 @@
       "location": "wasteChuteLocation"
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c75f28e9a0][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_200_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c75f28e9a0][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_200_filter].json
@@ -23226,6 +23226,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c7e87da2fe][Flex_S_v2_16_PL_Zymo_Magbead_DNA_Flex_Multi-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c7e87da2fe][Flex_S_v2_16_PL_Zymo_Magbead_DNA_Flex_Multi-Cells].json
@@ -17935,6 +17935,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c821e64fad][OT2_S_v2_13_P300M_P20S_MM_TC_TM_Smoke620Release].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c821e64fad][OT2_S_v2_13_P300M_P20S_MM_TC_TM_Smoke620Release].json
@@ -10519,6 +10519,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c8d2ca0089][Flex_S_v2_18_QIASeq_FX_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c8d2ca0089][Flex_S_v2_18_QIASeq_FX_48x].json
@@ -66246,6 +66246,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c8d4237127][OT2_S_v2_9_PL_sci-idt-xgen-mc].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c8d4237127][OT2_S_v2_9_PL_sci-idt-xgen-mc].json
@@ -9693,6 +9693,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c94ae6ae32][Flex_S_v2_18_PL_AMPure-XP-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c94ae6ae32][Flex_S_v2_18_PL_AMPure-XP-48x].json
@@ -23073,6 +23073,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c9e6e3d59d][OT2_X_v4_P300M_P20S_MM_TC1_TM_e2eTests].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c9e6e3d59d][OT2_X_v4_P300M_P20S_MM_TC1_TM_e2eTests].json
@@ -6577,6 +6577,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cb5adc3d23][OT2_S_v6_P20S_P300M_TransferReTransferLiquid].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cb5adc3d23][OT2_S_v6_P20S_P300M_TransferReTransferLiquid].json
@@ -12925,6 +12925,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cb5c7fbd06][Flex_S_v2_18_PL_KAPA-Library-Quant-48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cb5c7fbd06][Flex_S_v2_18_PL_KAPA-Library-Quant-48x].json
@@ -30010,6 +30010,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cbdf799f0c][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_consolidate_liquid_Override_1000_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cbdf799f0c][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_consolidate_liquid_Override_1000_filter].json
@@ -11841,6 +11841,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cc26c104b4][Flex_S_v2_20_8_None_SINGLE_HappyPath].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cc26c104b4][Flex_S_v2_20_8_None_SINGLE_HappyPath].json
@@ -7129,6 +7129,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cdeb821849][OT2_S_v2_13_PL_Zymo_Magbead_DNA_OT2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[cdeb821849][OT2_S_v2_13_PL_Zymo_Magbead_DNA_OT2].json
@@ -37271,6 +37271,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ce45da67d5][OT2_S_v2_15_PL_flex-custom-parameters-cherrypicking].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ce45da67d5][OT2_S_v2_15_PL_flex-custom-parameters-cherrypicking].json
@@ -10559,6 +10559,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ceff7e73e4][Flex_S_v2_24_P50_8ch_None_partial_tip_liquid].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ceff7e73e4][Flex_S_v2_24_P50_8ch_None_partial_tip_liquid].json
@@ -9435,6 +9435,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d0154b1493][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_right].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d0154b1493][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_eight_partial_column_bottom_right].json
@@ -1331,6 +1331,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d040dd6a75][Flex_S_2_15_MPL_cherrypicking_flex_v3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d040dd6a75][Flex_S_2_15_MPL_cherrypicking_flex_v3].json
@@ -10559,6 +10559,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d19c75d393][OT2_S_v2_9_PL_dinosaur].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d19c75d393][OT2_S_v2_9_PL_dinosaur].json
@@ -5444,6 +5444,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d1b4db3d02][Flex_S_v2_16_PL_invitrogen_elisa_captureabcoating].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d1b4db3d02][Flex_S_v2_16_PL_invitrogen_elisa_captureabcoating].json
@@ -4966,6 +4966,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d20f34f45f][Flex_S_v2_24_96_Live_Row_NIR].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d20f34f45f][Flex_S_v2_24_96_Live_Row_NIR].json
@@ -13493,6 +13493,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d2c818bf00][Flex_S_v2_20_P50_LPD].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d2c818bf00][Flex_S_v2_20_P50_LPD].json
@@ -5161,6 +5161,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d2e641ad8a][OT2_X_v2_17_P300M_P20S_HS_TC_TM_dispense_changes].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d2e641ad8a][OT2_X_v2_17_P300M_P20S_HS_TC_TM_dispense_changes].json
@@ -3198,6 +3198,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d391213095][Flex_S_v2_15_P1000_96_GRIP_HS_TM_QuickZymoMagbeadRNAExtractionCellsOrBacteria].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d391213095][Flex_S_v2_15_P1000_96_GRIP_HS_TM_QuickZymoMagbeadRNAExtractionCellsOrBacteria].json
@@ -25324,6 +25324,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d48bc4f0c9][OT2_S_v2_17_P300M_P20S_HS_TC_TM_SmokeTestV3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d48bc4f0c9][OT2_S_v2_17_P300M_P20S_HS_TC_TM_SmokeTestV3].json
@@ -16839,6 +16839,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d50ea72948][OT2_S_v2_2_PL_omega_biotek_magbind_totalpure_ngs].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d50ea72948][OT2_S_v2_2_PL_omega_biotek_magbind_totalpure_ngs].json
@@ -115173,6 +115173,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d598237327][Flex_S_v2_18_PL_Illumina-DNA-Prep-PCR-Free].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d598237327][Flex_S_v2_18_PL_Illumina-DNA-Prep-PCR-Free].json
@@ -27214,6 +27214,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d5ee78d7ab][OT2_S_v2_15_PL_6d901d-1-2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d5ee78d7ab][OT2_S_v2_15_PL_6d901d-1-2].json
@@ -15769,6 +15769,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d5f2b08aa5][OT2_S_v2_20_8_None_SINGLE_TubeRackCollision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d5f2b08aa5][OT2_S_v2_20_8_None_SINGLE_TubeRackCollision].json
@@ -1758,6 +1758,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d6026e11c5][OT2_X_v2_7_P300S_TwinningError].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d6026e11c5][OT2_X_v2_7_P300S_TwinningError].json
@@ -2854,6 +2854,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d61739e6a3][Flex_S_v2_19_IDT_xGen_EZ_48x].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d61739e6a3][Flex_S_v2_19_IDT_xGen_EZ_48x].json
@@ -59598,6 +59598,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d7e862d601][OT2_S_v2_18_None_None_duplicateChoiceValue].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d7e862d601][OT2_S_v2_18_None_None_duplicateChoiceValue].json
@@ -42,6 +42,7 @@
   "errors": [],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d93831d524][Flex_S_v2_24_P1000_8ch_50ulTips_None_HappyPath_all3_liquid].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d93831d524][Flex_S_v2_24_P1000_8ch_50ulTips_None_HappyPath_all3_liquid].json
@@ -33972,6 +33972,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d979799443][OT2_S_v2_20_8_None_SINGLE_HappyPath].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[d979799443][OT2_S_v2_20_8_None_SINGLE_HappyPath].json
@@ -8292,6 +8292,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[da02cc8ca8][Flex_S_v2_20_PL_quickr_2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[da02cc8ca8][Flex_S_v2_20_PL_quickr_2].json
@@ -29434,6 +29434,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[da6ed25021][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_transfer_liquid_Override_200].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[da6ed25021][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_transfer_liquid_Override_200].json
@@ -9254,6 +9254,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dabb7872d8][Flex_S_v2_19_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dabb7872d8][Flex_S_v2_19_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -15988,6 +15988,46 @@
       }
     }
   ],
+  "labwareOffsets": [
+    {
+      "createdAt": "TIMESTAMP",
+      "definitionUri": "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
+      "id": "UUID",
+      "location": {
+        "slotName": "C2"
+      },
+      "locationSequence": [
+        {
+          "addressableAreaName": "C2",
+          "kind": "onAddressableArea"
+        }
+      ],
+      "vector": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 10.0
+      }
+    },
+    {
+      "createdAt": "TIMESTAMP",
+      "definitionUri": "opentrons/nest_96_wellplate_100ul_pcr_full_skirt/2",
+      "id": "UUID",
+      "location": {
+        "slotName": "D2"
+      },
+      "locationSequence": [
+        {
+          "addressableAreaName": "D2",
+          "kind": "onAddressableArea"
+        }
+      ],
+      "vector": {
+        "x": 0.0,
+        "y": 0.0,
+        "z": 10.0
+      }
+    }
+  ],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[db1fae41ec][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_ninety_six_partial_column_3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[db1fae41ec][Flex_X_v2_20_96_and_8_Overrides_InvalidConfigs_Override_ninety_six_partial_column_3].json
@@ -1258,6 +1258,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[db74d8697a][OT2_S_v2_3_PL_3359a5].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[db74d8697a][OT2_S_v2_3_PL_3359a5].json
@@ -10363,6 +10363,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dbba7a71a8][OT2_S_v2_16_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dbba7a71a8][OT2_S_v2_16_NO_PIPETTES_TC_VerifyThermocyclerLoadedSlots].json
@@ -49,6 +49,7 @@
   "errors": [],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dc4d2c35f8][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_consolidate_liquid_Override_1000].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dc4d2c35f8][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_consolidate_liquid_Override_1000].json
@@ -8597,6 +8597,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dcd3c0777c][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_distribute_liquid_Override_50].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dcd3c0777c][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_distribute_liquid_Override_50].json
@@ -8955,6 +8955,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dd480eb066][OT2_S_v2_15_PL_omega-bio-tek-mag-bind-environmental-dna-96].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dd480eb066][OT2_S_v2_15_PL_omega-bio-tek-mag-bind-environmental-dna-96].json
@@ -61220,6 +61220,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dde0e82261][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_200_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[dde0e82261][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_200_filter].json
@@ -85419,6 +85419,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[de4249ddfb][Flex_X_v2_16_NO_PIPETTES_TC_TrashBinAndThermocyclerConflict].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[de4249ddfb][Flex_X_v2_16_NO_PIPETTES_TC_TrashBinAndThermocyclerConflict].json
@@ -75,6 +75,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[df64ff8efd][Flex_S_PD_8_4_2_Zymo_Magbead_DNA_Cells-Flex_96_channel].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[df64ff8efd][Flex_S_PD_8_4_2_Zymo_Magbead_DNA_Cells-Flex_96_channel].json
@@ -43442,6 +43442,7 @@
       "location": "offDeck"
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e18bdd6f5d][Flex_S_2_15_P1000M_P50M_GRIP_HS_TM_MB_TC_KAPALibraryQuantv4_8].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e18bdd6f5d][Flex_S_2_15_P1000M_P50M_GRIP_HS_TM_MB_TC_KAPALibraryQuantv4_8].json
@@ -33897,6 +33897,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e21231cdf0][OT2_S_v2_11_PL_sci-phytip-protein-puri].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e21231cdf0][OT2_S_v2_11_PL_sci-phytip-protein-puri].json
@@ -31359,6 +31359,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e3ebaac020][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_50].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e3ebaac020][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_50].json
@@ -85447,6 +85447,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e42e36e3ca][OT2_X_v2_13_None_None_PythonSyntaxError].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e42e36e3ca][OT2_X_v2_13_None_None_PythonSyntaxError].json
@@ -42,6 +42,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e4660ca6df][OT2_S_v4_P300S_None_MM_TM_TM_MOAMTemps].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e4660ca6df][OT2_S_v4_P300S_None_MM_TM_TM_MOAMTemps].json
@@ -1519,6 +1519,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e496fec176][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_default].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e496fec176][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_default].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e4b5b30b2e][Flex_S_v2_18_Illumina_DNA_PCR_Free].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e4b5b30b2e][Flex_S_v2_18_Illumina_DNA_PCR_Free].json
@@ -27214,6 +27214,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e4c3685417][OT2_S_v8_4_4P300GEN2_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e4c3685417][OT2_S_v8_4_4P300GEN2_Smoke].json
@@ -11924,6 +11924,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e58704f21b][OT2_S_v2_10_PL_swift-fully-automated].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e58704f21b][OT2_S_v2_10_PL_swift-fully-automated].json
@@ -26765,6 +26765,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e59e0e10a3][Flex_S_v2_20_96_None_SINGLE_TubeRackCollision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e59e0e10a3][Flex_S_v2_20_96_None_SINGLE_TubeRackCollision].json
@@ -1735,6 +1735,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e66e443deb][Flex_S_v2_15_PL_seqwell-expressplex-pooling].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e66e443deb][Flex_S_v2_15_PL_seqwell-expressplex-pooling].json
@@ -36707,6 +36707,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e670e626e3][Flex_S_2_18_MPL_QIASeq_FX_48x_v8].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e670e626e3][Flex_S_2_18_MPL_QIASeq_FX_48x_v8].json
@@ -71137,6 +71137,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e7cf2a4f57][Flex_X_v8_PD_P1000_96_HS_GRIP_TC_TM_GripperCollisionWithTips].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e7cf2a4f57][Flex_X_v8_PD_P1000_96_HS_GRIP_TC_TM_GripperCollisionWithTips].json
@@ -12156,6 +12156,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e84e23a4ea][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_top_edge].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e84e23a4ea][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_top_edge].json
@@ -1261,6 +1261,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e898f1b208][OT2_S_v2_4_PL_sci-zymo-directzol-magbead].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e898f1b208][OT2_S_v2_4_PL_sci-zymo-directzol-magbead].json
@@ -28890,6 +28890,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e8c950ac0b][Flex_S_v2_24_8_channel_1000_flex_do_it_all_custom_liquid_class_PD_8_5].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e8c950ac0b][Flex_S_v2_24_8_channel_1000_flex_do_it_all_custom_liquid_class_PD_8_5].json
@@ -41067,6 +41067,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e8f451df45][Flex_S_v2_20_96_None_Column3_SINGLE_].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e8f451df45][Flex_S_v2_20_96_None_Column3_SINGLE_].json
@@ -27174,6 +27174,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e9c9e2d4fe][Flex_S_v2_18_PL_bca_peptide_assay].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e9c9e2d4fe][Flex_S_v2_18_PL_bca_peptide_assay].json
@@ -41386,6 +41386,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e9ea6f5739][OT2_S_v2_9_PL_Illumina-DNA-Prep-24x-for-OT2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[e9ea6f5739][OT2_S_v2_9_PL_Illumina-DNA-Prep-24x-for-OT2].json
@@ -97402,6 +97402,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ea50dd6373][Flex_S_v2_24_96_Live_Full_NIR].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ea50dd6373][Flex_S_v2_24_96_Live_Full_NIR].json
@@ -27393,6 +27393,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ecfa1f5fe5][Flex_S_2_7_Camera].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ecfa1f5fe5][Flex_S_2_7_Camera].json
@@ -645,6 +645,7 @@
   "errors": [],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ed1e64c539][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInCol2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ed1e64c539][Flex_X_v2_16_NO_PIPETTES_TM_ModuleInCol2].json
@@ -102,6 +102,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ed26635ff7][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_consolidate_source_collision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ed26635ff7][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_consolidate_source_collision].json
@@ -3931,6 +3931,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ed2f3800b6][Flex_S_2_18_P1000M_P50M_GRIP_HS_TM_MB_TC_IlluminaDNAPrep24xV4_7].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ed2f3800b6][Flex_S_2_18_P1000M_P50M_GRIP_HS_TM_MB_TC_IlluminaDNAPrep24xV4_7].json
@@ -40823,6 +40823,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ee641de355][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_transfer_liquid_Override_200_filter].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ee641de355][Flex_S_v2_24_P1000_8ch_None_HappyPath_Overrides_transfer_liquid_Override_200_filter].json
@@ -7997,6 +7997,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ef18043af6][Flex_S_v2_20_P50_touch_tip_directly].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ef18043af6][Flex_S_v2_20_P50_touch_tip_directly].json
@@ -4206,6 +4206,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ef35b5649b][Flex_S_2_16_MPL_Omega_HDQ_DNA_Cells_Flex_multi].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ef35b5649b][Flex_S_2_16_MPL_Omega_HDQ_DNA_Cells_Flex_multi].json
@@ -17442,6 +17442,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f02844293e][Flex_S_v2_24_P1000_8ch_1000ulTips_None_HappyPath_all3_liquid_exceeds].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f02844293e][Flex_S_v2_24_P1000_8ch_1000ulTips_None_HappyPath_all3_liquid_exceeds].json
@@ -51566,6 +51566,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f0bc07ae2e][Flex_S_v2_16_PL_agar_plate_method_bacteria].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f0bc07ae2e][Flex_S_v2_16_PL_agar_plate_method_bacteria].json
@@ -42734,6 +42734,7 @@
       "location": "offDeck"
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f0efddcd7d][Flex_X_v2_16_P1000_96_DropTipsWithNoTrash].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f0efddcd7d][Flex_X_v2_16_P1000_96_DropTipsWithNoTrash].json
@@ -1500,6 +1500,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f24bb0b4d9][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TC_TM_IlluminaDNAPrep96PART3].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f24bb0b4d9][Flex_S_v2_15_P1000_96_GRIP_HS_MB_TC_TM_IlluminaDNAPrep96PART3].json
@@ -18832,6 +18832,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f301704f56][OT2_S_v6_P300M_P300S_HS_HS_NormalUseWithTransfer].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f301704f56][OT2_S_v6_P300M_P300S_HS_HS_NormalUseWithTransfer].json
@@ -6747,6 +6747,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f345e8e33a][OT2_S_v4_P300M_P20S_MM_TM_TC1_PD40].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f345e8e33a][OT2_S_v4_P300M_P20S_MM_TM_TC1_PD40].json
@@ -10018,6 +10018,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f37bb0ec36][OT2_S_v2_16_NO_PIPETTES_verifyDoesNotDeadlock].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f37bb0ec36][OT2_S_v2_16_NO_PIPETTES_verifyDoesNotDeadlock].json
@@ -28,6 +28,7 @@
   "errors": [],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f3e0f3b0d1][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_50_filter_exceeds].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f3e0f3b0d1][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_50_filter_exceeds].json
@@ -84367,6 +84367,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f51172f73b][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f51172f73b][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -24531,6 +24531,7 @@
       "location": "offDeck"
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f5699a73e8][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_200_filter_under].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f5699a73e8][Flex_S_v2_24_96_HappyPath_Overrides_consolidate_liquid_Override_200_filter_under].json
@@ -77147,6 +77147,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f5f3b9c5bb][Flex_X_v2_16_P1000_96_TM_ModuleAndWasteChuteConflict].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f5f3b9c5bb][Flex_X_v2_16_P1000_96_TM_ModuleAndWasteChuteConflict].json
@@ -1373,6 +1373,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f61c4fcb30][Flex_S_v2_16_PL_Magmax_RNA_Flex_96-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f61c4fcb30][Flex_S_v2_16_PL_Magmax_RNA_Flex_96-Cells].json
@@ -41518,6 +41518,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f62f9ee647][OT2_S_v2_13_PL_transient_transfection_of_A549cells_Protocol_2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f62f9ee647][OT2_S_v2_13_PL_transient_transfection_of_A549cells_Protocol_2].json
@@ -9189,6 +9189,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f6eebe4920][Flex_S_2_16_MPL_Omega_HDQ_DNA_Bacteria_Flex_96_channel].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f6eebe4920][Flex_S_2_16_MPL_Omega_HDQ_DNA_Bacteria_Flex_96_channel].json
@@ -46237,6 +46237,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f7085d7134][Flex_X_v2_16_P1000_96_TC_pipetteCollisionWithThermocyclerLidClips].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f7085d7134][Flex_X_v2_16_P1000_96_TC_pipetteCollisionWithThermocyclerLidClips].json
@@ -1307,6 +1307,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {},

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f7731d7e20][Flex_S_2_18_MPL_Illumina_DNA_PCR_Free].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f7731d7e20][Flex_S_2_18_MPL_Illumina_DNA_PCR_Free].json
@@ -27214,6 +27214,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f834b97da1][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_DeckConfiguration1].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f834b97da1][Flex_S_v2_16_P1000_96_GRIP_HS_MB_TC_TM_DeckConfiguration1].json
@@ -14353,6 +14353,7 @@
       "location": "wasteChuteLocation"
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f86713b4d4][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_distribute_source_collision].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f86713b4d4][Flex_X_v2_20_96_None_Overrides_TooTallLabware_Override_distribute_source_collision].json
@@ -3931,6 +3931,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f88b7d6e30][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_display_name].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f88b7d6e30][Flex_X_v2_18_NO_PIPETTES_Overrides_BadTypesInRTP_Override_wrong_type_in_display_name].json
@@ -38,6 +38,7 @@
   ],
   "files": [],
   "labware": [],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f967029946][OT2_S_v2_13_PL_cell_viability_and_cytotoxicity_assay_K562_cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[f967029946][OT2_S_v2_13_PL_cell_viability_and_cytotoxicity_assay_K562_cells].json
@@ -14701,6 +14701,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fa24954076][OT2_S_v2_9_PL_bc-rnadvance-viral].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fa24954076][OT2_S_v2_9_PL_bc-rnadvance-viral].json
@@ -84140,6 +84140,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fb0b8051f8][Flex_S_v2_21_PL_plate_read_abs].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fb0b8051f8][Flex_S_v2_21_PL_plate_read_abs].json
@@ -2008,6 +2008,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fb40609e73][Flex_S_v2_24_P50_P1000_HappyPath_all3_liquid].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fb40609e73][Flex_S_v2_24_P50_P1000_HappyPath_all3_liquid].json
@@ -115751,6 +115751,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fbf920b623][Flex_S_2_18_MPL_AMPure_XP_48x_v8].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fbf920b623][Flex_S_2_18_MPL_AMPure_XP_48x_v8].json
@@ -27677,6 +27677,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fc60ef9cbd][OT2_S_v2_16_P300M_P20S_HS_TC_TM_dispense_changes].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fc60ef9cbd][OT2_S_v2_16_P300M_P20S_HS_TC_TM_dispense_changes].json
@@ -3156,6 +3156,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fd26a20b4c][Flex_X_v2_21_plate_reader_wrong_plate].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fd26a20b4c][Flex_X_v2_21_plate_reader_wrong_plate].json
@@ -1597,6 +1597,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fe1440fe86][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_1000].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fe1440fe86][Flex_S_v2_24_96_HappyPath_Overrides_distribute_liquid_Override_1000].json
@@ -15688,6 +15688,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [
     {
       "aspirate": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fe6ff68470][Flex_S_v2_18_PL_imac-by-ni-nta-magnetic-agarose-beads-on-flex-plate-preparation].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fe6ff68470][Flex_S_v2_18_PL_imac-by-ni-nta-magnetic-agarose-beads-on-flex-plate-preparation].json
@@ -17808,6 +17808,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fe9c98fbe3][Flex_S_v2_16_PL_HDQ_DNA_Flex_Multi-Cells].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[fe9c98fbe3][Flex_S_v2_16_PL_HDQ_DNA_Flex_Multi-Cells].json
@@ -17442,6 +17442,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ff4a494935][OT2_S_v2_4_PL_nucleic_acid_purification_with_magnetic_beads].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ff4a494935][OT2_S_v2_4_PL_nucleic_acid_purification_with_magnetic_beads].json
@@ -33538,6 +33538,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [],
   "metadata": {

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ff9882358d][Flex_S_2_15_MPL_Dynabeads_IP_Flex_96well_final].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[ff9882358d][Flex_S_2_15_MPL_Dynabeads_IP_Flex_96well_final].json
@@ -38954,6 +38954,7 @@
       }
     }
   ],
+  "labwareOffsets": [],
   "liquidClasses": [],
   "liquids": [
     {

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -1,10 +1,11 @@
 import type {
   LabwareDefinition,
+  LabwareOffsetRecord,
+  LegacyLabwareOffsetLocation,
   Liquid,
   LoadedLabware,
   LoadedModule,
   LoadedPipette,
-  ModuleModel,
   NozzleLayoutConfig,
   OnDeckLabwareLocation,
   RunCommandError,
@@ -19,6 +20,10 @@ import type {
 } from '../types'
 
 export * from './commands/types'
+export type {
+  LegacyLabwareOffsetLocation,
+  LabwareOffsetRecord,
+} from '@opentrons/shared-data'
 
 export const RUN_STATUS_IDLE = 'idle' as const
 export const RUN_STATUS_RUNNING = 'running' as const
@@ -89,14 +94,6 @@ export interface VectorOffset {
   y: number
   z: number
 }
-export interface LabwareOffset {
-  id: string
-  createdAt: string
-  definitionUri: string
-  location: LegacyLabwareOffsetLocation
-  locationSequence?: LabwareOffsetLocationSequence
-  vector: VectorOffset
-}
 
 export interface RunLoadedLabwareDefinitions {
   data: LabwareDefinition[]
@@ -166,11 +163,8 @@ export interface CreateRunActionData {
   actionType: RunActionType
 }
 
-export interface LegacyLabwareOffsetLocation {
-  slotName: string
-  moduleModel?: ModuleModel
-  definitionUri?: string
-}
+export type LabwareOffset = LabwareOffsetRecord
+
 export interface LegacyLabwareOffsetCreateData {
   definitionUri: string
   location: LegacyLabwareOffsetLocation

--- a/api/src/opentrons/cli/analyze.py
+++ b/api/src/opentrons/cli/analyze.py
@@ -51,6 +51,7 @@ from opentrons.protocol_engine.types import (
     CommandPreconditions,
     CSVRuntimeParamPaths,
     EngineStatus,
+    LabwareOffset,
     PrimitiveRunTimeParamValuesType,
     RunTimeParameter,
 )
@@ -464,6 +465,7 @@ async def _analyze(  # noqa: C901
         commandAnnotations=analysis.command_annotations,
         liquidClasses=analysis.state_summary.liquidClasses,
         commandPreconditions=analysis.command_preconditions,
+        labwareOffsets=analysis.state_summary.labwareOffsets,
     )
 
     _call_for_output_of_kind(
@@ -555,3 +557,4 @@ class AnalyzeResults(BaseModel):
     errors: List[ErrorOccurrence]
     commandAnnotations: List[CommandAnnotation]
     commandPreconditions: Optional[CommandPreconditions]
+    labwareOffsets: List[LabwareOffset]

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -323,6 +323,7 @@ def test_run_time_parameter_setting(
             "default": False,
         }
     ]
+    assert result.json_output["labwareOffsets"] == []
 
 
 @pytest.mark.parametrize("output", ["--json-output", "--human-json-output"])
@@ -373,6 +374,7 @@ def test_run_time_parameter_error(
         "TypeError [line 5]: ParameterContext.add_bool() missing 1"
         " required positional argument: 'default'"
     )
+    assert result.json_output["labwareOffsets"] == []
 
 
 @pytest.mark.parametrize("output", ["--json-output", "--human-json-output"])
@@ -431,6 +433,7 @@ def test_rtp_csv_file_setting(
             "file": {"id": "", "name": "csv_file.csv"},
         }
     ]
+    assert result.json_output["labwareOffsets"] == []
 
 
 @pytest.mark.parametrize("output", ["--json-output", "--human-json-output"])
@@ -476,6 +479,7 @@ def test_file_required_error(
     }
     assert result.json_output["files"] == [{"name": "protocol.py", "role": "main"}]
     assert result.json_output["errors"]
+    assert result.json_output["labwareOffsets"] == []
 
 
 @pytest.mark.parametrize("output", ["--json-output", "--human-json-output"])
@@ -569,3 +573,43 @@ def test_analyze_json_protocol(
     assert op is not None
     assert len(op["commands"]) == 27
     assert op["result"] == AnalysisResult.OK.value
+
+
+@pytest.mark.parametrize("output", ["--json-output", "--human-json-output"])
+def test_analyze_protocol_with_offsets(
+    tmp_path: Path,
+    output: str,
+) -> None:
+    """Test that a protocol that sets a custom offset sees the offset in results."""
+    protocol = textwrap.dedent("""\
+                requirements = {"apiLevel": "2.18", "robotType": "Flex"} # line 1
+                                                                         # line 2
+                def run(protocol):                                       # line 3
+                    tip_rack = protocol.load_labware(                    # line 4
+                        "opentrons_flex_96_tiprack_1000ul", "A2"         # line 5
+                    )                                                    # line 6
+                    tip_rack.set_offset(x=1, y=2, z=3)                   # line 7
+                    pipette = protocol.load_instrument(                  # line 8
+                        "flex_1channel_1000", "left"                     # line 9
+                    )                                                    # line 10
+                    pipette.pick_up_tip(tip_rack["A1"])                  # line 11
+                """)
+
+    protocol_source_file = tmp_path / "protocol.py"
+    protocol_source_file.write_text(protocol, encoding="utf-8")
+    result = _get_analysis_result([protocol_source_file], output)
+
+    assert result.exit_code == 0
+
+    assert result.json_output is not None
+    assert result.json_output["robotType"] == "OT-3 Standard"
+    assert result.json_output["result"] == AnalysisResult.OK
+    assert len(result.json_output["labwareOffsets"])
+    offset = result.json_output["labwareOffsets"][0]
+    assert offset["id"]
+    assert offset["definitionUri"] == "opentrons/opentrons_flex_96_tiprack_1000ul/1"
+    assert offset["location"]["slotName"] == "A2"
+    assert offset["locationSequence"] == [
+        {"kind": "onAddressableArea", "addressableAreaName": "A2"}
+    ]
+    assert offset["vector"] == {"x": 1.0, "y": 2.0, "z": 3.0}

--- a/api/tests/opentrons/cli/test_cli.py
+++ b/api/tests/opentrons/cli/test_cli.py
@@ -582,17 +582,17 @@ def test_analyze_protocol_with_offsets(
 ) -> None:
     """Test that a protocol that sets a custom offset sees the offset in results."""
     protocol = textwrap.dedent("""\
-                requirements = {"apiLevel": "2.18", "robotType": "Flex"} # line 1
-                                                                         # line 2
-                def run(protocol):                                       # line 3
-                    tip_rack = protocol.load_labware(                    # line 4
-                        "opentrons_flex_96_tiprack_1000ul", "A2"         # line 5
-                    )                                                    # line 6
-                    tip_rack.set_offset(x=1, y=2, z=3)                   # line 7
-                    pipette = protocol.load_instrument(                  # line 8
-                        "flex_1channel_1000", "left"                     # line 9
-                    )                                                    # line 10
-                    pipette.pick_up_tip(tip_rack["A1"])                  # line 11
+                requirements = {"apiLevel": "2.18", "robotType": "Flex"}
+
+                def run(protocol):
+                    tip_rack = protocol.load_labware(
+                        "opentrons_flex_96_tiprack_1000ul", "A2"
+                    )
+                    tip_rack.set_offset(x=1, y=2, z=3)
+                    pipette = protocol.load_instrument(
+                        "flex_1channel_1000", "left"
+                    )
+                    pipette.pick_up_tip(tip_rack["A1"])
                 """)
 
     protocol_source_file = tmp_path / "protocol.py"

--- a/robot-server/robot_server/protocols/analysis_models.py
+++ b/robot-server/robot_server/protocols/analysis_models.py
@@ -9,6 +9,7 @@ from typing_extensions import Literal
 from opentrons.protocol_engine import (
     Command,
     ErrorOccurrence,
+    LabwareOffset,
     Liquid,
     LiquidClassRecordWithId,
     LoadedLabware,
@@ -208,6 +209,10 @@ class CompletedAnalysis(BaseModel):
     commandPreconditions: Optional[CommandPreconditions] = Field(
         default=None,
         description="Optional preconditions for commands used in this run.",
+    )
+    labwareOffsets: List[LabwareOffset] = Field(
+        default_factory=list,
+        description="List of loaded labware offsets (since this is an analysis, only those set by the protocol).",
     )
 
 

--- a/robot-server/robot_server/protocols/analysis_store.py
+++ b/robot-server/robot_server/protocols/analysis_store.py
@@ -22,6 +22,7 @@ from opentrons.protocol_engine.types import (
     CommandAnnotation,
     CommandPreconditions,
     CSVParameter,
+    LabwareOffset,
     RunTimeParameter,
 )
 from opentrons_shared_data.errors import ErrorCodes
@@ -160,6 +161,7 @@ class AnalysisStore:
         liquids: List[Liquid],
         liquidClasses: List[LiquidClassRecordWithId],
         command_annotations: List[CommandAnnotation],
+        labware_offsets: List[LabwareOffset],
         command_preconditions: Optional[CommandPreconditions] = None,
     ) -> None:
         """Promote a pending analysis to completed, adding details of its results.
@@ -180,6 +182,7 @@ class AnalysisStore:
             robot_type: See `CompletedAnalysis.robotType`.
             command_annotations: See `CompletedAnalysis.command_annotations`.
             command_preconditions: See `CompletedAnalysis.command_preconditions`.
+            labware_offsets: See `CompletedAnalysis.labware_offsets`.
         """
         protocol_id = self._pending_store.get_protocol_id(analysis_id=analysis_id)
 
@@ -216,6 +219,7 @@ class AnalysisStore:
             liquidClasses=liquidClasses,
             commandAnnotations=command_annotations,
             commandPreconditions=command_preconditions,
+            labwareOffsets=labware_offsets,
         )
         completed_analysis_resource = CompletedAnalysisResource(
             id=completed_analysis.id,
@@ -257,6 +261,7 @@ class AnalysisStore:
             errors=errors,
             liquids=[],
             liquidClasses=[],
+            labwareOffsets=[],
         )
         completed_analysis_resource = CompletedAnalysisResource(
             id=completed_analysis.id,

--- a/robot-server/robot_server/protocols/protocol_analyzer.py
+++ b/robot-server/robot_server/protocols/protocol_analyzer.py
@@ -108,6 +108,7 @@ class ProtocolAnalyzer:
             liquidClasses=result.state_summary.liquidClasses,
             command_annotations=result.command_annotations,
             command_preconditions=result.command_preconditions,
+            labware_offsets=result.state_summary.labwareOffsets,
         )
 
     async def update_to_failed_analysis(
@@ -139,6 +140,7 @@ class ProtocolAnalyzer:
             liquids=[],
             liquidClasses=[],
             command_annotations=[],
+            labware_offsets=[],
         )
 
     def __del__(self) -> None:

--- a/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v6_json_upload.tavern.yaml
@@ -617,6 +617,7 @@ stages:
                 description: Liquid H2O
                 displayColor: '#7332a8'
             liquidClasses: []
+            labwareOffsets: []
 
 ---
 test_name: Upload and analyze a JSONv6 protocol, with liquids

--- a/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_flex.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_flex.tavern.yaml
@@ -224,7 +224,7 @@ stages:
                       moduleId: temperatureModuleId
                     - kind: onCutoutFixture
                       cutoutId: cutoutD1
-                      possibleCutoutFixtureIds: ["temperatureModuleV2"]
+                      possibleCutoutFixtureIds: ['temperatureModuleV2']
                 notes: []
                 startedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
                 completedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
@@ -251,7 +251,12 @@ stages:
                       moduleId: magneticBlockId
                     - kind: onCutoutFixture
                       cutoutId: cutoutD3
-                      possibleCutoutFixtureIds: ["flexStackerModuleV1WithMagneticBlockV1", "magneticBlockV1", "stagingAreaSlotWithMagneticBlockV1"]
+                      possibleCutoutFixtureIds:
+                        [
+                          'flexStackerModuleV1WithMagneticBlockV1',
+                          'magneticBlockV1',
+                          'stagingAreaSlotWithMagneticBlockV1',
+                        ]
                 notes: []
                 startedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
                 completedAt: !re_fullmatch "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+(Z|([+-]\\d{2}:\\d{2}))"
@@ -668,6 +673,7 @@ stages:
                 description: Liquid H2O
                 displayColor: '#7332a8'
             liquidClasses: []
+            labwareOffsets: []
 
 ---
 test_name: Upload and analyze a JSONv8 protocol, with liquids

--- a/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_ot2.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_v8_json_upload_ot2.tavern.yaml
@@ -671,6 +671,7 @@ stages:
                 description: Liquid H2O
                 displayColor: '#7332a8'
             liquidClasses: []
+            labwareOffsets: []
 
 ---
 test_name: Upload and analyze a JSONv8 protocol, with liquids

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -207,6 +207,7 @@ async def test_returned_in_order_added(
             liquids=[],
             liquidClasses=[],
             command_annotations=[],
+            labware_offsets=[],
         )
 
     subject.add_pending(
@@ -273,6 +274,7 @@ async def test_update_adds_details_and_completes_analysis(
         liquids=[],
         liquidClasses=[],
         command_annotations=[command_annotation],
+        labware_offsets=[],
     )
 
     result = await subject.get("analysis-id")
@@ -401,6 +403,7 @@ async def test_update_adds_rtp_values_to_completed_store(
         liquids=[],
         liquidClasses=[],
         command_annotations=[],
+        labware_offsets=[],
     )
     decoy.verify(
         await mock_completed_store.make_room_and_add(
@@ -506,6 +509,7 @@ async def test_update_infers_status_from_errors(
         liquids=[],
         liquidClasses=[],
         command_annotations=[],
+        labware_offsets=[],
     )
     analysis = (await subject.get_by_protocol("protocol-id"))[0]
     assert isinstance(analysis, CompletedAnalysis)

--- a/robot-server/tests/protocols/test_analysis_store.py
+++ b/robot-server/tests/protocols/test_analysis_store.py
@@ -329,6 +329,7 @@ async def test_update_adds_details_and_completes_analysis(
         "commandAnnotations": [
             {"annotationType": "custom", "commandKeys": ["abc", "xyz"]}
         ],
+        "labwareOffsets": [],
     }
 
 

--- a/robot-server/tests/protocols/test_completed_analysis_store.py
+++ b/robot-server/tests/protocols/test_completed_analysis_store.py
@@ -220,6 +220,7 @@ async def test_get_by_analysis_id_as_document(
         "modules": [],
         "pipettes": [],
         "commandAnnotations": [],
+        "labwareOffsets": [],
     }
 
 

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -172,6 +172,20 @@ async def test_analyze(
 
     command_annotation = pe_types.CustomCommandAnnotation(commandKeys=["abc", "xyz"])
     command_preconditions = pe_types.CommandPreconditions(isCameraUsed=False)
+    offset = pe_types.LabwareOffset(
+        id="1234123",
+        createdAt=datetime.now(),
+        definitionUri="opentrons/abcxyz/1",
+        location=pe_types.LegacyLabwareOffsetLocation(
+            slotName=DeckSlotName.SLOT_A1, moduleModel=None, definitionUri=None
+        ),
+        locationSequence=[
+            pe_types.OnAddressableAreaOffsetLocationSequenceComponent(
+                addressableAreaName="A1"
+            )
+        ],
+        vector=pe_types.LabwareOffsetVector(x=1.0, y=2.0, z=3.0),
+    )
 
     orchestrator = decoy.mock(cls=simulating_runner.SimulatingRunOrchestrator)
     decoy.when(
@@ -199,7 +213,7 @@ async def test_analyze(
                 labware=[analysis_labware],
                 pipettes=[analysis_pipette],
                 modules=[],
-                labwareOffsets=[],
+                labwareOffsets=[offset],
                 liquids=[],
                 liquidClasses=[],
                 wells=[],
@@ -229,6 +243,7 @@ async def test_analyze(
             liquidClasses=[],
             command_annotations=[command_annotation],
             command_preconditions=command_preconditions,
+            labware_offsets=[offset],
         )
     )
 
@@ -314,5 +329,6 @@ async def test_analyze_updates_pending_on_error(
             liquids=[],
             liquidClasses=[],
             command_annotations=[],
+            labware_offsets=[],
         ),
     )

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -171,12 +171,18 @@ export type LabwareOffsetLocationSequenceComponent =
 export type LabwareOffsetLocationSequence =
   LabwareOffsetLocationSequenceComponent[]
 
+export interface LegacyLabwareOffsetLocation {
+  slotName: string
+  moduleModel?: ModuleModel
+  definitionUri?: string
+}
+
 export interface LabwareOffsetRecord {
   id: string
   createdAt: string
   definitionUri: string
-  location: LabwareLocation
-  locationSequence: LabwareOffsetLocationSequence
+  location: LegacyLabwareOffsetLocation
+  locationSequence?: LabwareOffsetLocationSequence
   vector: LabwareOffset
 }
 

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -1,4 +1,8 @@
-import type { LoadedLabwareLocation, RunTimeCommand } from '../command/types'
+import type {
+  LabwareLocation,
+  LoadedLabwareLocation,
+  RunTimeCommand,
+} from '../command/types'
 import type { CommandAnnotation } from '../commandAnnotation/types'
 import type { AddressableAreaName, CutoutFixtureId, CutoutId } from '../deck'
 import type {
@@ -143,6 +147,38 @@ export interface Vector3D {
 }
 
 export type LabwareOffset = Vector3D
+
+export interface OnLabwareOffsetLocationSequenceComponent {
+  kind: 'onLabware'
+  labwareUri: string
+}
+
+export interface OnModuleOffsetLocationSequenceComponent {
+  kind: 'onModule'
+  moduleModel: ModuleModel
+}
+
+export interface OnAddressableAreaOffsetLocationSequenceComponent {
+  kind: 'onAddressableArea'
+  addressableAreaName: AddressableAreaName
+}
+
+export type LabwareOffsetLocationSequenceComponent =
+  | OnLabwareOffsetLocationSequenceComponent
+  | OnModuleOffsetLocationSequenceComponent
+  | OnAddressableAreaOffsetLocationSequenceComponent
+
+export type LabwareOffsetLocationSequence =
+  LabwareOffsetLocationSequenceComponent[]
+
+export interface LabwareOffsetRecord {
+  id: string
+  createdAt: string
+  definitionUri: string
+  location: LabwareLocation
+  locationSequence: LabwareOffsetLocationSequence
+  vector: LabwareOffset
+}
 
 // 1. Valid pipette type for a container (i.e. is there multi channel access?)
 // 2. Is the container a tiprack?
@@ -1074,6 +1110,7 @@ export interface CompletedProtocolAnalysis {
   runTimeParameters?: RunTimeParameter[]
   commandAnnotations?: CommandAnnotation[]
   commandPreconditions?: CommandPreconditions
+  labwareOffsets?: LabwareOffsetRecord[]
 }
 
 export interface ResourceFile {

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -1,8 +1,4 @@
-import type {
-  LabwareLocation,
-  LoadedLabwareLocation,
-  RunTimeCommand,
-} from '../command/types'
+import type { LoadedLabwareLocation, RunTimeCommand } from '../command/types'
 import type { CommandAnnotation } from '../commandAnnotation/types'
 import type { AddressableAreaName, CutoutFixtureId, CutoutId } from '../deck'
 import type {

--- a/shared-data/protocol/types/schemaV8/index.ts
+++ b/shared-data/protocol/types/schemaV8/index.ts
@@ -2,6 +2,7 @@ import type { CreateCommand } from '../../../command/types'
 import type { CommandAnnotation } from '../../../commandAnnotation/types'
 import type {
   CommandPreconditions,
+  LabwareOffsetRecord,
   Liquid,
   LoadedLabware,
   LoadedModule,
@@ -192,6 +193,7 @@ export interface ProtocolAnalysisOutput {
   robotType?: RobotType
   commandAnnotations?: CommandAnnotation[]
   commandPreconditions?: CommandPreconditions
+  labwareOffsets?: LabwareOffsetRecord[]
   result: 'ok' | 'not-ok' | 'error' | 'parameter-value-required'
 }
 


### PR DESCRIPTION
# Overview

Protocol run records offer a view of all labware offsets that were loaded into a run. Protocol _analyses_ however do not, for some reason. Likely this was because when we run analysis, we don't load offsets from the user's robot (there may not be one, after all, and even if there is we want a more general view) - but the protocol itself may load offsets through the use of `set_offset()`.

The app really wants to know which labware have offsets set through `set_offset()`; we display UI about them to note that doing LPC for them is pointless. Today, that happens by looking at the `labware` key of the protocol analysis, and displaying that UI for any labware that have an offset ID set in the analysis.

The thing is, the `labware` key essentially captures a snapshot of the engine's labware state at the point where the analysis ends. Since offsets are based on the current location of a labware, if the labware was in previous locations that (did or didn't) have an offset and ends the protocol in a position that (doesn't or does) have an offset, then the offset ID being present or absent is meaningless - in general, information in the `labware` key just isn't generally applicable to its contents throughout the protocol. This leads to many bugs about when labware is displayed in the app as having a hardcoded offset.

Since we actually have the information, let's just... put it in the analysis. This PR adds a `labwareOffsets` key to analysis records, just like the run records have, that contains the same information as the run records. In the common case of a protocol having no `set_offset()` calls, the key will be empty, because the client isn't loading in a bunch of offsets; but if the protocol uses `set_offset()`, the resulting labware offset with its ID, the labware URI to which it applies, and the location (by vector and by dict) to which it applies will be present in the analysis for each offset that was set, including those that are no longer in active use by the time the protocol ends.

## Test Plan and Hands on Testing

- [x] Run the analysis CLI on a protocol that uses `set_offset()` and check that the offset is included
- [x] Put the branch on a robot with pre-existing analyses and check that stored analyses without the key are still rendered (the default is to have an empty list)
- [x] Put the branch on a robot and upload a protocol that uses set_offset; check that the offset is included in the analysis

## Changelog

- Add `labwareOffsets: List[LabwareOffset]` to the analysis CLI results object and the robot server analysis results object
- Add TS types in `shared-data` that list the new key as optional so it can handle previously-generated analyses

## Review requests

- Just whether this is a good idea, I guess? see the risk assessment for more, but this adds data that already exists in the engine state store to the analysis docs without altering it in any way.

## Risk assessment

Low on the face of it, maybe medium for altering analysis schemata that apply to stored analyses.

This doesn't actually close the below ticket but it does pertain to it.

Closes EXEC-2418