### PR TITLE
refactor(app): Consolidate logic for when to show the initial loading spinner

### DIFF
--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -160,36 +160,32 @@ const onDeviceDisplayEvents: Array<keyof DocumentEventMap> = [
 const TURN_OFF_BACKLIGHT = '7'
 
 export const OnDeviceDisplayApp = (): JSX.Element => {
-  useSoftwareUpdatePoll()
-  const { brightness: userSetBrightness, sleepMs } = useSelector(
-    getOnDeviceDisplaySettings
-  )
-  const localRobot = useSelector(getLocalRobot)
+  const dispatch = useDispatch<Dispatch>()
 
+  const [showModuleSetupModal, setShowModuleSetupModal] = useState(false)
+
+  useSoftwareUpdatePoll()
+
+  // Normally, our hooks get the HostConfig from the nearest ApiHostProvider context.
+  // But here at the app root, that doesn't exist. So we need to make sure we pass this
+  // override into all the hooks in this component that will try to use the robot API.
   const hostConfig = useMemo<HostConfig>(
     () => ({
       hostname: '127.0.0.1',
     }),
     []
   )
+  const localRobot = useSelector(getLocalRobot)
 
+  const { brightness: userSetBrightness, sleepMs } = useSelector(
+    getOnDeviceDisplaySettings
+  )
   const sleepTime = sleepMs ?? SLEEP_NEVER_MS
   const options = {
     events: onDeviceDisplayEvents,
     initialState: false,
   }
-  const dispatch = useDispatch<Dispatch>()
   const isIdle = useScreenIdle(sleepTime, options)
-  const [showModuleSetupModal, setShowModuleSetupModal] = useState(false)
-
-  // ensure robot-server api, etc. is up and running
-  const isShellReady = useSelector(getIsShellReady)
-  // ensure settings query data is available for localization provider
-  const { settings } =
-    useRobotSettingsQuery({ retry: true, retryDelay: 1000 }, hostConfig).data ??
-    {}
-  const isReady = isShellReady && settings != null
-
   useEffect(() => {
     if (isIdle) {
       dispatch(updateBrightness(TURN_OFF_BACKLIGHT))
@@ -202,6 +198,14 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
       )
     }
   }, [dispatch, isIdle, userSetBrightness])
+
+  // ensure robot-server api, etc. is up and running
+  const isShellReady = useSelector(getIsShellReady)
+  // ensure settings query data is available for localization provider
+  const { settings } =
+    useRobotSettingsQuery({ retry: true, retryDelay: 1000 }, hostConfig).data ??
+    {}
+  const isReady = isShellReady && settings != null
 
   // TODO (sb:6/12/23) Create a notification manager to set up preference and order of takeover modals
   return (

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { useDispatch, useSelector } from 'react-redux'
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
@@ -11,7 +11,10 @@ import {
   OVERFLOW_AUTO,
   POSITION_RELATIVE,
 } from '@opentrons/components'
-import { ApiHostProvider } from '@opentrons/react-api-client'
+import {
+  ApiHostProvider,
+  useRobotSettingsQuery,
+} from '@opentrons/react-api-client'
 
 import { ReactQueryDevtools } from '/app/App/tools'
 import { SleepScreen } from '/app/atoms/SleepScreen'
@@ -50,7 +53,7 @@ import {
   updateConfigValue,
 } from '/app/redux/config'
 import { getLocalRobot } from '/app/redux/discovery'
-import { updateBrightness } from '/app/redux/shell'
+import { getIsShellReady, updateBrightness } from '/app/redux/shell'
 
 import { LocalizationProvider } from '../LocalizationProvider'
 import { hackWindowNavigatorOnLine } from './hacks'
@@ -65,6 +68,7 @@ import { ODDTopLevelRedirects } from './ODDTopLevelRedirects'
 import { OnDeviceDisplayAppFallback } from './OnDeviceDisplayAppFallback'
 import { PortalRoot as ModalPortalRoot } from './portal'
 
+import type { HostConfig } from '@opentrons/api-client'
 import type { Dispatch } from '/app/redux/types'
 
 // forces electron to think we're online which means axios won't elide
@@ -162,6 +166,13 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
   )
   const localRobot = useSelector(getLocalRobot)
 
+  const hostConfig = useMemo<HostConfig>(
+    () => ({
+      hostname: '127.0.0.1',
+    }),
+    []
+  )
+
   const sleepTime = sleepMs ?? SLEEP_NEVER_MS
   const options = {
     events: onDeviceDisplayEvents,
@@ -170,6 +181,14 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
   const dispatch = useDispatch<Dispatch>()
   const isIdle = useScreenIdle(sleepTime, options)
   const [showModuleSetupModal, setShowModuleSetupModal] = useState(false)
+
+  // ensure robot-server api, etc. is up and running
+  const isShellReady = useSelector(getIsShellReady)
+  // ensure settings query data is available for localization provider
+  const { settings } =
+    useRobotSettingsQuery({ retry: true, retryDelay: 1000 }, hostConfig).data ??
+    {}
+  const isReady = isShellReady && settings != null
 
   useEffect(() => {
     if (isIdle) {
@@ -186,9 +205,9 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
 
   // TODO (sb:6/12/23) Create a notification manager to set up preference and order of takeover modals
   return (
-    <ApiHostProvider hostname="127.0.0.1">
+    <ApiHostProvider hostname={hostConfig.hostname}>
       <ReactQueryDevtools />
-      <InitialLoadingScreen>
+      {isReady ? (
         <LocalizationProvider>
           <ErrorBoundary FallbackComponent={OnDeviceDisplayAppFallback}>
             <Box width="100%" css="user-select: none;">
@@ -231,7 +250,9 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
             <ODDTopLevelRedirects />
           </ErrorBoundary>
         </LocalizationProvider>
-      </InitialLoadingScreen>
+      ) : (
+        <InitialLoadingScreen />
+      )}
     </ApiHostProvider>
   )
 }

--- a/app/src/pages/ODD/InitialLoadingScreen/index.tsx
+++ b/app/src/pages/ODD/InitialLoadingScreen/index.tsx
@@ -1,5 +1,3 @@
-import { useSelector } from 'react-redux'
-
 import {
   ALIGN_CENTER,
   COLORS,
@@ -9,26 +7,9 @@ import {
   JUSTIFY_CENTER,
   SPACING,
 } from '@opentrons/components'
-import { useRobotSettingsQuery } from '@opentrons/react-api-client'
 
-import { getIsShellReady } from '/app/redux/shell'
-
-import type { ReactNode } from 'react'
-
-export function InitialLoadingScreen({
-  children,
-}: {
-  children?: ReactNode
-}): JSX.Element {
-  const isShellReady = useSelector(getIsShellReady)
-
-  // ensure robot-server api is up and settings query data available for localization provider
-  const { settings } =
-    useRobotSettingsQuery({ retry: true, retryDelay: 1000 }).data ?? {}
-
-  return isShellReady && settings != null ? (
-    <>{children}</>
-  ) : (
+export function InitialLoadingScreen(): JSX.Element {
+  return (
     <Flex
       backgroundColor={COLORS.grey35}
       flexDirection={DIRECTION_COLUMN}

--- a/react-api-client/src/robot/useRobotSettingsQuery.ts
+++ b/react-api-client/src/robot/useRobotSettingsQuery.ts
@@ -5,19 +5,21 @@ import { getRobotSettings } from '@opentrons/api-client'
 import { useHost } from '../api'
 
 import type { UseQueryOptions, UseQueryResult } from 'react-query'
-import type { RobotSettingsResponse } from '@opentrons/api-client'
+import type { HostConfig, RobotSettingsResponse } from '@opentrons/api-client'
 
 export type UseRobotSettingsQueryOptions =
   UseQueryOptions<RobotSettingsResponse>
 
 export function useRobotSettingsQuery(
-  options: UseRobotSettingsQueryOptions = {}
+  options: UseRobotSettingsQueryOptions = {},
+  hostOverride?: HostConfig | null
 ): UseQueryResult<RobotSettingsResponse> {
-  const host = useHost()
+  const hostFromProvider = useHost()
+  const host = hostOverride ?? hostFromProvider
   const query = useQuery<RobotSettingsResponse>(
     [host!, 'robot_settings'],
     () => getRobotSettings(host!).then(response => response.data),
-    { enabled: host !== null, ...options }
+    { enabled: host != null, ...options }
   )
 
   return query


### PR DESCRIPTION
## Overview

This is a small refactor to the way the ODD's early start-up works. It prepares the area for EXEC-2538.

## Changelog

The root component, `OnDeviceDisplayApp`, renders a loading spinner, `InitialLoadingScreen`, while certain early startup tasks are in-progress. Previously, the logic was split between the two components. This PR centralizes it in `OnDeviceDisplayApp`.

The theory is that `OnDeviceDisplayApp` is the thing responsible for actually wiring together the outputs of these early startup tasks. So, the type safety will work out better if the same component is responsible for deciding when the outputs are "ready".

In particular, for EXEC-2538: we will want to show the loading spinner until we've first fetched the value of the robot's `enableAccessControl` setting. That way, if we find that we need to render the "currently locked" overlay, we can do that without a UI flicker.

## Test Plan and Hands on Testing

* [x] It still gets past the loading spinner if you run `make -C app dev-odd` and `make dev-backend-flex`.
* [x] It still gets past the loading spinner when run on a real robot.

## Review requests

It may be easiest to view this commit-by-commit.

* 19effd678cff589414fa0cc4a4eda6e15c7e1bb6 is the actual change.
* 4b1ccf8b9b1aee57134d4d28b8fa86fe1ceef817 just reorders some hooks for readability.

## Risk assessment

Medium.

This component isn't enclosed inside an `ApiHostProvider` context, so, by default, queries to the robot API will just be black-holed. We need to remember to pass in an explicit `HostConfig` to everything that might query the robot API. If that goes wrong, it'll cause an infinite loading spinner because the query will never complete.

