### PR TITLE
fix(components): hide slot clips

### DIFF
--- a/components/src/hardware-sim/BaseDeck/SingleSlotFixture.tsx
+++ b/components/src/hardware-sim/BaseDeck/SingleSlotFixture.tsx
@@ -29,7 +29,7 @@ export function SingleSlotFixture(
     slotClipColor,
     showExpansion = false,
     stroke = 'none',
-    showSlotClips = true,
+    showSlotClips = false,
     ...restProps
   } = props
 

--- a/components/src/hardware-sim/BaseDeck/StagingAreaFixture.tsx
+++ b/components/src/hardware-sim/BaseDeck/StagingAreaFixture.tsx
@@ -28,7 +28,7 @@ export function StagingAreaFixture(
     deckDefinition,
     fixtureBaseColor,
     slotClipColor,
-    showSlotClips = true,
+    showSlotClips = false,
     ...restProps
   } = props
 

--- a/components/src/hardware-sim/BaseDeck/WasteChuteStagingAreaFixture.tsx
+++ b/components/src/hardware-sim/BaseDeck/WasteChuteStagingAreaFixture.tsx
@@ -33,7 +33,7 @@ export function WasteChuteStagingAreaFixture(
     wasteChuteColor = COLORS.grey50,
     showHighlight,
     tagInfo,
-    showSlotClips = true,
+    showSlotClips = false,
     ...restProps
   } = props
 

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
@@ -289,7 +289,6 @@ export function DeckSetupContainer(
                             slotClipColor={darkFill}
                             showExpansion={cutoutId === 'cutoutA1'}
                             fixtureBaseColor={lightFill}
-                            showSlotClips={false}
                           />
                         ) : null
                       })}
@@ -305,7 +304,6 @@ export function DeckSetupContainer(
                               deckDefinition={deckDef}
                               slotClipColor={darkFill}
                               fixtureBaseColor={lightFill}
-                              showSlotClips={false}
                             />
                           )
                         }
@@ -321,7 +319,6 @@ export function DeckSetupContainer(
                                   deckDefinition={deckDef}
                                   slotClipColor={COLORS.transparent}
                                   fixtureBaseColor={lightFill}
-                                  showSlotClips={false}
                                 />
                                 <FlexTrash
                                   robotType={robotType}
@@ -364,7 +361,6 @@ export function DeckSetupContainer(
                               deckDefinition={deckDef}
                               slotClipColor={darkFill}
                               fixtureBaseColor={lightFill}
-                              showSlotClips={false}
                             />
                           )
                         }

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
@@ -165,7 +165,6 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
                       showExpansion={cutoutId === 'cutoutA1'}
                       fixtureBaseColor={lightFill}
                       slotClipColor={darkFill}
-                      showSlotClips={false}
                     />
                   ) : null
                 })}
@@ -176,7 +175,6 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
                     deckDefinition={deckDef}
                     fixtureBaseColor={lightFill}
                     slotClipColor={darkFill}
-                    showSlotClips={false}
                   />
                 ))}
                 {trash != null
@@ -188,7 +186,6 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
                             deckDefinition={deckDef}
                             slotClipColor={COLORS.transparent}
                             fixtureBaseColor={lightFill}
-                            showSlotClips={false}
                           />
                           <FlexTrash
                             robotType={robotType}
@@ -215,7 +212,6 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
                     deckDefinition={deckDef}
                     fixtureBaseColor={lightFill}
                     slotClipColor={darkFill}
-                    showSlotClips={false}
                   />
                 ))}
               </>


### PR DESCRIPTION


# Overview
hide slot clips
<img width="124" height="132" alt="Screenshot 2026-03-26 at 11 58 32 AM" src="https://github.com/user-attachments/assets/3782f8cb-9e12-4768-8b03-b384aa691df7" />
<img width="1432" height="655" alt="Screenshot 2026-03-26 at 11 58 41 AM" src="https://github.com/user-attachments/assets/a17d373e-3704-4547-b1cf-719ff0a76371" />
<img width="1453" height="1100" alt="Screenshot 2026-03-26 at 11 59 04 AM" src="https://github.com/user-attachments/assets/8630eee9-af16-4324-8e55-bbbf79d8d673" />
<img width="1452" height="1092" alt="Screenshot 2026-03-26 at 12 00 33 PM" src="https://github.com/user-attachments/assets/ecc189b1-0c96-4247-bf35-cf7ab94ac2f5" />



close AUTH-2821

## Test Plan and Hands on Testing
- run the desktop app
- setup a protocol
check deck views in each page(protocol landing, protocol details, protocol setup, and protocol visualization)

## Changelog

## Review requests

## Risk assessment
low
