### PR TITLE
refactor(app): clear styled-components out of LabwareDetails and HistoricalRunProtocol

### DIFF
--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRun.module.css
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRun.module.css
@@ -1,0 +1,5 @@
+.protocol_name {                                                                                                   
+    overflow: hidden;                                                                                              
+    white-space: nowrap;                                                                                             
+    text-overflow: ellipsis;
+  }  

--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRun.module.css
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRun.module.css
@@ -1,5 +1,5 @@
 .protocol_name {                                                                                                   
     overflow: hidden;                                                                                              
-    white-space: nowrap;                                                                                             
     text-overflow: ellipsis;
+    white-space: nowrap;                                                                                             
   }  

--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRun.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import styles from './HistoricalProtocolRun.module.css'
 
 import {
   ALIGN_CENTER,
@@ -11,7 +10,6 @@ import {
   Flex,
   Icon,
   JUSTIFY_SPACE_BETWEEN,
-  OVERFLOW_HIDDEN,
   SPACING,
   StyledText,
 } from '@opentrons/components'
@@ -21,6 +19,7 @@ import { EMPTY_TIMESTAMP } from '/app/resources/runs'
 import { formatInterval } from '/app/transformations/commands'
 import { formatTimestamp } from '/app/transformations/runs'
 
+import styles from './HistoricalProtocolRun.module.css'
 import { HistoricalProtocolRunDrawer as Drawer } from './HistoricalProtocolRunDrawer'
 import { HistoricalProtocolRunOverflowMenu as OverflowMenu } from './HistoricalProtocolRunOverflowMenu'
 

--- a/app/src/organisms/Desktop/Devices/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Desktop/Devices/HistoricalProtocolRun.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { css } from 'styled-components'
+import styles from './HistoricalProtocolRun.module.css'
 
 import {
   ALIGN_CENTER,
@@ -25,12 +25,6 @@ import { HistoricalProtocolRunDrawer as Drawer } from './HistoricalProtocolRunDr
 import { HistoricalProtocolRunOverflowMenu as OverflowMenu } from './HistoricalProtocolRunOverflowMenu'
 
 import type { RunData } from '@opentrons/api-client'
-
-const PROTOCOL_NAME_STYLE = css`
-  overflow: ${OVERFLOW_HIDDEN};
-  white-space: nowrap;
-  text-overflow: ellipsis;
-`
 
 const COLUMNS = '25% 27% 5% 14% 14% 12%'
 
@@ -102,7 +96,7 @@ export function HistoricalProtocolRun(
           <StyledText
             desktopStyle="bodyDefaultRegular"
             data-testid={`RecentProtocolRuns_Protocol_${protocolKey}`}
-            css={PROTOCOL_NAME_STYLE}
+            className={styles.protocol_name}
           >
             {protocolName}
           </StyledText>

--- a/app/src/organisms/Desktop/Labware/LabwareDetails/LabwareDetails.module.css
+++ b/app/src/organisms/Desktop/Labware/LabwareDetails/LabwareDetails.module.css
@@ -1,0 +1,24 @@
+.close_icon {
+  border-radius: 50%;
+}
+
+.close_icon:hover {
+    background: var(--grey-30);
+}
+
+.close_icon:active {
+    background: var(--grey-35);
+}
+
+.copy_icon {
+  transform: translateY(var(--spacing-4));
+}
+
+.copy_icon:hover {
+  color: var(--blue-50);
+}
+
+.copy_icon:active,
+.copy_icon:focus {
+    color: var(--black-90);
+}

--- a/app/src/organisms/Desktop/Labware/LabwareDetails/index.tsx
+++ b/app/src/organisms/Desktop/Labware/LabwareDetails/index.tsx
@@ -1,7 +1,6 @@
 import { Fragment, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { format } from 'date-fns'
-import styles from './LabwareDetails.module.css'
 
 import {
   ALIGN_CENTER,
@@ -36,6 +35,7 @@ import { Dimensions } from './Dimensions'
 import { Gallery } from './Gallery'
 import { getWellLabel } from './helpers/labels'
 import { InsertDetails } from './InsertDetails'
+import styles from './LabwareDetails.module.css'
 import { ManufacturerDetails } from './ManufacturerDetails'
 import { WellCount } from './WellCount'
 import { WellDimensions } from './WellDimensions'
@@ -43,7 +43,6 @@ import { WellProperties } from './WellProperties'
 import { WellSpacing } from './WellSpacing'
 
 import type { LabwareDefAndDate } from '/app/local-resources/labware'
-
 
 export interface LabwareDetailsProps {
   onClose: () => void
@@ -165,7 +164,11 @@ export function LabwareDetails(props: LabwareDetailsProps): JSX.Element {
             <Box fontSize={TYPOGRAPHY.fontSizeP} color={COLORS.black90}>
               {apiName}
               <span {...targetProps}>
-                <Icon size={SIZE_1} name="copy-text" className={styles.copy_icon} />
+                <Icon
+                  size={SIZE_1}
+                  name="copy-text"
+                  className={styles.copy_icon}
+                />
               </span>
             </Box>
           </Flex>

--- a/app/src/organisms/Desktop/Labware/LabwareDetails/index.tsx
+++ b/app/src/organisms/Desktop/Labware/LabwareDetails/index.tsx
@@ -1,7 +1,7 @@
 import { Fragment, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { format } from 'date-fns'
-import { css } from 'styled-components'
+import styles from './LabwareDetails.module.css'
 
 import {
   ALIGN_CENTER,
@@ -44,27 +44,6 @@ import { WellSpacing } from './WellSpacing'
 
 import type { LabwareDefAndDate } from '/app/local-resources/labware'
 
-const CLOSE_ICON_STYLE = css`
-  border-radius: 50%;
-
-  &:hover {
-    background: ${COLORS.grey30};
-  }
-  &:active {
-    background: ${COLORS.grey35};
-  }
-`
-
-const COPY_ICON_STYLE = css`
-  transform: translateY(${SPACING.spacing4});
-  &:hover {
-    color: ${COLORS.blue50};
-  }
-  &:active,
-  &:focus {
-    color: ${COLORS.black90};
-  }
-`
 
 export interface LabwareDetailsProps {
   onClose: () => void
@@ -127,7 +106,7 @@ export function LabwareDetails(props: LabwareDetailsProps): JSX.Element {
           <Icon
             name="close"
             height={SPACING.spacing24}
-            css={CLOSE_ICON_STYLE}
+            className={styles.close_icon}
           />
         </Link>
       </Flex>
@@ -186,7 +165,7 @@ export function LabwareDetails(props: LabwareDetailsProps): JSX.Element {
             <Box fontSize={TYPOGRAPHY.fontSizeP} color={COLORS.black90}>
               {apiName}
               <span {...targetProps}>
-                <Icon size={SIZE_1} name="copy-text" css={COPY_ICON_STYLE} />
+                <Icon size={SIZE_1} name="copy-text" className={styles.copy_icon} />
               </span>
             </Box>
           </Flex>


### PR DESCRIPTION
# Overview

Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.

This change updates the syntax from `styled-components` to `modules.css` in App `LabwareDetails` and `HistoricalRunProtocol` files.

## Test Plan and Hands on Testing

Ran make -C app dev and verify that everything looks good.

## Changelog

`styled-components` usage removed from `LabwareDetails/index.tsx` and `HistoricalRunProtocol.tsx` files with `module.css` files added holding component definitions.

## Review requests

- Take a look and make sure the screenshots match between orig and updated app appearance.

## Risk assessment
- Low risk
