### PR TITLE
fix(protocol-designer): fix hardware configuration update bug

### DIFF
--- a/protocol-designer/src/components/organisms/HardwareConfigurator/hooks/__tests__/useMemoizedUpdatedDeckConfig.test.ts
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/hooks/__tests__/useMemoizedUpdatedDeckConfig.test.ts
@@ -1,0 +1,111 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import {
+  FLEX_ROBOT_TYPE,
+  getDeckDefFromRobotType,
+  getEmptyDeckConfiguration,
+  HEATERSHAKER_MODULE_TYPE,
+  HEATERSHAKER_MODULE_V1,
+  STAGING_AREA_RIGHT_SLOT_FIXTURE,
+} from '@opentrons/shared-data'
+
+import { useMemoizedUpdatedDeckConfig } from '../useMemoizedUpdatedDeckConfig'
+
+import type { FormModules } from '/protocol-designer/step-forms'
+import type { Fixtures } from '../../../types'
+
+const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
+
+describe('useMemoizedUpdatedDeckConfig', () => {
+  it('matches getEmptyDeckConfiguration when modules and fixtures are empty', () => {
+    const modules: FormModules = {}
+    const fixtures: Fixtures = {}
+    const expected = getEmptyDeckConfiguration(deckDef)
+
+    const { result } = renderHook(() =>
+      useMemoizedUpdatedDeckConfig(modules, fixtures)
+    )
+
+    expect(result.current).toEqual(expected)
+  })
+
+  it('returns the same array reference when modules and fixtures references are unchanged', () => {
+    const modules: FormModules = {}
+    const fixtures: Fixtures = {}
+
+    const { result, rerender } = renderHook(() =>
+      useMemoizedUpdatedDeckConfig(modules, fixtures)
+    )
+    const first = result.current
+
+    rerender()
+
+    expect(result.current).toBe(first)
+  })
+
+  it('recomputes when modules reference changes', () => {
+    const fixtures: Fixtures = {}
+    let modules: FormModules = {}
+
+    const { result, rerender } = renderHook(
+      ({ mods, fix }: { mods: FormModules; fix: Fixtures }) =>
+        useMemoizedUpdatedDeckConfig(mods, fix),
+      { initialProps: { mods: modules, fix: fixtures } }
+    )
+    const emptyConfig = result.current
+
+    modules = {
+      1: {
+        model: HEATERSHAKER_MODULE_V1,
+        type: HEATERSHAKER_MODULE_TYPE,
+        slot: 'D1',
+        cutoutFixtureId: null,
+        cutoutId: null,
+      },
+    }
+    rerender({ mods: modules, fix: fixtures })
+
+    expect(result.current).not.toBe(emptyConfig)
+    const d1 = result.current.find(c => c.cutoutId === 'cutoutD1')
+    expect(d1?.cutoutFixtureId).toBe('heaterShakerModuleV1')
+  })
+
+  it('applies fixture cutout configuration', () => {
+    const modules: FormModules = {}
+    const fixtures: Fixtures = {
+      staging1: {
+        cutoutId: 'cutoutA3',
+        name: 'stagingArea',
+        cutoutFixtureId: STAGING_AREA_RIGHT_SLOT_FIXTURE,
+      },
+    }
+
+    const { result } = renderHook(() =>
+      useMemoizedUpdatedDeckConfig(modules, fixtures)
+    )
+
+    const a3 = result.current.find(c => c.cutoutId === 'cutoutA3')
+    expect(a3?.cutoutFixtureId).toBe(STAGING_AREA_RIGHT_SLOT_FIXTURE)
+  })
+
+  it('applies module cutout configuration', () => {
+    const modules: FormModules = {
+      '1': {
+        model: HEATERSHAKER_MODULE_V1,
+        type: HEATERSHAKER_MODULE_TYPE,
+        slot: 'D1',
+        cutoutFixtureId: null,
+        cutoutId: null,
+      },
+    }
+    const fixtures: Fixtures = {}
+
+    const { result } = renderHook(() =>
+      useMemoizedUpdatedDeckConfig(modules, fixtures)
+    )
+
+    const d1 = result.current.find(c => c.cutoutId === 'cutoutD1')
+    expect(d1?.cutoutFixtureId).toBe(HEATERSHAKER_MODULE_V1)
+  })
+})

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/hooks/useMemoizedUpdatedDeckConfig.ts
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/hooks/useMemoizedUpdatedDeckConfig.ts
@@ -38,9 +38,11 @@ export function useMemoizedUpdatedDeckConfig(
       replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA(
         emptyDeckConfiguration
       )
+    const modulesValues = Object.values(modules)
+    const fixturesValues = Object.values(fixtures)
     const simpleDeckConfig: DeckConfiguration = emptyDeckConfiguration.filter(
       ({ cutoutId }) => {
-        const hasModule = Object.values(modules).some(
+        const hasModule = modulesValues.some(
           module =>
             getCutoutIdFromAddressableArea(module.slot as string, deckDef) ===
             cutoutId
@@ -48,17 +50,17 @@ export function useMemoizedUpdatedDeckConfig(
         //  since we are adding cutoutA1 in moduleConfig if
         //  there is a TC
         const hasTCAndCutoutA1 =
-          Object.values(modules).some(
+          modulesValues.some(
             module => module.type === THERMOCYCLER_MODULE_TYPE
           ) && cutoutId === 'cutoutA1'
-        const hasFixture = Object.values(fixtures).some(
+        const hasFixture = fixturesValues.some(
           fixture => fixture.cutoutId === cutoutId
         )
         return !hasModule && !hasFixture && !hasTCAndCutoutA1
       }
     )
 
-    const moduleConfig: CutoutConfigMap[] = Object.values(modules).flatMap(
+    const moduleConfig: CutoutConfigMap[] = modulesValues.flatMap(
       (module: FormModule | ModuleExtended): CutoutConfigMap[] => {
         const fixtureModule = getCutoutFixtureIdsForModuleModel(module.model)[0]
         const cutoutId = getCutoutIdFromAddressableArea(module.slot, deckDef)!
@@ -81,14 +83,11 @@ export function useMemoizedUpdatedDeckConfig(
         )
       }
     )
-    const additionalEquipmentConfig: DeckConfiguration = Object.values(
-      fixtures
-    ).map(
-      (ae): CutoutConfig => ({
-        cutoutId: ae.cutoutId as CutoutId,
-        cutoutFixtureId: ae.cutoutFixtureId,
-      })
-    )
+    const additionalEquipmentConfig: DeckConfiguration =
+      fixturesValues.map<CutoutConfig>(fixtureItem => ({
+        cutoutId: fixtureItem.cutoutId as CutoutId,
+        cutoutFixtureId: fixtureItem.cutoutFixtureId,
+      }))
 
     // Merge modules and fixtures into combo fixtures where applicable
     const {

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/hooks/useMemoizedUpdatedDeckConfig.ts
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/hooks/useMemoizedUpdatedDeckConfig.ts
@@ -1,0 +1,107 @@
+import { useMemo } from 'react'
+
+import {
+  FLEX_ROBOT_TYPE,
+  getAddedMissingThermocyclerFixtures,
+  getCutoutFixtureIdsForModuleModel,
+  getCutoutIdFromAddressableArea,
+  getDeckDefFromRobotType,
+  getEmptyDeckConfiguration,
+  replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA,
+  THERMOCYCLER_MODULE_TYPE,
+} from '@opentrons/shared-data'
+
+import { mergeToComboFixtures } from '../utils'
+
+import type {
+  AddressableAreaNamesWithFakes,
+  CutoutConfig,
+  CutoutConfigMap,
+  CutoutId,
+  DeckConfiguration,
+} from '@opentrons/shared-data'
+import type { FormModule, FormModules } from '/protocol-designer/step-forms'
+import type { Fixtures } from '../../types'
+import type {
+  InitialDeckStateModules,
+  ModuleExtended,
+} from '../AddFixtureModal'
+
+export function useMemoizedUpdatedDeckConfig(
+  modules: FormModules | InitialDeckStateModules,
+  fixtures: Fixtures
+): DeckConfiguration {
+  return useMemo((): DeckConfiguration => {
+    const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
+    const emptyDeckConfiguration = getEmptyDeckConfiguration(deckDef)
+    const deckConfigWithAA =
+      replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA(
+        emptyDeckConfiguration
+      )
+    const simpleDeckConfig: DeckConfiguration = emptyDeckConfiguration.filter(
+      ({ cutoutId }) => {
+        const hasModule = Object.values(modules).some(
+          module =>
+            getCutoutIdFromAddressableArea(module.slot as string, deckDef) ===
+            cutoutId
+        )
+        //  since we are adding cutoutA1 in moduleConfig if
+        //  there is a TC
+        const hasTCAndCutoutA1 =
+          Object.values(modules).some(
+            module => module.type === THERMOCYCLER_MODULE_TYPE
+          ) && cutoutId === 'cutoutA1'
+        const hasFixture = Object.values(fixtures).some(
+          fixture => fixture.cutoutId === cutoutId
+        )
+        return !hasModule && !hasFixture && !hasTCAndCutoutA1
+      }
+    )
+
+    const moduleConfig: CutoutConfigMap[] = Object.values(modules).flatMap(
+      (module: FormModule | ModuleExtended): CutoutConfigMap[] => {
+        const fixtureModule = getCutoutFixtureIdsForModuleModel(module.model)[0]
+        const cutoutId = getCutoutIdFromAddressableArea(module.slot, deckDef)!
+        const matchingDeckConfigEntry = deckConfigWithAA.find(
+          config =>
+            config.cutoutId === cutoutId &&
+            config.cutoutFixtureId === fixtureModule
+        )
+        const defaultModuleConfig: CutoutConfigMap = {
+          cutoutId,
+          cutoutFixtureId: fixtureModule,
+          addressableAreaId:
+            matchingDeckConfigEntry?.addressableAreaId ??
+            (module.slot as AddressableAreaNamesWithFakes),
+        }
+        // getAddedMissingThermocyclerFixtures returns input array + any missing TC fixtures
+        return getAddedMissingThermocyclerFixtures(
+          [defaultModuleConfig],
+          deckDef
+        )
+      }
+    )
+    const additionalEquipmentConfig: DeckConfiguration = Object.values(
+      fixtures
+    ).map(
+      (ae): CutoutConfig => ({
+        cutoutId: ae.cutoutId as CutoutId,
+        cutoutFixtureId: ae.cutoutFixtureId,
+      })
+    )
+
+    // Merge modules and fixtures into combo fixtures where applicable
+    const {
+      comboFixtures,
+      remainingModuleConfig,
+      remainingAdditionalEquipmentConfig,
+    } = mergeToComboFixtures(moduleConfig, additionalEquipmentConfig)
+
+    return [
+      ...simpleDeckConfig,
+      ...remainingModuleConfig,
+      ...remainingAdditionalEquipmentConfig,
+      ...comboFixtures,
+    ] as DeckConfiguration
+  }, [modules, fixtures])
+}

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/index.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/index.tsx
@@ -1,34 +1,17 @@
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
-import {
-  FLEX_ROBOT_TYPE,
-  getAddedMissingThermocyclerFixtures,
-  getCutoutFixtureIdsForModuleModel,
-  getCutoutIdFromAddressableArea,
-  getDeckDefFromRobotType,
-  getEmptyDeckConfiguration,
-  replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA,
-  THERMOCYCLER_MODULE_TYPE,
-} from '@opentrons/shared-data'
-
 import { editDeckConfiguration } from '/protocol-designer/step-forms/actions'
 import { getDeckConfiguration } from '/protocol-designer/step-forms/selectors'
 
 import { HardwareConfiguratorContainer } from './HardwareConfiguratorContainer'
-import { mergeToComboFixtures } from './utils'
+import { useMemoizedUpdatedDeckConfig } from './hooks/useMemoizedUpdatedDeckConfig'
 
 import type { UseFormSetValue } from 'react-hook-form'
-import type {
-  AddressableAreaNamesWithFakes,
-  CutoutConfig,
-  CutoutConfigMap,
-  CutoutId,
-  DeckConfiguration,
-} from '@opentrons/shared-data'
-import type { FormModule, FormModules } from '/protocol-designer/step-forms'
+import type { CutoutConfigMap, DeckConfiguration } from '@opentrons/shared-data'
+import type { FormModules } from '/protocol-designer/step-forms'
 import type { Fixtures, WizardFormState } from '../types'
-import type { InitialDeckStateModules, ModuleExtended } from './AddFixtureModal'
+import type { InitialDeckStateModules } from './AddFixtureModal'
 
 interface HardwareConfiguratorProps {
   modules: FormModules | InitialDeckStateModules
@@ -47,89 +30,15 @@ export function HardwareConfigurator(
     props
   const dispatch = useDispatch()
   const { deckConfig } = useSelector(getDeckConfiguration)
-  const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
-  const emptyDeckConfiguration = getEmptyDeckConfiguration(deckDef)
+  const updatedDeckConfig = useMemoizedUpdatedDeckConfig(modules, fixtures)
 
-  const deckConfigWithAA =
-    replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA(
-      emptyDeckConfiguration
+  useEffect(() => {
+    dispatch(
+      editDeckConfiguration({
+        deckConfig: updatedDeckConfig,
+      })
     )
-  const simpleDeckConfig: DeckConfiguration = emptyDeckConfiguration.filter(
-    ({ cutoutId }) => {
-      const hasModule = Object.values(modules).some(
-        module =>
-          getCutoutIdFromAddressableArea(module.slot as string, deckDef) ===
-          cutoutId
-      )
-      //  since we are adding cutoutA1 in moduleConfig if
-      //  there is a TC
-      const hasTCAndCutoutA1 =
-        Object.values(modules).some(
-          module => module.type === THERMOCYCLER_MODULE_TYPE
-        ) && cutoutId === 'cutoutA1'
-      const hasFixture = Object.values(fixtures).some(
-        fixture => fixture.cutoutId === cutoutId
-      )
-      return !hasModule && !hasFixture && !hasTCAndCutoutA1
-    }
-  )
-
-  const moduleConfig: CutoutConfigMap[] = Object.values(modules).flatMap(
-    (module: FormModule | ModuleExtended): CutoutConfigMap[] => {
-      const fixtureModule = getCutoutFixtureIdsForModuleModel(module.model)[0]
-      const cutoutId = getCutoutIdFromAddressableArea(module.slot, deckDef)!
-      const matchingDeckConfigEntry = deckConfigWithAA.find(
-        config =>
-          config.cutoutId === cutoutId &&
-          config.cutoutFixtureId === fixtureModule
-      )
-      const defaultModuleConfig: CutoutConfigMap = {
-        cutoutId,
-        cutoutFixtureId: fixtureModule,
-        addressableAreaId:
-          matchingDeckConfigEntry?.addressableAreaId ??
-          (module.slot as AddressableAreaNamesWithFakes),
-      }
-      // getAddedMissingThermocyclerFixtures returns input array + any missing TC fixtures
-      return getAddedMissingThermocyclerFixtures([defaultModuleConfig], deckDef)
-    }
-  )
-  const additionalEquipmentConfig: DeckConfiguration = Object.values(
-    fixtures
-  ).map(
-    (ae): CutoutConfig => ({
-      cutoutId: ae.cutoutId as CutoutId,
-      cutoutFixtureId: ae.cutoutFixtureId,
-    })
-  )
-
-  // Merge modules and fixtures into combo fixtures where applicable
-  const {
-    comboFixtures,
-    remainingModuleConfig,
-    remainingAdditionalEquipmentConfig,
-  } = mergeToComboFixtures(moduleConfig, additionalEquipmentConfig)
-
-  const updatedDeckConfig = [
-    ...simpleDeckConfig,
-    ...remainingModuleConfig,
-    ...remainingAdditionalEquipmentConfig,
-    ...comboFixtures,
-  ]
-
-  //  initiate deck config
-  useEffect(
-    () => {
-      dispatch(
-        editDeckConfiguration({
-          deckConfig: updatedDeckConfig as DeckConfiguration,
-        })
-      )
-    },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  )
+  }, [dispatch, updatedDeckConfig])
   return (
     <HardwareConfiguratorContainer
       modules={modules}

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -890,7 +890,8 @@ export const savedStepForms = (
             form.stepType === 'absorbanceReader' ||
             form.stepType === 'thermocycler' ||
             form.stepType === 'flexStacker' ||
-            form.stepType === 'pause') &&
+            form.stepType === 'pause' ||
+            form.stepType === 'vacuum') &&
           form.moduleId === moduleId
         ) {
           return { ...form, moduleId: null }

--- a/protocol-designer/src/step-forms/test/reducers.test.ts
+++ b/protocol-designer/src/step-forms/test/reducers.test.ts
@@ -1235,6 +1235,14 @@ describe('savedStepForms reducer: initial deck setup step', () => {
           engageHeight: '4',
         },
       },
+      {
+        testName: 'vacuum step',
+        step: {
+          id: stepId,
+          stepType: 'vacuum',
+          moduleId,
+        },
+      },
     ]
     testCases.forEach(({ testName, step }) => {
       it(testName, () => {

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -650,6 +650,12 @@ const VACUUM_PROFILE_REQUIRED: FormError = {
   dependentFields: ['orderedProfileIds', 'profileItemsById'],
   location: ['field'],
 }
+const VACUUM_MODULE_ID_REQUIRED: FormError = {
+  title: 'Select vacuum module',
+  dependentFields: ['moduleId'],
+  location: ['field'],
+  showOnReopen: true,
+}
 export type FormErrorChecker = (
   arg: HydratedFormData,
   moduleEntities?: ModuleEntities
@@ -1630,6 +1636,13 @@ export const vacuumDurationRequired = (
     !pumpDurationTime
     ? VACUUM_DURATION_REQUIRED
     : null
+}
+
+export const vacuumModuleIdRequired = (
+  fields: HydratedVacuumFormData
+): FormError | null => {
+  const { moduleId } = fields
+  return moduleId == null ? VACUUM_MODULE_ID_REQUIRED : null
 }
 
 /*******************

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -74,6 +74,7 @@ import {
   transferVolumeMin,
   vacuumDurationRequired,
   vacuumModeRequired,
+  vacuumModuleIdRequired,
   vacuumProfileRequired,
   vacuumProgramRequired,
   vacuumStateRequired,
@@ -303,7 +304,8 @@ const stepFormHelperMap: {
       vacuumModeRequired,
       gaugePressureRequired,
       vacuumDurationRequired,
-      vacuumProfileRequired
+      vacuumProfileRequired,
+      vacuumModuleIdRequired
     ),
   },
 }


### PR DESCRIPTION
# Overview

This PR refactors the useEffect logic in PD's HardwareConfigurator component to correctly live update. The error stemmed from the useEffect's dependency array being incorrectly empty (only running on mount). I move the buesiness logic for the updated config to a custom hook with memoization and populate the useEffect (that dispatches the update) with modules and fixtures.

It also updates forms that referenced a removed vacuum module's ID in step forms reducers, and adds form errors requiring a module ID for vacuum step forms.

### Before

https://github.com/user-attachments/assets/f32632da-b9e2-4021-ae46-354cdad4a4c6


### After

https://github.com/user-attachments/assets/c3d5c614-201f-423c-b1a2-68ab48665d7c


## Test Plan and Hands on Testing

- create or upload a protocol with a vacuum module + vacuum step
- navigate to deck configuration and clear the vacuum module (will require confirmation modal)
- verify that the deck config updates immediately
- verify that the step form shows a form error
- re-add the vacuum module to A3 in deck config
- re-open the vacuum step and verify that the vacuum module option is now present. save the form and verify that the timeline error clears

## Changelog

- update `HardwareConfigurator` to dispatch deck config updates correctly
- refactor update logic to a memoized hook
- create and wire up form error requiring vacuum module ID
- update step forms when vacuum module is deleted from deck config
- write tests

## Review requests

see test plan

## Risk assessment

lowish. mainly fixing a bug and improving form logic