### PR TITLE
fix(shared-data): fix lld for 20uL tips on p50S

### DIFF
--- a/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_5.json
+++ b/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_5.json
@@ -12,6 +12,10 @@
     "A1": [-8.0, -22.0, -259.15]
   },
   "lldSettings": {
+    "t20": {
+      "minHeight": 1.0,
+      "minVolume": 0
+    },
     "t50": {
       "minHeight": 1.0,
       "minVolume": 0


### PR DESCRIPTION
geometry p50S for 3_5.json does not have lld for 20uL tips like it should

fix [RQA5286](https://opentrons.atlassian.net/browse/RQA-5286) by adding lld 

# Overview
We didn't add lld even though our pipettes use `p50_single_v3.5` so we get this error when attempting lld 

<img width="507" height="312" alt="Screenshot 2026-03-31 at 8 09 02 PM" src="https://github.com/user-attachments/assets/4363ac80-c3cb-443d-a661-f67b34e2d597" />


```
ProtocolCommandFailedError [line 36]: Error 4000 GENERAL_ERROR (ProtocolCommandFailedError): PythonException: KeyError: 't20'


```

## Test Plan and Hands on Testing

Test 
## Changelog

Run 
[200uL_20uL_tip_test.py](https://github.com/user-attachments/files/26392172/200uL_20uL_tip_test.py) and ensure LLD works 

## Review requests

@ryanthecoder 
## Risk assessment
There are probably better ways of handling this like updating the pipettes to 
`opentrons/shared-data/pipette/definitions/2/geometry/single_channel/p50/3_6.json` but this is the best I can do on short notice