### PR TITLE
chore: add exclude-newer to improve security

### DIFF
--- a/auth-server/pyproject.toml
+++ b/auth-server/pyproject.toml
@@ -83,6 +83,8 @@ dependency-metadata = [
     { name = "systemd-python", version = "234", requires-python = ">=3.7", requires-dist = [
     ] },
 ]
+# cooldown time for security
+exclude-newer = "1 week"
 
 # local editable sources satisfying the 0.0.0 placeholders
 [tool.uv.sources]

--- a/g-code-testing/pyproject.toml
+++ b/g-code-testing/pyproject.toml
@@ -66,6 +66,8 @@ dependency-metadata = [
     { name = "systemd-python", version = "234", requires-python = ">=3.7", requires-dist = [
     ] },
 ]
+# cooldown time for security
+exclude-newer = "1 week"
 
 [project.urls]
 "Source Code On Github" = "https://github.com/Opentrons/opentrons/tree/edge/g-code-testing"

--- a/key-server/pyproject.toml
+++ b/key-server/pyproject.toml
@@ -77,6 +77,8 @@ dependency-metadata = [
     { name = "systemd-python", version = "234", requires-python = ">=3.7", requires-dist = [
     ] },
 ]
+# cooldown time for security
+exclude-newer = "1 week"
 
 # local editable sources satisfying the 0.0.0 placeholders
 [tool.uv.sources]

--- a/robot-server/pyproject.toml
+++ b/robot-server/pyproject.toml
@@ -115,6 +115,8 @@ dependency-metadata = [
     { name = "systemd-python", version = "234", requires-python = ">=3.7", requires-dist = [
     ] },
 ]
+# cooldown time for security
+exclude-newer = "1 week"
 
 # local editable sources satisfying the 0.0.0 placeholders
 [tool.uv.sources]

--- a/server-utils/pyproject.toml
+++ b/server-utils/pyproject.toml
@@ -76,6 +76,8 @@ dependency-metadata = [
     { name = "systemd-python", version = "234", requires-python = ">=3.7", requires-dist = [
     ] },
 ]
+# cooldown time for security
+exclude-newer = "1 week"
 
 [project.urls]
 "Source Code On Github" = "https://github.com/Opentrons/opentrons/tree/edge/server-utils"

--- a/system-server/pyproject.toml
+++ b/system-server/pyproject.toml
@@ -135,6 +135,8 @@ dependency-metadata = [
     { name = "systemd-python", version = "234", requires-python = ">=3.7", requires-dist = [
     ] },
 ]
+# cooldown time for security
+exclude-newer = "1 week"
 
 [tool.pytest]
 addopts = ["--cov=system_server", "--cov-report", "term-missing:skip-covered", "--cov-report", "xml:coverage.xml", "--color=yes", "--strict-markers"]

--- a/update-server/pyproject.toml
+++ b/update-server/pyproject.toml
@@ -49,6 +49,8 @@ dev = [
 dependency-metadata = [
     { name = "systemd-python", version = "234", requires-python = ">=3.7", requires-dist = [] },
 ]
+# cooldown time for security
+exclude-newer = "1 week"
 
 [tool.uv.sources]
 server-utils = { path = "../server-utils", editable = true }
@@ -172,4 +174,3 @@ module = [
     "tests.openembedded.test_updater",
 ]
 ignore_errors = true
-


### PR DESCRIPTION


# Overview
add exclude-newer = "1 week"
https://opentrons.slack.com/archives/G01J0KL5XAA/p1775250967895069

https://docs.astral.sh/uv/reference/settings/#exclude-newer

## Test Plan and Hands on Testing
`make setup-py` or `make setup` works as expected


## Changelog
- add `exclude-newer = "1 week"` to all project.toml files

## Review requests


## Risk assessment
low
