### PR TITLE
feat(protocol-designer,step-generation): eagerly computes enriched robot state at initial deck state

### DIFF
--- a/protocol-designer/src/file-data/selectors/commands.ts
+++ b/protocol-designer/src/file-data/selectors/commands.ts
@@ -105,7 +105,11 @@ export const getInitialRobotState: (
       pipetteLocations: pipettes,
     })
     robotState.liquidState.labware = labwareLiquidState
-    return robotState
+    return StepGeneration.enrichRobotStateForStackGraphTraversals(
+      robotState,
+      invariantContext.moduleEntities,
+      invariantContext.labwareEntities
+    )
   }
 )
 

--- a/protocol-designer/src/file-data/selectors/traversals.ts
+++ b/protocol-designer/src/file-data/selectors/traversals.ts
@@ -2,7 +2,6 @@ import { createSelector } from 'reselect'
 
 import { getDeckDefFromRobotType } from '@opentrons/shared-data'
 import {
-  enrichRobotStateForStackGraphTraversals,
   getAllLargestStacks,
   getAllProvidedAddressableAreasFromDeckConfig as getAllProvidedAddressableAreasFromDeckConfigUtil,
   getProvidedAddressableAreasExposed,
@@ -19,26 +18,18 @@ import type {
 import type { RobotState } from '@opentrons/step-generation'
 import type { Selector } from '../../types'
 
-/** Initial-deck robot state with `stackedOnNode` (and sibling `contains` when applicable) for traversals. */
-export const getRobotStateEnrichedForStackGraphFromRobotState: Selector<RobotState> =
-  createSelector(
-    getInitialRobotState,
-    stepFormSelectors.getModuleEntities,
-    stepFormSelectors.getLabwareEntities,
-    (robotState, moduleEntities, labwareEntities) =>
-      enrichRobotStateForStackGraphTraversals(
-        robotState,
-        moduleEntities,
-        labwareEntities
-      )
-  )
+/**
+ * Alias of {@link getInitialRobotState}: stack-graph fields (`stackedOnNode`, sibling `contains`)
+ * are applied once when that selector builds robot state, not when reading timeline frames.
+ */
+export const getInitialEnrichedRobotState: Selector<RobotState> =
+  getInitialRobotState
 
 /** All largest `LoadedLabwareLocation` stacks on the initial deck. */
 export const getAllLargestStacksForInitialRobotState: Selector<
   LoadedLabwareLocation[][]
-> = createSelector(
-  getRobotStateEnrichedForStackGraphFromRobotState,
-  robotState => getAllLargestStacks(robotState)
+> = createSelector(getInitialEnrichedRobotState, robotState =>
+  getAllLargestStacks(robotState)
 )
 
 /** Addressable areas provided by the current deck fixture configuration. */
@@ -60,7 +51,7 @@ export const getAllProvidedAddressableAreasFromDeckConfig: Selector<
 export const getProvidedAddressableAreasExposedForRobotState: Selector<
   Set<AddressableAreaName>
 > = createSelector(
-  getRobotStateEnrichedForStackGraphFromRobotState,
+  getInitialEnrichedRobotState,
   getRobotType,
   stepFormSelectors.getDeckConfiguration,
   stepFormSelectors.getModuleEntities,

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -19,7 +19,6 @@ import {
 } from '@opentrons/shared-data'
 import {
   COLUMN_4_SLOTS,
-  enrichRobotStateForStackGraphTraversals,
   getAllLargestStacks,
   getProvidedAddressableAreasExposed,
   getSlotInLocationStack,
@@ -382,28 +381,21 @@ export const getDeckSetupForActiveItem: Selector<AllTemporalPropertiesForTimelin
     }
   )
 
-/** Memoized largest stacks at the active timeline item (`stack` → `stackedOnNode`; sibling `contains` when applicable). */
+/**
+ * Largest stacks at the active timeline item.
+ * Expects `robotState` from simulation to already carry `stackedOnNode` / `contains` (initial deck
+ * from {@link getInitialRobotState}, then per-command updaters such as `forMoveLabware`).
+ */
 export const getAllLargestStacksAtActiveItem: Selector<
   LoadedLabwareLocation[][]
-> = createSelector(
-  getRobotStateAtActiveItem,
-  getModuleEntities,
-  getLabwareEntities,
-  (robotState, moduleEntities, labwareEntities) => {
-    if (robotState == null) {
-      return []
-    }
-    return getAllLargestStacks(
-      enrichRobotStateForStackGraphTraversals(
-        robotState,
-        moduleEntities,
-        labwareEntities
-      )
-    )
+> = createSelector(getRobotStateAtActiveItem, robotState => {
+  if (robotState == null) {
+    return []
   }
-)
+  return getAllLargestStacks(robotState)
+})
 
-/** Memoized: provided addressable areas not covered by a labware stack at the timeline’s active item. */
+/** Provided addressable areas not covered by a labware stack at the timeline’s active item. */
 export const getProvidedAddressableAreasExposedAtActiveItem: Selector<
   Set<AddressableAreaName>
 > = createSelector(
@@ -411,23 +403,12 @@ export const getProvidedAddressableAreasExposedAtActiveItem: Selector<
   getRobotType,
   stepFormSelectors.getDeckConfiguration,
   getModuleEntities,
-  getLabwareEntities,
-  (
-    robotState,
-    robotType,
-    deckConfigurationState,
-    moduleEntities,
-    labwareEntities
-  ) => {
+  (robotState, robotType, deckConfigurationState, moduleEntities) => {
     if (robotState == null) {
       return new Set<AddressableAreaName>()
     }
     return getProvidedAddressableAreasExposed({
-      robotState: enrichRobotStateForStackGraphTraversals(
-        robotState,
-        moduleEntities,
-        labwareEntities
-      ),
+      robotState,
       deckConfiguration: deckConfigurationState.deckConfig,
       deckDefinition: getDeckDefFromRobotType(robotType),
       moduleEntities,

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -988,7 +988,6 @@ export const replaceCutoutFixtureWithComboFixture = (
     cutoutId,
     getDeckDefFromRobotType('OT-3 Standard')
   )
-  console.log('addressableAreasById', addressableAreasById)
 
   return addedCutoutConfigs.map(aaCutoutItem => {
     // Handle waste chute combo fixtures

--- a/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
@@ -1,11 +1,4 @@
-import {
-  FLEX_CUTOUT_BY_SLOT_ID,
-  FLEX_ROBOT_TYPE,
-  FLEX_STACKER_ADDRESSABLE_AREAS,
-  FLEX_STACKER_V1_FIXTURE,
-  getDeckDefFromRobotType,
-  SYSTEM_LOCATION,
-} from '@opentrons/shared-data'
+import { SYSTEM_LOCATION } from '@opentrons/shared-data'
 
 import {
   BOTTOM_UP_LABWARE_POOL_KEYS,
@@ -15,7 +8,6 @@ import { flexStackerStateGetter } from '../robotStateSelectors'
 import { getFlexStackerShuttleAddressableArea } from '../utils/misc'
 
 import type {
-  AddressableAreaName,
   FlexStackerEmptyCreateCommand,
   FlexStackerFillItemsParams,
   FlexStackerFillParams,
@@ -677,24 +669,4 @@ export const forFlexStackerStore = (
       }
     }
   }
-}
-
-const _getStackerShuttleAA = (
-  moduleSlot: string
-): AddressableAreaName | null => {
-  // stacker only compatible with Flex
-  const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
-
-  // Flex stacker slots are currently set in column 4, so we need to transform the slot name to the correct cutout id
-  const transformedSlot = `${moduleSlot[0]}3`
-  const cutuoutId = FLEX_CUTOUT_BY_SLOT_ID[transformedSlot]
-  const flexStackerAAs = deckDef.cutoutFixtures.find(
-    ({ id }) => id === FLEX_STACKER_V1_FIXTURE
-  )?.providesAddressableAreas[cutuoutId]
-
-  // pick off the shuttle AA that is exposed by the stacker
-  return (
-    FLEX_STACKER_ADDRESSABLE_AREAS.find(aa => flexStackerAAs?.includes(aa)) ??
-    null
-  )
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
@@ -1,4 +1,11 @@
-import { SYSTEM_LOCATION } from '@opentrons/shared-data'
+import {
+  FLEX_CUTOUT_BY_SLOT_ID,
+  FLEX_ROBOT_TYPE,
+  FLEX_STACKER_ADDRESSABLE_AREAS,
+  FLEX_STACKER_V1_FIXTURE,
+  getDeckDefFromRobotType,
+  SYSTEM_LOCATION,
+} from '@opentrons/shared-data'
 
 import {
   BOTTOM_UP_LABWARE_POOL_KEYS,
@@ -8,6 +15,7 @@ import { flexStackerStateGetter } from '../robotStateSelectors'
 import { getFlexStackerShuttleAddressableArea } from '../utils/misc'
 
 import type {
+  AddressableAreaName,
   FlexStackerEmptyCreateCommand,
   FlexStackerFillItemsParams,
   FlexStackerFillParams,
@@ -669,4 +677,24 @@ export const forFlexStackerStore = (
       }
     }
   }
+}
+
+const _getStackerShuttleAA = (
+  moduleSlot: string
+): AddressableAreaName | null => {
+  // stacker only compatible with Flex
+  const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
+
+  // Flex stacker slots are currently set in column 4, so we need to transform the slot name to the correct cutout id
+  const transformedSlot = `${moduleSlot[0]}3`
+  const cutuoutId = FLEX_CUTOUT_BY_SLOT_ID[transformedSlot]
+  const flexStackerAAs = deckDef.cutoutFixtures.find(
+    ({ id }) => id === FLEX_STACKER_V1_FIXTURE
+  )?.providesAddressableAreas[cutuoutId]
+
+  // pick off the shuttle AA that is exposed by the stacker
+  return (
+    FLEX_STACKER_ADDRESSABLE_AREAS.find(aa => flexStackerAAs?.includes(aa)) ??
+    null
+  )
 }

--- a/step-generation/src/utils/__tests__/traversals.test.ts
+++ b/step-generation/src/utils/__tests__/traversals.test.ts
@@ -440,7 +440,8 @@ describe('traversals', () => {
     it('derives stackedOnNode from PD-style stack for labware on a deck slot', () => {
       const result = enrichRobotStateForStackGraphTraversals(
         pdStyleStackRobotState,
-        {} as ModuleEntities
+        {} as ModuleEntities,
+        {} as LabwareEntities
       )
       expect(result.labware.plate).toMatchObject({
         stack: ['plate', 'B2'],
@@ -454,7 +455,8 @@ describe('traversals', () => {
       }
       const result = enrichRobotStateForStackGraphTraversals(
         pdStyleStackRobotState,
-        {} as ModuleEntities
+        {} as ModuleEntities,
+        {} as LabwareEntities
       )
       expect(result.labware.plate.stackedOnNode).toEqual({ slotName: 'C3' })
     })

--- a/step-generation/src/utils/traversals.ts
+++ b/step-generation/src/utils/traversals.ts
@@ -589,11 +589,16 @@ export const assignContainsAmongSiblings = (
  *
  * When `labwareEntities` is passed, pairs of labware that share the same eligible parent
  * `stackedOnNode` may set `contains` on the larger footprint to the smaller labware id.
+ *
+ * **Protocol Designer:** call once when composing initial robot state (see PD
+ * {@link getInitialEnrichedRobotState}). After that, timeline `robotState` frames should keep this metadata
+ * current via command-specific updaters (`forMoveLabware`, stacker handlers, etc.), not by
+ * re-running this helper on every active step.
  */
 export const enrichRobotStateForStackGraphTraversals = (
   robotState: RobotState,
   moduleEntities: ModuleEntities,
-  labwareEntities?: LabwareEntities
+  labwareEntities: LabwareEntities
 ): RobotState => {
   const labwareIds = Object.keys(robotState.labware)
   const labwareEntityIds = new Set(labwareIds)
@@ -609,9 +614,9 @@ export const enrichRobotStateForStackGraphTraversals = (
       })
     return stackedOnNode != null ? { ...lw, stackedOnNode } : { ...lw }
   })
-  if (labwareEntities != null) {
-    labware = assignContainsAmongSiblings(labware, labwareEntities)
-  }
+  // assign contains among siblings
+  labware = assignContainsAmongSiblings(labware, labwareEntities)
+
   return {
     ...robotState,
     labware,


### PR DESCRIPTION
NOTE: This PR is targeting another branch upon whose merging this PR is dependent so that the diff is clear. Once that PR merges, I will rebase this branch off `edge`
- [x] 🚨 Rebase off `edge` once #21265 merges 🚨

# Overview

This PR tightens how PD and step-generation build the labware stack graph (stackedOnNode and sibling contains). Labware temporal properties are enriched with these two properties once when building getInitialRobotState, instead of again on every active timeline step, so mid-protocol state is expected to stay correct via command updaters (moves, stacker flows, etc.). Related PD selectors still expose largest stacks and free addressable areas for the initial deck and the active simulated step based on these populated properties, but they will not recompute the enriched graph.

## Test Plan and Hands on Testing

- unit testing
- logging inside `enrichRobotStateForStackGraphTraversals` across steps to ensure it only is run when initial deck setup changes

## Changelog

- only enrich labware temporal properties with stackedOnNode/contains at migration or initial deck setup
- remove straggling console log!

## Review requests

Please mainly review code for sanity and style

## Risk assessment

lowish