### PR TITLE
ci: use lockfile to install packages

### DIFF
--- a/.github/actions/js/setup/action.yml
+++ b/.github/actions/js/setup/action.yml
@@ -29,4 +29,4 @@ runs:
 
     - name: 'Setup JS'
       shell: bash
-      run: make setup-js
+      run: make setup-js-ci

--- a/.github/workflows/g-code-testing-lint-test.yaml
+++ b/.github/workflows/g-code-testing-lint-test.yaml
@@ -74,7 +74,7 @@ jobs:
         run: |
           npm config set cache ${{ github.workspace }}/.npm-cache
           yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
-          make setup-js
+          make setup-js-ci
       - name: Lint
         run: make -C g-code-testing lint
       - name: Test

--- a/.github/workflows/react-api-client-test.yaml
+++ b/.github/workflows/react-api-client-test.yaml
@@ -60,7 +60,7 @@ jobs:
         run: |
           npm config set cache ./.npm-cache
           yarn config set cache-folder ./.yarn-cache
-          make setup-js
+          make setup-js-ci
       - name: 'run api-client and react-api-client unit tests'
         run: make -C api-client test-cov
       - name: 'Upload coverage report'

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -131,7 +131,7 @@ jobs:
         run: |
           npm config set cache ./.npm-cache
           yarn config set cache-folder ./.yarn-cache
-          make setup-js
+          make setup-js-ci
       - name: 'run shared-data JS unit tests'
         run: make -C shared-data test-cov
       - name: 'Upload coverage report'
@@ -210,7 +210,7 @@ jobs:
           elif [ "${{ format('{0}', startsWith(github.ref, 'refs/tags/components')) }}" = "true" ] ; then
             echo "Publishing builds for components@ tags"
             echo 'should_publish=true' >> $GITHUB_OUTPUT
-          else 
+          else
             echo "No publish for ref ${{github.ref}} and event ${{github.event_type}}"
             echo 'should_publish=false' >> $GITHUB_OUTPUT
           fi
@@ -250,7 +250,7 @@ jobs:
         run: |
           npm config set cache ./.npm-cache
           yarn config set cache-folder ./.yarn-cache
-          make setup-js
+          make setup-js-ci
       - name: 'build typescript'
         run: make build-ts
       - name: 'build library'

--- a/Makefile
+++ b/Makefile
@@ -64,12 +64,13 @@ setup-js:
 	$(MAKE) -C $(APP_SHELL_DIR) setup
 	$(MAKE) -C $(APP_SHELL_ODD_DIR) setup
 
+# front-end dependencies install for CI
 .PHONY: setup-js-ci
 setup-js-ci:
-		yarn config set network-timeout 60000
-		yarn install --frozen-lockfile
-		$(MAKE) -C $(APP_SHELL_DIR) setup
-		$(MAKE) -C $(APP_SHELL_ODD_DIR) setup
+	yarn config set network-timeout 60000
+	yarn install --frozen-lockfile
+	$(MAKE) -C $(APP_SHELL_DIR) setup
+	$(MAKE) -C $(APP_SHELL_ODD_DIR) setup
 
 
 PYTHON_SETUP_TARGETS := $(addsuffix -py-setup, $(PYTHON_DIRS))

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,14 @@ setup-js:
 	$(MAKE) -C $(APP_SHELL_DIR) setup
 	$(MAKE) -C $(APP_SHELL_ODD_DIR) setup
 
+.PHONY: setup-js-ci
+setup-js-ci:
+		yarn config set network-timeout 60000
+		yarn install --frozen-lockfile
+		$(MAKE) -C $(APP_SHELL_DIR) setup
+		$(MAKE) -C $(APP_SHELL_ODD_DIR) setup
+
+
 PYTHON_SETUP_TARGETS := $(addsuffix -py-setup, $(PYTHON_DIRS))
 
 .PHONY: setup-py
@@ -314,7 +322,7 @@ test-js-internal:
 	yarn vitest $(tests) $(test_opts) $(cov_opts)
 
 .PHONY: test-js-%
-test-js-%: 
+test-js-%:
 	$(MAKE) test-js-internal tests="$(if $(tests),$(foreach test,$(tests),$*/$(test)),$*)" test_opts="$(test_opts)" cov_opts="$(cov_opts)"
 
 .PHONY: validate-codecov-yml


### PR DESCRIPTION


# Overview
use lockfile to install packages on CI. 
this will mitigation strategy for compromised npm packages

close AUTH-2853

## Test Plan and Hands on Testing
- none

## Changelog
- add setup-js-ci for CI

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment
low