### PR TITLE
feat(api): add timeout and pressure tolerance for vacuum module.

### DIFF
--- a/api/src/opentrons/drivers/vacuum_module/abstract.py
+++ b/api/src/opentrons/drivers/vacuum_module/abstract.py
@@ -58,7 +58,8 @@ class AbstractVacuumModuleDriver(Protocol):
         self,
         enable_vacuum: bool,
         guage_pressure_mbar: Optional[float] = None,
-        duration: Optional[int] = None,
+        duration_s: Optional[int] = None,
+        timeout_s: Optional[int] = None,
         rate: Optional[float] = None,
         vent_after: Optional[bool] = None,
     ) -> None:
@@ -94,6 +95,7 @@ class AbstractVacuumModuleDriver(Protocol):
         overshoot: Optional[float] = None,
         k_velocity: Optional[float] = None,
         k_holding: Optional[float] = None,
+        tolerance: Optional[float] = None,
         reset: bool = False,
     ) -> None:
         """Sets the PID tuning parameters for the pressure control."""

--- a/api/src/opentrons/drivers/vacuum_module/driver.py
+++ b/api/src/opentrons/drivers/vacuum_module/driver.py
@@ -86,7 +86,7 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
     @classmethod
     def parse_get_pressure_pid(cls, response: str) -> PressureControlTunings:
         """Parse the get pressure pid."""
-        pattern = r"P:(?P<P>\d.+) I:(?P<I>\d.+) D:(?P<D>\d.+) O:(?P<O>-?\d.+) V:(?P<V>\d.+) H:(?P<H>\d.+)"
+        pattern = r"P:(?P<P>\d.+) I:(?P<I>\d.+) D:(?P<D>\d.+) O:(?P<O>-?\d.+) V:(?P<V>\d.+) H:(?P<H>\d.+) T:(?P<T>\d.+)"
         _RE = re.compile(rf"^{GCODE.GET_PRESSURE_PID} {pattern}$")
         match = _RE.match(response)
         if not match:
@@ -98,6 +98,7 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
             float(match.group("O")),
             float(match.group("V")),
             float(match.group("H")),
+            float(match.group("T")),
         )
 
     @classmethod
@@ -272,7 +273,8 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
         self,
         enable_vacuum: bool,
         guage_pressure_mbar: Optional[float] = None,
-        duration: Optional[int] = None,
+        duration_s: Optional[int] = None,
+        timeout_s: Optional[int] = None,
         rate: Optional[float] = None,
         vent_after: Optional[bool] = None,
     ) -> None:
@@ -288,8 +290,10 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
                 min(max(guage_pressure_mbar, MAX_PRESSURE_MBAR), 0),
                 GCODE_ROUNDING_PRECISION,
             )
-        if duration is not None:
-            command.add_int("D", duration)
+        if duration_s is not None:
+            command.add_int("D", duration_s)
+        if timeout_s is not None:
+            command.add_int("T", timeout_s)
         if rate is not None:
             command.add_float("R", min(max(rate, MAX_RAMP_RATE), 0))
         if vent_after is not None:
@@ -349,6 +353,7 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
         overshoot: Optional[float] = None,
         k_velocity: Optional[float] = None,
         k_holding: Optional[float] = None,
+        tolerance: Optional[float] = None,
         reset: bool = False,
     ) -> None:
         """Sets the PID tuning parameters for the pressure control."""
@@ -366,6 +371,8 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
             command.add_float("V", k_velocity, GCODE_ROUNDING_PRECISION)
         if k_holding is not None:
             command.add_float("H", k_holding, GCODE_ROUNDING_PRECISION)
+        if tolerance is not None:
+            command.add_float("T", tolerance, GCODE_ROUNDING_PRECISION)
         command.add_int("R", int(reset))
 
         resp = await self._connection.send_command(command)

--- a/api/src/opentrons/drivers/vacuum_module/simulator.py
+++ b/api/src/opentrons/drivers/vacuum_module/simulator.py
@@ -85,12 +85,12 @@ class SimulatingDriver(AbstractVacuumModuleDriver):
         """Get the register value of the pressure sensor driver."""
         pass
 
-    # TODO: update the pressure arg with the units when we find out which unit
     async def set_vacuum_state(
         self,
         enable_vacuum: bool,
         guage_pressure_mbar: Optional[float] = None,
-        duration: Optional[int] = None,
+        duration_s: Optional[int] = None,
+        timeout_s: Optional[int] = None,
         rate: Optional[float] = None,
         vent_after: Optional[bool] = None,
     ) -> None:
@@ -136,6 +136,7 @@ class SimulatingDriver(AbstractVacuumModuleDriver):
         overshoot: Optional[float] = None,
         k_velocity: Optional[float] = None,
         k_holding: Optional[float] = None,
+        tolerance: Optional[float] = None,
         reset: bool = False,
     ) -> None:
         """Sets the PID tuning parameters for the pressure control."""
@@ -143,7 +144,7 @@ class SimulatingDriver(AbstractVacuumModuleDriver):
 
     async def get_pressure_control_tunings(self) -> PressureControlTunings:
         """Get the pressure control pid tunings."""
-        return PressureControlTunings(0, 0, 0, 0, 0, 0)
+        return PressureControlTunings(0, 0, 0, 0, 0, 0, 0)
 
     async def set_waste_configs(
         self,

--- a/api/src/opentrons/drivers/vacuum_module/types.py
+++ b/api/src/opentrons/drivers/vacuum_module/types.py
@@ -119,6 +119,7 @@ class PressureControlTunings:
     overshoot_error: float
     k_velocity: float
     k_holding: float
+    tolerance_error: float
 
 
 @dataclass

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -308,13 +308,15 @@ class VacuumModule(mod_abc.AbstractModule):
 
     async def set_vent_state(self, vent_state: VentState) -> None:
         """Open or close the vent."""
+        # TODO: Handle error
         await self._driver.set_vent_state(state=vent_state)
 
     async def set_vacuum_state(
         self,
         enable_vacuum: bool,
         guage_pressure_mbar: Optional[float] = None,
-        duration: Optional[int] = None,
+        duration_s: Optional[int] = None,
+        timeout_s: Optional[int] = None,
         rate: Optional[float] = None,
         vent_after: Optional[bool] = None,
     ) -> None:
@@ -322,7 +324,8 @@ class VacuumModule(mod_abc.AbstractModule):
         await self._driver.set_vacuum_state(
             enable_vacuum=enable_vacuum,
             guage_pressure_mbar=guage_pressure_mbar,
-            duration=duration,
+            duration_s=duration_s,
+            timeout_s=timeout_s,
             rate=rate,
             vent_after=vent_after,
         )
@@ -337,10 +340,6 @@ class VacuumModule(mod_abc.AbstractModule):
         await self._driver.set_pump_state(
             start_pump=start_pump, target_rpm=target_rpm, duty_cycle=duty_cycle
         )
-
-    async def set_serial_number(self, sn: str) -> None:
-        """Set the serial number."""
-        await self._driver.set_serial_number(sn=sn)
 
 
 class VacuumModuleReader(Reader):

--- a/api/tests/opentrons/drivers/vacuum_module/test_driver.py
+++ b/api/tests/opentrons/drivers/vacuum_module/test_driver.py
@@ -133,16 +133,17 @@ async def test_set_vacuum_state(
     connection.send_command.assert_any_call(set_pressure)
     connection.reset_mock()
 
-    # With duration and rate
+    # With duration, timeout, and rate
     connection.send_command.return_value = "M120"
 
-    await subject.set_vacuum_state(True, -600, 500, rate=-10)
+    await subject.set_vacuum_state(True, -600, 500, 30, rate=-10)
 
     set_pressure = (
         types.GCODE.SET_PRESSURE_STATE.build_command()
         .add_int("S", 1)
         .add_float("P", -600)
         .add_int("D", 500)
+        .add_int("T", 30)
         .add_float("R", -10)
     )
 
@@ -313,7 +314,9 @@ async def test_get_pressure_control_tunings(
     subject: VacuumModuleDriver, connection: AsyncMock
 ) -> None:
     """It should send a get pressure pid command"""
-    connection.send_command.return_value = "M126 P:1.0 I:0.0 D:0.0 O:-2.0 V:20.0 H:43.0"
+    connection.send_command.return_value = (
+        "M126 P:1.0 I:0.0 D:0.0 O:-2.0 V:20.0 H:43.0 T:0.2"
+    )
 
     pressure_state = await subject.get_pressure_control_tunings()
 
@@ -321,4 +324,4 @@ async def test_get_pressure_control_tunings(
     connection.send_command.assert_any_call(get_pressure)
     connection.reset_mock()
 
-    assert pressure_state == types.PressureControlTunings(1, 0, 0, -2, 20, 43)
+    assert pressure_state == types.PressureControlTunings(1, 0, 0, -2, 20, 43, 0.2)

--- a/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
@@ -194,10 +194,17 @@ async def test_set_vent_state(
 
 
 @pytest.mark.parametrize(
-    ("enable_vacuum", "guage_pressure_mbar", "duration", "rate", "vent_after"),
+    (
+        "enable_vacuum",
+        "guage_pressure_mbar",
+        "duration",
+        "timeout",
+        "rate",
+        "vent_after",
+    ),
     [
-        (True, 100.0, 67, 55.5, False),
-        (False, 99.8, 45, 54, None),
+        (True, 100.0, 67, 30, 55.5, False),
+        (False, 99.8, 45, 30, 54, None),
     ],
 )
 async def test_set_vacuum_state(
@@ -206,6 +213,7 @@ async def test_set_vacuum_state(
     enable_vacuum: bool,
     guage_pressure_mbar: Optional[float],
     duration: Optional[int],
+    timeout: Optional[int],
     rate: Optional[float],
     vent_after: Optional[bool],
     decoy: Decoy,
@@ -214,7 +222,8 @@ async def test_set_vacuum_state(
     await subject.set_vacuum_state(
         enable_vacuum=enable_vacuum,
         guage_pressure_mbar=guage_pressure_mbar,
-        duration=duration,
+        duration_s=duration,
+        timeout_s=timeout,
         rate=rate,
         vent_after=vent_after,
     )
@@ -222,7 +231,8 @@ async def test_set_vacuum_state(
         await mock_driver.set_vacuum_state(
             enable_vacuum=enable_vacuum,
             guage_pressure_mbar=guage_pressure_mbar,
-            duration=duration,
+            duration_s=duration,
+            timeout_s=timeout,
             rate=rate,
             vent_after=vent_after,
         )
@@ -249,18 +259,6 @@ async def test_set_pump_state(
             start_pump=start_pump, target_rpm=target_rpm, duty_cycle=duty_cycle
         )
     )
-
-
-@pytest.mark.parametrize("serial_number", ["VM111110100101", "myfunkyvacuum"])
-async def test_set_serial_number(
-    subject: modules.VacuumModule,
-    mock_driver: SimulatingDriver,
-    decoy: Decoy,
-    serial_number: str,
-) -> None:
-    """Ensure that the hardware controller calls the driver method w the correct arguments."""
-    await subject.set_serial_number(sn=serial_number)
-    decoy.verify(await mock_driver.set_serial_number(sn=serial_number))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Overview

This pull request adds the ability to set a timeout in seconds when setting the pressure state. We also need to be able to set the percent error that the target is off by, so the user can customize this.

## Test Plan and Hands on Testing

- Make sure we can set the timeout in seconds and receive a pressure_not_reached error if not reached within the time
- Make sure we can set the pressure tolerance

## Changelog

- Add timeout_s argument to `set_vacuum_state` to control the timeout for reaching the given target pressure
- Add tolerance argument to `set_pressure_control_tunings` to set the percent from the target pressure we can be off and still be considered "target pressure reached".

## Review requests
## Risk assessment