### PR TITLE
fix(protocol-designer): center single channel pipette in reservoirs

### DIFF
--- a/e2e-testing/tests/pd/test_pd_flex_stacker.py
+++ b/e2e-testing/tests/pd/test_pd_flex_stacker.py
@@ -160,6 +160,11 @@ def test_flex_stacker(page: Page, eyes: Eyes | None) -> None:
     plate_reader_page.button_selection("Done")
     print("✓ Add labware to deck and stackers")
 
+    protocol_editor.add_labware_to_slot("C2")
+    protocol_editor.select_labware_category_by_name("Well plates")
+    protocol_editor.select_labware_by_name("Bio-Rad 96 Well Plate 200 µL PCR")
+    plate_reader_page.button_selection("Done")
+
     protocol_editor.add_labware_to_slot("hopperD4")
     protocol_editor.select_labware_category_by_name("Tip racks")
     protocol_editor.select_labware_by_name("Opentrons Flex 96 Tip Rack 50 µL", stacker=True, fill_num=4, lid=True)
@@ -208,13 +213,11 @@ def test_flex_stacker(page: Page, eyes: Eyes | None) -> None:
     plate_reader_page.button_selection("Save")
     protocol_editor.add_step("Move")
     protocol_editor.move_labware("C4 Opentrons Tough 96 Well Plate", "Thermocycler Module GEN2")
-    protocol_editor.add_step("Move")
-    protocol_editor.move_labware("A1+B1 Opentrons Tough 96 Well Plate", "C2")
 
     ## Transfer from reservoir to plate
     protocol_editor.add_step()
     SOURCE_LABWARE = "NEST 1 Well Reservoir 195 mL"
-    DESTINATION_LABWARE = "Opentrons Tough 96 Well Plate"
+    DESTINATION_LABWARE = "Bio-Rad 96 Well Plate 200 µL PCR"
     transfer_page.source_labware_select(SOURCE_LABWARE)
     transfer_page.destination_labware_select(DESTINATION_LABWARE)
     transfer_page.open_nozzle_and_well_selector()
@@ -249,7 +252,7 @@ def test_flex_stacker(page: Page, eyes: Eyes | None) -> None:
     protocol_editor.add_step("Move")
     protocol_editor.move_labware("A2 Opentrons Flex 96 Tip Rack", "D4")
     protocol_editor.add_step("Move")
-    protocol_editor.move_labware("C2 Opentrons Tough 96 Well", "C4")
+    protocol_editor.move_labware("A1+B1 Opentrons Tough 96 Well Plate", "C4")
     protocol_editor.add_step("Stacker")
     flex_stacker_page.store_stacker("C4 Flex Stacker")
     plate_reader_page.button_selection("Save")

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -122,9 +122,13 @@ export const getHoveredOffsetFromWell = (args: {
   const labwareHasOneRowAndIsRectangular =
     labware.def.ordering[0].length === 1 && well.shape === 'rectangular'
   const wellHeight = labwareHasOneRowAndIsRectangular ? well.yDimension : well.y
+  const wellX = well.x + xOffset
+  const wellY = wellHeight + yOffset
+  const singleChannelPipette = pipetteSpec.channels === 1
+
   return {
-    x: well.x + xOffset,
-    y: wellHeight + yOffset,
+    x: wellX,
+    y: singleChannelPipette ? wellY / 2 : wellY,
   }
 }
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -126,11 +126,11 @@ export const getHoveredOffsetFromWell = (args: {
   const wellHeight = labwareHasOneRowAndIsRectangular ? well.yDimension : well.y
   const wellX = well.x + xOffset
   const wellY = wellHeight + yOffset
-  const singleChannelPipette = pipetteSpec.channels === 1
+  const isSingleChannelPipette = pipetteSpec.channels === 1
 
   return {
     x: wellX,
-    y: singleChannelPipette && wellIsRectangular ? wellY / 2 : wellY,
+    y: isSingleChannelPipette && wellIsRectangular ? wellY / 2 : wellY,
   }
 }
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -119,8 +119,10 @@ export const getHoveredOffsetFromWell = (args: {
     }
   }
   const well = labware.def.wells[wellName]
+  const wellIsRectangular = well.shape === 'rectangular'
+
   const labwareHasOneRowAndIsRectangular =
-    labware.def.ordering[0].length === 1 && well.shape === 'rectangular'
+    labware.def.ordering[0].length === 1 && wellIsRectangular
   const wellHeight = labwareHasOneRowAndIsRectangular ? well.yDimension : well.y
   const wellX = well.x + xOffset
   const wellY = wellHeight + yOffset
@@ -128,7 +130,7 @@ export const getHoveredOffsetFromWell = (args: {
 
   return {
     x: wellX,
-    y: singleChannelPipette ? wellY / 2 : wellY,
+    y: singleChannelPipette && wellIsRectangular ? wellY / 2 : wellY,
   }
 }
 


### PR DESCRIPTION
# Overview

Center single channel pipette shadow in rectangular wells

Previously, the shadow was going to the wells exact location. This is correct in most cases, but for reservoir troughs, the 1ch pipette should go to the center of the trough.

## Test Plan and Hands on Testing

- smoke tested with protocol attached in RQA-5320
<img width="874" height="673" alt="Screenshot 2026-04-09 at 4 50 36 PM" src="https://github.com/user-attachments/assets/6a194b8f-31c4-4c9e-8de3-6d9190a9dc1a" />

## Changelog

- when using `getHoveredOffsetFromWell` divide wellY position by 2 when a single channel pipette being used.

## Review requests

- any other instances where custom positioning would be needed?

## Risk assessment

- low - cosmetic

closes RQA-5320