### PR TITLE
docs: hide resin tip methods from Python API reference

### DIFF
--- a/docs/python-api/docs/reference/instruments.md
+++ b/docs/python-api/docs/reference/instruments.md
@@ -8,3 +8,4 @@ description: "Instrument and pipette API reference for the Python Protocol API."
       filters:
         - "!^__"
         - "!delay"
+        - "!^resin"


### PR DESCRIPTION
# Overview

Users working with resin tips in their Python protocols should use individual `RobotContext` methods instead of the complex `InstrumentContext` methods originally designed for this purpose.

## Test Plan and Hands on Testing

[Sandbox](https://sandbox.docs.opentrons.com/docs-hide-resin-tip-methods/python-api/reference/instruments/)

Before

<img width="233" height="139" alt="image" src="https://github.com/user-attachments/assets/2eb4211b-b53e-4732-8067-4df66952728d" />

After

<img width="243" height="55" alt="image" src="https://github.com/user-attachments/assets/992ca477-0b6e-4c52-b6c2-8f4f0b2ddbf0" />

## Changelog

+1 line of ignore rules

## Review requests

- Confirm that all and only the resin tip methods are hidden.
- Do we also want to update the docstrings for anyone who stumbles upon them in code?

## Risk assessment

vvv low, only removing portion of docs.