### PR TITLE
feat(app): modify the condition of openExternal for Windows

### DIFF
--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -74,7 +74,7 @@ module.exports = async () => ({
   },
   dmg: {
     icon: project === 'robot-stack' ? 'build/icon.icns' : 'build/three.icns',
-    // The final universal OT-2 app exceeds 1 GiB once the bundled Python
+    // The final universal Flex app exceeds 1 GiB once the bundled Python
     // runtime is copied in. Use a fixed DMG image size with extra headroom
     // instead of relying on auto-sizing, which has been too small in CI.
     size: '3g',

--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -74,6 +74,11 @@ module.exports = async () => ({
   },
   dmg: {
     icon: project === 'robot-stack' ? 'build/icon.icns' : 'build/three.icns',
+    // The final universal OT-2 app exceeds 1 GiB once the bundled Python
+    // runtime is copied in. Use a fixed DMG image size with extra headroom
+    // instead of relying on auto-sizing, which has been too small in CI.
+    size: '3g',
+    shrink: false,
   },
   win: {
     target: ['nsis'],

--- a/app-shell/src/ot2App.ts
+++ b/app-shell/src/ot2App.ts
@@ -1,4 +1,4 @@
-import { shell } from 'electron'
+import { app, shell } from 'electron'
 
 import { createLogger } from './log'
 
@@ -22,10 +22,11 @@ export async function openOT2AppExternal(payload?: {
       ? `${PROTOCOL_NAME}://open?${params.toString()}`
       : `${PROTOCOL_NAME}://open`
 
-  try {
-    await shell.openExternal(url)
-  } catch {
+  if (app.getApplicationNameForProtocol(url) === '') {
     log.debug('OT-2 App is not installed and open the download page')
     await shell.openExternal(OT2_APP_DOWNLOAD_PAGE)
+    return
   }
+
+  await shell.openExternal(url)
 }

--- a/app-shell/src/ot2App.ts
+++ b/app-shell/src/ot2App.ts
@@ -23,10 +23,23 @@ export async function openOT2AppExternal(payload?: {
       : `${PROTOCOL_NAME}://open`
 
   if (app.getApplicationNameForProtocol(url) === '') {
-    log.debug('OT-2 App is not installed and open the download page')
-    await shell.openExternal(OT2_APP_DOWNLOAD_PAGE)
+    try {
+      await shell.openExternal(OT2_APP_DOWNLOAD_PAGE)
+    } catch (error) {
+      log.error(
+        'Failed to open OT-2 App download page',
+        error instanceof Error ? error.message : String(error)
+      )
+    }
     return
   }
 
-  await shell.openExternal(url)
+  try {
+    await shell.openExternal(url)
+  } catch (error) {
+    log.error(
+      'Failed to open OT-2 App external URL',
+      error instanceof Error ? error.message : String(error)
+    )
+  }
 }


### PR DESCRIPTION


# Overview
modify the condition of openExternal for Windows. 
since the current implementation tries to open app store with the registered url schema

this pr requires https://github.com/Opentrons/opentrons-ot2/pull/39

close EXEC-2534

## Test Plan and Hands on Testing
- download the app on Windows
- install one of them
- import an invalid protocol
- click Get the app
check App Store won't be opened

## Changelog
- update `ot2App.ts` for Windows

## Review requests


## Risk assessment
low