### PR TITLE
ci(analyses snapshots,locize): upgrade external actions versions

### DIFF
--- a/.github/workflows/analyses-snapshot-test.yaml
+++ b/.github/workflows/analyses-snapshot-test.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Setup UV
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.12'
           enable-cache: true
@@ -97,7 +97,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Setup UV
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.12'
           enable-cache: true
@@ -134,7 +134,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
       - name: Setup UV
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.12'
           enable-cache: true

--- a/.github/workflows/analyses-snapshot-test.yaml
+++ b/.github/workflows/analyses-snapshot-test.yaml
@@ -40,9 +40,9 @@ jobs:
       matrix_json: ${{ steps.set-matrix.outputs.json }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup UV
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: '3.12'
           enable-cache: true
@@ -54,7 +54,7 @@ jobs:
         working-directory: ./analyses-snapshot-testing
         run: make gen-chunks
       - name: Save Chunks
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: chunks
           path: analyses-snapshot-testing/chunks/
@@ -67,7 +67,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Are the analyses snapshots in my PR branch in sync with the target branch?
         if: github.event_name == 'pull_request'
         run: |
@@ -95,9 +95,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup UV
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: '3.12'
           enable-cache: true
@@ -105,7 +105,7 @@ jobs:
       - name: Setup the project
         working-directory: ./analyses-snapshot-testing
         run: make setup
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: chunks
           path: analyses-snapshot-testing/chunks/
@@ -113,7 +113,7 @@ jobs:
         working-directory: ./analyses-snapshot-testing
         run: make analyze-chunk CHUNK=${{ matrix.chunk.chunk_id }}
       - name: Upload Analysis Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           # Each chunk uploads its files as one artifact named after the chunk
           name: analysis-results-${{ matrix.chunk.chunk_id }}.zip
@@ -132,9 +132,9 @@ jobs:
       PR_TARGET_BRANCH: ${{ github.event.pull_request.base.ref || 'edge'}}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup UV
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: '3.12'
           enable-cache: true
@@ -143,7 +143,7 @@ jobs:
         working-directory: ./analyses-snapshot-testing
         run: make setup
       - name: Download All Analysis Results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: analysis-results-*
           path: all_analysis_results
@@ -164,7 +164,7 @@ jobs:
 
       - name: Upload Report
         if: '!cancelled()'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-report
           path: analyses-snapshot-testing/results/
@@ -178,7 +178,7 @@ jobs:
       - name: Create Snapshot update Request
         id: create_pull_request
         if: always() && steps.handle_failure.outcome == 'success' && env.OPEN_PR_ON_FAILURE == 'true' && github.event_name == 'pull_request'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: 'fix(analyses-snapshot-testing): heal analyses snapshots'
           title: 'fix(analyses-snapshot-testing): heal ${{ github.event.pull_request.head.ref }} snapshots'
@@ -203,7 +203,7 @@ jobs:
 
       - name: Create Snapshot update Request on edge overnight failure
         if: always() && steps.handle_failure.outcome == 'success' && github.event_name == 'schedule'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: 'fix(analyses-snapshot-testing): heal edge snapshots'
           title: 'fix(analyses-snapshot-testing): heal edge snapshots'

--- a/.github/workflows/locize-sync.yaml
+++ b/.github/workflows/locize-sync.yaml
@@ -41,7 +41,7 @@ jobs:
       - uses: ./.github/actions/js/setup
 
       - name: Setup UV
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/locize-sync.yaml
+++ b/.github/workflows/locize-sync.yaml
@@ -33,7 +33,7 @@ jobs:
       CI: true
     steps:
       - name: Checkout target branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.target_branch }}
           fetch-depth: 1
@@ -41,7 +41,7 @@ jobs:
       - uses: ./.github/actions/js/setup
 
       - name: Setup UV
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
           python-version: '3.12'
 
@@ -52,7 +52,7 @@ jobs:
         run: uv run scripts/locize_sync.py ${{ inputs.locize_action }}
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: automation/locize-${{ inputs.locize_action }}-${{ github.run_id }}
           base: ${{ inputs.target_branch }}


### PR DESCRIPTION
## Overview

### Main reason for this is `peter-evans/create-pull-request@v7` has a warning

Bump GitHub Actions in **analyses snapshot** (`.github/workflows/analyses-snapshot-test.yaml`) and **Locize sync** (`.github/workflows/locize-sync.yaml`) to current tags: `actions/checkout@v6`, `astral-sh/setup-uv@v8`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `peter-evans/create-pull-request@v8`. CI-only; no app or package code.

**Done when:** both workflows run green and artifact plus optional heal / Locize PR steps still behave as before.

## Test plan

- Let CI run on this PR; confirm analyses snapshot matrix, artifact upload/download, and Locize job succeed.
- If you use heal or Locize PR creation, spot-check one run after merge.

## Changelog

- CI: upgraded checkout, UV setup, artifact, and create-pull-request actions in the two workflows above.

## Review focus

- Artifact names/paths unchanged; `create-pull-request` `with:` still valid for v8.

## Risk

- **Medium:** several action majors; blast radius is CI only. Mitigated by green runs and quick checks on PR automation paths.