### PR TITLE
feat(app): disable to routing when a protocol type is different from the app type

### DIFF
--- a/app/src/organisms/Desktop/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/Desktop/ProtocolsLanding/ProtocolCard.tsx
@@ -80,6 +80,12 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
     />
   )
 
+  const handleClickCard = (): void => {
+    if (mostRecentAnalysis?.robotType === FLEX_ROBOT_TYPE) {
+      navigate(`/protocols/${protocolKey}`)
+    }
+  }
+
   return (
     <Box
       backgroundColor={COLORS.white}
@@ -88,9 +94,7 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
       minWidth="36rem"
       padding={SPACING.spacing16}
       position="relative"
-      onClick={() => {
-        navigate(`/protocols/${protocolKey}`)
-      }}
+      onClick={handleClickCard}
     >
       <ErrorBoundary fallback={UnknownAttachmentError}>
         <AnalysisInfo

--- a/app/src/organisms/Desktop/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/Desktop/ProtocolsLanding/ProtocolCard.tsx
@@ -27,6 +27,7 @@ import {
   getGripperDisplayName,
   getModuleType,
   getPipetteNameSpecs,
+  OT2_ROBOT_TYPE,
   parseAllRequiredModuleModels,
   parseInitialPipetteNamesByMount,
 } from '@opentrons/shared-data'
@@ -81,7 +82,10 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
   )
 
   const handleClickCard = (): void => {
-    if (mostRecentAnalysis?.robotType === FLEX_ROBOT_TYPE) {
+    if (
+      mostRecentAnalysis?.robotType != null &&
+      mostRecentAnalysis.robotType !== OT2_ROBOT_TYPE
+    ) {
       navigate(`/protocols/${protocolKey}`)
     }
   }

--- a/app/src/organisms/Desktop/ProtocolsLanding/__tests__/ProtocolCard.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolsLanding/__tests__/ProtocolCard.test.tsx
@@ -1,0 +1,141 @@
+import { MemoryRouter } from 'react-router-dom'
+import { fireEvent, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  FLEX_ROBOT_TYPE,
+  OT2_ROBOT_TYPE,
+  simpleAnalysisFileFixture,
+} from '@opentrons/shared-data'
+
+import { renderWithProviders } from '/app/__testing-utils__'
+import { i18n } from '/app/i18n'
+import { getIsProtocolAnalysisInProgress } from '/app/redux/protocol-storage'
+import { storedProtocolData } from '/app/redux/protocol-storage/__fixtures__'
+
+import { ProtocolCard } from '../ProtocolCard'
+
+import type { ComponentProps } from 'react'
+import type { NavigateFunction } from 'react-router-dom'
+import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
+import type { StoredProtocolData } from '/app/redux/protocol-storage'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async importOriginal => {
+  const actual = await importOriginal<NavigateFunction>()
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+vi.mock('/app/redux/protocol-storage', async importOriginal => {
+  const actual = await importOriginal<typeof getIsProtocolAnalysisInProgress>()
+  return {
+    ...actual,
+    getIsProtocolAnalysisInProgress: vi.fn(),
+  }
+})
+
+vi.mock('../ProtocolOverflowMenu', () => ({
+  ProtocolOverflowMenu: vi.fn(() => <div>mock protocol overflow menu</div>),
+}))
+
+vi.mock('../ProtocolAnalysisFailure', () => ({
+  ProtocolAnalysisFailure: vi.fn(({ errors }: { errors: string[] }) => (
+    <div>{errors.join(', ')}</div>
+  )),
+}))
+
+vi.mock('../ProtocolAnalysisFailure/ProtocolAnalysisStale', () => ({
+  ProtocolAnalysisStale: vi.fn(() => <div>mock protocol analysis stale</div>),
+}))
+
+vi.mock('../ProtocolStatusBanner', () => ({
+  ProtocolStatusBanner: vi.fn(() => <div>mock protocol status banner</div>),
+}))
+
+const makeStoredProtocolData = (
+  analysis: Partial<ProtocolAnalysisOutput>
+): StoredProtocolData => ({
+  ...storedProtocolData,
+  mostRecentAnalysis: {
+    ...simpleAnalysisFileFixture,
+    metadata: { protocolName: 'Mock Protocol' },
+    ...analysis,
+  } as ProtocolAnalysisOutput,
+})
+
+const render = (props: ComponentProps<typeof ProtocolCard>) => {
+  return renderWithProviders(
+    <MemoryRouter>
+      <ProtocolCard {...props} />
+    </MemoryRouter>,
+    {
+      i18nInstance: i18n,
+    }
+  )[0]
+}
+
+describe('ProtocolCard', () => {
+  let props: ComponentProps<typeof ProtocolCard>
+
+  beforeEach(() => {
+    props = {
+      handleRunProtocol: vi.fn(),
+      handleSendProtocolToFlex: vi.fn(),
+      storedProtocolData: makeStoredProtocolData({
+        robotType: FLEX_ROBOT_TYPE,
+        errors: [],
+      }),
+    }
+    vi.mocked(getIsProtocolAnalysisInProgress).mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders protocol information and overflow menu', () => {
+    render(props)
+
+    screen.getByText('Mock Protocol')
+    screen.getByText('mock protocol overflow menu')
+    screen.getByText('P300 Single-Channel GEN2')
+    screen.getByText('Modules')
+  })
+
+  it('navigates when clicking an Flex protocol card', () => {
+    render(props)
+
+    fireEvent.click(screen.getByText('Mock Protocol'))
+
+    expect(mockNavigate).toHaveBeenCalledWith('/protocols/protocolKeyStub')
+  })
+
+  it('does not navigate for OT2 protocol', () => {
+    render({
+      ...props,
+      storedProtocolData: makeStoredProtocolData({
+        robotType: OT2_ROBOT_TYPE,
+        errors: [],
+      }),
+    })
+
+    screen.getByTestId('InlineNotification_alert')
+    screen.getByText('Get the app')
+
+    fireEvent.click(screen.getByText('Mock Protocol'))
+
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('renders loading state while analysis is in progress', () => {
+    vi.mocked(getIsProtocolAnalysisInProgress).mockReturnValue(true)
+
+    render(props)
+
+    screen.getByText('Loading data...')
+  })
+})


### PR DESCRIPTION



# Overview
disable to routing when a protocol type is different from the app type
close EXEC-2530


## Test Plan and Hands on Testing
- open the app
- import an OT-2 protocol
- click the protocol card that imported
Check the app doesn't respond to the click

## Changelog
- update handle function for the protocol card
- add test for Protocol card component

## Review requests


## Risk assessment
low
