### PR TITLE
docs: heater-shaker g-codes

### DIFF
--- a/docs/heater-shaker/docs/em-dash-title-test.md
+++ b/docs/heater-shaker/docs/em-dash-title-test.md
@@ -1,7 +1,0 @@
----
-Title: "Em—Dash Title Test"
-Description: "This is a journey into sight and sound"
----
-
-Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores 
-

--- a/docs/heater-shaker/docs/em-dash-title-test.md
+++ b/docs/heater-shaker/docs/em-dash-title-test.md
@@ -1,0 +1,7 @@
+---
+Title: "Em—Dash Title Test"
+Description: "This is a journey into sight and sound"
+---
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores 
+

--- a/docs/heater-shaker/docs/error-codes.md
+++ b/docs/heater-shaker/docs/error-codes.md
@@ -26,7 +26,7 @@ This table lists Heater-Shaker error codes. These codes are also used by other O
 | `ERR213` | Indicates the back-right thermistor is disconnected. This can happen when the thermistor reads off-scale high, indicating a disconnected or broken wire. |
 | `ERR214` | Indicates the back-right thermistor is shorted. This can happen when the thermistor reads off-scale low, indicating a short circuit. |
 | `ERR215` | Indicates the back-right thermistor is in an overtemp condition. This can happen when the thermistor reaches a temperature over its internal limits. |
-| `ERR216` | Indicates the back left thermistor is disconnected. This can happen when the thermistor reads off-scale high, indicating a disconnect or broken wire. |
+| `ERR216` | Indicates the back-left thermistor is disconnected. This can happen when the thermistor reads off-scale high, indicating a disconnect or broken wire. |
 | `ERR217` | Indicates the back-left thermistor is shorted. This can happen when the thermistor reads off-scale low, indicating a short circuit. |
 | `ERR218` | Indicates a back-left thermistor is in an overtemp condition. This can happen when the thermistor reads a temperature over internal limits. |
 | `ERR219` | Indicates the back-center thermistor is disconnected. This can happen when the thermistor reads off-scale high, indicating a disconnect or broken wire. |

--- a/docs/heater-shaker/docs/error-codes.md
+++ b/docs/heater-shaker/docs/error-codes.md
@@ -1,0 +1,57 @@
+---
+title: "Heater-Shaker Module: Error Codes"
+description: "Lists error codes returned by a Heater-Shaker."
+---
+
+This table lists Heater-Shaker error codes. These codes are also used by other Opentrons modules. Descriptions are based on literal firmware output, edited for brevity and clarity.
+
+| Error code | Description |
+|---|---|
+| `ERR002` | The module's internal queue is full. This can happen when the module receives too many commands too quickly. |
+| `ERR003` | Indicates an unhandled G-code. This means the G-code is unknown or misspelled. |
+| `ERR004` | The module's G-code cache is full. This can happen when the module receives too many G-codes too quickly. |
+| `ERR005` | This is a bad message acknowledgement. It's a type of internal error that indicates something sent an acknowledgement for a G-code that was already acknowledged. |
+| `ERR201` | Indicates the module's heat sink thermistor is disconnected. This can happen when the thermistor on the heat sink reads off-scale high, which indicates a disconnected or broken wire. |
+| `ERR202` | Indicates the module's heat sink thermistor is shorted. This can happen when the thermistor on the heat sink reads off-scale low, which indicates a short circuit. |
+| `ERR203` | Indicates a heat sink thermistor overtemp condition. This can happen when the thermistor on the heat sink reaches a temperature over its internal limits. |
+| `ERR204` | Indicates the front-right thermistor is disconnected. This can happen when the thermistor reads off-scale high, which indicates a disconnected or broken wire. |
+| `ERR205` | Indicates the front-right thermistor is shorted. This can happen when the thermistor reads off-scale low, which indicates a short circuit. |
+| `ERR206` | Indicates a front-right thermistor overtemp condition. This can happen when the thermistor reads a temperature over its internal limits. |
+| `ERR207` | Indicates the front-left thermistor is disconnected. This can happen when the thermistor reads off-scale high, which indicates a disconnected or broken wire. |
+| `ERR208` | Indicates the front-left thermistor is shorted. This can happen when the thermistor reads off-scale low, which indicates a short circuit. |
+| `ERR209` | Indicates a front-left thermistor overtemp condition. This can happen when the thermistor reaches a temperature over its internal limits. |
+| `ERR210` | Indicates the front-center thermistor is disconnected. This can happen when the thermistor reads off-scale high, which indicates a disconnected or broken wire. |
+| `ERR211` | Indicates the front-center thermistor is shorted. This can happen when the thermistor reads off-scale low, which indicates a short circuit. |
+| `ERR212` | Indicates a front-center thermistor overtemp condition. This can happen when the thermistor reaches a temperature over its internal limits. |
+| `ERR213` | Indicates the back-right thermistor is disconnected. This can happen when the thermistor reads off-scale high, indicating a disconnected or broken wire. |
+| `ERR214` | Indicates the back-right thermistor is shorted. This can happen when the thermistor reads off-scale low, indicating a short circuit. |
+| `ERR215` | Indicates the back-right thermistor is in an overtemp condition. This can happen when the thermistor reaches a temperature over its internal limits. |
+| `ERR216` | Indicates the back left thermistor is disconnected. This can happen when the thermistor reads off-scale high, indicating a disconnect or broken wire. |
+| `ERR217` | Indicates the back-left thermistor is shorted. This can happen when the thermistor reads off-scale low, indicating a short circuit. |
+| `ERR218` | Indicates a back-left thermistor is in an overtemp condition. This can happen when the thermistor reads a temperature over internal limits. |
+| `ERR219` | Indicates the back-center thermistor is disconnected. This can happen when the thermistor reads off-scale high, indicating a disconnect or broken wire. |
+| `ERR220` | Indicates the back-center thermistor is shorted. This can happen when the thermistor reads off-scale low, indicating a short circuit. |
+| `ERR221` | Indicates the back-center thermistor is in an overtemp condition. This can happen when the thermistor reads a temperature over internal limits. |
+| `ERR222` | Indicates the lid thermistor is disconnected. This can happen when the thermistor reads off-scale high, indicating a disconnected or broken wire. |
+| `ERR223` | Indicates the lid thermistor is shorted. This can happen when the thermistor reads off-scale low, indicating a short circuit. |
+| `ERR224` | Indicates the lid thermistor is in an overtemp condition. This can happen when the thermistor reads a temperature over internal limits. |
+| `ERR301` | Indicates a module's serial number is invalid. |
+| `ERR302` | Indicates the hardware abstraction layer (HAL) is busy or timed out. This can happen when the hardware abstraction layer raises an error while writing the EEPROM. |
+| `ERR303` | Indicates an EEPROM communication error. This can happen when the on-board EEPROM could not be communicated with. |
+| `ERR401` | Indicates the thermal plate is busy. This can happen when the thermal plate is currently executing a command that cannot be interrupted. |
+| `ERR402` | Indicates the Peltier drivers could not activate the module's heating/cooling plates. |
+| `ERR403` | Indicates the module could not control the heat sink fan. This can happen when the heat sink fan driver indicates a problem. |
+| `ERR404` | Indicates the module's lid heater is executing a command that cannot be interrupted. |
+| `ERR405` | Indicates the module cannot control its lid heater. |
+| `ERR406` | Indicates the PID controller is reporting that the set of numbers defining how the thermal control loop should behave are invalid or outside the device's acceptable limits. |
+| `ERR407` | Indicates an invalid target temperature. |
+| `ERR408` | Indicates a thermal drift of more than 4 °C. This can happen when the thermistors read values that are different from each other by more than 4 °C. |
+| `ERR501` | Indicates the lid motor is busy executing a command that cannot be interrupted. |
+| `ERR502` | Indicates a lid motor fault as reported by the lid's motor driver. |
+| `ERR503` | Indicates a seal peripheral interface error. This can happen when communication with the seal motor driver fails. |
+| `ERR504` | Indicates the seal motor is busy executing a command that cannot be interrupted. |
+| `ERR505` | Indicates the seal motor motor driver reports a fault. |
+| `ERR506` | Indicates the seal motor driver detected a stall event. |
+| `ERR507` | Indicates that the lid is closed but must be open. |
+| `ERR508` | Indicates the seal switch should not be engaged. This can happen when the seal switch is in an unexpected state. |
+| `ERR509` | Indicates the lid state is not what is expected (e.g., after the lid was closed and the seal was engaged, the lid closed sensor indicates the lid is open). |

--- a/docs/heater-shaker/docs/g-code-concepts.md
+++ b/docs/heater-shaker/docs/g-code-concepts.md
@@ -72,7 +72,9 @@ Every Opentrons module returns a response after executing a command. A response 
   </tbody>
 </table>
 
-## Connection parameters
+## Connection em&mdash;dash parameters {: #connection-em-dash-electric-boogaloo }
+
+Now let's link to a [page title with an em—dash](./em-dash-title-test.md)
 
 To establish a serial USB connection with a Heater-Shaker, your application must specify the baud rate and identify the module using its Vendor ID (VID) and Product ID (PID).
 

--- a/docs/heater-shaker/docs/g-code-concepts.md
+++ b/docs/heater-shaker/docs/g-code-concepts.md
@@ -72,6 +72,8 @@ Every Opentrons module returns a response after executing a command. A response 
   </tbody>
 </table>
 
+## Connection parameters
+
 To establish a serial USB connection with a Heater-Shaker, your application must specify the baud rate and identify the module using its Vendor ID (VID) and Product ID (PID).
 
 - **Baud rate**: `115200`

--- a/docs/heater-shaker/docs/g-code-concepts.md
+++ b/docs/heater-shaker/docs/g-code-concepts.md
@@ -67,7 +67,7 @@ Every Opentrons module returns a response after executing a command. A response 
     </tr>
     <tr>
       <td>Error</td>
-      <td>An error indicates a command failed and does not echo the command code.<br><br>Error responses are strings formatted as <code>ERRNNN:error</code>, where <code>N</code> is an integer followed by a plain text description. For example, sending too many commands to a module too quickly might result in the response <code>ERR004:G-code cache full</code>.<br><br>See the <font color="red">PLACEHOLDER</font> for a complete list.</td>
+      <td>An error indicates a command failed and does not echo the command code.<br><br>Error responses are strings formatted as <code>ERRNNN:error</code>, where <code>N</code> is an integer followed by a plain text description. For example, sending too many commands to a module too quickly might result in the response <code>ERR004:G-code cache full</code>.<br><br>See the <a href="../error-codes/">Heater-Shaker Error Codes section</a> for a complete list.</td>
     </tr>
   </tbody>
 </table>

--- a/docs/heater-shaker/docs/g-code-concepts.md
+++ b/docs/heater-shaker/docs/g-code-concepts.md
@@ -72,10 +72,6 @@ Every Opentrons module returns a response after executing a command. A response 
   </tbody>
 </table>
 
-## Connection em&mdash;dash parameters {: #connection-em-dash-electric-boogaloo }
-
-Now let's link to a [page title with an em—dash](./em-dash-title-test.md)
-
 To establish a serial USB connection with a Heater-Shaker, your application must specify the baud rate and identify the module using its Vendor ID (VID) and Product ID (PID).
 
 - **Baud rate**: `115200`

--- a/docs/heater-shaker/docs/g-code-concepts.md
+++ b/docs/heater-shaker/docs/g-code-concepts.md
@@ -7,7 +7,7 @@ G-codes are machine-readable instructions used to control hardware. You do not n
 
 ## G-Code command syntax
 
-Heater-Shaker G-codes are strings starting with `M` followed by an integer. Arguments are formatted as letter-number combinations without separators. Each command must end with a new line character; Opentrons modules do not support multiple commands on a single line. For a complete list of codes and examples see <font color="red">LINK PLACEHOLDER</font>
+Heater-Shaker G-codes are strings starting with `M` followed by an integer. Arguments are formatted as letter-number combinations without separators. Each command must end with a new line character; Opentrons modules do not support multiple commands on a single line. For a complete list of codes and examples see [Heater-Shaker G-codes](./g-codes.md).
 
 - **Syntax:** `MCOMMAND [ARGUMENT-KEY][ARGUMENT-VALUE] TERMINATOR`
 - **Examples:** `M115 \n` or `M104 S25 \n`

--- a/docs/heater-shaker/docs/g-code-concepts.md
+++ b/docs/heater-shaker/docs/g-code-concepts.md
@@ -1,0 +1,84 @@
+---
+title: "Heater-Shaker Module: G-Code Concepts"
+description: "Heater-Shaker G-code syntax, examples, and configuration information."
+---
+
+G-codes are machine-readable instructions used to control hardware. You do not need to understand or use G-codes to operate a Heater-Shaker with Flex or OT-2. This section is a technical resource for developers building custom applications that work with the Heater-Shaker.
+
+## G-Code command syntax
+
+Heater-Shaker G-codes are strings starting with `M` followed by an integer. Arguments are formatted as letter-number combinations without separators. Each command must end with a new line character; Opentrons modules do not support multiple commands on a single line. For a complete list of codes and examples see <font color="red">LINK PLACEHOLDER</font>
+
+- **Syntax:** `MCOMMAND [ARGUMENT-KEY][ARGUMENT-VALUE] TERMINATOR`
+- **Examples:** `M115 \n` or `M104 S25 \n`
+
+The following table explains these G-code command elements.
+
+<table>
+  <thead>
+    <tr>
+      <th>Element</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><span style="white-space: nowrap;"><code>MCOMMAND</code></span></td>
+      <td>This is a G-code command itself. For example, sending a simple looking command like <code>M115 \n</code> to the Heater-Shaker returns its hardware version, firmware version, and serial number.</td>
+    </tr>
+    <tr>
+      <td><code>ARGUMENT-KEY ARGUMENT-VALUE</code></td>
+      <td>
+        An optional key-value pair used to pass parameters to a command.
+        <br><br>
+        Typically, the key is a single, uppercase letter followed by its value (usually an integer). For example, sending <code>M104 S95 \n</code> sets the Heater-Shaker temperature to 95 °C. In this command:
+        <ul>
+          <li><code>S</code> is the key for temperature.</li>
+          <li><code>95</code> is the value for °C.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><span style="white-space: nowrap;"><code>TERMINATOR</code></span></td>
+      <td>Every G-code sequence ends with a terminator, which is always a newline character (<code>\n</code>).</td>
+    </tr>
+  </tbody>
+</table>
+
+## G-Code response syntax
+
+Every Opentrons module returns a response after executing a command. A response will be one of the types defined below.
+
+<table>
+  <thead>
+    <tr>
+      <th>Response type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Acknowledgement</td>
+      <td>An acknowledgement returns <code>OK</code> when the command is successful.<br><br>This response type does not echo the command code.</td>
+    </tr>
+    <tr>
+      <td>Response</td>
+      <td>Some responses echo the command code and append <code>OK</code> to the response string when the command is successful. For example, successfully sending the command <code>M106</code> (deactivate the heater) would return <code>M106 OK</code>.<br><br>Other responses do not echo the command code and only return an acknowledgement (<code>OK</code>) or an error code.</td>
+    </tr>
+    <tr>
+      <td>Error</td>
+      <td>An error indicates a command failed and does not echo the command code.<br><br>Error responses are strings formatted as <code>ERRNNN:error</code>, where <code>N</code> is an integer followed by a plain text description. For example, sending too many commands to a module too quickly might result in the response <code>ERR004:G-code cache full</code>.<br><br>See the <font color="red">PLACEHOLDER</font> for a complete list.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Connection parameters
+
+To establish a serial USB connection with a Heater-Shaker, your application must specify the baud rate and identify the module using its Vendor ID (VID) and Product ID (PID).
+
+- **Baud rate**: `115200`
+- **VID**: `0x0483`
+- **PID**: `0x4853`
+
+!!! tip "Making Good G-Code Connections"
+    Identifying modules by their VID and PID helps you write resilient, cross-platform code. Hard coding for a specific port (e.g., `COM3` for Windows or `/dev/ttyUSB0` for macOS) makes code brittle. By using a library like [pyserial](https://pythonhosted.org/pyserial/) to scan for specific VID/PID combinations, your application can dynamically find and connect to the correct Opentrons module regardless of its physical connection point.

--- a/docs/heater-shaker/docs/g-codes.md
+++ b/docs/heater-shaker/docs/g-codes.md
@@ -5,8 +5,6 @@ description: "Lists all Heater-Shaker G-codes and responses."
 
 The Thermocycler accepts the G-code commands listed below.
 
-This is my [em—dash link](./g-code-concepts.md#connection-em-dash-electric-boogaloo)
-
 !!! tip
     These commands rarely change, but you can always check for updates in the [Heater-Shaker driver file](https://github.com/Opentrons/opentrons/blob/edge/api/src/opentrons/drivers/heater_shaker/driver.py).
 

--- a/docs/heater-shaker/docs/g-codes.md
+++ b/docs/heater-shaker/docs/g-codes.md
@@ -19,49 +19,49 @@ The Thermocycler accepts the G-code commands listed below.
     <tr>
       <td><code>G28</code></td>
       <td>
-        <strong>Command:</strong> home the shaker plate [cite: 3]<br>
-        <strong>Arguments:</strong> none [cite: 3]<br>
-        <strong>Response:</strong> <code>G28 OK</code> (acknowledge only or error) [cite: 3]
+        <strong>Command:</strong> home the shaker plate<br>
+        <strong>Arguments:</strong> none<br>
+        <strong>Response:</strong> <code>G28 OK</code> (acknowledge only or error)
       </td>
     </tr>
     <tr>
       <td><code>M3</code></td>
       <td>
-        <strong>Command:</strong> set shaking rpm [cite: 3]<br>
-        <strong>Arguments:</strong> <code>S</code>: set rpm [cite: 3]<br>
-        <strong>Example:</strong> <code>M3 S500</code> sets target rpm to 500 [cite: 3]<br>
-        <strong>Response:</strong> <code>M3 OK</code> (acknowledge only or error) [cite: 3]
+        <strong>Command:</strong> set shaking rpm<br>
+        <strong>Arguments:</strong> <code>S</code>: set rpm<br>
+        <strong>Example:</strong> <code>M3 S500</code> sets target rpm to 500<br>
+        <strong>Response:</strong> <code>M3 OK</code> (acknowledge only or error)
       </td>
     </tr>
     <tr>
       <td><code>M104</code></td>
       <td>
-        <strong>Command:</strong> set temperature in °C [cite: 3]<br>
-        <strong>Arguments:</strong> <code>S</code>: set temperature in °C [cite: 3]<br>
-        <strong>Example:</strong> <code>M104 S25</code> sets target temperature to 25 °C [cite: 3]<br>
-        <strong>Response:</strong> <code>M104 OK</code> (acknowledge only or error) [cite: 3]
+        <strong>Command:</strong> set temperature in °C<br>
+        <strong>Arguments:</strong> <code>S</code>: set temperature in °C<br>
+        <strong>Example:</strong> <code>M104 S25</code> sets target temperature to 25 °C<br>
+        <strong>Response:</strong> <code>M104 OK</code> (acknowledge only or error)
       </td>
     </tr>
     <tr>
       <td><code>M105</code></td>
       <td>
-        <strong>Command:</strong> get temperature in °C [cite: 3]<br>
-        <strong>Arguments:</strong> none [cite: 3]<br>
-        <strong>Response elements:</strong> [cite: 3]
+        <strong>Command:</strong> get temperature in °C<br>
+        <strong>Arguments:</strong> none<br>
+        <strong>Response elements:</strong>
         <ul>
-          <li><code>T</code>: target temperature in °C (can be none) [cite: 3]</li>
-          <li><code>C</code>: current temperature in °C [cite: 3]</li>
+          <li><code>T</code>: target temperature in °C (can be none)</li>
+          <li><code>C</code>: current temperature in °C</li>
         </ul>
-        <strong>Response:</strong> <code>M105 T:none C:82.4 OK</code> indicates the module is neither heating or cooling and its current temperature is 82.4 °C. [cite: 3]
+        <strong>Response:</strong> <code>M105 T:none C:82.4 OK</code> indicates the module is neither heating or cooling and its current temperature is 82.4 °C.
       </td>
     </tr>
     <tr>
       <td><code>M106</code></td>
       <td>
-        <strong>Command:</strong> deactivate heater [cite: 3]<br>
-        <strong>Arguments:</strong> none [cite: 3]<br>
-        <strong>Example:</strong> <code>M106</code> [cite: 4]<br>
-        <strong>Response:</strong> <code>M106 OK</code> (acknowledge only or error) [cite: 4]
+        <strong>Command:</strong> deactivate heater<br>
+        <strong>Arguments:</strong> none<br>
+        <strong>Example:</strong> <code>M106</code><br>
+        <strong>Response:</strong> <code>M106 OK</code> (acknowledge only or error)
       </td>
     </tr>
     <tr>
@@ -75,69 +75,69 @@ The Thermocycler accepts the G-code commands listed below.
     <tr>
       <td><code>M115</code></td>
       <td>
-        <strong>Command:</strong> get hardware and software version and serial number [cite: 4]<br>
-        <strong>Arguments:</strong> none [cite: 4]<br>
-        <strong>Response elements:</strong> [cite: 4]
+        <strong>Command:</strong> get hardware and software version and serial number<br>
+        <strong>Arguments:</strong> none<br>
+        <strong>Response elements:</strong>
         <ul>
-          <li><code>HW</code>: hardware version [cite: 4]</li>
-          <li><code>FW</code>: firmware version [cite: 4]</li>
-          <li><code>SerialNo</code>: serial number of the module [cite: 4]</li>
+          <li><code>HW</code>: hardware version</li>
+          <li><code>FW</code>: firmware version</li>
+          <li><code>SerialNo</code>: serial number of the module</li>
         </ul>
-        <strong>Response:</strong> <code>M115 FW:v1.0.6 HW: Opentrons Heater-Shaker SerialNo: HSV012024041303 OK</code> indicates the module is on firmware version 1.0.6, is a Heater-Shaker, and has serial number HSV012024041303. [cite: 4]
+        <strong>Response:</strong> <code>M115 FW:v1.0.6 HW: Opentrons Heater-Shaker SerialNo: HSV012024041303 OK</code> indicates the module is on firmware version 1.0.6, is a Heater-Shaker, and has serial number HSV012024041303.
       </td>
     </tr>
     <tr>
       <td><code>M123</code></td>
       <td>
-        <strong>Command:</strong> get shaking rpm [cite: 4]<br>
-        <strong>Arguments:</strong> none [cite: 4]<br>
-        <strong>Response elements:</strong> [cite: 4]
+        <strong>Command:</strong> get shaking rpm<br>
+        <strong>Arguments:</strong> none<br>
+        <strong>Response elements:</strong>
         <ul>
-          <li><code>C</code>: current speed in rpm [cite: 4]</li>
-          <li><code>T</code>: target speed in rpm (or none) [cite: 4]</li>
+          <li><code>C</code>: current speed in rpm</li>
+          <li><code>T</code>: target speed in rpm (or none)</li>
         </ul>
-        <strong>Response:</strong> <code>M123 C:0 T:0 OK</code> indicates the current and target rpm is 0 (the module is not moving). [cite: 4]
+        <strong>Response:</strong> <code>M123 C:0 T:0 OK</code> indicates the current and target rpm is 0 (the module is not moving).
       </td>
     </tr>
     <tr>
       <td><code>M241</code></td>
       <td>
-        <strong>Command:</strong> get labware latch state [cite: 5]<br>
-        <strong>Arguments:</strong> none [cite: 5]<br>
-        <strong>Response elements:</strong> [cite: 5]
+        <strong>Command:</strong> get labware latch state<br>
+        <strong>Arguments:</strong> none<br>
+        <strong>Response elements:</strong>
         <ul>
-          <li><code>IDLE_OPEN</code>: latch is open [cite: 5]</li>
-          <li><code>IDLE_CLOSED</code>: latch is closed [cite: 5]</li>
-          <li><code>OPENING</code>: latch is opening [cite: 5]</li>
-          <li><code>CLOSING</code>: latch is closing [cite: 5]</li>
-          <li><code>IDLE_UNKNOWN</code>: latch is not sensed [cite: 5]</li>
+          <li><code>IDLE_OPEN</code>: latch is open</li>
+          <li><code>IDLE_CLOSED</code>: latch is closed</li>
+          <li><code>OPENING</code>: latch is opening</li>
+          <li><code>CLOSING</code>: latch is closing</li>
+          <li><code>IDLE_UNKNOWN</code>: latch is not sensed</li>
         </ul>
-        <strong>Response:</strong> <code>M241 STATUS: CLOSING OK</code> indicates the latch is closing. [cite: 5]
+        <strong>Response:</strong> <code>M241 STATUS: CLOSING OK</code> indicates the latch is closing.
       </td>
     </tr>
     <tr>
       <td><code>M242</code></td>
       <td>
-        <strong>Command:</strong> open labware latch [cite: 5]<br>
-        <strong>Arguments:</strong> none [cite: 5]<br>
-        <strong>Response:</strong> <code>M242 OK</code> (acknowledge only or error) [cite: 5]
+        <strong>Command:</strong> open labware latch<br>
+        <strong>Arguments:</strong> none<br>
+        <strong>Response:</strong> <code>M242 OK</code> (acknowledge only or error)
       </td>
     </tr>
     <tr>
       <td><code>M243</code></td>
       <td>
-        <strong>Command:</strong> close labware latch [cite: 5]<br>
-        <strong>Arguments:</strong> none [cite: 5]<br>
-        <strong>Response:</strong> <code>M243 OK</code> (acknowledge only or error) [cite: 5]
+        <strong>Command:</strong> close labware latch<br>
+        <strong>Arguments:</strong> none<br>
+        <strong>Response:</strong> <code>M243 OK</code> (acknowledge only or error)
       </td>
     </tr>
     <tr>
       <td><code>M411</code></td>
       <td>
-        <strong>Command:</strong> get error state (available in robot software 8.8.0 and later) [cite: 5]<br>
-        <strong>Arguments:</strong> none [cite: 10]<br>
-        <strong>Example:</strong> <code>M411</code> [cite: 10]<br>
-        <strong>Response:</strong> <code>M411 OK</code> (acknowledge only or error) [cite: 11]
+        <strong>Command:</strong> get error state (available in robot software 8.8.0 and later)<br>
+        <strong>Arguments:</strong> none<br>
+        <strong>Example:</strong> <code>M411</code><br>
+        <strong>Response:</strong> <code>M411 OK</code> (acknowledge only or error)
       </td>
     </tr>
     <tr>

--- a/docs/heater-shaker/docs/g-codes.md
+++ b/docs/heater-shaker/docs/g-codes.md
@@ -1,0 +1,80 @@
+---
+title: "Heater-Shaker Module: G-codes"
+description: "Lists all Heater-Shaker G-codes and responses."
+---
+
+The Thermocycler accepts the G-code commands listed below.
+
+!!! tip
+    These commands rarely change, but you can always check for updates in the [Heater-Shaker driver file](https://github.com/Opentrons/opentrons/blob/edge/api/src/opentrons/drivers/heater_shaker/driver.py).
+
+<table>
+  <thead>
+    <tr>
+      <th>G-Code</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>G28</code></td> <td>
+        <strong>Command:</strong> home the shaker plate<br> <strong>Arguments:</strong> none<br> <strong>Response:</strong> <code>G28 OK</code> (acknowledge only or error) </td>
+    </tr>
+    <tr>
+      <td><code>M3</code></td> <td>
+        <strong>Command:</strong> set shaking rpm<br> <strong>Arguments:</strong> <code>S</code>: set rpm<br> <strong>Example:</strong> <code>M3 S500</code> sets target rpm to 500<br> <strong>Response:</strong> <code>M3 OK</code> (acknowledge only or error) </td>
+    </tr>
+    <tr>
+      <td><code>M104</code></td> <td>
+        <strong>Command:</strong> set temperature in °C<br> <strong>Arguments:</strong> <code>S</code>: set temperature in °C<br> <strong>Example:</strong> <code>M104 S25</code> sets target temperature to 25 °C<br> <strong>Response:</strong> <code>M104 OK</code> (acknowledge only or error) </td>
+    </tr>
+    <tr>
+      <td><code>M105</code></td> <td>
+        <strong>Command:</strong> get temperature in °C<br> <strong>Arguments:</strong> none<br> <strong>Response elements:</strong> <ul>
+          <li><code>T</code>: target temperature in °C (can be none)</li> <li><code>C</code>: current temperature in °C</li> </ul>
+        <strong>Response:</strong> <code>M105 T:none C:82.4 OK</code> indicates the module is neither heating or cooling and its current temperature is 82.4 °C. </td>
+    </tr>
+    <tr>
+      <td><code>M106</code></td> <td>
+        <strong>Command:</strong> deactivate heater<br> <strong>Arguments:</strong> none<br> <strong>Example:</strong> <code>M106</code><br> <strong>Response:</strong> <code>M106 OK</code> (acknowledge only or error) </td>
+    </tr>
+    <tr>
+      <td><code>M115</code></td> <td>
+        <strong>Command:</strong> get hardware and software version and serial number<br> <strong>Arguments:</strong> none<br> <strong>Response elements:</strong> <ul>
+          <li><code>HW</code>: hardware version</li> <li><code>FW</code>: firmware version</li> <li><code>SerialNo</code>: serial number of the module</li> </ul>
+        <strong>Response:</strong> <code>M115 FW:v1.0.6 HW: Opentrons Heater-Shaker SerialNo: HSV012024041303 OK</code> indicates the module is on firmware version 1.0.6, is a Heater-Shaker, and has serial number HSV012024041303. </td>
+    </tr>
+    <tr>
+      <td><code>M123</code></td> <td>
+        <strong>Command:</strong> get shaking rpm<br> <strong>Arguments:</strong> none<br> <strong>Response elements:</strong> <ul>
+          <li><code>C</code>: current speed in rpm</li> <li><code>T</code>: target speed in rpm (or none)</li> </ul>
+        <strong>Response:</strong> <code>M123 C:0 T:0 OK</code> indicates the current and target rpm is 0 (the module is not moving). </td>
+    </tr>
+    <tr>
+      <td><code>M204</code></td> <td>
+        <strong>Command:</strong> set acceleration<br> <strong>Arguments:</strong> <code>S</code>: sets acceleration rate<br> <strong>Example:</strong> <code>M204 S1000</code> sets the acceleration to 1000 rpm/s<br> <strong>Response:</strong> <code>M204 OK</code> (acknowledge only or error) </td>
+    </tr>
+    <tr>
+      <td><code>M241</code></td> <td>
+        <strong>Command:</strong> get labware latch state<br> <strong>Arguments:</strong> none<br> <strong>Response elements:</strong> <ul>
+          <li><code>IDLE_OPEN</code>: latch is open</li> <li><code>IDLE_CLOSED</code>: latch is closed</li> <li><code>OPENING</code>: latch is opening</li> <li><code>CLOSING</code>: latch is closing</li> <li><code>IDLE_UNKNOWN</code>: latch is not sensed</li> </ul>
+        <strong>Response:</strong> <code>M241 STATUS: CLOSING OK</code> indicates the latch is closing. </td>
+    </tr>
+    <tr>
+      <td><code>M242</code></td> <td>
+        <strong>Command:</strong> open labware latch<br> <strong>Arguments:</strong> none<br> <strong>Response:</strong> <code>M242 OK</code> (acknowledge only or error) </td>
+    </tr>
+    <tr>
+      <td><code>M243</code></td> <td>
+        <strong>Command:</strong> close labware latch<br> <strong>Arguments:</strong> none<br> <strong>Response:</strong> <code>M243 OK</code> (acknowledge only or error) </td>
+    </tr>
+    <tr>
+      <td><code>M411</code></td> <td>
+        <strong>Command:</strong> get error state (available in robot software 8.8.0 and later)<br> <strong>Arguments:</strong> none<br> <strong>Example:</strong> <code>M411</code><br> <strong>Response:</strong> <code>M411 OK</code> (acknowledge only or error) </td>
+    </tr>
+    <tr>
+      <td><code>M413</code></td> <td>
+        <strong>Command:</strong> clear error state (available in robot software 8.8.0 and later)<br> <strong>Arguments:</strong> none<br> <strong>Example:</strong> <code>M413</code><br> <strong>Response:</strong> <code>M413 OK</code> (acknowledge only or error) </td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/heater-shaker/docs/g-codes.md
+++ b/docs/heater-shaker/docs/g-codes.md
@@ -100,16 +100,6 @@ The Thermocycler accepts the G-code commands listed below.
       </td>
     </tr>
     <tr>
-      <td><code>M204</code></td>
-      <td>
-        <font color="red">NOT IN `driver.py` FOR MODULE</font></p>
-        <strong>Command:</strong> set acceleration [cite: 4]<br>
-        <strong>Arguments:</strong> <code>S</code>: sets acceleration rate [cite: 5]<br>
-        <strong>Example:</strong> <code>M204 S1000</code> sets the acceleration to 1000 rpm/s [cite: 5]<br>
-        <strong>Response:</strong> <code>M204 OK</code> (acknowledge only or error) [cite: 5]
-      </td>
-    </tr>
-    <tr>
       <td><code>M241</code></td>
       <td>
         <strong>Command:</strong> get labware latch state [cite: 5]<br>
@@ -148,16 +138,6 @@ The Thermocycler accepts the G-code commands listed below.
         <strong>Arguments:</strong> none [cite: 10]<br>
         <strong>Example:</strong> <code>M411</code> [cite: 10]<br>
         <strong>Response:</strong> <code>M411 OK</code> (acknowledge only or error) [cite: 11]
-      </td>
-    </tr>
-    <tr>
-      <td><code>M413</code></td>
-      <td>
-        <font color="red">NOT IN `driver.py` FOR MODULE</font></p>
-        <strong>Command:</strong> clear error state (available in robot software 8.8.0 and later) [cite: 12]<br>
-        <strong>Arguments:</strong> none [cite: 13]<br>
-        <strong>Example:</strong> <code>M413</code> [cite: 14]<br>
-        <strong>Response:</strong> <code>M413 OK</code> (acknowledge only or error) [cite: 15]
       </td>
     </tr>
     <tr>

--- a/docs/heater-shaker/docs/g-codes.md
+++ b/docs/heater-shaker/docs/g-codes.md
@@ -5,6 +5,8 @@ description: "Lists all Heater-Shaker G-codes and responses."
 
 The Thermocycler accepts the G-code commands listed below.
 
+This is my [em—dash link](./g-code-concepts.md#connection-em-dash-electric-boogaloo)
+
 !!! tip
     These commands rarely change, but you can always check for updates in the [Heater-Shaker driver file](https://github.com/Opentrons/opentrons/blob/edge/api/src/opentrons/drivers/heater_shaker/driver.py).
 

--- a/docs/heater-shaker/docs/g-codes.md
+++ b/docs/heater-shaker/docs/g-codes.md
@@ -17,64 +17,156 @@ The Thermocycler accepts the G-code commands listed below.
   </thead>
   <tbody>
     <tr>
-      <td><code>G28</code></td> <td>
-        <strong>Command:</strong> home the shaker plate<br> <strong>Arguments:</strong> none<br> <strong>Response:</strong> <code>G28 OK</code> (acknowledge only or error) </td>
+      <td><code>G28</code></td>
+      <td>
+        <strong>Command:</strong> home the shaker plate [cite: 3]<br>
+        <strong>Arguments:</strong> none [cite: 3]<br>
+        <strong>Response:</strong> <code>G28 OK</code> (acknowledge only or error) [cite: 3]
+      </td>
     </tr>
     <tr>
-      <td><code>M3</code></td> <td>
-        <strong>Command:</strong> set shaking rpm<br> <strong>Arguments:</strong> <code>S</code>: set rpm<br> <strong>Example:</strong> <code>M3 S500</code> sets target rpm to 500<br> <strong>Response:</strong> <code>M3 OK</code> (acknowledge only or error) </td>
+      <td><code>M3</code></td>
+      <td>
+        <strong>Command:</strong> set shaking rpm [cite: 3]<br>
+        <strong>Arguments:</strong> <code>S</code>: set rpm [cite: 3]<br>
+        <strong>Example:</strong> <code>M3 S500</code> sets target rpm to 500 [cite: 3]<br>
+        <strong>Response:</strong> <code>M3 OK</code> (acknowledge only or error) [cite: 3]
+      </td>
     </tr>
     <tr>
-      <td><code>M104</code></td> <td>
-        <strong>Command:</strong> set temperature in °C<br> <strong>Arguments:</strong> <code>S</code>: set temperature in °C<br> <strong>Example:</strong> <code>M104 S25</code> sets target temperature to 25 °C<br> <strong>Response:</strong> <code>M104 OK</code> (acknowledge only or error) </td>
+      <td><code>M104</code></td>
+      <td>
+        <strong>Command:</strong> set temperature in °C [cite: 3]<br>
+        <strong>Arguments:</strong> <code>S</code>: set temperature in °C [cite: 3]<br>
+        <strong>Example:</strong> <code>M104 S25</code> sets target temperature to 25 °C [cite: 3]<br>
+        <strong>Response:</strong> <code>M104 OK</code> (acknowledge only or error) [cite: 3]
+      </td>
     </tr>
     <tr>
-      <td><code>M105</code></td> <td>
-        <strong>Command:</strong> get temperature in °C<br> <strong>Arguments:</strong> none<br> <strong>Response elements:</strong> <ul>
-          <li><code>T</code>: target temperature in °C (can be none)</li> <li><code>C</code>: current temperature in °C</li> </ul>
-        <strong>Response:</strong> <code>M105 T:none C:82.4 OK</code> indicates the module is neither heating or cooling and its current temperature is 82.4 °C. </td>
+      <td><code>M105</code></td>
+      <td>
+        <strong>Command:</strong> get temperature in °C [cite: 3]<br>
+        <strong>Arguments:</strong> none [cite: 3]<br>
+        <strong>Response elements:</strong> [cite: 3]
+        <ul>
+          <li><code>T</code>: target temperature in °C (can be none) [cite: 3]</li>
+          <li><code>C</code>: current temperature in °C [cite: 3]</li>
+        </ul>
+        <strong>Response:</strong> <code>M105 T:none C:82.4 OK</code> indicates the module is neither heating or cooling and its current temperature is 82.4 °C. [cite: 3]
+      </td>
     </tr>
     <tr>
-      <td><code>M106</code></td> <td>
-        <strong>Command:</strong> deactivate heater<br> <strong>Arguments:</strong> none<br> <strong>Example:</strong> <code>M106</code><br> <strong>Response:</strong> <code>M106 OK</code> (acknowledge only or error) </td>
+      <td><code>M106</code></td>
+      <td>
+        <strong>Command:</strong> deactivate heater [cite: 3]<br>
+        <strong>Arguments:</strong> none [cite: 3]<br>
+        <strong>Example:</strong> <code>M106</code> [cite: 4]<br>
+        <strong>Response:</strong> <code>M106 OK</code> (acknowledge only or error) [cite: 4]
+      </td>
     </tr>
     <tr>
-      <td><code>M115</code></td> <td>
-        <strong>Command:</strong> get hardware and software version and serial number<br> <strong>Arguments:</strong> none<br> <strong>Response elements:</strong> <ul>
-          <li><code>HW</code>: hardware version</li> <li><code>FW</code>: firmware version</li> <li><code>SerialNo</code>: serial number of the module</li> </ul>
-        <strong>Response:</strong> <code>M115 FW:v1.0.6 HW: Opentrons Heater-Shaker SerialNo: HSV012024041303 OK</code> indicates the module is on firmware version 1.0.6, is a Heater-Shaker, and has serial number HSV012024041303. </td>
+      <td><code>M114</code></td>
+      <td>
+        <strong>Command:</strong> get reset reason<br>
+        <strong>Arguments:</strong> none<br>
+        <strong>Response:</strong> <code>M114 OK</code> (acknowledge only or error)
+      </td>
     </tr>
     <tr>
-      <td><code>M123</code></td> <td>
-        <strong>Command:</strong> get shaking rpm<br> <strong>Arguments:</strong> none<br> <strong>Response elements:</strong> <ul>
-          <li><code>C</code>: current speed in rpm</li> <li><code>T</code>: target speed in rpm (or none)</li> </ul>
-        <strong>Response:</strong> <code>M123 C:0 T:0 OK</code> indicates the current and target rpm is 0 (the module is not moving). </td>
+      <td><code>M115</code></td>
+      <td>
+        <strong>Command:</strong> get hardware and software version and serial number [cite: 4]<br>
+        <strong>Arguments:</strong> none [cite: 4]<br>
+        <strong>Response elements:</strong> [cite: 4]
+        <ul>
+          <li><code>HW</code>: hardware version [cite: 4]</li>
+          <li><code>FW</code>: firmware version [cite: 4]</li>
+          <li><code>SerialNo</code>: serial number of the module [cite: 4]</li>
+        </ul>
+        <strong>Response:</strong> <code>M115 FW:v1.0.6 HW: Opentrons Heater-Shaker SerialNo: HSV012024041303 OK</code> indicates the module is on firmware version 1.0.6, is a Heater-Shaker, and has serial number HSV012024041303. [cite: 4]
+      </td>
     </tr>
     <tr>
-      <td><code>M204</code></td> <td>
-        <strong>Command:</strong> set acceleration<br> <strong>Arguments:</strong> <code>S</code>: sets acceleration rate<br> <strong>Example:</strong> <code>M204 S1000</code> sets the acceleration to 1000 rpm/s<br> <strong>Response:</strong> <code>M204 OK</code> (acknowledge only or error) </td>
+      <td><code>M123</code></td>
+      <td>
+        <strong>Command:</strong> get shaking rpm [cite: 4]<br>
+        <strong>Arguments:</strong> none [cite: 4]<br>
+        <strong>Response elements:</strong> [cite: 4]
+        <ul>
+          <li><code>C</code>: current speed in rpm [cite: 4]</li>
+          <li><code>T</code>: target speed in rpm (or none) [cite: 4]</li>
+        </ul>
+        <strong>Response:</strong> <code>M123 C:0 T:0 OK</code> indicates the current and target rpm is 0 (the module is not moving). [cite: 4]
+      </td>
     </tr>
     <tr>
-      <td><code>M241</code></td> <td>
-        <strong>Command:</strong> get labware latch state<br> <strong>Arguments:</strong> none<br> <strong>Response elements:</strong> <ul>
-          <li><code>IDLE_OPEN</code>: latch is open</li> <li><code>IDLE_CLOSED</code>: latch is closed</li> <li><code>OPENING</code>: latch is opening</li> <li><code>CLOSING</code>: latch is closing</li> <li><code>IDLE_UNKNOWN</code>: latch is not sensed</li> </ul>
-        <strong>Response:</strong> <code>M241 STATUS: CLOSING OK</code> indicates the latch is closing. </td>
+      <td><code>M204</code></td>
+      <td>
+        <font color="red">NOT IN `driver.py` FOR MODULE</font></p>
+        <strong>Command:</strong> set acceleration [cite: 4]<br>
+        <strong>Arguments:</strong> <code>S</code>: sets acceleration rate [cite: 5]<br>
+        <strong>Example:</strong> <code>M204 S1000</code> sets the acceleration to 1000 rpm/s [cite: 5]<br>
+        <strong>Response:</strong> <code>M204 OK</code> (acknowledge only or error) [cite: 5]
+      </td>
     </tr>
     <tr>
-      <td><code>M242</code></td> <td>
-        <strong>Command:</strong> open labware latch<br> <strong>Arguments:</strong> none<br> <strong>Response:</strong> <code>M242 OK</code> (acknowledge only or error) </td>
+      <td><code>M241</code></td>
+      <td>
+        <strong>Command:</strong> get labware latch state [cite: 5]<br>
+        <strong>Arguments:</strong> none [cite: 5]<br>
+        <strong>Response elements:</strong> [cite: 5]
+        <ul>
+          <li><code>IDLE_OPEN</code>: latch is open [cite: 5]</li>
+          <li><code>IDLE_CLOSED</code>: latch is closed [cite: 5]</li>
+          <li><code>OPENING</code>: latch is opening [cite: 5]</li>
+          <li><code>CLOSING</code>: latch is closing [cite: 5]</li>
+          <li><code>IDLE_UNKNOWN</code>: latch is not sensed [cite: 5]</li>
+        </ul>
+        <strong>Response:</strong> <code>M241 STATUS: CLOSING OK</code> indicates the latch is closing. [cite: 5]
+      </td>
     </tr>
     <tr>
-      <td><code>M243</code></td> <td>
-        <strong>Command:</strong> close labware latch<br> <strong>Arguments:</strong> none<br> <strong>Response:</strong> <code>M243 OK</code> (acknowledge only or error) </td>
+      <td><code>M242</code></td>
+      <td>
+        <strong>Command:</strong> open labware latch [cite: 5]<br>
+        <strong>Arguments:</strong> none [cite: 5]<br>
+        <strong>Response:</strong> <code>M242 OK</code> (acknowledge only or error) [cite: 5]
+      </td>
     </tr>
     <tr>
-      <td><code>M411</code></td> <td>
-        <strong>Command:</strong> get error state (available in robot software 8.8.0 and later)<br> <strong>Arguments:</strong> none<br> <strong>Example:</strong> <code>M411</code><br> <strong>Response:</strong> <code>M411 OK</code> (acknowledge only or error) </td>
+      <td><code>M243</code></td>
+      <td>
+        <strong>Command:</strong> close labware latch [cite: 5]<br>
+        <strong>Arguments:</strong> none [cite: 5]<br>
+        <strong>Response:</strong> <code>M243 OK</code> (acknowledge only or error) [cite: 5]
+      </td>
     </tr>
     <tr>
-      <td><code>M413</code></td> <td>
-        <strong>Command:</strong> clear error state (available in robot software 8.8.0 and later)<br> <strong>Arguments:</strong> none<br> <strong>Example:</strong> <code>M413</code><br> <strong>Response:</strong> <code>M413 OK</code> (acknowledge only or error) </td>
+      <td><code>M411</code></td>
+      <td>
+        <strong>Command:</strong> get error state (available in robot software 8.8.0 and later) [cite: 5]<br>
+        <strong>Arguments:</strong> none [cite: 10]<br>
+        <strong>Example:</strong> <code>M411</code> [cite: 10]<br>
+        <strong>Response:</strong> <code>M411 OK</code> (acknowledge only or error) [cite: 11]
+      </td>
+    </tr>
+    <tr>
+      <td><code>M413</code></td>
+      <td>
+        <font color="red">NOT IN `driver.py` FOR MODULE</font></p>
+        <strong>Command:</strong> clear error state (available in robot software 8.8.0 and later) [cite: 12]<br>
+        <strong>Arguments:</strong> none [cite: 13]<br>
+        <strong>Example:</strong> <code>M413</code> [cite: 14]<br>
+        <strong>Response:</strong> <code>M413 OK</code> (acknowledge only or error) [cite: 15]
+      </td>
+    </tr>
+    <tr>
+      <td><code>dfu</code></td>
+      <td>
+        <strong>Command:</strong> enter programming mode<br>
+        <strong>Arguments:</strong> none<br>
+        <strong>Response:</strong> <code>OK</code> (acknowledge only or error)
+      </td>
     </tr>
   </tbody>
 </table>

--- a/docs/heater-shaker/mkdocs.yml
+++ b/docs/heater-shaker/mkdocs.yml
@@ -11,6 +11,10 @@ nav:
       - OT-2 Attachment Steps: installation-ot2.md
   - Software Control: software.md
   - Maintenance and Cleaning: maintenance.md
+  - Heater-Shaker G-Codes:
+      - Heater-Shaker G-Code Concepts: g-code-concepts.md
+      - Heater-Shaker G-Codes: g-codes.md
+      - Heater-Shaker Error Codes: error-codes.md
   - Additional Product Information: additional-info.md
 
 theme:

--- a/docs/heater-shaker/mkdocs.yml
+++ b/docs/heater-shaker/mkdocs.yml
@@ -12,7 +12,6 @@ nav:
   - Software Control: software.md
   - Maintenance and Cleaning: maintenance.md
   - Heater-Shaker G-Codes:
-      - "Em—Dash Title Test": em-dash-title-test.md
       - Heater-Shaker G-Code Concepts: g-code-concepts.md
       - Heater-Shaker G-Codes: g-codes.md
       - Heater-Shaker Error Codes: error-codes.md

--- a/docs/heater-shaker/mkdocs.yml
+++ b/docs/heater-shaker/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
   - Software Control: software.md
   - Maintenance and Cleaning: maintenance.md
   - Heater-Shaker G-Codes:
+      - "Em—Dash Title Test": em-dash-title-test.md
       - Heater-Shaker G-Code Concepts: g-code-concepts.md
       - Heater-Shaker G-Codes: g-codes.md
       - Heater-Shaker Error Codes: error-codes.md


### PR DESCRIPTION
# Overview

This PR adds a Heater-Shaker G-code section to the module's online manual. Identical (except for codes) to [Thermocycler G-codes section](https://docs.opentrons.com/thermocycler/g-code-concepts/) in that manual.

**Sandbox:** https://sandbox.docs.opentrons.com/docs-heater-shaker-gcodes/heater-shaker/g-code-concepts/

RTC-945

## Test Plan and Hands on Testing

Compared codes listed in the Flex service manual with the `driver.py` file for this module. Found and removed 2 codes that aren't in the driver file. For comparison, see the [Thermocycler manual](https://docs.opentrons.com/thermocycler/).

## Changelog

Adds a new section and 3 docs to the Heater-Shaker manual:

- `g-codes-concepts.md`
- `g-codes.md`
- `error-codes.md`

## Review requests

This is the same organization and content as the Thermocycler. The codes are Heater-Shaker specific. The error codes are shared by multiple modules.

## Risk assessment

- Low, docs only.
