### PR TITLE
chore(robot-server): Fix failing test

### DIFF
--- a/robot-server/tests/integration/http_api/protocols/test_analyses_with_command_annotations.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_analyses_with_command_annotations.tavern.yaml
@@ -45,7 +45,7 @@ stages:
       status_code: 200
       json:
         data:
-          analyses: [ ]
+          analyses: []
           analysisSummaries:
             - id: '{analysis_id}'
               status: completed
@@ -167,3 +167,4 @@ stages:
             errors: []
             liquids: []
             liquidClasses: []
+            labwareOffsets: []


### PR DESCRIPTION
## Overview

This fixes a test failing in edge. It looks like it was just some kind of conflict with #21090.

## Test Plan and Hands on Testing

Just CI.

## Review requests

None.

## Risk assessment

Low.