### PR TITLE
fix(api): reduce gripper grip force from 20N to 5N during calibration

### DIFF
--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -58,7 +58,7 @@ LOG = getLogger(__name__)
 
 LINEAR_TRANSIT_HEIGHT: Final[float] = 1
 SEARCH_TRANSIT_HEIGHT: Final[float] = 5
-GRIPPER_GRIP_FORCE: Final[float] = 20  # FIXME: (andy s) this adds error, reduce to 5N
+GRIPPER_GRIP_FORCE: Final[float] = 5
 
 SLOT_CENTER = 5
 SLOT_FRONT_LEFT = 1


### PR DESCRIPTION
# Overview

Resolves a documented FIXME in `api/src/opentrons/hardware_control/ot3_calibration.py:61` where `GRIPPER_GRIP_FORCE` was set to 20N, which introduces calibration error. The original developer (Andy S.) noted this should be reduced to 5N.

The constant is used in `calibrate_gripper_jaw()` at line 787 when gripping during gripper calibration. The excessive force (20N vs 5N) causes measurement inaccuracy during the calibration process.

## Test Plan and Hands on Testing

- All 18 tests in `test_ot3_calibration.py` pass
- All 15 tests in `test_gripper.py` pass (13 passed, 2 xpassed)
- All 2 tests in `test_gripper_config.py` pass
- Full `api` test suite: **6846 passed**, 84 skipped, 10 xfailed, 3 xpassed, 0 failures
- `mypy` type checking: no issues in 1137 source files
- `ruff` linting and formatting: all checks passed

Note: This change affects physical hardware calibration behavior. On-robot testing is recommended to validate the improved calibration accuracy with 5N grip force.

## Changelog

- Reduced `GRIPPER_GRIP_FORCE` from 20N to 5N in `ot3_calibration.py` to improve gripper calibration accuracy
- Removed the associated FIXME comment as the issue is now resolved

## Review requests

- Confirmation from the hardware team that 5N is the correct target force for gripper calibration, as noted in the original FIXME
- Any on-robot validation data would be appreciated

## Risk assessment

**Low risk.** This is a single constant change that was explicitly called out by the original developer as needing correction. The change reduces grip force during calibration only (`calibrate_gripper_jaw`), not during normal labware movement operations (which use `default_grip_force` from the gripper config). All existing tests pass without modification.
