### PR TITLE
fix(protocol-designer): make nozzle selector subtext more descriptive

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -13,6 +13,7 @@
   "advanced_settings": "Advanced pipetting settings",
   "air_gap_volume": "Air gap volume",
   "all_nozzles": "All nozzles (recommended)",
+  "all_nozzles_are_preselected": "All nozzles are preselected",
   "and": "and",
   "aspirate": "Aspirate",
   "aspirate_labware": "Source labware",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/PipetteNozzleSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/PipetteNozzleSelector.tsx
@@ -110,6 +110,8 @@ export function PipetteNozzleSelector(
 
   if (isPartialNozzle) {
     subText = t('number_of_nozzles_used')
+  } else if (nozzleConfiguration === ALL) {
+    subText = t('all_nozzles_are_preselected')
   } else {
     subText = t('click_on_highlighted_nozzles')
   }


### PR DESCRIPTION
# Overview

Fix text when nozzle configuration is `ALL` to say "All nozzles are preselected

## Test Plan and Hands on Testing

smoke tested all pipettes
<img width="887" height="678" alt="Screenshot 2026-04-07 at 4 34 25 PM" src="https://github.com/user-attachments/assets/0f3d8798-1967-4343-83b9-f0fc25246cbd" />

<img width="900" height="705" alt="Screenshot 2026-04-07 at 4 35 16 PM" src="https://github.com/user-attachments/assets/50929152-5ee4-49b9-b079-0f2b2df8e371" />
<img width="889" height="676" alt="Screenshot 2026-04-07 at 4 34 54 PM" src="https://github.com/user-attachments/assets/0f0759a0-d33f-4e45-93b7-dad2a7e3303f" />


## Changelog

add new text
## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment
low

Closes RQA-5296