### PR TITLE
fix(robot-server): Output logs from server_utils

### DIFF
--- a/robot-server/robot_server/service/logging.py
+++ b/robot-server/robot_server/service/logging.py
@@ -72,7 +72,7 @@ def _robot_log_config(log_level: int) -> Dict[str, Any]:
                 "level": log_level,
                 "propagate": False,
             },
-             "server_utils": {
+            "server_utils": {
                 "handlers": ["syslog_plus_unit"],
                 "level": log_level,
                 "propagate": False,

--- a/robot-server/robot_server/service/logging.py
+++ b/robot-server/robot_server/service/logging.py
@@ -72,6 +72,11 @@ def _robot_log_config(log_level: int) -> Dict[str, Any]:
                 "level": log_level,
                 "propagate": False,
             },
+             "server_utils": {
+                "handlers": ["syslog_plus_unit"],
+                "level": log_level,
+                "propagate": False,
+            },
             "uvicorn.error": {
                 "handlers": ["syslog_plus_unit"],
                 "level": log_level,
@@ -125,6 +130,11 @@ def _dev_log_config(log_level: int) -> Dict[str, Any]:
         },
         "loggers": {
             "robot_server": {
+                "handlers": ["robot_server"],
+                "level": log_level,
+                "propagate": False,
+            },
+            "server_utils": {
                 "handlers": ["robot_server"],
                 "level": log_level,
                 "propagate": False,


### PR DESCRIPTION
## Overview

By default, robot-server does not output any logs from its dependencies. Each package needs to be explicitly allowlisted. That list was missing `server_utils`. So this PR simply adds it.

This closes EXEC-2373 for robot-server (but not other servers).

## Test Plan and Hands on Testing

* [x] `server_utils` logs now show up when locally running `make -C robot-server dev`.
* [x] `server_utils` logs now show up on-robot when running `journalctl -u opentrons-robot-server`.

## Review requests

Anything else that we want to add here?

## Risk assessment

Low.
