### PR TITLE
fix(protocol-designer): Add state when mouse moves out of well on WellSelector

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -132,6 +132,8 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
     useState<string[][]>(getSelectedWells())
 
   const [hoveredWells, setHoveredWells] = useState<string[] | null>(null)
+  const currentHoveredWellRef = useRef<string[] | null>(null)
+
   useEffect(
     () => {
       setSelectedWells(getSelectedWells())
@@ -141,6 +143,19 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [stepType]
   )
+
+  const handleLeaveWell = (_: WellMouseEvent): void => {
+    if (leaveTimeoutRef.current) {
+      clearTimeout(leaveTimeoutRef.current)
+    }
+    leaveTimeoutRef.current = setTimeout(() => {
+      if (currentHoveredWellRef.current === hoveredWells) {
+        setHoveredWells(null)
+        currentHoveredWellRef.current = null
+      }
+      leaveTimeoutRef.current = null
+    }, 120)
+  }
 
   const handleHoverWell = (e: WellMouseEvent): void => {
     if (leaveTimeoutRef.current) {
@@ -155,8 +170,12 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
       primaryNozzle,
       channels
     )
-
+    if (leaveTimeoutRef.current) {
+      clearTimeout(leaveTimeoutRef.current)
+      leaveTimeoutRef.current = null
+    }
     setHoveredWells(hovered)
+    currentHoveredWellRef.current = hovered
   }
 
   const allWellsWithStatus = useMemo(
@@ -416,6 +435,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
           y={slotPosition[1]}
           handleClickWell={handleClickWell}
           onMouseEnterWell={handleHoverWell}
+          onMouseLeaveWell={handleLeaveWell}
           selectedTipsByIndex={allWellsWithStatus}
           statusByWellName={allWellsWithState}
           fill={COLORS.white}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -136,6 +136,11 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
 
   useEffect(
     () => {
+      if (leaveTimeoutRef.current) {
+        clearTimeout(leaveTimeoutRef.current)
+        leaveTimeoutRef.current = null
+      }
+      currentHoveredWellRef.current = null
       setSelectedWells(getSelectedWells())
       setHoveredWells(null)
     },
@@ -170,10 +175,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
       primaryNozzle,
       channels
     )
-    if (leaveTimeoutRef.current) {
-      clearTimeout(leaveTimeoutRef.current)
-      leaveTimeoutRef.current = null
-    }
+
     setHoveredWells(hovered)
     currentHoveredWellRef.current = hovered
   }


### PR DESCRIPTION
# Overview

Adds handleLeaveWell mouse event to set hovered wells to null and therefore remove the shadow.

## Test Plan and Hands on Testing

- smoke tested:

https://github.com/user-attachments/assets/2e331b2c-8a32-44ae-95df-647ac3a22ba9

## Changelog

- added handleLeaveWell mouse event
- added useRef state to keep track of currrently tracked well to avoid flickery mouse behavior

## Review requests

- timing of hover removal? is 120 seconds too fast?

## Risk assessment
low

Closes RQA-5298-b
