### PR TITLE
feat(app): add TouchTextarea component

### DIFF
--- a/app/src/molecules/TouchTextAreaField/TouchTextAreaField.stories.tsx
+++ b/app/src/molecules/TouchTextAreaField/TouchTextAreaField.stories.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react'
+
+import { DIRECTION_COLUMN, SPACING, VIEWPORT } from '@opentrons/components'
+
+import { TouchTextAreaField as TouchTextAreaFieldComponent } from '.'
+
+import type { Meta, StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+const meta: Meta<typeof TouchTextAreaFieldComponent> = {
+  title: 'ODD/Molecules/TouchTextAreaField',
+  component: TouchTextAreaFieldComponent,
+  parameters: VIEWPORT.touchScreenViewport,
+  argTypes: {},
+}
+
+export default meta
+type Story = StoryObj<typeof TouchTextAreaFieldComponent>
+
+export const TextAreaField: Story = (
+  args: ComponentProps<typeof TouchTextAreaFieldComponent>
+) => {
+  const [value, setValue] = React.useState(args.value)
+  return (
+    <div style={{ flexDirection: DIRECTION_COLUMN, gap: SPACING.spacing4 }}>
+      <TouchTextAreaFieldComponent
+        {...args}
+        value={value}
+        onChange={e => {
+          setValue(e.currentTarget.value)
+        }}
+      />
+    </div>
+  )
+}
+
+TextAreaField.args = {
+  label: 'This is TouchTextAreaField',
+  height: '22.5rem',
+  placeholder: 'Placeholder Text',
+}

--- a/app/src/molecules/TouchTextAreaField/__tests__/TouchTextAreaField.test.tsx
+++ b/app/src/molecules/TouchTextAreaField/__tests__/TouchTextAreaField.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderWithProviders } from '/app/__testing-utils__'
+
+import { TouchTextAreaField } from '..'
+
+import type { ComponentProps } from 'react'
+
+const render = (props: ComponentProps<typeof TouchTextAreaField>) => {
+  return renderWithProviders(<TouchTextAreaField {...props} />)
+}
+
+describe('TouchTextAreaField', () => {
+  let props: ComponentProps<typeof TouchTextAreaField>
+
+  beforeEach(() => {
+    props = {
+      label: 'TouchTextAreaField',
+      placeholder: 'Enter text...',
+      value: '',
+      onChange: vi.fn(),
+      id: 'touchTextArea',
+    }
+  })
+
+  it('renders the TextAreaField component', () => {
+    render(props)
+    screen.getByText('TouchTextAreaField')
+    const textarea = screen.getByRole('textbox', { name: /touchTextArea/i })
+    expect(textarea).toBeInTheDocument()
+  })
+
+  it('displays the correct placeholder text', () => {
+    render(props)
+    expect(screen.getByPlaceholderText('Enter text...')).toBeInTheDocument()
+  })
+
+  it('updates value when user types', () => {
+    render(props)
+    const textarea = screen.getByRole('textbox', { name: /touchTextArea/i })
+    fireEvent.change(textarea, { target: { value: 'Hello, world!' } })
+    expect(props.onChange).toHaveBeenCalledTimes(1)
+  })
+
+  it('disables the textarea when disabled prop is true', () => {
+    props.disabled = true
+    render(props)
+    const textarea = screen.getByRole('textbox', { name: /touchTextArea/i })
+    expect(textarea).toBeDisabled()
+  })
+
+  it('displays an error message when error prop is provided', () => {
+    props.error = 'Error: Invalid input'
+    render(props)
+    expect(screen.getByText('Error: Invalid input')).toBeInTheDocument()
+  })
+})

--- a/app/src/molecules/TouchTextAreaField/index.tsx
+++ b/app/src/molecules/TouchTextAreaField/index.tsx
@@ -1,0 +1,140 @@
+import { forwardRef, useId } from 'react'
+import clsx from 'clsx'
+
+import { COLORS, StyledText } from '@opentrons/components'
+
+import styles from './touchtextareafield.module.css'
+
+import type {
+  ComponentPropsWithoutRef,
+  CSSProperties,
+  MouseEventHandler,
+} from 'react'
+
+type NativeTextareaProps = Omit<ComponentPropsWithoutRef<'textarea'>, 'title'>
+
+// ToDo support a11y add aria-*
+interface TouchTextAreaFieldProps extends NativeTextareaProps {
+  /** optional label */
+  label?: string | null
+  /** if included, TextAreaField will use error style and display error instead of caption */
+  error?: string | null
+  /** optional caption. hidden when `error` is given */
+  caption?: string | null
+  /** horizontal text alignment for label, textarea, and (sub)captions */
+  textAlign?: 'left' | 'center'
+  /** if true, style the background of textarea field to error state */
+  hasBackgroundError?: boolean
+  /** optional prop to support focus when tapping text area */
+  onWrapperClick?: MouseEventHandler<HTMLDivElement>
+  /** optional prop to override textarea field border radius */
+  borderRadius?: CSSProperties['borderRadius']
+  /** optional prop to override textarea field padding */
+  padding?: CSSProperties['padding']
+  /** optional prop to override textarea field height */
+  height?: CSSProperties['height']
+  /** optional prop to override textarea field resize default is none */
+  resize?: CSSProperties['resize']
+  /** if true, clear out value and add '-' placeholder */
+  isIndeterminate?: boolean
+}
+
+export const TouchTextAreaField = forwardRef<
+  HTMLTextAreaElement,
+  TouchTextAreaFieldProps
+>((props, ref): JSX.Element => {
+  const {
+    label,
+    error,
+    caption,
+    textAlign = 'left',
+    hasBackgroundError = false,
+    onWrapperClick,
+    borderRadius,
+    padding,
+    height,
+    resize = 'none',
+    isIndeterminate,
+    ...textareaProps
+  } = props
+  const {
+    disabled: rawDisabled,
+    placeholder: rawPlaceholder,
+    value: rawValue,
+    ...restTextareaProps
+  } = textareaProps
+  const generatedId = useId()
+  const textareaId = restTextareaProps.id ?? generatedId
+  const hasError = error != null
+  const value = (isIndeterminate ?? false) ? '' : (rawValue ?? '')
+  const placeHolderText = (isIndeterminate ?? false) ? '-' : rawPlaceholder
+
+  const wrapperClasses = clsx(
+    styles.wrapper,
+    error != null ? styles.warning_color : styles.default_color,
+    rawDisabled === true && styles.disabled
+  )
+
+  const textareaClasses = clsx(
+    styles.textarea,
+    hasError && styles.textarea_error,
+    hasBackgroundError && styles.textarea_background_error
+  )
+
+  const labelClasses = clsx(
+    styles.label_text,
+    textAlign === 'center' ? styles.label_text_center : styles.label_text_left
+  )
+
+  return (
+    <div className={wrapperClasses}>
+      <div className={styles.column_container}>
+        {label != null && (
+          <div className={styles.label_row}>
+            <label htmlFor={textareaId}>
+              <StyledText oddStyle="bodyTextRegular" className={labelClasses}>
+                {label}
+              </StyledText>
+            </label>
+          </div>
+        )}
+        <div
+          className={styles.clickable_column}
+          onClick={!rawDisabled ? onWrapperClick : undefined}
+        >
+          <div className={styles.textarea_row}>
+            <textarea
+              id={textareaId}
+              className={textareaClasses}
+              style={{
+                borderRadius: borderRadius ?? undefined,
+                padding: padding ?? undefined,
+                height: height ?? undefined,
+                resize: resize,
+              }}
+              disabled={rawDisabled}
+              value={value}
+              placeholder={placeHolderText}
+              ref={ref}
+              {...restTextareaProps}
+            />
+          </div>
+        </div>
+        {!hasError && caption != null && (
+          <StyledText
+            oddStyle="bodyTextRegular"
+            className={styles.caption_text}
+            color={COLORS.grey60}
+          >
+            {caption}
+          </StyledText>
+        )}
+        {hasError && (
+          <StyledText oddStyle="bodyTextRegular" className={styles.error_text}>
+            {error}
+          </StyledText>
+        )}
+      </div>
+    </div>
+  )
+})

--- a/app/src/molecules/TouchTextAreaField/touchtextareafield.module.css
+++ b/app/src/molecules/TouchTextAreaField/touchtextareafield.module.css
@@ -1,0 +1,102 @@
+.wrapper {
+  display: flex;
+  width: 100%;
+  align-items: center;
+}
+
+.warning_color {
+  color: var(--yellow-60);
+}
+
+.default_color {
+  color: var(--black-90);
+}
+
+.disabled {
+  opacity: 0.5;
+}
+
+.column_container {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+}
+
+.label_row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--spacing-8);
+}
+
+.clickable_column {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+}
+
+.textarea_row {
+  display: flex;
+  align-items: center;
+}
+
+.textarea {
+  width: 100%;
+  height: 100%;
+  padding: var(--spacing-8);
+  border: 1px solid var(--grey-50);
+  border-radius: var(--border-radius-4);
+  background-color: var(--white);
+  font-size: var(--font-size-h3);
+  font-weight: var(--font-weight-regular);
+  resize: none;
+}
+
+.textarea:focus {
+  border: 1px solid var(--blue-50);
+  outline: none;
+}
+
+.textarea:disabled {
+  border: 1px solid var(--grey-30);
+  background-color: var(--grey-20);
+}
+
+.textarea_error {
+  border: 1px solid var(--red-50);
+}
+
+.textarea_error:focus {
+  border: 1px solid var(--red-50);
+}
+
+.textarea_background_error {
+  border: none;
+  background-color: var(--red-30);
+}
+
+.label_text {
+  padding-bottom: var(--spacing-4);
+  color: var(--grey-60);
+  font-size: var(--font-size-h3);
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-20);
+}
+
+.label_text_left {
+  text-align: left;
+}
+
+.label_text_center {
+  text-align: center;
+}
+
+.caption_text {
+  padding-top: var(--spacing-4);
+  color: var(--grey-60);
+}
+
+.error_text {
+  padding-top: var(--spacing-4);
+  color: var(--red-50);
+}

--- a/app/src/molecules/TouchTextAreaField/touchtextareafield.module.css
+++ b/app/src/molecules/TouchTextAreaField/touchtextareafield.module.css
@@ -47,8 +47,10 @@
   border: 1px solid var(--grey-50);
   border-radius: var(--border-radius-4);
   background-color: var(--white);
-  font-size: var(--font-size-h3);
+  font-size: var(--font-size-22);
+  font-style: normal;
   font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-28);
   resize: none;
 }
 


### PR DESCRIPTION
# Overview
This component is based on Text area component but the structure was changed to improve maintainability and type safe

**fyi**
still waiting for a few design inputs
https://opentrons.slack.com/archives/C0A43CT6Q6Q/p1774298245212019

close EXEC-2452

`TextAreaField` component will be updated to align with `TouchTextAreaField` component's structure.


## Test Plan and Hands on Testing
- not yet
This component and Full software keyboard will be used to create a dev test page for the QA process

## Changelog
- Add TouchTextAreaField, its test, and its storybook

## Review requests


## Risk assessment
low
