### PR TITLE
fix(protocol-nozzle): ensure nozzle and well description is seen for already created steps

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
@@ -37,9 +37,7 @@ export function ExtendedPartialTipField(
   const { channels } = pipetteSpecs
   const [isNozzleAndWellModalOpen, setIsNozzleAndWellModalOpen] =
     useState<boolean>(false)
-  const [isClicked, setIsClicked] = useState(false)
   const handleOpen = (): void => {
-    setIsClicked(true)
     setIsNozzleAndWellModalOpen(true)
   }
   const primaryNozzle =
@@ -109,7 +107,7 @@ export function ExtendedPartialTipField(
       (channels === 8 && nozzleConfiguration === ALL) ||
       nozzleConfiguration === COLUMN
     const isRow = nozzleConfiguration === ROW
-    if (!nozzleText || !isClicked || isNozzleAndWellModalOpen) {
+    if (!nozzleText || aspWellsLength === 0) {
       return t('no_nozzles_and_wells_selected')
     }
     let positionType: string = 'wells'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/NozzleAndWellSelectionModal.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/NozzleAndWellSelectionModal.tsx
@@ -81,7 +81,11 @@ export function NozzleAndWellSelectionModal(
     setCurrentStepIndex(currentStepIndex => currentStepIndex - 1)
   }
   const handleClose = (): void => {
-    showModal(false)
+    if (currentStepIndex === 2 && wellValues.length === 0) {
+      setShowError(true)
+    } else {
+      showModal(false)
+    }
   }
 
   const nozzleAndWellSelectionBaseModalProps = {


### PR DESCRIPTION
# Overview

Ensure text on nozzle and well selector displays if there are known aspirate wells and nozzle configuration

## Test Plan and Hands on Testing

- smoke tested in protocol on all three transfer steps  attached to ticket RQA-5308
<img width="1493" height="804" alt="Screenshot 2026-04-06 at 2 03 22 PM" src="https://github.com/user-attachments/assets/97a9eb19-cdf5-4baa-bf16-b49857014826" />

## Changelog

- removed click state tracking and replaced with seeing if there were aspirate wells
- added fix to ensure no well selected shows on the modal and not just in the step form if it is the last step

## Risk assessment

low - cosmetic changes

Closes RQA-5308