### PR TITLE
fix(api): Fix update module, the isinstance args were reversed.

### DIFF
--- a/api/src/opentrons/hardware_control/scripts/update_module_fw.py
+++ b/api/src/opentrons/hardware_control/scripts/update_module_fw.py
@@ -229,9 +229,9 @@ async def main(args: argparse.Namespace) -> None:  # noqa: C901
             # refresh the device info
             print(f"Device {module.port} is back online, refreshing device info.")
             device_info = await module._driver.get_device_info()  # type: ignore
-            if not isinstance(dict, device_info):
+            if not isinstance(device_info, dict):
                 device_info = device_info.to_dict()
-
+            print(f"New version {device_info['version']}")
             success = device_info["version"] == target_version
             msg = "updated successfully!" if success else "failed to update"
             print(f"Device {name} {serial} {msg}")


### PR DESCRIPTION
# Overview
Also threw in a verison print, because dev versions will always fail cause the version is build with something like 1.1.3-3-123456 from the git info, so it will say failure but a dev would know if the git hash is the one they want or not
