### PR TITLE
fix(protocol-designer, e2e-testing): make mix form labels more specific

### DIFF
--- a/e2e-testing/tests/pd/test_pd_mix_step.py
+++ b/e2e-testing/tests/pd/test_pd_mix_step.py
@@ -49,7 +49,7 @@ def test_mix_step_configuration_workflow(page: Page, pd_base_url: str) -> None:
 
     for label in [
         "Pipette nozzles and wells",
-        "Volume per well",
+        "Mix volume",
         "Mix repetitions",
     ]:
         mix_form.expect_text(label)

--- a/protocol-designer/src/assets/localization/en/application.json
+++ b/protocol-designer/src/assets/localization/en/application.json
@@ -65,6 +65,7 @@
     "minutes": "m",
     "nanometer": "nm",
     "rpm": "rpm",
+    "repetitions": "repetitions",
     "seconds": "s",
     "seconds_long": "seconds",
     "time": "mm:ss",

--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -391,7 +391,8 @@
   "volume_per_well": {
     "multiAspirate": "Aspirate volume per well",
     "multiDispense": "Dispense volume per well",
-    "single": "Volume per well"
+    "single": "Volume per well",
+    "mix": "Mix volume"
   },
   "well_name": "Well {{wellName}}",
   "well_order_title": "{{prefix}} well order",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/VolumeField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/VolumeField.tsx
@@ -2,21 +2,26 @@ import { useTranslation } from 'react-i18next'
 
 import { InputStepFormField } from '/protocol-designer/components/molecules'
 
-import type { PathOption } from '/protocol-designer/form-types'
+import type { PathOption, StepType } from '/protocol-designer/form-types'
 import type { FieldProps } from '../types'
 
 interface VolumeFieldProps {
   fieldProps: FieldProps
+  stepType: StepType
   path?: PathOption
 }
 
 export function VolumeField(props: VolumeFieldProps): JSX.Element {
   const { t } = useTranslation(['protocol_steps', 'application'])
-  const { fieldProps, path = 'single' } = props
-
+  const { fieldProps, stepType, path = 'single' } = props
+  const isMixStep = stepType === 'mix'
   return (
     <InputStepFormField
-      title={t(`volume_per_well.${path}`)}
+      title={
+        isMixStep
+          ? t(`volume_per_well.${stepType}`)
+          : t(`volume_per_well.${path}`)
+      }
       units={t('application:units.microliter')}
       showTooltip={false}
       {...fieldProps}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/FirstStepMixTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MixTools/FirstStepMixTools.tsx
@@ -62,11 +62,14 @@ export function FirstStepMixTools({
       {completedSteps ? (
         <>
           <Divider marginY="0" />
-          <VolumeField fieldProps={propsForFields.volume} />
+          <VolumeField
+            fieldProps={propsForFields.volume}
+            stepType={formData.stepType}
+          />
           <Divider marginY="0" />
           <InputStepFormField
             {...propsForFields.times}
-            units={t('units.times')}
+            units={t('units.repetitions')}
             title={t('protocol_steps:mix_repetitions')}
             showTooltip={false}
           />

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/FirstStepMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/FirstStepMoveLiquidTools.tsx
@@ -97,6 +97,7 @@ export function FirstStepMoveLiquidTools({
           <VolumeField
             fieldProps={propsForFields.volume}
             path={formData.path}
+            stepType={formData.stepType}
           />
         </>
       ) : null}


### PR DESCRIPTION
# Overview

Copy errors on mix form fields. We want the form field labels to be more specific to the mix step.

## Test Plan and Hands on Testing
Smoke tested and ensured changes matched design
<img width="354" height="752" alt="Screenshot 2026-03-31 at 11 31 06 AM" src="https://github.com/user-attachments/assets/48b12719-687d-416e-970c-e84789f1f3df" />


## Changelog

- pass step type to volumeField to determine if it is a mix step
- updated playwright test
- added text strings

## Risk assessment

low

Closes RQA-5284, RQA-5285