### PR TITLE
chore: "fix" lint-js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ $(SHARED_DATA_DIR)-py-lint:
 lint-js: lint-js-eslint lint-js-prettier
 
 .PHONY: lint-js-eslint
-lint-js-eslint:
+lint-js-eslint: build-ts
 	yarn eslint --quiet=$(quiet) --ignore-pattern "node_modules/" ".*.@(js|ts|tsx)" "**/*.@(js|ts|tsx)"
 
 .PHONY: lint-js-prettier


### PR DESCRIPTION
If you do make setup-js and then make lint-js, you get one million failures from the typescript-eslint untyped-argument checker. However, if you run make build-ts first (aka run tsc) then you don't (which is why more frequent js devs don't get these errors). This is probably because we use divergent configurations for eslint's typescript plugin invocations of tsc and our normal invocations of tsc. This is very complicated and I think would be very annoying to fix, so we can just add a makefile dependency so you always build first.


## Test Plan and Hands on Testing

- run teardown, then setup, then lint-js. it shouldn't fail

## Review requests

- hurt your soul too much?

## Risk assessment

- none (doesn't even break CI, since the check workflow in CI happens to run make check-js first, which runs tsc)
