### PR TITLE
fix(protocol-designer): default primary nozzle to A1 for all pipettes if not selected

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/NozzleAndWellSelectionModal.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/NozzleAndWellSelectionModal.tsx
@@ -61,9 +61,11 @@ export function NozzleAndWellSelectionModal(
 
   const handleContinue = (): void => {
     setShowError(false)
-    if (currentStepIndex === 0 && pipetteSpecs.channels === 1) {
+    if (currentStepIndex === 0 && propsForFields.primaryNozzle.value === null) {
       propsForFields.primaryNozzle.updateValue(A1_NOZZLE)
-      propsForFields.nozzles.updateValue(ALL)
+      if (pipetteSpecs.channels === 1) {
+        propsForFields.nozzles.updateValue(ALL)
+      }
     }
     if (currentStepIndex !== 0 && activeFieldKey !== null) {
       if (wellValues.length === 0) {


### PR DESCRIPTION
# Overview

Default the primaryNozzle to A1 if not already set for all pipettes. This is needed to ensure the pipette shadow renders in alignment with the wells when the nozzle configuration is set to All

## Test Plan and Hands on Testing
- smoke tested 8ch pipette
- <img width="910" height="713" alt="Screenshot 2026-03-30 at 4 40 36 PM" src="https://github.com/user-attachments/assets/fd5e6e98-0b3d-4aad-b455-fb557ba84bd3" />
<img width="918" height="690" alt="Screenshot 2026-03-31 at 10 57 20 AM" src="https://github.com/user-attachments/assets/c9304713-529a-4449-acbd-285349109970" />
<img width="907" height="704" alt="Screenshot 2026-03-31 at 10 58 39 AM" src="https://github.com/user-attachments/assets/22c6ced6-f5a7-4ed5-b32d-8b07906982a8" />


## Changelog

- added default primaryNozzle if value is null

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment

partially closes RQA-5278 . I am continuing to work on why the nozzles are not appearing more on the left hand side.