### PR TITLE
refactor(protocol-designer, e2e-testing): remove data-testid to implementation dependencies

### DIFF
--- a/e2e-testing/automation/pd_pages/mix_step_form.py
+++ b/e2e-testing/automation/pd_pages/mix_step_form.py
@@ -210,27 +210,18 @@ class MixStepForm(BasePage):
                 # continue to label/test-id based fallbacks.
                 pass
 
-        # Try CheckboxExpandStepFormField - these use ListButton with a Btn containing Check icon
-        # The inner Btn has a testId like "delay_checkbox", "blowout_checkbox", etc.
-        checkbox_buttons = self.page.locator('[data-testid*="checkbox"]')
-        if checkbox_buttons.count() > index:
-            checkbox_button = checkbox_buttons.nth(index)
-            self.wait_for_visible(checkbox_button)
-            checkbox_button.click()
+        # CheckboxExpandStepFormField renders ListButton rows with visible titles.
+        checkbox_titles = ["Delay", "Push out", "Blowout", "Touch tip", "Air gap", "Mix"]
+        visible_rows: list[Locator] = []
+        for title in checkbox_titles:
+            row = self.page.locator('[data-testid="ListButton_noActive"]').filter(has_text=title).first
+            if row.count() > 0 and row.is_visible():
+                visible_rows.append(row)
+        if len(visible_rows) > index:
+            checkbox_row = visible_rows[index]
+            self.wait_for_visible(checkbox_row)
+            checkbox_row.click()
             return
-
-        # Fallback: CheckboxExpandStepFormField wraps everything in a ListButton that's also clickable
-        # Find ListButtons that contain checkbox-related text (Delay, Push out, Blowout, etc.)
-        # These are the clickable containers for CheckboxExpandStepFormField
-        # Look for buttons containing text that matches checkbox labels
-        checkbox_texts = ["Delay", "Push out", "Blowout", "Touch tip", "Air gap", "Mix"]
-        for text in checkbox_texts:
-            buttons_with_text = self.page.locator("button").filter(has_text=text)
-            if buttons_with_text.count() > index:
-                list_button = buttons_with_text.nth(index)
-                self.wait_for_visible(list_button)
-                list_button.click()
-                return
 
         # Last resort: try to find input[type="checkbox"] (CheckboxField component)
         checkbox_input = self.page.locator('input[type="checkbox"]').nth(index)
@@ -266,31 +257,9 @@ class MixStepForm(BasePage):
 
     def open_blowout_location_dropdown(self) -> None:
         """Open the blowout location dropdown menu."""
-
-        # First, ensure the blowout checkbox is checked (dropdown only appears when checked)
-        # The checkbox has testId="blowout_checkbox"
-        blowout_checkbox_button = self.page.get_by_test_id("blowout_checkbox").first
-        if blowout_checkbox_button.count() > 0:
-            # Check if checkbox is already checked by looking for the checked state
-            # If not checked, click it to enable the dropdown
-            try:
-                # Try to find if the checkbox area is expanded (dropdown should be visible)
-                dropdown_check = self.page.locator('[data-testid="blowout_location_dropdownMenu"]')
-                if dropdown_check.count() == 0:
-                    # Checkbox is not checked, click it to enable
-                    self.wait_for_visible(blowout_checkbox_button)
-                    blowout_checkbox_button.click()
-                    # Wait a moment for React to update the DOM
-                    self.page.wait_for_timeout(500)
-            except Exception:
-                pass
-
-        # Now wait for the dropdown to appear in the DOM
-        # The dropdown has testId="blowout_location_dropdownMenu" (field name + _dropdownMenu)
+        # Prefer the rendered dropdown if the blowout row is already expanded.
         dropdown_locator = self.page.locator('[data-testid="blowout_location_dropdownMenu"]')
 
-        # Wait for the dropdown to be attached to the DOM with a longer timeout
-        # This handles the case where the checkbox was just toggled and the DOM is updating
         try:
             dropdown_locator.wait_for(state="attached", timeout=15000)
             dropdown = dropdown_locator.first
@@ -298,8 +267,20 @@ class MixStepForm(BasePage):
             dropdown.click()
             return
         except Exception:
-            # If waiting for attached fails, try alternative approaches
-            pass
+            # If the dropdown isn't rendered yet, explicitly expand the Blowout row.
+            blowout_row = self.page.locator('[data-testid="ListButton_noActive"]').filter(has_text="Blowout").first
+            if blowout_row.count() > 0 and blowout_row.is_visible():
+                self.wait_for_visible(blowout_row)
+                blowout_row.click()
+                self.page.wait_for_timeout(300)
+                try:
+                    dropdown_locator.wait_for(state="attached", timeout=5000)
+                    dropdown = dropdown_locator.first
+                    self.wait_for_visible(dropdown, timeout=5000)
+                    dropdown.click()
+                    return
+                except Exception:
+                    pass
 
         # Fallback: Try using the dropdown_by_title helper which finds dropdowns by their label text
         try:

--- a/e2e-testing/automation/pd_pages/protocol_editor_page.py
+++ b/e2e-testing/automation/pd_pages/protocol_editor_page.py
@@ -44,7 +44,9 @@ class ProtocolEditorPage(BasePage):
             else:
                 self.wait_for_visible(add_button)
                 add_button.click()
-                self.page.get_by_test_id("SlotOverflowMenu_openTools").click()
+                edit_labware_option = self.page.get_by_text("Edit labware", exact=True).last
+                self.wait_for_visible(edit_labware_option)
+                edit_labware_option.click()
 
         else:
             self.wait_for_visible(add_button)
@@ -102,10 +104,29 @@ class ProtocolEditorPage(BasePage):
 
     def select_labware_category_by_name(self, category_name: str) -> None:
         """Select a labware category by its visible label."""
+        self._open_select_labware_modal()
 
-        category = self.page.get_by_role("button", name=category_name, exact=False)
+        search_input = self.page.locator("input[placeholder='Search labware']").first
+        if search_input.count() > 0 and search_input.is_visible():
+            search_input.fill("")
+
+        modal = self.page.get_by_label("ModalShell_ModalArea")
+        category = modal.locator("[data-testid^='ListButton_']").filter(has_text=category_name).first
         if category.count() == 0:
-            category = self.page.get_by_text(category_name, exact=False)
+            category = modal.get_by_text(category_name, exact=False)
+        if category.count() == 0:
+            category_index_by_name = {
+                "Tip racks": 0,
+                "Tube racks": 1,
+                "Well plates": 2,
+                "Reservoirs": 3,
+                "Aluminum blocks": 4,
+                "Adapters": 5,
+                "Lids": 6,
+            }
+            category_index = category_index_by_name.get(category_name)
+            if category_index is not None:
+                category = self.page.get_by_test_id("ListButton_noActive").nth(category_index)
         self.wait_for_visible(category.first)
         category.first.click()
 
@@ -134,32 +155,45 @@ class ProtocolEditorPage(BasePage):
                 filter_label.click()
 
         pattern = re.compile(re.escape(labware_name), re.IGNORECASE)
-        target = self.page.locator("label").filter(has_text=pattern).first
+        modal = self.page.get_by_label("ModalShell_ModalArea")
+        target = modal.locator("label").filter(has_text=pattern).first
 
         try:
             target.wait_for(state="visible", timeout=1000)
         except TimeoutError as error:
-            category_button = (
-                self.page.locator("[data-testid='ListButton_noActive']")
-                .filter(has_text=re.compile("Well plates", re.IGNORECASE))
-                .first
-            )
-            if category_button.count() > 0:
-                category_button.click()
-                try:
-                    target.wait_for(state="visible", timeout=1000)
-                except TimeoutError as retry_error:
-                    visible_options = self.page.locator("label").all_inner_texts()
+            fallback_target = modal.get_by_text(pattern, exact=False).first
+            try:
+                fallback_target.wait_for(state="visible", timeout=1000)
+                target = fallback_target
+            except TimeoutError as retry_error:
+                if search_input.count() > 0 and search_input.is_visible():
+                    search_input.fill("")
+                category_buttons = self.page.get_by_test_id("ListButton_noActive")
+                found = False
+                for index in range(category_buttons.count()):
+                    category_buttons.nth(index).click()
+                    label_target = modal.locator("label").filter(has_text=pattern).first
+                    text_target = modal.get_by_text(pattern, exact=False).first
+                    try:
+                        label_target.wait_for(state="visible", timeout=500)
+                        target = label_target
+                        found = True
+                        break
+                    except TimeoutError:
+                        try:
+                            text_target.wait_for(state="visible", timeout=500)
+                            target = text_target
+                            found = True
+                            break
+                        except TimeoutError:
+                            continue
+
+                if not found:
+                    visible_options = modal.locator("label, [role='label'], button").all_inner_texts()
                     raise AssertionError(
                         f"Labware '{labware_name}' was not found in the selection modal. "
                         f"Available options: {visible_options}"
                     ) from retry_error
-            else:
-                visible_options = self.page.locator("label").all_inner_texts()
-                raise AssertionError(
-                    f"Labware '{labware_name}' was not found in the selection modal. "
-                    f"Available options: {visible_options}"
-                ) from error
 
         target.click()
         if stacker:
@@ -167,9 +201,7 @@ class ProtocolEditorPage(BasePage):
             self.page.get_by_test_id("customize-expand-button-input-field").fill(str(fill_num))
         if lid:
             self._add_lid("Opentrons Flex 96 Tip Rack 50", "CheckboxField_icon")
-        self.click_test_id("SelectLabwareModal_confirm")
-
-        modal = self.page.get_by_role("dialog", name="Add labware", exact=False)
+        modal.get_by_role("button", name=re.compile(r"^Add labware$", re.IGNORECASE)).click()
         if modal.count() > 0:
             modal.wait_for(state="hidden", timeout=5000)
 

--- a/e2e-testing/automation/pd_pages/protocol_editor_page.py
+++ b/e2e-testing/automation/pd_pages/protocol_editor_page.py
@@ -160,7 +160,7 @@ class ProtocolEditorPage(BasePage):
 
         try:
             target.wait_for(state="visible", timeout=1000)
-        except TimeoutError as error:
+        except TimeoutError:
             fallback_target = modal.get_by_text(pattern, exact=False).first
             try:
                 fallback_target.wait_for(state="visible", timeout=1000)

--- a/e2e-testing/automation/pd_pages/settings_page.py
+++ b/e2e-testing/automation/pd_pages/settings_page.py
@@ -14,7 +14,7 @@ class SettingsPage(BasePage):
     def navigate_to_settings(self) -> None:
         """Navigate to settings page via clicking Settings button."""
         # Cypress: cy.getByTestId('SettingsIconButton').click()
-        self.page.get_by_test_id("SettingsIconButton").click()
+        self.page.get_by_label("Settings Icon Button").click()
 
     def wait_for_settings_page(self) -> None:
         """Wait for settings page to load.

--- a/e2e-testing/automation/pd_pages/tc_step_form_page.py
+++ b/e2e-testing/automation/pd_pages/tc_step_form_page.py
@@ -186,7 +186,7 @@ class ThermocyclerProfileModal(BasePage):
             count: The cycle count as a string (e.g., "2").
         """
         # Find the cycle container and locate the "Number of cycles" input
-        cycle_container = self.page.get_by_test_id("thermocyclerCycle").nth(cycle_index)
+        cycle_container = self.page.locator(f'[aria-label="Thermocycler cycle {cycle_index + 1}"]')
 
         # Click on the "Number of cycles" area
         num_cycles_div = cycle_container.locator("div").filter(has_text="Number of cycles").nth(3)
@@ -224,7 +224,7 @@ class ThermocyclerProfileModal(BasePage):
             temperature: The temperature (e.g., "40").
             time: The time in M:SS format (e.g., "1:00").
         """
-        step_container = self.page.get_by_test_id(f"cycleStep-{step_index}")
+        step_container = self.page.locator(f'[aria-label="Thermocycler cycle step {step_index + 1}"]')
         self.wait_for_visible(step_container)
 
         # Fill step name
@@ -255,8 +255,9 @@ class ThermocyclerProfileModal(BasePage):
             cycle_index: The index of the cycle (0-based).
             step_index: The index of the step within the cycle (0-based).
         """
-        step_container = self.page.get_by_test_id(f"cycleStep-{step_index}")
-        delete_button = step_container.get_by_role("button", name="Delete")
+        step_container = self.page.locator(f'[aria-label="Thermocycler cycle step {step_index + 1}"]')
+        self.wait_for_visible(step_container)
+        delete_button = self.page.locator(f'[aria-label="Delete thermocycler cycle step {step_index + 1}"]')
         delete_button.click()
 
     def save_cycle(self, cycle_index: int) -> None:
@@ -266,7 +267,7 @@ class ThermocyclerProfileModal(BasePage):
         Args:
             cycle_index: The index of the cycle (0-based).
         """
-        cycle_container = self.page.get_by_test_id("thermocyclerCycle").nth(cycle_index)
+        cycle_container = self.page.locator(f'[aria-label="Thermocycler cycle {cycle_index + 1}"]')
         save_button = cycle_container.get_by_role("button", name="Save")
         save_button.click()
 
@@ -324,7 +325,7 @@ class ThermocyclerProfileModal(BasePage):
         Args:
             step_index: The index of the thermocycler step (0-based).
         """
-        delete_button = self.page.get_by_test_id("cycleStep-0").locator("path")
+        delete_button = self.page.get_by_label(f"Delete thermocycler cycle step {step_index + 1}")
         delete_button.click()
 
     def save_thermocycler_step(self, step_index: int) -> None:

--- a/e2e-testing/tests/pd/test_pd_home.py
+++ b/e2e-testing/tests/pd/test_pd_home.py
@@ -29,7 +29,7 @@ def test_home_page_loads_successfully(page: Page, pd_base_url: str) -> None:
     # Verify header elements (use first for elements that appear multiple times)
     expect(page.get_by_text("Protocol Designer").first).to_be_visible()
     expect(page.get_by_text("Create new")).to_be_visible()
-    expect(page.get_by_test_id("SettingsIconButton")).to_be_visible()
+    expect(page.get_by_label("Settings Icon Button")).to_be_visible()
 
     # Verify home page specific elements
     expect(page.get_by_text("Welcome to Protocol Designer!")).to_be_visible()

--- a/protocol-designer/src/components/molecules/CheckboxExpandStepFormField/index.tsx
+++ b/protocol-designer/src/components/molecules/CheckboxExpandStepFormField/index.tsx
@@ -26,7 +26,7 @@ interface CheckboxExpandStepFormFieldProps {
 export function CheckboxExpandStepFormField(
   props: CheckboxExpandStepFormFieldProps
 ): JSX.Element {
-  const { children, title, tooltipOverride, testId, fieldProps } = props
+  const { children, title, tooltipOverride, fieldProps } = props
 
   const {
     value,

--- a/protocol-designer/src/components/molecules/CheckboxExpandStepFormField/index.tsx
+++ b/protocol-designer/src/components/molecules/CheckboxExpandStepFormField/index.tsx
@@ -64,7 +64,6 @@ export function CheckboxExpandStepFormField(
             <>
               <StyledText desktopStyle="bodyDefaultRegular">{title}</StyledText>
               <Btn
-                data-testid={testId}
                 onClick={() => {
                   updateValue(!value)
                 }}

--- a/protocol-designer/src/components/molecules/ConcurrentGroup/ConcurrentGroup.tsx
+++ b/protocol-designer/src/components/molecules/ConcurrentGroup/ConcurrentGroup.tsx
@@ -61,7 +61,7 @@ function OrnamentalLine(props: { active: boolean }): JSX.Element {
         height="100%"
         borderRadius={SPACING.spacing2}
         backgroundColor={active ? COLORS.blue50 : COLORS.grey50}
-        data-testid="ConcurrentGroup_OrnamentalLine"
+        aria-label="ConcurrentGroup OrnamentalLine"
       />
     </Box>
   )

--- a/protocol-designer/src/components/molecules/ConcurrentGroup/__tests__/ConcurrentGroup.test.tsx
+++ b/protocol-designer/src/components/molecules/ConcurrentGroup/__tests__/ConcurrentGroup.test.tsx
@@ -37,13 +37,17 @@ describe('ConcurrentGroup', () => {
 
   it('renders a gray line when not active', () => {
     render({ active: false })
-    const ornamentalLine = screen.getByTestId('ConcurrentGroup_OrnamentalLine')
+    const ornamentalLine = screen.getByLabelText(
+      'ConcurrentGroup OrnamentalLine'
+    )
     expect(ornamentalLine).toHaveStyle(`background-color: ${COLORS.grey50}`)
   })
 
   it('renders a blue line when active', () => {
     render({ active: true })
-    const ornamentalLine = screen.getByTestId('ConcurrentGroup_OrnamentalLine')
+    const ornamentalLine = screen.getByLabelText(
+      'ConcurrentGroup OrnamentalLine'
+    )
     expect(ornamentalLine).toHaveStyle(`background-color: ${COLORS.blue50}`)
   })
 })

--- a/protocol-designer/src/components/molecules/ExportButton/__tests__/ExportButton.test.tsx
+++ b/protocol-designer/src/components/molecules/ExportButton/__tests__/ExportButton.test.tsx
@@ -26,13 +26,14 @@ describe('ExportButton', () => {
   })
   it('should render icon and text', () => {
     render(props)
-    screen.getByTestId('export-icon')
-    screen.getByText('Export')
+    const exportButton = screen.getByRole('button', { name: 'Export' })
+    expect(exportButton).toBeInTheDocument()
   })
 
   it('should call a mock function when clicking', () => {
     render(props)
-    fireEvent.click(screen.getByText('Export'))
+    const exportButton = screen.getByRole('button', { name: 'Export' })
+    fireEvent.click(exportButton)
     expect(mockOnClick).toHaveBeenCalled()
   })
 })

--- a/protocol-designer/src/components/molecules/ExportButton/index.tsx
+++ b/protocol-designer/src/components/molecules/ExportButton/index.tsx
@@ -12,7 +12,7 @@ export function ExportButton({ onClick }: ExportButtonProps): JSX.Element {
 
   return (
     <Btn css={GREY_BUTTON_STYLE} onClick={onClick}>
-      <Icon size="1rem" name="export" data-testid="export-icon" />
+      <Icon size="1rem" name="export" />
       <StyledText desktopStyle="bodyDefaultSemiBold">{t('export')}</StyledText>
     </Btn>
   )

--- a/protocol-designer/src/components/molecules/LiquidButton/__tests__/LiquidButton.test.tsx
+++ b/protocol-designer/src/components/molecules/LiquidButton/__tests__/LiquidButton.test.tsx
@@ -27,7 +27,6 @@ describe('LiquidButton', () => {
 
   it('should render icon and text', () => {
     render(props)
-    screen.getByTestId('water-drop')
     screen.getByText('Liquids')
   })
 

--- a/protocol-designer/src/components/molecules/LiquidButton/index.tsx
+++ b/protocol-designer/src/components/molecules/LiquidButton/index.tsx
@@ -33,11 +33,7 @@ export function LiquidButton({
         showLiquidOverflowMenu(true)
       }}
     >
-      <Icon
-        size={isInToolbox ? '1.25rem' : '1rem'}
-        name="water-drop"
-        data-testid="water-drop"
-      />
+      <Icon size={isInToolbox ? '1.25rem' : '1rem'} name="water-drop" />
       <StyledText
         desktopStyle={
           isInToolbox ? 'bodyDefaultRegular' : 'bodyDefaultSemiBold'

--- a/protocol-designer/src/components/molecules/StepContainer/index.tsx
+++ b/protocol-designer/src/components/molecules/StepContainer/index.tsx
@@ -73,6 +73,7 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
     onOverflowMenuButtonClick,
     dataTestId,
   } = props
+  const accessibleLabel = stepNumber != null ? `${stepNumber}. ${text}` : text
 
   let backgroundColor = type === 'alt' ? COLORS.blue20 : COLORS.grey20
   let textColor = COLORS.black90
@@ -106,6 +107,7 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
       // the inner overflow menu button somehow, because you can't have nested
       // interactable elements.)
       role="button"
+      aria-label={accessibleLabel}
       data-testid={dataTestId}
       onDoubleClick={onDoubleClick}
       onClick={onClick}
@@ -120,7 +122,6 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
         borderRadius={BORDERS.borderRadius8}
         backgroundColor={backgroundColor}
         opacity={semiTransparent ? '50%' : '100%'}
-        data-testid="StepContainer_buttonSansPadding"
       >
         <Flex
           flexDirection={DIRECTION_ROW}
@@ -171,7 +172,7 @@ export function StepContainer(props: StepContainerProps): JSX.Element {
                 </Flex>
                 <OverflowBtn
                   flex="none"
-                  data-testid="StepContainer_OverflowBtn"
+                  aria-label={`${accessibleLabel} options`}
                   fillColor={COLORS.white}
                   onClick={onOverflowMenuButtonClick}
                   // Even when this inner OverflowBtn isn't shown, it needs to contribute to

--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -229,7 +229,6 @@ export function LabwareStackToolbox({
           alignItems={ALIGN_CENTER}
           gridGap={SPACING.spacing8}
           width="100%"
-          data-testid="Toolbox_confirmButton"
           onClick={handleAddAnotherLabware}
         >
           <Icon size="1.5rem" name="plus" />

--- a/protocol-designer/src/components/organisms/DisabledScreen/__tests__/DisabledScreen.test.tsx
+++ b/protocol-designer/src/components/organisms/DisabledScreen/__tests__/DisabledScreen.test.tsx
@@ -15,7 +15,6 @@ const render = () => {
 describe('DisabledScreen', () => {
   it('should render icon and text', () => {
     render()
-    screen.getByTestId('browser_icon_in_DisabledScreen')
     screen.getByText('Your browser size is too small')
     screen.getByText(
       'Resize your browser to at least 768px wide and 650px tall to continue editing your protocol'

--- a/protocol-designer/src/components/organisms/DisabledScreen/index.tsx
+++ b/protocol-designer/src/components/organisms/DisabledScreen/index.tsx
@@ -39,12 +39,7 @@ export function DisabledScreen(): JSX.Element {
         justifyContent={JUSTIFY_CENTER}
         paddingX={SPACING.spacing80}
       >
-        <Icon
-          name="browser"
-          size="2.5rem"
-          color={COLORS.white}
-          data-testid="browser_icon_in_DisabledScreen"
-        />
+        <Icon name="browser" size="2.5rem" color={COLORS.white} />
         <Flex
           flexDirection={DIRECTION_COLUMN}
           gridGap={SPACING.spacing4}

--- a/protocol-designer/src/components/organisms/EditInstrumentsModal/PipetteConfiguration.tsx
+++ b/protocol-designer/src/components/organisms/EditInstrumentsModal/PipetteConfiguration.tsx
@@ -236,7 +236,6 @@ export function PipetteConfiguration({
                         {t('add_custom_tips')}
                       </StyledText>
                       <input
-                        data-testid="SelectPipettes_customTipInput"
                         type="file"
                         onChange={e => dispatch(createCustomTiprackDef(e))}
                       />

--- a/protocol-designer/src/components/organisms/EditNickNameModal/index.tsx
+++ b/protocol-designer/src/components/organisms/EditNickNameModal/index.tsx
@@ -116,7 +116,6 @@ export function EditNickNameModal(props: EditNickNameModalProps): JSX.Element {
             error={
               nickName.length >= MAX_NICK_NAME_LENGTH ? t('rename_error') : null
             }
-            data-testid="renameLabware_inputField"
             name="renameLabware"
             onChange={e => {
               setNickName(e.target.value)

--- a/protocol-designer/src/components/organisms/EditProtocolMetadataModal/index.tsx
+++ b/protocol-designer/src/components/organisms/EditProtocolMetadataModal/index.tsx
@@ -70,10 +70,9 @@ export function EditProtocolMetadataModal(
             {t('shared:cancel')}
           </SecondaryButton>
           <PrimaryButton
-            data-testid="EditProtocolMetadataModal_saveButton"
             disabled={!isDirty}
             onClick={() => {
-              handleSubmit(saveFileMetadata)()
+              void handleSubmit(saveFileMetadata)()
             }}
           >
             {t('shared:save')}
@@ -81,7 +80,11 @@ export function EditProtocolMetadataModal(
         </Flex>
       }
     >
-      <form onSubmit={handleSubmit(saveFileMetadata)}>
+      <form
+        onSubmit={() => {
+          void handleSubmit(saveFileMetadata)
+        }}
+      >
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing12}>
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
             <StyledText color={COLORS.grey60} desktopStyle="captionRegular">

--- a/protocol-designer/src/components/organisms/LabwareButton/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareButton/index.tsx
@@ -34,7 +34,6 @@ export function LabwareButton(props: LabwareButtonProps): JSX.Element {
   const [showOverflowMenu, setShowOverflowMenu] = useState<boolean>(false)
   return (
     <button
-      data-testid={`LabwareButton-${numberInStack}`}
       onClick={(event: MouseEvent<HTMLButtonElement>) => {
         onClick(id, event)
       }}
@@ -59,7 +58,6 @@ export function LabwareButton(props: LabwareButtonProps): JSX.Element {
         {isSelected ? (
           <Box position={POSITION_RELATIVE}>
             <OverflowBtn
-              data-testid="LabwareCard_overflowBtn"
               onClick={() => {
                 setShowOverflowMenu(true)
               }}

--- a/protocol-designer/src/components/organisms/LabwareCard/__tests__/LabwareCard.test.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/__tests__/LabwareCard.test.tsx
@@ -110,19 +110,24 @@ describe('LabwareCard', () => {
     fireEvent.click(screen.getByText('Edit liquid'))
     expect(mockNavigate).toHaveBeenCalledWith('/liquids')
     expect(vi.mocked(openIngredientSelector)).toHaveBeenCalled()
-    fireEvent.click(screen.getByTestId('LabwareCard_overflowBtn'))
+    fireEvent.click(
+      screen.getByLabelText('ANSI 96 Standard Microplate options')
+    )
     screen.getByText('mock LabwareCardOverflowMenu')
   })
+
   it('renders a labware card with 2 liquids added', () => {
     vi.mocked(getLiquidIdsOnLabwareStack).mockReturnValue(['0', '1'])
     render(props)
     screen.getByText('Multiple liquid layouts')
   })
+
   it('renders a labware card with 1 liquid added', () => {
     vi.mocked(getLiquidIdsOnLabwareStack).mockReturnValue(['0'])
     render(props)
     screen.getByText('1 liquid')
   })
+
   it('renders a labware card with edit quantity copy and pressing button renders modal', () => {
     props.labware = {
       ...props.labware,

--- a/protocol-designer/src/components/organisms/LabwareCard/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/index.tsx
@@ -165,7 +165,6 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
                   textDecoration={TYPOGRAPHY.textDecorationUnderline}
                   css={LINK_BUTTON_STYLE}
                   onClick={handleOnClick}
-                  data-testid="LabwareCard_addLiquid_button"
                 >
                   <StyledText desktopStyle="captionRegular">
                     {editButton}
@@ -176,7 +175,7 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
           </Flex>
           <Flex padding={`${SPACING.spacing4} ${SPACING.spacing4} 0 0`}>
             <OverflowBtn
-              data-testid="LabwareCard_overflowBtn"
+              aria-label={`${displayName} options`}
               onClick={() => {
                 setShowOverflowMenu(true)
               }}

--- a/protocol-designer/src/components/organisms/LiquidsOverflowMenu/__tests__/LiquidsOverflowMenu.test.tsx
+++ b/protocol-designer/src/components/organisms/LiquidsOverflowMenu/__tests__/LiquidsOverflowMenu.test.tsx
@@ -32,7 +32,7 @@ const render = (props: ComponentProps<typeof LiquidsOverflowMenu>) => {
   })[0]
 }
 
-describe('SlotOverflowMenu', () => {
+describe('LiquidsOverflowMenu', () => {
   let props: ComponentProps<typeof LiquidsOverflowMenu>
 
   beforeEach(() => {
@@ -57,13 +57,11 @@ describe('SlotOverflowMenu', () => {
   })
   it('renders the overflow buttons with 1 liquid defined', () => {
     render(props)
-    screen.getByText('mockname')
-    fireEvent.click(screen.getByTestId('mockname_0'))
+    fireEvent.click(screen.getByRole('button', { name: 'mockname' }))
     expect(props.onClose).toHaveBeenCalled()
     expect(props.showLiquidsModal).toHaveBeenCalled()
     expect(vi.mocked(labwareIngredActions.selectLiquidGroup)).toHaveBeenCalled()
-    screen.getByText('Define a liquid')
-    fireEvent.click(screen.getByTestId('defineLiquid'))
+    fireEvent.click(screen.getByRole('button', { name: 'Define a liquid' }))
     expect(props.onClose).toHaveBeenCalled()
     expect(
       vi.mocked(labwareIngredActions.createNewLiquidGroup)

--- a/protocol-designer/src/components/organisms/LiquidsOverflowMenu/index.tsx
+++ b/protocol-designer/src/components/organisms/LiquidsOverflowMenu/index.tsx
@@ -90,7 +90,6 @@ export function LiquidsOverflowMenu({
         ({ displayName, displayColor, liquidGroupId }) => {
           return (
             <MenuItem
-              data-testid={`${displayName}_${liquidGroupId}`}
               onClick={() => {
                 onClose()
                 showLiquidsModal()
@@ -125,7 +124,6 @@ export function LiquidsOverflowMenu({
         <Divider color={COLORS.grey20} marginY="0" />
       ) : null}
       <MenuItem
-        data-testid="defineLiquid"
         onClick={() => {
           onClose()
           showLiquidsModal()

--- a/protocol-designer/src/components/organisms/RenameStepModal/index.tsx
+++ b/protocol-designer/src/components/organisms/RenameStepModal/index.tsx
@@ -71,7 +71,6 @@ export function RenameStepModal(props: RenameStepModalProps): JSX.Element {
             {t('shared:cancel')}
           </SecondaryButton>
           <PrimaryButton
-            data-testid="RenameStepModal_saveButton"
             disabled={stepName.length >= MAX_STEP_NAME_LENGTH}
             onClick={handleSave}
           >

--- a/protocol-designer/src/components/organisms/ResetSettingsModal.tsx
+++ b/protocol-designer/src/components/organisms/ResetSettingsModal.tsx
@@ -61,7 +61,6 @@ export function ResetSettingsModal(
             {t('shared:cancel')}
           </SecondaryButton>
           <PrimaryButton
-            data-testid="ResetSettingsModal_continueButton"
             onClick={() => {
               handleContinue()
             }}

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/__tests__/SelectLabwareModal.test.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/__tests__/SelectLabwareModal.test.tsx
@@ -129,8 +129,15 @@ describe('SelectLabwareModal', () => {
 
   it('renders the custom labware flow', () => {
     render(props)
-    screen.getByText('Upload custom labware')
-    fireEvent.change(screen.getByTestId('customLabwareInput'))
+    fireEvent.change(screen.getByLabelText('Upload custom labware'), {
+      target: {
+        files: [
+          new File(['{}'], 'custom-labware.json', {
+            type: 'application/json',
+          }),
+        ],
+      },
+    })
     expect(vi.mocked(createCustomLabwareDef)).toHaveBeenCalled()
   })
 

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -366,7 +366,6 @@ export function SelectLabwareModal(
                     {t('upload_custom_labware')}
                   </StyledText>
                   <input
-                    data-testid="customLabwareInput"
                     type="file"
                     onChange={e => {
                       dispatch(createCustomLabwareDef(e))
@@ -394,10 +393,7 @@ export function SelectLabwareModal(
             >
               {t('shared:cancel')}
             </SecondaryButton>
-            <PrimaryButton
-              data-testid="SelectLabwareModal_confirm"
-              onClick={handleAddLabwareClick}
-            >
+            <PrimaryButton onClick={handleAddLabwareClick}>
               {t('add_labware')}
             </PrimaryButton>
           </Flex>

--- a/protocol-designer/src/components/organisms/SelectPipetteModal/SelectPipetteTips.tsx
+++ b/protocol-designer/src/components/organisms/SelectPipetteModal/SelectPipetteTips.tsx
@@ -106,7 +106,6 @@ export function SelectPipetteTips(props: SelectPipetteTipsProps): JSX.Element {
               {t('add_custom_tips')}
             </StyledText>
             <input
-              data-testid="SelectPipettes_customTipInput"
               type="file"
               onChange={e => dispatch(createCustomTiprackDef(e))}
             />

--- a/protocol-designer/src/components/organisms/SelectPipetteModal/__test__/SelectPipetteModal.test.tsx
+++ b/protocol-designer/src/components/organisms/SelectPipetteModal/__test__/SelectPipetteModal.test.tsx
@@ -172,7 +172,15 @@ describe('SelectPipetteModal', () => {
     screen.getByText('Add custom pipette tips')
 
     //  add custom pipette tips
-    fireEvent.change(screen.getByTestId('SelectPipettes_customTipInput'))
+    fireEvent.change(screen.getByLabelText('Add custom pipette tips'), {
+      target: {
+        files: [
+          new File(['{}'], 'custom-tips.json', {
+            type: 'application/json',
+          }),
+        ],
+      },
+    })
     expect(vi.mocked(createCustomTiprackDef)).toHaveBeenCalled()
 
     //  change all tip setting

--- a/protocol-designer/src/components/organisms/SettingsIcon/__tests__/SettingsIcon.test.tsx
+++ b/protocol-designer/src/components/organisms/SettingsIcon/__tests__/SettingsIcon.test.tsx
@@ -34,7 +34,7 @@ describe('SettingsIcon', () => {
   })
   it('renders the SettingsIcon', () => {
     render()
-    fireEvent.click(screen.getByTestId('SettingsIconButton'))
+    fireEvent.click(screen.getByLabelText('Settings Icon Button'))
     expect(mockNavigate).toHaveBeenCalled()
   })
 })

--- a/protocol-designer/src/components/organisms/SettingsIcon/index.tsx
+++ b/protocol-designer/src/components/organisms/SettingsIcon/index.tsx
@@ -12,7 +12,7 @@ import {
 
 import styles from './settingsicon.module.css'
 
-const BUTTON_NAME = 'SettingsIconButton'
+const BUTTON_NAME = 'Settings Icon Button'
 
 export const SettingsIcon = (): JSX.Element => {
   const location = useLocation()
@@ -30,7 +30,6 @@ export const SettingsIcon = (): JSX.Element => {
 
   return (
     <Flex
-      data-testid="SettingsIcon"
       borderRadius={BORDERS.borderRadiusFull}
       backgroundColor={
         location.pathname === '/settings' ? COLORS.grey35 : COLORS.transparent
@@ -41,7 +40,6 @@ export const SettingsIcon = (): JSX.Element => {
       <Btn
         onClick={handleNavigate}
         className={styles.gear_icon_button}
-        data-testid={BUTTON_NAME}
         aria-label={BUTTON_NAME}
       >
         <Icon size="1rem" name="gear" />

--- a/protocol-designer/src/components/organisms/SlotDetailModal/LiquidDetailCard.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/LiquidDetailCard.tsx
@@ -72,7 +72,6 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
       onClick={handleSelectedValue}
       width="10.3rem"
       minHeight={FLEX_MAX_CONTENT}
-      data-testid="LiquidDetailCard_box"
     >
       <Flex flexDirection={DIRECTION_COLUMN} gap={SPACING.spacing16}>
         <Flex

--- a/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/SlotOverflowMenu.tsx
@@ -277,7 +277,6 @@ export function SlotOverflowMenu(
         }}
       >
         <MenuItem
-          data-testid="SlotOverflowMenu_openTools"
           onClick={() => {
             addEquipment(location)
             setShowMenuList(false)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteLabel/PipetteLabel.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteLabel/PipetteLabel.tsx
@@ -32,7 +32,6 @@ function PipetteLabelComponent(
       <Flex
         ref={ref}
         fontSize={isZoomed ? '5px' : '13px'}
-        data-testid={`PipetteLabel_${isError ? 'Inaccessible' : 'Accessible'}`}
         className={clsx(styles.pipette_label_base, {
           [styles[`pipette_label_${placement}`]]: placement,
           [styles.pipette_label_accessible]: !isError,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/MultiInputField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/MultiInputField.tsx
@@ -63,12 +63,7 @@ export function MultiInputField(props: MultiInputFieldProps): JSX.Element {
           {t(`protocol_steps:${name}`)}
         </StyledText>
         <Flex {...targetProps}>
-          <Icon
-            name="information"
-            size="1rem"
-            color={COLORS.grey60}
-            data-testid="information_icon"
-          />
+          <Icon name="information" size="1rem" color={COLORS.grey60} />
         </Flex>
         <Tooltip tooltipProps={tooltipProps}>{tooltipContent}</Tooltip>
       </Flex>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/MultiInputField.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/MultiInputField.test.tsx
@@ -56,7 +56,6 @@ describe('MultiInputField', () => {
   it('should render a caption with InputStepFromFields wrapped by ListItem', () => {
     render(props)
     screen.getByText('Retract')
-    screen.getByTestId('information_icon')
     const listItem = screen.getByTestId('ListItem_default')
     expect(listItem).toHaveStyle(`backgroundColor: ${COLORS.grey20}`)
     screen.getAllByText('mock InputStepFormField')

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerCycle.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerCycle.tsx
@@ -386,11 +386,11 @@ export function ThermocyclerCycle(props: ThermocyclerCycleProps): JSX.Element {
           return showEdit ? (
             <Flex
               key={cycleStepId}
+              aria-label={`Thermocycler cycle step ${cycleStepIndex + 1}`}
               gridGap={SPACING.spacing24}
               backgroundColor={COLORS.grey10}
               padding={SPACING.spacing12}
               borderRadius={BORDERS.borderRadius4}
-              data-testid={`cycleStep-${cycleStepIndex}`}
             >
               <Flex
                 flexDirection={DIRECTION_COLUMN}
@@ -492,6 +492,9 @@ export function ThermocyclerCycle(props: ThermocyclerCycleProps): JSX.Element {
                 />
               </Flex>
               <Flex
+                aria-label={`Delete thermocycler cycle step ${
+                  cycleStepIndex + 1
+                }`}
                 css={css`
                   &:hover {
                     background-color: ${COLORS.grey40};
@@ -510,11 +513,11 @@ export function ThermocyclerCycle(props: ThermocyclerCycleProps): JSX.Element {
           ) : (
             <Flex
               key={cycleStepId}
+              aria-label={`Thermocycler cycle step ${cycleStepIndex + 1}`}
               gridGap={SPACING.spacing24}
               backgroundColor={COLORS.grey10}
               padding={SPACING.spacing12}
               borderRadius={BORDERS.borderRadius4}
-              data-testid={`cycleStep-${cycleStepIndex}`}
             >
               <StyledText
                 desktopStyle="bodyDefaultRegular"
@@ -570,10 +573,10 @@ export function ThermocyclerCycle(props: ThermocyclerCycleProps): JSX.Element {
 
   return (
     <Flex
+      aria-label={`Thermocycler cycle ${getStepIndex(steps, cycleId ?? '')}`}
       flexDirection={DIRECTION_COLUMN}
       backgroundColor={backgroundColor}
       borderRadius={BORDERS.borderRadius4}
-      data-testid="thermocyclerCycle"
     >
       {header}
       {bodyContent}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerStep.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerStep.tsx
@@ -337,7 +337,6 @@ export function ThermocyclerStep(props: ThermocyclerStepProps): JSX.Element {
       flexDirection={DIRECTION_COLUMN}
       backgroundColor={backgroundColor}
       borderRadius={BORDERS.borderRadius4}
-      data-testid="thermocyclerStep"
     >
       {header}
       {showEdit ? editContent : null}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/ConnectedStepContainer.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/ConnectedStepContainer.test.tsx
@@ -90,8 +90,8 @@ describe('ConnectedStepContainer', () => {
     render(props)
 
     fireEvent.click(
-      within(screen.getByTestId('StepContainer_mockStepId')).getByTestId(
-        'StepContainer_OverflowBtn'
+      within(screen.getByLabelText('Starting deck state')).getByLabelText(
+        'Starting deck state options'
       )
     )
     screen.getByText('mock StepOverflowMenu')
@@ -107,14 +107,10 @@ describe('ConnectedStepContainer', () => {
     }
     render(props)
 
-    const buttonSansPadding = within(
-      screen.getByTestId('StepContainer_mockStepId')
-    ).getByTestId('StepContainer_buttonSansPadding')
     const stepNumber = screen.getByText('123.')
     const text = screen.getByText('Transfer')
     const subtext = screen.getByText('Subtext')
 
-    expect(buttonSansPadding).toHaveStyle(`background-color: ${COLORS.blue50}`)
     expect(stepNumber).toHaveStyle(`color: ${COLORS.white}`)
     expect(text).toHaveStyle(`color: ${COLORS.white}`)
     expect(subtext).toHaveStyle(`color: ${COLORS.transparentWhite80}`)
@@ -129,14 +125,10 @@ describe('ConnectedStepContainer', () => {
       selected: false,
     }
     render(props)
-    const buttonSansPadding = within(
-      screen.getByTestId('StepContainer_mockStepId')
-    ).getByTestId('StepContainer_buttonSansPadding')
     const stepNumber = screen.getByText('123.')
     const text = screen.getByText('Transfer')
     const subtext = screen.getByText('Subtext')
 
-    expect(buttonSansPadding).toHaveStyle(`background-color: ${COLORS.grey20}`)
     expect(stepNumber).toHaveStyle(`color: ${COLORS.black90}`)
     expect(text).toHaveStyle(`color: ${COLORS.black90}`)
     expect(subtext).toHaveStyle(`color: ${COLORS.grey60}`)
@@ -154,14 +146,10 @@ describe('ConnectedStepContainer', () => {
       setOpenedOverflowMenuId: vi.fn(),
     }
     render(props)
-    const buttonSansPadding = within(
-      screen.getByTestId('StepContainer_mockStepId')
-    ).getByTestId('StepContainer_buttonSansPadding')
     const stepNumber = screen.getByText('123.')
     const text = screen.getByText('Transfer')
     const subtext = screen.getByText('Subtext')
 
-    expect(buttonSansPadding).toHaveStyle(`background-color: ${COLORS.red50}`)
     expect(stepNumber).toHaveStyle(`color: ${COLORS.white}`)
     expect(text).toHaveStyle(`color: ${COLORS.white}`)
     expect(subtext).toHaveStyle(`color: ${COLORS.transparentWhite80}`)
@@ -179,14 +167,10 @@ describe('ConnectedStepContainer', () => {
       setOpenedOverflowMenuId: vi.fn(),
     }
     render(props)
-    const buttonSansPadding = within(
-      screen.getByTestId('StepContainer_mockStepId')
-    ).getByTestId('StepContainer_buttonSansPadding')
     const stepNumber = screen.getByText('123.')
     const text = screen.getByText('Transfer')
     const subtext = screen.getByText('Subtext')
 
-    expect(buttonSansPadding).toHaveStyle(`background-color: ${COLORS.red30}`)
     expect(stepNumber).toHaveStyle(`color: ${COLORS.red60}`)
     expect(text).toHaveStyle(`color: ${COLORS.red60}`)
     expect(subtext).toHaveStyle(`color: ${COLORS.red60}`)

--- a/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/ProtocolMetadata.tsx
@@ -48,7 +48,6 @@ export function ProtocolMetadata({
               setShowEditMetadataModal(true)
             }}
             css={LINK_BUTTON_STYLE}
-            data-testid="ProtocolOverview_MetadataEditButton"
           >
             <StyledText desktopStyle="bodyDefaultRegular">
               {t('edit')}

--- a/protocol-designer/src/pages/ProtocolOverview/StartingDeck.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/StartingDeck.tsx
@@ -67,7 +67,6 @@ function StartingDeckHeader(props: StartingDeckHeaderProps): JSX.Element {
         </StyledText>
         <Flex padding={SPACING.spacing4}>
           <Btn
-            data-testid="Materials_list"
             textDecoration={TYPOGRAPHY.textDecorationUnderline}
             onClick={() => {
               setShowMaterialsListModal(true)

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolMetadata.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/ProtocolMetadata.test.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { renderWithProviders } from '../../../__testing-utils__'
-import { i18n } from '../../../assets/localization'
+import { renderWithProviders } from '/protocol-designer/__testing-utils__'
+import { i18n } from '/protocol-designer/assets/localization'
+
 import { ProtocolMetadata } from '../ProtocolMetadata'
 
 import type { ComponentProps } from 'react'


### PR DESCRIPTION
# Overview
remove data-testid to improve implementation dependencies
edge in protocol-designer has 43 `data-testid`.
this will remove 41 `data-testid`

‎`react-testing-library` and similar tools recommend that, rather than adding more dedicated hooks like ‎`data-testid` just for testing, you should first identify elements using the same information that real users rely on. For example, roles, label text, placeholders, or visible text. Because these align closely with what accessibility APIs (such as screen readers) reference, the more tests you write this way, the more your accessibility will naturally improve as well.

the rest of work will be followed by another pr (need to re-review props)
- ToggleButton
- StepContainer 

close AUTH-2843

Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.

## Test Plan and Hands on Testing
- `make -C protocol-designer test`
no error
- `make -C e2e-testing test-pd-local`
no error

Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.

## Changelog
- remove `data-testid`
- add `aria-*` for e2e test

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment
low-mid
