### PR TITLE
refactor(app): Clarify "top portal" vs. "modal portal"

### DIFF
--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -38,7 +38,7 @@ import { ProtocolVisualization } from '../pages/Desktop/Protocols/ProtocolVisual
 import { DesktopAppFallback } from './DesktopAppFallback'
 import { useSoftwareUpdatePoll } from './hooks'
 import { Navbar } from './Navbar'
-import { PortalRoot as ModalPortalRoot } from './portal'
+import { ModalPortalRoot } from './portal'
 import { ReactQueryDevtools } from './tools'
 
 import type { RouteProps } from './types'

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -63,7 +63,7 @@ import {
 import { SharedScrollRefProvider } from './ODDProviders/ScrollRefProvider'
 import { ODDTopLevelRedirects } from './ODDTopLevelRedirects'
 import { OnDeviceDisplayAppFallback } from './OnDeviceDisplayAppFallback'
-import { PortalRoot as ModalPortalRoot } from './portal'
+import { ModalPortalRoot } from './portal'
 
 import type { Dispatch } from '/app/redux/types'
 

--- a/app/src/App/portal.tsx
+++ b/app/src/App/portal.tsx
@@ -11,16 +11,18 @@
 
 import { Box } from '@opentrons/components'
 
-export const TOP_PORTAL_ID = '__otAppTopPortalRoot'
 export const MODAL_PORTAL_ID = '__otAppModalPortalRoot'
-export function getTopPortalEl(): HTMLElement {
-  return global.document.getElementById(TOP_PORTAL_ID) ?? global.document.body
-}
+export const TOP_PORTAL_ID = '__otAppTopPortalRoot'
+
 export function getModalPortalEl(): HTMLElement {
   return global.document.getElementById(MODAL_PORTAL_ID) ?? global.document.body
 }
 
-export function PortalRoot(): JSX.Element {
+export function getTopPortalEl(): HTMLElement {
+  return global.document.getElementById(TOP_PORTAL_ID) ?? global.document.body
+}
+
+export function ModalPortalRoot(): JSX.Element {
   return <Box zIndex={1} id={MODAL_PORTAL_ID} data-testid={MODAL_PORTAL_ID} />
 }
 

--- a/app/src/App/portal.tsx
+++ b/app/src/App/portal.tsx
@@ -1,3 +1,14 @@
+/**
+ * Portals in which to render modals, overlays, etc.
+ *
+ * The "modal portal" is for things that should NOT occlude global navigation
+ * in the desktop app. Generally, these are things that the user is allowed to dismiss
+ * or navigate away from, or things that are scoped to a specific robot.
+ *
+ * The "top portal" is for things that SHOULD occlude global navigation
+ * in the desktop app.
+ */
+
 import { Box } from '@opentrons/components'
 
 export const TOP_PORTAL_ID = '__otAppTopPortalRoot'

--- a/app/src/App/portal.tsx
+++ b/app/src/App/portal.tsx
@@ -7,6 +7,9 @@
  *
  * The "top portal" is for things that SHOULD occlude global navigation
  * in the desktop app.
+ *
+ * On the on-device display, there is no such distinction. By convention, ODD-only
+ * things should use the top portal.
  */
 
 import { Box } from '@opentrons/components'

--- a/app/src/organisms/IncompatibleModule/__tests__/IncompatibleModuleTakeover.test.tsx
+++ b/app/src/organisms/IncompatibleModule/__tests__/IncompatibleModuleTakeover.test.tsx
@@ -7,7 +7,7 @@ import '@testing-library/jest-dom/vitest'
 import { renderWithProviders } from '/app/__testing-utils__'
 import {
   MODAL_PORTAL_ID,
-  PortalRoot,
+  ModalPortalRoot,
   TOP_PORTAL_ID,
   TopPortalRoot,
 } from '/app/App/portal'
@@ -39,7 +39,7 @@ const getRenderer = (incompatibleModules: AttachedModule[]) => {
   return (props: ComponentProps<typeof IncompatibleModuleTakeover>) => {
     const [rendered] = renderWithProviders(
       <>
-        <PortalRoot />
+        <ModalPortalRoot />
         <TopPortalRoot />
         <IncompatibleModuleTakeover {...(props as any)} />
       </>,
@@ -49,7 +49,7 @@ const getRenderer = (incompatibleModules: AttachedModule[]) => {
     )
     rendered.rerender(
       <>
-        <PortalRoot />
+        <ModalPortalRoot />
         <TopPortalRoot />
         <IncompatibleModuleTakeover {...(props as any)} />
       </>


### PR DESCRIPTION
## Overview

Our desktop app and ODD have two React portals, `TopPortalRoot` and `ModalPortalRoot`, and it wasn't clear to me what the difference was. This documents it, following discussion with @mjhuff.

## Test Plan and Hands on Testing

None needed.

## Changelog

* Add documentation
* Complete an incomplete rename of `PortalRoot` to `ModalPortalRoot`

## Review requests

* Is everything here strictly factually correct?
* Is there anything else we can clarify?

## Risk assessment

Very low.