### PR TITLE
fix(app): remove duplicate svg render

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewModules.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewModules.tsx
@@ -1,10 +1,6 @@
 import { Fragment } from 'react'
 
-import {
-  CenterLabwareInModuleChildSlot,
-  COLORS,
-  Module,
-} from '@opentrons/components'
+import { COLORS, Module } from '@opentrons/components'
 import {
   FLEX_STACKER_MODULE_TYPE,
   getModuleDef,
@@ -18,7 +14,6 @@ import { getModuleInnerProps } from '../utils/getModuleInnerProps'
 import { getTopmostLabwareOnModuleFromStack } from '../utils/getTopmostLabwareOnModuleFromStack'
 import { DeckViewOverlay } from './DeckViewOverlay'
 import { DeckViewStacker } from './DeckViewStacker'
-import { LabwareOnDeck } from './LabwareOnDeck'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { ThermocyclerVizProps } from '@opentrons/components'
@@ -107,30 +102,6 @@ export function DeckViewModules(props: DeckViewModulesProps): JSX.Element {
           !showLabwareCommandSummary
         return (
           <Fragment key={id}>
-            {moduleType !== THERMOCYCLER_MODULE_TYPE &&
-            labwareLoadedOnModuleId != null ? (
-              <CenterLabwareInModuleChildSlot
-                deckId={deckDef.otId}
-                slotId={slot}
-                moduleDefinition={moduleDef}
-                labwareDefinition={
-                  labwareEntitiesExtended[labwareLoadedOnModuleId].def
-                }
-              >
-                <LabwareOnDeck
-                  robotState={robotState}
-                  labwareDef={
-                    labwareEntitiesExtended[labwareLoadedOnModuleId].def
-                  }
-                  liquids={liquids}
-                  labwareId={labwareLoadedOnModuleId}
-                  x={0}
-                  y={0}
-                  setSelectedSlot={setSelectedSlot}
-                  setHoveredSlot={setHoveredSlot}
-                />
-              </CenterLabwareInModuleChildSlot>
-            ) : null}
             <Module
               key={id}
               x={slotPosition[0]}


### PR DESCRIPTION
# Overview

looks like we were rendering the svg on the modules like twice? oops.

## Test Plan and Hands on Testing

please smoke test all the modules with labware and make sure things work as expected. i smoke tested a bit and it worked with stacker + thermocycler + temperature module. but i don't feel confident still

## Changelog

remove a probable double svg render of the labware on the module

## Risk assessment

high - this is the last PV bug to get into RS 9.0.0