### PR TITLE
feat(app): Add a feature flag for access control mode

### DIFF
--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -1,4 +1,5 @@
 {
+  "__dev_internal__accessControlMode": "Enable frontend for access control mode",
   "__dev_internal__enableLabwareCreator": "Enable App Labware Creator",
   "__dev_internal__enableRunNotes": "Display Notes During a Protocol Run",
   "__dev_internal__externalKeyboardTest": "Enable External Keyboard Test screen",

--- a/app/src/redux/config/constants.ts
+++ b/app/src/redux/config/constants.ts
@@ -11,6 +11,7 @@ export const DEV_INTERNAL_FLAGS: DevInternalFlag[] = [
   'quickTransferProtocolContentsLog',
   'ignoreOT2App',
   'externalKeyboardTest',
+  'accessControlMode',
 ]
 
 // action type constants

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -19,6 +19,7 @@ export type DevInternalFlag =
   | 'quickTransferProtocolContentsLog'
   | 'ignoreOT2App'
   | 'externalKeyboardTest'
+  | 'accessControlMode'
 
 export type FeatureFlags = Partial<Record<DevInternalFlag, boolean | undefined>>
 


### PR DESCRIPTION
## Overview

This adds a feature flag to the desktop app and on-device display for enabling the frontend half of access control mode. Nothing uses this yet.

Closes EXEC-2533.

## Test Plan and Hands on Testing

* [x] It looks reasonable in the desktop app.
* [x] It looks reasonable in the ODD.

## Review requests

Is this copy OK? I'm a little bit worried about someone out-of-the-know enabling this out of curiosity, and then we leak their password over HTTP or something, since we don't have any protections against that yet. There's no room for extended description text, unfortunately.

## Risk assessment

Very low.