### PR TITLE
fix(protocol-designer): add default selection to TiprackSelector and fix accessibility calculation

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTiprack.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTiprack.tsx
@@ -68,6 +68,10 @@ export function SelectTiprack(props: SelectTiprackProps): JSX.Element {
           labwareEntities,
           validTiprackIds,
         })
+        if (selectedTiprackId === null && isTiprackSelectable) {
+          setSelectedTiprackId(id)
+        }
+
         return isTiprackSelectable ? (
           <>
             {id === selectedTiprackId ? (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -309,7 +309,7 @@ export function SelectTips(
       },
       {}
     )
-
+    const is96Channel = channels === 96
     const tipStatusByWellName =
       tipState != null
         ? Object.entries(tipState).reduce<Record<string, TipType>>(
@@ -380,6 +380,7 @@ export function SelectTips(
             primaryNozzle={primaryNozzle}
             enclosingViewbox={viewBox}
             nozzles={nozzles}
+            rotate={is96Channel}
           />
         ) : null}
       </>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
@@ -1,7 +1,13 @@
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 
-import { COLUMN, PARTIAL_COLUMN, ROW, SINGLE } from '@opentrons/shared-data'
+import {
+  ALL,
+  COLUMN,
+  PARTIAL_COLUMN,
+  ROW,
+  SINGLE,
+} from '@opentrons/shared-data'
 import {
   getIsSafePickupWithinTiprack,
   getIsSafePipetteMovement,
@@ -34,7 +40,7 @@ export const getWellsToCheck = (
       return wellOrdering[0]
     case COLUMN:
       return wellOrdering.map(row => row[0])
-
+    case ALL:
     case SINGLE:
     case PARTIAL_COLUMN:
       return wellOrdering.flat()


### PR DESCRIPTION
# Overview

This PR rotates the 96ch shadow and assigns a default selected tiprack to match designs. It also fixes a bug where it was not calculating accessibility status for tip racks when the pipette had `ALL` configuration due to a missing case statement.

## Test Plan and Hands on Testing

- smoke tested 96 with SINGLE, COLUMN, ROW, and ALL configuration
[RQA_5283.py](https://github.com/user-attachments/files/26385212/RQA_5283.py)
https://github.com/user-attachments/assets/48a56d6b-f75c-47eb-8211-b302b53763eb

## Changelog

- When no tiprack is selected, it will default to select the first available tip rack
- rotate prop passed into `PipetteShadow` to ensure correct alignment for 96ch
- when nozzle configuration is set to `ALL` it checks all wells in the rack for availability

## Risk assessment

- medium 

Addresses RQA-5283, RQA-5282