### PR TITLE
fix(protocol-designer): set nozzleConfiguration to ALL when undefined

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/PipetteNozzleSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/PipetteNozzleSelector.tsx
@@ -48,10 +48,8 @@ export function PipetteNozzleSelector(
   const { pipetteSpecs, propsForFields, robotType } = props
   const { channels, displayName } = pipetteSpecs
   const { t } = useTranslation('protocol_steps')
-  const singleChannel = channels === 1
-  const nozzleConfiguration = singleChannel
-    ? ALL
-    : (propsForFields.nozzles.value as NozzleConfigurationStyle)
+  const nozzleConfiguration =
+    (propsForFields.nozzles?.value as NozzleConfigurationStyle) ?? ALL
   const primaryNozzle =
     (propsForFields.primaryNozzle?.value as PrimaryNozzleConfigurationStyle) ??
     A1_NOZZLE

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/PipetteNozzleSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/PipetteNozzleSelector.tsx
@@ -48,9 +48,10 @@ export function PipetteNozzleSelector(
   const { pipetteSpecs, propsForFields, robotType } = props
   const { channels, displayName } = pipetteSpecs
   const { t } = useTranslation('protocol_steps')
-
-  const nozzleConfiguration = propsForFields.nozzles
-    .value as NozzleConfigurationStyle
+  const singleChannel = channels === 1
+  const nozzleConfiguration = singleChannel
+    ? ALL
+    : (propsForFields.nozzles.value as NozzleConfigurationStyle)
   const primaryNozzle =
     (propsForFields.primaryNozzle?.value as PrimaryNozzleConfigurationStyle) ??
     A1_NOZZLE


### PR DESCRIPTION
# Overview

When a nozzleConfiguration is undefined, default it to `ALL`

This reduces redundancy for the user and also fixes a misalignment but between the nozzle and pipette shadow

## Test Plan and Hands on Testing

- Created a protocol with a 1ch and confirmed that the radio button for nozzle configuration was selected
[1ch_protocol.py](https://github.com/user-attachments/files/26194527/1ch_protocol.py)
https://github.com/user-attachments/assets/39ab9b29-c4b7-4406-b4ee-df869717e856
- checked nozzle alignment in well selector

## Changelog

- sets nozzleConfiguration to `ALL` when undefined


## Review requests

None

## Risk assessment

low

Closes RQA-5258, RQA-5255