### PR TITLE
fix(protocol-designer): remove pipette shadow when no well is hovered

### DIFF
--- a/components/src/hardware-sim/Labware/labwareInternals/Wells/EmptyWell.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/Wells/EmptyWell.tsx
@@ -33,9 +33,21 @@ export function EmptyWell({
   const viewBoxHeight = isCircular ? circularSize : height
   const viewBox = `0 0 ${viewBoxWidth} ${viewBoxHeight}`
   const lineStrokeWidth = isCircular ? 2 : 1
-  const lineProps = isLabware
-    ? { x1: 0, y1: 0, x2: viewBoxWidth, y2: viewBoxHeight }
-    : { x1: viewBoxWidth, y1: 0, x2: 0, y2: viewBoxHeight }
+
+  const cx = 10
+  const cy = 10
+  const r = 9
+  const angle = Math.PI / 4
+  const dx = r * Math.cos(angle)
+  const dy = r * Math.sin(angle)
+  const lineProps = isCircular
+    ? {
+        x1: cx - dx,
+        y1: cy - dy,
+        x2: cx + dx,
+        y2: cy + dy,
+      }
+    : { x1: 0, y1: 0, x2: viewBoxWidth, y2: viewBoxHeight }
 
   const maskId = 'emptyWellMask'
 
@@ -47,21 +59,6 @@ export function EmptyWell({
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <mask
-        id={maskId}
-        maskUnits="userSpaceOnUse"
-        x="0"
-        y="0"
-        width={viewBoxWidth}
-        height={viewBoxHeight}
-      >
-        {isCircular ? (
-          <circle cx="10" cy="10" r="9.5" fill="white" {...commonProps} />
-        ) : (
-          <rect width={width} height={height} fill="white" {...commonProps} />
-        )}
-      </mask>
-
       <g mask={`url(#${maskId})`}>
         {isCircular ? (
           <circle
@@ -70,7 +67,7 @@ export function EmptyWell({
             r="9"
             fill="#CBCCCC"
             stroke={outlineColor}
-            strokeWidth="3"
+            strokeWidth="2"
             {...commonProps}
           />
         ) : (

--- a/components/src/hardware-sim/Labware/labwareInternals/Wells/EmptyWell.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/Wells/EmptyWell.tsx
@@ -14,68 +14,55 @@ interface EmptyWellProps {
   size: string
 }
 
-export function EmptyWell(props: EmptyWellProps): JSX.Element {
-  const { size, wellMap, wellName, parentType } = props
+export function EmptyWell({
+  size,
+  wellMap,
+  wellName,
+  parentType,
+}: EmptyWellProps): JSX.Element {
   const commonProps = {
     [INTERACTIVE_WELL_DATA_ATTRIBUTE]: wellName,
   }
-  const firstWell = wellMap.A1
-  const isCircular = firstWell.shape === 'circular'
-  const isRectangular = firstWell.shape === 'rectangular'
+  const { shape } = wellMap.A1
+  const isCircular = shape === 'circular'
   const [width, height] = getWidthAndHeightOfWellSVG(wellMap)
   const isLabware = parentType === LABWARE
   const outlineColor = isLabware ? COLORS.grey50 : COLORS.black90
-  const circularDimension = 20
-  const viewBoxWidth = isCircular ? circularDimension : width
-  const viewBoxHeight = isCircular ? circularDimension : height
-  const viewBox = !isRectangular
-    ? `0 0 20 20`
-    : `0 0 ${viewBoxWidth} ${viewBoxHeight}`
+  const circularSize = 20
+  const viewBoxWidth = isCircular ? circularSize : width
+  const viewBoxHeight = isCircular ? circularSize : height
+  const viewBox = `0 0 ${viewBoxWidth} ${viewBoxHeight}`
   const lineStrokeWidth = isCircular ? 2 : 1
   const lineProps = isLabware
-    ? {
-        x1: 0,
-        y1: 0,
-        x2: viewBoxWidth,
-        y2: viewBoxHeight,
-      }
-    : {
-        x1: viewBoxWidth,
-        y1: 0,
-        x2: 0,
-        y2: viewBoxHeight,
-      }
+    ? { x1: 0, y1: 0, x2: viewBoxWidth, y2: viewBoxHeight }
+    : { x1: viewBoxWidth, y1: 0, x2: 0, y2: viewBoxHeight }
+
+  const maskId = 'emptyWellMask'
+
   return (
     <svg
-      width={isRectangular ? width : size}
-      height={isRectangular ? height : size}
+      width={isCircular ? size : width}
+      height={isCircular ? size : height}
       viewBox={viewBox}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
       <mask
-        id="emptyWellMask"
+        id={maskId}
         maskUnits="userSpaceOnUse"
         x="0"
         y="0"
-        width={isCircular ? circularDimension : width}
-        height={isCircular ? circularDimension : height}
+        width={viewBoxWidth}
+        height={viewBoxHeight}
       >
         {isCircular ? (
           <circle cx="10" cy="10" r="9.5" fill="white" {...commonProps} />
         ) : (
-          <rect
-            x="0"
-            y="0"
-            width={width}
-            height={height}
-            fill="white"
-            {...commonProps}
-          />
+          <rect width={width} height={height} fill="white" {...commonProps} />
         )}
       </mask>
 
-      <g mask="url(#emptyWellMask)">
+      <g mask={`url(#${maskId})`}>
         {isCircular ? (
           <circle
             cx="10"
@@ -83,19 +70,17 @@ export function EmptyWell(props: EmptyWellProps): JSX.Element {
             r="9"
             fill="#CBCCCC"
             stroke={outlineColor}
-            {...commonProps}
             strokeWidth="3"
+            {...commonProps}
           />
         ) : (
           <rect
-            x="0"
-            y="0"
             width={width}
             height={height}
             fill="#CBCCCC"
             stroke={outlineColor}
-            {...commonProps}
             strokeWidth="2"
+            {...commonProps}
           />
         )}
 

--- a/components/src/hardware-sim/Labware/labwareInternals/Wells/EmptyWell.tsx
+++ b/components/src/hardware-sim/Labware/labwareInternals/Wells/EmptyWell.tsx
@@ -11,7 +11,7 @@ interface EmptyWellProps {
   wellMap: LabwareWellMap
   parentType: ParentType
   wellName: string
-  size?: string
+  size: string
 }
 
 export function EmptyWell(props: EmptyWellProps): JSX.Element {
@@ -21,13 +21,16 @@ export function EmptyWell(props: EmptyWellProps): JSX.Element {
   }
   const firstWell = wellMap.A1
   const isCircular = firstWell.shape === 'circular'
+  const isRectangular = firstWell.shape === 'rectangular'
   const [width, height] = getWidthAndHeightOfWellSVG(wellMap)
   const isLabware = parentType === LABWARE
   const outlineColor = isLabware ? COLORS.grey50 : COLORS.black90
   const circularDimension = 20
   const viewBoxWidth = isCircular ? circularDimension : width
   const viewBoxHeight = isCircular ? circularDimension : height
-  const viewBox = `0 0 ${viewBoxWidth} ${viewBoxHeight}`
+  const viewBox = !isRectangular
+    ? `0 0 20 20`
+    : `0 0 ${viewBoxWidth} ${viewBoxHeight}`
   const lineStrokeWidth = isCircular ? 2 : 1
   const lineProps = isLabware
     ? {
@@ -44,8 +47,8 @@ export function EmptyWell(props: EmptyWellProps): JSX.Element {
       }
   return (
     <svg
-      width={size ?? width}
-      height={size ?? height}
+      width={isRectangular ? width : size}
+      height={isRectangular ? height : size}
       viewBox={viewBox}
       fill="none"
       xmlns="http://www.w3.org/2000/svg"

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -492,7 +492,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
           ignoreMissingTips
           wellLabelOptions="SHOW_LABEL_INSIDE"
         />
-        {hasMoreThanOneWell ? (
+        {hasMoreThanOneWell && wellShadow !== null ? (
           <PipetteShadow
             {...pipettePositionProps}
             robotType={robotType}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -176,7 +176,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
       setWellShadow(null)
       currentHoveredWellRef.current = null
       leaveTimeoutRef.current = null
-    }, 120)
+    }, 350)
   }
   const [wellShadow, setWellShadow] = useState<string | null>(null)
   const handleHoverWell = (e: WellMouseEvent): void => {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux'
 
 import {
   COLORS,
-  DEFAULT_TIP_SIZE,
   INACCESSIBLE,
   Module,
   SELECTED,
@@ -485,7 +484,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
           </div>
         </SelectionRect>
         <div className={styles.well_legend_box}>
-          <SelectionLegend selectionType={WELL} size={DEFAULT_TIP_SIZE} />
+          <SelectionLegend selectionType={WELL} />
         </div>
       </div>
     </>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -1,11 +1,4 @@
-import {
-  Fragment,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
@@ -109,7 +102,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
   const hasMoreThanOneWell = allWells.flat().length > 1
   const displayName = labwareDef.metadata.displayName
 
-  const getWellsField = useCallback((): FieldProps | null => {
+  const wellsField = ((): FieldProps | null => {
     switch (stepType) {
       case 'mix':
         return propsForFields.wells
@@ -120,10 +113,9 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
       default:
         return null
     }
-  }, [stepType, propsForFields])
+  })()
 
   const computedSelectedWells = useMemo((): string[][] => {
-    const wellsField = getWellsField()
     const wells = (wellsField?.value as string[]) || []
 
     if (!hasMoreThanOneWell) {
@@ -140,7 +132,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
       )
     )
   }, [
-    getWellsField,
+    wellsField,
     hasMoreThanOneWell,
     allWells,
     labwareDef.ordering,
@@ -261,65 +253,6 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
     deckDef
   )
 
-  const handleClickWell = (wellName: string): void => {
-    const wellsField = getWellsField()
-
-    const wellIsSelected = selectedWells.flat().includes(wellName)
-    let wellsToToggle: string[] = []
-    if (wellIsSelected) {
-      const primaryWells = wellsField?.value as string[]
-      for (const primaryWell of primaryWells) {
-        const group = getEntireWellSelection(
-          primaryWell,
-          labwareDef.ordering,
-          nozzleConfiguration,
-          primaryNozzle,
-          channels
-        )
-        if (group.includes(wellName)) {
-          wellsToToggle = group
-          break
-        }
-      }
-    } else {
-      wellsToToggle = getEntireWellSelection(
-        wellName,
-        labwareDef.ordering,
-        nozzleConfiguration,
-        primaryNozzle,
-        channels
-      )
-    }
-    const allWellsWithStatus = getAllWellsSafetyStatus({
-      allWells,
-      robotState,
-      invariantContext,
-      pipetteId,
-      labwareId,
-      primaryNozzle,
-      nozzleConfiguration,
-    })
-
-    if (allWellsWithStatus[wellName] === 1) {
-      return
-    }
-
-    setSelectedWells(prev => {
-      const next = prev.filter(group => group[0] !== wellsToToggle[0])
-      const hadOverlap = next.length !== prev.length
-
-      if (!hadOverlap) {
-        next.push(wellsToToggle)
-      }
-
-      if (wellsField != null) {
-        wellsField.updateValue(next.map(group => group[0]))
-      }
-
-      return next
-    })
-  }
-
   const _getWellsFromRect: (rect: GenericRect) => string[][] = rect => {
     const wellsInRect = getCollidingWells(rect)
     const highlightedWells: string[][] = []
@@ -331,10 +264,13 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
         primaryNozzle,
         channels
       )
-      const noOverlapInList = highlightedWells
+      const noOverlapInInaccessibleWells = inaccessiblePartialWells
         .flat()
         .some(well => wellSelection.includes(well))
-      if (!noOverlapInList) {
+      const noOverlapInAlreadySelected = highlightedWells
+        .flat()
+        .some(well => wellSelection.includes(well))
+      if (!noOverlapInAlreadySelected && !noOverlapInInaccessibleWells) {
         highlightedWells.push(wellSelection)
       }
     }
@@ -385,7 +321,6 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
             }
           })
         }
-        const wellsField = getWellsField()
         if (wellsField != null) {
           wellsField.updateValue(updated.map(wellGroup => wellGroup[0]))
         }
@@ -484,7 +419,6 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
         <LabwareOnDeck
           labwareOnDeck={labware}
           {...labwarePositionProps}
-          handleClickWell={handleClickWell}
           onMouseEnterWell={handleHoverWell}
           onMouseLeaveWell={handleLeaveWell}
           selectedTipsByIndex={allWellsWithStatus}
@@ -500,6 +434,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
             slotPosition={
               isLabwareOnModule ? defaultSlotPosition : slotPosition
             }
+            hoveredWell={wellShadow}
             selectedLabwareId={labwareId}
             labwareState={deckSetup.labware}
             hasPickupsRemaining={null}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -1,4 +1,11 @@
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
@@ -102,7 +109,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
   const hasMoreThanOneWell = allWells.length > 1
   const displayName = labwareDef.metadata.displayName
 
-  const getWellsField = (): FieldProps | null => {
+  const getWellsField = useCallback((): FieldProps | null => {
     switch (stepType) {
       case 'mix':
         return propsForFields.wells
@@ -113,14 +120,16 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
       default:
         return null
     }
-  }
+  }, [stepType, propsForFields])
 
-  const getSelectedWells = (): string[][] => {
+  const computedSelectedWells = useMemo((): string[][] => {
     const wellsField = getWellsField()
     const wells = (wellsField?.value as string[]) || []
+
     if (!hasMoreThanOneWell) {
       return allWells
     }
+
     return wells.map(well =>
       getEntireWellSelection(
         well,
@@ -130,38 +139,42 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
         channels
       )
     )
-  }
+  }, [
+    getWellsField,
+    hasMoreThanOneWell,
+    allWells,
+    labwareDef.ordering,
+    nozzleConfiguration,
+    primaryNozzle,
+    channels,
+  ])
 
-  const [selectedWells, setSelectedWells] =
-    useState<string[][]>(getSelectedWells())
-
+  const [selectedWells, setSelectedWells] = useState<string[][]>(
+    computedSelectedWells
+  )
   const [hoveredWells, setHoveredWells] = useState<string[] | null>(null)
   const currentHoveredWellRef = useRef<string[] | null>(null)
 
-  useEffect(
-    () => {
-      if (leaveTimeoutRef.current) {
-        clearTimeout(leaveTimeoutRef.current)
-        leaveTimeoutRef.current = null
-      }
-      currentHoveredWellRef.current = null
-      setSelectedWells(getSelectedWells())
-      setHoveredWells(null)
-    },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [stepType]
-  )
+  useEffect(() => {
+    if (leaveTimeoutRef.current) {
+      clearTimeout(leaveTimeoutRef.current)
+      leaveTimeoutRef.current = null
+    }
 
-  const handleLeaveWell = (_: WellMouseEvent): void => {
+    currentHoveredWellRef.current = null
+    setSelectedWells(computedSelectedWells)
+    setHoveredWells(null)
+  }, [stepType, computedSelectedWells])
+
+  const handleLeaveWell = (): void => {
     if (leaveTimeoutRef.current) {
       clearTimeout(leaveTimeoutRef.current)
     }
+
     leaveTimeoutRef.current = setTimeout(() => {
-      if (currentHoveredWellRef.current === hoveredWells) {
-        setHoveredWells(null)
-        currentHoveredWellRef.current = null
-      }
+      setHoveredWells(null)
+      setWellShadow(null)
+      currentHoveredWellRef.current = null
       leaveTimeoutRef.current = null
     }, 120)
   }
@@ -485,7 +498,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
             robotType={robotType}
             pipetteSpec={pipetteSpecs}
             slotPosition={slotPosition}
-            hoveredWell={wellShadow ?? ''}
+            hoveredWell={wellShadow}
             selectedLabwareId={labwareId}
             labwareState={deckSetup.labware}
             hasPickupsRemaining={null}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteShadow.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteShadow.tsx
@@ -50,7 +50,7 @@ const SHADOW_BY_ROBOT_TYPE_AND_CHANNELS: Record<
 export function PipetteShadow(props: {
   pipetteSpec: PipetteV2Specs
   slotPosition?: CoordinateTuple
-  hoveredWell: string
+  hoveredWell: string | null
   selectedLabwareId: string
   labwareState: AllTemporalPropertiesForTimelineFrame['labware']
   isAccessible: boolean
@@ -165,17 +165,23 @@ export function PipetteShadow(props: {
     isOt2EightChannel,
   })
   return (
-    <g className={styles.shadow_overlay}>
-      <PipetteLabel
-        ref={labelRef}
-        text={labelText}
-        isZoomed
-        x={slotX + xOffset + labelOffsetX}
-        y={slotY + yOffset + labelOffsetY}
-        placement={labelPlacement}
-        isError={isError}
-      />
-      <ShadowComponent {...shadowProps} />
-    </g>
+    <>
+      {hoveredWell !== null ? (
+        <g className={styles.shadow_overlay}>
+          <PipetteLabel
+            ref={labelRef}
+            text={labelText}
+            isZoomed
+            x={slotX + xOffset + labelOffsetX}
+            y={slotY + yOffset + labelOffsetY}
+            placement={labelPlacement}
+            isError={isError}
+          />
+          <ShadowComponent {...shadowProps} />
+        </g>
+      ) : (
+        <></>
+      )}
+    </>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteShadow.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteShadow.tsx
@@ -50,7 +50,7 @@ const SHADOW_BY_ROBOT_TYPE_AND_CHANNELS: Record<
 export function PipetteShadow(props: {
   pipetteSpec: PipetteV2Specs
   slotPosition?: CoordinateTuple
-  hoveredWell: string | null
+  hoveredWell: string
   selectedLabwareId: string
   labwareState: AllTemporalPropertiesForTimelineFrame['labware']
   isAccessible: boolean
@@ -165,23 +165,17 @@ export function PipetteShadow(props: {
     isOt2EightChannel,
   })
   return (
-    <>
-      {hoveredWell !== null ? (
-        <g className={styles.shadow_overlay}>
-          <PipetteLabel
-            ref={labelRef}
-            text={labelText}
-            isZoomed
-            x={slotX + xOffset + labelOffsetX}
-            y={slotY + yOffset + labelOffsetY}
-            placement={labelPlacement}
-            isError={isError}
-          />
-          <ShadowComponent {...shadowProps} />
-        </g>
-      ) : (
-        <></>
-      )}
-    </>
+    <g className={styles.shadow_overlay}>
+      <PipetteLabel
+        ref={labelRef}
+        text={labelText}
+        isZoomed
+        x={slotX + xOffset + labelOffsetX}
+        y={slotY + yOffset + labelOffsetY}
+        placement={labelPlacement}
+        isError={isError}
+      />
+      <ShadowComponent {...shadowProps} />
+    </g>
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -6,7 +6,6 @@ import {
   ALIGN_CENTER,
   Chip,
   COLORS,
-  DEFAULT_TIP_SIZE,
   Flex,
   INACCESSIBLE,
   JUSTIFY_SPACE_BETWEEN,
@@ -472,7 +471,7 @@ export function SelectTips(
           </SelectionRect>
         </div>
         <div className={styles.legend_box}>
-          <SelectionLegend selectionType={TIP} size={DEFAULT_TIP_SIZE} />
+          <SelectionLegend selectionType={TIP} />
         </div>
       </div>
     </div>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectionLegend.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectionLegend.tsx
@@ -1,11 +1,12 @@
 import {
   COLORS,
+  DEFAULT_TIP_SIZE,
   LABWARE,
   StyledText,
   TipStatus,
   WellStatus,
 } from '@opentrons/components'
-import { fixture96Plate, fixtureTiprack1000ul } from '@opentrons/shared-data'
+import { fixtureTiprack1000ul } from '@opentrons/shared-data'
 
 import styles from './tipselectionwizard.module.css'
 import { useLegendItems } from './useLegendItems'
@@ -15,22 +16,14 @@ import type { LabwareWellMap } from '@opentrons/shared-data'
 
 interface SelectionLegendProps {
   selectionType: 'tip' | 'well'
-  size: string
 }
 
 export function SelectionLegend({
   selectionType,
-  size,
 }: SelectionLegendProps): JSX.Element {
-  let labwareWellMap: LabwareWellMap
+  const labwareWellMap = fixtureTiprack1000ul.wells as LabwareWellMap
   const isTipSelection = selectionType === 'tip'
-  if (isTipSelection) {
-    labwareWellMap = fixtureTiprack1000ul.wells as LabwareWellMap
-  } else {
-    labwareWellMap = fixture96Plate.wells as LabwareWellMap
-  }
   const legendItems = useLegendItems(selectionType)
-
   return (
     <div className={styles.tip_select_legend_container}>
       {legendItems.map(({ type, label }) => (
@@ -38,7 +31,7 @@ export function SelectionLegend({
           {isTipSelection ? (
             <TipStatus
               type={type as TipType}
-              size={size}
+              size={DEFAULT_TIP_SIZE}
               wellMap={labwareWellMap}
               wellName={label}
             />
@@ -46,7 +39,7 @@ export function SelectionLegend({
             <div className={styles.well_legend_item}>
               <WellStatus
                 type={type as WellType}
-                size={size}
+                size={DEFAULT_TIP_SIZE}
                 parentType={LABWARE}
                 wellMap={labwareWellMap}
                 wellName={label}


### PR DESCRIPTION
# Overview

Updated WellSelector logic for a more stable render and remove shadow when a well is not selected.

## Test Plan and Hands on Testing

smoke tested:
https://github.com/user-attachments/assets/a09039d2-eacc-4835-a321-907af61f054f

## Changelog
- only show pipetteShadow if a well is being hovered
- removed handleClickWell because this is now being handled with handleSelectionDone
- added filtering in handleSelectionDone to not allow selection of inaccessible wells
 
**Stabilized hook dependencies**

- Replaced `getSelectedWells` function with computedSelectedWells via useMemo
- Memoized `getWellsField` with useCallback to stabilize dependencies
- Updated `useEffect` to depend on `computedSelectedWells` instead of a function reference
- Initialized `selectedWells` state using the memoized value


## Risk assessment

- medium - changes behavior of selector

Closes RQA-5298