### PR TITLE
fix(package-testing): expect errors on OT2 protocol simulate

### DIFF
--- a/package-testing/run_tests.py
+++ b/package-testing/run_tests.py
@@ -36,9 +36,9 @@ tests: List[Union[TestHelp, TestSimulate]] = [
         expected_return_code="0",
     ),
     TestSimulate(
-        test_key="OT2_v2_20_expect_success",
+        test_key="OT2_v2_20_expect_error",
         test_helper="simulate",
-        protocol_path="../analyses-snapshot-testing/files/protocols/OT2_S_v2_20_8_None_SINGLE_HappyPath.py",
+        protocol_path="../analyses-snapshot-testing/files/protocols/OT2_S_v2_20_P50_touch_tip.py",
         expected_return_code="1",
     ),
     TestSimulate(
@@ -50,7 +50,7 @@ tests: List[Union[TestHelp, TestSimulate]] = [
     TestSimulate(
         test_key="OT2_v6PD_expect_error",
         test_helper="simulate",
-        protocol_path="../analyses-snapshot-testing/files/protocols/protocol_designer/OT2_X_v6_P300M_P20S_HS_MM_TM_TC_AllMods.json",
+        protocol_path="../g-code-testing/g_code_test_data/protocol/protocols/fast/OT2_P300M_P20S_HS_TM_6_3_SmokeV3.json",
         expected_return_code="1",
     ),
 ]


### PR DESCRIPTION
## Overview

Package-testing runs `opentrons_simulate` against fixture protocols to sanity-check the `opentrons` wheel. OT-2 Python protocols and OT-2 JSON (Protocol Designer) fixtures no longer simulate successfully in this stack.

This PR updates `package-testing/run_tests.py` so OT-2 cases use **existing** fixture paths and **expect exit code 1**, renames the OT-2 Python case to `OT2_v2_20_expect_error`, and points the JSON case at `g-code-testing/g_code_test_data/protocol/protocols/fast/OT2_P300M_P20S_HS_TM_6_3_SmokeV3.json`. Flex success and Flex error cases are unchanged.

**Done when:** CI package-testing job passes on Linux, macOS, and Windows; local `make test` in `package-testing/` passes after setup.

## Test Plan and Hands on Testing

- From `package-testing/`: run `make setup` (or existing venv with `../api` and `../shared-data` installed), then `make test` or `python run_tests.py venv results all`.
- Confirm `Flex_v2_19_expect_success` still expects `0` and OT-2 cases expect `1`.
- Rely on `api-test-lint-deploy` (or equivalent) package-testing matrix for Unix and Windows.

## Changelog

- **Developers:** Package-testing simulate fixtures for OT-2 were updated to match current behavior (simulate failure) and current repo file locations; test key `OT2_v2_20_expect_success` was renamed to `OT2_v2_20_expect_error`. Anyone filtering runs by the old test key should switch to the new name.
- **Users:** None (internal CI / packaging harness only).

## Risk assessment

- **Attention level:** Low. Only `package-testing/run_tests.py` and packaged-install smoke behavior; no runtime robot or app changes.
- **Trade-offs:** Package-testing now depends on a path under `g-code-testing/` for the JSON case; if that file moves, CI will need a follow-up.
- **Blast radius:** Package-testing CI and anyone running `package-testing` locally.
- **Mitigation:** Automated package-testing in CI exercises the full script list on multiple OS/Python versions.