### PR TITLE
fix(protocol-designer): ensure 8.5 protocols have submerge and retract speeds when migrating

### DIFF
--- a/protocol-designer/src/load-file/migration/8_5_5.ts
+++ b/protocol-designer/src/load-file/migration/8_5_5.ts
@@ -1,24 +1,39 @@
+import { FLEX_ROBOT_TYPE, getPipetteSpecsV2 } from '@opentrons/shared-data'
+
+import { CHANNELS_MAPPED_TO_MAX_SPEED } from '../../constants'
+
 import type { ProtocolFile } from '@opentrons/shared-data'
 import type { PDMetadata } from '../../file-types'
 
 export const migrateFile = (
   appData: ProtocolFile<PDMetadata>
 ): ProtocolFile<PDMetadata> => {
-  const { designerApplication } = appData
+  const { designerApplication, robot } = appData
 
   if (designerApplication == null || designerApplication?.data == null) {
     throw Error('The designerApplication key in your file is corrupt.')
   }
-  const { savedStepForms, pipetteTiprackAssignments, labware } =
+
+  const { savedStepForms, pipetteTiprackAssignments, labware, pipettes } =
     designerApplication.data
 
+  const robotType = robot.model
   const savedStepsWithUpdatedPipettingFields = Object.entries(
     savedStepForms
   ).reduce((acc: typeof savedStepForms, [stepId, form]) => {
     if (form.stepType === 'moveLiquid' || form.stepType === 'mix') {
       const { tipRack, pipette } = form
-      const assignedTipracks = pipetteTiprackAssignments[pipette] ?? []
 
+      // get max submerge and retract speed
+      const pipetteName = pipettes?.[pipette]?.pipetteName ?? null
+      const pipetteSpecs =
+        pipetteName != null ? getPipetteSpecsV2(pipetteName) : null
+      const channelsForSpeed =
+        pipetteSpecs?.channels ?? (robotType === FLEX_ROBOT_TYPE ? 96 : 8)
+      const maxZSpeed =
+        CHANNELS_MAPPED_TO_MAX_SPEED[robotType][channelsForSpeed].z
+
+      const assignedTipracks = pipetteTiprackAssignments[pipette] ?? []
       // if the tiprack assigned in the form step isn't in the pipette's assigned tipracks
       // then update it
       if (!assignedTipracks.includes(tipRack as string)) {
@@ -27,14 +42,22 @@ export const migrateFile = (
         const newLoadLabwareInfo = Object.values(labware).find(lw =>
           assignedTipracks.includes(lw.labwareDefURI)
         )
+
         acc[stepId] = {
           ...form,
           tipRack: newLoadLabwareInfo?.labwareDefURI ?? null,
         }
         return acc
       }
+
+      acc[stepId] = {
+        ...form,
+        aspirate_retract_speed: form.aspirate_retract_speed ?? maxZSpeed,
+        dispense_retract_speed: form.dispense_retract_speed ?? maxZSpeed,
+        aspirate_submerge_speed: form.aspirate_submerge_speed ?? maxZSpeed,
+        dispense_submerge_speed: form.dispense_submerge_speed ?? maxZSpeed,
+      }
     }
-    acc[stepId] = form
     return acc
   }, {})
 


### PR DESCRIPTION
# Overview

Ensure `8.5.0` protocols made in protocol designer have submerge and retract speeds. 

The 8.5 protocol attached in AUTH-2828 was missing submerge and retract speed args in the transfer_with_liquid_class and raising an error during analysis

## Test Plan and Hands on Testing

- upload .json protocol attached in AUTH-2828, migrated, and exported and ran in 9.0.0 app without error
- checked to confirm that default max speeds had been added to the transfer steps

## Changelog

- added an additional migration to `8_5_5`. If there are no submerge or retract speeds already in the file, it will use the calculated defaults depending on pipette and robot type

## Review requests

- not sure why the 8.5 protocol would not have submerge speeds considering it is included in the 8_5 migration? but this fix will prevent future migrated 8.5 protocols from missing them

## Risk assessment

low

closes AUTH-2828