### PR TITLE
fix(app): fix LPC UI `set_offset()` behavior

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/__tests__/getLocationSpecificOffsetDetailsForLabware.test.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/__tests__/getLocationSpecificOffsetDetailsForLabware.test.ts
@@ -56,6 +56,13 @@ describe('getLocationSpecificOffsetDetailsForLabware', () => {
         offsetId: OFFSET_ID,
       },
     ],
+    labwareOffsets: [
+      {
+        id: OFFSET_ID,
+        definitionUri: LABWARE_URI,
+        locationSequence: MOCK_OFFSET_LOC_SEQ,
+      },
+    ],
     commands: [MOCK_LOAD_COMMAND],
     modules: [],
   } as any
@@ -152,13 +159,30 @@ describe('getLocationSpecificOffsetDetailsForLabware', () => {
     expect(result[0].locationDetails.hardCodedOffsetId).toBe(null)
   })
 
-  it('should handle when no labware has offsetId', () => {
-    const protocolDataWithoutOffsetId = {
+  it('should handle when no labwareOffsets exist', () => {
+    const protocolDataWithoutLabwareOffsets = {
       ...MOCK_PROTOCOL_DATA,
-      labware: [
+      labwareOffsets: [],
+    }
+
+    const result = getLocationSpecificOffsetDetailsForLabware({
+      uri: LABWARE_URI,
+      lwLocInfo: MOCK_LW_LOC_COMBOS,
+      currentOffsets: [],
+      protocolData: protocolDataWithoutLabwareOffsets,
+    } as any)
+
+    expect(result[0].locationDetails.hardCodedOffsetId).toBe(null)
+  })
+
+  it('should handle when labwareOffsets uri does not match', () => {
+    const protocolDataWithDifferentUri = {
+      ...MOCK_PROTOCOL_DATA,
+      labwareOffsets: [
         {
-          id: LABWARE_ID,
-          definitionUri: LABWARE_URI,
+          id: OFFSET_ID,
+          definitionUri: 'different-uri',
+          locationSequence: MOCK_OFFSET_LOC_SEQ,
         },
       ],
     }
@@ -167,7 +191,31 @@ describe('getLocationSpecificOffsetDetailsForLabware', () => {
       uri: LABWARE_URI,
       lwLocInfo: MOCK_LW_LOC_COMBOS,
       currentOffsets: [],
-      protocolData: protocolDataWithoutOffsetId,
+      protocolData: protocolDataWithDifferentUri,
+    } as any)
+
+    expect(result[0].locationDetails.hardCodedOffsetId).toBe(null)
+  })
+
+  it('should handle when labwareOffsets locationSequence does not match', () => {
+    const protocolDataWithDifferentLocSeq = {
+      ...MOCK_PROTOCOL_DATA,
+      labwareOffsets: [
+        {
+          id: OFFSET_ID,
+          definitionUri: LABWARE_URI,
+          locationSequence: [
+            { kind: 'onAddressableArea', addressableAreaName: 'B1' },
+          ],
+        },
+      ],
+    }
+
+    const result = getLocationSpecificOffsetDetailsForLabware({
+      uri: LABWARE_URI,
+      lwLocInfo: MOCK_LW_LOC_COMBOS,
+      currentOffsets: [],
+      protocolData: protocolDataWithDifferentLocSeq,
     } as any)
 
     expect(result[0].locationDetails.hardCodedOffsetId).toBe(null)

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/getLocationSpecificOffsetDetailsForLabware.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/hooks/useLPCLabwareInfo/getLPCLabwareInfoFrom/getLocationSpecificOffsetDetailsForLabware.ts
@@ -2,14 +2,10 @@ import isEqual from 'lodash/isEqual'
 
 import { ANY_LOCATION } from '@opentrons/api-client'
 
-import { getLwOffsetLocSeqFromLocSeq } from '/app/local-resources/offsets'
 import { OFFSET_KIND_LOCATION_SPECIFIC } from '/app/redux/protocol-runs'
 
 import type { LabwareOffsetLocationSequence } from '@opentrons/api-client'
-import type {
-  CompletedProtocolAnalysis,
-  LoadLabwareRunTimeCommand,
-} from '@opentrons/shared-data'
+import type { CompletedProtocolAnalysis } from '@opentrons/shared-data'
 import type { LocationSpecificOffsetDetails } from '/app/redux/protocol-runs'
 import type { GetLPCLabwareInfoForURI } from '.'
 
@@ -61,9 +57,9 @@ interface HardcodedOffsetInfo {
   [uri: string]: HardcodedOffsetIdAndOffsetLocSeq[]
 }
 
-// Returns hardcoded offset information for identifying other location-specific
-// offsets.
-// This logic is predicated on API level 2.18+ set_offset() behavior.
+// Returns hardcoded offset information for identifying other location-specific offsets.
+// This behavior is predicated on API level 2.18+ set_offset() behavior, since modern LPC flows
+// act on labware uris instead of specific labware instances.
 function getHardCodedOffsetInfo(
   protocolData: CompletedProtocolAnalysis | null
 ): HardcodedOffsetInfo {
@@ -71,57 +67,24 @@ function getHardCodedOffsetInfo(
 
   if (protocolData == null) {
     return result
-  } else {
-    const { labware } = protocolData
-
-    labware.forEach(lw => {
-      // The presence of this id means a labware offset is set using set_offset().
-      const hardcodedOffsetId = lw.offsetId
-
-      if (hardcodedOffsetId != null) {
-        // This is a nested command loop, but it really should only ever iterate over
-        // the initial load commands.
-        const loqSeq = getHardcodedOffsetLocSeqFor(lw.id, protocolData)
-
-        if (loqSeq.length === 0) {
-          console.error(
-            `Expected to find matching load command with result for hardcoded offset for labware: ${lw.id}`
-          )
-        }
-
-        // Initialize the array if it doesn't exist yet
-        if (!result[lw.definitionUri]) {
-          result[lw.definitionUri] = []
-        }
-
-        // Now we can safely push to the initialized array
-        result[lw.definitionUri].push([hardcodedOffsetId, loqSeq])
-      }
-    })
-
-    return result
   }
-}
 
-// Returns the offset location sequence associated with the labware that has
-// a hardcoded offset.
-function getHardcodedOffsetLocSeqFor(
-  lwId: string,
-  protocolData: CompletedProtocolAnalysis
-): LabwareOffsetLocationSequence {
-  const { commands, modules, labware } = protocolData
-
-  const matchingCommand = commands.find(c => {
-    if (c.commandType === 'loadLabware' && c.result?.labwareId === lwId) {
-      return true
+  const { labwareOffsets } = protocolData
+  labwareOffsets?.forEach(offset => {
+    if (offset.locationSequence == null) {
+      console.error(
+        `Expected to find matching labware offset location sequence for labware: ${offset.definitionUri}`
+      )
     } else {
-      return false
+      if (!(offset.definitionUri in result)) {
+        result[offset.definitionUri] = []
+      }
+
+      result[offset.definitionUri].push([offset.id, offset.locationSequence])
     }
-  }) as LoadLabwareRunTimeCommand
+  })
 
-  const loqSeq = matchingCommand.result?.locationSequence ?? []
-
-  return getLwOffsetLocSeqFromLocSeq(loqSeq, labware, modules)
+  return result
 }
 
 // Given the labware uri and offset location sequence, returns the associated


### PR DESCRIPTION
Closes [EXEC-2418](https://opentrons.atlassian.net/browse/EXEC-2418)

# Overview

The LPC labware offsets table attempts to label certain offsets as "hardcoded", those offsets that are set using `set_offset()` when authoring a protocol. https://github.com/Opentrons/opentrons/pull/21090 provides an in-depth overview of the issue and works towards a fix by including `labwareOffsets` on completed protocol analyses.

This PR implements the UI fix by updating LPC's utilities to check if a hardcoded offset is present for a particular labware in a given slot, making use of `labwareOffsets`. 

Note that modern LPC provies offsets to types of labware (labware URIs) and not specific labware instances, and the utility and UI cannot make affordances for the `set_offset()` [behavior present](https://github.com/Opentrons/opentrons/blob/app_lpc-hardcoded-label-fix/api/src/opentrons/protocol_api/labware.py#L851) in API versions `2.12`-`2.13`.

### Current Behavior

<img width="905" height="372" alt="Screenshot 2026-03-24 at 12 05 14 PM" src="https://github.com/user-attachments/assets/1fa8f0ce-4a4c-4fd1-9f66-f4caa99b1bc3" />

### Fixed Behavior

<img width="907" height="362" alt="Screenshot 2026-03-24 at 12 01 30 PM" src="https://github.com/user-attachments/assets/b192aca4-ce9b-4b5c-acb8-cc46f3fd2539" />

## Test Plan and Hands on Testing

- See ticket for protocol utilized for testing.
- See images.

## Changelog

- Fixed the LPC labware offsets table not correctly reflecting hardcoded offsets.

## Risk assessment

- lowish, LPC uses hardcoded offsets to determine whether users are allowed to configure location specific offsets, render a few banners, and populate the UI with "hardcoded" instead of other offset types.


[EXEC-2418]: https://opentrons.atlassian.net/browse/EXEC-2418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ