### PR TITLE
feat(key-server): rotate TLS EE certificates

### DIFF
--- a/key-server/key_server/tls/ca_manager.py
+++ b/key-server/key_server/tls/ca_manager.py
@@ -1,6 +1,5 @@
 """Code for managing TLS CAs."""
 
-import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -102,23 +101,7 @@ class TLSCAManager:
             LOG.info(
                 f"Current CA expires at {self._current_ca.cert.not_valid_after_utc} which is less than 3 months from {now} and we have no next CA, creating"
             )
-            self._next_ca = cryptography_utils.create_ca(
-                key_dir, ca_cert_dir, now, self.CA_EXPIRY_DURATION
-            )
-            LOG.info(
-                f"Created {cryptography_utils.fingerprint(self._next_ca.cert)} ({self._next_ca.cert.not_valid_before_utc}-{self._next_ca.cert.not_valid_after_utc}) as next CA"
-            )
-        self._expiry_task: "asyncio.Task[None]" = asyncio.create_task(
-            self._expiry_task_outer()
-        )
-
-    async def teardown(self) -> None:
-        """Run code necessary to stop the CA manager."""
-        self._expiry_task.cancel()
-        try:
-            await self._expiry_task
-        except asyncio.CancelledError:
-            pass
+            self.build_next(now)
 
     def must_rotate(self, now: datetime) -> bool:
         """True if we need to rotate certificates."""
@@ -140,12 +123,9 @@ class TLSCAManager:
     def rotate(self, now: datetime) -> None:
         """Rotate the CAs, removing the current and replacing it with the next."""
         LOG.info("Rotating CA certificates")
-
         if self.must_build_next(now):
             LOG.warning("No next CA present at rotation")
-            self._next_ca = cryptography_utils.create_ca(
-                self._key_dir, self._ca_cert_dir, now, self.CA_EXPIRY_DURATION
-            )
+            self.build_next(now)
 
         old_current = self._current_ca
         assert self._next_ca
@@ -153,22 +133,16 @@ class TLSCAManager:
         self._next_ca = None
         cryptography_utils.delete_certpair(old_current, "rotated away")
         if self.must_build_next(now):
-            self._next_ca = cryptography_utils.create_ca(
-                self._key_dir, self._ca_cert_dir, now, self.CA_EXPIRY_DURATION
-            )
+            self.build_next(now)
 
-    async def _expiry_task_outer(self) -> None:
-        try:
-            await self._expiry_task_inner()
-        except asyncio.CancelledError:
-            LOG.info("Stopping expiry task")
-
-    async def _expiry_task_inner(self) -> None:
-        while True:
-            now = datetime.now(tz=timezone.utc)
-            if self.must_rotate(now):
-                self.rotate(now)
-            await asyncio.sleep(self.CA_EXPIRY_CHECK_POLL_PERIOD.total_seconds())
+    def build_next(self, now: datetime) -> None:
+        """Build the next CA that will be used."""
+        self._next_ca = cryptography_utils.create_ca(
+            self._key_dir, self._ca_cert_dir, now, self.CA_EXPIRY_DURATION
+        )
+        LOG.info(
+            f"Created {cryptography_utils.fingerprint(self._next_ca.cert)} ({self._next_ca.cert.not_valid_before_utc}-{self._next_ca.cert.not_valid_after_utc}) as next CA"
+        )
 
     def sign_precert(
         self, precert: cryptography_utils.PartialCertWithSigningRequired

--- a/key-server/key_server/tls/ee_manager.py
+++ b/key-server/key_server/tls/ee_manager.py
@@ -36,6 +36,7 @@ class TLSEEManager:
     """
 
     EE_EXPIRY_DURATION: Final = timedelta(days=1)
+    EE_EXPIRY_GRACE_DURATION: Final = timedelta(hours=1)
 
     def __init__(
         self,
@@ -67,17 +68,23 @@ class TLSEEManager:
             self._robot_ips,
         )
 
-    def ready(self, now: datetime) -> bool:
+    def ready(self, as_of: datetime) -> bool:
         """True if the system is ready; False otherwise.
 
-        The system is ready if it has a certificate and the certificate expires in more than 1 hour.
+        The system is ready if it has a certificate and the certificate will be valid one hour after the
+        time specified.
 
         There are circumstances beyond this that would make this cert a bad choice to terminate TLS
         with - for instance, the robot's hostname or IP has changed, or the CA has rotated - but this
         system is only checking the validity of the certificate itself.
         """
-        return self._ee_pair is not None and (
-            now + timedelta(hours=1) < self._ee_pair.cert.not_valid_after_utc
+        return (
+            self._ee_pair is not None
+            and (self._ee_pair.cert.not_valid_before_utc < as_of)
+            and (
+                (as_of + self.EE_EXPIRY_GRACE_DURATION)
+                < self._ee_pair.cert.not_valid_after_utc
+            )
         )
 
     def install_cert(self, cert: cryptography_utils.SignedCert) -> None:

--- a/key-server/key_server/tls/ee_manager.py
+++ b/key-server/key_server/tls/ee_manager.py
@@ -67,12 +67,18 @@ class TLSEEManager:
             self._robot_ips,
         )
 
-    def ready(self) -> bool:
+    def ready(self, now: datetime) -> bool:
         """True if the system is ready; False otherwise.
 
-        For now, this only handles the case where the certificate is not generated yet.
+        The system is ready if it has a certificate and the certificate expires in more than 1 hour.
+
+        There are circumstances beyond this that would make this cert a bad choice to terminate TLS
+        with - for instance, the robot's hostname or IP has changed, or the CA has rotated - but this
+        system is only checking the validity of the certificate itself.
         """
-        return self._ee_pair is not None
+        return self._ee_pair is not None and (
+            now + timedelta(hours=1) < self._ee_pair.cert.not_valid_after_utc
+        )
 
     def install_cert(self, cert: cryptography_utils.SignedCert) -> None:
         """Install a signed EE cert."""

--- a/key-server/key_server/tls/manager.py
+++ b/key-server/key_server/tls/manager.py
@@ -16,7 +16,7 @@ LOG = logging.getLogger(__name__)
 class TLSManager:
     """A class for managing the combination of CAs and end-entities that allows TLS communication."""
 
-    EXPIRY_CHECKER_POLL_PERIOD: Final = timedelta(hours=23)
+    EXPIRY_CHECKER_POLL_PERIOD: Final = timedelta(hours=7)
 
     def __init__(self, ca_manager: TLSCAManager, ee_manager: TLSEEManager) -> None:
         """Build the TLSManager."""
@@ -87,12 +87,12 @@ class TLSManager:
     async def _expiry_task_inner(self, poll_time: timedelta) -> None:
         while True:
             now = datetime.now(tz=timezone.utc)
-            if self._ca_manager.must_build_next(now):
+            if self._ca_manager.must_build_next(now + poll_time):
                 self._ca_manager.build_next(now)
             # Rotating CAs means rotating EEs
-            if self._ca_manager.must_rotate(now):
+            if self._ca_manager.must_rotate(now + poll_time):
                 self._ca_manager.rotate(now)
                 self.refresh_ee()
-            if not self._ee_manager.ready(now):
+            if not self._ee_manager.ready(now + poll_time):
                 self.refresh_ee()
             await asyncio.sleep(poll_time.total_seconds())

--- a/key-server/key_server/tls/manager.py
+++ b/key-server/key_server/tls/manager.py
@@ -1,20 +1,28 @@
 """tls.manager contains code for managing the robot's TLS stack."""
 
+import asyncio
+import logging
 import socket
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Self, Type
+from typing import Final, Self, Type
 
 from .ca_manager import TLSCAManager
 from .ee_manager import TLSEEManager
+
+LOG = logging.getLogger(__name__)
 
 
 class TLSManager:
     """A class for managing the combination of CAs and end-entities that allows TLS communication."""
 
+    EXPIRY_CHECKER_POLL_PERIOD: Final = timedelta(hours=23)
+
     def __init__(self, ca_manager: TLSCAManager, ee_manager: TLSEEManager) -> None:
         """Build the TLSManager."""
         self._ca_manager = ca_manager
         self._ee_manager = ee_manager
+        self._expiry_task: "asyncio.Task[None] | None" = None
 
     @classmethod
     async def create(
@@ -35,11 +43,12 @@ class TLSManager:
         )
         obj = cls(ca_manager=ca_manager, ee_manager=ee_manager)
         obj.refresh_ee()
+        await obj.schedule_expiry_task(cls.EXPIRY_CHECKER_POLL_PERIOD)
         return obj
 
     async def teardown(self) -> None:
         """Tear down the TLS manager at the end of a session."""
-        await self._ca_manager.teardown()
+        await self.cancel_expiry_task()
         self._ee_manager.remove_cert("shutting down")
 
     def refresh_ee(self) -> None:
@@ -47,3 +56,43 @@ class TLSManager:
         precert = self._ee_manager.generate_precert()
         signed = self._ca_manager.sign_precert(precert)
         self._ee_manager.install_cert(signed)
+
+    def expiry_task_running(self) -> bool:
+        """True if the expiry task is running properly. Mostly used internally and for testing."""
+        return self._expiry_task is not None and not self._expiry_task.done()
+
+    async def cancel_expiry_task(self) -> None:
+        """Cancel a running expiry task. Mostly used for testing; callers should prefer teardown()."""
+        if not self._expiry_task:
+            return
+        if not self._expiry_task.done():
+            self._expiry_task.cancel()
+            try:
+                await self._expiry_task
+            except asyncio.CancelledError:
+                pass
+        self._expiry_task = None
+
+    async def schedule_expiry_task(self, poll_time: timedelta) -> None:
+        """Create and run the expiry monitoring task. Mostly used for testing; callers should prefer create()."""
+        await self.cancel_expiry_task()
+        self._expiry_task = asyncio.create_task(self._expiry_task_outer(poll_time))
+
+    async def _expiry_task_outer(self, poll_time: timedelta) -> None:
+        try:
+            await self._expiry_task_inner(poll_time)
+        except asyncio.CancelledError:
+            LOG.info("Stopping expiry task")
+
+    async def _expiry_task_inner(self, poll_time: timedelta) -> None:
+        while True:
+            now = datetime.now(tz=timezone.utc)
+            if self._ca_manager.must_build_next(now):
+                self._ca_manager.build_next(now)
+            # Rotating CAs means rotating EEs
+            if self._ca_manager.must_rotate(now):
+                self._ca_manager.rotate(now)
+                self.refresh_ee()
+            if not self._ee_manager.ready(now):
+                self.refresh_ee()
+            await asyncio.sleep(poll_time.total_seconds())

--- a/key-server/tests/tls/test_ca_manager.py
+++ b/key-server/tests/tls/test_ca_manager.py
@@ -1,4 +1,3 @@
-import asyncio
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from shutil import rmtree
@@ -6,7 +5,6 @@ from typing import Any, AsyncIterator, Iterator
 
 import pytest
 from cryptography import x509
-from cryptography.hazmat.primitives import hashes
 
 from key_server.tls import ca_manager, cryptography_utils
 
@@ -39,7 +37,6 @@ class SubjectFactory:
 
     async def destroy(self, *args: Any, **kwargs: Any) -> None:
         if self._manager:
-            await self._manager.teardown()
             self._manager = None
 
 
@@ -97,14 +94,14 @@ async def test_init_limits_to_two_certs(
     subject = subject_factory.create()
 
     assert subject._current_ca.certpath == current.certpath
-    assert subject._current_ca.cert.fingerprint(
-        hashes.SHA256()
-    ) == current.cert.fingerprint(hashes.SHA256())
+    assert cryptography_utils.fingerprint(
+        subject._current_ca.cert
+    ) == cryptography_utils.fingerprint(current.cert)
     assert subject._next_ca
     assert subject._next_ca.certpath == next.certpath
-    assert subject._next_ca.cert.fingerprint(hashes.SHA256()) == next.cert.fingerprint(
-        hashes.SHA256()
-    )
+    assert cryptography_utils.fingerprint(
+        subject._next_ca.cert
+    ) == cryptography_utils.fingerprint(next.cert)
     assert current.certpath.exists()
     assert current.keypath.exists()
     assert next.certpath.exists()
@@ -184,34 +181,10 @@ async def test_rotates_ca_if_necessary_on_boot(
         key_dir, ca_cert_dir, nowish - timedelta(days=30), timedelta(days=365, hours=1)
     )
     subject = subject_factory.create()
-    assert subject._current_ca.cert.fingerprint(
-        hashes.SHA256()
-    ) == next.cert.fingerprint(hashes.SHA256())
+    assert cryptography_utils.fingerprint(
+        subject._current_ca.cert
+    ) == cryptography_utils.fingerprint(next.cert)
     assert subject._next_ca is None
-
-
-async def test_rotates_ca_while_live(
-    key_dir: Path, ca_cert_dir: Path, subject_factory: SubjectFactory
-) -> None:
-    """While the manager is running, if it detects expiry it should rotate CAs."""
-    nowish = datetime.now(timezone.utc)
-    current = cryptography_utils.create_ca(
-        key_dir,
-        ca_cert_dir,
-        nowish - timedelta(days=365, minutes=59, seconds=58),
-        timedelta(days=365, hours=1),
-    )
-    subject = subject_factory.create()
-    await subject.teardown()
-    # this is a Final so we have to ignore a type error to overwrite it
-    subject.CA_EXPIRY_CHECK_POLL_PERIOD = timedelta(seconds=3)  # type: ignore[misc]
-    subject._expiry_task = asyncio.create_task(subject._expiry_task_outer())
-    await asyncio.sleep(4)
-    assert subject._current_ca.cert.fingerprint(
-        hashes.SHA256()
-    ) != current.cert.fingerprint(hashes.SHA256())
-    assert not current.certpath.exists()
-    assert not current.keypath.exists()
 
 
 async def test_signs_ee_certificates(

--- a/key-server/tests/tls/test_ee_manager.py
+++ b/key-server/tests/tls/test_ee_manager.py
@@ -92,6 +92,21 @@ def test_subject_becomes_unready_after_removing_a_cert(
     assert not initialized_subject.ready(datetime.now(timezone.utc))
 
 
+def test_subject_readiness_based_on_argument(
+    initialized_subject: TLSEEManager,
+) -> None:
+    """It should base its readiness assessment on the time point provided."""
+    assert not initialized_subject.ready(
+        datetime.now(timezone.utc) + timedelta(hours=23, minutes=1)
+    )
+    assert initialized_subject.ready(
+        datetime.now(timezone.utc) + timedelta(hours=22, minutes=59)
+    )
+    assert not initialized_subject.ready(
+        datetime.now(timezone.utc) - timedelta(hours=1)
+    )
+
+
 def test_subject_uses_robot_details(
     initialized_subject: TLSEEManager, hostname: str, ip_addresses: list[str]
 ) -> None:

--- a/key-server/tests/tls/test_ee_manager.py
+++ b/key-server/tests/tls/test_ee_manager.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import pytest
 from cryptography import x509
-from cryptography.hazmat.primitives import hashes
 
 from key_server.tls import constants, cryptography_utils, file_utils
 from key_server.tls.ee_manager import TLSEEManager
@@ -70,19 +69,19 @@ def test_subject_does_not_reuse_certs(
     cryptography_utils.install_tls_cert(ee_dir, signed)
     subject = TLSEEManager(ee_dir, ee_dir, hostname, ip_addresses)
     assert subject._ee_pair is None
-    assert not subject.ready()
+    assert not subject.ready(now)
 
 
 def test_subject_not_born_ready(subject: TLSEEManager) -> None:
     """It should start life unready, as do we all."""
-    assert not subject.ready()
+    assert not subject.ready(datetime.now(timezone.utc))
 
 
 def test_subject_becomes_ready_after_generating_a_cert(
     initialized_subject: TLSEEManager,
 ) -> None:
     """It should become ready when generating a certificate."""
-    assert initialized_subject.ready()
+    assert initialized_subject.ready(datetime.now(timezone.utc))
 
 
 def test_subject_becomes_unready_after_removing_a_cert(
@@ -90,7 +89,7 @@ def test_subject_becomes_unready_after_removing_a_cert(
 ) -> None:
     """It should stop being ready after removing a certificate."""
     initialized_subject.remove_cert("test")
-    assert not initialized_subject.ready()
+    assert not initialized_subject.ready(datetime.now(timezone.utc))
 
 
 def test_subject_uses_robot_details(
@@ -130,6 +129,6 @@ def test_install_cert_saves_cert(
     cert = file_utils.load_cert(ee_dir / constants.TLS_CERT_NAME, "PEM")
     assert cert
     assert initialized_subject._ee_pair
-    assert cert.fingerprint(
-        hashes.SHA256()
-    ) == initialized_subject._ee_pair.cert.fingerprint(hashes.SHA256())
+    assert cryptography_utils.fingerprint(cert) == cryptography_utils.fingerprint(
+        initialized_subject._ee_pair.cert
+    )

--- a/key-server/tests/tls/test_manager.py
+++ b/key-server/tests/tls/test_manager.py
@@ -1,11 +1,14 @@
 """Tests for the TLS system manager."""
 
+import asyncio
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import AsyncIterator
 
 import pytest
 from cryptography import x509
 
-from key_server.tls import constants
+from key_server.tls import constants, cryptography_utils
 from key_server.tls.manager import TLSManager
 
 
@@ -28,18 +31,22 @@ def ca_key_dir(tmp_path: Path) -> Path:
 
 
 @pytest.fixture
-async def subject(ee_dir: Path, ca_cert_dir: Path, ca_key_dir: Path) -> TLSManager:
+async def subject(
+    ee_dir: Path, ca_cert_dir: Path, ca_key_dir: Path
+) -> AsyncIterator[TLSManager]:
     """A TLSManager instance."""
-    return await TLSManager.create(ca_cert_dir, ca_key_dir, ee_dir)
+    manager = await TLSManager.create(ca_cert_dir, ca_key_dir, ee_dir)
+    try:
+        yield manager
+    finally:
+        await manager.teardown()
 
 
 async def test_initializes_ca_manager(
     subject: TLSManager, ca_cert_dir: Path, ca_key_dir: Path
 ) -> None:
     """It should build a CA manager and have its task running and CA built."""
-    assert subject._ca_manager._expiry_task
     assert subject._ca_manager._current_ca is not None
-    assert not subject._ca_manager._expiry_task.done()
     cert_contents = list(ca_cert_dir.iterdir())
     assert len(cert_contents) == 1
     assert constants.CA_CERT_NAME_PATTERN.match(cert_contents[0].name)
@@ -50,7 +57,7 @@ async def test_initializes_ca_manager(
 
 async def test_initializes_ee_manager(subject: TLSManager, ee_dir: Path) -> None:
     """It should build an EE manager and set up its certs."""
-    assert subject._ee_manager.ready()
+    assert subject._ee_manager.ready(datetime.now(timezone.utc))
     ee_contents = list(ee_dir.iterdir())
     assert len(ee_contents) == 2
     assert sorted([content.name for content in ee_contents]) == sorted(
@@ -74,15 +81,141 @@ async def test_uses_ca_for_ee_manager(subject: TLSManager) -> None:
     )
 
 
-async def test_tears_down_ca_manager(subject: TLSManager) -> None:
-    """When torn down it should tear down the CA."""
-    await subject.teardown()
-    assert subject._ca_manager._expiry_task.done()
-
-
 async def test_tears_down_ee_manager(subject: TLSManager, ee_dir: Path) -> None:
     """When torn down it should tear down the EE."""
     await subject.teardown()
     assert subject._ee_manager._ee_pair is None
     contents = list(ee_dir.iterdir())
     assert len(contents) == 0
+
+
+async def test_expiry_task_lifetime(subject: TLSManager) -> None:
+    """Its task control methods should work."""
+    assert subject.expiry_task_running()
+    await subject.cancel_expiry_task()
+    assert not subject.expiry_task_running()
+    await subject.schedule_expiry_task(timedelta(seconds=1))
+    assert subject.expiry_task_running()
+    await subject.schedule_expiry_task(timedelta(seconds=1))
+    assert subject.expiry_task_running()
+    await subject.cancel_expiry_task()
+    assert not subject.expiry_task_running()
+    await subject.cancel_expiry_task()
+    assert not subject.expiry_task_running()
+    await subject.schedule_expiry_task(timedelta(seconds=1))
+    assert subject.expiry_task_running()
+    await subject.teardown()
+    assert not subject.expiry_task_running()
+
+
+async def test_rotates_ca_while_live(
+    ca_cert_dir: Path, ca_key_dir: Path, ee_dir: Path
+) -> None:
+    """While the manager is running, if it detects expiry it should rotate CAs."""
+    nowish = datetime.now(timezone.utc)
+    current = cryptography_utils.create_ca(
+        ca_key_dir,
+        ca_cert_dir,
+        nowish - timedelta(days=365, minutes=59, seconds=58),
+        timedelta(days=365, hours=1),
+    )
+    subject = await TLSManager.create(
+        ca_cert_dir=ca_cert_dir, ca_key_dir=ca_key_dir, tls_ee_dir=ee_dir
+    )
+    await subject.cancel_expiry_task()
+
+    await subject.schedule_expiry_task(timedelta(seconds=3))
+    await asyncio.sleep(4)
+    assert cryptography_utils.fingerprint(
+        subject._ca_manager._current_ca.cert
+    ) != cryptography_utils.fingerprint(current.cert)
+    assert not current.certpath.exists()
+    assert not current.keypath.exists()
+
+
+async def test_rotates_tls_while_live(
+    ca_cert_dir: Path, ca_key_dir: Path, ee_dir: Path
+) -> None:
+    """It should rotate TLS EE certs when they expire."""
+    subject = await TLSManager.create(
+        ca_cert_dir=ca_cert_dir, ca_key_dir=ca_key_dir, tls_ee_dir=ee_dir
+    )
+    await subject.cancel_expiry_task()
+    subject._ee_manager.EE_EXPIRY_DURATION = timedelta(seconds=3)  # type: ignore[misc]
+    subject.refresh_ee()
+    assert subject._ee_manager._ee_pair
+    old_ee = subject._ee_manager._ee_pair.cert
+    await subject.schedule_expiry_task(timedelta(seconds=2))
+    await asyncio.sleep(4)
+    new_ee = subject._ee_manager._ee_pair.cert
+    assert cryptography_utils.fingerprint(new_ee) != cryptography_utils.fingerprint(
+        old_ee
+    )
+
+
+async def test_rotates_tls_after_ca(
+    ca_cert_dir: Path, ca_key_dir: Path, ee_dir: Path
+) -> None:
+    """If the CA rotated, the EE should also."""
+    nowish = datetime.now(timezone.utc)
+    old_ca = cryptography_utils.create_ca(
+        ca_key_dir,
+        ca_cert_dir,
+        nowish - timedelta(days=365, minutes=59, seconds=58),
+        timedelta(days=365, hours=1),
+    )
+    subject = await TLSManager.create(
+        ca_cert_dir=ca_cert_dir, ca_key_dir=ca_key_dir, tls_ee_dir=ee_dir
+    )
+    await subject.cancel_expiry_task()
+    subject._ee_manager.EE_EXPIRY_DURATION = timedelta(seconds=5)  # type: ignore[misc]
+    subject.refresh_ee()
+    old_ee = subject._ee_manager._ee_pair
+    assert old_ee
+    # now, the CA expires in less than the expiry check and so does the ee
+
+    await subject.schedule_expiry_task(timedelta(seconds=2))
+    await asyncio.sleep(4)
+    # the CA should have rotated
+    current_ca = subject._ca_manager._current_ca
+    assert cryptography_utils.fingerprint(
+        current_ca.cert
+    ) != cryptography_utils.fingerprint(old_ca.cert)
+    assert not old_ca.certpath.exists()
+    assert not old_ca.keypath.exists()
+    # so should the EE
+    current_ee = subject._ee_manager._ee_pair
+    assert current_ee
+    assert cryptography_utils.fingerprint(
+        current_ee.cert
+    ) != cryptography_utils.fingerprint(old_ee.cert)
+    # and critically the new EE should be signed by the new CA
+    aki = current_ee.cert.extensions.get_extension_for_class(
+        x509.AuthorityKeyIdentifier
+    )
+    # note: this is not a secure way to do tls signature verification in practice. however
+    # it is really good for unit tests that make sure we didn't use the wrong cert
+    assert (
+        aki.value.key_identifier
+        == current_ca.cert.extensions.get_extension_for_class(
+            x509.SubjectKeyIdentifier
+        ).value.key_identifier
+    )
+
+
+async def test_does_not_rotate_if_not_needed(subject: TLSManager) -> None:
+    """If nothing needs to rotate, nothing should rotate."""
+    await subject.cancel_expiry_task()
+    orig_ca = subject._ca_manager._current_ca.cert
+    assert subject._ee_manager._ee_pair
+    orig_ee = subject._ee_manager._ee_pair.cert
+    await subject.schedule_expiry_task(timedelta(seconds=1))
+    await asyncio.sleep(3)
+    current_ca = subject._ca_manager._current_ca.cert
+    current_ee = subject._ee_manager._ee_pair.cert
+    assert cryptography_utils.fingerprint(current_ca) == cryptography_utils.fingerprint(
+        orig_ca
+    )
+    assert cryptography_utils.fingerprint(current_ee) == cryptography_utils.fingerprint(
+        orig_ee
+    )


### PR DESCRIPTION
Our TLS certificates need to rotate every <24 hours, because we want them to be essentially ephemeral and this enforces that requirement.

So, we need to rotate them! This is very similar logic to the rotation that happens in the CA manager, but on a shorter timescale (and without the double-buffering). We can condense the rotation code into the single higher-level manager. This is also important because there's a dependency here: when we rotate the CA cert, we need to rotate the TLS cert (to make sure that it's been signed by the new CA - otherwise clients would break).

So, that's what we do:
- Hoist expiry checking into the TLS manager, and its tests
- Add expiry checking to the TLS EE manager
- Also switch the EE certs whenever we update the CA cert

Closes EXEC-2455

## Test Plan and Hands on Testing

Not much testing; this isn't integrated. Unit tests.

## Changelog

- Rotate TLS certs
- 
## Review requests

- Look it over; does the code make sense?

## Risk assessment

It's important in that it's a security thing, but nothing uses it yet.
 