### PR TITLE
fix(protocol-designer): handle SINGLE configuration for 1ch pipette

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/utils.ts
@@ -122,7 +122,7 @@ export const getAvailablePrimaryNozzles = (
         F1_NOZZLE,
       ],
     },
-    1: { ALL: [A1_NOZZLE] },
+    1: { ALL: [A1_NOZZLE], SINGLE: [A1_NOZZLE] },
   }
   const filteredAllowedNozzles =
     allowedNozzlesMapping[channels][nozzleConfiguration]


### PR DESCRIPTION
# Overview

This PR adds additional case handling for when 1ch pipettes have SINGLE configuration.

This ensures the correct primary nozzle options will be generated in the `NozzleSelection` modal.

## Test Plan and Hands on Testing

- smoke tested with protocol attached to ticket RQA-5303
<img width="910" height="707" alt="Screenshot 2026-04-03 at 10 06 41 AM" src="https://github.com/user-attachments/assets/aa2c29ab-0e72-42b8-ad66-1543b3370182" />

## Changelog

- added SINGLE case to util `getAvailablePrimaryNozzles`

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment

low

Closes RQA-5303