### PR TITLE
fix(protocol-designer): add lines delineating deck expansion slots

### DIFF
--- a/components/src/hardware-sim/BaseDeck/StagingAreaFixture.tsx
+++ b/components/src/hardware-sim/BaseDeck/StagingAreaFixture.tsx
@@ -51,29 +51,25 @@ export function StagingAreaFixture(
             d="M150.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
             fill={fixtureBaseColor}
           />
-          {showSlotClips ? (
-            <>
-              <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
-              <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
-              <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
-              <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
-            </>
-          ) : null}
         </g>
         <g transform={'translate(328, 107)'}>
           <SlotBase
             d="M163.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
             fill={fixtureBaseColor}
           />
-          {showSlotClips ? (
-            <>
-              <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
-              <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
-              <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
-              <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
-            </>
-          ) : null}
         </g>
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
+            <SlotClip d="M490,398.9v10.1h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M490,329.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,398.9v10.1h-10.8" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,329.8v-10.7h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
 
@@ -84,29 +80,25 @@ export function StagingAreaFixture(
             d="M150.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
             fill={fixtureBaseColor}
           />
-          {showSlotClips ? (
-            <>
-              <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
-              <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
-              <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
-              <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
-            </>
-          ) : null}
         </g>
         <g transform={'translate(328, 0)'}>
           <SlotBase
             d="M163.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
             fill={fixtureBaseColor}
           />
-          {showSlotClips ? (
-            <>
-              <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
-              <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
-              <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
-              <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
-            </>
-          ) : null}
         </g>
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M326,291.9V302h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M326,222.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,291.9V302H447" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,222.8v-10.7H447" stroke={slotClipColor} />
+            <SlotClip d="M490,291.9v10.1h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M490,222.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,291.9v10.1h-10.8" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,222.8v-10.7h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutC3: (
@@ -116,29 +108,25 @@ export function StagingAreaFixture(
             d="M150.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
             fill={fixtureBaseColor}
           />
-          {showSlotClips ? (
-            <>
-              <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
-              <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
-              <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
-              <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
-            </>
-          ) : null}
         </g>
         <g transform={'translate(328, -107)'}>
           <SlotBase
             d="M163.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
             fill={fixtureBaseColor}
           />
-          {showSlotClips ? (
-            <>
-              <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
-              <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
-              <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
-              <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
-            </>
-          ) : null}
         </g>
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M326,185v10.1h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M326,115.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,185v10.1H447" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,115.8v-10.7H447" stroke={slotClipColor} />
+            <SlotClip d="M490,185v10.1h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M490,115.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,185v10.1h-10.8" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,115.8v-10.7h-10.8" stroke={slotClipColor} />
+          </>
+        ) : null}
       </>
     ),
     cutoutD3: (
@@ -149,29 +137,25 @@ export function StagingAreaFixture(
               d="M150.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
               fill={fixtureBaseColor}
             />
-            {showSlotClips ? (
-              <>
-                <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
-                <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
-                <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
-                <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
-              </>
-            ) : null}
           </g>
           <g transform={'translate(328, -214)'}>
             <SlotBase
               d="M163.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
               fill={fixtureBaseColor}
             />
-            {showSlotClips ? (
-              <>
-                <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
-                <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
-                <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
-                <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
-              </>
-            ) : null}
           </g>
+          {showSlotClips ? (
+            <>
+              <SlotClip d="M326,77.9V88h10.8" stroke={slotClipColor} />
+              <SlotClip d="M326,8.8V-1.7h10.6" stroke={slotClipColor} />
+              <SlotClip d="M457.8,77.9V88H447" stroke={slotClipColor} />
+              <SlotClip d="M457.8,8.8V-1.9H447" stroke={slotClipColor} />
+              <SlotClip d="M490,77.9v10.1h10.8" stroke={slotClipColor} />,
+              <SlotClip d="M490,8.8v-10.5h10.6" stroke={slotClipColor} />,
+              <SlotClip d="M621.8,77.9v10.1h-10.8" stroke={slotClipColor} />,
+              <SlotClip d="M621.8,8.8v-10.7h-10.8" stroke={slotClipColor} />
+            </>
+          ) : null}
         </>
       </>
     ),

--- a/components/src/hardware-sim/BaseDeck/StagingAreaFixture.tsx
+++ b/components/src/hardware-sim/BaseDeck/StagingAreaFixture.tsx
@@ -41,88 +41,138 @@ export function StagingAreaFixture(
     )
     return null
   }
-
   const contentsByCutoutLocation: {
     [cutoutId in StagingAreaLocation]: JSX.Element
   } = {
     cutoutA3: (
       <>
-        <SlotBase
-          d="M314.8,417.1h329.9c2.4,0,4.3-1.9,4.3-4.3v-97.4c0-2.4-1.9-4.3-4.3-4.3H314.8c-2.4,0-4.3,1.9-4.3,4.3v97.4C310.5,415.1,312.4,417.1,314.8,417.1z"
-          fill={fixtureBaseColor}
-        />
-        {showSlotClips ? (
-          <>
-            <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
-            <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
-            <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
-            <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
-            <SlotClip d="M490,398.9v10.1h10.8" stroke={slotClipColor} />,
-            <SlotClip d="M490,329.8v-10.5h10.6" stroke={slotClipColor} />,
-            <SlotClip d="M621.8,398.9v10.1h-10.8" stroke={slotClipColor} />,
-            <SlotClip d="M621.8,329.8v-10.7h-10.8" stroke={slotClipColor} />
-          </>
-        ) : null}
+        <g transform={'translate(164, 107)'}>
+          <SlotBase
+            d="M150.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
+            fill={fixtureBaseColor}
+          />
+          {showSlotClips ? (
+            <>
+              <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
+              <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
+              <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
+              <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
+            </>
+          ) : null}
+        </g>
+        <g transform={'translate(328, 107)'}>
+          <SlotBase
+            d="M163.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
+            fill={fixtureBaseColor}
+          />
+          {showSlotClips ? (
+            <>
+              <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
+              <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
+              <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
+              <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
+            </>
+          ) : null}
+        </g>
       </>
     ),
+
     cutoutB3: (
       <>
-        <SlotBase
-          d="M314.8,310h329.9c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H314.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C310.5,308.1,312.4,310,314.8,310z"
-          fill={fixtureBaseColor}
-        />
-        {showSlotClips ? (
-          <>
-            <SlotClip d="M326,291.9V302h10.8" stroke={slotClipColor} />,
-            <SlotClip d="M326,222.8v-10.5h10.6" stroke={slotClipColor} />,
-            <SlotClip d="M457.8,291.9V302H447" stroke={slotClipColor} />,
-            <SlotClip d="M457.8,222.8v-10.7H447" stroke={slotClipColor} />
-            <SlotClip d="M490,291.9v10.1h10.8" stroke={slotClipColor} />,
-            <SlotClip d="M490,222.8v-10.5h10.6" stroke={slotClipColor} />,
-            <SlotClip d="M621.8,291.9v10.1h-10.8" stroke={slotClipColor} />,
-            <SlotClip d="M621.8,222.8v-10.7h-10.8" stroke={slotClipColor} />
-          </>
-        ) : null}
+        <g transform={'translate(164, 0)'}>
+          <SlotBase
+            d="M150.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
+            fill={fixtureBaseColor}
+          />
+          {showSlotClips ? (
+            <>
+              <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
+              <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
+              <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
+              <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
+            </>
+          ) : null}
+        </g>
+        <g transform={'translate(328, 0)'}>
+          <SlotBase
+            d="M163.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
+            fill={fixtureBaseColor}
+          />
+          {showSlotClips ? (
+            <>
+              <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
+              <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
+              <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
+              <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
+            </>
+          ) : null}
+        </g>
       </>
     ),
     cutoutC3: (
       <>
-        <SlotBase
-          d="M314.8,203.1h329.9c2.4,0,4.3-1.9,4.3-4.3v-97.4c0-2.4-1.9-4.3-4.3-4.3H314.8c-2.4,0-4.3,1.9-4.3,4.3v97.4C310.5,201.2,312.4,203.1,314.8,203.1z"
-          fill={fixtureBaseColor}
-        />
-        {showSlotClips ? (
-          <>
-            <SlotClip d="M326,185v10.1h10.8" stroke={slotClipColor} />,
-            <SlotClip d="M326,115.8v-10.5h10.6" stroke={slotClipColor} />,
-            <SlotClip d="M457.8,185v10.1H447" stroke={slotClipColor} />,
-            <SlotClip d="M457.8,115.8v-10.7H447" stroke={slotClipColor} />
-            <SlotClip d="M490,185v10.1h10.8" stroke={slotClipColor} />,
-            <SlotClip d="M490,115.8v-10.5h10.6" stroke={slotClipColor} />,
-            <SlotClip d="M621.8,185v10.1h-10.8" stroke={slotClipColor} />,
-            <SlotClip d="M621.8,115.8v-10.7h-10.8" stroke={slotClipColor} />
-          </>
-        ) : null}
+        <g transform={'translate(164, -107)'}>
+          <SlotBase
+            d="M150.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
+            fill={fixtureBaseColor}
+          />
+          {showSlotClips ? (
+            <>
+              <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
+              <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
+              <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
+              <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
+            </>
+          ) : null}
+        </g>
+        <g transform={'translate(328, -107)'}>
+          <SlotBase
+            d="M163.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
+            fill={fixtureBaseColor}
+          />
+          {showSlotClips ? (
+            <>
+              <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
+              <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
+              <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
+              <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
+            </>
+          ) : null}
+        </g>
       </>
     ),
     cutoutD3: (
       <>
-        <SlotBase
-          d="M314.8,96.1h329.9c2.4,0,4.3-1.9,4.3-4.3V-5.6c0-2.4-1.9-4.3-4.3-4.3H314.8c-2.4,0-4.3,1.9-4.3,4.3v97.4C310.5,94.2,312.4,96.1,314.8,96.1z"
-          fill={fixtureBaseColor}
-        />
-        {showSlotClips ? (
-          <>
-            <SlotClip d="M326,77.9V88h10.8" stroke={slotClipColor} />
-            <SlotClip d="M326,8.8V-1.7h10.6" stroke={slotClipColor} />
-            <SlotClip d="M457.8,77.9V88H447" stroke={slotClipColor} />
-            <SlotClip d="M457.8,8.8V-1.9H447" stroke={slotClipColor} />
-            <SlotClip d="M490,77.9v10.1h10.8" stroke={slotClipColor} />,
-            <SlotClip d="M490,8.8v-10.5h10.6" stroke={slotClipColor} />,
-            <SlotClip d="M621.8,77.9v10.1h-10.8" stroke={slotClipColor} />,
-            <SlotClip d="M621.8,8.8v-10.7h-10.8" stroke={slotClipColor} />
-          </>
-        ) : null}
+        <>
+          <g transform={'translate(164, -214)'}>
+            <SlotBase
+              d="M150.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
+              fill={fixtureBaseColor}
+            />
+            {showSlotClips ? (
+              <>
+                <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
+                <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
+                <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
+                <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
+              </>
+            ) : null}
+          </g>
+          <g transform={'translate(328, -214)'}>
+            <SlotBase
+              d="M163.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
+              fill={fixtureBaseColor}
+            />
+            {showSlotClips ? (
+              <>
+                <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
+                <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
+                <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
+                <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
+              </>
+            ) : null}
+          </g>
+        </>
       </>
     ),
   }

--- a/components/src/hardware-sim/BaseDeck/WasteChuteFixture.tsx
+++ b/components/src/hardware-sim/BaseDeck/WasteChuteFixture.tsx
@@ -12,7 +12,6 @@ import { Icon } from '../../icons'
 import { DeckLabelSet } from '../../organisms'
 import { RobotCoordsForeignObject } from '../Deck/RobotCoordsForeignObject'
 import styles from './basedeck.module.css'
-import { SlotBase } from './SlotBase'
 
 import type { SVGProps } from 'react'
 import type {
@@ -68,10 +67,6 @@ export function WasteChuteFixture(
 
   return (
     <g {...restProps}>
-      <SlotBase
-        d="M314.8,96.1h238.9c2.4,0,4.3-1.9,4.3-4.3V-5.6c0-2.4-1.9-4.3-4.3-4.3H314.8c-2.4,0-4.3,1.9-4.3,4.3v97.4C310.5,94.2,312.4,96.1,314.8,96.1z"
-        fill={fixtureBaseColor}
-      />
       <WasteChute
         backgroundColor={wasteChuteColor}
         wasteIconColor={fixtureBaseColor}
@@ -105,7 +100,6 @@ export function WasteChute(props: WasteChuteProps): JSX.Element {
     overlay,
     opacity,
   } = props
-
   return (
     <>
       <RobotCoordsForeignObject

--- a/components/src/hardware-sim/BaseDeck/WasteChuteStagingAreaFixture.tsx
+++ b/components/src/hardware-sim/BaseDeck/WasteChuteStagingAreaFixture.tsx
@@ -56,18 +56,20 @@ export function WasteChuteStagingAreaFixture(
 
   return (
     <g {...restProps}>
-      <SlotBase
-        d="M314.8,96.1h329.9c2.4,0,4.3-1.9,4.3-4.3V-5.6c0-2.4-1.9-4.3-4.3-4.3H314.8c-2.4,0-4.3,1.9-4.3,4.3v97.4C310.5,94.2,312.4,96.1,314.8,96.1z"
-        fill={fixtureBaseColor}
-      />
-      {showSlotClips ? (
-        <>
-          <SlotClip d="M490,77.9v10.1h10.8" stroke={slotClipColor} />,
-          <SlotClip d="M490,8.8v-10.5h10.6" stroke={slotClipColor} />,
-          <SlotClip d="M621.8,77.9v10.1h-10.8" stroke={slotClipColor} />,
-          <SlotClip d="M621.8,8.8v-10.7h-10.8" stroke={slotClipColor} />
-        </>
-      ) : null}
+      <g transform={'translate(328, -214)'}>
+        <SlotBase
+          d="M150.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
+          fill={fixtureBaseColor}
+        />
+        {showSlotClips ? (
+          <>
+            <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
+            <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
+          </>
+        ) : null}
+      </g>
       <WasteChute
         wasteIconColor={fixtureBaseColor}
         backgroundColor={wasteChuteColor}

--- a/components/src/hardware-sim/BaseDeck/WasteChuteStagingAreaFixture.tsx
+++ b/components/src/hardware-sim/BaseDeck/WasteChuteStagingAreaFixture.tsx
@@ -56,17 +56,25 @@ export function WasteChuteStagingAreaFixture(
 
   return (
     <g {...restProps}>
-      <g transform={'translate(328, -214)'}>
+      <g transform={'translate(164, -214)'}>
         <SlotBase
           d="M150.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
           fill={fixtureBaseColor}
         />
+      </g>
+      <g transform={'translate(328, -214)'}>
+        <SlotBase
+          d="M163.8,310h154.3c2.4,0,4.3-1.9,4.3-4.3v-97.2c0-2.4-1.9-4.3-4.3-4.3H150.8c-2.4,0-4.3,1.9-4.3,4.3v97.2C146.5,308.1,148.4,310,150.8,310z"
+          fill={fixtureBaseColor}
+        />
+      </g>
+      <g>
         {showSlotClips ? (
           <>
-            <SlotClip d="M326,398.9V409h10.8" stroke={slotClipColor} />,
-            <SlotClip d="M326,329.8v-10.5h10.6" stroke={slotClipColor} />,
-            <SlotClip d="M457.8,398.9V409H447" stroke={slotClipColor} />,
-            <SlotClip d="M457.8,329.8v-10.7H447" stroke={slotClipColor} />
+            <SlotClip d="M490,77.9v10.1h10.8" stroke={slotClipColor} />,
+            <SlotClip d="M490,8.8v-10.5h10.6" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,77.9v10.1h-10.8" stroke={slotClipColor} />,
+            <SlotClip d="M621.8,8.8v-10.7h-10.8" stroke={slotClipColor} />
           </>
         ) : null}
       </g>

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
@@ -216,11 +216,15 @@ export function DeckSetupContainer(
       STAGING_AREA_CUTOUTS.includes(aE.location as CutoutId) &&
       aE.name === 'stagingArea'
   )
-
-  const filteredAddressableAreas = deckDef.locations.addressableAreas.filter(
-    aa => isAddressableAreaStandardSlot(aa.id, deckDef)
+  const stagingAreaCutoutIds = stagingAreaFixtures.map(
+    stagingArea => stagingArea.location.split('cutout')[1]
   )
 
+  const filteredAddressableAreas = deckDef.locations.addressableAreas.filter(
+    aa =>
+      isAddressableAreaStandardSlot(aa.id, deckDef) &&
+      !stagingAreaCutoutIds.includes(aa.id)
+  )
   const svgContainerWidth = getSVGContainerWidth(robotType, isZoomed)
   return (
     <>
@@ -281,7 +285,10 @@ export function DeckSetupContainer(
                           addressableArea.id,
                           deckDef.cutoutFixtures
                         )
-                        return cutoutId != null ? (
+                        return cutoutId != null &&
+                          !Object.keys(stagingAreaFixtures).includes(
+                            cutoutId
+                          ) ? (
                           <SingleSlotFixture
                             key={addressableArea.id}
                             cutoutId={cutoutId}

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
@@ -136,6 +136,12 @@ export function DeckSetupContainer(
   const hasFlexStacker = Object.values(activeDeckSetup.modules).some(
     module => module.type === FLEX_STACKER_MODULE_TYPE
   )
+  const flexStackerLocations = Object.values(activeDeckSetup.modules)
+    .filter(stacker => stacker.type === FLEX_STACKER_MODULE_TYPE)
+    .map(({ slot: location, ...rest }) => ({ ...rest, location }))
+  flexStackerLocations.forEach(
+    stacker => (stacker.location = `cutout${stacker.location.slice(0, 1)}3`)
+  )
   const isZoomed = Object.values(zoomIn).some(val => val != null)
   const viewBoxNumerical = viewBox?.split(' ').map(val => Number(val)) ?? []
   const viewBoxAdjustedNumerical = [
@@ -216,7 +222,11 @@ export function DeckSetupContainer(
       STAGING_AREA_CUTOUTS.includes(aE.location as CutoutId) &&
       aE.name === 'stagingArea'
   )
-  const stagingAreaCutoutIds = stagingAreaFixtures.map(
+  const stagingAreaFixturesAndStacker = [
+    ...stagingAreaFixtures,
+    ...flexStackerLocations,
+  ]
+  const stagingAreaCutoutIds = stagingAreaFixturesAndStacker.map(
     stagingArea => stagingArea.location.split('cutout')[1]
   )
 
@@ -226,6 +236,7 @@ export function DeckSetupContainer(
       !stagingAreaCutoutIds.includes(aa.id)
   )
   const svgContainerWidth = getSVGContainerWidth(robotType, isZoomed)
+  console.log(zoomIn)
   return (
     <>
       <Flex
@@ -286,7 +297,7 @@ export function DeckSetupContainer(
                           deckDef.cutoutFixtures
                         )
                         return cutoutId != null &&
-                          !Object.keys(stagingAreaFixtures).includes(
+                          !Object.keys(stagingAreaFixturesAndStacker).includes(
                             cutoutId
                           ) ? (
                           <SingleSlotFixture
@@ -300,11 +311,12 @@ export function DeckSetupContainer(
                           />
                         ) : null
                       })}
-                      {stagingAreaFixtures.map(fixture => {
+                      {stagingAreaFixturesAndStacker.map(fixture => {
                         if (
                           zoomIn.cutout == null ||
                           zoomIn.cutout !== fixture.location
                         ) {
+
                           return (
                             <StagingAreaFixture
                               key={fixture.id}
@@ -386,7 +398,7 @@ export function DeckSetupContainer(
                     addEquipment={addEquipment}
                     activeDeckSetup={activeDeckSetup}
                     currentStep={currentStep}
-                    stagingAreaCutoutIds={stagingAreaFixtures.map(
+                    stagingAreaCutoutIds={stagingAreaFixturesAndStacker.map(
                       areas => areas.location as CutoutId
                     )}
                     {...{
@@ -396,7 +408,7 @@ export function DeckSetupContainer(
                   />
                   <SlotLabels
                     robotType={robotType}
-                    show4thColumn={stagingAreaFixtures.length > 0}
+                    show4thColumn={stagingAreaFixturesAndStacker.length > 0}
                   />
                 </>
               )}

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
@@ -88,9 +88,6 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
       STAGING_AREA_CUTOUTS.includes(aE.location as CutoutId) &&
       aE.name === 'stagingArea'
   )
-  const stagingAreaCutoutIds = stagingAreaFixtures.map(
-    stagingArea => stagingArea.location.split('cutout')[1]
-  )
   const wasteChuteStagingAreaFixtures = Object.values(
     initialDeckSetup.additionalEquipmentOnDeck
   ).filter(
@@ -101,16 +98,22 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
       wasteChuteFixtures.length > 0
   )
 
+  const stagingAreaCutoutIds = stagingAreaFixtures.map(
+    stagingArea => stagingArea.location.split('cutout')[1]
+  )
+
   const hasWasteChute =
     wasteChuteFixtures.length > 0 || wasteChuteStagingAreaFixtures.length > 0
 
   const hasFlexStacker = Object.values(initialDeckSetup.modules).some(
     module => getModuleType(module.model) === FLEX_STACKER_MODULE_TYPE
   )
+
   const filteredAddressableAreas = deckDef.locations.addressableAreas.filter(
     aa =>
       isAddressableAreaStandardSlot(aa.id, deckDef) &&
-      !stagingAreaCutoutIds.includes(aa.id)
+      !stagingAreaCutoutIds.includes(aa.id) &&
+      ((hasWasteChute && aa.id !== 'D3') || hasFlexStacker)
   )
   const hasRightColumnFixtures =
     stagingAreaFixtures.length + wasteChuteFixtures.length > 0 || hasFlexStacker

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
@@ -113,7 +113,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
     aa =>
       isAddressableAreaStandardSlot(aa.id, deckDef) &&
       !stagingAreaCutoutIds.includes(aa.id) &&
-      ((hasWasteChute && aa.id !== 'D3') || hasFlexStacker)
+      (!hasWasteChute || aa.id !== 'D3')
   )
   const hasRightColumnFixtures =
     stagingAreaFixtures.length + wasteChuteFixtures.length > 0 || hasFlexStacker

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
@@ -88,7 +88,9 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
       STAGING_AREA_CUTOUTS.includes(aE.location as CutoutId) &&
       aE.name === 'stagingArea'
   )
-
+  const stagingAreaCutoutIds = stagingAreaFixtures.map(
+    stagingArea => stagingArea.location.split('cutout')[1]
+  )
   const wasteChuteStagingAreaFixtures = Object.values(
     initialDeckSetup.additionalEquipmentOnDeck
   ).filter(
@@ -106,7 +108,9 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
     module => getModuleType(module.model) === FLEX_STACKER_MODULE_TYPE
   )
   const filteredAddressableAreas = deckDef.locations.addressableAreas.filter(
-    aa => isAddressableAreaStandardSlot(aa.id, deckDef)
+    aa =>
+      isAddressableAreaStandardSlot(aa.id, deckDef) &&
+      !stagingAreaCutoutIds.includes(aa.id)
   )
   const hasRightColumnFixtures =
     stagingAreaFixtures.length + wasteChuteFixtures.length > 0 || hasFlexStacker

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
@@ -98,17 +98,25 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
       wasteChuteFixtures.length > 0
   )
 
-  const stagingAreaCutoutIds = stagingAreaFixtures.map(
-    stagingArea => stagingArea.location.split('cutout')[1]
-  )
-
   const hasWasteChute =
     wasteChuteFixtures.length > 0 || wasteChuteStagingAreaFixtures.length > 0
 
   const hasFlexStacker = Object.values(initialDeckSetup.modules).some(
     module => getModuleType(module.model) === FLEX_STACKER_MODULE_TYPE
   )
-
+  const flexStackerLocations = Object.values(initialDeckSetup.modules)
+    .filter(stacker => stacker.type === FLEX_STACKER_MODULE_TYPE)
+    .map(({ slot: location, ...rest }) => ({ ...rest, location }))
+  flexStackerLocations.forEach(
+    stacker => (stacker.location = `cutout${stacker.location.slice(0, 1)}3`)
+  )
+  const stagingAreaFixturesAndStacker = [
+    ...stagingAreaFixtures,
+    ...flexStackerLocations,
+  ]
+  const stagingAreaCutoutIds = stagingAreaFixturesAndStacker.map(
+    stagingArea => stagingArea.location.split('cutout')[1]
+  )
   const filteredAddressableAreas = deckDef.locations.addressableAreas.filter(
     aa =>
       isAddressableAreaStandardSlot(aa.id, deckDef) &&
@@ -176,7 +184,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
                     />
                   ) : null
                 })}
-                {stagingAreaFixtures.map(fixture => (
+                {stagingAreaFixturesAndStacker.map(fixture => (
                   <StagingAreaFixture
                     key={fixture.id}
                     cutoutId={fixture.location as StagingAreaLocation}
@@ -232,7 +240,7 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
               hover={hoverSlot}
               setHover={setHoverSlot}
               initialDeckSetup={initialDeckSetup}
-              stagingAreaCutoutIds={stagingAreaFixtures.map(
+              stagingAreaCutoutIds={stagingAreaFixturesAndStacker.map(
                 areas => areas.location as CutoutId
               )}
               {...{

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/DeckThumbnail.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/DeckThumbnail.test.tsx
@@ -62,7 +62,7 @@ describe('DeckThumbnail', () => {
     })
   })
 
-  it('renders a flex deck with a labware and all single slot fixutres', () => {
+  it('renders a flex deck with a labware and all single slot fixtures', () => {
     render(props)
     screen.getByText('mock LabwareOnDeck')
     expect(screen.getAllByText('mock single slot fixture')).toHaveLength(12)


### PR DESCRIPTION
# Overview

Show a line delineating deck expansion slot vs deck slot

## Test Plan and Hands on Testing

smoke tested starting deck and protocol starting deck with all expansion slots and waste chute and an expansion slot and a flex stacker

<img width="1378" height="914" alt="image" src="https://github.com/user-attachments/assets/94c92c8f-62ea-4e26-adc8-9bbf98f3c029" />
<img width="671" height="530" alt="Screenshot 2026-04-07 at 3 34 25 PM" src="https://github.com/user-attachments/assets/189cd651-53b5-4464-ad05-ac5fce3e7e80" />
<img width="770" height="629" alt="Screenshot 2026-04-07 at 3 34 40 PM" src="https://github.com/user-attachments/assets/b5de723a-b468-46a0-9bbc-da650453a392" />
<img width="812" height="657" alt="Screenshot 2026-04-08 at 12 08 03 PM" src="https://github.com/user-attachments/assets/d1081fea-db90-47d8-be27-c03656717bba" />
<img width="634" height="580" alt="Screenshot 2026-04-08 at 12 08 14 PM" src="https://github.com/user-attachments/assets/68017cb1-afbc-4fbf-9687-1918e072e155" />

## Changelog

- used a middle slot svg and transformed it to sit in the appropriate spot on the deck
- filtered out cutoutIds that were being used as staging slots so that two slot renders would not occur

## Review requests

- is there anywhere else in pd that the deck is displayed?

## Risk assessment

- medium 

Closes RQA-5309