### PR TITLE
refactor(api): change dataclasses into pydantic for pyro

### DIFF
--- a/api/src/opentrons/hardware_control/nozzle_manager.py
+++ b/api/src/opentrons/hardware_control/nozzle_manager.py
@@ -1,7 +1,8 @@
 from collections import OrderedDict
-from dataclasses import dataclass
 from itertools import chain
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, cast
+
+from pydantic import BaseModel
 
 from opentrons_shared_data.errors import ErrorCodes, GeneralError, PythonException
 from opentrons_shared_data.pipette.pipette_definition import (
@@ -44,8 +45,7 @@ def _row_col_indices_for_nozzle(
     )
 
 
-@dataclass
-class NozzleMap:
+class NozzleMap(BaseModel):
     """
     A NozzleMap instance represents a specific configuration of active nozzles on a pipette.
 

--- a/api/src/opentrons/protocol_engine/state/commands.py
+++ b/api/src/opentrons/protocol_engine/state/commands.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple, Union
 
+from pydantic import BaseModel, ConfigDict
 from typing_extensions import assert_never
 
 from opentrons_shared_data.errors import EnumeratedError, ErrorCodes, PythonException
@@ -122,27 +123,30 @@ class RunResult(enum.Enum):
     STOPPED = enum.auto()
 
 
-@dataclass(frozen=True)
-class CommandSlice:
+class CommandSlice(BaseModel):
     """A subset of all commands in state."""
+
+    model_config = ConfigDict(frozen=True)
 
     commands: List[Command]
     cursor: int
     total_length: int
 
 
-@dataclass(frozen=True)
-class CommandErrorSlice:
+class CommandErrorSlice(BaseModel):
     """A subset of all commands errors in state."""
+
+    model_config = ConfigDict(frozen=True)
 
     commands_errors: List[ErrorOccurrence]
     cursor: int
     total_length: int
 
 
-@dataclass(frozen=True)
-class CommandPointer:
+class CommandPointer(BaseModel):
     """Brief info about a command and where to find it."""
+
+    model_config = ConfigDict(frozen=True)
 
     command_id: str
     command_key: str
@@ -150,9 +154,10 @@ class CommandPointer:
     index: int
 
 
-@dataclass(frozen=True)
-class CommandAnnotationsSlice:
+class CommandAnnotationsSlice(BaseModel):
     """A subset of all commands annotations in state."""
+
+    model_config = ConfigDict(frozen=True)
 
     command_annotations: List[CommandAnnotation]
     cursor: int

--- a/api/src/opentrons/protocol_engine/state/module_substates/flex_stacker_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/flex_stacker_substate.py
@@ -1,7 +1,8 @@
 """Flex Stacker substate."""
 
-from dataclasses import dataclass
 from typing import NewType
+
+from pydantic import BaseModel, ConfigDict
 
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 
@@ -17,13 +18,14 @@ from opentrons.protocol_engine.types.module import (
 FlexStackerId = NewType("FlexStackerId", str)
 
 
-@dataclass(frozen=True)
-class FlexStackerSubState:
+class FlexStackerSubState(BaseModel):
     """Flex Stacker-specific state.
 
     Provides calculations and read-only state access
     for an individual loaded Flex Stacker Module.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     module_id: FlexStackerId
     pool_primary_definition: LabwareDefinition | None

--- a/api/src/opentrons/protocol_reader/protocol_source.py
+++ b/api/src/opentrons/protocol_reader/protocol_source.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
+from pydantic import BaseModel, ConfigDict
 from typing_extensions import Literal
 
 from opentrons_shared_data.robot.types import RobotType
@@ -94,8 +95,7 @@ Metadata must be a simple JSON-serializable dictionary.
 """
 
 
-@dataclass(frozen=True)
-class ProtocolSource:
+class ProtocolSource(BaseModel):
     """A value object representing a protocol and its source files on disk.
 
     This includes pointers to the files,
@@ -116,6 +116,8 @@ class ProtocolSource:
             This is not necessarily the same set of labware definitions
             that the protocol will actually attempt to load.
     """
+
+    model_config = ConfigDict(frozen=True)
 
     directory: Optional[Path]
     main_file: Path

--- a/api/src/opentrons/protocol_runner/protocol_runner.py
+++ b/api/src/opentrons/protocol_runner/protocol_runner.py
@@ -2,9 +2,10 @@
 
 import asyncio
 from abc import ABC, abstractmethod
-from typing import Dict, List, NamedTuple, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import anyio
+from pydantic import BaseModel
 
 from ..protocol_engine.errors import ProtocolCommandFailedError
 from ..protocol_engine.types import (
@@ -57,7 +58,7 @@ from opentrons.util.async_helpers import asyncio_yield
 from opentrons.util.broker import Broker
 
 
-class RunResult(NamedTuple):
+class RunResult(BaseModel):
     """Result data from a run, pulled from the ProtocolEngine."""
 
     commands: List[Command]

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_common.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_common.py
@@ -2139,7 +2139,7 @@ def test_build_retrieve_labware_move_updates(
     decoy: Decoy,
 ) -> None:
     """It should build appropriate data for batch labware location."""
-    stacker = FlexStackerSubState(
+    stacker = FlexStackerSubState.model_construct(
         module_id=FlexStackerId("stacker-id"),
         pool_primary_definition=sentinel.pool_primary_definition,
         pool_adapter_definition=sentinel.pool_adapter_definition,

--- a/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
+++ b/api/tests/opentrons/protocol_engine/commands/flex_stacker/test_store.py
@@ -406,7 +406,7 @@ async def test_store_raises_if_labware_does_not_match(
         moduleId=stacker_id, strategy=StackerLabwareMovementStrategy.AUTOMATIC
     )
 
-    fs_module_substate = FlexStackerSubState(
+    fs_module_substate = FlexStackerSubState.model_construct(
         module_id=stacker_id,
         pool_primary_definition=sentinel.primary,
         pool_adapter_definition=pool_adapter,

--- a/api/tests/opentrons/protocol_engine/state/command_fixtures.py
+++ b/api/tests/opentrons/protocol_engine/state/command_fixtures.py
@@ -1,7 +1,7 @@
 """Command factories to use in tests as data fixtures."""
 
 from datetime import datetime
-from typing import Dict, Optional, cast
+from typing import Dict, Optional
 
 from pydantic import BaseModel
 
@@ -33,97 +33,81 @@ class FixtureModel(BaseModel):
 def create_queued_command(
     command_id: str = "command-id",
     command_key: str = "command-key",
-    command_type: str = "command-type",
     intent: cmd.CommandIntent = cmd.CommandIntent.PROTOCOL,
-    params: Optional[BaseModel] = None,
 ) -> cmd.Command:
-    """Given command data, build a pending command model."""
+    """Create a queued command."""
+    params = cmd.CommentParams(message="succeeded")
 
-    class DummyParams(BaseModel):
-        pass
-
-    return cast(
-        cmd.Command,
-        cmd.BaseCommand(
-            id=command_id,
-            key=command_key,
-            commandType=command_type,
-            createdAt=datetime(year=2021, month=1, day=1),
-            status=cmd.CommandStatus.QUEUED,
-            params=params or DummyParams(),
-            intent=intent,
-        ),
+    return cmd.Comment(
+        id=command_id,
+        key=command_key,
+        status=cmd.CommandStatus.QUEUED,
+        createdAt=datetime(year=2021, month=1, day=1),
+        params=params,
+        intent=intent,
     )
 
 
 def create_running_command(
     command_id: str = "command-id",
     command_key: str = "command-key",
-    command_type: str = "command-type",
     created_at: datetime = datetime(year=2021, month=1, day=1),
-    params: Optional[BaseModel] = None,
 ) -> cmd.Command:
-    """Given command data, build a running command model."""
-    return cast(
-        cmd.Command,
-        cmd.BaseCommand(
-            id=command_id,
-            key=command_key,
-            createdAt=created_at,
-            commandType=command_type,
-            status=cmd.CommandStatus.RUNNING,
-            params=params or FixtureModel(),
-        ),
+    """Create a running command."""
+    params = cmd.CommentParams(message="running")
+
+    result = cmd.CommentResult()
+
+    return cmd.Comment(
+        id=command_id,
+        key=command_key,
+        status=cmd.CommandStatus.RUNNING,
+        createdAt=created_at,
+        params=params,
+        result=result,
     )
 
 
 def create_failed_command(
     command_id: str = "command-id",
     command_key: str = "command-key",
-    command_type: str = "command-type",
     created_at: datetime = datetime(year=2021, month=1, day=1),
     completed_at: datetime = datetime(year=2022, month=2, day=2),
-    params: Optional[BaseModel] = None,
     error: Optional[ErrorOccurrence] = None,
     intent: Optional[cmd.CommandIntent] = None,
 ) -> cmd.Command:
-    """Given command data, build a failed command model."""
-    return cast(
-        cmd.Command,
-        cmd.BaseCommand(
-            id=command_id,
-            key=command_key,
-            createdAt=created_at,
-            completedAt=completed_at,
-            commandType=command_type,
-            status=cmd.CommandStatus.FAILED,
-            params=params or FixtureModel(),
-            error=error,
-            intent=intent,
-        ),
+    """Create a failed command."""
+    params = cmd.CommentParams(message="failed")
+
+    return cmd.Comment(
+        id=command_id,
+        key=command_key,
+        status=cmd.CommandStatus.FAILED,
+        createdAt=created_at,
+        completedAt=completed_at,
+        params=params,
+        error=error,
+        intent=intent,
     )
 
 
 def create_succeeded_command(
     command_id: str = "command-id",
     command_key: str = "command-key",
-    command_type: str = "command-type",
     created_at: datetime = datetime(year=2021, month=1, day=1),
-    params: Optional[BaseModel] = None,
-    result: Optional[BaseModel] = None,
-) -> cmd.Command:
-    """Given command data and result, build a completed command model."""
-    return cast(
-        cmd.Command,
-        cmd.BaseCommand(
-            id=command_id,
-            key=command_key,
-            createdAt=created_at,
-            commandType=command_type,
-            status=cmd.CommandStatus.SUCCEEDED,
-            params=params or FixtureModel(),
-            result=result or FixtureModel(),
-        ),
+) -> cmd.Comment:
+    """Create a succeeded command."""
+    params = cmd.CommentParams(message="succeeded")
+
+    result = cmd.CommentResult()
+
+    return cmd.Comment(
+        id=command_id,
+        key=command_key,
+        status=cmd.CommandStatus.SUCCEEDED,
+        createdAt=created_at,
+        params=params,
+        result=result,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_command_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_state.py
@@ -1359,7 +1359,7 @@ def test_get_errors_slice() -> None:
     result = subject_view.get_errors_slice(cursor=1, length=3)
 
     assert result == CommandErrorSlice(
-        [
+        commands_errors=[
             ErrorOccurrence(
                 id="error-id",
                 createdAt=datetime(2023, 3, 3, 0, 0),

--- a/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
+++ b/api/tests/opentrons/protocol_engine/state/test_command_view_old.py
@@ -906,18 +906,18 @@ def test_get_current() -> None:
         created_at=datetime(year=2022, month=2, day=2),
     )
 
-    command_1 = create_succeeded_command(
+    command_3 = create_succeeded_command(
         "command-id-1",
         command_key="key-1",
         created_at=datetime(year=2021, month=1, day=1),
     )
-    command_2 = create_failed_command(
+    command_4 = create_failed_command(
         "command-id-2",
         command_key="key-2",
         created_at=datetime(year=2022, month=2, day=2),
     )
-    subject = get_command_view(commands=[command_1, command_2])
-    subject._state.command_history._set_most_recently_completed_command_id(command_1.id)
+    subject = get_command_view(commands=[command_3, command_4])
+    subject._state.command_history._set_most_recently_completed_command_id(command_3.id)
 
     assert subject.get_current() == CommandPointer(
         index=1,

--- a/api/tests/opentrons/protocol_engine/state/test_flex_stacker_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_flex_stacker_state.py
@@ -166,7 +166,7 @@ def test_get_labware_definition_list(
     result: list[LabwareDefinition] | None,
 ) -> None:
     """It should return definitions in proper order."""
-    subject = FlexStackerSubState(
+    subject = FlexStackerSubState.model_construct(
         module_id=FlexStackerId("someModuleId"),
         pool_primary_definition=primary_def,
         pool_adapter_definition=adapter_def,
@@ -181,7 +181,7 @@ def test_get_labware_definition_list(
 
 def test_get_contained_labware() -> None:
     """It should present a list of contained labware."""
-    subject = FlexStackerSubState(
+    subject = FlexStackerSubState.model_construct(
         module_id=FlexStackerId("someModuleId"),
         pool_primary_definition=sentinel.primary_def,
         pool_adapter_definition=sentinel.adapter_def,

--- a/api/tests/opentrons/protocol_runner/test_protocol_runner.py
+++ b/api/tests/opentrons/protocol_runner/test_protocol_runner.py
@@ -26,6 +26,7 @@ from opentrons.protocol_engine import (
     CommandStatus,
     Liquid,
     ProtocolEngine,
+    StateSummary,
 )
 from opentrons.protocol_engine import (
     commands as pe_commands,
@@ -340,6 +341,11 @@ async def test_run_json_runner(
     """It should run a protocol to completion."""
     decoy.when(protocol_engine.state_view.commands.has_been_played()).then_return(
         False, True
+    )
+
+    decoy.when(protocol_engine.state_view.commands.get_all()).then_return([])
+    decoy.when(protocol_engine.state_view.get_summary()).then_return(
+        StateSummary.model_construct()  # type: ignore[call-arg]
     )
 
     assert json_runner_subject.was_started() is False
@@ -851,6 +857,14 @@ async def test_run_python_runner(
         False, True
     )
 
+    decoy.when(protocol_engine.state_view.commands.get_all()).then_return([])
+    decoy.when(protocol_engine.state_view.get_summary()).then_return(
+        StateSummary.model_construct()  # type: ignore[call-arg]
+    )
+    decoy.when(
+        protocol_engine.state_view.commands.get_all_command_annotations()
+    ).then_return([])
+
     assert python_runner_subject.was_started() is False
     await python_runner_subject.run(deck_configuration=sentinel.deck_configuration)
     assert python_runner_subject.was_started() is True
@@ -873,6 +887,11 @@ async def test_run_live_runner(
     """It should run a protocol to completion."""
     decoy.when(protocol_engine.state_view.commands.has_been_played()).then_return(
         False, True
+    )
+
+    decoy.when(protocol_engine.state_view.commands.get_all()).then_return([])
+    decoy.when(protocol_engine.state_view.get_summary()).then_return(
+        StateSummary.model_construct()  # type: ignore[call-arg]
     )
 
     assert live_runner_subject.was_started() is False

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -275,7 +275,7 @@ async def test_create(
     """It should create an engine and a persisted run resource."""
     run_id = "hello world"
     created_at = datetime(year=2021, month=1, day=1)
-    protocol_source = ProtocolSource(
+    protocol_source = ProtocolSource.model_construct(
         directory=sentinel.directory,
         main_file=sentinel.main_file,
         content_hash=sentinel.content_hash,


### PR DESCRIPTION
# Overview

There are a few dataclasses that are used to communicate between the robot server and the protocol process that were dataclasses. Since these are sent between pyro proxies, and serpent serialization for pydantic is much simpler than dataclasses, they have been converted. Pydantic has its own built-in recursive serialization, while dataclasses require hardcoding the dict to class method for deserialization.

## Test Plan and Hands on Testing

Covered by existing unit tests. Some had to be modified because pydantic validation is much stricter than dataclasses.

## Changelog

- Changed a bunch of dataclasses into pydantic model

## Review requests

Double check that none of these go into the database and need special loading or storing handling.

## Risk assessment

Low-medium, simple changes but they are to long-existing objects and we need to make sure that they are handled by the database properly if any interact with that.