### PR TITLE
refactor(api): add a generic enum serializer for pyro

### DIFF
--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -1,44 +1,17 @@
 """Registry for use with a Pyro Daemon client and server to allow serialization of Opentrons Hardware types and classes."""
 
-import enum
 from typing import Any, Dict
-
-import serpent
 
 import opentrons.config.types
 import opentrons.hardware_control.types
 import opentrons.types
 from opentrons.util.pyro.pyro_serialization import (
+    OpentronsPyroSerializer,
     find_enums_in_packages,
     register_type_to_serpent,
+    serpent_enum_registration,
 )
 
-
-def _serpent_enum_serializer(obj, serializer, stream, level):  # type: ignore
-    """Serpent serializer for generic Enum values."""
-    serializer._serialize(obj.value, stream, level)
-
-
-# Opentrons Enum types registry
-def _generic_enum_class_to_dict(obj: Any) -> Dict:  # type: ignore
-    return {
-        "__class__": ".".join((obj.__module__, obj.__class__.__name__)),
-        "value": obj.value,
-    }
-
-
-def _generic_enum_dict_to_class(classname: str, d: Any) -> Any:
-    module_path, class_name = classname.rsplit(".", 1)
-    # Check type imports here, for now we only take from known opentrons modules
-    if "opentrons.hardware_control.types" in module_path:
-        opentrons_type = getattr(opentrons.hardware_control.types, class_name)
-    elif "opentrons.config.types" in module_path:
-        opentrons_type = getattr(opentrons.config.types, class_name)
-    elif "opentrons.types" in module_path:
-        opentrons_type = getattr(opentrons.types, class_name)
-    else:
-        raise RuntimeError(f"Unsupported module processed in Pyro request: {classname}")
-    return opentrons_type(d["value"])
 
 
 # Estop Overall Status registry
@@ -93,18 +66,10 @@ def register_hardware_types() -> None:
     opentrons_types = find_enums_in_packages(
         [opentrons.types, opentrons.config.types, opentrons.hardware_control.types]
     )
-    # Serpent matches by first isinstance() in registry order, so unregister enums first so that
-    # types like "Mount" don't automatically become strings/ints, then register the enums after.
-    serpent.unregister_class(enum.Enum)  # type: ignore
 
-    for enum_type in opentrons_types:
-        register_type_to_serpent(
-            class_type=enum_type,
-            dict_to_class=_generic_enum_dict_to_class,
-            class_to_dict=_generic_enum_class_to_dict,
-        )
-
-    serpent.register_class(enum.Enum, _serpent_enum_serializer)  # type: ignore
+    with serpent_enum_registration():
+        for enum_type in opentrons_types:
+            OpentronsPyroSerializer.register_enum(enum_type)
 
     # E-Stop Overall registration
     register_type_to_serpent(

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -13,7 +13,6 @@ from opentrons.util.pyro.pyro_serialization import (
 )
 
 
-
 # Estop Overall Status registry
 def _estop_overall_status_dict_to_class(  # type: ignore
     classname, d

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -1,6 +1,6 @@
 """Registry for use with a Pyro Daemon client and server to allow serialization of Opentrons Hardware types and classes."""
 
-from typing import Any, Dict
+from typing import Dict
 
 import opentrons.config.types
 import opentrons.hardware_control.types

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -84,7 +84,9 @@ class OpentronsPyroSerializer:
         try:
             enum_type = cls._enum_class_name_to_model[class_name]
         except KeyError:
-            raise RuntimeError(f"Unsupported module processed in Pyro request: {class_name}")
+            raise RuntimeError(
+                f"Unsupported module processed in Pyro request: {class_name}"
+            )
         return enum_type(d["value"])
 
     @classmethod

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -2,13 +2,16 @@
 
 import enum
 import inspect
-from typing import Any, Callable
+from contextlib import contextmanager
+from types import ModuleType
+from typing import Any, Callable, Iterator
 
+import serpent
 from pydantic import BaseModel
 from Pyro5 import api as pyro
 
 
-def find_enums_in_packages(modules: list) -> list:  # type: ignore
+def find_enums_in_packages(modules: list[ModuleType]) -> list[type[enum.Enum]]:
     """Returns a list of enums in the given list of modules."""
     enums = []
     for module in modules:
@@ -16,6 +19,27 @@ def find_enums_in_packages(modules: list) -> list:  # type: ignore
             if issubclass(obj, enum.Enum) and obj is not enum.Enum:
                 enums.append(obj)
     return enums
+
+
+def _serpent_enum_serializer(
+    obj: Any, serializer: Any, stream: Any, level: Any
+) -> None:
+    """Serpent serializer for generic Enum values."""
+    serializer._serialize(obj.value, stream, level)
+
+
+@contextmanager
+def serpent_enum_registration() -> Iterator[None]:
+    """Context manager for registering enums correctly with pyro/serpent.
+
+    Because Serpent matches by first isinstance() in registry order, we need to unregister enums first
+    so that types like "Mount" don't automatically become strings/ints, then register the enums after.
+    """
+    serpent.unregister_class(enum.Enum)  # type: ignore[no-untyped-call]
+    try:
+        yield
+    finally:
+        serpent.register_class(enum.Enum, _serpent_enum_serializer)  # type: ignore[no-untyped-call]
 
 
 def register_type_to_serpent(
@@ -30,18 +54,46 @@ def register_type_to_serpent(
     return class_path
 
 
-class PydanticPyroSerializer:
-    """A pyro serializer for Pydantic models."""
+class OpentronsPyroSerializer:
+    """A pyro serializer for custom Opentrons classes."""
 
-    _class_name_to_model: dict[str, type[BaseModel]] = {}
+    _pydantic_class_name_to_model: dict[str, type[BaseModel]] = {}
+    _enum_class_name_to_model: dict[str, type[enum.Enum]] = {}
 
     @classmethod
-    def register_model(cls, model: type[BaseModel]) -> None:
+    def register_enum(cls, enum_type: type[enum.Enum]) -> None:
+        """Registers an enumerated type to be sent and received via pyro proxies."""
+        class_name = register_type_to_serpent(
+            enum_type,
+            cls._generic_enum_dict_to_class,
+            cls._generic_enum_class_to_dict,
+        )
+        cls._enum_class_name_to_model[class_name] = enum_type
+
+    @classmethod
+    def _generic_enum_class_to_dict(cls, enum_obj: enum.Enum) -> dict[str, str]:
+        return {
+            "__class__": ".".join((enum_obj.__module__, enum_obj.__class__.__name__)),
+            "value": enum_obj.value,
+        }
+
+    @classmethod
+    def _generic_enum_dict_to_class(
+        cls, class_name: str, d: dict[str, str]
+    ) -> enum.Enum:
+        try:
+            enum_type = cls._enum_class_name_to_model[class_name]
+        except KeyError:
+            raise RuntimeError(f"Unsupported module processed in Pyro request: {class_name}")
+        return enum_type(d["value"])
+
+    @classmethod
+    def register_pydantic_model(cls, model: type[BaseModel]) -> None:
         """Registers a pydantic model type to be sent and received via pyro proxies."""
         class_name = register_type_to_serpent(
             model, cls._pydantic_dict_to_class, cls._pydantic_class_to_dict
         )
-        cls._class_name_to_model[class_name] = model
+        cls._pydantic_class_name_to_model[class_name] = model
 
     @classmethod
     def _pydantic_class_to_dict(cls, model: BaseModel) -> dict[str, Any]:
@@ -53,7 +105,7 @@ class PydanticPyroSerializer:
     def _pydantic_dict_to_class(cls, class_name: str, d: dict[str, Any]) -> BaseModel:
         del d["__class__"]
         try:
-            model = cls._class_name_to_model[class_name]
+            model = cls._pydantic_class_name_to_model[class_name]
         except KeyError:
             raise TypeError(
                 f"Could not convert {class_name} to an object, unregistered with pyro."

--- a/api/tests/opentrons/util/test_pyro_serialization.py
+++ b/api/tests/opentrons/util/test_pyro_serialization.py
@@ -3,7 +3,7 @@
 from pydantic import BaseModel
 
 from opentrons.hardware_control.types import CriticalPoint
-from opentrons.util.pyro.pyro_serialization import PydanticPyroSerializer
+from opentrons.util.pyro.pyro_serialization import OpentronsPyroSerializer
 
 
 class NestedTest(BaseModel):
@@ -22,7 +22,7 @@ class TestModel(BaseModel):
 
 def test_pydantic_serialization() -> None:
     """It should register a pydantic class and serialize it from class to dict and back."""
-    PydanticPyroSerializer.register_model(TestModel)
+    OpentronsPyroSerializer.register_pydantic_model(TestModel)
 
     test_model = TestModel(
         bar=123,
@@ -30,7 +30,7 @@ def test_pydantic_serialization() -> None:
         critical=CriticalPoint.XY_CENTER,
     )
 
-    test_dict = PydanticPyroSerializer._pydantic_class_to_dict(test_model)
+    test_dict = OpentronsPyroSerializer._pydantic_class_to_dict(test_model)
     assert test_dict == {
         "bar": 123,
         "xyzzy": {"foo": "xzibit"},
@@ -38,7 +38,7 @@ def test_pydantic_serialization() -> None:
         "__class__": "tests.opentrons.util.test_pyro_serialization.TestModel",
     }
 
-    result = PydanticPyroSerializer._pydantic_dict_to_class(
+    result = OpentronsPyroSerializer._pydantic_dict_to_class(
         "tests.opentrons.util.test_pyro_serialization.TestModel",
         test_dict,
     )

--- a/api/tests/opentrons/util/test_pyro_serialization.py
+++ b/api/tests/opentrons/util/test_pyro_serialization.py
@@ -1,8 +1,13 @@
 """Test for the Pyro Serialization."""
 
+import enum
+
+import pytest
 from pydantic import BaseModel
 
 from opentrons.hardware_control.types import CriticalPoint
+from opentrons.protocol_engine.types.module import ModuleModel
+from opentrons.types import DeckSlotName
 from opentrons.util.pyro.pyro_serialization import OpentronsPyroSerializer
 
 
@@ -12,7 +17,7 @@ class NestedTest(BaseModel):
     foo: str
 
 
-class TestModel(BaseModel):
+class BasicTestModel(BaseModel):
     """A basic pydantic model for serialization tests. Contains a basic type, nested model, and an enum."""
 
     bar: int
@@ -20,11 +25,52 @@ class TestModel(BaseModel):
     critical: CriticalPoint
 
 
+@pytest.mark.parametrize(
+    "enum_class, enum_instance, class_name",
+    [
+        # A basic enum.Enum
+        (
+            DeckSlotName,
+            DeckSlotName.SLOT_A1,
+            "opentrons.types.DeckSlotName",
+        ),
+        # An enum that uses enum.auto()
+        (
+            CriticalPoint,
+            CriticalPoint.TIP,
+            "opentrons.hardware_control.types.CriticalPoint",
+        ),
+        # An enum that inherits from StrEnum
+        (
+            ModuleModel,
+            ModuleModel.THERMOCYCLER_MODULE_V2,
+            "opentrons.protocol_engine.types.module.ModuleModel",
+        ),
+    ],
+)
+def test_enum_serialization_str_enum(
+    enum_class: type[enum.Enum],
+    enum_instance: enum.Enum,
+    class_name: str,
+) -> None:
+    """It should register an enum and keep it that type."""
+    OpentronsPyroSerializer.register_enum(enum_class)
+
+    test_dict = OpentronsPyroSerializer._generic_enum_class_to_dict(enum_instance)
+    assert test_dict == {
+        "__class__": class_name,
+        "value": enum_instance.value,
+    }
+
+    result = OpentronsPyroSerializer._generic_enum_dict_to_class(class_name, test_dict)
+    assert result == enum_instance
+
+
 def test_pydantic_serialization() -> None:
     """It should register a pydantic class and serialize it from class to dict and back."""
-    OpentronsPyroSerializer.register_pydantic_model(TestModel)
+    OpentronsPyroSerializer.register_pydantic_model(BasicTestModel)
 
-    test_model = TestModel(
+    test_model = BasicTestModel(
         bar=123,
         xyzzy=NestedTest(foo="xzibit"),
         critical=CriticalPoint.XY_CENTER,
@@ -35,11 +81,11 @@ def test_pydantic_serialization() -> None:
         "bar": 123,
         "xyzzy": {"foo": "xzibit"},
         "critical": 4,
-        "__class__": "tests.opentrons.util.test_pyro_serialization.TestModel",
+        "__class__": "tests.opentrons.util.test_pyro_serialization.BasicTestModel",
     }
 
     result = OpentronsPyroSerializer._pydantic_dict_to_class(
-        "tests.opentrons.util.test_pyro_serialization.TestModel",
+        "tests.opentrons.util.test_pyro_serialization.BasicTestModel",
         test_dict,
     )
     assert result == test_model


### PR DESCRIPTION
# Overview

Previously we had serialization for enums but it required hardcoding the path for every module the enum was in. This new serializer uses the same structure as the pydantic serializer. The two were combined into one OpentronsPyroSerializer for convenience.

## Test Plan and Hands on Testing

This is already partially tested by some of the hardware pyro unit tests, an additional unit test has been added to test enum serialization in isolation.

## Changelog

- renamed `PydanticPyroSerializer` to `OpentronsPyroSerializer`
- added generic enum serialization to `OpentronsPyroSerializer`

## Review requests

## Risk assessment

Low, small changes to new code behind feature flag