### PR TITLE
fix(api): Fix update_module_fw.py script + add vacuum-module to update list.

### DIFF
--- a/api/src/opentrons/hardware_control/scripts/update_module_fw.py
+++ b/api/src/opentrons/hardware_control/scripts/update_module_fw.py
@@ -29,6 +29,7 @@ MODULES: Final[Dict[str, str]] = {
     "heater-shaker": "heatershaker",
     "absorbance-reader": "absorbancereader",
     "flex-stacker": "flexstacker",
+    "vacuum-module": "vacuummodule",
 }
 
 
@@ -120,7 +121,7 @@ def enable_udev_rules(enable: bool) -> None:
     This is done so the module is not automatically picked up by the server
     while we are updating it.
     """
-    rule = "95-opentrons-modules.rules"
+    rule = "95-opentrons-udev.rules"
     original = f"/etc/udev/rules.d/{rule}"
     destination = f"/var/lib/{rule}"
     src = original if not enable else destination
@@ -226,7 +227,10 @@ async def main(args: argparse.Namespace) -> None:  # noqa: C901
 
             # refresh the device info
             print(f"Device {module.port} is back online, refreshing device info.")
-            device_info = (await module._driver.get_device_info()).to_dict()  # type: ignore
+            device_info = await module._driver.get_device_info()  # type: ignore
+            if not isinstance(dict, device_info):
+                device_info = device_info.to_dict()
+
             success = device_info["version"] == target_version
             msg = "updated successfully!" if success else "failed to update"
             print(f"Device {name} {serial} {msg}")


### PR DESCRIPTION
# Overview

This broke when we changed the dev rules file, so just update the name to the correct one, plus add the vacuum-module to the list.

## Test Plan and Hands on Testing

- Make sure we can update modules, including the vacuum module

## Changelog

- fix udev rule file
- add vacuum-module to update list

## Review requests
## Risk assessment