### PR TITLE
chore: Allow running dev servers together behind port 31950

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,6 +337,14 @@ validate-codecov-yml:
 # to the appropriate dev server.
 .PHONY: dev-proxy
 dev-proxy:
+# In this command, the first port (:2) is a placeholder for the origin server's port.
+# dev_proxy.py *should* overwrite it in all cases, but in case something goes
+# with that, we choose port 2 because it's probably not assigned to anything.
+# `connection_strategy=lazy` gives dev_proxy.py a chance to overwrite the port before
+# mitmproxy tries use port 2.
+#
+# The second port (@31950) is where the reverse proxy should listen.
 	$(UV) tool run --from mitmproxy==12.2.1  mitmdump \
-	    --mode reverse:http://localhost:31950@31950 \
+	    --mode reverse:http://localhost:2@31950 \
+	    --set connection_strategy=lazy \
 	    --script scripts/dev_proxy.py

--- a/Makefile
+++ b/Makefile
@@ -338,7 +338,7 @@ validate-codecov-yml:
 .PHONY: dev-proxy
 dev-proxy:
 # In this command, the first port (:2) is a placeholder for the origin server's port.
-# dev_proxy.py *should* overwrite it in all cases, but in case something goes
+# dev_proxy.py *should* overwrite it in all cases, but in case something goes wrong
 # with that, we choose port 2 because it's probably not assigned to anything.
 # `connection_strategy=lazy` gives dev_proxy.py a chance to overwrite the port before
 # mitmproxy tries use port 2.

--- a/Makefile
+++ b/Makefile
@@ -332,6 +332,19 @@ test-js-%:
 validate-codecov-yml:
 	curl --data-binary @.codecov.yml https://codecov.io/validate
 
+# A convenience command for running all of our servers in dev mode, together,
+# behind a reverse proxy listening on port 31950.
+#
+# This naively amalgamates all of the logs into a single stdout stream.
+# If that's a bit much, you can also just manually run these commands in separate terminals.
+.PHONY: dev-backend
+dev-backend:
+	$(python) scripts/run_concurrently.py \
+		$(MAKE) -C robot-server dev BEHIND_DEV_PROXY=1 ';' \
+		$(MAKE) -C auth-server dev ';' \
+		$(MAKE) -C system-server dev ';' \
+		$(MAKE) dev-proxy
+
 # Assuming our dev servers are running separately (make -C robot-server dev, make -C auth-server dev, etc.),
 # this sets up a reverse proxy that listens on localhost:31950 and forwards each request
 # to the appropriate dev server.

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 
 # make OT_PYTHON available
 include ./scripts/python.mk
+# make UV available
+include ./scripts/python-uv.mk
 
 API_CLIENT_DIR := api-client
 API_DIR := api
@@ -329,3 +331,12 @@ test-js-%:
 .PHONY: validate-codecov-yml
 validate-codecov-yml:
 	curl --data-binary @.codecov.yml https://codecov.io/validate
+
+# Assuming our dev servers are running separately (make -C robot-server dev, make -C auth-server dev, etc.),
+# this sets up a reverse proxy that listens on localhost:31950 and forwards each request
+# to the appropriate dev server.
+.PHONY: dev-proxy
+dev-proxy:
+	$(UV) tool run --from mitmproxy==12.2.1  mitmdump \
+	    --mode reverse:http://localhost:31950@31950 \
+	    --script scripts/dev_proxy.py

--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ dev-proxy:
 # mitmproxy tries use port 2.
 #
 # The second port (@31950) is where the reverse proxy should listen.
-	$(UV) tool run --from mitmproxy==12.2.1  mitmdump \
+	$(UV) tool run --python $(UV_PYTHON) --from mitmproxy==12.2.1  mitmdump \
 	    --mode reverse:http://localhost:2@31950 \
 	    --set connection_strategy=lazy \
 	    --script scripts/dev_proxy.py

--- a/robot-server/Makefile
+++ b/robot-server/Makefile
@@ -46,8 +46,15 @@ clean_cmd = $(SHX) rm -rf build .coverage coverage.xml '*.egg-info'
 clean_cache_cmd = $(SHX) rm -rf '**/__pycache__' '**/*.pyc' '**/.mypy_cache'
 clean_wheel_cmd = $(clean_cmd) dist/*.whl
 clean_all_cmd = $(clean_cmd) dist
-# Uvicorn command to run the robot server in dev mode.
-#
+
+# When the env has BEHIND_DEV_PROXY=1 (or any non-empty string), switch the `make dev` port
+# from 31950 to 31951, to support coexisting with other dev servers (auth-server, etc.)
+# behind a reverse proxy on 31950. See `make dev-proxy` in the top-level Makefile.
+BEHIND_DEV_PROXY ?=
+dev_port_when_running_alone ?= "31950"
+dev_port_when_behind_dev_proxy ?= "31951"
+dev_port ?= $(if $(BEHIND_DEV_PROXY), $(dev_port_when_behind_dev_proxy), $(dev_port_when_running_alone))
+dev_host ?= "localhost"
 # todo(mm, 2021-07-08): Figure out how to run the server with Python development
 # mode enabled, to expose more errors and warnings.
 #   * Using a Makefile target-specific variable to set PYTHONDEVMODE=1
@@ -58,8 +65,6 @@ clean_all_cmd = $(clean_cmd) dist
 #     OT_ROBOT_SERVER_DOT_ENV_PATH doesn't work because that's read too late.
 #   * Doing `uv run env PYTHONDEVMODE=1 uvicorn ...` works, except it's
 #     probably POSIX-only.
-dev_port ?= "31950"
-dev_host ?= "localhost"
 run_dev ?= uvicorn "robot_server.app:app" --host $(dev_host) --port $(dev_port) --ws wsproto --reload --reload-dir robot_server
 
 .PHONY: all

--- a/scripts/dev_proxy.py
+++ b/scripts/dev_proxy.py
@@ -1,0 +1,23 @@
+# This is a mitmproxy addon to route requests to the appropriate Opentrons dev server,
+# based on the request's HTTP path.
+
+# These should match the dev server ports in robot-server/Makefile, system-server/Makefile, etc.
+ROBOT_SERVER_PORT = 31951
+SYSTEM_SERVER_PORT = 32950
+UPDATE_SERVER_PORT = 34000
+AUTH_SERVER_PORT = 33950
+
+def request(flow) -> None:
+    path = flow.request.path
+
+    # This routing logic should match how nginx is configured on real robots.
+    if path.startswith("/system"):
+        flow.request.port = SYSTEM_SERVER_PORT
+        if path.startswith("/system/time"):
+            flow.request.port = ROBOT_SERVER_PORT
+    elif path.startswith("/server"):
+        flow.request.port = UPDATE_SERVER_PORT
+    elif path.startswith("/auth"):
+        flow.request.port = AUTH_SERVER_PORT
+    else:
+        flow.request.port = ROBOT_SERVER_PORT

--- a/scripts/python-uv.mk
+++ b/scripts/python-uv.mk
@@ -1,6 +1,9 @@
 # UV is required for Python dependency management
 UV ?= uv
 UV_PYTHON = 3.12
+# todo(mm, 2026-04-03): This export will implicitly affect uv behavior in any Makefile
+# that includes this one, which is a bit confusing. This shouldn't be necessary if we
+# consistently call `uv` through the Makefile variables defined here.
 export UV_PYTHON
 # Python/pip/pytest commands using UV
 python := $(UV) run --python $(UV_PYTHON) python

--- a/scripts/run_concurrently.py
+++ b/scripts/run_concurrently.py
@@ -1,0 +1,81 @@
+"""Run multiple commands concurrently, and stop them all on ^C.
+
+Usage:
+    python run_concurrently.py cmd1 cmd1_arg1 cmd1_arg2 ';' cmd2 cmd2_arg1 cmd2_arg2
+
+Use ';' to delimit the separate commands.
+Make sure it's appropriately quoted if you're running this in a shell.
+"""
+
+import asyncio
+import asyncio.subprocess
+import sys
+import typing
+
+DELIMITER = ";"
+TERMINATE_TIMEOUT_SEC = 5
+
+
+async def run_command(command: list[str]) -> None:
+    output(f"Launching command {command}")
+    subprocess = await asyncio.create_subprocess_exec(
+        command[0],
+        *command[1:],
+        stdin=asyncio.subprocess.DEVNULL,
+    )
+    try:
+        await subprocess.wait()
+    except asyncio.CancelledError:
+        output(f"Killing command {command}")
+        await terminate_process(subprocess, TERMINATE_TIMEOUT_SEC)
+    output(f"Command {command} exited, code {subprocess.returncode}")
+
+
+async def run_commands_concurrently(commands: list[list[str]]) -> None:
+    try:
+        async with asyncio.TaskGroup() as task_group:
+            for command in commands:
+                task_group.create_task(run_command(command))
+    except asyncio.CancelledError:
+        pass
+
+
+async def terminate_process(
+    process: asyncio.subprocess.Process, timeout_sec: float
+) -> None:
+    """Politely terminate a process, or force-kill it if that takes too long.
+
+    Returns after the process is no longer running.
+    """
+    if process.returncode is not None:
+        return  # Already stopped.
+
+    try:
+        async with asyncio.timeout(timeout_sec):
+            process.terminate()
+            await process.wait()
+    except asyncio.TimeoutError:
+        process.kill()
+        await process.wait()
+
+def split(
+    source: typing.Iterable[str], delimiter: str
+) -> typing.Generator[list[str], None, None]:
+    chunk: list[str] = []
+    for element in source:
+        if element == delimiter:
+            yield chunk
+            chunk = []
+        else:
+            chunk.append(element)
+    yield chunk
+
+
+def output(message: str) -> None:
+    print(f"{__file__}: {message}")
+
+
+if __name__ == "__main__":
+    commands = list(split(sys.argv[1:], DELIMITER))
+    asyncio.run(run_commands_concurrently(commands))
+    output("Exiting")


### PR DESCRIPTION
## Overview

This adds a new Makefile target, `make dev-proxy`, to let multiple dev servers (`make -C robot-server`, `make -C auth-server`, etc.) share port 31950.

This matches how it works on real robots. A reverse proxy listens on port 31950 and routes each request to the appropriate backend service depending on the HTTP route. So `GET /auth/settings` goes to `auth-server`, `PUT /system/oem_mode/enable` goes to `system-server`, and so on.

We need this to develop access control mode. Previously, robot-server bogarted port 31950 for itself, which meant the app could only use robot-server endpoints—everything else would return a 404 error. We got away with this because robot-server happened to own 99% of the endpoints that we cared about. But now, the app will very frequently need to talk to auth-server, too.

## Changelog

If you run these commands in separate terminals:

* `make dev-proxy` (✨ new)
* `make -C robot-server dev BEHIND_DEV_PROXY=1`
  * (`DEV_PROXY=1` politely asks robot-server to use a port other than 31950, so `make dev-proxy` can have it instead)
* `make -C system-server dev`
* `make -C auth-server dev`

Then you'll be able to access all of their endpoints over http://localhost:31950. For example, try `GET /settings` (robot-server) vs. `GET /auth/settings` (system-server).  

You only need to run the servers that you care about. For example, you can skip `make -C system-server dev` if you're not testing any system-server endpoints.

## Test Plan and Hands on Testing

* [x] The commands work as described above.

## Review requests

* Does using [mitmproxy]( https://www.mitmproxy.org/) seem reasonable for this? It's not the best tool for the job, but I like it because it can use our existing Python toolchain. e.g. no Docker dependency.
* Does using `uv tool run` in the top-level Makefile, as opposed to spinning up an entire new Python project with an entire pyproject.toml, seem reasonable?
* The thing I did where robot-server conditionally runs on port 31950 or 31951, depending on `BEHIND_DEV_PROXY=1`, is certainly confusing. I didn't want to disrupt people who have external tools like Postman pointed at 31950. But maybe we should just bite the bullet?

## Risk assessment

Low. Just dev tooling.