### PR TITLE
docs: thermocycler g-code frontmatter

### DIFF
--- a/docs/thermocycler/docs/error-codes.md
+++ b/docs/thermocycler/docs/error-codes.md
@@ -1,9 +1,9 @@
 ---
 title: "Thermocycler Module: Error Codes"
-description: "Lists error codes returned by a Thermocycler."
+description: "Lists errors returned by Thermocycler G-code commands."
 ---
 
-This table lists Thermocycler error codes. These codes are also used by other Opentrons modules. Descriptions are based on literal firmware output, edited for brevity and clarity.
+The following table defines errors returned by G-code commands sent to a Thermocycler. While documented here for the Thermocycler, these codes are also used by other Opentrons modules. Descriptions are adapted from firmware output and edited for brevity and clarity.
 
 | Error code | Description |
 |---|---|

--- a/docs/thermocycler/docs/error-codes.md
+++ b/docs/thermocycler/docs/error-codes.md
@@ -1,6 +1,6 @@
 ---
 title: "Thermocycler Module: Error Codes"
-description: "Lists errors returned by Thermocycler G-code commands."
+description: "Thermocycler G-code errors."
 ---
 
 The following table defines errors returned by G-code commands sent to a Thermocycler. While documented here for the Thermocycler, these codes are also used by other Opentrons modules. Descriptions are adapted from firmware output and edited for brevity and clarity.

--- a/docs/thermocycler/docs/g-code-concepts.md
+++ b/docs/thermocycler/docs/g-code-concepts.md
@@ -1,5 +1,5 @@
 ---
-title: "Thermocycler Module: G-Code Essentials"
+title: "Thermocycler Module: G-Code Concepts"
 description: "Thermocycler G-code syntax, examples, and configuration information."
 ---
 

--- a/docs/thermocycler/docs/g-codes.md
+++ b/docs/thermocycler/docs/g-codes.md
@@ -1,6 +1,6 @@
 ---
-title: "Thermocycler Module: Thermocycler Module G-Codes"
-description: "Lists all Thermocycler G-codes and responses."
+title: "Thermocycler Module: G-Codes"
+description: "Thermocycler G-code commands and responses."
 ---
 
 The Thermocycler accepts the G-code commands listed below.


### PR DESCRIPTION
# Overview

This change revises the frontmatter to match the page titles of the Thermocycler G-code docs. Some changes to intro text too.

Minor revisions to `description` frontmatter too.

**Note:** accidentally included `ot2` in the branch name. This has nothing to do with OT-2.

## Test Plan and Hands on Testing

Changed frontmatter and scrolled the page to make sure frontmatter matched the page title.

**Sandbox:** https://sandbox.docs.opentrons.com/docs-ot2-gcode-frontmatter/thermocycler/g-code-concepts/

RTC-971

## Changelog

In the Thermocycler docs, this changes `error-codes.md`, `g-code-concepts.md`, and `g-codes.md`. 

## Review requests

Scroll the page, check the banner title.

## Risk assessment

- Trivial. Most people won't notice the banner title and may never see the `description` text.
