### PR TITLE
chore: Switch .cursorignore to .cursorindexignore to fix sandboxing

### DIFF
--- a/.cursorindexignore
+++ b/.cursorindexignore
@@ -1,5 +1,9 @@
 # Add directories or file patterns to ignore during indexing (e.g. foo/ or *.csv)
 
+# NOTE: This is .cursorindexignore, not .cursorignore, to NOT prevent agent tools
+# from accessing these files. We want agents to be able to e.g. run tests that write
+# to the ignored `coverage` directory.
+
 # Generated files for local API server config paths
 api/.env
 api/index.json


### PR DESCRIPTION
## Overview

This fixes one issue preventing Cursor agents from running things in their sandbox.

`.cursorindexignore` prevents files from being indexed by Cursor. `.cursorignore` does that, *and* it *also* tries to prevent AI features from accessing those files. (Though this cannot be relied upon for safety.) See [docs](https://cursor.com/docs/reference/ignore-file).

We *do* want AI features to be able to access these files. For example, an agent should be able to run `make test`, which will try to write to `coverage` files. So, we need to use `.cursorindexignore` instead of `.cursorignore`. Otherwise, agents get permission errors and require unsandboxed access.

## Test Plan and Hands on Testing

* [x] Instructing an agent to run `make -C auth-server test` now succeeds in the sandbox.

## Review requests

Makes sense?

## Risk assessment

Low.