### PR TITLE
feat(api): Create the peripheral discovery layer and implement the barcode scanner

### DIFF
--- a/api/src/opentrons/drivers/barcode_scanner/__init__.py
+++ b/api/src/opentrons/drivers/barcode_scanner/__init__.py
@@ -1,5 +1,6 @@
 from .abstract import AbstractBarcodeScannerDriver
 from .rtscanner_driver import RTScanner
+from .simulator import BarcodeSimulatorDriver
 from .types import BarcodeModuleInfo, SoundProfile
 
 __all__ = [
@@ -7,4 +8,5 @@ __all__ = [
     "SoundProfile",
     "BarcodeModuleInfo",
     "RTScanner",
+    "BarcodeSimulatorDriver",
 ]

--- a/api/src/opentrons/hardware_control/abstract_device.py
+++ b/api/src/opentrons/hardware_control/abstract_device.py
@@ -1,0 +1,125 @@
+import abc
+import asyncio
+from typing import Any, Mapping, Optional
+
+from .execution_manager import ExecutionManager
+from .modules.types import (
+    ModuleDisconnectedCallback,
+    ModuleErrorCallback,
+)
+from opentrons.drivers.rpi_drivers.types import USBPort
+
+
+class AbstractDevice(abc.ABC):
+    @classmethod
+    @abc.abstractmethod
+    async def build(
+        cls,
+        port: str,
+        usb_port: USBPort,
+        hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
+        poll_interval_seconds: float | None = None,
+        simulating: bool = False,
+        sim_model: Optional[str] = None,
+        sim_serial_number: Optional[str] = None,
+    ) -> "AbstractDevice":
+        """Devices should always be created using this factory.
+
+        This lets the (perhaps blocking) work of connecting to and initializing
+        a device be in a place that can be async.
+        """
+
+    @property
+    @abc.abstractmethod
+    def loop(self) -> asyncio.AbstractEventLoop: ...
+
+    @abc.abstractmethod
+    def disconnected_callback(self) -> None:
+        """Called from within the module object to signify the object is no longer connected"""
+        ...
+
+    @abc.abstractmethod
+    def error_callback(self, exc: Exception) -> None:
+        """Called from within the module object when an asynchronous hardware error occurrs."""
+        ...
+
+    @abc.abstractmethod
+    async def wait_for_is_running(self) -> None: ...
+
+    @abc.abstractmethod
+    async def deactivate(self, must_be_running: bool = True) -> None:
+        """Deactivate the module.
+
+        Contains an override to the `wait_for_is_running` step in cases where the
+        module must be deactivated regardless of context."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def status(self) -> str:
+        """Return some string describing status."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def device_info(self) -> Mapping[str, str]:
+        """Return a dict of the module's static information (serial, etc)"""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def is_simulated(self) -> bool:
+        """True if >this is a simulated module."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def port(self) -> str:
+        """The virtual port where the module is connected."""
+        ...
+
+    @property
+    @abc.abstractmethod
+    def usb_port(self) -> USBPort:
+        """The physical port where the module is connected."""
+        ...
+
+    @property
+    @abc.abstractmethod
+    def serial_number(self) -> Optional[str]:
+        """The usb serial number of this device."""
+        ...
+
+    @abc.abstractmethod
+    def model(self) -> str:
+        """A name for this specific module, matching module defs"""
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def name(cls) -> str:
+        """A shortname used for matching usb ports, among other things"""
+        pass
+
+    async def cleanup(self) -> None:
+        """Clean up the module instance.
+
+        Clean up, i.e. stop pollers, disconnect serial, etc in preparation for
+        object destruction.
+        """
+        pass
+
+    def event_listener(self, event: Any) -> None:
+        """Listen for events and update the module state."""
+        pass
+
+    async def identify(self, start: bool, color_name: Optional[str] = None) -> None:
+        """Identify the module."""
+        pass
+
+    def cleanup_persistent(self) -> None:
+        """Reset any persistent data on the module that should not exist outside of a run."""
+        pass

--- a/api/src/opentrons/hardware_control/api.py
+++ b/api/src/opentrons/hardware_control/api.py
@@ -1329,7 +1329,7 @@ class API(  # type: ignore[misc]
     ) -> modules.AbstractModule:
         """Get a simulating module hardware API interface for the given model."""
 
-        return await self._backend.module_controls.register_simulated_module(
+        module = await self._backend.module_controls.register_simulated_device(
             simulated_usb_port=USBPort(
                 name="", port_number=1, port_group=PortGroup.MAIN
             ),
@@ -1337,6 +1337,8 @@ class API(  # type: ignore[misc]
             sim_model=model.value,
             sim_serial=sim_serial,
         )
+        assert isinstance(module, modules.AbstractModule)
+        return module
 
     def get_instrument_max_height(
         self, mount: top_types.Mount, critical_point: Optional[CriticalPoint] = None

--- a/api/src/opentrons/hardware_control/backends/controller.py
+++ b/api/src/opentrons/hardware_control/backends/controller.py
@@ -292,7 +292,7 @@ class Controller:
                 event_name = event.name
                 flags = aionotify.Flags.parse(event.flags)
                 event_description = AionotifyEvent.build(event_name, flags)
-                await self.module_controls.handle_module_appearance(event_description)
+                await self.module_controls.handle_device_appearance(event_description)
 
     async def watch(self, loop: asyncio.AbstractEventLoop) -> None:
         can_watch = aionotify is not None

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -1316,7 +1316,7 @@ class OT3Controller(FlexBackend):
             if "ot_module" in event.name:
                 event_name = event.name
                 event_description = AionotifyEvent.build(event_name, flags)
-                await self.module_controls.handle_module_appearance(event_description)
+                await self.module_controls.handle_device_appearance(event_description)
 
     async def watch(self, loop: asyncio.AbstractEventLoop) -> None:
         can_watch = aionotify is not None

--- a/api/src/opentrons/hardware_control/backends/ot3simulator.py
+++ b/api/src/opentrons/hardware_control/backends/ot3simulator.py
@@ -623,7 +623,9 @@ class OT3Simulator(FlexBackend):
                         model=module_details.model,
                     )
                 )
-        await self.module_controls.register_modules(new_mods_at_ports=new_mods_at_ports)
+        await self.module_controls.register_devices(
+            new_devices_at_ports=new_mods_at_ports
+        )
 
     @property
     def axis_bounds(self) -> OT3AxisMap[Tuple[float, float]]:

--- a/api/src/opentrons/hardware_control/backends/simulator.py
+++ b/api/src/opentrons/hardware_control/backends/simulator.py
@@ -346,7 +346,9 @@ class Simulator:
                         model=module_details.model,
                     )
                 )
-        await self.module_controls.register_modules(new_mods_at_ports=new_mods_at_ports)
+        await self.module_controls.register_devices(
+            new_devices_at_ports=new_mods_at_ports
+        )
 
     @contextmanager
     def save_current(self) -> Iterator[None]:

--- a/api/src/opentrons/hardware_control/device.py
+++ b/api/src/opentrons/hardware_control/device.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Dict, Optional, Type, Union
+from typing import Dict, Optional, Union
 
 from . import modules, peripherals
 from .execution_manager import ExecutionManager

--- a/api/src/opentrons/hardware_control/device.py
+++ b/api/src/opentrons/hardware_control/device.py
@@ -1,0 +1,54 @@
+import asyncio
+from typing import Dict, Optional, Type, Union
+
+from . import modules, peripherals
+from .execution_manager import ExecutionManager
+from .modules.types import (
+    ModuleDisconnectedCallback,
+    ModuleErrorCallback,
+)
+from opentrons.drivers.rpi_drivers.types import USBPort
+
+DeviceType = Union[modules.ModuleType, peripherals.PeripheralType]
+
+AbstractDevice = Union[modules.AbstractModule, peripherals.AbstractPeripheral]
+
+
+async def build_attached_device(
+    port: str,
+    type: DeviceType,
+    simulating: bool,
+    usb_port: USBPort,
+    hw_control_loop: asyncio.AbstractEventLoop,
+    execution_manager: ExecutionManager,
+    disconnected_callback: ModuleDisconnectedCallback,
+    error_callback: ModuleErrorCallback,
+    sim_model: Optional[str] = None,
+    sim_serial_number: Optional[str] = None,
+) -> AbstractDevice:
+    if isinstance(type, modules.ModuleType):
+        return await modules.build(
+            port=port,
+            type=type,
+            usb_port=usb_port,
+            simulating=simulating,
+            hw_control_loop=hw_control_loop,
+            execution_manager=execution_manager,
+            disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
+            sim_model=sim_model,
+            sim_serial_number=sim_serial_number,
+        )
+    else:
+        return await peripherals.build(
+            port=port,
+            type=type,
+            usb_port=usb_port,
+            simulating=simulating,
+            hw_control_loop=hw_control_loop,
+            execution_manager=execution_manager,
+            disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
+            sim_model=sim_model,
+            sim_serial_number=sim_serial_number,
+        )

--- a/api/src/opentrons/hardware_control/device.py
+++ b/api/src/opentrons/hardware_control/device.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import Dict, Optional, Union
 
 from . import modules, peripherals
+from .abstract_device import AbstractDevice
 from .execution_manager import ExecutionManager
 from .modules.types import (
     ModuleDisconnectedCallback,
@@ -10,8 +11,6 @@ from .modules.types import (
 from opentrons.drivers.rpi_drivers.types import USBPort
 
 DeviceType = Union[modules.ModuleType, peripherals.PeripheralType]
-
-AbstractDevice = Union[modules.AbstractModule, peripherals.AbstractPeripheral]
 
 DEVICE_TYPE_BY_NAME: Dict[
     str, Union[peripherals.PeripheralType, modules.ModuleType]

--- a/api/src/opentrons/hardware_control/device.py
+++ b/api/src/opentrons/hardware_control/device.py
@@ -13,6 +13,13 @@ DeviceType = Union[modules.ModuleType, peripherals.PeripheralType]
 
 AbstractDevice = Union[modules.AbstractModule, peripherals.AbstractPeripheral]
 
+DEVICE_TYPE_BY_NAME: Dict[
+    str, Union[peripherals.PeripheralType, modules.ModuleType]
+] = {
+    **modules.MODULE_TYPE_BY_NAME,
+    **peripherals.PERIPHERAL_TYPE_BY_NAME,
+}
+
 
 async def build_attached_device(
     port: str,

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -9,9 +9,9 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Union
 from opentrons_shared_data.errors.exceptions import EnumeratedError
 
 from . import modules, peripherals
+from .abstract_device import AbstractDevice
 from .device import (
     DEVICE_TYPE_BY_NAME,
-    AbstractDevice,
     DeviceType,
     build_attached_device,
 )

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -9,7 +9,12 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Union
 from opentrons_shared_data.errors.exceptions import EnumeratedError
 
 from . import modules, peripherals
-from .device import AbstractDevice, DeviceType, build_attached_device
+from .device import (
+    DEVICE_TYPE_BY_NAME,
+    AbstractDevice,
+    DeviceType,
+    build_attached_device,
+)
 from .types import (
     AionotifyEvent,
     AsynchronousModuleErrorNotification,
@@ -87,7 +92,7 @@ class AttachedModulesControl:
         if not IS_ROBOT and not api.is_simulator:
             # Start task that registers emulated modules.
             self._emulation_listen_task: asyncio.Task[None] | None = (
-                api.loop.create_task(listen_module_connection(self.register_modules))
+                api.loop.create_task(listen_module_connection(self.register_devices))
             )
         else:
             self._emulation_listen_task = None
@@ -112,9 +117,8 @@ class AttachedModulesControl:
         )
 
         if not api_instance.is_simulator:
-            # Do an initial scan of modules.
-            await mc_instance.register_modules(mc_instance.scan())
-            await mc_instance.register_peripherals(mc_instance.scan_peripherals())
+            # Do an initial scan of devices.
+            await mc_instance.register_devices(mc_instance.scan())
 
         return mc_instance
 
@@ -198,7 +202,7 @@ class AttachedModulesControl:
         """Used by the module to indicate that it was disconnected and should be deleted."""
         mod = ModuleAtPort(port=port, serial=serial, name="")
         asyncio.run_coroutine_threadsafe(
-            self.unregister_modules([mod]),
+            self.unregister_devices([mod]),
             self._api.loop,
         )
         try:
@@ -238,26 +242,32 @@ class AttachedModulesControl:
                 f"Async error callback for module {model} {serial} at {port} for exc {exc} failed"
             )
 
-    async def unregister_modules(
+    async def unregister_devices(
         self,
-        mods_at_ports: Union[
+        devices_at_ports: Union[
             List[modules.ModuleAtPort], List[modules.SimulatingModuleAtPort]
         ],
     ) -> None:
         """
-        De-register Modules.
+        De-register Devices.
 
         Remove any modules that are no longer found by aionotify.
         """
         removed_modules = []
-        for mod in mods_at_ports:
+        removed_peripherals = []
+        for dev in devices_at_ports:
             for attached_mod in self.available_modules:
                 if (
-                    attached_mod.serial_number == mod.serial
-                    or attached_mod.port == mod.port
+                    attached_mod.serial_number == dev.serial
+                    or attached_mod.port == dev.port
                 ):
                     removed_modules.append(attached_mod)
-
+            for attached_per in self.available_peripherals:
+                if (
+                    attached_per.serial_number == dev.serial
+                    or attached_per.port == dev.port
+                ):
+                    removed_peripherals.append(attached_per)
         for removed_mod in removed_modules:
             try:
                 self._available_modules.remove(removed_mod)
@@ -269,36 +279,6 @@ class AttachedModulesControl:
                 log.warning(
                     f"Removed Module {removed_mod} not found in attached modules"
                 )
-
-        for removed_mod in removed_modules:
-            log.info(
-                f"Module {removed_mod.name()} detached from port {removed_mod.port}"
-            )
-            await removed_mod.cleanup()
-        self._available_modules = sorted(
-            self._available_modules, key=modules.AbstractModule.sort_key
-        )
-
-    async def unregister_peripherals(
-        self,
-        pers_at_ports: Union[
-            List[modules.ModuleAtPort], List[modules.SimulatingModuleAtPort]
-        ],
-    ) -> None:
-        """
-        De-register Modules.
-
-        Remove any modules that are no longer found by aionotify.
-        """
-        removed_peripherals = []
-        for mod in pers_at_ports:
-            for attached_per in self.available_peripherals:
-                if (
-                    attached_per.serial_number == mod.serial
-                    or attached_per.port == mod.port
-                ):
-                    removed_peripherals.append(attached_per)
-
         for removed_peripheral in removed_peripherals:
             try:
                 self._available_peripherals.remove(removed_peripheral)
@@ -310,110 +290,76 @@ class AttachedModulesControl:
                 log.warning(
                     f"Removed Module {removed_peripheral} not found in attached modules"
                 )
-
+        for removed_mod in removed_modules:
+            log.info(
+                f"Module {removed_mod.name()} detached from port {removed_mod.port}"
+            )
+            await removed_mod.cleanup()
         for removed_peripheral in removed_peripherals:
             log.info(
-                f"Module {removed_peripheral.name()} detached from port {removed_peripheral.port}"
+                f"Peripheral {removed_peripheral.name()} detached from port {removed_peripheral.port}"
             )
             await removed_peripheral.cleanup()
         self._available_modules = sorted(
             self._available_modules, key=modules.AbstractModule.sort_key
         )
-
-    async def register_peripherals(
-        self,
-        new_per_at_ports: Optional[
-            Union[List[modules.ModuleAtPort], List[modules.SimulatingModuleAtPort]]
-        ] = None,
-        removed_per_at_ports: Optional[List[modules.ModuleAtPort]] = None,
-    ) -> None:
-        if new_per_at_ports is None:
-            new_per_at_ports = []
-        if removed_per_at_ports is None:
-            removed_per_at_ports = []
-
-        # destroy removed mods
-        await self.unregister_peripherals(removed_per_at_ports)
-        unsorted_per_at_port = self._usb.match_virtual_ports(new_per_at_ports)
-        # build new peripherals
-        for per in unsorted_per_at_port:
-            try:
-                new_instance = await self.build_device(
-                    port=per.port,
-                    usb_port=per.usb_port,
-                    type=peripherals.PERIPHERAL_TYPE_BY_NAME[per.name],
-                    sim_serial_number=(
-                        per.serial_number
-                        if isinstance(per, SimulatingModuleAtPort)
-                        else None
-                    ),
-                    sim_model=(
-                        per.model if isinstance(per, SimulatingModuleAtPort) else None
-                    ),
-                )
-                assert isinstance(new_instance, peripherals.AbstractPeripheral)
-                self._available_peripherals.append(new_instance)
-                log.info(
-                    f"Peripheral {per.name} discovered and attached"
-                    f" at port {per.port}, new_instance: {new_instance}"
-                )
-            except Exception as e:
-                log.exception(
-                    f"Failed to build peripheral {per.name} at port {per.port}: {e}"
-                )
         self._available_peripherals = sorted(
             self._available_peripherals, key=peripherals.AbstractPeripheral.sort_key
         )
 
-    async def register_modules(
+    async def register_devices(
         self,
-        new_mods_at_ports: Optional[
+        new_devices_at_ports: Optional[
             Union[List[modules.ModuleAtPort], List[modules.SimulatingModuleAtPort]]
         ] = None,
-        removed_mods_at_ports: Optional[List[modules.ModuleAtPort]] = None,
+        removed_devices_at_ports: Optional[List[modules.ModuleAtPort]] = None,
     ) -> None:
-        """
-        Register Modules.
-
-        Upon system recognition of a module being plugged in, we should
-        register that module and de-register any modules that are
-        no longer found on the system.
-        """
-        if new_mods_at_ports is None:
-            new_mods_at_ports = []
-        if removed_mods_at_ports is None:
-            removed_mods_at_ports = []
-
+        if new_devices_at_ports is None:
+            new_devices_at_ports = []
+        if removed_devices_at_ports is None:
+            removed_devices_at_ports = []
         # destroy removed mods
-        await self.unregister_modules(removed_mods_at_ports)
-        unsorted_mods_at_port = self._usb.match_virtual_ports(new_mods_at_ports)
-
-        # build new mods
-        for mod in unsorted_mods_at_port:
+        await self.unregister_devices(removed_devices_at_ports)
+        unsorted_device_at_port = self._usb.match_virtual_ports(
+            removed_devices_at_ports
+        )
+        for device in unsorted_device_at_port:
             try:
                 new_instance = await self.build_device(
-                    port=mod.port,
-                    usb_port=mod.usb_port,
-                    type=modules.MODULE_TYPE_BY_NAME[mod.name],
+                    port=device.port,
+                    usb_port=device.usb_port,
+                    type=DEVICE_TYPE_BY_NAME[device.name],
                     sim_serial_number=(
-                        mod.serial_number
-                        if isinstance(mod, SimulatingModuleAtPort)
+                        device.serial_number
+                        if isinstance(device, SimulatingModuleAtPort)
                         else None
                     ),
                     sim_model=(
-                        mod.model if isinstance(mod, SimulatingModuleAtPort) else None
+                        device.model
+                        if isinstance(device, SimulatingModuleAtPort)
+                        else None
                     ),
                 )
-                assert isinstance(new_instance, modules.AbstractModule)
-                self._available_modules.append(new_instance)
-                log.info(
-                    f"Module {mod.name} discovered and attached"
-                    f" at port {mod.port}, new_instance: {new_instance}"
-                )
+                if isinstance(new_instance, peripherals.AbstractPeripheral):
+                    self._available_peripherals.append(new_instance)
+                    log.info(
+                        f"Peripheral {device.name} discovered and attached"
+                        f" at port {device.port}, new_instance: {new_instance}"
+                    )
+                else:
+                    assert isinstance(new_instance, modules.AbstractModule)
+                    self._available_modules.append(new_instance)
+                    log.info(
+                        f"Module {device.name} discovered and attached"
+                        f" at port {device.port}, new_instance: {new_instance}"
+                    )
             except Exception as e:
                 log.exception(
-                    f"Failed to build module {mod.name} at port {mod.port}: {e}"
+                    f"Failed to build device {device.name} at port {device.port}: {e}"
                 )
+        self._available_peripherals = sorted(
+            self._available_peripherals, key=peripherals.AbstractPeripheral.sort_key
+        )
         self._available_modules = sorted(
             self._available_modules, key=modules.AbstractModule.sort_key
         )
@@ -431,32 +377,15 @@ class AttachedModulesControl:
 
         for port in devices:
             symlink_port = port.split("dev/")[1]
+            peripheral_at_port = self.get_peripheral_at_port(symlink_port)
             module_at_port = self.get_module_at_port(symlink_port)
             if module_at_port:
                 discovered_modules.append(module_at_port)
-
-        log.debug("Discovered modules: {}".format(discovered_modules))
-        return discovered_modules
-
-    def scan_peripherals(self) -> List[modules.ModuleAtPort]:
-        """Scan for connected peripherals and return list of
-        tuples of serial ports and device names
-        """
-        if IS_ROBOT and IS_LINUX:
-            devices = glob("/dev/ot_module*")
-        else:
-            devices = []
-
-        discovered_peripherals = []
-
-        for port in devices:
-            symlink_port = port.split("dev/")[1]
-            peripheral_at_port = self.get_peripheral_at_port(symlink_port)
             if peripheral_at_port:
-                discovered_peripherals.append(peripheral_at_port)
+                discovered_modules.append(peripheral_at_port)
 
-        log.debug("Discovered peripherals: {}".format(discovered_peripherals))
-        return discovered_peripherals
+        log.debug("Discovered devices: {}".format(discovered_modules))
+        return discovered_modules
 
     @staticmethod
     def get_module_at_port(port: str) -> Optional[modules.ModuleAtPort]:
@@ -499,92 +428,49 @@ class AttachedModulesControl:
         """
         maybe_module_at_port = self.get_module_at_port(event.name)
         maybe_peripheral_at_port = self.get_peripheral_at_port(event.name)
-        if maybe_module_at_port is not None:
-            await self.handle_module_appearance(event, maybe_module_at_port)
-        if maybe_peripheral_at_port is not None:
-            await self.handle_peripheral_appearance(event, maybe_peripheral_at_port)
+        maybe_device_at_port = maybe_module_at_port or maybe_peripheral_at_port or None
+        new_devices = None
+        removed_devices = None
+        if maybe_device_at_port is not None:
+            if hasattr(event.flags, "DELETE") or hasattr(event.flags, "MOVED_FROM"):
+                # NOTE: The absorbance reader is a hidraw device, when we first
+                # plug it into the Flex, udev rules create a
+                # /dev/ot_module_absorbancereader(n) symlink which aionotify
+                # detects as a CREATE event and registers an absorbance module.
+                # When we create this Absorbance module and connect to it,
+                # the Byonoy library opens the device via hidapi which removes
+                # the symlink and triggers a DELETE action from aionoify.
+                # When the device is deleted, we disconnect from it causing
+                # the /dev/ot_module_absorbance(n) symlink to get created, repeating
+                # the cycle.
 
-    async def handle_peripheral_appearance(
-        self, event: AionotifyEvent, maybe_peripheral_at_port: modules.ModuleAtPort
-    ) -> None:
-        """Only called upon availability of aionotify. Check that
-        the file system has changed and either remove or add peripheral
-        depending on the result.
-
-        Args:
-            event: The event passed from aionotify.
-
-        Returns:
-            None
-        """
-        new_peripherals = None
-        removed_peripherals = None
-        if hasattr(event.flags, "DELETE") or hasattr(event.flags, "MOVED_FROM"):
-            removed_peripherals = [maybe_peripheral_at_port]
-        elif hasattr(event.flags, "CREATE") or hasattr(event.flags, "MOVED_TO"):
-            new_peripherals = [maybe_peripheral_at_port]
-        try:
-            await self.register_peripherals(
-                removed_per_at_ports=removed_peripherals,
-                new_per_at_ports=new_peripherals,
-            )
-        except Exception:
-            log.exception("Exception in Module registration")
-
-    async def handle_module_appearance(
-        self, event: AionotifyEvent, maybe_module_at_port: modules.ModuleAtPort
-    ) -> None:
-        """Only called upon availability of aionotify. Check that
-        the file system has changed and either remove or add modules
-        depending on the result.
-
-        Args:
-            event: The event passed from aionotify.
-
-        Returns:
-            None
-        """
-        new_modules = None
-        removed_modules = None
-        if hasattr(event.flags, "DELETE") or hasattr(event.flags, "MOVED_FROM"):
-            # NOTE: The absorbance reader is a hidraw device, when we first
-            # plug it into the Flex, udev rules create a
-            # /dev/ot_module_absorbancereader(n) symlink which aionotify
-            # detects as a CREATE event and registers an absorbance module.
-            # When we create this Absorbance module and connect to it,
-            # the Byonoy library opens the device via hidapi which removes
-            # the symlink and triggers a DELETE action from aionoify.
-            # When the device is deleted, we disconnect from it causing
-            # the /dev/ot_module_absorbance(n) symlink to get created, repeating
-            # the cycle.
-
-            # This DELETE action would normally delete the device, but in this case
-            # Lets ignore these events for the absorbance reader and handle
-            # cleanup when the poller attempts to read data and fails.
-            if maybe_module_at_port.name == "absorbancereader":
-                return
-            removed_modules = [maybe_module_at_port]
-            log.info(f"Module Removed: {maybe_module_at_port}")
-        elif hasattr(event.flags, "CREATE") or hasattr(event.flags, "MOVED_TO"):
-            # NOTE: Absorbance reader gets disonnected when updating, so
-            # if the device is updating, dont create a new instance.
-            for module in self._available_modules:
-                if (
-                    maybe_module_at_port.name == "absorbancereader"
-                    and isinstance(module, AbsorbanceReader)
-                    and module.updating
-                ):
+                # This DELETE action would normally delete the device, but in this case
+                # Lets ignore these events for the absorbance reader and handle
+                # cleanup when the poller attempts to read data and fails.
+                if maybe_device_at_port.name == "absorbancereader":
                     return
+                removed_devices = [maybe_device_at_port]
+                log.info(f"Device Removed: {maybe_device_at_port}")
+            elif hasattr(event.flags, "CREATE") or hasattr(event.flags, "MOVED_TO"):
+                # NOTE: Absorbance reader gets disonnected when updating, so
+                # if the device is updating, dont create a new instance.
+                for module in self._available_modules:
+                    if (
+                        maybe_device_at_port.name == "absorbancereader"
+                        and isinstance(module, AbsorbanceReader)
+                        and module.updating
+                    ):
+                        return
 
-            new_modules = [maybe_module_at_port]
-            log.info(f"Module Added: {maybe_module_at_port}")
-        try:
-            await self.register_modules(
-                removed_mods_at_ports=removed_modules,
-                new_mods_at_ports=new_modules,
-            )
-        except Exception:
-            log.exception("Exception in Module registration")
+                new_devices = [maybe_device_at_port]
+                log.info(f"Device Added: {maybe_device_at_port}")
+            try:
+                await self.register_devices(
+                    removed_devices_at_ports=removed_devices,
+                    new_devices_at_ports=new_devices,
+                )
+            except Exception:
+                log.exception("Exception in Device registration")
 
     def get_module_by_module_id(
         self, module_id: str

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -320,7 +320,6 @@ class AttachedModulesControl:
             new_per_at_ports = []
         if removed_per_at_ports is None:
             removed_per_at_ports = []
-        self._new_per_at_ports = new_per_at_ports
         unsorted_per_at_port = self._usb.match_virtual_ports(new_per_at_ports)
         # build new peripherals
         for per in unsorted_per_at_port:
@@ -372,7 +371,6 @@ class AttachedModulesControl:
 
         # destroy removed mods
         await self.unregister_modules(removed_mods_at_ports)
-        self._new_mods_at_ports = new_mods_at_ports
         unsorted_mods_at_port = self._usb.match_virtual_ports(new_mods_at_ports)
 
         # build new mods

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -51,6 +51,17 @@ MODULE_PORT_REGEX = re.compile(
     + r"\d+(?!\.tmp-c\d+:\d+)",
     re.I,
 )
+PERIPHERAL_PORT_REGEX = re.compile(
+    # add a negative lookbehind to suppress matches on OT-2 tempfiles udev creates
+    r"(?<!\.#ot_module_)"
+    # capture all modules by name using alternation
+    + "("
+    + "|".join(peripherals.PERIPHERAL_TYPE_BY_NAME.keys())
+    + ")"
+    # add a negative lookahead to suppress matches on Flex tempfiles udev creates
+    + r"\d+(?!\.tmp-c\d+:\d+)",
+    re.I,
+)
 
 PERIPHERALS = ["barcodescanner"]
 
@@ -102,6 +113,7 @@ class AttachedModulesControl:
         if not api_instance.is_simulator:
             # Do an initial scan of modules.
             await mc_instance.register_modules(mc_instance.scan())
+            await mc_instance.register_peripherals(mc_instance.scan_peripherals())
 
         return mc_instance
 
@@ -412,6 +424,26 @@ class AttachedModulesControl:
         log.debug("Discovered modules: {}".format(discovered_modules))
         return discovered_modules
 
+    def scan_peripherals(self) -> List[modules.ModuleAtPort]:
+        """Scan for connected peripherals and return list of
+        tuples of serial ports and device names
+        """
+        if IS_ROBOT and IS_LINUX:
+            devices = glob("/dev/ot_module*")
+        else:
+            devices = []
+
+        discovered_peripherals = []
+
+        for port in devices:
+            symlink_port = port.split("dev/")[1]
+            peripheral_at_port = self.get_peripheral_at_port(symlink_port)
+            if peripheral_at_port:
+                discovered_peripherals.append(peripheral_at_port)
+
+        log.debug("Discovered peripherals: {}".format(discovered_peripherals))
+        return discovered_peripherals
+
     @staticmethod
     def get_module_at_port(port: str) -> Optional[modules.ModuleAtPort]:
         """Given a port, returns either a ModuleAtPort
@@ -426,7 +458,68 @@ class AttachedModulesControl:
             return modules.ModuleAtPort(port=f"/dev/{port}", name=name)
         return None
 
-    async def handle_module_appearance(self, event: AionotifyEvent) -> None:
+    @staticmethod
+    def get_peripheral_at_port(port: str) -> Optional[modules.ModuleAtPort]:
+        """Given a port, returns either a ModuleAtPort
+        if it is a recognized peripheral, or None if not recognized.
+        """
+        match = PERIPHERAL_PORT_REGEX.search(port)
+        if match:
+            name = match.group(1).lower()
+            if name not in peripherals.PERIPHERAL_TYPE_BY_NAME:
+                log.warning(f"Unexpected peripheral connected: {name} on {port}")
+                return None
+            return modules.ModuleAtPort(port=f"/dev/{port}", name=name)
+        return None
+
+    async def handle_device_appearance(self, event: AionotifyEvent) -> None:
+        """Only called upon availability of aionotify. Check that
+        the file system has changed and either remove or add devices
+        depending on the result.
+
+        Args:
+            event: The event passed from aionotify.
+
+        Returns:
+            None
+        """
+        maybe_module_at_port = self.get_module_at_port(event.name)
+        maybe_peripheral_at_port = self.get_peripheral_at_port(event.name)
+        if maybe_module_at_port is not None:
+            await self.handle_module_appearance(event, maybe_module_at_port)
+        if maybe_peripheral_at_port is not None:
+            await self.handle_peripheral_appearance(event, maybe_peripheral_at_port)
+
+    async def handle_peripheral_appearance(
+        self, event: AionotifyEvent, maybe_peripheral_at_port: modules.ModuleAtPort
+    ) -> None:
+        """Only called upon availability of aionotify. Check that
+        the file system has changed and either remove or add peripheral
+        depending on the result.
+
+        Args:
+            event: The event passed from aionotify.
+
+        Returns:
+            None
+        """
+        new_peripherals = None
+        removed_peripherals = None
+        if hasattr(event.flags, "DELETE") or hasattr(event.flags, "MOVED_FROM"):
+            removed_peripherals = [maybe_peripheral_at_port]
+        elif hasattr(event.flags, "CREATE") or hasattr(event.flags, "MOVED_TO"):
+            new_peripherals = [maybe_peripheral_at_port]
+        try:
+            await self.register_peripherals(
+                removed_per_at_ports=removed_peripherals,
+                new_per_at_ports=new_peripherals,
+            )
+        except Exception:
+            log.exception("Exception in Module registration")
+
+    async def handle_module_appearance(
+        self, event: AionotifyEvent, maybe_module_at_port: modules.ModuleAtPort
+    ) -> None:
         """Only called upon availability of aionotify. Check that
         the file system has changed and either remove or add modules
         depending on the result.
@@ -437,55 +530,47 @@ class AttachedModulesControl:
         Returns:
             None
         """
-        maybe_module_at_port = self.get_module_at_port(event.name)
         new_modules = None
         removed_modules = None
-        if maybe_module_at_port is not None:
-            if hasattr(event.flags, "DELETE") or hasattr(event.flags, "MOVED_FROM"):
-                # NOTE: The absorbance reader is a hidraw device, when we first
-                # plug it into the Flex, udev rules create a
-                # /dev/ot_module_absorbancereader(n) symlink which aionotify
-                # detects as a CREATE event and registers an absorbance module.
-                # When we create this Absorbance module and connect to it,
-                # the Byonoy library opens the device via hidapi which removes
-                # the symlink and triggers a DELETE action from aionoify.
-                # When the device is deleted, we disconnect from it causing
-                # the /dev/ot_module_absorbance(n) symlink to get created, repeating
-                # the cycle.
+        if hasattr(event.flags, "DELETE") or hasattr(event.flags, "MOVED_FROM"):
+            # NOTE: The absorbance reader is a hidraw device, when we first
+            # plug it into the Flex, udev rules create a
+            # /dev/ot_module_absorbancereader(n) symlink which aionotify
+            # detects as a CREATE event and registers an absorbance module.
+            # When we create this Absorbance module and connect to it,
+            # the Byonoy library opens the device via hidapi which removes
+            # the symlink and triggers a DELETE action from aionoify.
+            # When the device is deleted, we disconnect from it causing
+            # the /dev/ot_module_absorbance(n) symlink to get created, repeating
+            # the cycle.
 
-                # This DELETE action would normally delete the device, but in this case
-                # Lets ignore these events for the absorbance reader and handle
-                # cleanup when the poller attempts to read data and fails.
-                if maybe_module_at_port.name == "absorbancereader":
+            # This DELETE action would normally delete the device, but in this case
+            # Lets ignore these events for the absorbance reader and handle
+            # cleanup when the poller attempts to read data and fails.
+            if maybe_module_at_port.name == "absorbancereader":
+                return
+            removed_modules = [maybe_module_at_port]
+            log.info(f"Module Removed: {maybe_module_at_port}")
+        elif hasattr(event.flags, "CREATE") or hasattr(event.flags, "MOVED_TO"):
+            # NOTE: Absorbance reader gets disonnected when updating, so
+            # if the device is updating, dont create a new instance.
+            for module in self._available_modules:
+                if (
+                    maybe_module_at_port.name == "absorbancereader"
+                    and isinstance(module, AbsorbanceReader)
+                    and module.updating
+                ):
                     return
-                removed_modules = [maybe_module_at_port]
-                log.info(f"Module Removed: {maybe_module_at_port}")
-            elif hasattr(event.flags, "CREATE") or hasattr(event.flags, "MOVED_TO"):
-                # NOTE: Absorbance reader gets disonnected when updating, so
-                # if the device is updating, dont create a new instance.
-                for module in self._available_modules:
-                    if (
-                        maybe_module_at_port.name == "absorbancereader"
-                        and isinstance(module, AbsorbanceReader)
-                        and module.updating
-                    ):
-                        return
 
-                new_modules = [maybe_module_at_port]
-                log.info(f"Module Added: {maybe_module_at_port}")
-            try:
-                if maybe_module_at_port.name in PERIPHERALS:
-                    await self.register_peripherals(
-                        removed_per_at_ports=removed_modules,
-                        new_per_at_ports=new_modules,
-                    )
-                else:
-                    await self.register_modules(
-                        removed_mods_at_ports=removed_modules,
-                        new_mods_at_ports=new_modules,
-                    )
-            except Exception:
-                log.exception("Exception in Module registration")
+            new_modules = [maybe_module_at_port]
+            log.info(f"Module Added: {maybe_module_at_port}")
+        try:
+            await self.register_modules(
+                removed_mods_at_ports=removed_modules,
+                new_mods_at_ports=new_modules,
+            )
+        except Exception:
+            log.exception("Exception in Module registration")
 
     def get_module_by_module_id(
         self, module_id: str

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -304,9 +304,7 @@ class AttachedModulesControl:
             removed_devices_at_ports = []
         # destroy removed mods
         await self.unregister_devices(removed_devices_at_ports)
-        unsorted_device_at_port = self._usb.match_virtual_ports(
-            removed_devices_at_ports
-        )
+        unsorted_device_at_port = self._usb.match_virtual_ports(new_devices_at_ports)
         for device in unsorted_device_at_port:
             try:
                 new_instance = await self.build_device(

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 from opentrons_shared_data.errors.exceptions import EnumeratedError
 
-from . import modules
+from . import modules, peripherals
 from .types import (
     AionotifyEvent,
     AsynchronousModuleErrorNotification,
@@ -52,6 +52,8 @@ MODULE_PORT_REGEX = re.compile(
     re.I,
 )
 
+PERIPHERALS = ["barcodescanner"]
+
 
 class AttachedModulesControl:
     """
@@ -66,6 +68,7 @@ class AttachedModulesControl:
         event_callback: Callable[[HardwareEvent], None],
     ) -> None:
         self._available_modules: List[modules.AbstractModule] = []
+        self._available_peripherals: List[peripherals.AbstractPeripheral] = []
         self._api = api
         self._usb = usb
         self._event_callback = event_callback
@@ -106,6 +109,10 @@ class AttachedModulesControl:
     def available_modules(self) -> List[modules.AbstractModule]:
         return self._available_modules
 
+    @property
+    def available_peripherals(self) -> List[peripherals.AbstractPeripheral]:
+        return self._available_peripherals
+
     async def clean_up(self) -> None:
         """Clean up all registered modules and emulator scanning tasks (if any)."""
         for module in self._available_modules:
@@ -138,6 +145,22 @@ class AttachedModulesControl:
         )
         return module
 
+    async def register_simulated_peripheral(
+        self,
+        simulated_usb_port: types.USBPort,
+        type: peripherals.PeripheralType,
+        sim_model: str,
+    ) -> peripherals.AbstractPeripheral:
+        """Register a simulated peripheral."""
+        peripheral = await self.build_peripheral(
+            "", simulated_usb_port, type, sim_model, sim_serial_number=None
+        )
+        self._available_peripherals.append(peripheral)
+        self._available_peripherals = sorted(
+            self._available_peripherals, key=peripherals.AbstractPeripheral.sort_key
+        )
+        return peripheral
+
     async def build_module(
         self,
         port: str,
@@ -164,6 +187,28 @@ class AttachedModulesControl:
         mod.event_listener(last_event)
         self.subscribe_to_api_event(mod)
         return mod
+
+    async def build_peripheral(
+        self,
+        port: str,
+        usb_port: types.USBPort,
+        type: peripherals.PeripheralType,
+        sim_model: Optional[str] = None,
+        sim_serial_number: Optional[str] = None,
+    ) -> peripherals.AbstractPeripheral:
+        per = await peripherals.build(
+            port=port,
+            usb_port=usb_port,
+            type=type,
+            simulating=self._api.is_simulator,
+            hw_control_loop=self._api.loop,
+            execution_manager=self._api._execution_manager,
+            sim_model=sim_model,
+            sim_serial_number=sim_serial_number,
+            disconnected_callback=self._disconnected_callback,
+            error_callback=self._async_error_callback,
+        )
+        return per
 
     def _disconnected_callback(
         self, model: str, port: str, serial: Optional[str]
@@ -250,6 +295,48 @@ class AttachedModulesControl:
             await removed_mod.cleanup()
         self._available_modules = sorted(
             self._available_modules, key=modules.AbstractModule.sort_key
+        )
+
+    async def register_peripherals(
+        self,
+        new_per_at_ports: Optional[
+            Union[List[modules.ModuleAtPort], List[modules.SimulatingModuleAtPort]]
+        ] = None,
+        removed_per_at_ports: Optional[List[modules.ModuleAtPort]] = None,
+    ) -> None:
+        if new_per_at_ports is None:
+            new_per_at_ports = []
+        if removed_per_at_ports is None:
+            removed_per_at_ports = []
+        self._new_per_at_ports = new_per_at_ports
+        unsorted_per_at_port = self._usb.match_virtual_ports(new_per_at_ports)
+        # build new peripherals
+        for per in unsorted_per_at_port:
+            try:
+                new_instance = await self.build_peripheral(
+                    port=per.port,
+                    usb_port=per.usb_port,
+                    type=peripherals.PERIPHERAL_TYPE_BY_NAME[per.name],
+                    sim_serial_number=(
+                        per.serial_number
+                        if isinstance(per, SimulatingModuleAtPort)
+                        else None
+                    ),
+                    sim_model=(
+                        per.model if isinstance(per, SimulatingModuleAtPort) else None
+                    ),
+                )
+                self._available_peripherals.append(new_instance)
+                log.info(
+                    f"Peripheral {per.name} discovered and attached"
+                    f" at port {per.port}, new_instance: {new_instance}"
+                )
+            except Exception as e:
+                log.exception(
+                    f"Failed to build peripheral {per.name} at port {per.port}: {e}"
+                )
+        self._available_peripherals = sorted(
+            self._available_peripherals, key=peripherals.AbstractPeripheral.sort_key
         )
 
     async def register_modules(
@@ -387,10 +474,16 @@ class AttachedModulesControl:
                 new_modules = [maybe_module_at_port]
                 log.info(f"Module Added: {maybe_module_at_port}")
             try:
-                await self.register_modules(
-                    removed_mods_at_ports=removed_modules,
-                    new_mods_at_ports=new_modules,
-                )
+                if maybe_module_at_port.name in PERIPHERALS:
+                    await self.register_peripherals(
+                        removed_per_at_ports=removed_modules,
+                        new_per_at_ports=new_modules,
+                    )
+                else:
+                    await self.register_modules(
+                        removed_mods_at_ports=removed_modules,
+                        new_mods_at_ports=new_modules,
+                    )
             except Exception:
                 log.exception("Exception in Module registration")
 

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Callable, List, Optional, Union
 from opentrons_shared_data.errors.exceptions import EnumeratedError
 
 from . import modules, peripherals
+from .device import AbstractDevice, DeviceType, build_attached_device
 from .types import (
     AionotifyEvent,
     AsynchronousModuleErrorNotification,
@@ -91,8 +92,8 @@ class AttachedModulesControl:
         else:
             self._emulation_listen_task = None
 
-    def subscribe_to_api_event(self, module: modules.AbstractModule) -> None:
-        self._api.add_status_bar_listener(module.event_listener)
+    def subscribe_to_api_event(self, device: AbstractDevice) -> None:
+        self._api.add_status_bar_listener(device.event_listener)
 
     @classmethod
     async def build(
@@ -140,48 +141,39 @@ class AttachedModulesControl:
             finally:
                 self._emulation_listen_task = None
 
-    async def register_simulated_module(
+    async def register_simulated_device(
         self,
         simulated_usb_port: types.USBPort,
-        type: modules.ModuleType,
+        type: DeviceType,
         sim_model: str,
         sim_serial: Optional[str] = None,
-    ) -> modules.AbstractModule:
-        """Register a simulated module."""
-        module = await self.build_module(
+    ) -> AbstractDevice:
+        device = await self.build_device(
             "", simulated_usb_port, type, sim_model, sim_serial_number=sim_serial
         )
-        self._available_modules.append(module)
-        self._available_modules = sorted(
-            self._available_modules, key=modules.AbstractModule.sort_key
-        )
-        return module
+        if isinstance(type, modules.ModuleType):
+            assert isinstance(device, modules.AbstractModule)
+            self._available_modules.append(device)
+            self._available_modules = sorted(
+                self._available_modules, key=modules.AbstractModule.sort_key
+            )
+        else:
+            assert isinstance(device, peripherals.AbstractPeripheral)
+            self._available_peripherals.append(device)
+            self._available_peripherals = sorted(
+                self._available_peripherals, key=peripherals.AbstractPeripheral.sort_key
+            )
+        return device
 
-    async def register_simulated_peripheral(
-        self,
-        simulated_usb_port: types.USBPort,
-        type: peripherals.PeripheralType,
-        sim_model: str,
-    ) -> peripherals.AbstractPeripheral:
-        """Register a simulated peripheral."""
-        peripheral = await self.build_peripheral(
-            "", simulated_usb_port, type, sim_model, sim_serial_number=None
-        )
-        self._available_peripherals.append(peripheral)
-        self._available_peripherals = sorted(
-            self._available_peripherals, key=peripherals.AbstractPeripheral.sort_key
-        )
-        return peripheral
-
-    async def build_module(
+    async def build_device(
         self,
         port: str,
         usb_port: types.USBPort,
-        type: modules.ModuleType,
+        type: DeviceType,
         sim_model: Optional[str] = None,
         sim_serial_number: Optional[str] = None,
-    ) -> modules.AbstractModule:
-        mod = await modules.build(
+    ) -> AbstractDevice:
+        device = await build_attached_device(
             port=port,
             usb_port=usb_port,
             type=type,
@@ -196,31 +188,9 @@ class AttachedModulesControl:
         last_event = StatusBarUpdateEvent(
             self._api.get_status_bar_state(), self._api.get_status_bar_enabled()
         )
-        mod.event_listener(last_event)
-        self.subscribe_to_api_event(mod)
-        return mod
-
-    async def build_peripheral(
-        self,
-        port: str,
-        usb_port: types.USBPort,
-        type: peripherals.PeripheralType,
-        sim_model: Optional[str] = None,
-        sim_serial_number: Optional[str] = None,
-    ) -> peripherals.AbstractPeripheral:
-        per = await peripherals.build(
-            port=port,
-            usb_port=usb_port,
-            type=type,
-            simulating=self._api.is_simulator,
-            hw_control_loop=self._api.loop,
-            execution_manager=self._api._execution_manager,
-            sim_model=sim_model,
-            sim_serial_number=sim_serial_number,
-            disconnected_callback=self._disconnected_callback,
-            error_callback=self._async_error_callback,
-        )
-        return per
+        device.event_listener(last_event)
+        self.subscribe_to_api_event(device)
+        return device
 
     def _disconnected_callback(
         self, model: str, port: str, serial: Optional[str]
@@ -309,6 +279,47 @@ class AttachedModulesControl:
             self._available_modules, key=modules.AbstractModule.sort_key
         )
 
+    async def unregister_peripherals(
+        self,
+        pers_at_ports: Union[
+            List[modules.ModuleAtPort], List[modules.SimulatingModuleAtPort]
+        ],
+    ) -> None:
+        """
+        De-register Modules.
+
+        Remove any modules that are no longer found by aionotify.
+        """
+        removed_peripherals = []
+        for mod in pers_at_ports:
+            for attached_per in self.available_peripherals:
+                if (
+                    attached_per.serial_number == mod.serial
+                    or attached_per.port == mod.port
+                ):
+                    removed_peripherals.append(attached_per)
+
+        for removed_peripheral in removed_peripherals:
+            try:
+                self._available_peripherals.remove(removed_peripheral)
+                # Important: this wants to be after the remove because this may trigger
+                # recursion back to here; we therefore want the module to already be
+                # removed so that the recursion terminates next loop
+                removed_peripheral.disconnected_callback()
+            except ValueError:
+                log.warning(
+                    f"Removed Module {removed_peripheral} not found in attached modules"
+                )
+
+        for removed_peripheral in removed_peripherals:
+            log.info(
+                f"Module {removed_peripheral.name()} detached from port {removed_peripheral.port}"
+            )
+            await removed_peripheral.cleanup()
+        self._available_modules = sorted(
+            self._available_modules, key=modules.AbstractModule.sort_key
+        )
+
     async def register_peripherals(
         self,
         new_per_at_ports: Optional[
@@ -320,11 +331,14 @@ class AttachedModulesControl:
             new_per_at_ports = []
         if removed_per_at_ports is None:
             removed_per_at_ports = []
+
+        # destroy removed mods
+        await self.unregister_peripherals(removed_per_at_ports)
         unsorted_per_at_port = self._usb.match_virtual_ports(new_per_at_ports)
         # build new peripherals
         for per in unsorted_per_at_port:
             try:
-                new_instance = await self.build_peripheral(
+                new_instance = await self.build_device(
                     port=per.port,
                     usb_port=per.usb_port,
                     type=peripherals.PERIPHERAL_TYPE_BY_NAME[per.name],
@@ -337,6 +351,7 @@ class AttachedModulesControl:
                         per.model if isinstance(per, SimulatingModuleAtPort) else None
                     ),
                 )
+                assert isinstance(new_instance, peripherals.AbstractPeripheral)
                 self._available_peripherals.append(new_instance)
                 log.info(
                     f"Peripheral {per.name} discovered and attached"
@@ -376,7 +391,7 @@ class AttachedModulesControl:
         # build new mods
         for mod in unsorted_mods_at_port:
             try:
-                new_instance = await self.build_module(
+                new_instance = await self.build_device(
                     port=mod.port,
                     usb_port=mod.usb_port,
                     type=modules.MODULE_TYPE_BY_NAME[mod.name],
@@ -389,6 +404,7 @@ class AttachedModulesControl:
                         mod.model if isinstance(mod, SimulatingModuleAtPort) else None
                     ),
                 )
+                assert isinstance(new_instance, modules.AbstractModule)
                 self._available_modules.append(new_instance)
                 log.info(
                     f"Module {mod.name} discovered and attached"

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -253,53 +253,37 @@ class AttachedModulesControl:
 
         Remove any modules that are no longer found by aionotify.
         """
-        removed_modules = []
-        removed_peripherals = []
+        removed_devices = []
         for dev in devices_at_ports:
-            for attached_mod in self.available_modules:
+            for attached_dev in self.available_modules + self.available_peripherals:
                 if (
-                    attached_mod.serial_number == dev.serial
-                    or attached_mod.port == dev.port
+                    attached_dev.serial_number == dev.serial
+                    or attached_dev.port == dev.port
                 ):
-                    removed_modules.append(attached_mod)
-            for attached_per in self.available_peripherals:
-                if (
-                    attached_per.serial_number == dev.serial
-                    or attached_per.port == dev.port
-                ):
-                    removed_peripherals.append(attached_per)
-        for removed_mod in removed_modules:
+                    removed_devices.append(attached_dev)
+        for removed_dev in removed_devices:
             try:
-                self._available_modules.remove(removed_mod)
+                if removed_dev in self._available_modules and isinstance(
+                    removed_dev, modules.AbstractModule
+                ):
+                    self._available_modules.remove(removed_dev)
+                if removed_dev in self._available_peripherals and isinstance(
+                    removed_dev, peripherals.AbstractPeripheral
+                ):
+                    self._available_peripherals.remove(removed_dev)
                 # Important: this wants to be after the remove because this may trigger
                 # recursion back to here; we therefore want the module to already be
                 # removed so that the recursion terminates next loop
-                removed_mod.disconnected_callback()
+                removed_dev.disconnected_callback()
             except ValueError:
                 log.warning(
-                    f"Removed Module {removed_mod} not found in attached modules"
+                    f"Removed Device {removed_dev} not found in attached device"
                 )
-        for removed_peripheral in removed_peripherals:
-            try:
-                self._available_peripherals.remove(removed_peripheral)
-                # Important: this wants to be after the remove because this may trigger
-                # recursion back to here; we therefore want the module to already be
-                # removed so that the recursion terminates next loop
-                removed_peripheral.disconnected_callback()
-            except ValueError:
-                log.warning(
-                    f"Removed Module {removed_peripheral} not found in attached modules"
-                )
-        for removed_mod in removed_modules:
+        for removed_dev in removed_devices:
             log.info(
-                f"Module {removed_mod.name()} detached from port {removed_mod.port}"
+                f"Device {removed_dev.name()} detached from port {removed_dev.port}"
             )
-            await removed_mod.cleanup()
-        for removed_peripheral in removed_peripherals:
-            log.info(
-                f"Peripheral {removed_peripheral.name()} detached from port {removed_peripheral.port}"
-            )
-            await removed_peripheral.cleanup()
+            await removed_dev.cleanup()
         self._available_modules = sorted(
             self._available_modules, key=modules.AbstractModule.sort_key
         )

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -2,10 +2,11 @@ import abc
 import asyncio
 import logging
 import re
-from typing import Any, ClassVar, Mapping, Optional, TypeVar
+from typing import ClassVar, Optional, TypeVar
 
 from packaging.version import InvalidVersion, Version, parse
 
+from ..abstract_device import AbstractDevice
 from ..execution_manager import ExecutionManager
 from .types import (
     BundledFirmware,
@@ -37,7 +38,7 @@ def parse_fw_version(version: str) -> Version:
     return device_version
 
 
-class AbstractModule(abc.ABC):
+class AbstractModule(AbstractDevice):
     """Defines the common methods of a module."""
 
     MODULE_TYPE: ClassVar[ModuleType]
@@ -143,36 +144,10 @@ class AbstractModule(abc.ABC):
         if self._execution_manager is not None:
             self._execution_manager.register_cancellable_task(task)
 
-    @abc.abstractmethod
-    async def deactivate(self, must_be_running: bool = True) -> None:
-        """Deactivate the module.
-
-        Contains an override to the `wait_for_is_running` step in cases where the
-        module must be deactivated regardless of context."""
-        pass
-
-    @property
-    @abc.abstractmethod
-    def status(self) -> str:
-        """Return some string describing status."""
-        pass
-
-    @property
-    @abc.abstractmethod
-    def device_info(self) -> Mapping[str, str]:
-        """Return a dict of the module's static information (serial, etc)"""
-        pass
-
     @property
     @abc.abstractmethod
     def live_data(self) -> LiveData:
         """Return a dict of the module's dynamic information"""
-        pass
-
-    @property
-    @abc.abstractmethod
-    def is_simulated(self) -> bool:
-        """True if >this is a simulated module."""
         pass
 
     @property
@@ -213,17 +188,6 @@ class AbstractModule(abc.ABC):
         return self._bundled_fw
 
     @abc.abstractmethod
-    def model(self) -> str:
-        """A name for this specific module, matching module defs"""
-        pass
-
-    @classmethod
-    @abc.abstractmethod
-    def name(cls) -> str:
-        """A shortname used for matching usb ports, among other things"""
-        pass
-
-    @abc.abstractmethod
     def firmware_prefix(self) -> str:
         """The prefix used for looking up firmware"""
         pass
@@ -231,24 +195,4 @@ class AbstractModule(abc.ABC):
     @abc.abstractmethod
     def bootloader(self) -> UploadFunction:
         """Method used to upload file to this module's bootloader."""
-        pass
-
-    async def cleanup(self) -> None:
-        """Clean up the module instance.
-
-        Clean up, i.e. stop pollers, disconnect serial, etc in preparation for
-        object destruction.
-        """
-        pass
-
-    def event_listener(self, event: Any) -> None:
-        """Listen for events and update the module state."""
-        pass
-
-    async def identify(self, start: bool, color_name: Optional[str] = None) -> None:
-        """Identify the module."""
-        pass
-
-    def cleanup_persistent(self) -> None:
-        """Reset any persistent data on the module that should not exist outside of a run."""
         pass

--- a/api/src/opentrons/hardware_control/modules/utils.py
+++ b/api/src/opentrons/hardware_control/modules/utils.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 
 # TODO (lc 05-12-2021) This is pretty gross. We should think
 # of a better way to do this.
-MODULE_TYPE_BY_NAME = {
+MODULE_TYPE_BY_NAME: Dict[str, ModuleType] = {
     MagDeck.name(): MagDeck.MODULE_TYPE,
     TempDeck.name(): TempDeck.MODULE_TYPE,
     Thermocycler.name(): Thermocycler.MODULE_TYPE,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -41,7 +41,7 @@ from opentrons_shared_data.pipette import (
 )
 from opentrons_shared_data.pipette.types import PipetteModelType, PipetteName
 
-from . import modules
+from . import modules, peripherals
 from .backends.errors import SubsystemUpdating
 from .backends.flex_protocol import FlexBackend
 from .backends.ot3simulator import OT3Simulator
@@ -640,6 +640,11 @@ class OT3API(
     def attached_modules(self) -> List[modules.AbstractModule]:
         return self._backend.module_controls.available_modules
 
+    @property
+    @pyro_behavior(specialty_func=convert_result_to_proxy, apply_local=False)
+    def attached_peripherals(self) -> List[peripherals.AbstractPeripheral]:
+        return self._backend.module_controls.available_peripherals
+
     async def create_simulating_module(
         self,
         model: modules.types.ModuleModel,
@@ -654,6 +659,23 @@ class OT3API(
             type=modules.ModuleType.from_model(model),
             sim_model=model.value,
             sim_serial=sim_serial,
+        )
+
+    async def create_simulating_peripheral(
+        self,
+        model: peripherals.types.PeripheralModel,
+    ) -> peripherals.AbstractPeripheral:
+        """Create a simulating peripheral hardware interface."""
+        assert self.is_simulator, (
+            "Cannot build simulating peripheral from non-simulating hardware control API"
+        )
+
+        return await self._backend.module_controls.register_simulated_peripheral(
+            simulated_usb_port=USBPort(
+                name="", port_number=1, port_group=PortGroup.LEFT
+            ),
+            type=peripherals.PeripheralType.from_model(model),
+            sim_model=model.value,
         )
 
     def _gantry_load_from_instruments(self) -> GantryLoad:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -652,7 +652,7 @@ class OT3API(
     ) -> modules.AbstractModule:
         """Create a simulating module hardware interface."""
 
-        return await self._backend.module_controls.register_simulated_module(
+        module = await self._backend.module_controls.register_simulated_device(
             simulated_usb_port=USBPort(
                 name="", port_number=1, port_group=PortGroup.LEFT
             ),
@@ -660,6 +660,8 @@ class OT3API(
             sim_model=model.value,
             sim_serial=sim_serial,
         )
+        assert isinstance(module, modules.AbstractModule)
+        return module
 
     async def create_simulating_peripheral(
         self,
@@ -670,13 +672,15 @@ class OT3API(
             "Cannot build simulating peripheral from non-simulating hardware control API"
         )
 
-        return await self._backend.module_controls.register_simulated_peripheral(
+        peripheral = await self._backend.module_controls.register_simulated_device(
             simulated_usb_port=USBPort(
                 name="", port_number=1, port_group=PortGroup.LEFT
             ),
             type=peripherals.PeripheralType.from_model(model),
             sim_model=model.value,
         )
+        assert isinstance(peripheral, peripherals.AbstractPeripheral)
+        return peripheral
 
     def _gantry_load_from_instruments(self) -> GantryLoad:
         """Compute the gantry load based on attached instruments."""

--- a/api/src/opentrons/hardware_control/peripherals/__init__.py
+++ b/api/src/opentrons/hardware_control/peripherals/__init__.py
@@ -1,0 +1,19 @@
+from .barcode_scanner import BarcodeScanner
+from .peripheral_abc import AbstractPeripheral
+from .types import (
+    BarcodeScannerModel,
+    PeripheralModel,
+    PeripheralType,
+)
+from .utils import PERIPHERAL_TYPE_BY_NAME, build
+
+__all__ = [
+    "AbstractPeripheral",
+    "BarcodeScanner",
+    "PeripheralType",
+    "BarcodeScannerModel",
+    "PeripheralModel",
+    "PERIPHERAL_TYPE_BY_NAME",
+    "PeripheralType",
+    "build",
+]

--- a/api/src/opentrons/hardware_control/peripherals/barcode_scanner.py
+++ b/api/src/opentrons/hardware_control/peripherals/barcode_scanner.py
@@ -1,0 +1,101 @@
+import asyncio
+from typing import Mapping, Optional
+
+from ..execution_manager import ExecutionManager
+from ..modules.types import (
+    ModuleDisconnectedCallback,
+    ModuleErrorCallback,
+)
+from .peripheral_abc import AbstractPeripheral
+from .types import PeripheralType
+from opentrons.drivers.barcode_scanner import (
+    AbstractBarcodeScannerDriver,
+    BarcodeSimulatorDriver,
+    RTScanner,
+)
+from opentrons.drivers.rpi_drivers.types import USBPort
+
+
+class BarcodeScanner(AbstractPeripheral):
+    PERIPHERAL_TYPE = PeripheralType.BARCODE_SCANNER
+
+    @classmethod
+    async def build(
+        cls,
+        port: str,
+        usb_port: USBPort,
+        hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
+        poll_interval_seconds: float | None = None,
+        simulating: bool = False,
+        sim_model: Optional[str] = None,
+        sim_serial_number: Optional[str] = None,
+    ) -> "BarcodeScanner":
+        """Build a barcode scanner object."""
+        if simulating:
+            driver: AbstractBarcodeScannerDriver = BarcodeSimulatorDriver()
+        else:
+            driver = await RTScanner.create()
+
+        return BarcodeScanner(
+            port,
+            usb_port,
+            hw_control_loop,
+            execution_manager,
+            disconnected_callback,
+            error_callback,
+            driver,
+        )
+
+    def __init__(
+        self,
+        port: str,
+        usb_port: USBPort,
+        hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
+        driver: AbstractBarcodeScannerDriver,
+    ) -> None:
+        super().__init__(
+            port=port,
+            usb_port=usb_port,
+            hw_control_loop=hw_control_loop,
+            execution_manager=execution_manager,
+            disconnected_callback=disconnected_callback,
+            error_callback=error_callback,
+        )
+        self._driver = driver
+
+    async def deactivate(self, must_be_running: bool = True) -> None:
+        """Deactivate the module.
+
+        Contains an override to the `wait_for_is_running` step in cases where the
+        module must be deactivated regardless of context."""
+        await self._driver.disconnect()
+
+    @property
+    def status(self) -> str:
+        """Return some string describing status."""
+        return f"{'Not' if self._driver.is_connected() else ''} Connected"
+
+    @property
+    def device_info(self) -> Mapping[str, str]:
+        """Return a dict of the module's static information (serial, etc)"""
+        return self._driver.get_device_info().to_dict()
+
+    @property
+    def is_simulated(self) -> bool:
+        """True if >this is a simulated module."""
+        return isinstance(self._driver, BarcodeSimulatorDriver)
+
+    def model(self) -> str:
+        """A name for this specific module, matching module defs"""
+        return self.device_info["product_name"]
+
+    @classmethod
+    def name(cls) -> str:
+        """A shortname used for matching usb ports, among other things"""
+        return "barcodescanner"

--- a/api/src/opentrons/hardware_control/peripherals/peripheral_abc.py
+++ b/api/src/opentrons/hardware_control/peripherals/peripheral_abc.py
@@ -1,7 +1,8 @@
 import abc
 import asyncio
-from typing import Any, ClassVar, Mapping, Optional
+from typing import ClassVar, Optional
 
+from ..abstract_device import AbstractDevice
 from ..execution_manager import ExecutionManager
 from ..modules.mod_abc import TaskPayload
 from ..modules.types import (
@@ -12,7 +13,7 @@ from .types import PeripheralType
 from opentrons.drivers.rpi_drivers.types import USBPort
 
 
-class AbstractPeripheral(abc.ABC):
+class AbstractPeripheral(AbstractDevice):
     PERIPHERAL_TYPE: ClassVar[PeripheralType]
 
     @classmethod
@@ -86,32 +87,6 @@ class AbstractPeripheral(abc.ABC):
         if self._execution_manager is not None:
             self._execution_manager.register_cancellable_task(task)
 
-    @abc.abstractmethod
-    async def deactivate(self, must_be_running: bool = True) -> None:
-        """Deactivate the module.
-
-        Contains an override to the `wait_for_is_running` step in cases where the
-        module must be deactivated regardless of context."""
-        pass
-
-    @property
-    @abc.abstractmethod
-    def status(self) -> str:
-        """Return some string describing status."""
-        pass
-
-    @property
-    @abc.abstractmethod
-    def device_info(self) -> Mapping[str, str]:
-        """Return a dict of the module's static information (serial, etc)"""
-        pass
-
-    @property
-    @abc.abstractmethod
-    def is_simulated(self) -> bool:
-        """True if >this is a simulated module."""
-        pass
-
     @property
     def port(self) -> str:
         """The virtual port where the module is connected."""
@@ -126,34 +101,3 @@ class AbstractPeripheral(abc.ABC):
     def serial_number(self) -> Optional[str]:
         """The usb serial number of this device."""
         return self.device_info.get("serial")
-
-    @abc.abstractmethod
-    def model(self) -> str:
-        """A name for this specific module, matching module defs"""
-        pass
-
-    @classmethod
-    @abc.abstractmethod
-    def name(cls) -> str:
-        """A shortname used for matching usb ports, among other things"""
-        pass
-
-    async def cleanup(self) -> None:
-        """Clean up the module instance.
-
-        Clean up, i.e. stop pollers, disconnect serial, etc in preparation for
-        object destruction.
-        """
-        pass
-
-    def event_listener(self, event: Any) -> None:
-        """Listen for events and update the module state."""
-        pass
-
-    async def identify(self, start: bool, color_name: Optional[str] = None) -> None:
-        """Identify the module."""
-        pass
-
-    def cleanup_persistent(self) -> None:
-        """Reset any persistent data on the module that should not exist outside of a run."""
-        pass

--- a/api/src/opentrons/hardware_control/peripherals/peripheral_abc.py
+++ b/api/src/opentrons/hardware_control/peripherals/peripheral_abc.py
@@ -1,0 +1,159 @@
+import abc
+import asyncio
+from typing import Any, ClassVar, Mapping, Optional
+
+from ..execution_manager import ExecutionManager
+from ..modules.mod_abc import TaskPayload
+from ..modules.types import (
+    ModuleDisconnectedCallback,
+    ModuleErrorCallback,
+)
+from .types import PeripheralType
+from opentrons.drivers.rpi_drivers.types import USBPort
+
+
+class AbstractPeripheral(abc.ABC):
+    PERIPHERAL_TYPE: ClassVar[PeripheralType]
+
+    @classmethod
+    @abc.abstractmethod
+    async def build(
+        cls,
+        port: str,
+        usb_port: USBPort,
+        hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
+        poll_interval_seconds: float | None = None,
+        simulating: bool = False,
+        sim_model: Optional[str] = None,
+        sim_serial_number: Optional[str] = None,
+    ) -> "AbstractPeripheral":
+        """Peripherals should always be created using this factory.
+
+        This lets the (perhaps blocking) work of connecting to and initializing
+        a peripheral be in a place that can be async.
+        """
+
+    def __init__(
+        self,
+        port: str,
+        usb_port: USBPort,
+        hw_control_loop: asyncio.AbstractEventLoop,
+        execution_manager: ExecutionManager,
+        disconnected_callback: ModuleDisconnectedCallback,
+        error_callback: ModuleErrorCallback,
+    ) -> None:
+        self._port = port
+        self._usb_port = usb_port
+        self._loop = hw_control_loop
+        self._execution_manager = execution_manager
+        self._disconnected_callback = disconnected_callback
+        self._error_callback = error_callback
+
+    @staticmethod
+    def sort_key(inst: "AbstractPeripheral") -> int:
+        usb_port = inst.usb_port
+
+        primary_port = usb_port.port_number
+
+        if usb_port.hub_port is not None:
+            secondary_port = usb_port.hub_port
+        else:
+            secondary_port = 0
+
+        return primary_port * 1000 + secondary_port
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop:
+        return self._loop
+
+    def disconnected_callback(self) -> None:
+        """Called from within the module object to signify the object is no longer connected"""
+        if self._disconnected_callback is not None:
+            self._disconnected_callback(self.model(), self.port, self.serial_number)
+
+    def error_callback(self, exc: Exception) -> None:
+        """Called from within the module object when an asynchronous hardware error occurrs."""
+        self._error_callback(exc, self.model(), self.port, self.serial_number)
+
+    async def wait_for_is_running(self) -> None:
+        if not self.is_simulated and self._execution_manager is not None:
+            await self._execution_manager.wait_for_is_running()
+
+    def make_cancellable(self, task: "asyncio.Task[TaskPayload]") -> None:
+        if self._execution_manager is not None:
+            self._execution_manager.register_cancellable_task(task)
+
+    @abc.abstractmethod
+    async def deactivate(self, must_be_running: bool = True) -> None:
+        """Deactivate the module.
+
+        Contains an override to the `wait_for_is_running` step in cases where the
+        module must be deactivated regardless of context."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def status(self) -> str:
+        """Return some string describing status."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def device_info(self) -> Mapping[str, str]:
+        """Return a dict of the module's static information (serial, etc)"""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def is_simulated(self) -> bool:
+        """True if >this is a simulated module."""
+        pass
+
+    @property
+    def port(self) -> str:
+        """The virtual port where the module is connected."""
+        return self._port
+
+    @property
+    def usb_port(self) -> USBPort:
+        """The physical port where the module is connected."""
+        return self._usb_port
+
+    @property
+    def serial_number(self) -> Optional[str]:
+        """The usb serial number of this device."""
+        return self.device_info.get("serial")
+
+    @abc.abstractmethod
+    def model(self) -> str:
+        """A name for this specific module, matching module defs"""
+        pass
+
+    @classmethod
+    @abc.abstractmethod
+    def name(cls) -> str:
+        """A shortname used for matching usb ports, among other things"""
+        pass
+
+    async def cleanup(self) -> None:
+        """Clean up the module instance.
+
+        Clean up, i.e. stop pollers, disconnect serial, etc in preparation for
+        object destruction.
+        """
+        pass
+
+    def event_listener(self, event: Any) -> None:
+        """Listen for events and update the module state."""
+        pass
+
+    async def identify(self, start: bool, color_name: Optional[str] = None) -> None:
+        """Identify the module."""
+        pass
+
+    def cleanup_persistent(self) -> None:
+        """Reset any persistent data on the module that should not exist outside of a run."""
+        pass

--- a/api/src/opentrons/hardware_control/peripherals/types.py
+++ b/api/src/opentrons/hardware_control/peripherals/types.py
@@ -1,0 +1,28 @@
+from typing import Union
+
+from opentrons_shared_data.util import StrEnum
+
+
+class BarcodeScannerModel(StrEnum):
+    BARCODE_SCANNER_V1 = "BarcodeScannerV1"
+
+
+PeripheralModel = Union[BarcodeScannerModel]
+
+
+class PeripheralType(StrEnum):
+    BARCODE_SCANNER = "barcodeScannerPeripheralType"
+
+    @classmethod
+    def from_model(cls, model: PeripheralModel) -> "PeripheralType":
+        if isinstance(model, BarcodeScannerModel):
+            return cls.BARCODE_SCANNER
+
+    @classmethod
+    def to_module_fixture_id(cls, peripheral_type: "PeripheralType") -> str:
+        if peripheral_type == PeripheralType.BARCODE_SCANNER:
+            return "BarcodeScannerV1"
+        else:
+            raise ValueError(
+                f"Peripheral Type {peripheral_type} does not have a related fixture ID."
+            )

--- a/api/src/opentrons/hardware_control/peripherals/utils.py
+++ b/api/src/opentrons/hardware_control/peripherals/utils.py
@@ -11,7 +11,7 @@ from .peripheral_abc import AbstractPeripheral
 from .types import PeripheralType
 from opentrons.drivers.rpi_drivers.types import USBPort
 
-PERIPHERAL_TYPE_BY_NAME = {
+PERIPHERAL_TYPE_BY_NAME: Dict[str, PeripheralType] = {
     BarcodeScanner.name(): BarcodeScanner.PERIPHERAL_TYPE,
 }
 

--- a/api/src/opentrons/hardware_control/peripherals/utils.py
+++ b/api/src/opentrons/hardware_control/peripherals/utils.py
@@ -1,0 +1,45 @@
+import asyncio
+from typing import Dict, Optional, Type
+
+from ..execution_manager import ExecutionManager
+from ..modules.types import (
+    ModuleDisconnectedCallback,
+    ModuleErrorCallback,
+)
+from .barcode_scanner import BarcodeScanner
+from .peripheral_abc import AbstractPeripheral
+from .types import PeripheralType
+from opentrons.drivers.rpi_drivers.types import USBPort
+
+PERIPHERAL_TYPE_BY_NAME = {
+    BarcodeScanner.name(): BarcodeScanner.PERIPHERAL_TYPE,
+}
+
+_PERIPHERAL_CLS_BY_TYPE: Dict[PeripheralType, Type[AbstractPeripheral]] = {
+    BarcodeScanner.PERIPHERAL_TYPE: BarcodeScanner,
+}
+
+
+async def build(
+    port: str,
+    type: PeripheralType,
+    simulating: bool,
+    usb_port: USBPort,
+    hw_control_loop: asyncio.AbstractEventLoop,
+    execution_manager: ExecutionManager,
+    disconnected_callback: ModuleDisconnectedCallback,
+    error_callback: ModuleErrorCallback,
+    sim_model: Optional[str] = None,
+    sim_serial_number: Optional[str] = None,
+) -> AbstractPeripheral:
+    return await _PERIPHERAL_CLS_BY_TYPE[type].build(
+        port=port,
+        usb_port=usb_port,
+        simulating=simulating,
+        hw_control_loop=hw_control_loop,
+        execution_manager=execution_manager,
+        disconnected_callback=disconnected_callback,
+        error_callback=error_callback,
+        sim_model=sim_model,
+        sim_serial_number=sim_serial_number,
+    )

--- a/api/tests/opentrons/hardware_control/test_module_control.py
+++ b/api/tests/opentrons/hardware_control/test_module_control.py
@@ -9,6 +9,7 @@ from opentrons.drivers.rpi_drivers.interfaces import USBDriverInterface
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control import API as HardwareAPI
 from opentrons.hardware_control import types
+from opentrons.hardware_control.abstract_device import AbstractDevice
 from opentrons.hardware_control.module_control import AttachedModulesControl
 from opentrons.hardware_control.modules import AbstractModule
 from opentrons.hardware_control.modules.types import (
@@ -16,6 +17,8 @@ from opentrons.hardware_control.modules.types import (
     ModuleType,
     SimulatingModuleAtPort,
 )
+from opentrons.hardware_control.peripherals import AbstractPeripheral
+from opentrons.hardware_control.peripherals.types import PeripheralType
 
 
 @pytest.fixture()
@@ -31,7 +34,7 @@ def usb_bus(decoy: Decoy) -> USBDriverInterface:
 
 
 @pytest.fixture()
-def build_device(decoy: Decoy) -> Callable[..., Awaitable[AbstractModule]]:
+def build_device(decoy: Decoy) -> Callable[..., Awaitable[AbstractDevice]]:
     """Get a mocked out AttachedModuleControl.build_device.
 
     !!! warning
@@ -42,7 +45,7 @@ def build_device(decoy: Decoy) -> Callable[..., Awaitable[AbstractModule]]:
         are too brittle and of questionable value.
     """
     return cast(
-        Callable[..., Awaitable[AbstractModule]],
+        Callable[..., Awaitable[AbstractDevice]],
         decoy.mock(name="build_device", is_async=True),
     )
 
@@ -56,7 +59,7 @@ def event_callback(decoy: Decoy) -> Callable[[types.HardwareEvent], None]:
 def subject(
     hardware_api: HardwareAPI,
     usb_bus: USBDriverInterface,
-    build_device: Callable[..., Awaitable[AbstractModule]],
+    build_device: Callable[..., Awaitable[AbstractDevice]],
     event_callback: Callable[[types.HardwareEvent], None],
 ) -> AttachedModulesControl:
     modules_control = AttachedModulesControl(
@@ -68,6 +71,60 @@ def subject(
     # https://github.com/testdouble/contributing-tests/wiki/Partial-Mock
     modules_control.build_device = build_device  # type: ignore[assignment]
     return modules_control
+
+
+async def test_register_mixed_devices(
+    decoy: Decoy,
+    usb_bus: USBDriverInterface,
+    build_device: Callable[..., Awaitable[AbstractDevice]],
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """It should register attached modules."""
+    actual_ports = [
+        ModuleAtPort(
+            port="/dev/foo1",
+            name="tempdeck",
+            usb_port=USBPort(name="baz1", port_number=0),
+        ),
+        ModuleAtPort(
+            port="/dev/foo2",
+            name="barcodescanner",
+            usb_port=USBPort(name="baz2", port_number=1),
+        ),
+    ]
+
+    module = decoy.mock(cls=AbstractModule)
+    peripheral = decoy.mock(cls=AbstractPeripheral)
+    decoy.when(module.usb_port).then_return(USBPort(name="baz1", port_number=0))
+    decoy.when(peripheral.usb_port).then_return(USBPort(name="baz2", port_number=1))
+
+    decoy.when(usb_bus.match_virtual_ports(actual_ports)).then_return(actual_ports)
+    decoy.when(
+        await build_device(
+            port="/dev/foo1",
+            usb_port=USBPort(name="baz1", port_number=0),
+            type=ModuleType.TEMPERATURE,
+            sim_serial_number=None,
+            sim_model=None,
+        )
+    ).then_return(module)
+    decoy.when(
+        await build_device(
+            port="/dev/foo2",
+            usb_port=USBPort(name="baz2", port_number=1),
+            type=PeripheralType.BARCODE_SCANNER,
+            sim_serial_number=None,
+            sim_model=None,
+        )
+    ).then_return(peripheral)
+
+    await subject.register_devices(new_devices_at_ports=actual_ports)
+    modules = subject.available_modules
+    peripherals = subject.available_peripherals
+
+    assert modules == [module]
+    assert peripherals == [peripheral]
 
 
 @pytest.mark.parametrize(
@@ -89,7 +146,7 @@ def subject(
 async def test_register_modules(
     decoy: Decoy,
     usb_bus: USBDriverInterface,
-    build_device: Callable[..., Awaitable[AbstractModule]],
+    build_device: Callable[..., Awaitable[AbstractDevice]],
     hardware_api: HardwareAPI,
     subject: AttachedModulesControl,
     module_at_port_input: Union[List[ModuleAtPort], List[SimulatingModuleAtPort]],
@@ -128,7 +185,7 @@ async def test_register_modules(
 async def test_register_modules_sort(
     decoy: Decoy,
     usb_bus: USBDriverInterface,
-    build_device: Callable[..., Awaitable[AbstractModule]],
+    build_device: Callable[..., Awaitable[AbstractDevice]],
     hardware_api: HardwareAPI,
     subject: AttachedModulesControl,
 ) -> None:

--- a/api/tests/opentrons/hardware_control/test_module_control.py
+++ b/api/tests/opentrons/hardware_control/test_module_control.py
@@ -31,8 +31,8 @@ def usb_bus(decoy: Decoy) -> USBDriverInterface:
 
 
 @pytest.fixture()
-def build_module(decoy: Decoy) -> Callable[..., Awaitable[AbstractModule]]:
-    """Get a mocked out AttachedModuleControl.build_module.
+def build_device(decoy: Decoy) -> Callable[..., Awaitable[AbstractModule]]:
+    """Get a mocked out AttachedModuleControl.build_device.
 
     !!! warning
 
@@ -43,7 +43,7 @@ def build_module(decoy: Decoy) -> Callable[..., Awaitable[AbstractModule]]:
     """
     return cast(
         Callable[..., Awaitable[AbstractModule]],
-        decoy.mock(name="build_module", is_async=True),
+        decoy.mock(name="build_device", is_async=True),
     )
 
 
@@ -56,7 +56,7 @@ def event_callback(decoy: Decoy) -> Callable[[types.HardwareEvent], None]:
 def subject(
     hardware_api: HardwareAPI,
     usb_bus: USBDriverInterface,
-    build_module: Callable[..., Awaitable[AbstractModule]],
+    build_device: Callable[..., Awaitable[AbstractModule]],
     event_callback: Callable[[types.HardwareEvent], None],
 ) -> AttachedModulesControl:
     modules_control = AttachedModulesControl(
@@ -66,7 +66,7 @@ def subject(
     # TODO(mc, 2022-03-01): partial patching the class under test creates
     # a contaminated test subject that reduces the value of these tests
     # https://github.com/testdouble/contributing-tests/wiki/Partial-Mock
-    modules_control.build_module = build_module  # type: ignore[assignment]
+    modules_control.build_device = build_device  # type: ignore[assignment]
     return modules_control
 
 
@@ -89,7 +89,7 @@ def subject(
 async def test_register_modules(
     decoy: Decoy,
     usb_bus: USBDriverInterface,
-    build_module: Callable[..., Awaitable[AbstractModule]],
+    build_device: Callable[..., Awaitable[AbstractModule]],
     hardware_api: HardwareAPI,
     subject: AttachedModulesControl,
     module_at_port_input: Union[List[ModuleAtPort], List[SimulatingModuleAtPort]],
@@ -110,7 +110,7 @@ async def test_register_modules(
         actual_ports
     )
     decoy.when(
-        await build_module(
+        await build_device(
             port="/dev/foo",
             usb_port=USBPort(name="baz", port_number=0),
             type=ModuleType.TEMPERATURE,
@@ -119,7 +119,7 @@ async def test_register_modules(
         )
     ).then_return(module)
 
-    await subject.register_modules(new_mods_at_ports=module_at_port_input)
+    await subject.register_devices(new_devices_at_ports=module_at_port_input)
     result = subject.available_modules
 
     assert result == [module]
@@ -128,7 +128,7 @@ async def test_register_modules(
 async def test_register_modules_sort(
     decoy: Decoy,
     usb_bus: USBDriverInterface,
-    build_module: Callable[..., Awaitable[AbstractModule]],
+    build_device: Callable[..., Awaitable[AbstractModule]],
     hardware_api: HardwareAPI,
     subject: AttachedModulesControl,
 ) -> None:
@@ -167,7 +167,7 @@ async def test_register_modules_sort(
 
     for mod in [module_1, module_2, module_3, module_4, module_5]:
         decoy.when(
-            await build_module(
+            await build_device(
                 usb_port=mod.usb_port,
                 port=matchers.Anything(),
                 type=matchers.Anything(),
@@ -176,7 +176,7 @@ async def test_register_modules_sort(
             )
         ).then_return(mod)
 
-    await subject.register_modules(new_mods_at_ports=new_mods_at_ports)
+    await subject.register_devices(new_devices_at_ports=new_mods_at_ports)
     result = subject.available_modules
 
     assert result == [module_5, module_4, module_3, module_2, module_1]

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -92,7 +92,7 @@ async def test_module_caching() -> None:
     assert len(with_magdeck) == 2
     assert with_magdeck[0] is found_mods[0]
     await api._backend.module_controls.register_devices(
-        new_devices_at_ports=[
+        removed_devices_at_ports=[
             ModuleAtPort(port="/dev/ot_module_sim_tempdeck111", name="tempdeck")
         ]
     )

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -83,16 +83,16 @@ async def test_module_caching() -> None:
     # Check that we can add and remove modules and the caching keeps up
     found_mods = api.attached_modules
     assert found_mods[0].name() == "tempdeck"
-    await api._backend.module_controls.register_modules(
-        new_mods_at_ports=[
+    await api._backend.module_controls.register_devices(
+        new_devices_at_ports=[
             ModuleAtPort(port="/dev/ot_module_sim_magdeck1", name="magdeck")
         ]
     )
     with_magdeck = api.attached_modules.copy()
     assert len(with_magdeck) == 2
     assert with_magdeck[0] is found_mods[0]
-    await api._backend.module_controls.register_modules(
-        removed_mods_at_ports=[
+    await api._backend.module_controls.register_devices(
+        new_devices_at_ports=[
             ModuleAtPort(port="/dev/ot_module_sim_tempdeck111", name="tempdeck")
         ]
     )
@@ -102,8 +102,8 @@ async def test_module_caching() -> None:
 
     # Check that two modules of the same kind on different ports are
     # distinct
-    await api._backend.module_controls.register_modules(
-        new_mods_at_ports=[
+    await api._backend.module_controls.register_devices(
+        new_devices_at_ports=[
             ModuleAtPort(port="/dev/ot_module_sim_magdeck2", name="magdeck")
         ]
     )

--- a/api/tests/opentrons/hardware_control/test_thread_manager.py
+++ b/api/tests/opentrons/hardware_control/test_thread_manager.py
@@ -70,8 +70,8 @@ async def test_module_cache_remove_entry() -> None:
 
     # The coroutine must be called using the threadmanager's loop.
     future = asyncio.run_coroutine_threadsafe(
-        thread_manager._backend.module_controls.register_modules(
-            removed_mods_at_ports=[
+        thread_manager._backend.module_controls.register_devices(
+            removed_devices_at_ports=[
                 ModuleAtPort(port="/dev/ot_module_sim_tempdeck111", name="tempdeck")
             ]
         ),


### PR DESCRIPTION
# Overview
There is a fundamental difference between peripherals and modules I am exposing them throughout the stack as a seperate class of device vs modules.
they are typically plug and play, they may or may not have any path to doing a firmware update, they will not take up a "slot" in the system and more than likely will not be made by us and instead will be 3rd party integrations.

This PR creates a parallel architecture that in many ways is just the module discovery layer but simplified. At the end of the day it works in the same principle but exposes api.attached_peripherals in addition to api.attached_modules

This PR builds off of the driver PR that was already merged and an OE-CORE PR that adds the port renaming udev rule for the the scanner.

The implementation here for the BarcodeScanner object is very simple just to keep that separated but does expose device_info, status, name etc.