### PR TITLE
fix(protocol-designer): use correct slot position when on module

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -242,7 +242,6 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
 
   const deckDef = getDeckDefFromRobotType(robotType)
   const slot = getSlotInLocationStack(labware.stack)
-  const slotPosition = getPositionFromSlotId(slot, deckDef)
 
   const viewBox = getViewboxFromSelectedLabware(labwareId, deckSetup, deckDef)
 
@@ -415,6 +414,16 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
   }
 
   let controls: JSX.Element = <></>
+  const modulesOnDeck = deckSetup.modules
+  const moduleIds = new Set(Object.keys(modulesOnDeck))
+  const moduleLocation = labware.stack.find(loc => moduleIds.has(loc))
+
+  const moduleDef = moduleLocation
+    ? getModuleDef(modulesOnDeck[moduleLocation].model)
+    : null
+  const isLabwareOnModule = moduleDef !== null
+  const defaultSlot: [number, number, number] = [0, 0, 0]
+  const slotPosition = getPositionFromSlotId(slot, deckDef)
 
   if (slotPosition && labware && robotState) {
     inaccessiblePartialWells.forEach(well => {
@@ -441,30 +450,21 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
         ? INACCESSIBLE_PARTIAL_TIP
         : INACCESSIBLE_COLLISION
     const is96Channel = channels === 96
-    const modulesOnDeck = deckSetup.modules
-    const moduleIds = new Set(Object.keys(modulesOnDeck))
-    const moduleLocation = labware.stack.find(loc => moduleIds.has(loc))
 
-    const moduleDef = moduleLocation
-      ? getModuleDef(modulesOnDeck[moduleLocation].model)
-      : null
-
-    const labwarePositionProps =
-      moduleDef != null
-        ? {
-            x: 0,
-            y: 0,
-          }
-        : {
-            x: slotPosition[0],
-            y: slotPosition[1],
-          }
-    const pipettePositionProps =
-      moduleDef === null
-        ? {
-            slotPosition: slotPosition,
-          }
-        : {}
+    const labwarePositionProps = isLabwareOnModule
+      ? {
+          x: 0,
+          y: 0,
+        }
+      : {
+          x: slotPosition[0],
+          y: slotPosition[1],
+        }
+    const pipettePositionProps = isLabwareOnModule
+      ? {
+          slotPosition: slotPosition,
+        }
+      : {}
     const labwarePipetteContent = (
       <>
         <LabwareOnDeck
@@ -484,7 +484,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
             {...pipettePositionProps}
             robotType={robotType}
             pipetteSpec={pipetteSpecs}
-            slotPosition={slotPosition}
+            slotPosition={isLabwareOnModule ? defaultSlot : slotPosition}
             hoveredWell={wellShadow ?? ''}
             selectedLabwareId={labwareId}
             labwareState={deckSetup.labware}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -478,7 +478,9 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
           <PipetteShadow
             robotType={robotType}
             pipetteSpec={pipetteSpecs}
-            slotPosition={isLabwareOnModule ? defaultSlotPosition : slotPosition}
+            slotPosition={
+              isLabwareOnModule ? defaultSlotPosition : slotPosition
+            }
             hoveredWell={wellShadow ?? ''}
             selectedLabwareId={labwareId}
             labwareState={deckSetup.labware}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -422,7 +422,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
     ? getModuleDef(modulesOnDeck[moduleLocation].model)
     : null
   const isLabwareOnModule = moduleDef !== null
-  const defaultSlot: [number, number, number] = [0, 0, 0]
+  const defaultSlotPosition: [number, number, number] = [0, 0, 0]
   const slotPosition = getPositionFromSlotId(slot, deckDef)
 
   if (slotPosition && labware && robotState) {
@@ -460,11 +460,6 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
           x: slotPosition[0],
           y: slotPosition[1],
         }
-    const pipettePositionProps = isLabwareOnModule
-      ? {
-          slotPosition: slotPosition,
-        }
-      : {}
     const labwarePipetteContent = (
       <>
         <LabwareOnDeck
@@ -481,10 +476,9 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
         />
         {hasMoreThanOneWell ? (
           <PipetteShadow
-            {...pipettePositionProps}
             robotType={robotType}
             pipetteSpec={pipetteSpecs}
-            slotPosition={isLabwareOnModule ? defaultSlot : slotPosition}
+            slotPosition={isLabwareOnModule ? defaultSlotPosition : slotPosition}
             hoveredWell={wellShadow ?? ''}
             selectedLabwareId={labwareId}
             labwareState={deckSetup.labware}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -241,9 +241,12 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
   )
 
   const deckDef = getDeckDefFromRobotType(robotType)
-  const slot = getSlotInLocationStack(labware.stack)
-
-  const viewBox = getViewboxFromSelectedLabware(labwareId, deckSetup, deckDef)
+  const viewBox = getViewboxFromSelectedLabware(
+    labwareId,
+    robotState,
+    deckSetup,
+    deckDef
+  )
 
   const handleClickWell = (wellName: string): void => {
     const wellsField = getWellsField()
@@ -423,9 +426,12 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
     : null
   const isLabwareOnModule = moduleDef !== null
   const defaultSlotPosition: [number, number, number] = [0, 0, 0]
-  const slotPosition = getPositionFromSlotId(slot, deckDef)
 
-  if (slotPosition && labware && robotState) {
+  if (labware && robotState) {
+    const activeLabware = robotState.labware[labwareId]
+    const slot = getSlotInLocationStack(activeLabware.stack)
+    const slotPosition =
+      getPositionFromSlotId(slot, deckDef) ?? defaultSlotPosition
     inaccessiblePartialWells.forEach(well => {
       if (!selectedWells.flat().includes(well)) {
         if (hoveredWells?.includes(well)) {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -103,10 +103,13 @@ export function SelectTips(
     primaryNozzle,
   } = props
   const labwareName = labwareNicknamesById[selectedTiprackId ?? '']
+  const robotState = useSelector(getRobotStateAtActiveItem)
+
   const viewBox =
     selectedTiprackId != null
       ? getViewboxFromSelectedLabware(
           selectedTiprackId,
+          robotState,
           activeDeckSetup,
           deckDef
         )
@@ -116,7 +119,6 @@ export function SelectTips(
     console.warn(`no viewbox for selected tiprack ${selectedTiprackId}`)
   }
 
-  const robotState = useSelector(getRobotStateAtActiveItem)
   const tipState = robotState?.tipState.tipracks[selectedTiprackId ?? '']
 
   const labwareDef = activeDeckSetup.labware[selectedTiprackId ?? '']?.def

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/__tests__/utils.test.ts
@@ -10,6 +10,7 @@ import { getSlotInLocationStack } from '@opentrons/step-generation'
 import { getIsTiprackSelectable, getViewboxFromSelectedLabware } from '../utils'
 
 import type { PipetteV2Specs } from '@opentrons/shared-data'
+import type { RobotState } from '@opentrons/step-generation'
 import type { LabwareOnDeck } from '/protocol-designer/step-forms'
 
 vi.mock(import('@opentrons/step-generation'), async importOriginal => {
@@ -38,7 +39,13 @@ const activeDeckSetup = {
 const mockTiprackId = 'mockTiprackId'
 const MOCK_ADAPTER_ID = 'mockAdapterId'
 const MOCK_ADAPTER_URI = 'opentrons/opentrons_flex_96_tiprack_adapter/1'
-
+const mockRobotState: RobotState = {
+  labware: { labId: { stack: ['labId', 'mockHsId', 'D1'] } },
+  pipettes: {},
+  modules: {},
+  tipState: {} as any,
+  liquidState: {} as any,
+}
 const labware = {
   id: mockTiprackId,
   labwareDefURI: MOCK_TIPRACK_URI,
@@ -202,6 +209,7 @@ describe('getViewboxFromSelectedLabware', () => {
     expect(
       getViewboxFromSelectedLabware(
         MOCK_TIPRACK_URI,
+        mockRobotState,
         activeDeckSetup,
         MOCK_DECK_DEF
       )
@@ -212,6 +220,7 @@ describe('getViewboxFromSelectedLabware', () => {
     expect(
       getViewboxFromSelectedLabware(
         BAD_LABWARE_URI,
+        mockRobotState,
         activeDeckSetup,
         MOCK_DECK_DEF
       )
@@ -223,6 +232,7 @@ describe('getViewboxFromSelectedLabware', () => {
     expect(
       getViewboxFromSelectedLabware(
         MOCK_TIPRACK_URI,
+        mockRobotState,
         activeDeckSetup,
         MOCK_DECK_DEF
       )

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/__tests__/utils.test.ts
@@ -40,7 +40,9 @@ const mockTiprackId = 'mockTiprackId'
 const MOCK_ADAPTER_ID = 'mockAdapterId'
 const MOCK_ADAPTER_URI = 'opentrons/opentrons_flex_96_tiprack_adapter/1'
 const mockRobotState: RobotState = {
-  labware: { labId: { stack: ['labId', 'mockHsId', 'D1'] } },
+  labware: {
+    [MOCK_TIPRACK_URI]: { stack: ['mockTiprackId', 'mockHsId', 'D1'] },
+  },
   pipettes: {},
   modules: {},
   tipState: {} as any,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -51,10 +51,16 @@ const OFFSET_OT2_8_CHANNEL = 10
 
 export const getViewboxFromSelectedLabware = (
   selectedLabwareId: string,
+  robotState: TimelineFrame | null,
   activeDeckSetup: AllTemporalPropertiesForTimelineFrame,
   deckDef: DeckDefinition
 ): string | null => {
+  if (robotState == null) {
+    return null
+  }
   const { labware, modules } = activeDeckSetup
+
+  const { labware: labwareState } = robotState
   const selectedLabware = labware[selectedLabwareId]
   if (selectedLabware == null) {
     return null
@@ -78,7 +84,7 @@ export const getViewboxFromSelectedLabware = (
   const { xDimension, yDimension } = moduleDef
     ? moduleDef.dimensions
     : selectedLabware.def.dimensions
-  const slot = getSlotInLocationStack(selectedLabware.stack)
+  const slot = getSlotInLocationStack(labwareState[selectedLabwareId].stack)
   const slotPosition = getPositionFromSlotId(slot, deckDef)
   if (slotPosition == null) {
     return null


### PR DESCRIPTION
# Overview

Ensure pipette shadow is aligned over labware on modules in `WellSelector` and the most up to date labware location is used for the viewBox.

## Test Plan and Hands on Testing
**Commit 1-3- fixed pipette shadow**

Smoke tested with protocol in the ticket and added steps where labware is on modules on the right hand side of the deck to ensure proper placement.
[RQA-5323-extrasteps.py](https://github.com/user-attachments/files/26686285/RQA-5323-extrasteps.py)
<img width="882" height="681" alt="Screenshot 2026-04-13 at 3 15 27 PM" src="https://github.com/user-attachments/assets/b12e7a98-ac66-43d5-a7f4-8d996d8ef512" />
**Commit 4 - fixed the labware positioning**
smoke tested with protocol attached in ticket RQA-5324 and added a transfer step for the labware that got moved off deck successfully 
[RQA-5324.py](https://github.com/user-attachments/files/26689571/RQA-5324.py)

## Changelog

- If the labware is on the module it will not further adjust the slot position because it is already accounted for with labware positioning
- passes robotState into util `getViewboxFromSelectedLabware` to ensure the slot being used is its current location and not from initial deck setup.

## Review requests


## Risk assessment

low - cosmetic change to show where the pipette is

Closes RQA-5323 in commit 1-3, RQA-5324 in commit 4