### PR TITLE
feat(key-server): rotate CA certificates when they expire

### DIFF
--- a/key-server/key_server/tls/ca_manager.py
+++ b/key-server/key_server/tls/ca_manager.py
@@ -258,9 +258,11 @@ def _fingerprint(cert: x509.Certificate) -> str:
     return cert.fingerprint(hashes.SHA256()).hex()
 
 
-def _create_ca(key_dir: Path, ca_cert_dir: Path, now: datetime) -> X509Pair:
+def _create_ca(
+    key_dir: Path, ca_cert_dir: Path, now: datetime, duration: timedelta
+) -> X509Pair:
     """Make a new CA pair."""
-    expiry = now + timedelta(days=365, hours=1)
+    expiry = now + duration
     key = ec.generate_private_key(ec.SECP256R1())
     cert = (
         x509.CertificateBuilder()
@@ -338,6 +340,10 @@ class TLSCAManager:
     - CA cert export
     """
 
+    CA_EXPIRY_DURATION: Final = timedelta(days=365, hours=1)
+    CA_OVERLAP_DURATION: Final = timedelta(days=30 * 3)
+    CA_ROTATION_TIME_BEFORE_EXPIRY: Final = timedelta(days=1)
+
     def __init__(self, key_dir: Path, ca_cert_dir: Path) -> None:
         """Build the object. Scans the given directories to set up the first set of CAs."""
         self._key_dir = key_dir
@@ -401,21 +407,28 @@ class TLSCAManager:
             LOG.info("Found no next CA to load")
         else:
             LOG.info("Found no CAs to load, creating")
-            self._current_ca = _create_ca(key_dir, ca_cert_dir, now)
+            self._current_ca = _create_ca(
+                key_dir, ca_cert_dir, now, self.CA_EXPIRY_DURATION
+            )
             LOG.info(
                 f"Created {_fingerprint(self._current_ca.cert)} ({self._current_ca.cert.not_valid_before_utc}-{self._current_ca.cert.not_valid_after_utc}) as current CA"
             )
             self._next_ca = None
 
         # if we don't have a next CA and our current expires in <90 days (ish), make a next one
-        if (
-            self._current_ca.cert.not_valid_after_utc < (now + timedelta(days=3 * 30))
-            and not self._next_ca
-        ):
+        if self._must_build_next(now):
             LOG.info(
                 f"Current CA expires at {self._current_ca.cert.not_valid_after_utc} which is less than 3 months from {now} and we have no next CA, creating"
             )
-            self._next_ca = _create_ca(key_dir, ca_cert_dir, now)
+            self._next_ca = _create_ca(
+                key_dir, ca_cert_dir, now, self.CA_EXPIRY_DURATION
+            )
             LOG.info(
                 f"Created {_fingerprint(self._next_ca.cert)} ({self._next_ca.cert.not_valid_before_utc}-{self._next_ca.cert.not_valid_after_utc}) as next CA"
             )
+    def _must_build_next(self, now: datetime) -> bool:
+        return (
+            self._current_ca.cert.not_valid_after_utc < (now + self.CA_OVERLAP_DURATION)
+            and not self._next_ca
+        )
+

--- a/key-server/key_server/tls/ca_manager.py
+++ b/key-server/key_server/tls/ca_manager.py
@@ -1,5 +1,6 @@
 """Code for managing TLS CAs."""
 
+import asyncio
 import logging
 import re
 from dataclasses import dataclass
@@ -331,6 +332,11 @@ def _create_ca(
     return pair
 
 
+def _delete_certpair(pair: X509Pair) -> None:
+    _safe_del(pair.certpath, "rotated away")
+    _safe_del(pair.keypath, "rotated away")
+
+
 class TLSCAManager:
     """Class that manages TLS CAs.
 
@@ -343,6 +349,7 @@ class TLSCAManager:
     CA_EXPIRY_DURATION: Final = timedelta(days=365, hours=1)
     CA_OVERLAP_DURATION: Final = timedelta(days=30 * 3)
     CA_ROTATION_TIME_BEFORE_EXPIRY: Final = timedelta(days=1)
+    CA_EXPIRY_CHECK_POLL_PERIOD: Final = timedelta(days=1)
 
     def __init__(self, key_dir: Path, ca_cert_dir: Path) -> None:
         """Build the object. Scans the given directories to set up the first set of CAs."""
@@ -426,9 +433,61 @@ class TLSCAManager:
             LOG.info(
                 f"Created {_fingerprint(self._next_ca.cert)} ({self._next_ca.cert.not_valid_before_utc}-{self._next_ca.cert.not_valid_after_utc}) as next CA"
             )
+        self._expiry_task: "asyncio.Task[None]" = asyncio.create_task(
+            self._expiry_task_outer()
+        )
+
+    async def teardown(self) -> None:
+        """Run code necessary to stop the CA manager."""
+        self._expiry_task.cancel()
+        try:
+            await self._expiry_task
+        except asyncio.CancelledError:
+            pass
+
+    def _must_rotate(self, now: datetime) -> bool:
+        must_rotate = self._current_ca.cert.not_valid_after_utc < (
+            now + self.CA_ROTATION_TIME_BEFORE_EXPIRY
+        )
+        LOG.info(
+            f"Rotation required at {now} for cert expiring at {self._current_ca.cert.not_valid_after_utc}: {must_rotate}"
+        )
+        return must_rotate
+
     def _must_build_next(self, now: datetime) -> bool:
         return (
             self._current_ca.cert.not_valid_after_utc < (now + self.CA_OVERLAP_DURATION)
             and not self._next_ca
         )
 
+    def _rotate(self, now: datetime) -> None:
+        LOG.info("Rotating CA certificates")
+
+        if self._must_build_next(now):
+            LOG.warning("No next CA present at rotation")
+            self._next_ca = _create_ca(
+                self._key_dir, self._ca_cert_dir, now, self.CA_EXPIRY_DURATION
+            )
+
+        old_current = self._current_ca
+        assert self._next_ca
+        self._current_ca = self._next_ca
+        self._next_ca = None
+        _delete_certpair(old_current)
+        if self._must_build_next(now):
+            self._next_ca = _create_ca(
+                self._key_dir, self._ca_cert_dir, now, self.CA_EXPIRY_DURATION
+            )
+
+    async def _expiry_task_outer(self) -> None:
+        try:
+            await self._expiry_task_inner()
+        except asyncio.CancelledError:
+            LOG.info("Stopping expiry task")
+
+    async def _expiry_task_inner(self) -> None:
+        while True:
+            now = datetime.now(tz=timezone.utc)
+            if self._must_rotate(now):
+                self._rotate(now)
+            await asyncio.sleep(self.CA_EXPIRY_CHECK_POLL_PERIOD.total_seconds())

--- a/key-server/tests/tls/test_ca_manager.py
+++ b/key-server/tests/tls/test_ca_manager.py
@@ -1,9 +1,10 @@
+import asyncio
 import random
 import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from shutil import rmtree
-from typing import Any, Callable, Iterator, Literal
+from typing import Any, AsyncIterator, Callable, Iterator, Literal
 
 import pytest
 from cryptography import x509
@@ -422,7 +423,34 @@ def ca_cert_dir(tmp_path: Path) -> Iterator[Path]:
     rmtree(ca_dir)
 
 
-def test_init_limits_to_two_certs(key_dir: Path, ca_cert_dir: Path) -> None:
+class SubjectFactory:
+    def __init__(self, key_dir: Path, ca_cert_dir: Path) -> None:
+        self._key_dir = key_dir
+        self._ca_cert_dir = ca_cert_dir
+        self._manager: None | ca_manager.TLSCAManager
+
+    def create(self) -> ca_manager.TLSCAManager:
+        self._manager = ca_manager.TLSCAManager(self._key_dir, self._ca_cert_dir)
+        return self._manager
+
+    async def destroy(self, *args: Any, **kwargs: Any) -> None:
+        if self._manager:
+            await self._manager.teardown()
+            self._manager = None
+
+
+@pytest.fixture
+async def subject_factory(
+    key_dir: Path, ca_cert_dir: Path
+) -> AsyncIterator[SubjectFactory]:
+    ctm = SubjectFactory(key_dir, ca_cert_dir)
+    yield ctm
+    await ctm.destroy()
+
+
+async def test_init_limits_to_two_certs(
+    key_dir: Path, ca_cert_dir: Path, subject_factory: SubjectFactory
+) -> None:
     """It should use multiple criteria to limit itself to two valid CAs."""
     not_yet_valid = ca_manager._create_ca(
         key_dir,
@@ -462,7 +490,7 @@ def test_init_limits_to_two_certs(key_dir: Path, ca_cert_dir: Path) -> None:
             timedelta(days=365, hours=1),
         ),
     ]
-    subject = ca_manager.TLSCAManager(key_dir, ca_cert_dir)
+    subject = subject_factory.create()
 
     assert subject._current_ca.certpath == current.certpath
     assert subject._current_ca.cert.fingerprint(
@@ -486,7 +514,9 @@ def test_init_limits_to_two_certs(key_dir: Path, ca_cert_dir: Path) -> None:
         assert not sd.keypath.exists()
 
 
-def test_does_not_create_next_ca(key_dir: Path, ca_cert_dir: Path) -> None:
+async def test_does_not_create_next_ca(
+    key_dir: Path, ca_cert_dir: Path, subject_factory: SubjectFactory
+) -> None:
     """If it finds only one CA and it expires in more than 3 months it should not create a next."""
     current = ca_manager._create_ca(
         key_dir,
@@ -494,7 +524,7 @@ def test_does_not_create_next_ca(key_dir: Path, ca_cert_dir: Path) -> None:
         datetime.now() - timedelta(days=1),
         timedelta(days=365, hours=1),
     )
-    subject = ca_manager.TLSCAManager(key_dir, ca_cert_dir)
+    subject = subject_factory.create()
     assert subject._current_ca.cert == current.cert
     assert subject._next_ca is None
 
@@ -503,7 +533,9 @@ def dt_isclose(a: datetime, b: datetime) -> bool:
     return (a > b - timedelta(minutes=1)) and (a < b + timedelta(minutes=1))
 
 
-def test_creates_next_ca(key_dir: Path, ca_cert_dir: Path) -> None:
+async def test_creates_next_ca(
+    key_dir: Path, ca_cert_dir: Path, subject_factory: SubjectFactory
+) -> None:
     """If it finds only one CA and it expires in less than 3 months it should create a next."""
     nowish = datetime.now(timezone.utc)
     current = ca_manager._create_ca(
@@ -512,7 +544,7 @@ def test_creates_next_ca(key_dir: Path, ca_cert_dir: Path) -> None:
         nowish - timedelta(days=350),
         timedelta(days=365, hours=1),
     )
-    subject = ca_manager.TLSCAManager(key_dir, ca_cert_dir)
+    subject = subject_factory.create()
     assert subject._current_ca.cert == current.cert
     assert subject._next_ca is not None
 
@@ -521,11 +553,58 @@ def test_creates_next_ca(key_dir: Path, ca_cert_dir: Path) -> None:
     )
 
 
-def test_creates_current_ca(key_dir: Path, ca_cert_dir: Path) -> None:
+async def test_creates_current_ca(
+    key_dir: Path, ca_cert_dir: Path, subject_factory: SubjectFactory
+) -> None:
     """If it finds no CAs, it should make a current one and not a next one."""
-    subject = ca_manager.TLSCAManager(key_dir, ca_cert_dir)
+    subject = subject_factory.create()
     assert dt_isclose(
         subject._current_ca.cert.not_valid_after_utc,
         datetime.now(timezone.utc) + timedelta(days=365, hours=1),
     )
     assert subject._next_ca is None
+
+
+async def test_rotates_ca_if_necessary_on_boot(
+    key_dir: Path, ca_cert_dir: Path, subject_factory: SubjectFactory
+) -> None:
+    """If the current CA is soon to expire, it should switch to the next."""
+    nowish = datetime.now(timezone.utc)
+    ca_manager._create_ca(
+        key_dir,
+        ca_cert_dir,
+        nowish - timedelta(days=365, hours=3),
+        timedelta(days=365, hours=1),
+    )
+    next = ca_manager._create_ca(
+        key_dir, ca_cert_dir, nowish - timedelta(days=30), timedelta(days=365, hours=1)
+    )
+    subject = subject_factory.create()
+    assert subject._current_ca.cert.fingerprint(
+        hashes.SHA256()
+    ) == next.cert.fingerprint(hashes.SHA256())
+    assert subject._next_ca is None
+
+
+async def test_rotates_ca_while_live(
+    key_dir: Path, ca_cert_dir: Path, subject_factory: SubjectFactory
+) -> None:
+    """While the manager is running, if it detects expiry it should rotate CAs."""
+    nowish = datetime.now(timezone.utc)
+    current = ca_manager._create_ca(
+        key_dir,
+        ca_cert_dir,
+        nowish - timedelta(days=365, minutes=59, seconds=58),
+        timedelta(days=365, hours=1),
+    )
+    subject = subject_factory.create()
+    await subject.teardown()
+    # this is a Final so we have to ignore a type error to overwrite it
+    subject.CA_EXPIRY_CHECK_POLL_PERIOD = timedelta(seconds=3)  # type: ignore[misc]
+    subject._expiry_task = asyncio.create_task(subject._expiry_task_outer())
+    await asyncio.sleep(4)
+    assert subject._current_ca.cert.fingerprint(
+        hashes.SHA256()
+    ) != current.cert.fingerprint(hashes.SHA256())
+    assert not current.certpath.exists()
+    assert not current.keypath.exists()

--- a/key-server/tests/tls/test_ca_manager.py
+++ b/key-server/tests/tls/test_ca_manager.py
@@ -264,7 +264,7 @@ def test_load_create_ca_cert_roundtrips(tmp_path: Path) -> None:
     key_dir.mkdir()
     ca_dir.mkdir()
     now = datetime.now(timezone.utc)
-    pair = ca_manager._create_ca(key_dir, ca_dir, now)
+    pair = ca_manager._create_ca(key_dir, ca_dir, now, timedelta(days=25))
     assert ca_manager._load_ca_cert(pair.certpath) == pair.cert
 
 
@@ -397,7 +397,10 @@ def test_create_ca_handles_fs_issues(
     # manipulation.
     prep_fs(tmp_path)
     pair = ca_manager._create_ca(
-        tmp_path / key_subdir, tmp_path / cert_subdir, datetime.now()
+        tmp_path / key_subdir,
+        tmp_path / cert_subdir,
+        datetime.now(),
+        timedelta(days=25),
     )
     assert pair.key.public_key() == pair.cert.public_key()
     assert re.search(log_pattern, caplog.text)
@@ -422,22 +425,42 @@ def ca_cert_dir(tmp_path: Path) -> Iterator[Path]:
 def test_init_limits_to_two_certs(key_dir: Path, ca_cert_dir: Path) -> None:
     """It should use multiple criteria to limit itself to two valid CAs."""
     not_yet_valid = ca_manager._create_ca(
-        key_dir, ca_cert_dir, datetime.now() + timedelta(days=1)
+        key_dir,
+        ca_cert_dir,
+        datetime.now() + timedelta(days=1),
+        timedelta(days=365, hours=1),
     )
     already_invalid = ca_manager._create_ca(
-        key_dir, ca_cert_dir, datetime.now() - timedelta(days=365 * 10)
+        key_dir,
+        ca_cert_dir,
+        datetime.now() - timedelta(days=365 * 10),
+        timedelta(days=365, hours=1),
     )
     current = ca_manager._create_ca(
-        key_dir, ca_cert_dir, datetime.now() - timedelta(days=30 * 6)
+        key_dir,
+        ca_cert_dir,
+        datetime.now() - timedelta(days=30 * 6),
+        timedelta(days=365, hours=1),
     )
     next = ca_manager._create_ca(
-        key_dir, ca_cert_dir, datetime.now() - timedelta(days=30 * 3)
+        key_dir,
+        ca_cert_dir,
+        datetime.now() - timedelta(days=30 * 3),
+        timedelta(days=365, hours=1),
     )
     should_delete = [
         ca_manager._create_ca(
-            key_dir, ca_cert_dir, datetime.now() - timedelta(days=10)
+            key_dir,
+            ca_cert_dir,
+            datetime.now() - timedelta(days=10),
+            timedelta(days=365, hours=1),
         ),
-        ca_manager._create_ca(key_dir, ca_cert_dir, datetime.now() - timedelta(days=5)),
+        ca_manager._create_ca(
+            key_dir,
+            ca_cert_dir,
+            datetime.now() - timedelta(days=5),
+            timedelta(days=365, hours=1),
+        ),
     ]
     subject = ca_manager.TLSCAManager(key_dir, ca_cert_dir)
 
@@ -466,7 +489,10 @@ def test_init_limits_to_two_certs(key_dir: Path, ca_cert_dir: Path) -> None:
 def test_does_not_create_next_ca(key_dir: Path, ca_cert_dir: Path) -> None:
     """If it finds only one CA and it expires in more than 3 months it should not create a next."""
     current = ca_manager._create_ca(
-        key_dir, ca_cert_dir, datetime.now() - timedelta(days=1)
+        key_dir,
+        ca_cert_dir,
+        datetime.now() - timedelta(days=1),
+        timedelta(days=365, hours=1),
     )
     subject = ca_manager.TLSCAManager(key_dir, ca_cert_dir)
     assert subject._current_ca.cert == current.cert
@@ -480,7 +506,12 @@ def dt_isclose(a: datetime, b: datetime) -> bool:
 def test_creates_next_ca(key_dir: Path, ca_cert_dir: Path) -> None:
     """If it finds only one CA and it expires in less than 3 months it should create a next."""
     nowish = datetime.now(timezone.utc)
-    current = ca_manager._create_ca(key_dir, ca_cert_dir, nowish - timedelta(days=350))
+    current = ca_manager._create_ca(
+        key_dir,
+        ca_cert_dir,
+        nowish - timedelta(days=350),
+        timedelta(days=365, hours=1),
+    )
     subject = ca_manager.TLSCAManager(key_dir, ca_cert_dir)
     assert subject._current_ca.cert == current.cert
     assert subject._next_ca is not None


### PR DESCRIPTION
# Overview

CA certificates have a defined lifetime, and when that lifetime expires they need to be swapped out for a new one.

We create a staging certificate (not yet used for TLS cert signing) 3 months ahead of time; this will be available encrypted or unencrypted (with the design intent being that unencrypted cert access happens via a TLS connection that was established with the current CA to provide an identity-attested secure channel). A day or so before the current certificate expires, we'll swap to that next certificate and remove the old one. This will also eventually include swapping out the TLS certificate for one signed by the new CA.

This PR adds the rotation mechanism for CAs (alone, since TLS certs aren't created yet) and some tests for them. We still haven't gotten to the point where we're actually running this code in the key server; that will happen when we have TLS cert creation and rotation.

## Test Plan and Hands on Testing

- [x] automated tests are extensive enough
- [x] import and run the manager on a robot

## Review requests

- make sense?
- Ask questions.

## Risk assessment

- None; the code isn't running yet.