### PR TITLE
ci: change setup-js to setup-js-ci in workflows

### DIFF
--- a/.github/workflows/g-code-testing-lint-test.yaml
+++ b/.github/workflows/g-code-testing-lint-test.yaml
@@ -70,7 +70,7 @@ jobs:
             ${{ github.workspace }}/.npm-cache/_prebuild
             ${{ github.workspace }}/.yarn-cache
           key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
-      - name: 'setup-js'
+      - name: 'setup-js-ci'
         run: |
           npm config set cache ${{ github.workspace }}/.npm-cache
           yarn config set cache-folder ${{ github.workspace }}/.yarn-cache

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -73,26 +73,26 @@ jobs:
           key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
-      - name: 'setup-js'
-        id: 'setup-js'
+      - name: 'setup-js-ci'
+        id: 'setup-js-ci'
         run: |
           npm config set cache ${{ github.workspace }}/.npm-cache
           yarn config set cache-folder ${{ github.workspace }}/.yarn-cache
-          make setup-js
+          make setup-js-ci
         # Use the if to run all the lint checks even of some fail
         shell: bash
       - name: 'typechecks'
-        if: always() && steps.setup-js.outcome == 'success'
+        if: always() && steps.setup-js-ci.outcome == 'success'
         run: make check-js
       - name: 'lint js'
-        if: always() && steps.setup-js.outcome == 'success'
+        if: always() && steps.setup-js-ci.outcome == 'success'
         run: make lint-js
       - name: 'circular deps'
-        if: always() && steps.setup-js.outcome == 'success'
+        if: always() && steps.setup-js-ci.outcome == 'success'
         run: make circular-dependencies-js
       - name: 'lint json'
-        if: always() && steps.setup-js.outcome == 'success'
+        if: always() && steps.setup-js-ci.outcome == 'success'
         run: make lint-json
       - name: 'lint css'
-        if: always() && steps.setup-js.outcome == 'success'
+        if: always() && steps.setup-js-ci.outcome == 'success'
         run: make lint-css

--- a/.github/workflows/react-api-client-test.yaml
+++ b/.github/workflows/react-api-client-test.yaml
@@ -56,7 +56,7 @@ jobs:
           key: js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             js-${{ secrets.GH_CACHE_VERSION }}-${{ runner.os }}-yarn-
-      - name: 'setup-js'
+      - name: 'setup-js-ci'
         run: |
           npm config set cache ./.npm-cache
           yarn config set cache-folder ./.yarn-cache


### PR DESCRIPTION


# Overview
change setup-js to setup-js-ci in workflows for the following comment and to align `name` with the actual command

https://github.com/Opentrons/opentrons-ot2/pull/23#pullrequestreview-4045843343


## Test Plan and Hands on Testing



## Changelog



## Review requests



## Risk assessment
low
