### PR TITLE
feat(api): Implement pyro_behavior for special dictionary serialization

### DIFF
--- a/api/src/opentrons/hardware_control/backends/ot3utils.py
+++ b/api/src/opentrons/hardware_control/backends/ot3utils.py
@@ -666,7 +666,9 @@ class UpdateProgress:
                 if isinstance(target, NodeId)
                 else SubSystem.rear_panel
             )
-            self._tracker[target] = UpdateStatus(subsystem, UpdateState.queued, 0)
+            self._tracker[target] = UpdateStatus.model_construct(
+                subsystem=subsystem, state=UpdateState.queued, progress=0
+            )
 
     @property
     def targets(self) -> Set[FirmwareTarget]:
@@ -689,7 +691,9 @@ class UpdateProgress:
         )
         state = fw_update_state_from_status(fw_update_status)
         progress = int(progress * 100)
-        self._tracker[target] = UpdateStatus(subsystem, state, progress)
+        self._tracker[target] = UpdateStatus.model_construct(
+            subsystem=subsystem, state=state, progress=progress
+        )
         return set(self._tracker.values())
 
 

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -387,7 +387,7 @@ class OT3API(
 
     def _reset_last_mount(self) -> None:
         self._last_moved_mount = None
-    
+
     @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     def get_deck_from_machine(
         self, machine_pos: Dict[Axis, float]
@@ -1058,7 +1058,9 @@ class OT3API(
         fail_on_not_homed: bool = False,
     ) -> Dict[Axis, float]:
         realmount = OT3Mount.from_mount(mount)
-        ot3_pos = await self.current_position_ot3(realmount, critical_point, refresh)
+        ot3_pos: Dict[Axis, float] = await self.current_position_ot3(
+            realmount, critical_point, refresh
+        )
         return ot3_pos
 
     @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
@@ -1158,7 +1160,10 @@ class OT3API(
         """
         Return the encoder position in absolute deck coords specified mount.
         """
-        return await self.encoder_current_position_ot3(mount, critical_point, refresh)
+        ot3_encoder_position: Dict[
+            Axis, float
+        ] = await self.encoder_current_position_ot3(mount, critical_point, refresh)
+        return ot3_encoder_position
 
     @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     async def encoder_current_position_ot3(
@@ -1757,7 +1762,8 @@ class OT3API(
     @property
     @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     def engaged_axes(self) -> Dict[Axis, bool]:
-        return self.get_engaged_axes()
+        axes: Dict[Axis, bool] = self.get_engaged_axes()
+        return axes
 
     async def disengage_axes(self, which: List[Axis]) -> None:
         await self._backend.disengage_axes(which)
@@ -2541,7 +2547,8 @@ class OT3API(
     @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     def get_attached_instruments(self) -> Dict[top_types.Mount, PipetteDict]:
         # Warning: don't use this in new code, used `get_attached_pipettes` instead
-        return self.get_attached_pipettes()
+        pipettes: Dict[top_types.Mount, PipetteDict] = self.get_attached_pipettes()
+        return pipettes
 
     async def get_instrument_state(
         self,
@@ -2821,7 +2828,8 @@ class OT3API(
         )
         machine_pos = await self._backend.update_position()
         machine_pos[Axis.by_mount(mount)] = end_z
-        deck_end_z = self.get_deck_from_machine(machine_pos)[Axis.by_mount(mount)]
+        deck_from_machine: Dict[Axis, float] = self.get_deck_from_machine(machine_pos)
+        deck_end_z = deck_from_machine[Axis.by_mount(mount)]
         offset = offset_for_mount(
             mount,
             top_types.Point(*self._config.left_mount_offset),

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -143,6 +143,7 @@ from opentrons.hardware_control.modules.module_calibration import (
 )
 from opentrons.util.pyro.pyro_synchronous_adapter import (
     convert_result_to_proxy,
+    convert_result_to_wrapped_dict,
     pyro_behavior,
 )
 
@@ -386,7 +387,8 @@ class OT3API(
 
     def _reset_last_mount(self) -> None:
         self._last_moved_mount = None
-
+    
+    @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     def get_deck_from_machine(
         self, machine_pos: Dict[Axis, float]
     ) -> Dict[Axis, float]:
@@ -724,6 +726,7 @@ class OT3API(
         self._gripper_handler.gripper = g
         return skipped
 
+    @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     def get_all_attached_instr(self) -> Dict[OT3Mount, Optional[InstrumentDict]]:
         # NOTE (spp, 2023-03-07): The return type of this method indicates that
         #  if a particular mount has no attached instrument then it will provide a
@@ -1046,6 +1049,7 @@ class OT3API(
     def _carriage_offset(self) -> top_types.Point:
         return top_types.Point(*self._config.carriage_offset)
 
+    @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     async def current_position(
         self,
         mount: Union[top_types.Mount, OT3Mount],
@@ -1057,6 +1061,7 @@ class OT3API(
         ot3_pos = await self.current_position_ot3(realmount, critical_point, refresh)
         return ot3_pos
 
+    @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     async def current_position_ot3(
         self,
         mount: OT3Mount,
@@ -1143,6 +1148,7 @@ class OT3API(
     def encoder_status_ok(self, axis: Axis) -> bool:
         return self._backend.check_encoder_status([axis])
 
+    @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     async def encoder_current_position(
         self,
         mount: Union[top_types.Mount, OT3Mount],
@@ -1154,6 +1160,7 @@ class OT3API(
         """
         return await self.encoder_current_position_ot3(mount, critical_point, refresh)
 
+    @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     async def encoder_current_position_ot3(
         self,
         mount: Union[top_types.Mount, OT3Mount],
@@ -1742,11 +1749,13 @@ class OT3API(
         async with self._motion_lock:
             await self._home(home_seq)
 
+    @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     def get_engaged_axes(self) -> Dict[Axis, bool]:
         """Which axes are engaged and holding."""
         return self._backend.engaged_axes()
 
     @property
+    @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     def engaged_axes(self) -> Dict[Axis, bool]:
         return self.get_engaged_axes()
 
@@ -1761,6 +1770,7 @@ class OT3API(
     def axis_is_present(self, axis: Axis) -> bool:
         return self._backend.axis_is_present(axis)
 
+    @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     async def get_limit_switches(self) -> Dict[Axis, bool]:
         res = await self._backend.get_limit_switches()
         return {ax: val for ax, val in res.items()}
@@ -2520,6 +2530,7 @@ class OT3API(
         # Warning: don't use this in new code, used `hardware_pipettes` instead
         return self.hardware_pipettes
 
+    @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     def get_attached_pipettes(self) -> Dict[top_types.Mount, PipetteDict]:
         return {
             m.to_mount(): pd
@@ -2527,6 +2538,7 @@ class OT3API(
             if m != OT3Mount.GRIPPER
         }
 
+    @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     def get_attached_instruments(self) -> Dict[top_types.Mount, PipetteDict]:
         # Warning: don't use this in new code, used `get_attached_pipettes` instead
         return self.get_attached_pipettes()
@@ -2653,6 +2665,7 @@ class OT3API(
         return self.attached_pipettes
 
     @property
+    @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     def attached_pipettes(self) -> Dict[top_types.Mount, PipetteDict]:
         return {
             m.to_mount(): d
@@ -3223,6 +3236,7 @@ class OT3API(
             dispense_spec.instr.remove_current_volume(dispense_spec.volume)
 
     @property
+    @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)
     def attached_subsystems(self) -> Dict[SubSystem, SubSystemState]:
         """Get a view of the state of the currently-attached subsystems."""
         return self._backend.subsystems

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -4,10 +4,13 @@ from typing import Dict
 
 import opentrons.config.types
 import opentrons.hardware_control.types
+import opentrons.hardware_control.dev_types
 import opentrons.types
 from opentrons.util.pyro.pyro_serialization import (
     OpentronsPyroSerializer,
     find_enums_in_packages,
+    find_pydantic_classes_in_packages,
+    find_typed_dict_classes_in_packages,
     register_type_to_serpent,
     serpent_enum_registration,
 )
@@ -37,49 +40,37 @@ def _estop_overall_status_class_to_dict(obj) -> Dict:  # type: ignore
     }
 
 
-# UpdateStatus registry
-def _update_status_dict_to_class(  # type: ignore
-    classname, d
-) -> opentrons.hardware_control.types.UpdateStatus:
-    return opentrons.hardware_control.types.UpdateStatus(
-        subsystem=opentrons.hardware_control.types.SubSystem(d["subsystem"]),
-        state=opentrons.hardware_control.types.UpdateState(d["state"]),
-        progress=d["progress"],
-    )
-
-
-def _update_status_class_to_dict(obj) -> Dict:  # type: ignore
-    return {
-        "__class__": "opentrons.hardware_control.types.UpdateStatus",
-        "subsystem": obj.subsystem.value,
-        "state": obj.state.value,
-        "progress": obj.progress,
-    }
-
-
 # Handy function to map all registries for the Hardware controller
 def register_hardware_types() -> None:
     """Registers serialize and deserialize behavior for Opentrons Hardware types and classes.
     Pyro serializes our dataclasses into dicts, but doesn't convert them back to their native types automatically.
     """
     opentrons_types = find_enums_in_packages(
-        [opentrons.types, opentrons.config.types, opentrons.hardware_control.types]
+        [opentrons.types, opentrons.config.types, opentrons.hardware_control.types, opentrons.hardware_control.dev_types]
     )
 
     with serpent_enum_registration():
         for enum_type in opentrons_types:
             OpentronsPyroSerializer.register_enum(enum_type)
 
+    opentrons_pydantic_types = find_pydantic_classes_in_packages(
+        [opentrons.types, opentrons.config.types, opentrons.hardware_control.types]
+    )
+    for pydantic_type in opentrons_pydantic_types:
+        OpentronsPyroSerializer.register_pydantic_model(pydantic_type)
+
+    opentrons_typed_dicts = find_typed_dict_classes_in_packages(
+        [opentrons.hardware_control.dev_types]
+    )
+    for typed_dict in opentrons_typed_dicts:
+        OpentronsPyroSerializer.register_typed_dict(typed_dict)
+
+    OpentronsPyroSerializer.register_unhashable_dicts()
+
+
     # E-Stop Overall registration
     register_type_to_serpent(
         class_type=opentrons.hardware_control.types.EstopOverallStatus,
         dict_to_class=_estop_overall_status_dict_to_class,
         class_to_dict=_estop_overall_status_class_to_dict,
-    )
-
-    # UpdateStatus registration
-    register_type_to_serpent(
-        class_type=opentrons.hardware_control.types.UpdateStatus,
-        dict_to_class=_update_status_dict_to_class,
-        class_to_dict=_update_status_class_to_dict,
     )

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -3,8 +3,8 @@
 from typing import Dict
 
 import opentrons.config.types
-import opentrons.hardware_control.types
 import opentrons.hardware_control.dev_types
+import opentrons.hardware_control.types
 import opentrons.types
 from opentrons.util.pyro.pyro_serialization import (
     OpentronsPyroSerializer,
@@ -46,7 +46,12 @@ def register_hardware_types() -> None:
     Pyro serializes our dataclasses into dicts, but doesn't convert them back to their native types automatically.
     """
     opentrons_types = find_enums_in_packages(
-        [opentrons.types, opentrons.config.types, opentrons.hardware_control.types, opentrons.hardware_control.dev_types]
+        [
+            opentrons.types,
+            opentrons.config.types,
+            opentrons.hardware_control.types,
+            opentrons.hardware_control.dev_types,
+        ]
     )
 
     with serpent_enum_registration():
@@ -66,7 +71,6 @@ def register_hardware_types() -> None:
         OpentronsPyroSerializer.register_typed_dict(typed_dict)
 
     OpentronsPyroSerializer.register_unhashable_dicts()
-
 
     # E-Stop Overall registration
     register_type_to_serpent(

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -26,6 +26,8 @@ from opentrons.config import feature_flags
 # to live in this file
 from opentrons.config.types import OT3AxisKind as OT3AxisKind
 
+from pydantic import BaseModel
+
 if TYPE_CHECKING:
     from .modules.types import ModuleModel
 
@@ -302,15 +304,13 @@ class UpdateState(enum.Enum):
         return self.value
 
 
-@dataclass(frozen=True)
-class UpdateStatus:
+class UpdateStatus(BaseModel):
     subsystem: SubSystem
     state: UpdateState
     progress: int
 
 
-@dataclass
-class SubSystemState:
+class SubSystemState(BaseModel):
     ok: bool
     current_fw_version: int
     next_fw_version: int

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -14,6 +14,7 @@ from typing import (
     cast,
 )
 
+from pydantic import BaseModel, ConfigDict
 from typing_extensions import Literal
 
 from opentrons_shared_data.errors.exceptions import EnumeratedError
@@ -25,8 +26,6 @@ from opentrons.config import feature_flags
 # this is an explicit re-export that exists for backward compatibility - this type used
 # to live in this file
 from opentrons.config.types import OT3AxisKind as OT3AxisKind
-
-from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from .modules.types import ModuleModel
@@ -305,6 +304,8 @@ class UpdateState(enum.Enum):
 
 
 class UpdateStatus(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     subsystem: SubSystem
     state: UpdateState
     progress: int

--- a/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
@@ -5,6 +5,8 @@ from typing import Any, Iterator, ParamSpec, TypeVar
 
 import Pyro5.api
 
+from opentrons.util.pyro.pyro_serialization import UnhashableDictWrapper
+
 T = TypeVar("T")
 P = ParamSpec("P")
 
@@ -58,7 +60,7 @@ def _build_classdict(
             yield (method, async_method)
         else:
             # For standard method calls forward the direct call to the method on the PSO Proxy.
-            yield (method, attribute)
+            yield (method, wrap_parameter_validation(attribute))
     # Attach PSO exposed attributes to the AsyncClientPyroObject
     for attr in pso._pyroAttrs:
         # For property attributes we use to attach a wrapped `getattr` call for that attribute.
@@ -91,7 +93,8 @@ def wrap_as_async(method_metadata: dict[str, Any]) -> Any:
             # This must be done because Pyro only accepts proxy calls from the thread that owns the proxy
             thread_proxy = Pyro5.api.Proxy(proxy._pyroUri)  # type: ignore
             func = getattr(thread_proxy, func_name)
-            return func(*args, **kwargs)
+            validated_func = wrap_parameter_validation(func)
+            return validated_func(self, *args, **kwargs)
 
         # Return a Coroutine that may be awaited, it will execute the `_thread_call` when called
         return await asyncio.to_thread(
@@ -111,3 +114,52 @@ def wrap_as_async(method_metadata: dict[str, Any]) -> Any:
 def wrap_property(proxy: Pyro5.api.Proxy, attr: str) -> Any:
     """Wrapper to produce a call forward to a specified attribute of a Proxy object."""
     return lambda self, current_attr=attr: getattr(proxy, current_attr)
+
+
+def wrap_parameter_validation(attr: Any) -> Any:
+    """Validate outbound parameter requests before allowing serialization."""
+
+    def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:
+        # Validate individual arguments before forwarding the call
+        def _validations(arg: Any) -> Any:
+            # Extend this as further validations are needed
+            arg = _validate_hashable(arg)
+            return arg
+        if len(args) > 0:
+            validated_args = tuple()
+            for arg in args:
+                validated_args = (*validated_args, _validations(arg))
+        else:
+            validated_args = args
+        if len(kwargs) > 0:
+            for key in kwargs.keys():
+                kwargs[key] = _validations(kwargs[key])
+
+        return attr(*validated_args, **kwargs)
+
+    return wrapper
+
+
+# Hashable dictionary parameter validation
+def _validate_hashable(arg: Any) -> Any:
+    if isinstance(arg, dict):
+        try:
+            hash(arg)
+        except TypeError:
+            if all(
+                isinstance(key, type(list(arg.keys())[0])) for key in arg.keys()
+            ) and all(
+                isinstance(value, type(list(arg.values())[0])) for value in arg.values()
+            ):
+                key_type = type(list(arg.keys())[0])
+                value_type = type(list(arg.values())[0])
+            else:
+                raise KeyError(
+                    "Async Client Pyro Object does not support transmission of multitype unhashable dictionaries."
+                )
+            return UnhashableDictWrapper(
+                dictionary=arg,
+                key_type=".".join((key_type.__module__, key_type.__qualname__)),
+                value_type=".".join((value_type.__module__, value_type.__qualname__)),
+            )
+    return arg

--- a/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
@@ -119,14 +119,15 @@ def wrap_property(proxy: Pyro5.api.Proxy, attr: str) -> Any:
 def wrap_parameter_validation(attr: Any) -> Any:
     """Validate outbound parameter requests before allowing serialization."""
 
-    def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:
+    def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:  # type: ignore
         # Validate individual arguments before forwarding the call
         def _validations(arg: Any) -> Any:
-            # Extend this as further validations are needed
+            # NOTE: Extend this as further validations are needed
             arg = _validate_hashable(arg)
             return arg
+
         if len(args) > 0:
-            validated_args = tuple()
+            validated_args = tuple()  # type: ignore
             for arg in args:
                 validated_args = (*validated_args, _validations(arg))
         else:
@@ -134,7 +135,6 @@ def wrap_parameter_validation(attr: Any) -> Any:
         if len(kwargs) > 0:
             for key in kwargs.keys():
                 kwargs[key] = _validations(kwargs[key])
-
         return attr(*validated_args, **kwargs)
 
     return wrapper

--- a/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
@@ -126,15 +126,13 @@ def wrap_parameter_validation(attr: Any) -> Any:
             arg = _validate_hashable(arg)
             return arg
 
-        if len(args) > 0:
-            validated_args = tuple()  # type: ignore
-            for arg in args:
-                validated_args = (*validated_args, _validations(arg))
-        else:
-            validated_args = args
-        if len(kwargs) > 0:
-            for key in kwargs.keys():
-                kwargs[key] = _validations(kwargs[key])
+        validated_args = tuple()  # type: ignore
+        for arg in args:
+            # Validate each non-keyword argument and reconstruct the argument tuple
+            validated_args = (*validated_args, _validations(arg))
+        # Validate each keyword argument and reconstruct the kwargs dictionary
+        kwargs = {key: _validations(kwargs[key]) for key in kwargs.keys()}
+
         return attr(*validated_args, **kwargs)
 
     return wrapper
@@ -142,6 +140,12 @@ def wrap_parameter_validation(attr: Any) -> Any:
 
 # Hashable dictionary parameter validation
 def _validate_hashable(arg: Any) -> Any:
+    """Handle an argument which is a dictionary and is not hashable (uses mutable Opentrons types as keys).
+
+    This function will do the above by stripping out the types for a given key and value (multityped dictionaries
+    not supported) and wrapping the entire dictionary and these known types into an UnhashableDictWrapper. This
+    will then be deserialized back into it's original form by the OpentronsPyroSerializer library.
+    """
     if isinstance(arg, dict):
         try:
             hash(arg)

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -4,19 +4,21 @@ import enum
 import inspect
 from contextlib import contextmanager
 from types import ModuleType
-from typing import Any, Callable, Iterator, Dict
-from typing_extensions import TypedDict, is_typeddict
+from typing import Any, Callable, Iterator
 
 import serpent
 from pydantic import BaseModel
 from Pyro5 import api as pyro
+from typing_extensions import TypedDict, is_typeddict
+
 
 class UnhashableDictWrapper(BaseModel):
     """This is a specialty model created to safely wrap dictionaries with mutable elements provided by Opentrons APIs.
-    
-    When registering types, be sure to utilize `register_unhashable_dicts` to ensure proper serialization between processes."""
 
-    dictionary: Dict
+    When registering types, be sure to utilize `register_unhashable_dicts` to ensure proper serialization between processes.
+    """
+
+    dictionary: dict[Any, Any]
     key_type: str
     value_type: str
 
@@ -30,7 +32,10 @@ def find_enums_in_packages(modules: list[ModuleType]) -> list[type[enum.Enum]]:
                 enums.append(obj)
     return enums
 
-def find_pydantic_classes_in_packages(modules: list[ModuleType]) -> list[type[BaseModel]]:
+
+def find_pydantic_classes_in_packages(
+    modules: list[ModuleType],
+) -> list[type[BaseModel]]:
     """Returns a list of pydantic classes in the given list of modules."""
     pydantic_classes = []
     for module in modules:
@@ -39,14 +44,18 @@ def find_pydantic_classes_in_packages(modules: list[ModuleType]) -> list[type[Ba
                 pydantic_classes.append(obj)
     return pydantic_classes
 
-def find_typed_dict_classes_in_packages(modules: list[ModuleType]) -> list[type[TypedDict]]:
+
+def find_typed_dict_classes_in_packages(
+    modules: list[ModuleType],
+) -> list[type[TypedDict]]:  # type: ignore
     """Returns a list of typed dict classes in the given list of modules."""
     dict_classes = []
     for module in modules:
         for name, obj in inspect.getmembers(module, inspect.isclass):
-            if is_typeddict(obj) and obj is not TypedDict:
+            if is_typeddict(obj):
                 dict_classes.append(obj)
     return dict_classes
+
 
 def _serpent_enum_serializer(
     obj: Any, serializer: Any, stream: Any, level: Any
@@ -86,7 +95,7 @@ class OpentronsPyroSerializer:
 
     _pydantic_class_name_to_model: dict[str, type[BaseModel]] = {}
     _enum_class_name_to_model: dict[str, type[enum.Enum]] = {}
-    _typed_dict_class_name_to_model: dict[str, type[TypedDict]] = {}
+    _typed_dict_class_name_to_model: dict[str, type[TypedDict]] = {}  # type: ignore
 
     @classmethod
     def register_enum(cls, enum_type: type[enum.Enum]) -> None:
@@ -141,105 +150,72 @@ class OpentronsPyroSerializer:
                 f"Could not convert {class_name} to an object, unregistered with pyro."
             )
         return model.model_validate(d)
-    
+
     @classmethod
-    def register_typed_dict(cls, typed_dict: TypedDict) -> None:
-        """Registered a TypedDict type to be sent and received via pyro proxies."""
-        # class_name = register_type_to_serpent(
-        #     typed_dict, cls._typed_dict_dict_to_class, cls._typed_dict_class_to_dict
-        # )
+    def register_typed_dict(cls, typed_dict: type) -> None:
+        """Registered a TypedDict type to the OpentronsPyroSerializer for tracking and deserialization purposes only."""
         class_name = ".".join((typed_dict.__module__, typed_dict.__qualname__))
         cls._typed_dict_class_name_to_model[class_name] = typed_dict
 
-    # @classmethod
-    # def _typed_dict_class_to_dict(cls, typed_dict: TypedDict) -> dict[str, Any]:
-    #     print("IN HERE FOR DICT CLASS")
-    #     typed_dict["__class__"] = ".".join((typed_dict.__module__, typed_dict.__class__.__name__))
-    #     print(f"typed dict class: {typed_dict["__class__"]}")
-    #     return typed_dict
-    
-    # @classmethod
-    # def _typed_dict_dict_to_class(cls, class_name: str, d: dict[str, Any]) -> TypedDict:
-    #     del d["__class__"]
-    #     print("IN HERE")
-    #     try:
-    #         model = cls._typed_dict_class_name_to_model[class_name]
-    #     except KeyError:
-    #         raise TypeError(
-    #             f"Could not convert {class_name} to an object, unregistered with pyro."
-    #         )
-    #     print("CONTINUING HERE")
-    #     return model(d)
-    
     @classmethod
     def register_unhashable_dicts(cls) -> None:
         """Registers the specialty handler for unhashable dicts using UnhashableDictWrapper."""
         class_name = register_type_to_serpent(
-            UnhashableDictWrapper, cls._unhashable_dict_wrapper_dict_to_class, cls._pydantic_class_to_dict
+            UnhashableDictWrapper,
+            cls._unhashable_dict_wrapper_dict_to_class,
+            cls._pydantic_class_to_dict,
         )
         cls._pydantic_class_name_to_model[class_name] = UnhashableDictWrapper
 
     @classmethod
-    def _unhashable_dict_wrapper_dict_to_class(cls, classname: str, d: dict[str, Any]) -> Dict:
-        del d["__class__"]
-        try:
-            key_model = cls._pydantic_class_name_to_model[d["key_type"]]
-        except KeyError:
-            try:
-                key_model = cls._enum_class_name_to_model[d["key_type"]]
-            except KeyError:
-                raise TypeError(
-                    f"Could not convert Dictionary Key {d["key_type"]} to an object, unregistered with pyro."
-                )
-        try:
-            value_model = cls._pydantic_class_name_to_model[d["value_type"]]
-        except KeyError:
-            try:
-                value_model = cls._enum_class_name_to_model[d["value_type"]]
-            except KeyError:
-                try:
-                    value_model = cls._typed_dict_class_name_to_model[d["value_type"]]
-                    print("found a dictionary")
-                except KeyError:
-                    raise TypeError(
-                        f"Could not convert Dictionary Value {d["value_type"]} to an object, unregistered with pyro."
-                    )
+    def _unhashable_dict_wrapper_dict_to_class(  # noqa: C901
+        cls, classname: str, d: dict[str, Any]
+    ) -> dict[Any, Any]:
+        registries: list[dict[str, Any]] = [
+            cls._pydantic_class_name_to_model,
+            cls._enum_class_name_to_model,
+            cls._typed_dict_class_name_to_model,
+        ]
+        key_model = None
+        value_model = None
+        for registry in registries:
+            if d["key_type"] in registry:
+                key_model = registry[d["key_type"]]
+            if d["value_type"] in registry:
+                value_model = registry[d["value_type"]]
+
+        if key_model is None or value_model is None:
+            raise TypeError(
+                f"Could not convert Dictionary item {key_model if key_model is None else value_model} to an object, unregistered with pyro."
+            )
         unwrapped_dictionary = {}
-        # Unwrap the dictionary and format all keys and values to respective expected types
-        print("getting this far")
+        # Unwrap the dictionary and format all keys and values to respective types
         for key in d["dictionary"]:
+            # Handle Key unwrapping
             if issubclass(key_model, enum.Enum):
                 try:
-                    converted_key = int(key)
+                    unwrapped_key = key_model(int(key))
                 except ValueError:
-                    converted_key = key
-                
-                # Handle values stored with `typing.Optional` results
-                if d["dictionary"][key] is None:
-                    unwrapped_dictionary[key_model(converted_key)] = d["dictionary"][key]
-                # Handle the remainder of formatting cases
-                elif issubclass(value_model, enum.Enum):
-                    try:
-                        unwrapped_dictionary[key_model(converted_key)] = value_model(int(d["dictionary"][key]))
-                    except ValueError:
-                        unwrapped_dictionary[key_model(converted_key)] = value_model(d["dictionary"][key])
-                elif issubclass(value_model, BaseModel):
-                    unwrapped_dictionary[key_model(converted_key)] = value_model.model_validate(d["dictionary"][key])
-                else:
-                    unwrapped_dictionary[key_model(converted_key)] = value_model(d["dictionary"][key])
+                    unwrapped_key = key_model(key)
+            elif issubclass(key_model, BaseModel):
+                unwrapped_key = key_model.model_validate(key)
             else:
-                # Handles values stored with `typing.Optional` results
-                if d["dictionary"][key] is None:
-                    unwrapped_dictionary[key_model.model_validate(key)] = d["dictionary"][key]
-                # Handle the remainder of formatting cases
-                elif issubclass(value_model, enum.Enum):
-                    try:
-                        unwrapped_dictionary[key_model.model_validate(key)] = value_model(int(d["dictionary"][key]))
-                    except ValueError:
-                        unwrapped_dictionary[key_model.model_validate(key)] = value_model(d["dictionary"][key])
-                
-                elif issubclass(value_model, BaseModel):
-                    unwrapped_dictionary[key_model.model_validate(key)] = value_model.model_validate(d["dictionary"][key])
-                else:
-                    unwrapped_dictionary[key_model.model_validate(key)] = value_model(d["dictionary"][key])
+                unwrapped_key = key_model(key)
+
+            # Handle Value unwrapping
+            if d["dictionary"][key] is None:
+                # Catching values that may have been `typing.Optional`
+                unwrapped_value = d["dictionary"][key]
+            elif issubclass(value_model, enum.Enum):
+                try:
+                    unwrapped_value = value_model(int(d["dictionary"][key]))
+                except ValueError:
+                    unwrapped_value = value_model(d["dictionary"][key])
+            elif issubclass(value_model, BaseModel):
+                unwrapped_value = value_model.model_validate(d["dictionary"][key])
+            else:
+                unwrapped_value = value_model(d["dictionary"][key])
+
+            unwrapped_dictionary[unwrapped_key] = unwrapped_value
+
         return unwrapped_dictionary

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -4,11 +4,21 @@ import enum
 import inspect
 from contextlib import contextmanager
 from types import ModuleType
-from typing import Any, Callable, Iterator
+from typing import Any, Callable, Iterator, Dict
+from typing_extensions import TypedDict, is_typeddict
 
 import serpent
 from pydantic import BaseModel
 from Pyro5 import api as pyro
+
+class UnhashableDictWrapper(BaseModel):
+    """This is a specialty model created to safely wrap dictionaries with mutable elements provided by Opentrons APIs.
+    
+    When registering types, be sure to utilize `register_unhashable_dicts` to ensure proper serialization between processes."""
+
+    dictionary: Dict
+    key_type: str
+    value_type: str
 
 
 def find_enums_in_packages(modules: list[ModuleType]) -> list[type[enum.Enum]]:
@@ -20,6 +30,23 @@ def find_enums_in_packages(modules: list[ModuleType]) -> list[type[enum.Enum]]:
                 enums.append(obj)
     return enums
 
+def find_pydantic_classes_in_packages(modules: list[ModuleType]) -> list[type[BaseModel]]:
+    """Returns a list of pydantic classes in the given list of modules."""
+    pydantic_classes = []
+    for module in modules:
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            if issubclass(obj, BaseModel) and obj is not BaseModel:
+                pydantic_classes.append(obj)
+    return pydantic_classes
+
+def find_typed_dict_classes_in_packages(modules: list[ModuleType]) -> list[type[TypedDict]]:
+    """Returns a list of typed dict classes in the given list of modules."""
+    dict_classes = []
+    for module in modules:
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            if is_typeddict(obj) and obj is not TypedDict:
+                dict_classes.append(obj)
+    return dict_classes
 
 def _serpent_enum_serializer(
     obj: Any, serializer: Any, stream: Any, level: Any
@@ -59,6 +86,7 @@ class OpentronsPyroSerializer:
 
     _pydantic_class_name_to_model: dict[str, type[BaseModel]] = {}
     _enum_class_name_to_model: dict[str, type[enum.Enum]] = {}
+    _typed_dict_class_name_to_model: dict[str, type[TypedDict]] = {}
 
     @classmethod
     def register_enum(cls, enum_type: type[enum.Enum]) -> None:
@@ -113,3 +141,105 @@ class OpentronsPyroSerializer:
                 f"Could not convert {class_name} to an object, unregistered with pyro."
             )
         return model.model_validate(d)
+    
+    @classmethod
+    def register_typed_dict(cls, typed_dict: TypedDict) -> None:
+        """Registered a TypedDict type to be sent and received via pyro proxies."""
+        # class_name = register_type_to_serpent(
+        #     typed_dict, cls._typed_dict_dict_to_class, cls._typed_dict_class_to_dict
+        # )
+        class_name = ".".join((typed_dict.__module__, typed_dict.__qualname__))
+        cls._typed_dict_class_name_to_model[class_name] = typed_dict
+
+    # @classmethod
+    # def _typed_dict_class_to_dict(cls, typed_dict: TypedDict) -> dict[str, Any]:
+    #     print("IN HERE FOR DICT CLASS")
+    #     typed_dict["__class__"] = ".".join((typed_dict.__module__, typed_dict.__class__.__name__))
+    #     print(f"typed dict class: {typed_dict["__class__"]}")
+    #     return typed_dict
+    
+    # @classmethod
+    # def _typed_dict_dict_to_class(cls, class_name: str, d: dict[str, Any]) -> TypedDict:
+    #     del d["__class__"]
+    #     print("IN HERE")
+    #     try:
+    #         model = cls._typed_dict_class_name_to_model[class_name]
+    #     except KeyError:
+    #         raise TypeError(
+    #             f"Could not convert {class_name} to an object, unregistered with pyro."
+    #         )
+    #     print("CONTINUING HERE")
+    #     return model(d)
+    
+    @classmethod
+    def register_unhashable_dicts(cls) -> None:
+        """Registers the specialty handler for unhashable dicts using UnhashableDictWrapper."""
+        class_name = register_type_to_serpent(
+            UnhashableDictWrapper, cls._unhashable_dict_wrapper_dict_to_class, cls._pydantic_class_to_dict
+        )
+        cls._pydantic_class_name_to_model[class_name] = UnhashableDictWrapper
+
+    @classmethod
+    def _unhashable_dict_wrapper_dict_to_class(cls, classname: str, d: dict[str, Any]) -> Dict:
+        del d["__class__"]
+        try:
+            key_model = cls._pydantic_class_name_to_model[d["key_type"]]
+        except KeyError:
+            try:
+                key_model = cls._enum_class_name_to_model[d["key_type"]]
+            except KeyError:
+                raise TypeError(
+                    f"Could not convert Dictionary Key {d["key_type"]} to an object, unregistered with pyro."
+                )
+        try:
+            value_model = cls._pydantic_class_name_to_model[d["value_type"]]
+        except KeyError:
+            try:
+                value_model = cls._enum_class_name_to_model[d["value_type"]]
+            except KeyError:
+                try:
+                    value_model = cls._typed_dict_class_name_to_model[d["value_type"]]
+                    print("found a dictionary")
+                except KeyError:
+                    raise TypeError(
+                        f"Could not convert Dictionary Value {d["value_type"]} to an object, unregistered with pyro."
+                    )
+        unwrapped_dictionary = {}
+        # Unwrap the dictionary and format all keys and values to respective expected types
+        print("getting this far")
+        for key in d["dictionary"]:
+            if issubclass(key_model, enum.Enum):
+                try:
+                    converted_key = int(key)
+                except ValueError:
+                    converted_key = key
+                
+                # Handle values stored with `typing.Optional` results
+                if d["dictionary"][key] is None:
+                    unwrapped_dictionary[key_model(converted_key)] = d["dictionary"][key]
+                # Handle the remainder of formatting cases
+                elif issubclass(value_model, enum.Enum):
+                    try:
+                        unwrapped_dictionary[key_model(converted_key)] = value_model(int(d["dictionary"][key]))
+                    except ValueError:
+                        unwrapped_dictionary[key_model(converted_key)] = value_model(d["dictionary"][key])
+                elif issubclass(value_model, BaseModel):
+                    unwrapped_dictionary[key_model(converted_key)] = value_model.model_validate(d["dictionary"][key])
+                else:
+                    unwrapped_dictionary[key_model(converted_key)] = value_model(d["dictionary"][key])
+            else:
+                # Handles values stored with `typing.Optional` results
+                if d["dictionary"][key] is None:
+                    unwrapped_dictionary[key_model.model_validate(key)] = d["dictionary"][key]
+                # Handle the remainder of formatting cases
+                elif issubclass(value_model, enum.Enum):
+                    try:
+                        unwrapped_dictionary[key_model.model_validate(key)] = value_model(int(d["dictionary"][key]))
+                    except ValueError:
+                        unwrapped_dictionary[key_model.model_validate(key)] = value_model(d["dictionary"][key])
+                
+                elif issubclass(value_model, BaseModel):
+                    unwrapped_dictionary[key_model.model_validate(key)] = value_model.model_validate(d["dictionary"][key])
+                else:
+                    unwrapped_dictionary[key_model.model_validate(key)] = value_model(d["dictionary"][key])
+        return unwrapped_dictionary

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -1,5 +1,6 @@
 """Pyro related utilities for serialization of objects."""
 
+import builtins
 import enum
 import inspect
 from contextlib import contextmanager
@@ -176,8 +177,17 @@ class OpentronsPyroSerializer:
             cls._enum_class_name_to_model,
             cls._typed_dict_class_name_to_model,
         ]
-        key_model = None
-        value_model = None
+        # Identify the types for the key and values, if available. Check for builtin types first.
+        key_model = (
+            None
+            if "builtins" not in d["key_type"]
+            else getattr(builtins, d["key_type"].removeprefix("builtins."))
+        )
+        value_model = (
+            None
+            if "builtins" not in d["value_type"]
+            else getattr(builtins, d["value_type"].removeprefix("builtins."))
+        )
         for registry in registries:
             if d["key_type"] in registry:
                 key_model = registry[d["key_type"]]
@@ -186,7 +196,7 @@ class OpentronsPyroSerializer:
 
         if key_model is None or value_model is None:
             raise TypeError(
-                f"Could not convert Dictionary item {key_model if key_model is None else value_model} to an object, unregistered with pyro."
+                f"Could not convert Dictionary item `{d["key_type"] if key_model is None else d["value_type"]}` to an object, unregistered with pyro."
             )
         unwrapped_dictionary = {}
         # Unwrap the dictionary and format all keys and values to respective types

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -196,7 +196,7 @@ class OpentronsPyroSerializer:
 
         if key_model is None or value_model is None:
             raise TypeError(
-                f"Could not convert Dictionary item `{d["key_type"] if key_model is None else d["value_type"]}` to an object, unregistered with pyro."
+                f"Could not convert Dictionary item `{d['key_type'] if key_model is None else d['value_type']}` to an object, unregistered with pyro."
             )
         unwrapped_dictionary = {}
         # Unwrap the dictionary and format all keys and values to respective types

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -5,6 +5,7 @@ import functools
 import inspect
 from types import FunctionType, MethodType
 from typing import Any, Callable, Dict, Iterator, Optional, ParamSpec, TypeVar
+from opentrons.util.pyro.pyro_serialization import UnhashableDictWrapper
 
 from pydantic import BaseModel
 from Pyro5 import api as pyro
@@ -331,14 +332,15 @@ def convert_result_to_proxy(  # noqa: C901
     """
 
     @functools.wraps(attr)
-    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
+    def wrapper(self, *args: P.args, **kwargs: P.kwargs) -> Any:
+        # Of note, the wrapper passes self to terminate the self instance passed by the PSO
         if inspect.iscoroutinefunction(attr):
             sync_func = synchronous(attr)
             bound_method = MethodType(sync_func, core_obj)
-            result = asyncio.run(bound_method(*args, **kwargs))
+            result = bound_method(*args, **kwargs)
         elif isinstance(attr, FunctionType):
             bound_method = MethodType(attr, core_obj)
-            result = asyncio.run(bound_method(*args, **kwargs))
+            result = bound_method(*args, **kwargs)
         elif isinstance(attr, property):
             result = getattr(core_obj, name)
         else:
@@ -367,6 +369,62 @@ def convert_result_to_proxy(  # noqa: C901
         return property(wrapper)
     return wrapper
 
+
+def convert_result_to_wrapped_dict(
+        utility: DaemonUtility, core_obj: Any, name: str, attr: Callable[P, T]
+) -> Callable[P, T]:
+    """Wrapper that ensures a result of a method call through Pyro is a wrapped dictionary, which
+    is later deserialzed by serpent using special registries for UnhashableDictWrapper.
+
+    This particularly pretains to dictionary results that may contain keys which are mutable, such as SubSystem.
+    """
+    @functools.wraps(attr)
+    def wrapper(self, *args: P.args, **kwargs: P.kwargs) -> Any:
+        # Of note, the wrapper passes self to terminate the self instance passed by the PSO
+        if inspect.iscoroutinefunction(attr):
+            sync_func = synchronous(attr)
+            bound_method = MethodType(sync_func, core_obj)
+            result = bound_method(*args, **kwargs)
+            return_types = attr.__annotations__['return']
+        elif isinstance(attr, FunctionType):
+            bound_method = MethodType(attr, core_obj)
+            result = bound_method(*args, **kwargs)
+            return_types = attr.__annotations__['return']
+        elif isinstance(attr, property):
+            result = getattr(core_obj, name)
+            return_types = attr.fget.__annotations__['return']
+        else:
+            raise ValueError(
+                "Provided base attribute must be a Property, a Method or an Async method."
+            )
+        if isinstance(result, dict):
+            if hasattr(return_types, "__args__"):
+                key_type, value_type = return_types.__args__
+                # Filter out `typing.Optional`` typings to the inner type, only works for non-tuples
+                # todo(chb: 2025-04-01): Catch and error on cases where we have optional tuples, does that even happen?
+                try:
+                    key_type = next(a for a in key_type.__args__ if a is not type(None))
+                except AttributeError:
+                    pass
+                try:
+                    value_type = next(a for a in value_type.__args__ if a is not type(None))
+                except AttributeError:
+                    pass
+                wrapped_dict = UnhashableDictWrapper(
+                    dictionary=result,
+                    key_type=".".join((key_type.__module__, key_type.__qualname__)),
+                    value_type=".".join((value_type.__module__, value_type.__qualname__))
+                )
+                return wrapped_dict
+            else:
+                raise ValueError("Pyro behavior for dictionary wrapping requires function return types.")
+        else:
+            raise ValueError("Pyro behavior for dictionary wrapping is only available for use with dictionaries.")
+
+    if isinstance(attr, property):
+        # If the original attribute was a property, ensure the wrapped attribute is
+        return property(wrapper)
+    return wrapper
 
 ## Local Specialty Functions - Used to wrap attributes on the original instance
 

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -297,6 +297,7 @@ def _build_classdict(  # noqa: C901
 
 ### Helpers ###
 
+
 def _build_metadata_dictionary(attr: Any) -> Dict[str, Any]:
     return {
         "__module__": attr.__module__,
@@ -305,6 +306,7 @@ def _build_metadata_dictionary(attr: Any) -> Dict[str, Any]:
         "__doc__": attr.__doc__,
         "__type_params__": attr.__type_params__,
     }
+
 
 def _get_specialty_behavior(func: Any, name: str) -> _PyroSpecialBehavior | None:
     if inspect.iscoroutinefunction(func) or isinstance(func, FunctionType):

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -241,13 +241,7 @@ def _build_classdict(  # noqa: C901
             ):
                 # Apply the specialty function to the attribute on this PSO instance and expose the wrapped specialty method
                 if inspect.iscoroutinefunction(attr):
-                    async_metadata = {
-                        "__module__": attr.__module__,
-                        "__name__": attr.__name__,
-                        "__qualname__": attr.__qualname__,
-                        "__doc__": attr.__doc__,
-                        "__type_params__": attr.__type_params__,
-                    }
+                    async_metadata = _build_metadata_dictionary(attr)
                     async_methods[name] = async_metadata
                 exposed = pyro.expose(
                     specialty_behavior.specialty_function(utility, core_obj, name, attr)
@@ -257,13 +251,7 @@ def _build_classdict(  # noqa: C901
                 # Wrap coroutines in a synchronous function call, bound it to the original instance and expose the wrapped method
                 exposed = pyro.expose(synchronous(attr))
                 # Track the known async functions so they may be provided as metadata to a client wrapper
-                async_metadata = {
-                    "__module__": attr.__module__,
-                    "__name__": attr.__name__,
-                    "__qualname__": attr.__qualname__,
-                    "__doc__": attr.__doc__,
-                    "__type_params__": attr.__type_params__,
-                }
+                async_metadata = _build_metadata_dictionary(attr)
                 async_methods[name] = async_metadata
 
                 bound_method = MethodType(exposed, core_obj)
@@ -309,6 +297,14 @@ def _build_classdict(  # noqa: C901
 
 ### Helpers ###
 
+def _build_metadata_dictionary(attr: Any) -> Dict[str, Any]:
+    return {
+        "__module__": attr.__module__,
+        "__name__": attr.__name__,
+        "__qualname__": attr.__qualname__,
+        "__doc__": attr.__doc__,
+        "__type_params__": attr.__type_params__,
+    }
 
 def _get_specialty_behavior(func: Any, name: str) -> _PyroSpecialBehavior | None:
     if inspect.iscoroutinefunction(func) or isinstance(func, FunctionType):

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -5,10 +5,11 @@ import functools
 import inspect
 from types import FunctionType, MethodType
 from typing import Any, Callable, Dict, Iterator, Optional, ParamSpec, TypeVar
-from opentrons.util.pyro.pyro_serialization import UnhashableDictWrapper
 
 from pydantic import BaseModel
 from Pyro5 import api as pyro
+
+from opentrons.util.pyro.pyro_serialization import UnhashableDictWrapper
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -332,7 +333,7 @@ def convert_result_to_proxy(  # noqa: C901
     """
 
     @functools.wraps(attr)
-    def wrapper(self, *args: P.args, **kwargs: P.kwargs) -> Any:
+    def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:
         # Of note, the wrapper passes self to terminate the self instance passed by the PSO
         if inspect.iscoroutinefunction(attr):
             sync_func = synchronous(attr)
@@ -367,32 +368,33 @@ def convert_result_to_proxy(  # noqa: C901
     if isinstance(attr, property):
         # If the original attribute was a property, ensure the wrapped attribute is
         return property(wrapper)
-    return wrapper
+    return wrapper  # type: ignore
 
 
-def convert_result_to_wrapped_dict(
-        utility: DaemonUtility, core_obj: Any, name: str, attr: Callable[P, T]
+def convert_result_to_wrapped_dict(  # noqa: C901
+    utility: DaemonUtility, core_obj: Any, name: str, attr: Callable[P, T]
 ) -> Callable[P, T]:
-    """Wrapper that ensures a result of a method call through Pyro is a wrapped dictionary, which
-    is later deserialzed by serpent using special registries for UnhashableDictWrapper.
+    """Wrapper that ensures a result of a method call through Pyro is a wrapped dictionary.
 
-    This particularly pretains to dictionary results that may contain keys which are mutable, such as SubSystem.
+    The result of this is later deserialzed by serpent using special registries for UnhashableDictWrapper. This
+    particularly pretains to dictionary results that may contain keys which are mutable, such as SubSystem.
     """
+
     @functools.wraps(attr)
-    def wrapper(self, *args: P.args, **kwargs: P.kwargs) -> Any:
+    def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:
         # Of note, the wrapper passes self to terminate the self instance passed by the PSO
         if inspect.iscoroutinefunction(attr):
             sync_func = synchronous(attr)
             bound_method = MethodType(sync_func, core_obj)
             result = bound_method(*args, **kwargs)
-            return_types = attr.__annotations__['return']
+            return_types = attr.__annotations__["return"]
         elif isinstance(attr, FunctionType):
             bound_method = MethodType(attr, core_obj)
             result = bound_method(*args, **kwargs)
-            return_types = attr.__annotations__['return']
+            return_types = attr.__annotations__["return"]
         elif isinstance(attr, property):
             result = getattr(core_obj, name)
-            return_types = attr.fget.__annotations__['return']
+            return_types = attr.fget.__annotations__["return"]
         else:
             raise ValueError(
                 "Provided base attribute must be a Property, a Method or an Async method."
@@ -407,24 +409,33 @@ def convert_result_to_wrapped_dict(
                 except AttributeError:
                     pass
                 try:
-                    value_type = next(a for a in value_type.__args__ if a is not type(None))
+                    value_type = next(
+                        a for a in value_type.__args__ if a is not type(None)
+                    )
                 except AttributeError:
                     pass
                 wrapped_dict = UnhashableDictWrapper(
                     dictionary=result,
                     key_type=".".join((key_type.__module__, key_type.__qualname__)),
-                    value_type=".".join((value_type.__module__, value_type.__qualname__))
+                    value_type=".".join(
+                        (value_type.__module__, value_type.__qualname__)
+                    ),
                 )
                 return wrapped_dict
             else:
-                raise ValueError("Pyro behavior for dictionary wrapping requires function return types.")
+                raise ValueError(
+                    "Pyro behavior for dictionary wrapping requires function return types."
+                )
         else:
-            raise ValueError("Pyro behavior for dictionary wrapping is only available for use with dictionaries.")
+            raise ValueError(
+                "Pyro behavior for dictionary wrapping is only available for use with dictionaries."
+            )
 
     if isinstance(attr, property):
         # If the original attribute was a property, ensure the wrapped attribute is
         return property(wrapper)
-    return wrapper
+    return wrapper  # type: ignore
+
 
 ## Local Specialty Functions - Used to wrap attributes on the original instance
 

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -240,6 +240,15 @@ def _build_classdict(  # noqa: C901
                 and specialty_behavior.apply_local is False
             ):
                 # Apply the specialty function to the attribute on this PSO instance and expose the wrapped specialty method
+                if inspect.iscoroutinefunction(attr):
+                    async_metadata = {
+                        "__module__": attr.__module__,
+                        "__name__": attr.__name__,
+                        "__qualname__": attr.__qualname__,
+                        "__doc__": attr.__doc__,
+                        "__type_params__": attr.__type_params__,
+                    }
+                    async_methods[name] = async_metadata
                 exposed = pyro.expose(
                     specialty_behavior.specialty_function(utility, core_obj, name, attr)
                 )

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
@@ -221,9 +221,12 @@ async def test_pyro_behavior_ot3api_unhashable_dicts(
         hw_types.Axis.Z_G: 0,
         hw_types.Axis.G: 0,
     }
+    # test with kwargs
     assert ot3api.get_deck_from_machine(
         machine_pos=data
     ) == managed_obj.get_deck_from_machine(machine_pos=data)
+    # test with args, no kwargs
+    assert ot3api.get_deck_from_machine(data) == managed_obj.get_deck_from_machine(data)
 
     await managed_obj.home()
     assert await ot3api.current_position(

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
@@ -11,7 +11,7 @@ from Pyro5 import api as pyro
 from Pyro5 import nameserver
 
 from opentrons.drivers.heater_shaker.simulator import SimulatingDriver
-from opentrons.hardware_control import HardwareControlAPI, ThreadManager, modules
+from opentrons.hardware_control import ThreadManager, modules
 from opentrons.hardware_control import types as hw_types
 from opentrons.hardware_control.module_control import AttachedModulesControl
 from opentrons.hardware_control.modules import (
@@ -157,7 +157,10 @@ async def test_pyro_behavior_on_modules(
         assert utility.find_PSO(mod) is None
 
 
-async def test_pyro_behavior_ot3api_unhashable_dicts(managed_obj: OT3API) -> None:
+async def test_pyro_behavior_ot3api_unhashable_dicts(
+    managed_obj: OT3API,
+    decoy: Decoy,
+) -> None:
     """Test the pyro behavior for unhashable dictionaries with pyro by ensuring several OT3API commands have the expected results."""
     sock = socket.socket()
     sock.bind(("localhost", 0))
@@ -204,7 +207,7 @@ async def test_pyro_behavior_ot3api_unhashable_dicts(managed_obj: OT3API) -> Non
     uri = pyro.resolve(uri="PYRONAME:OT3API")
     ot3_proxy = pyro.Proxy(uri)  # type: ignore
     ot3_async = AsyncClientPyroObject(ot3_proxy)
-    ot3api = cast(HardwareControlAPI, ot3_async)
+    ot3api = cast(OT3API, ot3_async)
     await ot3api.home()
 
     assert ot3api.get_all_attached_instr() == managed_obj.get_all_attached_instr()
@@ -222,22 +225,23 @@ async def test_pyro_behavior_ot3api_unhashable_dicts(managed_obj: OT3API) -> Non
         machine_pos=data
     ) == managed_obj.get_deck_from_machine(machine_pos=data)
 
-    assert ot3api.current_position(
+    await managed_obj.home()
+    assert await ot3api.current_position(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
     ) == await managed_obj.current_position(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
     )
-    assert ot3_proxy.current_position_ot3(
+    assert await ot3api.current_position_ot3(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
     ) == await managed_obj.current_position_ot3(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
     )
-    assert ot3_proxy.encoder_current_position(
+    assert await ot3api.encoder_current_position(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
     ) == await managed_obj.current_position(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
     )
-    assert ot3_proxy.encoder_current_position_ot3(
+    assert await ot3api.encoder_current_position_ot3(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
     ) == await managed_obj.current_position(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
@@ -245,7 +249,7 @@ async def test_pyro_behavior_ot3api_unhashable_dicts(managed_obj: OT3API) -> Non
     assert ot3api.get_engaged_axes() == managed_obj.get_engaged_axes()
     assert ot3api.engaged_axes == managed_obj.engaged_axes
 
-    assert ot3_proxy.get_limit_switches() == await managed_obj.get_limit_switches()
+    assert await ot3api.get_limit_switches() == await managed_obj.get_limit_switches()
     assert ot3api.get_attached_pipettes() == managed_obj.get_attached_pipettes()
     assert ot3api.get_attached_instruments() == managed_obj.get_attached_instruments()
     assert ot3api.attached_pipettes == managed_obj.attached_pipettes

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
@@ -10,9 +10,8 @@ from decoy import Decoy
 from Pyro5 import api as pyro
 from Pyro5 import nameserver
 
-from opentrons.hardware_control import HardwareControlAPI
 from opentrons.drivers.heater_shaker.simulator import SimulatingDriver
-from opentrons.hardware_control import ThreadManager, modules
+from opentrons.hardware_control import HardwareControlAPI, ThreadManager, modules
 from opentrons.hardware_control import types as hw_types
 from opentrons.hardware_control.module_control import AttachedModulesControl
 from opentrons.hardware_control.modules import (
@@ -28,12 +27,12 @@ from opentrons.hardware_control.poller import Poller
 from opentrons.hardware_control.pyro_utils.serpent_type_registry import (
     register_hardware_types,
 )
+from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
 from opentrons.util.pyro.pyro_daemon_utility import PYRO_TIMEOUT, create_pyro_daemon
 from opentrons.util.pyro.pyro_synchronous_adapter import (
     DaemonUtility,
     PyroSynchronousObject,
 )
-from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
 
 
 @pytest.fixture
@@ -209,25 +208,36 @@ async def test_pyro_behavior_ot3api_unhashable_dicts(managed_obj: OT3API) -> Non
     await ot3api.home()
 
     assert ot3api.get_all_attached_instr() == managed_obj.get_all_attached_instr()
-    data: Dict[hw_types.Axis, float] = {hw_types.Axis.X: 0.0}
-    #assert ot3api.get_deck_from_machine(machine_pos = data) == managed_obj.get_deck_from_machine(machine_pos=data)
+    data: Dict[hw_types.Axis, float] = {
+        hw_types.Axis.X: 0,
+        hw_types.Axis.Y: 0,
+        hw_types.Axis.Z_L: 0,
+        hw_types.Axis.Z_R: 0,
+        hw_types.Axis.P_L: 0,
+        hw_types.Axis.P_R: 0,
+        hw_types.Axis.Z_G: 0,
+        hw_types.Axis.G: 0,
+    }
+    assert ot3api.get_deck_from_machine(
+        machine_pos=data
+    ) == managed_obj.get_deck_from_machine(machine_pos=data)
 
     assert ot3api.current_position(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
     ) == await managed_obj.current_position(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
     )
-    assert await ot3api.current_position_ot3(
+    assert ot3_proxy.current_position_ot3(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
     ) == await managed_obj.current_position_ot3(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
     )
-    assert await ot3api.encoder_current_position(
+    assert ot3_proxy.encoder_current_position(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
     ) == await managed_obj.current_position(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
     )
-    assert await ot3api.encoder_current_position_ot3(
+    assert ot3_proxy.encoder_current_position_ot3(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
     ) == await managed_obj.current_position(
         mount=hw_types.OT3Mount.LEFT, critical_point=None
@@ -235,11 +245,9 @@ async def test_pyro_behavior_ot3api_unhashable_dicts(managed_obj: OT3API) -> Non
     assert ot3api.get_engaged_axes() == managed_obj.get_engaged_axes()
     assert ot3api.engaged_axes == managed_obj.engaged_axes
 
-    assert await ot3api.get_limit_switches() == await managed_obj.get_limit_switches()
+    assert ot3_proxy.get_limit_switches() == await managed_obj.get_limit_switches()
     assert ot3api.get_attached_pipettes() == managed_obj.get_attached_pipettes()
-    assert (
-        ot3api.get_attached_instruments() == managed_obj.get_attached_instruments()
-    )
+    assert ot3api.get_attached_instruments() == managed_obj.get_attached_instruments()
     assert ot3api.attached_pipettes == managed_obj.attached_pipettes
     assert ot3api.attached_subsystems == managed_obj.attached_subsystems
 

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
@@ -1,11 +1,19 @@
 """Tests for the Pyro instance of the hardware controller."""
 
+import asyncio
+import socket
+import threading
+from typing import Dict, cast
+
 import pytest
 from decoy import Decoy
 from Pyro5 import api as pyro
+from Pyro5 import nameserver
 
+from opentrons.hardware_control import HardwareControlAPI
 from opentrons.drivers.heater_shaker.simulator import SimulatingDriver
 from opentrons.hardware_control import ThreadManager, modules
+from opentrons.hardware_control import types as hw_types
 from opentrons.hardware_control.module_control import AttachedModulesControl
 from opentrons.hardware_control.modules import (
     AbsorbanceReader,
@@ -17,10 +25,23 @@ from opentrons.hardware_control.modules import (
 )
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.poller import Poller
+from opentrons.hardware_control.pyro_utils.serpent_type_registry import (
+    register_hardware_types,
+)
+from opentrons.util.pyro.pyro_daemon_utility import PYRO_TIMEOUT, create_pyro_daemon
 from opentrons.util.pyro.pyro_synchronous_adapter import (
     DaemonUtility,
     PyroSynchronousObject,
 )
+from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
+
+
+@pytest.fixture
+def managed_obj(ot3_hardware: ThreadManager[OT3API]) -> OT3API:
+    """OT3API fixture for tests."""
+    managed = ot3_hardware.managed_obj
+    assert managed
+    return managed
 
 
 @pytest.fixture
@@ -135,3 +156,92 @@ async def test_pyro_behavior_on_modules(
         await mod.cleanup()
         # Assert this module has been removed
         assert utility.find_PSO(mod) is None
+
+
+async def test_pyro_behavior_ot3api_unhashable_dicts(managed_obj: OT3API) -> None:
+    """Test the pyro behavior for unhashable dictionaries with pyro by ensuring several OT3API commands have the expected results."""
+    sock = socket.socket()
+    sock.bind(("localhost", 0))
+    host, port = sock.getsockname()
+    sock.close()
+
+    pyro.config.NS_HOST = host
+    pyro.config.NS_PORT = port
+
+    name_server_ready = threading.Event()
+
+    def _nameserver_loop() -> None:
+        # start_ns returns (nameserver, daemon, uri)
+        _, ns_daemon, _ = nameserver.start_ns(host=host, port=port)  # type: ignore
+        name_server_ready.set()
+        # Run until the test process exits; thread is marked daemon=True.
+        ns_daemon.requestLoop()
+
+    def _pyro_daemon() -> None:
+        # Wait for the nameserver to be ready so locate_ns can succeed.
+        name_server_ready.wait(timeout=PYRO_TIMEOUT)
+        create_pyro_daemon("OT3API", managed_obj, register_hardware_types)
+
+    ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
+    server_thread = threading.Thread(target=_pyro_daemon, daemon=True)
+
+    ns_thread.start()
+    server_thread.start()
+
+    # Client-side requests below
+    register_hardware_types()
+    name_server_ready.wait(timeout=PYRO_TIMEOUT)
+    ns = pyro.locate_ns()
+
+    retries_counter = 0
+    while ns.count() < 2:
+        # Wait and try again, the resource isnt registered yet
+        await asyncio.sleep(0.01)
+        retries_counter += 1
+        if retries_counter > 10:
+            # Stop waiting for the nameserver, will fail on pyro.resolve (something is wrong with nameserver and/or daemon)
+            raise TimeoutError("TEST FAILURE ON PYRO NAMESERVER.")
+
+    uri = pyro.resolve(uri="PYRONAME:OT3API")
+    ot3_proxy = pyro.Proxy(uri)  # type: ignore
+    ot3_async = AsyncClientPyroObject(ot3_proxy)
+    ot3api = cast(HardwareControlAPI, ot3_async)
+    await ot3api.home()
+
+    assert ot3api.get_all_attached_instr() == managed_obj.get_all_attached_instr()
+    data: Dict[hw_types.Axis, float] = {hw_types.Axis.X: 0.0}
+    #assert ot3api.get_deck_from_machine(machine_pos = data) == managed_obj.get_deck_from_machine(machine_pos=data)
+
+    assert ot3api.current_position(
+        mount=hw_types.OT3Mount.LEFT, critical_point=None
+    ) == await managed_obj.current_position(
+        mount=hw_types.OT3Mount.LEFT, critical_point=None
+    )
+    assert await ot3api.current_position_ot3(
+        mount=hw_types.OT3Mount.LEFT, critical_point=None
+    ) == await managed_obj.current_position_ot3(
+        mount=hw_types.OT3Mount.LEFT, critical_point=None
+    )
+    assert await ot3api.encoder_current_position(
+        mount=hw_types.OT3Mount.LEFT, critical_point=None
+    ) == await managed_obj.current_position(
+        mount=hw_types.OT3Mount.LEFT, critical_point=None
+    )
+    assert await ot3api.encoder_current_position_ot3(
+        mount=hw_types.OT3Mount.LEFT, critical_point=None
+    ) == await managed_obj.current_position(
+        mount=hw_types.OT3Mount.LEFT, critical_point=None
+    )
+    assert ot3api.get_engaged_axes() == managed_obj.get_engaged_axes()
+    assert ot3api.engaged_axes == managed_obj.engaged_axes
+
+    assert await ot3api.get_limit_switches() == await managed_obj.get_limit_switches()
+    assert ot3api.get_attached_pipettes() == managed_obj.get_attached_pipettes()
+    assert (
+        ot3api.get_attached_instruments() == managed_obj.get_attached_instruments()
+    )
+    assert ot3api.attached_pipettes == managed_obj.attached_pipettes
+    assert ot3api.attached_subsystems == managed_obj.attached_subsystems
+
+    # Clean up client resources.
+    ot3_proxy._pyroRelease()  # type: ignore

--- a/robot-server/tests/subsystems/test_firmware_update_manager.py
+++ b/robot-server/tests/subsystems/test_firmware_update_manager.py
@@ -127,10 +127,14 @@ async def _quick_update(
 ) -> AsyncIterator[HWUpdateStatus]:
     assert subsystems
     subsystem = next(iter(subsystems))
-    yield HWUpdateStatus(subsystem, HWUpdateState.queued, 0)
+    yield HWUpdateStatus.model_construct(
+        subsystem=subsystem, state=HWUpdateState.queued, progress=0
+    )
     await asyncio.sleep(0)
     for value in range(0, 100, 10):
-        yield HWUpdateStatus(subsystem, HWUpdateState.updating, value)
+        yield HWUpdateStatus.model_construct(
+            subsystem=subsystem, state=HWUpdateState.updating, progress=value
+        )
         await asyncio.sleep(0)
 
 
@@ -140,7 +144,9 @@ async def _eternal_update(
     assert subsystems
     subsystem = next(iter(subsystems))
     while True:
-        yield HWUpdateStatus(subsystem, HWUpdateState.queued, 0)
+        yield HWUpdateStatus.model_construct(
+            subsystem=subsystem, state=HWUpdateState.queued, progress=0
+        )
         await asyncio.sleep(0)
 
 
@@ -149,7 +155,9 @@ async def _instant_update(
 ) -> AsyncIterator[HWUpdateStatus]:
     assert subsystems
     subsystem = next(iter(subsystems))
-    yield HWUpdateStatus(subsystem, HWUpdateState.done, 100)
+    yield HWUpdateStatus.model_construct(
+        subsystem=subsystem, state=HWUpdateState.done, progress=100
+    )
     await asyncio.sleep(0)
 
 
@@ -166,10 +174,14 @@ async def _error_update(
 ) -> AsyncIterator[HWUpdateStatus]:
     assert subsystems
     subsystem = next(iter(subsystems))
-    yield HWUpdateStatus(subsystem, HWUpdateState.queued, 0)
+    yield HWUpdateStatus.model_construct(
+        subsystem=subsystem, state=HWUpdateState.queued, progress=0
+    )
     await asyncio.sleep(0)
     for value in range(0, 30, 10):
-        yield HWUpdateStatus(subsystem, HWUpdateState.updating, value)
+        yield HWUpdateStatus.model_construct(
+            subsystem=subsystem, state=HWUpdateState.updating, progress=value
+        )
         await asyncio.sleep(0)
     raise RuntimeError("oh no!")
 
@@ -179,10 +191,14 @@ async def _baseexception_update(
 ) -> AsyncIterator[HWUpdateStatus]:
     assert subsystems
     subsystem = next(iter(subsystems))
-    yield HWUpdateStatus(subsystem, HWUpdateState.queued, 0)
+    yield HWUpdateStatus.model_construct(
+        subsystem=subsystem, state=HWUpdateState.queued, progress=0
+    )
     await asyncio.sleep(0)
     for value in range(0, 30, 10):
-        yield HWUpdateStatus(subsystem, HWUpdateState.updating, value)
+        yield HWUpdateStatus.model_construct(
+            subsystem=subsystem, state=HWUpdateState.updating, progress=value
+        )
         await asyncio.sleep(0)
     raise BaseException()
 
@@ -229,7 +245,9 @@ async def test_conflicting_in_progress_updates_fail(
     ) -> AsyncIterator[HWUpdateStatus]:
         assert subsystems == {HWSubSystem.gantry_x}
         while True:
-            yield HWUpdateStatus(HWSubSystem.gantry_x, HWUpdateState.queued, 0)
+            yield HWUpdateStatus.model_construct(
+                subsystem=HWSubSystem.gantry_x, state=HWUpdateState.queued, progress=0
+            )
             await asyncio.sleep(0)
 
     decoy.when(ot3_hardware_api.update_firmware).then_return(_eternal_update)


### PR DESCRIPTION
# Overview
Covers EXEC-2465

We have a nice gaggle of types and dicts and typeddicts on the hardware API that are considered unhashable, and thus cause pyro problems when getting sent back and forth. This PR adds a new pyro behavior and new a deserialization methodology to account for this.

To achieve this, we set up two way "wrapping" behavior using the new UnhashableDictWrapper type. Basically:
- Types used in these dictionaries are registered with pyro on both ends
- When a dictionary of this kind is detected, its wrapped in a safe pydantic class
- That class contains key and value information about the actual types used, so that the serpent deserializer can look them up and "unwrap" them on whichever end is being delivered this kind of dictionary
- PyroSynchronousObjects look for attributes with a `pyro_behavior` indicating an attribute needs some dictionaries wrapped
- AsyncClientPyroObjects look for outbound calls with parameters that might be unhashable dictionaries for EVERY async and sync method on a given object, and validates them

This actually also gives us a nice expandable way to do *other kinds* of validations on outbound request in the future as well. Yippie!

## Test Plan and Hands on Testing

- [x] Unit test to check to see if all decorated OT3API class members are behaving as we expect
- [x] Test on a flex with the HWC subprocess to see if we get the behavior we want

## Changelog
Expands `pyro_behavior` to include a new dictionary wrapping decorator
Expand AsyncClientPyroObjects to be able to validate outbound parameters prior to serialization
Expands the OpentronsPyroSerializer to include some more pydantic utilities, UnhashableDictWrapper, and a registry of used TypedDicts

## Review requests
This currently will not support dictionaries that have multi-types values or keys. We don't really do that on the OT3API anywhere, but that might be an issue elsewhere. Maybe the answer is we "shouldn't do that" at all? Or we need to expand this further in the future.

## Risk assessment
Low/Medium - effects the subprocess work but doesn't touch any native running code