### PR TITLE
ci: use GitHub Actions var for OT_APP_OT3_DEPLOY_ROLE

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -373,7 +373,7 @@ jobs:
       - name: 'configure s3 deploy creds (GitHub OIDC)'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.OT_APP_OT3_DEPLOY_ROLE }}
+          role-to-assume: ${{ vars.OT_APP_OT3_DEPLOY_ROLE }}
           aws-region: us-east-2
       - name: 'deploy release builds to s3'
         run: |


### PR DESCRIPTION
Read the OIDC deploy role ARN from vars.OT_APP_OT3_DEPLOY_ROLE instead of secrets so the value can be managed as a non-secret repository variable.