### PR TITLE
fix(protocol-designer): temporarily filter lids

### DIFF
--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -189,6 +189,7 @@ export function SelectLabwareModal(
       const isSmallYDimension = yDimension < STANDARD_Y_DIMENSION
       const isIrregularSize = isSmallXDimension && isSmallYDimension
       const isAdapter = labwareDef.allowedRoles?.includes('adapter')
+      const isLid = labwareDef.allowedRoles?.includes('lid')
       const isAdapter96Channel = parameters.loadName === ADAPTER_96_CHANNEL
       return (
         (filterRecommended &&
@@ -203,7 +204,8 @@ export function SelectLabwareModal(
           isIrregularSize &&
           moduleType !== HEATERSHAKER_MODULE_TYPE) ||
         (isAdapter96Channel && !has96Channel) ||
-        (slot === 'offDeck' && isAdapter) ||
+        // NOTE (2026-03-30, RC): this is a temporary filter until this is allowed in PAPI
+        (slot === 'offDeck' && (isAdapter || isLid)) ||
         (PLATE_READER_LOADNAME === parameters.loadName &&
           moduleType !== ABSORBANCE_READER_TYPE) ||
         parameters.loadName === TIPRACK_LID_LOADNAME
@@ -284,7 +286,6 @@ export function SelectLabwareModal(
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [labwareByCategory, getIsLabwareFiltered, searchTerm]
   )
-
   const handleCategoryClick = (category: string, expand?: boolean): void => {
     const updatedExpandState = {
       ...userCategoryExpandState,

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -204,7 +204,7 @@ export function SelectLabwareModal(
           isIrregularSize &&
           moduleType !== HEATERSHAKER_MODULE_TYPE) ||
         (isAdapter96Channel && !has96Channel) ||
-        // NOTE (2026-03-30, RC): this is a temporary filter until this is allowed in PAPI
+        // NOTE (2026-03-30, RC): this is a temporary filter to prevent loading lids off deck until this is allowed in PAPI
         (slot === 'offDeck' && (isAdapter || isLid)) ||
         (PLATE_READER_LOADNAME === parameters.loadName &&
           moduleType !== ABSORBANCE_READER_TYPE) ||


### PR DESCRIPTION
# Overview

Prevent users from adding lids off deck. This will later be reverted when PAPI supports this.

## Test Plan and Hands on Testing

- smoke test:
<img width="1504" height="812" alt="Screenshot 2026-03-30 at 11 39 49 AM" src="https://github.com/user-attachments/assets/d422f10b-56c8-4fbf-bae7-5857641fa879" />

## Changelog

- filter out lids for off deck labware types

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment

- low - this will be later reverted

closes AUTH-2849