### PR TITLE
feat(app): update protocol card to align with the new design

### DIFF
--- a/app/src/organisms/Desktop/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/Desktop/ProtocolsLanding/ProtocolCard.tsx
@@ -13,20 +13,15 @@ import {
   Flex,
   Icon,
   JUSTIFY_FLEX_END,
-  LegacyStyledText,
   ModuleIcon,
   OVERFLOW_WRAP_ANYWHERE,
   POSITION_ABSOLUTE,
   ProtocolDeck,
-  SIZE_2,
-  SIZE_3,
   SPACING,
   StyledText,
-  TYPOGRAPHY,
   WRAP,
 } from '@opentrons/components'
 import {
-  FLEX_STANDARD_MODEL,
   getGripperDisplayName,
   getModuleType,
   getPipetteNameSpecs,
@@ -44,7 +39,6 @@ import { ProtocolAnalysisFailure } from '../ProtocolAnalysisFailure'
 import { ProtocolAnalysisStale } from '../ProtocolAnalysisFailure/ProtocolAnalysisStale'
 import { ProtocolStatusBanner } from '../ProtocolStatusBanner'
 import { ProtocolOverflowMenu } from './ProtocolOverflowMenu'
-import { getRobotTypeDisplayName } from './utils'
 
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 import type { StoredProtocolData } from '/app/redux/protocol-storage'
@@ -55,6 +49,7 @@ interface ProtocolCardProps {
   handleSendProtocolToFlex: (storedProtocolData: StoredProtocolData) => void
   storedProtocolData: StoredProtocolData
 }
+
 export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
   const navigate = useNavigate()
   const { handleRunProtocol, handleSendProtocolToFlex, storedProtocolData } =
@@ -145,7 +140,6 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
 
   const requiredModuleTypes = requiredModuleModels.map(getModuleType)
 
-  const robotType = mostRecentAnalysis?.robotType ?? null
   const hasPeripherals =
     mostRecentAnalysis?.commandPreconditions?.isCameraUsed ?? false
 
@@ -163,20 +157,10 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
         {
           {
             missing: (
-              <Icon
-                name="ot-spinner"
-                color={COLORS.grey60}
-                spin
-                size={SIZE_3}
-              />
+              <Icon name="ot-spinner" color={COLORS.grey60} spin size="4rem" />
             ),
             loading: (
-              <Icon
-                name="ot-spinner"
-                color={COLORS.grey60}
-                spin
-                size={SIZE_3}
-              />
+              <Icon name="ot-spinner" color={COLORS.grey60} spin size="4rem" />
             ),
             error: (
               <Box
@@ -228,41 +212,27 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
             <ProtocolAnalysisStale protocolKey={protocolKey} />
           ) : null}
           <Flex paddingRight={SPACING.spacing24}>
-            <LegacyStyledText
-              forwardedAs="h3"
-              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+            <StyledText
+              desktopStyle="bodyDefaultSemiBold"
               data-testid={`ProtocolCard_${protocolDisplayName}`}
               overflowWrap={OVERFLOW_WRAP_ANYWHERE}
             >
               {protocolDisplayName}
-            </LegacyStyledText>
+            </StyledText>
           </Flex>
         </Flex>
         {/* data section */}
         {analysisStatus === 'loading' ? (
-          <LegacyStyledText forwardedAs="p" flex="1" color={COLORS.grey60}>
+          <StyledText
+            desktopStyle="bodyDefaultRegular"
+            flex="1"
+            color={COLORS.grey60}
+          >
             {t('loading_data')}
-          </LegacyStyledText>
+          </StyledText>
         ) : (
           <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
             <Flex gridGap={SPACING.spacing16}>
-              <Flex
-                flex={`0 0 ${
-                  robotType === FLEX_STANDARD_MODEL ? '6.2rem' : SIZE_2
-                }`}
-                flexDirection={DIRECTION_COLUMN}
-                gridGap={SPACING.spacing4}
-              >
-                <StyledText
-                  color={COLORS.grey60}
-                  desktopStyle="bodyDefaultRegular"
-                >
-                  {i18n.format('robot', 'capitalize')}
-                </StyledText>
-                <LegacyStyledText forwardedAs="p">
-                  {getRobotTypeDisplayName(robotType)}
-                </LegacyStyledText>
-              </Flex>
               <Flex
                 flex="1"
                 flexDirection={DIRECTION_COLUMN}
@@ -278,29 +248,29 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
                 {
                   {
                     missing: (
-                      <LegacyStyledText forwardedAs="p">
+                      <StyledText desktopStyle="bodyDefaultRegular">
                         {t('no_data')}
-                      </LegacyStyledText>
+                      </StyledText>
                     ),
                     loading: (
-                      <LegacyStyledText forwardedAs="p">
+                      <StyledText desktopStyle="bodyDefaultRegular">
                         {t('no_data')}
-                      </LegacyStyledText>
+                      </StyledText>
                     ),
                     error: (
-                      <LegacyStyledText forwardedAs="p">
+                      <StyledText desktopStyle="bodyDefaultRegular">
                         {t('no_data')}
-                      </LegacyStyledText>
+                      </StyledText>
                     ),
                     parameterRequired: (
-                      <LegacyStyledText forwardedAs="p">
+                      <StyledText desktopStyle="bodyDefaultRegular">
                         {t('no_data')}
-                      </LegacyStyledText>
+                      </StyledText>
                     ),
                     stale: (
-                      <LegacyStyledText forwardedAs="p">
+                      <StyledText desktopStyle="bodyDefaultRegular">
                         {t('no_data')}
-                      </LegacyStyledText>
+                      </StyledText>
                     ),
                     complete: (
                       <Flex flexWrap={WRAP} gridGap={SPACING.spacing4}>
@@ -385,12 +355,12 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
               justifyContent={JUSTIFY_FLEX_END}
               data-testid={`ProtocolCard_date_${protocolDisplayName}`}
             >
-              <LegacyStyledText forwardedAs="label" color={COLORS.grey60}>
+              <StyledText desktopStyle="captionRegular" color={COLORS.grey60}>
                 {`${t('updated')} ${format(
                   new Date(modified),
                   'M/d/yy HH:mm'
                 )}`}
-              </LegacyStyledText>
+              </StyledText>
             </Flex>
           </Flex>
         )}


### PR DESCRIPTION
# Overview
update protocol card to align with the new design and replace LegacyStyledText with StyledText

design
https://www.figma.com/design/tNK1EODJD5NB8l0W64NIaT/Feature--Forking-the-OT-2?node-id=10301-12160&m=dev

<img width="1466" height="926" alt="Screenshot 2026-04-01 at 5 05 29 PM" src="https://github.com/user-attachments/assets/b3f088a0-42d6-4ede-85df-d9cd38e81d52" />


close EXEC-2486

## Test Plan and Hands on Testing
- open the app
check protocol card

## Changelog
- update protocol card component (remove robot type)
- replace LegacyStyledText with StyledText

## Review requests

## Risk assessment
low
