### PR TITLE
feat(key-server): use TLS certificates with nginx

### DIFF
--- a/key-server/key_server/app.py
+++ b/key-server/key_server/app.py
@@ -7,29 +7,32 @@ from fastapi import FastAPI
 
 from server_utils import systemd_utils
 
+from key_server.config.dependency import install_config, resolve_config
 from key_server.secure_volume.dependency import (
     build_secure_volume_manager,
     install_secure_volume_manager,
 )
+from key_server.settings.router import router as settings_router
+from key_server.settings.store import SettingsStore, install_settings_store
 from key_server.tls.dependency import (
     build_tls_manager,
     install_tls_manager,
 )
-from key_server.settings.router import router as settings_router
-from key_server.settings.store import SettingsStore, install_settings_store
 
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     async with AsyncExitStack() as exit_stack:
+        config = resolve_config()
+        install_config(app.state, config)
         settings_store = SettingsStore()
         install_settings_store(app.state, settings_store)
-        secure_volume_manager = build_secure_volume_manager(settings_store)
+        secure_volume_manager = build_secure_volume_manager(settings_store, config)
         install_secure_volume_manager(app.state, secure_volume_manager)
         await secure_volume_manager.mount()
         exit_stack.push_async_callback(secure_volume_manager.unmount)
-        tls_manager = await build_tls_manager(secure_volume_manager)
-        install_tls_manager(app_state, tls_manager)
+        tls_manager = await build_tls_manager(secure_volume_manager, config)
+        install_tls_manager(app.state, tls_manager)
         exit_stack.push_async_callback(tls_manager.teardown)
         systemd_utils.notify_up()
         yield

--- a/key-server/key_server/app.py
+++ b/key-server/key_server/app.py
@@ -11,6 +11,10 @@ from key_server.secure_volume.dependency import (
     build_secure_volume_manager,
     install_secure_volume_manager,
 )
+from key_server.tls.dependency import (
+    build_tls_manager,
+    install_tls_manager,
+)
 from key_server.settings.router import router as settings_router
 from key_server.settings.store import SettingsStore, install_settings_store
 
@@ -24,6 +28,9 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         install_secure_volume_manager(app.state, secure_volume_manager)
         await secure_volume_manager.mount()
         exit_stack.push_async_callback(secure_volume_manager.unmount)
+        tls_manager = await build_tls_manager(secure_volume_manager)
+        install_tls_manager(app_state, tls_manager)
+        exit_stack.push_async_callback(tls_manager.teardown)
         systemd_utils.notify_up()
         yield
 

--- a/key-server/key_server/config.py
+++ b/key-server/key_server/config.py
@@ -53,3 +53,7 @@ class KeyServerConfig(BaseSettings):
         description="The location at which to provide access to the mounted secure volume",
     )
     secure_volume_size_mb: int = 64
+    tls_directory: Literal["automatically_make_temporary"] | Path = Field(
+        default="automatically_make_temporary",
+        description="The location in which to store tls keys and certs for tls termination",
+    )

--- a/key-server/key_server/config/__init__.py
+++ b/key-server/key_server/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration management."""

--- a/key-server/key_server/config/dependency.py
+++ b/key-server/key_server/config/dependency.py
@@ -56,6 +56,7 @@ def resolve_config() -> ResolvedConfig:
         image_mount_point=image_mount,
         secure_volume_size_mb=base_config.secure_volume_size_mb,
         tls_directory=tls_base_dir,
+        tls_server_integration=base_config.tls_server_integration,
     )
 
 

--- a/key-server/key_server/config/dependency.py
+++ b/key-server/key_server/config/dependency.py
@@ -1,0 +1,64 @@
+import tempfile
+from pathlib import Path
+from typing import Annotated
+
+import fastapi
+
+from server_utils.fastapi_utils.app_state import (
+    AppState,
+    AppStateAccessor,
+    get_app_state,
+)
+
+from .models import ResolvedConfig, calculate_config
+
+_accessor = AppStateAccessor[ResolvedConfig]("config")
+
+
+def get_config(
+    app_state: Annotated[AppState, fastapi.Depends(get_app_state)],
+) -> ResolvedConfig:
+    """Get the resolved configuration, possibly resolving it."""
+    config = _accessor.get_from(app_state)
+    if config is None:
+        config = resolve_config()
+        _accessor.set_on(app_state, config)
+    return config
+
+
+def resolve_config() -> ResolvedConfig:
+    """Resolve config, possibly creating directories."""
+    base_config = calculate_config()
+    if base_config.secure_storage_implementation == "caam":
+        if base_config.base_directory == "automatically_make_temporary":
+            raise RuntimeError(
+                "CAAM secure volume cannot mount to a temporary directory"
+            )
+        if base_config.image_mount_point == "automatically_make_temporary":
+            raise RuntimeError(
+                "CAAM secure volume cannot mount to a temporary directory"
+            )
+    if base_config.base_directory == "automatically_make_temporary":
+        base_dir = Path(tempfile.mkdtemp())
+    else:
+        base_dir = base_config.base_directory
+    if base_config.image_mount_point == "automatically_make_temporary":
+        image_mount = Path(tempfile.mkdtemp())
+    else:
+        image_mount = base_config.image_mount_point
+    if base_config.tls_directory == "automatically_make_temporary":
+        tls_base_dir = Path(tempfile.mkdtemp())
+    else:
+        tls_base_dir = base_config.tls_directory
+    return ResolvedConfig(
+        secure_storage_implementation=base_config.secure_storage_implementation,
+        base_directory=base_dir,
+        image_mount_point=image_mount,
+        secure_volume_size_mb=base_config.secure_volume_size_mb,
+        tls_directory=tls_base_dir,
+    )
+
+
+def install_config(app_state: AppState, config: ResolvedConfig) -> None:
+    """Put the configuration in the app state."""
+    _accessor.set_on(app_state, config)

--- a/key-server/key_server/config/models.py
+++ b/key-server/key_server/config/models.py
@@ -57,6 +57,10 @@ class KeyServerConfig(BaseSettings):
         default="automatically_make_temporary",
         description="The location in which to store tls keys and certs for tls termination",
     )
+    tls_server_integration: Literal["systemd-nginx", "dev-none"] = Field(
+        description="How the server should notify a TLS termination layer a certificate has rotated.",
+        default="systemd-nginx",
+    )
 
 
 class ResolvedConfig(BaseModel):
@@ -67,3 +71,4 @@ class ResolvedConfig(BaseModel):
     image_mount_point: Path
     secure_volume_size_mb: int
     tls_directory: Path
+    tls_server_integration: Literal["systemd-nginx", "dev-none"]

--- a/key-server/key_server/config/models.py
+++ b/key-server/key_server/config/models.py
@@ -5,12 +5,12 @@ from pathlib import Path
 from typing import Literal
 
 from dotenv import load_dotenv
-from pydantic import Field
+from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 @lru_cache(maxsize=1)
-def get_config() -> KeyServerConfig:
+def calculate_config() -> KeyServerConfig:
     """Get the loaded config for the key server."""
     env = Environment()
     if env.dot_env_path:
@@ -57,3 +57,13 @@ class KeyServerConfig(BaseSettings):
         default="automatically_make_temporary",
         description="The location in which to store tls keys and certs for tls termination",
     )
+
+
+class ResolvedConfig(BaseModel):
+    """Key server configuration with optionals and defaults resolved."""
+
+    secure_storage_implementation: Literal["caam", "dev"]
+    base_directory: Path
+    image_mount_point: Path
+    secure_volume_size_mb: int
+    tls_directory: Path

--- a/key-server/key_server/secure_volume/dependency.py
+++ b/key-server/key_server/secure_volume/dependency.py
@@ -13,33 +13,25 @@ from server_utils.fastapi_utils.app_state import (
 from .manager.caam import CAAMSecureVolume
 from .manager.dev import DevSecureVolume
 from .manager.interface import SecureVolumeManager
-from key_server.config import get_config
+from key_server.config.dependency import get_config
+from key_server.config.models import ResolvedConfig
 from key_server.settings.store import SettingsStore, get_settings_store
 
 _accessor = AppStateAccessor[SecureVolumeManager]("secure_volume_manager")
 
 
-def build_secure_volume_manager(settings: SettingsStore) -> SecureVolumeManager:
+def build_secure_volume_manager(
+    settings: SettingsStore, config: ResolvedConfig
+) -> SecureVolumeManager:
     """Build the appropriate secure volume manager based on the server config."""
-    if get_config().secure_storage_implementation == "caam":
-        base_directory = get_config().base_directory
-        if base_directory == "automatically_make_temporary":
-            raise RuntimeError(
-                "CAAM secure volume cannot mount to a temporary directory"
-            )
-        image_mount_point = get_config().image_mount_point
-        if image_mount_point == "automatically_make_temporary":
-            raise RuntimeError(
-                "CAAM secure volume cannot mount to a temporary directory"
-            )
-
+    if config.secure_storage_implementation == "caam":
         return CAAMSecureVolume(
-            image_mount_point=image_mount_point,
-            base_directory=base_directory,
-            volume_size_mb=get_config().secure_volume_size_mb,
+            image_mount_point=config.image_mount_point,
+            base_directory=config.base_directory,
+            volume_size_mb=config.secure_volume_size_mb,
         )
     else:
-        return DevSecureVolume()
+        return DevSecureVolume(config.image_mount_point)
 
 
 def install_secure_volume_manager(
@@ -51,12 +43,13 @@ def install_secure_volume_manager(
 
 async def get_secure_volume_manager(
     app_state: Annotated[AppState, fastapi.Depends(get_app_state)],
+    config: Annotated[ResolvedConfig, fastapi.Depends(get_config)],
 ) -> SecureVolumeManager:
     """Return the server's singleton SecureVolumeManager."""
     secure_volume_manager = _accessor.get_from(app_state)
     if secure_volume_manager is None:
         secure_volume_manager = build_secure_volume_manager(
-            await get_settings_store(app_state)
+            await get_settings_store(app_state), get_config(app_state)
         )
         _accessor.set_on(app_state, secure_volume_manager)
     return secure_volume_manager

--- a/key-server/key_server/secure_volume/dependency.py
+++ b/key-server/key_server/secure_volume/dependency.py
@@ -45,7 +45,7 @@ def build_secure_volume_manager(settings: SettingsStore) -> SecureVolumeManager:
 def install_secure_volume_manager(
     app_state: AppState, secure_volume_manager: SecureVolumeManager
 ) -> None:
-    """Place the server's singleton SecureVolumeNaager in server state, for later retrieval by get_secure_volume_manager()."""
+    """Place the server's singleton SecureVolumeManager in server state, for later retrieval by get_secure_volume_manager()."""
     _accessor.set_on(app_state, secure_volume_manager)
 
 

--- a/key-server/key_server/secure_volume/manager/caam.py
+++ b/key-server/key_server/secure_volume/manager/caam.py
@@ -21,6 +21,7 @@ from typing import (
 )
 
 from .interface import SecureVolumeManager
+from key_server.util import subproc_wait_timeout
 
 LOG = getLogger(__name__)
 
@@ -38,19 +39,6 @@ def _lock(
             return await func(slf, *args, **kwargs)
 
     return _locked
-
-
-async def _subproc_wait_timeout(
-    subproc: asyncio.subprocess.Process,
-    timeout: float | None = None,
-) -> int:
-    """Wait for a subprocess with a timeout, returning -ETIMEDOUT if the timeout hits."""
-    try:
-        return await asyncio.wait_for(subproc.wait(), timeout=(timeout or 10))
-    except asyncio.TimeoutError:
-        LOG.error("subprocess call timed out, terminating")
-        subproc.terminate()
-        return -60
 
 
 async def _stringify_process(
@@ -134,7 +122,7 @@ class CAAMSecureVolume(SecureVolumeManager):
             stdout=PIPE,
             stderr=PIPE,
         )
-        if await _subproc_wait_timeout(import_key) != 0:
+        if await subproc_wait_timeout(import_key) != 0:
             LOG.error(f"Failed to import key: {await _stringify_process(import_key)}")
         else:
             LOG.info("Imported key from CAAM")
@@ -152,7 +140,7 @@ class CAAMSecureVolume(SecureVolumeManager):
         stdout_b, stderr_b = await keyring_add.communicate(input=key_data)
         stdout = stdout_b.decode()
         stderr = stderr_b.decode()
-        if await _subproc_wait_timeout(keyring_add) != 0:
+        if await subproc_wait_timeout(keyring_add) != 0:
             LOG.error(
                 f"Failed to add key to KKRS: {await _stringify_process(keyring_add, override_stdout=stdout, override_stderr=stderr)}"
             )
@@ -174,7 +162,7 @@ class CAAMSecureVolume(SecureVolumeManager):
         losetup = await asyncio.create_subprocess_exec(
             "/usr/sbin/losetup", "-f", str(self._image()), stdout=PIPE, stderr=PIPE
         )
-        if await _subproc_wait_timeout(losetup) != 0:
+        if await subproc_wait_timeout(losetup) != 0:
             LOG.error(f"losetup failed: {_stringify_process(losetup)}")
         else:
             LOG.info("Set up loopback device")
@@ -205,7 +193,7 @@ class CAAMSecureVolume(SecureVolumeManager):
             stdout=PIPE,
             stderr=PIPE,
         )
-        if await _subproc_wait_timeout(dmsetup) != 0:
+        if await subproc_wait_timeout(dmsetup) != 0:
             LOG.error(
                 f"dmsetup failed with table {dmsetup_table}: {await _stringify_process(dmsetup)}"
             )
@@ -234,7 +222,7 @@ class CAAMSecureVolume(SecureVolumeManager):
             stdout=PIPE,
             stderr=PIPE,
         )
-        if await _subproc_wait_timeout(mount) != 0:
+        if await subproc_wait_timeout(mount) != 0:
             LOG.error(
                 f"Failed to mount secure storage: {await _stringify_process(mount)}"
             )
@@ -248,7 +236,7 @@ class CAAMSecureVolume(SecureVolumeManager):
             "/usr/bin/umount", str(mount_path), stdout=PIPE, stderr=PIPE
         )
         # we don't care if this fails, really; it would only do so if the mount wasn't mounted
-        await _subproc_wait_timeout(unmount)
+        await subproc_wait_timeout(unmount)
         LOG.info("Unmounted secure volume")
 
     async def _unmap(self) -> None:
@@ -262,7 +250,7 @@ class CAAMSecureVolume(SecureVolumeManager):
             stdout=PIPE,
             stderr=PIPE,
         )
-        if await _subproc_wait_timeout(dmsetup_remove) != 0:
+        if await subproc_wait_timeout(dmsetup_remove) != 0:
             LOG.warning(
                 f"dmsetup remove failed: {await _stringify_process(dmsetup_remove)}"
             )
@@ -275,7 +263,7 @@ class CAAMSecureVolume(SecureVolumeManager):
         losetup_remove = await asyncio.create_subprocess_exec(
             "/usr/sbin/losetup", "-d", loopback_device, stdout=PIPE, stderr=PIPE
         )
-        if (await _subproc_wait_timeout(losetup_remove)) != 0:
+        if (await subproc_wait_timeout(losetup_remove)) != 0:
             LOG.error(f"losetup remove failed: {_stringify_process(losetup_remove)}")
         else:
             LOG.info(f"Removed loopback device {loopback_device}")
@@ -293,7 +281,7 @@ class CAAMSecureVolume(SecureVolumeManager):
             stderr=PIPE,
         )
         self._keyid = 0
-        if await _subproc_wait_timeout(timeout) != 0:
+        if await subproc_wait_timeout(timeout) != 0:
             LOG.warning(f"key timeout failed: {await _stringify_process(timeout)}")
         else:
             LOG.info("set key timeout from kkrs")
@@ -306,7 +294,7 @@ class CAAMSecureVolume(SecureVolumeManager):
             stdout=PIPE,
             stderr=PIPE,
         )
-        if await _subproc_wait_timeout(losetup_list) != 0:
+        if await subproc_wait_timeout(losetup_list) != 0:
             LOG.error(f"losetup list failed: {await _stringify_process(losetup_list)} ")
         assert losetup_list.stdout
         losetup_stdout_data = (await losetup_list.stdout.read()).decode().strip()
@@ -341,7 +329,7 @@ class CAAMSecureVolume(SecureVolumeManager):
             stdout=PIPE,
             stderr=PIPE,
         )
-        if await _subproc_wait_timeout(create_bk) != 0:
+        if await subproc_wait_timeout(create_bk) != 0:
             LOG.error(
                 f"Failed to create CAAM black key: {await _stringify_process(create_bk)}"
             )
@@ -365,7 +353,7 @@ class CAAMSecureVolume(SecureVolumeManager):
             stdout=PIPE,
             stderr=PIPE,
         )
-        if await _subproc_wait_timeout(create_backing_store) != 0:
+        if await subproc_wait_timeout(create_backing_store) != 0:
             LOG.error(
                 f"Creating secure volume: failed to create backing store: {await _stringify_process(create_backing_store)}"
             )
@@ -380,7 +368,7 @@ class CAAMSecureVolume(SecureVolumeManager):
             stdout=PIPE,
             stderr=PIPE,
         )
-        if await _subproc_wait_timeout(mkfs) != 0:
+        if await subproc_wait_timeout(mkfs) != 0:
             LOG.error(
                 f"Creating secure volume: failed to mkfs on the encrypted volume: {await _stringify_process(mkfs)}"
             )

--- a/key-server/key_server/secure_volume/manager/dev.py
+++ b/key-server/key_server/secure_volume/manager/dev.py
@@ -1,9 +1,7 @@
-import tempfile
 from logging import getLogger
 from pathlib import Path
 
 from .interface import SecureVolumeManager
-from key_server.config import get_config
 
 LOG = getLogger(__name__)
 
@@ -11,9 +9,9 @@ LOG = getLogger(__name__)
 class DevSecureVolume(SecureVolumeManager):
     """A fake secure volume suitable for tests or a dev server."""
 
-    def __init__(self) -> None:
+    def __init__(self, image_mount_point: Path) -> None:
         self._path: Path | None = None
-        self._maybe_tempdir: tempfile.TemporaryDirectory[str] | None = None
+        self._image_mount_point = image_mount_point
 
     @property
     def path(self) -> Path:
@@ -32,18 +30,12 @@ class DevSecureVolume(SecureVolumeManager):
 
     async def mount(self) -> None:
         """Mount (in this case, build) the secure volume."""
-        if get_config().image_mount_point == "automatically_make_temporary":
-            self._maybe_tempdir = tempfile.TemporaryDirectory()
-            self._path = Path(self._maybe_tempdir.name)
-        else:
-            self._path = Path(get_config().image_mount_point)
-            self._path.mkdir(parents=True, exist_ok=True)
-            if not self._path.is_dir():
-                raise RuntimeError(
-                    f"Mountpoint path {str(self._path)} is occupied by file"
-                )
-            if len(list(self._path.iterdir())) != 0:
-                LOG.warning(f"Mountpoint {str(self._path)} is not empty")
+        self._path = self._image_mount_point
+        self._path.mkdir(parents=True, exist_ok=True)
+        if not self._path.is_dir():
+            raise RuntimeError(f"Mountpoint path {str(self._path)} is occupied by file")
+        if len(list(self._path.iterdir())) != 0:
+            LOG.warning(f"Mountpoint {str(self._path)} is not empty")
 
     async def unmount(self) -> None:
         """Unmount (more or less) the secure volume."""

--- a/key-server/key_server/tls/dependency.py
+++ b/key-server/key_server/tls/dependency.py
@@ -1,0 +1,58 @@
+"""FastAPI dependencies for TLS certificates."""
+
+from logging import getLogger
+from typing import Annotated
+import fastapi
+from server_utils.fastapi_utils.app_state import (
+    AppState,
+    AppStateAccessor,
+    get_app_state,
+)
+import tempfile
+
+from .manager import TLSManager
+
+from key_server.config import get_config
+from key_server.secure_volume.interface import SecureVolumeManager
+from key_server.secure_volume.dependency import get_secure_volume_manager
+
+LOG = getLogger(__name__)
+
+_accessor = AppStateAccessor[TLSManager]("tls_manager")
+
+
+async def build_tls_manager(secure_volume_manager: SecureVolumeManager) -> TLSManager:
+    tls_base = get_config().tls_directory
+    if tls_base == "automatically_make_temporary":
+        tls_base_dir = get_config().base_directory / "tls"
+        LOG.info(
+            f"TLS certs will be temporarily in {tls_base_dir} inside the base directory"
+        )
+    else:
+        tls_base_dir = tls_base
+        LOG.info(f"TLS certs will be in permanent directory {tls_base_dir}")
+    secure_dir = secure_volume_manager.path
+    return await TLSManager.create(
+        tls_base_dir,
+        secure_dir / "ca_keys",
+        tls_base_dir,
+    )
+
+
+def install_tls_manager(app_state: AppState, tls_manager: TLSManager) -> None:
+    """Place the sever's singleton TLSManager in server state, for later retrieval by get_tls_manager()."""
+    _accessor.set_on(app_state, tls_manager)
+
+
+async def get_tls_manager(
+    app_state: Annotated[AppState, fastapi.Depends(get_app_state)],
+    secure_volume: Annotated[
+        SecureVolumeManager, fastapi.Depends(get_secure_volume_manager)
+    ],
+) -> TLSManager:
+    """Return the server's singleton TLSManager."""
+    tls_manager = _accessor.get_from(app_state)
+    if tls_manager is None:
+        tls_manager = await build_tls_manager(secure_volume)
+        _accessor.set_on(app_state, tls_manager)
+    return tls_manager

--- a/key-server/key_server/tls/dependency.py
+++ b/key-server/key_server/tls/dependency.py
@@ -28,7 +28,10 @@ async def build_tls_manager(
     """Build the TLS manager to control TLS certificates."""
     secure_dir = secure_volume_manager.path
     return await TLSManager.create(
-        config.tls_directory, secure_dir / "ca_keys", config.tls_directory
+        config.tls_directory,
+        secure_dir / "ca_keys",
+        config.tls_directory,
+        config.tls_server_integration,
     )
 
 

--- a/key-server/key_server/tls/dependency.py
+++ b/key-server/key_server/tls/dependency.py
@@ -2,40 +2,33 @@
 
 from logging import getLogger
 from typing import Annotated
+
 import fastapi
+
 from server_utils.fastapi_utils.app_state import (
     AppState,
     AppStateAccessor,
     get_app_state,
 )
-import tempfile
 
 from .manager import TLSManager
-
-from key_server.config import get_config
-from key_server.secure_volume.interface import SecureVolumeManager
+from key_server.config.dependency import get_config
+from key_server.config.models import ResolvedConfig
 from key_server.secure_volume.dependency import get_secure_volume_manager
+from key_server.secure_volume.manager.interface import SecureVolumeManager
 
 LOG = getLogger(__name__)
 
 _accessor = AppStateAccessor[TLSManager]("tls_manager")
 
 
-async def build_tls_manager(secure_volume_manager: SecureVolumeManager) -> TLSManager:
-    tls_base = get_config().tls_directory
-    if tls_base == "automatically_make_temporary":
-        tls_base_dir = get_config().base_directory / "tls"
-        LOG.info(
-            f"TLS certs will be temporarily in {tls_base_dir} inside the base directory"
-        )
-    else:
-        tls_base_dir = tls_base
-        LOG.info(f"TLS certs will be in permanent directory {tls_base_dir}")
+async def build_tls_manager(
+    secure_volume_manager: SecureVolumeManager, config: ResolvedConfig
+) -> TLSManager:
+    """Build the TLS manager to control TLS certificates."""
     secure_dir = secure_volume_manager.path
     return await TLSManager.create(
-        tls_base_dir,
-        secure_dir / "ca_keys",
-        tls_base_dir,
+        config.tls_directory, secure_dir / "ca_keys", config.tls_directory
     )
 
 
@@ -49,10 +42,11 @@ async def get_tls_manager(
     secure_volume: Annotated[
         SecureVolumeManager, fastapi.Depends(get_secure_volume_manager)
     ],
+    config: Annotated[ResolvedConfig, fastapi.Depends(get_config)],
 ) -> TLSManager:
     """Return the server's singleton TLSManager."""
     tls_manager = _accessor.get_from(app_state)
     if tls_manager is None:
-        tls_manager = await build_tls_manager(secure_volume)
+        tls_manager = await build_tls_manager(secure_volume, config)
         _accessor.set_on(app_state, tls_manager)
     return tls_manager

--- a/key-server/key_server/tls/ee_manager.py
+++ b/key-server/key_server/tls/ee_manager.py
@@ -1,11 +1,13 @@
 """Code for managing TLS end entities."""
 
+import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Final
+from typing import Awaitable, Callable, Final
 
 from . import cryptography_utils
+from key_server.util import subproc_wait_timeout
 
 LOG = logging.getLogger(__name__)
 
@@ -38,12 +40,38 @@ class TLSEEManager:
     EE_EXPIRY_DURATION: Final = timedelta(days=1)
     EE_EXPIRY_GRACE_DURATION: Final = timedelta(hours=1)
 
+    @staticmethod
+    async def rotate_cert_nginx() -> None:
+        """Notify nginx that it should rotate certs."""
+        LOG.info("Using systemd/nginx TLS terminator cert rotation")
+        reload_proc = await asyncio.create_subprocess_exec(
+            "/usr/bin/systemctl", "reload", "nginx-https.service"
+        )
+
+        reload_code = await subproc_wait_timeout(reload_proc)
+        if reload_code != 0:
+            LOG.warning(f"nginx could not reload ({reload_code}), restarting")
+            restart_proc = await asyncio.create_subprocess_exec(
+                "/usr/bin/systemctl", "restart", "nginx-https.service"
+            )
+            restart_code = await subproc_wait_timeout(restart_proc)
+            if restart_code != 0:
+                LOG.error(
+                    f"nginx could not restart ({restart_code}), https unavailable"
+                )
+
+    @staticmethod
+    async def rotate_cert_none() -> None:
+        """Notify (quote-unquote) nothing that certs should be rotated."""
+        LOG.info("Using none TLS terminator cert rotation")
+
     def __init__(
         self,
         key_dir: Path,
         ee_cert_dir: Path,
         robot_hostname: str,
         robot_ips: list[str],
+        rotate_fn: Callable[[], Awaitable[None]],
     ) -> None:
         """Build the TLSEEManager.
 
@@ -56,6 +84,7 @@ class TLSEEManager:
         self._ee_pair: cryptography_utils.X509Pair | None = None
         self._robot_hostname = robot_hostname
         self._robot_ips = robot_ips
+        self._tls_terminator_rotate = rotate_fn
 
     def generate_precert(self) -> cryptography_utils.PartialCertWithSigningRequired:
         """Generate a new precertificate for signing."""
@@ -87,13 +116,14 @@ class TLSEEManager:
             )
         )
 
-    def install_cert(self, cert: cryptography_utils.SignedCert) -> None:
+    async def install_cert(self, cert: cryptography_utils.SignedCert) -> None:
         """Install a signed EE cert."""
         LOG.info(
             f"Installing TLS certificate with fingerprint {cryptography_utils.fingerprint(cert.cert)}"
         )
         self.remove_cert("EE cert outdated")
         self._ee_pair = cryptography_utils.install_tls_cert(self._ee_cert_dir, cert)
+        await self._tls_terminator_rotate()
 
     def remove_cert(self, reason: str) -> None:
         """Remove the currently-managed certificate, if there is one."""

--- a/key-server/key_server/tls/manager.py
+++ b/key-server/key_server/tls/manager.py
@@ -5,7 +5,7 @@ import logging
 import socket
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Final, Self, Type
+from typing import Final, Literal, Self, Type
 
 from .ca_manager import TLSCAManager
 from .ee_manager import TLSEEManager
@@ -26,7 +26,11 @@ class TLSManager:
 
     @classmethod
     async def create(
-        cls: Type[Self], ca_cert_dir: Path, ca_key_dir: Path, tls_ee_dir: Path
+        cls: Type[Self],
+        ca_cert_dir: Path,
+        ca_key_dir: Path,
+        tls_ee_dir: Path,
+        terminator_reload: Literal["systemd-nginx", "dev-none"],
     ) -> Self:
         """Create a TLS manager, taking several useful setup steps."""
         hostname = socket.gethostname()
@@ -40,9 +44,14 @@ class TLSManager:
             # the easiest way is to start with no IP addresses and then to let the system that configures
             # IP addresses tell us when they start to exist.
             robot_ips=[],
+            rotate_fn=(
+                TLSEEManager.rotate_cert_nginx
+                if terminator_reload == "systemd-nginx"
+                else TLSEEManager.rotate_cert_none
+            ),
         )
         obj = cls(ca_manager=ca_manager, ee_manager=ee_manager)
-        obj.refresh_ee()
+        await obj.refresh_ee()
         await obj.schedule_expiry_task(cls.EXPIRY_CHECKER_POLL_PERIOD)
         return obj
 
@@ -51,11 +60,11 @@ class TLSManager:
         await self.cancel_expiry_task()
         self._ee_manager.remove_cert("shutting down")
 
-    def refresh_ee(self) -> None:
+    async def refresh_ee(self) -> None:
         """Refresh the end-entity cert that we're presenting."""
         precert = self._ee_manager.generate_precert()
         signed = self._ca_manager.sign_precert(precert)
-        self._ee_manager.install_cert(signed)
+        await self._ee_manager.install_cert(signed)
 
     def expiry_task_running(self) -> bool:
         """True if the expiry task is running properly. Mostly used internally and for testing."""
@@ -92,7 +101,7 @@ class TLSManager:
             # Rotating CAs means rotating EEs
             if self._ca_manager.must_rotate(now + poll_time):
                 self._ca_manager.rotate(now)
-                self.refresh_ee()
+                await self.refresh_ee()
             if not self._ee_manager.ready(now + poll_time):
-                self.refresh_ee()
+                await self.refresh_ee()
             await asyncio.sleep(poll_time.total_seconds())

--- a/key-server/key_server/util/__init__.py
+++ b/key-server/key_server/util/__init__.py
@@ -1,0 +1,19 @@
+"""Utilities useful across the server."""
+
+import asyncio
+from logging import getLogger
+
+LOG = getLogger(__name__)
+
+
+async def subproc_wait_timeout(
+    subproc: asyncio.subprocess.Process,
+    timeout: float | None = None,
+) -> int:
+    """Wait for a subprocess with a timeout, returning -ETIMEDOUT if the timeout hits."""
+    try:
+        return await asyncio.wait_for(subproc.wait(), timeout=(timeout or 10))
+    except asyncio.TimeoutError:
+        LOG.error("subprocess call timed out, terminating")
+        subproc.terminate()
+        return -60

--- a/key-server/tests/dev_server.py
+++ b/key-server/tests/dev_server.py
@@ -36,6 +36,7 @@ class DevServer:
         env["OT_KEY_SERVER_secure_storage_implementation"] = "dev"
         env["OT_KEY_SERVER_base_directory"] = self._base_dir.name
         env["OT_KEY_SERVER_image_mount_point"] = self._mount_dir.name
+        env["OT_KEY_SERVER_tls_server_integration"] = "dev-none"
         # In order to collect coverage we run using `coverage`.
         # `-a` is to append to existing `.coverage` file.
         # `--source` is the source code folder to collect coverage stats on.

--- a/key-server/tests/tls/test_ee_manager.py
+++ b/key-server/tests/tls/test_ee_manager.py
@@ -30,11 +30,13 @@ def ip_addresses() -> list[str]:
 @pytest.fixture
 def subject(ee_dir: Path, hostname: str, ip_addresses: list[str]) -> TLSEEManager:
     """An end-entity manager with typical settings."""
-    return TLSEEManager(ee_dir, ee_dir, hostname, ip_addresses)
+    return TLSEEManager(
+        ee_dir, ee_dir, hostname, ip_addresses, TLSEEManager.rotate_cert_none
+    )
 
 
 @pytest.fixture
-def initialized_subject(
+async def initialized_subject(
     subject: TLSEEManager,
     ca: cryptography_utils.X509Pair,
     hostname: str,
@@ -43,7 +45,7 @@ def initialized_subject(
     """An end-entity manager with certificates built."""
     precert = subject.generate_precert()
     signed = cryptography_utils.seal_cert_builder_with_ca(precert, ca)
-    subject.install_cert(signed)
+    await subject.install_cert(signed)
     return subject
 
 
@@ -67,7 +69,9 @@ def test_subject_does_not_reuse_certs(
     )
     signed = cryptography_utils.seal_cert_builder_with_ca(precert, ca)
     cryptography_utils.install_tls_cert(ee_dir, signed)
-    subject = TLSEEManager(ee_dir, ee_dir, hostname, ip_addresses)
+    subject = TLSEEManager(
+        ee_dir, ee_dir, hostname, ip_addresses, TLSEEManager.rotate_cert_none
+    )
     assert subject._ee_pair is None
     assert not subject.ready(now)
 

--- a/key-server/tests/tls/test_manager.py
+++ b/key-server/tests/tls/test_manager.py
@@ -35,7 +35,7 @@ async def subject(
     ee_dir: Path, ca_cert_dir: Path, ca_key_dir: Path
 ) -> AsyncIterator[TLSManager]:
     """A TLSManager instance."""
-    manager = await TLSManager.create(ca_cert_dir, ca_key_dir, ee_dir)
+    manager = await TLSManager.create(ca_cert_dir, ca_key_dir, ee_dir, "dev-none")
     try:
         yield manager
     finally:
@@ -120,7 +120,10 @@ async def test_rotates_ca_while_live(
         timedelta(days=365, hours=1),
     )
     subject = await TLSManager.create(
-        ca_cert_dir=ca_cert_dir, ca_key_dir=ca_key_dir, tls_ee_dir=ee_dir
+        ca_cert_dir=ca_cert_dir,
+        ca_key_dir=ca_key_dir,
+        tls_ee_dir=ee_dir,
+        terminator_reload="dev-none",
     )
     await subject.cancel_expiry_task()
 
@@ -138,11 +141,14 @@ async def test_rotates_tls_while_live(
 ) -> None:
     """It should rotate TLS EE certs when they expire."""
     subject = await TLSManager.create(
-        ca_cert_dir=ca_cert_dir, ca_key_dir=ca_key_dir, tls_ee_dir=ee_dir
+        ca_cert_dir=ca_cert_dir,
+        ca_key_dir=ca_key_dir,
+        tls_ee_dir=ee_dir,
+        terminator_reload="dev-none",
     )
     await subject.cancel_expiry_task()
     subject._ee_manager.EE_EXPIRY_DURATION = timedelta(seconds=3)  # type: ignore[misc]
-    subject.refresh_ee()
+    await subject.refresh_ee()
     assert subject._ee_manager._ee_pair
     old_ee = subject._ee_manager._ee_pair.cert
     await subject.schedule_expiry_task(timedelta(seconds=2))
@@ -165,11 +171,14 @@ async def test_rotates_tls_after_ca(
         timedelta(days=365, hours=1),
     )
     subject = await TLSManager.create(
-        ca_cert_dir=ca_cert_dir, ca_key_dir=ca_key_dir, tls_ee_dir=ee_dir
+        ca_cert_dir=ca_cert_dir,
+        ca_key_dir=ca_key_dir,
+        tls_ee_dir=ee_dir,
+        terminator_reload="dev-none",
     )
     await subject.cancel_expiry_task()
     subject._ee_manager.EE_EXPIRY_DURATION = timedelta(seconds=5)  # type: ignore[misc]
-    subject.refresh_ee()
+    await subject.refresh_ee()
     old_ee = subject._ee_manager._ee_pair
     assert old_ee
     # now, the CA expires in less than the expiry check and so does the ee

--- a/key-server/uv.lock
+++ b/key-server/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 
+[options]
+exclude-newer = "2026-04-02T18:59:16.44328Z"
+exclude-newer-span = "P1W"
+
 [manifest]
 
 [[manifest.dependency-metadata]]


### PR DESCRIPTION
# Overview

The point of having TLS certificates is to give them to nginx so that it can serve HTTPS traffic. This PR enables that!

We now actually use our fancy TLS EE and CA managers in the application lifecycle, so certs are generated and rotated automatically as the system comes up. This needed a little bit of config fettling; that's now a dependency and gets parsed in the lifecycle as well.

The other fun bit is that nginx needs to be explicitly told when a cert changes out from under it, because nginx aggressively caches them. We do this with systemd, but of course we don't have systemd in test or dev, so we have a new setting to just not do that.

There's a lot more to this, to do with nginx configuration, but that's over in oe-core: https://github.com/Opentrons/oe-core/pull/302

## Test Plan and Hands on Testing

This is the first thing that can be reasonably tested! You'll need an OE core build to do it, for reasons that become apparent in the OE core pr, but once you have that you can do the following:
- fetch the CA cert from the robot; it should be in `/var/lib/opentrons-key-server/tls/ot-robot-tls-ca-SOMEDATE.cer`. note that this is not in the secure volume; it is a public key and is public data. scp this cert to your computer
- Add that CA to your browser's trust store, in the way that seems best to you
- Navigate to `https://robotip:32313/health` and note that the browser (a) displays a lock and (b) displays our json error text: `{"message":"header.opentrons-version: Field required","errorCode":"4000"}`
- Note that the above may not reaaaly work because we don't have the robot IPs baked into the certs yet; but you should definitely get it doing HTTPS traffic even if it's not trusted, and the system should trace the end entity cert back to the CA cert you installed.
- If you can tell me why that's the port I picked you will feel very clever

## Review requests

Not that much code change over here, though there is in OE-core; still, take a look especially about the config dependency.

## Risk assessment

Low, not used yet.

Closes EXEC-2475