### PR TITLE
fix(protocol-designer): ensure pipette shadow hovers over entire well when there is only 1 row

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -105,9 +105,12 @@ export const getHoveredOffsetFromWell = (args: {
     }
   }
   const well = labware.def.wells[wellName]
+  const labwareHasOneRowAndIsRectangular =
+    labware.def.ordering[0].length === 1 && well.shape === 'rectangular'
+  const wellHeight = labwareHasOneRowAndIsRectangular ? well.yDimension : well.y
   return {
     x: well.x + xOffset,
-    y: well.y + yOffset,
+    y: wellHeight + yOffset,
   }
 }
 


### PR DESCRIPTION
# Overview

Center pipette shadow on 1 row labware when selecting wells

## Test Plan and Hands on Testing

- smoke tested with protocol attached in RQA-5300:

https://github.com/user-attachments/assets/b12deefd-f805-444d-9deb-1737b3641d0b


## Changelog

- Added check for if the labware has one row and is rectangular. If so, the well coordinate will be the wells ydimension instead of its coordinate

## Risk assessment
 low - cosmetic

Closes RQA-5300