### PR TITLE
fix(auth-server): add missing props to settings

### DIFF
--- a/auth-server/.env
+++ b/auth-server/.env
@@ -1,2 +1,0 @@
-  OT_AUTH_SERVER_persistence_directory=/tmp/auth-server-alembic
-  ALEMBIC_CONFIG=auth_server/alembic.ini

--- a/auth-server/.env
+++ b/auth-server/.env
@@ -1,0 +1,2 @@
+  OT_AUTH_SERVER_persistence_directory=/tmp/auth-server-alembic
+  ALEMBIC_CONFIG=auth_server/alembic.ini

--- a/auth-server/auth_server/settings/models.py
+++ b/auth-server/auth_server/settings/models.py
@@ -46,6 +46,18 @@ class SettingsResponseData(_StrictBaseModel):
         default=None,
         description="Minimum length of reason for interaction. Set to null to remove the requirement.",
     )
+    requireAdminCredsWhenUpdatingRobotSoftware: bool = pydantic.Field(
+        default=True,
+        description="Require admin credentials when updating robot settings.",
+    )
+    requireAdminCredsWhenSendingProtocolToRobot: bool = pydantic.Field(
+        default=True,
+        description="Require admin credentials when sending protocol to robot.",
+    )
+    requireAdminCredsForSignoffProtocol: bool = pydantic.Field(
+        default=False,
+        description="Require admin credentials for signoff protocol.",
+    )
 
 
 class PatchSettingsRequestData(_StrictBaseModel):
@@ -97,10 +109,6 @@ class PatchSettingsRequestData(_StrictBaseModel):
         bool | None,
         pydantic.Field(description="Require admin credentials for signoff protocol."),
     ] = None
-    requireSignoffForProtocolLog: Annotated[
-        bool | None,
-        pydantic.Field(description="Require signoff for protocol log."),
-    ] = None
     requireReasonForInteraction: Annotated[
         bool | None,
         pydantic.Field(description="Require reason for interaction."),
@@ -108,18 +116,6 @@ class PatchSettingsRequestData(_StrictBaseModel):
     minLengthOfReasonForInteraction: Annotated[
         int | None,
         pydantic.Field(description="Minimum length of reason for interaction."),
-    ] = None
-    requireLogsToBeSavedInApp: Annotated[
-        bool | None,
-        pydantic.Field(
-            description="Require logs to be saved in app. Path should be configured in the app."
-        ),
-    ] = None
-    deleteOverMaxOnDiskProtocols: Annotated[
-        bool | None,
-        pydantic.Field(
-            description="Automatically delete protocol run logs on the robot when there are 20 protocol run records."
-        ),
     ] = None
 
     _NON_NULLABLE_FIELDS: ClassVar[frozenset[str]] = frozenset(
@@ -129,10 +125,7 @@ class PatchSettingsRequestData(_StrictBaseModel):
             "requireAdminCredsWhenUpdatingRobotSoftware",
             "requireAdminCredsWhenSendingProtocolToRobot",
             "requireAdminCredsForSignoffProtocol",
-            "requireSignoffForProtocolLog",
             "requireReasonForInteraction",
-            "requireLogsToBeSavedInApp",
-            "deleteOverMaxOnDiskProtocols",
         }
     )
 

--- a/auth-server/tests/integration/test_settings.tavern.yaml
+++ b/auth-server/tests/integration/test_settings.tavern.yaml
@@ -20,6 +20,9 @@ stages:
           minLengthOfReasonForInteraction: null
           passwordComplexitySpecialCharacters: null
           passwordComplexityMinimumLength: null
+          requireAdminCredsWhenUpdatingRobotSoftware: true
+          requireAdminCredsWhenSendingProtocolToRobot: true
+          requireAdminCredsForSignoffProtocol: false
 
 
 
@@ -47,6 +50,9 @@ stages:
           idleLogout: 180.0
           requireReasonForInteraction: true
           minLengthOfReasonForInteraction: null
+          requireAdminCredsWhenUpdatingRobotSoftware: true
+          requireAdminCredsWhenSendingProtocolToRobot: true
+          requireAdminCredsForSignoffProtocol: false
 
   - name: PATCH more settings
     request:
@@ -62,6 +68,7 @@ stages:
           passwordComplexityMinimumLength: 8
           passwordComplexitySpecialCharacters: true
           requireReasonForInteraction: false
+          requireAdminCredsWhenUpdatingRobotSoftware: false
     response:
       status_code: 200
       json:
@@ -73,6 +80,9 @@ stages:
           idleLogout: 60.0
           requireReasonForInteraction: false
           minLengthOfReasonForInteraction: null
+          requireAdminCredsWhenUpdatingRobotSoftware: false
+          requireAdminCredsWhenSendingProtocolToRobot: true
+          requireAdminCredsForSignoffProtocol: false
 
   - name: GET settings after PATCH returns updated value
     request:
@@ -89,6 +99,9 @@ stages:
           idleLogout: 60.0
           requireReasonForInteraction: false
           minLengthOfReasonForInteraction: null
+          requireAdminCredsWhenUpdatingRobotSoftware: false
+          requireAdminCredsWhenSendingProtocolToRobot: true
+          requireAdminCredsForSignoffProtocol: false
 
   - name: GET settings unchanged after rejected PATCH
     request:
@@ -105,6 +118,9 @@ stages:
           idleLogout: 60.0
           requireReasonForInteraction: false
           minLengthOfReasonForInteraction: null
+          requireAdminCredsWhenUpdatingRobotSoftware: false
+          requireAdminCredsWhenSendingProtocolToRobot: true
+          requireAdminCredsForSignoffProtocol: false
 
 ---
 test_name: DELETE resets to defaults
@@ -130,6 +146,7 @@ stages:
           idleLogout: 60.0
           requireReasonForInteraction: false
           minLengthOfReasonForInteraction: 10
+          requireAdminCredsWhenUpdatingRobotSoftware: false
     response:
       status_code: 200
       json:
@@ -141,6 +158,9 @@ stages:
           idleLogout: 60.0
           requireReasonForInteraction: false
           minLengthOfReasonForInteraction: 10
+          requireAdminCredsWhenUpdatingRobotSoftware: false
+          requireAdminCredsWhenSendingProtocolToRobot: true
+          requireAdminCredsForSignoffProtocol: false
 
 
   - name: DELETE resets everything except accessControlEnabled to its default
@@ -160,7 +180,9 @@ stages:
           passwordComplexitySpecialCharacters: null
           idleLogout: 180.0
           requireReasonForInteraction: true
-
+          requireAdminCredsWhenUpdatingRobotSoftware: true
+          requireAdminCredsWhenSendingProtocolToRobot: true
+          requireAdminCredsForSignoffProtocol: false
 
 
 test_name: DELETE resets to defaults except including accessControlEnabled when not in db
@@ -191,6 +213,9 @@ stages:
           idleLogout: 180.0
           requireReasonForInteraction: true
           minLengthOfReasonForInteraction: null          
+          requireAdminCredsWhenUpdatingRobotSoftware: true
+          requireAdminCredsWhenSendingProtocolToRobot: true
+          requireAdminCredsForSignoffProtocol: false
 
   - name: DELETE returns the newly reset settings
     request:
@@ -209,7 +234,9 @@ stages:
           idleLogout: 180.0
           requireReasonForInteraction: true
           minLengthOfReasonForInteraction: null
-
+          requireAdminCredsWhenUpdatingRobotSoftware: true
+          requireAdminCredsWhenSendingProtocolToRobot: true
+          requireAdminCredsForSignoffProtocol: false
 ---
 test_name: enable access control enabled
 


### PR DESCRIPTION
# Overview

follow up work for https://github.com/Opentrons/opentrons/pull/21210
add missing settings to Response model and Request model

## Changelog

- added missing props for admin required settings response
- removed unused props from patch req model.

## Risk assessment
low. 