### PR TITLE
fix(protocol-designer): add hover state for unselected wells and remove for 1 well labware

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -114,6 +114,9 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
   const getSelectedWells = (): string[][] => {
     const wellsField = getWellsField()
     const wells = (wellsField?.value as string[]) || []
+    if (!hasMoreThanOneWell) {
+      return allWells
+    }
     return wells.map(well =>
       getEntireWellSelection(
         well,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -95,6 +95,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
   const labware = deckSetup.labware[labwareId]
   const labwareDef = labware.def
   const allWells = labwareDef.ordering
+  const hasMoreThanOneWell = allWells.length > 1
   const displayName = labwareDef.metadata.displayName
 
   const getWellsField = (): FieldProps | null => {
@@ -419,7 +420,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
           ignoreMissingTips
           wellLabelOptions="SHOW_LABEL_INSIDE"
         />
-        {hoveredWells?.[0] && (
+        {hoveredWells?.[0] && hasMoreThanOneWell ? (
           <PipetteShadow
             robotType={robotType}
             pipetteSpec={pipetteSpecs}
@@ -436,7 +437,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
             nozzles={nozzleConfiguration}
             rotate={is96Channel}
           />
-        )}
+        ) : null}
       </>
     )
   }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteShadow.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteShadow.tsx
@@ -112,9 +112,6 @@ export function PipetteShadow(props: {
       setLabelHeight(labelRef.current.offsetHeight)
     }
   }, [hoveredWell, labelText])
-  if (isHoveredWellSelected && !isTiprack) {
-    return <></>
-  }
   const { x: xOffset, y: yOffset } = getHoveredOffsetFromWell({
     selectedLabwareId,
     labwareState,


### PR DESCRIPTION
# Overview

This PR gives selected wells the state of unselected. It removes hover state entirely if the labware only has one well because it will already be selected by default. This change has been approved by design.

## Test Plan and Hands on Testing

- smoke tested with a 96 well and with a 1 well labware.
[RQA_5280.py](https://github.com/user-attachments/files/26388375/RQA_5280.py)
https://github.com/user-attachments/assets/f655dd55-7bf2-40d7-a515-82a0517e8b82

## Changelog
- removed filtering to remove unselect hover when it is a labware
- added filtering to not show the pipette shadow when there is a 1 well labware
- if there is one well in a labware, set that well as selected

## Risk assessment

low

Closes RQA-5280, RQA-5277