### PR TITLE
docs: Detach OT2 pipettes

### DIFF
--- a/docs/ot-2/docs/installation/instruments.md
+++ b/docs/ot-2/docs/installation/instruments.md
@@ -1,42 +1,44 @@
 ---
-title: "Opentrons OT-2: Pipette Installation, Removal, and Calibration"
-description: "Instructions for attaching, removing, calibrating pipettes on an OT-2."
+title: "Opentrons OT-2: Pipette Installation, Calibration, and Removal"
+description: "Instructions for attaching, removing, and calibrating pipettes on an OT-2."
 ---
 
-After the initial robot setup, your next step is to attach and calibrate a pipette. The OT-2 has two pipette mounts; each can hold a single-channel or multi-channel pipette. The Opentrons App provides detailed, illustrated instructions about attaching, removing, and calibrating an OT-2 pipette. Follow these instructions to begin.
+After the initial robot setup, your next step is to attach and calibrate a pipette. The OT-2 has two pipette mounts; each can hold a single-channel or multi-channel pipette. The Opentrons App provides detailed, illustrated instructions about attaching, removing, and calibrating these instruments. Follow these instructions to attach and calibrate a pipette or to remove it.
 
 ## Attaching and calibrating
 
 <div class="instruction-list" markdown>
 
-1. Prepare your robot for installation by removing any labware from the deck and clearing the working area to make attachment and calibration easier.
+1. Prepare your robot by removing any labware from the deck and clearing the working area. Give yourself room to work.
 
 2. In the Opentrons App, click the **Devices** tab and select the OT-2 you want to work with.
 
 3. In the Pipettes and Modules section for your device:
-
     - Select the left or right pipette mount.
-    - Click the three-dot menu (⋮), and then click **Attach pipette**. The gantry will move towards the front of the deck and the mount will lower.
+    - Click the three-dot menu (⋮) and then click **Attach pipette**. 
+    
+    !!! note
+        The gantry will move towards the front of the deck and the mount will lower.
 
-    ![pipette attachment](../images/pipettes-and-modules.png)
-
-4. In the Opentrons App, follow the on-screen instructions to attach and [calibrate your pipette](../calibration/robot-calibration.md#pipette-offset-calibration).
+4. In the Opentrons App, follow the on-screen instructions to connect the ribbon cable, secure the screws, and [calibrate your pipette](../calibration/robot-calibration.md#pipette-offset-calibration).
 
 </div>
 
-## Detaching
+## Detaching and removing
 
 <div class="instruction-list" markdown>
 
-1. Prepare your robot by removing any labware from the deck and clearing the working area.
+1. Prepare your robot by removing any labware from the deck and clearing the working area. Give yourself room to work.
 
 2. In the Opentrons App, click the **Devices** tab and select the OT-2 you want to work with.
 
-3. In the Pipettes and Modules section for your device, click the three-dot menu (⋮) for the pipette you want to remove and then click **Detach pipette**. The gantry will move towards the front of the deck and the mount will lower.
+3. In the Pipettes and Modules section for your device:
+    - Click the three-dot menu (⋮) for the pipette you want to remove.
+    - Click **Detach pipette**. 
+    
+    !!! note
+        The gantry will move towards the front of the deck and the mount will lower.
 
-    - Select the pipette you want to detach.
-    - Click the three-dot menu (⋮), and then click **Detach pipette**. The gantry will move towards the front of the deck and the mount will lower.
-
-4. In the Opentrons App, follow the on-screen instructions to remove a pipette from your OT-2.
+4. In the Opentrons App, follow the on-screen instructions to remove the screws and detach the ribbon cable.
 
 </div>

--- a/docs/ot-2/docs/installation/instruments.md
+++ b/docs/ot-2/docs/installation/instruments.md
@@ -1,9 +1,11 @@
 ---
-title: "Opentrons OT-2: Instrument Installation and Calibration"
-description: "Attach pipettes to the gantry and run calibration using the Opentrons App."
+title: "Opentrons OT-2: Pipette Installation, Removal, and Calibration"
+description: "Instructions for attaching, removing, calibrating pipettes on an OT-2."
 ---
 
-After the initial robot setup, your next step is to attach and calibrate a pipette. The OT-2 has two pipette mounts; each can hold a single-channel or multi-channel pipette. The information in this section will help you get started; the Opentrons App provides detailed, illustrated instructions about the attachment and calibration workflows. To begin:
+After the initial robot setup, your next step is to attach and calibrate a pipette. The OT-2 has two pipette mounts; each can hold a single-channel or multi-channel pipette. The Opentrons App provides detailed, illustrated instructions about attaching, removing, and calibrating an OT-2 pipette. Follow these instructions to begin.
+
+## Attaching and calibrating
 
 <div class="instruction-list" markdown>
 
@@ -18,6 +20,23 @@ After the initial robot setup, your next step is to attach and calibrate a pipet
 
     ![pipette attachment](../images/pipettes-and-modules.png)
 
-4. In the Opentrons App, follow the on-screen instructions and animations to attach and [calibrate your pipette](../calibration/robot-calibration.md#pipette-offset-calibration).
+4. In the Opentrons App, follow the on-screen instructions to attach and [calibrate your pipette](../calibration/robot-calibration.md#pipette-offset-calibration).
+
+</div>
+
+## Detaching
+
+<div class="instruction-list" markdown>
+
+1. Prepare your robot by removing any labware from the deck and clearing the working area.
+
+2. In the Opentrons App, click the **Devices** tab and select the OT-2 you want to work with.
+
+3. In the Pipettes and Modules section for your device, click the three-dot menu (⋮) for the pipette you want to remove and then click **Detach pipette**. The gantry will move towards the front of the deck and the mount will lower.
+
+    - Select the pipette you want to detach.
+    - Click the three-dot menu (⋮), and then click **Detach pipette**. The gantry will move towards the front of the deck and the mount will lower.
+
+4. In the Opentrons App, follow the on-screen instructions to remove a pipette from your OT-2.
 
 </div>

--- a/docs/ot-2/docs/pipettes.md
+++ b/docs/ot-2/docs/pipettes.md
@@ -32,7 +32,7 @@ OT-2 GEN2 pipettes are different than their GEN1 predecessors. GEN2 pipettes are
 
 ## Installing OT-2 pipettes
 
-For instructions on installing pipettes, see the [Instrument Installation and Calibration section](installation/instruments.md).
+For instructions on installing, calibrating, and detaching pipettes, see the [Instrument Installation and Calibration section](installation/instruments.md).
 
 ## Replacing OT-2 pipettes
 

--- a/docs/ot-2/mkdocs.yml
+++ b/docs/ot-2/mkdocs.yml
@@ -9,7 +9,7 @@ nav:
       - Installation Requirements: installation/requirements.md
       - Unboxing: installation/unboxing.md
       - First Run: installation/first-run.md
-      - Instrument Installation and Calibration: installation/instruments.md
+      - Pipette Installation, Removal, and Calibration: installation/instruments.md
       - Relocation: installation/relocation.md
   - System Description:
       - System Description: system-description/index.md


### PR DESCRIPTION
# Overview

The last OT-2 revision backlog item: a short section on removing a pipette.

RTC-962

## Test Plan and Hands on Testing

Tested by doing.

## Changelog

Makes title changes and adds section headers to `instruments.md`.

## Review requests

Please take a look. Better than "just do it in reverse."

## Risk assessment

Low, low, low. Docs only.
