### PR TITLE
chore(js linting): ignore MkDocs site output 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -41,6 +41,9 @@ analyses-snapshot-testing/chunks
 opentrons-ai-server/package
 opentrons-ai-server/api/storage/
 
+# MkDocs build output (generated; may exist locally after `mkdocs build`, gitignored)
+docs/**/site/**
+
 # Leave Markdown formatting alone because some of it is load-bearing for MkDocs.
 # Note that this is a Prettier thing, not an ESLint thing. Prettier shares this config file.
 /docs/**/*.md


### PR DESCRIPTION
Need to ignore this folder, LLM and I noticed it was getting scanned if it existed on your machine.