### PR TITLE
fix(app): fix sentry error app-4n

### DIFF
--- a/app/src/redux-resources/robots/hooks/__tests__/useIsRobotBusy.test.ts
+++ b/app/src/redux-resources/robots/hooks/__tests__/useIsRobotBusy.test.ts
@@ -196,6 +196,7 @@ describe('useIsRobotBusy', () => {
     const result = useIsRobotBusy()
     expect(result).toBe(true)
   })
+
   it('returns true when a subsystem update is in progress', () => {
     vi.mocked(useCurrentAllSubsystemUpdatesQuery).mockReturnValue({
       data: {
@@ -208,6 +209,14 @@ describe('useIsRobotBusy', () => {
           },
         ],
       },
+    } as any)
+    const result = useIsRobotBusy()
+    expect(result).toBe(true)
+  })
+
+  it('returns no error when data is empty', () => {
+    vi.mocked(useCurrentAllSubsystemUpdatesQuery).mockReturnValue({
+      data: {},
     } as any)
     const result = useIsRobotBusy()
     expect(result).toBe(true)

--- a/app/src/redux-resources/robots/hooks/useIsRobotBusy.ts
+++ b/app/src/redux-resources/robots/hooks/useIsRobotBusy.ts
@@ -39,7 +39,7 @@ export function useIsRobotBusy(
       refetchInterval: ROBOT_SUBSTATE_POLL_MS,
     })
   const isSubsystemUpdating =
-    currentSubsystemsUpdatesData?.data.some(
+    (currentSubsystemsUpdatesData?.data ?? []).some(
       update =>
         update.updateStatus === 'queued' || update.updateStatus === 'updating'
     ) ?? false


### PR DESCRIPTION


# Overview
fix sentry error [app-4n](https://opentrons-76.sentry.io/issues/7399530970/?project=4510008251711488)
the issue is that the current implementation does not account for cases where ‎`currentSubsystemsUpdatesData?.data` is `undefined`.


close AUTH-2870


## Test Plan and Hands on Testing


## Changelog
- modify isSubsystemUpdating
- add a test for the fix

## Review requests


## Risk assessment
low
