### PR TITLE
fix(components): display correct wells for tip pick up in all nozzle configurations

### DIFF
--- a/components/src/assets/localization/en/protocol_command_text.json
+++ b/components/src/assets/localization/en/protocol_command_text.json
@@ -88,6 +88,7 @@
   "on_location": "on {{location}}",
   "opening_tc_lid": "Opening Thermocycler lid",
   "partial_layout": "partial layout",
+  "partial_nozzles": "partial column",
   "pause": "Pause",
   "pause_on": "Pause on {{robot_name}}",
   "pickup_tip": "Picking up tip(s) from {{well_range}} of {{labware}} in {{labware_location}}",

--- a/components/src/organisms/CommandText/useCommandTextString/utils/__tests__/getWellRange.test.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/__tests__/getWellRange.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest'
+
+import { COLUMN, PARTIAL_COLUMN, ROW, SINGLE } from '@opentrons/shared-data'
+
+import { getWellRange } from '../getWellRange'
+
+import type { RunTimeCommand } from '@opentrons/shared-data'
+
+describe('getWellRange', () => {
+  const pipette96chName = 'p1000_96'
+  const pipette96chId = 'id_96ch'
+  const pipette8chName = 'p1000_multi_flex'
+  const pipette8chId = 'id_8ch'
+  const wellName = 'A1'
+  const mockLoad96Ch: RunTimeCommand[] = [
+    {
+      id: '97ba49a5-04f6-4f91-986a-04a0eb632882',
+      createdAt: '2022-09-07T19:47:42.781065+00:00',
+      commandType: 'loadPipette',
+      key: '0feeecaf-3895-46d7-ab71-564601265e35',
+      status: 'succeeded',
+      params: {
+        pipetteName: pipette96chName,
+        mount: 'left',
+        pipetteId: pipette96chId,
+      },
+      result: {
+        pipetteId: pipette96chId,
+      },
+      startedAt: '2022-09-07T19:47:42.782665+00:00',
+      completedAt: '2022-09-07T19:47:42.785061+00:00',
+    },
+    {
+      id: 'commands.LOAD_LABWARE-2',
+      createdAt: '2022-04-01T15:46:01.745870+00:00',
+      startedAt: '2025-06-09T19:03:33.876627Z',
+      completedAt: '2025-06-09T19:03:33.920770Z',
+      commandType: 'loadLabware',
+      key: 'commands.LOAD_LABWARE-2',
+      status: 'succeeded',
+      params: {
+        location: {
+          slotName: 'A1',
+        },
+        loadName: 'opentrons_flex_96_tiprack_1000ul',
+        namespace: 'opentrons',
+        version: 1,
+        labwareId: 'labware',
+        displayName: 'Opentrons Flex 96 Tip Rack 1000 µL',
+      },
+    },
+  ]
+  it('returns the correct well range for 96ch COLUMN tip pick up', () => {
+    const configureColumnLayout: RunTimeCommand[] = [
+      {
+        id: 'ddc7eb8a-125c-4cbe-a17b-d7656f4267ea',
+        key: 'd4beb0ebc152fc6721eda98eae414039',
+        commandType: 'configureNozzleLayout',
+        createdAt: '2025-06-09T19:03:33.875521Z',
+        startedAt: '2025-06-09T19:03:33.876627Z',
+        completedAt: '2025-06-09T19:03:33.920770Z',
+        status: 'succeeded',
+        params: {
+          pipetteId: pipette96chId,
+          configurationParams: {
+            style: COLUMN,
+            primaryNozzle: 'A1',
+          },
+        },
+        notes: [],
+      },
+    ]
+    const allColumnCommands = [...mockLoad96Ch, ...configureColumnLayout]
+    expect(
+      getWellRange(pipette96chId, allColumnCommands, wellName, pipette96chName)
+    ).toEqual('A1 - H1')
+  })
+  it('returns the correct well range for 96ch ROW tip pick up', () => {
+    const configureRowLayout: RunTimeCommand[] = [
+      {
+        id: 'ddc7eb8a-125c-4cbe-a17b-d7656f4267ea',
+        key: 'd4beb0ebc152fc6721eda98eae414039',
+        commandType: 'configureNozzleLayout',
+        createdAt: '2025-06-09T19:03:33.875521Z',
+        startedAt: '2025-06-09T19:03:33.876627Z',
+        completedAt: '2025-06-09T19:03:33.920770Z',
+        status: 'succeeded',
+        params: {
+          pipetteId: pipette96chId,
+          configurationParams: {
+            style: ROW,
+            primaryNozzle: 'A1',
+          },
+        },
+        notes: [],
+      },
+    ]
+    const allColumnCommands = [...mockLoad96Ch, ...configureRowLayout]
+    expect(
+      getWellRange(pipette96chId, allColumnCommands, wellName, pipette96chName)
+    ).toEqual('A1 - A12')
+  })
+  it('returns the correct well range for 96ch SINGLE tip pick up', () => {
+    const configureSingleLayout: RunTimeCommand[] = [
+      {
+        id: 'ddc7eb8a-125c-4cbe-a17b-d7656f4267ea',
+        key: 'd4beb0ebc152fc6721eda98eae414039',
+        commandType: 'configureNozzleLayout',
+        createdAt: '2025-06-09T19:03:33.875521Z',
+        startedAt: '2025-06-09T19:03:33.876627Z',
+        completedAt: '2025-06-09T19:03:33.920770Z',
+        status: 'succeeded',
+        params: {
+          pipetteId: pipette96chId,
+          configurationParams: {
+            style: SINGLE,
+            primaryNozzle: 'A1',
+          },
+        },
+        notes: [],
+      },
+    ]
+    const allColumnCommands = [...mockLoad96Ch, ...configureSingleLayout]
+    expect(
+      getWellRange(pipette96chId, allColumnCommands, 'H12', pipette96chName)
+    ).toEqual('H12')
+  })
+  it('returns the correct well range for 8ch SINGLE tip pick up', () => {
+    const configureSingleLayout: RunTimeCommand[] = [
+      {
+        id: 'ddc7eb8a-125c-4cbe-a17b-d7656f4267ea',
+        key: 'd4beb0ebc152fc6721eda98eae414039',
+        commandType: 'configureNozzleLayout',
+        createdAt: '2025-06-09T19:03:33.875521Z',
+        startedAt: '2025-06-09T19:03:33.876627Z',
+        completedAt: '2025-06-09T19:03:33.920770Z',
+        status: 'succeeded',
+        params: {
+          pipetteId: pipette8chId,
+          configurationParams: {
+            style: SINGLE,
+            primaryNozzle: 'A1',
+          },
+        },
+        notes: [],
+      },
+    ]
+    const allColumnCommands = [...mockLoad96Ch, ...configureSingleLayout]
+    expect(
+      getWellRange(pipette8chId, allColumnCommands, 'H12', pipette8chName)
+    ).toEqual('H12')
+  })
+  it('returns the correct well range for 8ch PARTIAL 2 tip pick up', () => {
+    const configurePartial2Layout: RunTimeCommand[] = [
+      {
+        id: 'ddc7eb8a-125c-4cbe-a17b-d7656f4267ea',
+        key: 'd4beb0ebc152fc6721eda98eae414039',
+        commandType: 'configureNozzleLayout',
+        createdAt: '2025-06-09T19:03:33.875521Z',
+        startedAt: '2025-06-09T19:03:33.876627Z',
+        completedAt: '2025-06-09T19:03:33.920770Z',
+        status: 'succeeded',
+        params: {
+          pipetteId: pipette8chId,
+          configurationParams: {
+            style: PARTIAL_COLUMN,
+            primaryNozzle: 'A1',
+            backLeftNozzle: 'G1',
+          },
+        },
+        notes: [],
+      },
+    ]
+    const allColumnCommands = [...mockLoad96Ch, ...configurePartial2Layout]
+    expect(
+      getWellRange(pipette8chId, allColumnCommands, 'A1', pipette8chName)
+    ).toEqual('A1 - B1')
+  })
+  it('returns the correct well range for 8ch PARTIAL 7 tip pick up', () => {
+    const configurePartial7Layout: RunTimeCommand[] = [
+      {
+        id: 'ddc7eb8a-125c-4cbe-a17b-d7656f4267ea',
+        key: 'd4beb0ebc152fc6721eda98eae414039',
+        commandType: 'configureNozzleLayout',
+        createdAt: '2025-06-09T19:03:33.875521Z',
+        startedAt: '2025-06-09T19:03:33.876627Z',
+        completedAt: '2025-06-09T19:03:33.920770Z',
+        status: 'succeeded',
+        params: {
+          pipetteId: pipette8chId,
+          configurationParams: {
+            style: PARTIAL_COLUMN,
+            primaryNozzle: 'A1',
+            backLeftNozzle: 'B1',
+          },
+        },
+        notes: [],
+      },
+    ]
+    const allColumnCommands = [...mockLoad96Ch, ...configurePartial7Layout]
+    expect(
+      getWellRange(pipette8chId, allColumnCommands, 'A1', pipette8chName)
+    ).toEqual('A1 - G1')
+  })
+})

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getWellRange.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getWellRange.ts
@@ -1,28 +1,51 @@
-import { getPipetteNameSpecs } from '@opentrons/shared-data'
+import {
+  COLUMN,
+  getPipetteNameSpecs,
+  PARTIAL_COLUMN,
+  PARTIAL_NOZZLE_MAP,
+  ROW,
+  SINGLE,
+} from '@opentrons/shared-data'
 
 import type {
+  ActiveNozzleNumber,
   ConfigureNozzleLayoutRunTimeCommand,
+  NozzleConfigurationParams,
+  PartialPrimaryNozzles,
   PipetteName,
   RunTimeCommand,
 } from '@opentrons/shared-data'
 
 const usedChannelsFromCommand = (
   command: ConfigureNozzleLayoutRunTimeCommand | undefined,
-  defaultChannels: number
-): number =>
-  command?.params?.configurationParams?.style === 'SINGLE'
-    ? 1
-    : command?.params?.configurationParams?.style === 'COLUMN'
-      ? 8
-      : command?.params?.configurationParams?.style === 'ROW'
-        ? 12
+  defaultChannels: ActiveNozzleNumber
+): ActiveNozzleNumber => {
+  const configurationStyle: NozzleConfigurationParams | undefined =
+    command?.params?.configurationParams
+
+  switch (configurationStyle?.style) {
+    case COLUMN:
+      return 8
+    case ROW:
+      return 12
+    case SINGLE:
+      return 1
+    case PARTIAL_COLUMN:
+      return configurationStyle?.primaryNozzle != null
+        ? PARTIAL_NOZZLE_MAP[
+            configurationStyle.primaryNozzle as PartialPrimaryNozzles
+          ]
         : defaultChannels
+    default:
+      return defaultChannels
+  }
+}
 
 const usedChannelsForPipette = (
   pipetteId: string,
   commands: RunTimeCommand[],
-  defaultChannels: number
-): number =>
+  defaultChannels: ActiveNozzleNumber
+): ActiveNozzleNumber =>
   usedChannelsFromCommand(
     commands.findLast(
       (c: RunTimeCommand): c is ConfigureNozzleLayoutRunTimeCommand =>
@@ -35,8 +58,8 @@ const usedChannelsForPipette = (
 const usedChannels = (
   pipetteId: string,
   commands: RunTimeCommand[],
-  pipetteChannels: number
-): number =>
+  pipetteChannels: ActiveNozzleNumber
+): ActiveNozzleNumber =>
   pipetteChannels === 96
     ? usedChannelsForPipette(pipetteId, commands, pipetteChannels)
     : pipetteChannels
@@ -56,15 +79,26 @@ export function getWellRange(
   const pipetteChannels = pipetteName
     ? (getPipetteNameSpecs(pipetteName)?.channels ?? 1)
     : 1
+
   const channelCount = usedChannels(pipetteId, commands, pipetteChannels)
-  if (channelCount === 96) {
-    return 'A1 - H12'
-  } else if (channelCount === 8) {
-    const column = wellName.substring(1)
-    return `A${column} - H${column}`
-  } else if (channelCount === 12) {
-    const row = wellName.charAt(0)
-    return `${row}1 - ${row}12`
+
+  switch (true) {
+    case channelCount === 96:
+      return 'A1 - H12'
+    case channelCount === 8: {
+      const column = wellName.substring(1)
+      return `A${column} - H${column}`
+    }
+    case channelCount === 12: {
+      const row = wellName.charAt(0)
+      return `${row}1 - ${row}12`
+    }
+    case channelCount >= 2 && channelCount <= 7: {
+      const column = wellName.substring(1)
+      const endRow = String.fromCharCode(64 + channelCount)
+      return `A${column} - ${endRow}${column}`
+    }
+    default:
+      return wellName
   }
-  return wellName
 }

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getWellRange.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getWellRange.ts
@@ -82,23 +82,19 @@ export function getWellRange(
 
   const channelCount = usedChannels(pipetteId, commands, pipetteChannels)
 
-  switch (true) {
-    case channelCount === 96:
-      return 'A1 - H12'
-    case channelCount === 8: {
-      const column = wellName.substring(1)
-      return `A${column} - H${column}`
-    }
-    case channelCount === 12: {
-      const row = wellName.charAt(0)
-      return `${row}1 - ${row}12`
-    }
-    case channelCount >= 2 && channelCount <= 7: {
-      const column = wellName.substring(1)
-      const endRow = String.fromCharCode(64 + channelCount)
-      return `A${column} - ${endRow}${column}`
-    }
-    default:
-      return wellName
+  if (channelCount === 96) {
+    return 'A1 - H12'
+  } else if (channelCount === 8) {
+    const column = wellName.substring(1)
+    return `A${column} - H${column}`
+  } else if (channelCount === 12) {
+    const row = wellName.charAt(0)
+    return `${row}1 - ${row}12`
+  } else if (channelCount >= 2 && channelCount <= 7) {
+    const column = wellName.substring(1)
+    const endRow = String.fromCharCode(64 + channelCount)
+    return `A${column} - ${endRow}${column}`
+  } else {
+    return wellName
   }
 }

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getWellRange.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getWellRange.ts
@@ -3,6 +3,7 @@ import {
   getPipetteNameSpecs,
   PARTIAL_COLUMN,
   PARTIAL_NOZZLE_MAP,
+  QUADRANT,
   ROW,
   SINGLE,
 } from '@opentrons/shared-data'
@@ -22,7 +23,6 @@ const usedChannelsFromCommand = (
 ): ActiveNozzleNumber => {
   const configurationStyle: NozzleConfigurationParams | undefined =
     command?.params?.configurationParams
-
   switch (configurationStyle?.style) {
     case COLUMN:
       return 8
@@ -30,12 +30,14 @@ const usedChannelsFromCommand = (
       return 12
     case SINGLE:
       return 1
+    case QUADRANT:
     case PARTIAL_COLUMN:
-      return configurationStyle?.primaryNozzle != null
+      return configurationStyle?.backLeftNozzle != null
         ? PARTIAL_NOZZLE_MAP[
-            configurationStyle.primaryNozzle as PartialPrimaryNozzles
+            configurationStyle?.backLeftNozzle as PartialPrimaryNozzles
           ]
         : defaultChannels
+
     default:
       return defaultChannels
   }
@@ -60,9 +62,7 @@ const usedChannels = (
   commands: RunTimeCommand[],
   pipetteChannels: ActiveNozzleNumber
 ): ActiveNozzleNumber =>
-  pipetteChannels === 96
-    ? usedChannelsForPipette(pipetteId, commands, pipetteChannels)
-    : pipetteChannels
+  usedChannelsForPipette(pipetteId, commands, pipetteChannels)
 
 /**
  * @param pipetteName name of pipette being used

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getWellRange.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getWellRange.ts
@@ -14,7 +14,9 @@ const usedChannelsFromCommand = (
     ? 1
     : command?.params?.configurationParams?.style === 'COLUMN'
       ? 8
-      : defaultChannels
+      : command?.params?.configurationParams?.style === 'ROW'
+        ? 12
+        : defaultChannels
 
 const usedChannelsForPipette = (
   pipetteId: string,
@@ -60,6 +62,9 @@ export function getWellRange(
   } else if (channelCount === 8) {
     const column = wellName.substring(1)
     return `A${column} - H${column}`
+  } else if (channelCount === 12) {
+    const row = wellName.charAt(0)
+    return `${row}1 - ${row}12`
   }
   return wellName
 }

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -344,6 +344,7 @@ export type PrimaryNozzleConfigurationStyle =
 
 export interface NozzleConfigurationParams {
   primaryNozzle?: PrimaryNozzleConfigurationStyle
+  backLeftNozzle?: PartialPrimaryNozzles
   style: NozzleConfigurationStyle
 }
 


### PR DESCRIPTION
# Overview

Correctly display tips being picked up for all nozzle configurations

## Test Plan and Hands on Testing

- smoke tested on the app to ensure the step says accessing tips "A1 - A12"
<img width="938" height="682" alt="Screenshot 2026-04-09 at 5 38 34 PM" src="https://github.com/user-attachments/assets/749d1f09-a05e-4c4b-9880-144e297f676b" />

## Changelog
- added additional case for when there are 12 active nozzles 
- added additional case for when there are partial 8ch active nozzles

## Review requests

none

## Risk assessment

- low cosmetic change

closes AUTH-2223