### PR TITLE
docs(api): API 2.28 final changes

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -95,7 +95,7 @@ extra_css:
   - python-api.css
 
 extra:
-  apiLevel: 2.27
-  robot_stack_version: 8.8.0
+  apiLevel: 2.28
+  robot_stack_version: 9.0.0
 
 copyright: '© Opentrons 2025. All rights reserved. <br /> Trademarks: Opentrons®, Opentrons drop logo (Opentrons Labworks, Inc.). <br /> Registered names, trademarks, etc. used in this document, even when not specifically marked as such, are not to be considered unprotected by law.'

--- a/docs/python-api/docs/modules/flex-stacker.md
+++ b/docs/python-api/docs/modules/flex-stacker.md
@@ -54,7 +54,7 @@ stacker_2.set_stored_labware(
 )
 ```
 
-In this example, `stacker_1` is configured to hold 5 Flex tip racks, each with a compatible lid. To be properly stored in the Stacker, all Flex tip racks must match: either all tip racks have lids, or none have lids.
+In this example, `stacker_1` is configured to hold 5 Flex tip racks, each with a compatible lid. To be properly stored in the Stacker, all Flex tip racks should have lids.
 
 `stacker_2` is configured to hold 12 PCR plates without lids. You must configure each Stacker in your protocol before using [`store()`][opentrons.protocol_api.FlexStackerContext.store] or [`retrieve()`][opentrons.protocol_api.FlexStackerContext.retrieve].
 
@@ -97,6 +97,9 @@ stacker_2.store()
 ```
 
 After placing labware on the shuttle in slot C3, `stacker_2` stores another well plate on the bottom of the stack.
+
+!!! note
+    You can store empty tip racks you'd like to reuse in a Stacker during your protocol, but each tip rack needs a lid to properly stack together. 
 
 You can use [`fill()`][opentrons.protocol_api.FlexStackerContext.fill] to fill the Stacker with as many of its configured labware as it can store. Alternatively, use [`empty()`][opentrons.protocol_api.FlexStackerContext.empty] to remove all labware from the Stacker:
 

--- a/docs/python-api/docs/pipettes/loading.md
+++ b/docs/python-api/docs/pipettes/loading.md
@@ -216,7 +216,7 @@ right_pipette.drop_tip()
 
 See also [Building Block Commands](../building-block-commands/index.md) and [Complex Commands](../complex-commands/index.md).
 
-### Tip–pipette compatibility
+### Tip-pipette compatibility
 
 Flex pipettes only accept tips with capacities less than or equal to the pipette capacity. 
 

--- a/docs/python-api/docs/pipettes/loading.md
+++ b/docs/python-api/docs/pipettes/loading.md
@@ -87,7 +87,7 @@ The pipette's API load name (`instrument_name`) is the first parameter of the `l
 
     See the [OT-2 Pipette Generations](characteristics.md#ot-2-pipette-generations) section if you're using GEN1 pipettes on an OT-2. The GEN1 family includes the P10, P50, and P300 single- and multi-channel pipettes, along with the P1000 single-channel model.
 
-Use the [tip-pipette compatibility](loading.md#tip-pipette-compatibility) section below to choose compatible pipette tips. 
+Use the [tip–pipette compatibility](loading.md#tip-pipette-compatibility) section below to choose compatible pipette tips. 
 
 ## Loading Flex 1- and 8-Channel Pipettes
 
@@ -216,11 +216,11 @@ right_pipette.drop_tip()
 
 See also [Building Block Commands](../building-block-commands/index.md) and [Complex Commands](../complex-commands/index.md).
 
-### Tip-pipette compatibility
+### Tip–pipette compatibility
 
 Flex pipettes only accept tips with capacities less than or equal to the pipette capacity. 
 
-| Pipette capacity | Pipettes {width="40%"} | Compatible tips {width="110%"}|
+| Pipette capacity {width="17%"}| Pipettes {width="31%"} | Compatible tips |
 |--------------|--------------|-----------------------------|
 | 1–50 µL    | <ul><li><code>flex_1channel_50</code></li><li><code>flex_8channel_50</code></li></ul> | <ul><li><code>opentrons_flex_96_tiprack_20ul</code></li><li><code>opentrons_flex_96_filtertiprack_20ul</code></li><li><code>opentrons_flex_96_tiprack_50ul</code></li><li><code>opentrons_flex_96_filtertiprack_50ul</code></li></ul> |
 | 1–200 µL | <ul><li><code>flex_96channel_200</code></li></ul> |<ul><li><code>opentrons_flex_96_tiprack_20ul</code></li><li><code>opentrons_flex_96_filtertiprack_20ul</code></li><li><code>opentrons_flex_96_tiprack_50ul</code></li><li><code>opentrons_flex_96_filtertiprack_50ul</code></li><li><code>opentrons_flex_96_tiprack_200ul</code></li><li><code>opentrons_flex_96_filtertiprack_200ul</code></li></ul> |

--- a/docs/python-api/docs/pipettes/loading.md
+++ b/docs/python-api/docs/pipettes/loading.md
@@ -226,7 +226,7 @@ Flex pipettes only accept tips with capacities less than or equal to the pipette
 | 1–200 µL | <ul><li><code>flex_96channel_200</code></li></ul> |<ul><li><code>opentrons_flex_96_tiprack_20ul</code></li><li><code>opentrons_flex_96_filtertiprack_20ul</code></li><li><code>opentrons_flex_96_tiprack_50ul</code></li><li><code>opentrons_flex_96_filtertiprack_50ul</code></li><li><code>opentrons_flex_96_tiprack_200ul</code></li><li><code>opentrons_flex_96_filtertiprack_200ul</code></li></ul> |
 | 5–1000 µL | <ul><li><code>flex_1channel_1000</code></li><li><code>flex_8channel_1000</code></li><li><code>flex_96channel_1000</code></li></ul> | <ul><li><code>opentrons_flex_96_tiprack_50ul</code></li><li><code>opentrons_flex_96_filtertiprack_50ul</code></li><li><code>opentrons_flex_96_tiprack_200ul</code></li><li><code>opentrons_flex_96_filtertiprack_200ul</code></li><li><code>opentrons_flex_96_tiprack_1000ul</code></li><li><code>opentrons_flex_96_filtertiprack_1000ul</code></li></ul> |
 
-*Changed in version 2.28*: Use 20 µL pipette tips in your Flex protocols. 
+*New in version 2.28*: Use 20 µL pipette tips in your Flex protocols. 
 
 The API includes less restrictions for OT-2 pipettes. We recommend choosing tips with capacities less than or equal to pipette capacity for the most accurate liquid handling.
 

--- a/docs/python-api/docs/pipettes/loading.md
+++ b/docs/python-api/docs/pipettes/loading.md
@@ -220,43 +220,14 @@ See also [Building Block Commands](../building-block-commands/index.md) and [Com
 
 Flex pipettes only accept tips with capacities less than or equal to the pipette capacity. 
 
-<table>
-    <thead>
-        <tr>
-            <th>Pipette capacity</th>
-            <th>Pipettes</th>
-            <th>Compatible tips</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr>
-                <td rowspan="4">1–50 µL</td>
-                <td>
-                  <ul>
-                    <li>
-                      <code>flex_1channel_50</code></li>
-                    <li>
-                      <code>flex_8channel_50</code></li>
-                  </ul>
-                </td>
-                <td>
-                  <ul>
-                    <li>
-                      <code>opentrons_flex_96_tiprack_20ul</code></li>
-                    <li>
-                      <code>opentrons_flex_96_filtertiprack_20ul</code></li>
-                    <li>
-                      <code>opentrons_flex_96_tiprack_50ul</code></li>
-                    <li>
-                      <code>opentrons_flex_96_filtertiprack_50ul</code></li>
-                  </ul>
-                </td>    
-            </tr>
-            <tr>
-        </tbody>
-    </table>
+| Pipette capacity | Pipettes {width="40%"} | Compatible tips {width="110%"}|
+|--------------|--------------|-----------------------------|
+| 1–50 µL    | <ul><li><code>flex_1channel_50</code></li><li><code>flex_8channel_50</code></li></ul> | <ul><li><code>opentrons_flex_96_tiprack_20ul</code></li><li><code>opentrons_flex_96_filtertiprack_20ul</code></li><li><code>opentrons_flex_96_tiprack_50ul</code></li><li><code>opentrons_flex_96_filtertiprack_50ul</code></li></ul> |
+| 1–200 µL | <ul><li><code>flex_96channel_200</code></li></ul> |<ul><li><code>opentrons_flex_96_tiprack_20ul</code></li><li><code>opentrons_flex_96_filtertiprack_20ul</code></li><li><code>opentrons_flex_96_tiprack_50ul</code></li><li><code>opentrons_flex_96_filtertiprack_50ul</code></li><li><code>opentrons_flex_96_tiprack_200ul</code></li><li><code>opentrons_flex_96_filtertiprack_200ul</code></li></ul> |
+| 5–1000 µL | <ul><li><code>flex_1channel_1000</code></li><li><code>flex_8channel_1000</code></li><li><code>flex_96channel_1000</code></li></ul> | <ul><li><code>opentrons_flex_96_tiprack_50ul</code></li><li><code>opentrons_flex_96_filtertiprack_50ul</code></li><li><code>opentrons_flex_96_tiprack_200ul</code></li><li><code>opentrons_flex_96_filtertiprack_200ul</code></li><li><code>opentrons_flex_96_tiprack_1000ul</code></li><li><code>opentrons_flex_96_filtertiprack_1000ul</code></li></ul> |
 
-The API includes less restrictions for OT-2 pipettes. Like the Flex, we recommend choosing tips with capacities less than or equal to pipette capacity for the most accurate liquid handling.
+
+The API includes less restrictions for OT-2 pipettes. We recommend choosing tips with capacities less than or equal to pipette capacity for the most accurate liquid handling.
 
 
 

--- a/docs/python-api/docs/pipettes/loading.md
+++ b/docs/python-api/docs/pipettes/loading.md
@@ -87,6 +87,8 @@ The pipette's API load name (`instrument_name`) is the first parameter of the `l
 
     See the [OT-2 Pipette Generations](characteristics.md#ot-2-pipette-generations) section if you're using GEN1 pipettes on an OT-2. The GEN1 family includes the P10, P50, and P300 single- and multi-channel pipettes, along with the P1000 single-channel model.
 
+Use the [tip-pipette compatibility](loading.md#tip-pipette-compatibility) section below to choose compatible pipette tips. 
+
 ## Loading Flex 1- and 8-Channel Pipettes
 
 This code sample loads a Flex 1-Channel Pipette in the left mount and a Flex 8-Channel Pipette in the right mount. Both pipettes are 1000 µL. Each pipette uses its own 1000 µL tip rack.
@@ -213,6 +215,50 @@ right_pipette.drop_tip()
 *New in version 2.0*
 
 See also [Building Block Commands](../building-block-commands/index.md) and [Complex Commands](../complex-commands/index.md).
+
+### Tip-pipette compatibility
+
+Flex pipettes only accept tips with capacities less than or equal to the pipette capacity. 
+
+<table>
+    <thead>
+        <tr>
+            <th>Pipette capacity</th>
+            <th>Pipettes</th>
+            <th>Compatible tips</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td rowspan="4">1–50 µL</td>
+                <td>
+                  <ul>
+                    <li>
+                      <code>flex_1channel_50</code></li>
+                    <li>
+                      <code>flex_8channel_50</code></li>
+                  </ul>
+                </td>
+                <td>
+                  <ul>
+                    <li>
+                      <code>opentrons_flex_96_tiprack_20ul</code></li>
+                    <li>
+                      <code>opentrons_flex_96_filtertiprack_20ul</code></li>
+                    <li>
+                      <code>opentrons_flex_96_tiprack_50ul</code></li>
+                    <li>
+                      <code>opentrons_flex_96_filtertiprack_50ul</code></li>
+                  </ul>
+                </td>    
+            </tr>
+            <tr>
+        </tbody>
+    </table>
+
+The API includes less restrictions for OT-2 pipettes. Like the Flex, we recommend choosing tips with capacities less than or equal to pipette capacity for the most accurate liquid handling.
+
+
 
 ## Adding trash containers
 

--- a/docs/python-api/docs/pipettes/loading.md
+++ b/docs/python-api/docs/pipettes/loading.md
@@ -226,6 +226,7 @@ Flex pipettes only accept tips with capacities less than or equal to the pipette
 | 1–200 µL | <ul><li><code>flex_96channel_200</code></li></ul> |<ul><li><code>opentrons_flex_96_tiprack_20ul</code></li><li><code>opentrons_flex_96_filtertiprack_20ul</code></li><li><code>opentrons_flex_96_tiprack_50ul</code></li><li><code>opentrons_flex_96_filtertiprack_50ul</code></li><li><code>opentrons_flex_96_tiprack_200ul</code></li><li><code>opentrons_flex_96_filtertiprack_200ul</code></li></ul> |
 | 5–1000 µL | <ul><li><code>flex_1channel_1000</code></li><li><code>flex_8channel_1000</code></li><li><code>flex_96channel_1000</code></li></ul> | <ul><li><code>opentrons_flex_96_tiprack_50ul</code></li><li><code>opentrons_flex_96_filtertiprack_50ul</code></li><li><code>opentrons_flex_96_tiprack_200ul</code></li><li><code>opentrons_flex_96_filtertiprack_200ul</code></li><li><code>opentrons_flex_96_tiprack_1000ul</code></li><li><code>opentrons_flex_96_filtertiprack_1000ul</code></li></ul> |
 
+*Changed in version 2.28*: Use 20 µL pipette tips in your Flex protocols. 
 
 The API includes less restrictions for OT-2 pipettes. We recommend choosing tips with capacities less than or equal to pipette capacity for the most accurate liquid handling.
 

--- a/docs/python-api/docs/versioning.md
+++ b/docs/python-api/docs/versioning.md
@@ -108,7 +108,7 @@ This table lists the correspondence between Protocol API versions and robot soft
     - an absolute `flow_rate`.
     - a blowout position for a liquid class transfer.
 - Simplifies [customizing liquid class](liquid-classes.md#customizing-liquid-classes) tip positions, including aspirate, dispense, and blowout positions.
-- Use Flex 20 μL pipette tips in your protocols. The tips are fully compatible with [liquid class](liquid-classes.md#using-liquid-classes) commands and with Flex 1- and 8-Channel (1–50 μL range) and 96-Channel (1–200 μL range) pipettes.
+- Use the load name `opentrons_flex_96_tiprack_20ul` to use Flex 20 μL pipette tips in your protocols. The tips are fully compatible with [liquid class](liquid-classes.md#using-liquid-classes) commands and with Flex 1- and 8-Channel (1–50 μL range) and 96-Channel (1–200 μL range) pipettes.
 - Control how quickly the Thermocycler Module's block heats or cools with the [`set_block_temperature()`][opentrons.protocol_api.ThermocyclerContext.set_block_temperature] and [`start_set_block_temperature()`][opentrons.protocol_api.ThermocyclerContext.start_set_block_temperature] methods' optional `ramp_rate` parameter.
 - Use the [`drop_tip()`][opentrons.protocol_api.InstrumentContext.drop_tip] method's optional `alternate_drop_location` argument to vary the tip drop location in a waste container, preventing tips from piling up in a single location.
 - In protocols using API version 2.28, the API raises an error when calling [`touch_tip()`][opentrons.protocol_api.InstrumentContext.touch_tip] in large spaces, like reservoirs and large well plates.

--- a/docs/python-api/docs/versioning.md
+++ b/docs/python-api/docs/versioning.md
@@ -108,6 +108,7 @@ This table lists the correspondence between Protocol API versions and robot soft
     - an absolute `flow_rate`.
     - a blowout position for a liquid class transfer.
 - Simplifies [customizing liquid class](liquid-classes.md#customizing-liquid-classes) tip positions, including aspirate, dispense, and blowout positions.
+- Use Flex 20 μL pipette tips in your protocols. The tips are fully compatible with [liquid class](liquid-classes.md#using-liquid-classes) commands and with Flex 1- and 8-Channel (1–50 μL range) and 96-Channel (1–200 μL range) pipettes.
 - Control how quickly the Thermocycler Module's block heats or cools with the [`set_block_temperature()`][opentrons.protocol_api.ThermocyclerContext.set_block_temperature] and [`start_set_block_temperature()`][opentrons.protocol_api.ThermocyclerContext.start_set_block_temperature] methods' optional `ramp_rate` parameter.
 - Use the [`drop_tip()`][opentrons.protocol_api.InstrumentContext.drop_tip] method's optional `alternate_drop_location` argument to vary the tip drop location in a waste container, preventing tips from piling up in a single location.
 - In protocols using API version 2.28, the API raises an error when calling [`touch_tip()`][opentrons.protocol_api.InstrumentContext.touch_tip] in large spaces, like reservoirs and large well plates.


### PR DESCRIPTION
# Overview

Checking the API 2.28 docs and adding a few small things: 
- updates to [versioning page](https://sandbox.docs.opentrons.com/docs-2.28-additional-mentions/python-api/versioning/)
- small update to the [Stacker article](https://sandbox.docs.opentrons.com/docs-2.28-additional-mentions/python-api/modules/flex-stacker/) (tip racks _do_ need a lid)
- adding a [tip-pipette compatibility table](https://sandbox.docs.opentrons.com/docs-2.28-additional-mentions/python-api/pipettes/loading/#tip-pipette-compatibility) (borrowed from Flex manual with some changes for API docs). 

## Test Plan and Hands on Testing

[sandbox](https://sandbox.docs.opentrons.com/docs-2.28-additional-mentions/)

## Changelog


## Review requests

does this cover it? do we like the tip-pipette compatibility table? it could be simplified a bit, given that some of this pipette model information is earlier on the page.

## Risk assessment

low.
