### PR TITLE
fix(components): fix useCommandTypeSummaries test error

### DIFF
--- a/components/src/assets/localization/en/command_type_summary.json
+++ b/components/src/assets/localization/en/command_type_summary.json
@@ -110,6 +110,7 @@
   "unsafe/ungripLabware": "Unsafe",
   "unsafe/updatePositionEstimators": "Unsafe",
   "unsealPipetteFromTip": "Unseal pipette",
+  "vacuum_module/stopVacuum": "Stop Vacuum",
   "verifyTipPresence": "Tip presence",
   "waitForDuration": "Wait",
   "waitForResume": "Wait",


### PR DESCRIPTION


# Overview
fix useCommandTypeSummaries test error
need to add the new item for `vacuum_module/stopVacuum` to i18n json file

```shell
 FAIL  components/src/hooks/__tests__/useCommandTypeSummaries.test.tsx > useCommandTypeSummaries > returns translations for all command types in the latest schema
AssertionError: vacuum_module/stopVacuum: expected 'Unknown' not to be 'Unknown' // Object.is equality
 ❯ components/src/hooks/__tests__/useCommandTypeSummaries.test.tsx:50:39
     48|       expect(result.current, cmd).toBeDefined()
     49|       expect(result.current, cmd).not.toBe('')
     50|       expect(result.current, cmd).not.toBe('Unknown')
       |                                       ^
     51|     }
     52|   })
```


## Test Plan and Hands on Testing
- `make -C components dev`
check that there is no erro.

## Changelog
- add `vacuum_module/stopVacuum` to the i18n json file

## Review requests
- text for `vacuum_module/stopVacuum`

## Risk assessment
low
