### PR TITLE
feat(api): Implement Pyro serializers for PipetteDict and OT3Config

### DIFF
--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -485,4 +485,21 @@ def build_with_defaults(robot_settings: Dict[str, Any]) -> OT3Config:
 
 
 def serialize(config: OT3Config) -> Dict[str, Any]:
-    return config.model_dump(mode="json")
+    from opentrons.hardware_control.types import InstrumentProbeType
+
+    def _scrub_key_types(obj: Any, target_type: Any) -> Any:
+        if isinstance(obj, dict):
+            new = {}
+            for k, v in obj.items():
+                new_key = k.name if isinstance(k, target_type) else k
+                new[new_key] = _scrub_key_types(v, target_type)
+            return new
+        if isinstance(obj, list):
+            return [_scrub_key_types(i, target_type) for i in obj]
+        return obj
+
+    raw = config.model_dump()
+    clean_axis: Dict[str, Any] = _scrub_key_types(raw, OT3AxisKind)
+    clean_probe: Dict[str, Any] = _scrub_key_types(clean_axis, InstrumentProbeType)
+
+    return clean_probe

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import asdict
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 from typing_extensions import Final
 
@@ -486,23 +485,4 @@ def build_with_defaults(robot_settings: Dict[str, Any]) -> OT3Config:
 
 
 def serialize(config: OT3Config) -> Dict[str, Any]:
-    # inline import prevents circular import error from hardware_control.types
-    from opentrons.hardware_control.types import InstrumentProbeType
-
-    def _build_dict(pairs: Iterable[Tuple[Any, Any]]) -> Dict[str, Any]:
-        def _normalize_key(key: Any) -> Any:
-            if isinstance(key, OT3AxisKind) or isinstance(key, InstrumentProbeType):
-                return key.name
-            return key
-
-        def _normalize_value(value: Any) -> Any:
-            if isinstance(value, dict):
-                return {
-                    _normalize_key(k): _normalize_value(v) for k, v in value.items()
-                }
-            else:
-                return value
-
-        return dict((_normalize_key(key), _normalize_value(val)) for key, val in pairs)
-
-    return asdict(config, dict_factory=_build_dict)
+    return config.model_dump(mode="json")

--- a/api/src/opentrons/config/defaults_ot3.py
+++ b/api/src/opentrons/config/defaults_ot3.py
@@ -485,6 +485,7 @@ def build_with_defaults(robot_settings: Dict[str, Any]) -> OT3Config:
 
 
 def serialize(config: OT3Config) -> Dict[str, Any]:
+    # inline import prevents circular import error from hardware_control.types
     from opentrons.hardware_control.types import InstrumentProbeType
 
     def _scrub_key_types(obj: Any, target_type: Any) -> Any:

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -1,4 +1,4 @@
-from dataclasses import asdict, dataclass, fields
+from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any, Dict, Generic, List, Mapping, Tuple, TypeVar, cast
 

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -2,7 +2,7 @@ from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any, Dict, Generic, List, Mapping, Tuple, TypeVar, cast
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, ValidationInfo, field_validator
 from typing_extensions import Literal, TypedDict
 
 
@@ -212,31 +212,25 @@ class LiquidProbeSettings(BaseModel):
     sample_time_sec: float
 
 
-@dataclass(frozen=True)
-class EdgeSenseSettings:
+class EdgeSenseSettings(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     overrun_tolerance_mm: float
     early_sense_tolerance_mm: float
     pass_settings: CapacitivePassSettings
     search_initial_tolerance_mm: float
     search_iteration_limit: int
 
-    def __init__(
-        self,
-        overrun_tolerance_mm: float,
-        early_sense_tolerance_mm: float,
-        pass_settings: CapacitivePassSettings,
-        search_initial_tolerance_mm: float,
-        search_iteration_limit: int,
-    ) -> None:
-        if overrun_tolerance_mm > pass_settings.max_overrun_distance_mm:
+    @field_validator("pass_settings")
+    @classmethod
+    def _validate_pass_settings(
+        cls, v: CapacitivePassSettings, info: ValidationInfo
+    ) -> CapacitivePassSettings:
+        overrun_tolerance_mm = info.data.get("overrun_tolerance_mm")
+        assert isinstance(overrun_tolerance_mm, float)
+        if overrun_tolerance_mm > v.max_overrun_distance_mm:
             raise ValueError("Overrun tolerance and pass setting distance do not match")
-        object.__setattr__(self, "overrun_tolerance_mm", overrun_tolerance_mm)
-        object.__setattr__(self, "early_sense_tolerance_mm", early_sense_tolerance_mm)
-        object.__setattr__(self, "pass_settings", pass_settings)
-        object.__setattr__(
-            self, "search_initial_tolerance_mm", search_initial_tolerance_mm
-        )
-        object.__setattr__(self, "search_iteration_limit", search_iteration_limit)
+        return v
 
 
 class OT3CalibrationSettings(BaseModel):

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -1,7 +1,8 @@
 from dataclasses import asdict, dataclass, fields
 from enum import Enum
-from typing import Dict, Generic, List, Tuple, TypeVar, cast
+from typing import Any, Dict, Generic, List, Mapping, Tuple, TypeVar, cast
 
+from pydantic import BaseModel, ConfigDict, field_validator
 from typing_extensions import Literal, TypedDict
 
 
@@ -104,8 +105,47 @@ class RobotConfig:
 OT3Transform = List[List[float]]
 
 
-@dataclass(frozen=True)
-class OT3MotionSettings:
+def _coerce_ot3_axis_kind(key: Any) -> OT3AxisKind:
+    if isinstance(key, OT3AxisKind):
+        return key
+    if isinstance(key, int):
+        return OT3AxisKind(key)
+    if isinstance(key, str):
+        try:
+            return OT3AxisKind[key]
+        except KeyError:
+            pass
+        return OT3AxisKind(int(key))
+    raise TypeError(f"Unsupported OT3 axis key type: {type(key)} ({key!r})")
+
+
+def _coerce_axis_map(raw: Any) -> Dict[OT3AxisKind, float]:
+    if not isinstance(raw, Mapping):
+        raise TypeError(f"Expected mapping for axis settings, got {type(raw)}")
+    return {_coerce_ot3_axis_kind(k): float(v) for k, v in raw.items()}
+
+
+def _coerce_by_gantry_load_axis_maps(
+    raw: Any,
+) -> ByGantryLoad[Dict[OT3AxisKind, float]]:
+    if isinstance(raw, ByGantryLoad):
+        return ByGantryLoad(
+            high_throughput_1000=_coerce_axis_map(raw.high_throughput_1000),
+            high_throughput_200=_coerce_axis_map(raw.high_throughput_200),
+            low_throughput=_coerce_axis_map(raw.low_throughput),
+        )
+    if not isinstance(raw, Mapping):
+        raise TypeError(f"Expected mapping/ByGantryLoad, got {type(raw)}")
+    return ByGantryLoad(
+        high_throughput_1000=_coerce_axis_map(raw["high_throughput_1000"]),
+        high_throughput_200=_coerce_axis_map(raw["high_throughput_200"]),
+        low_throughput=_coerce_axis_map(raw["low_throughput"]),
+    )
+
+
+class OT3MotionSettings(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     default_max_speed: PerPipetteAxisSettings
     acceleration: PerPipetteAxisSettings
     max_speed_discontinuity: PerPipetteAxisSettings
@@ -114,41 +154,53 @@ class OT3MotionSettings:
     def by_gantry_load(
         self, gantry_load: GantryLoad
     ) -> Dict[str, Dict[OT3AxisKind, float]]:
-        return dict(
-            (field.name, getattr(self, field.name)[gantry_load])
-            for field in fields(self)
-        )
+        return {name: getattr(self, name)[gantry_load] for name in self.model_fields}
+
+    @field_validator(
+        "default_max_speed",
+        "acceleration",
+        "max_speed_discontinuity",
+        "direction_change_speed_discontinuity",
+        mode="before",
+    )
+    @classmethod
+    def _coerce_axis_keyed_maps(cls, v: Any) -> ByGantryLoad[Dict[OT3AxisKind, float]]:
+        return _coerce_by_gantry_load_axis_maps(v)
 
 
-@dataclass(frozen=True)
-class OT3CurrentSettings:
+class OT3CurrentSettings(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     hold_current: PerPipetteAxisSettings
     run_current: PerPipetteAxisSettings
 
     def by_gantry_load(
         self, gantry_load: GantryLoad
     ) -> Dict[str, Dict[OT3AxisKind, float]]:
-        return dict(
-            (field.name, getattr(self, field.name)[gantry_load])
-            for field in fields(self)
-        )
+        return {name: getattr(self, name)[gantry_load] for name in self.model_fields}
+
+    @field_validator("hold_current", "run_current", mode="before")
+    @classmethod
+    def _coerce_axis_keyed_maps(cls, v: Any) -> ByGantryLoad[Dict[OT3AxisKind, float]]:
+        return _coerce_by_gantry_load_axis_maps(v)
 
 
-@dataclass(frozen=True)
-class CapacitivePassSettings:
+class CapacitivePassSettings(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     prep_distance_mm: float
     max_overrun_distance_mm: float
     speed_mm_per_s: float
     sensor_threshold_pf: float
 
 
-@dataclass(frozen=True)
-class ZSenseSettings:
+class ZSenseSettings(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     pass_settings: CapacitivePassSettings
 
 
-@dataclass
-class LiquidProbeSettings:
+class LiquidProbeSettings(BaseModel):
     mount_speed: float
     plunger_speed: float
     plunger_impulse_time: float
@@ -187,15 +239,15 @@ class EdgeSenseSettings:
         object.__setattr__(self, "search_iteration_limit", search_iteration_limit)
 
 
-@dataclass(frozen=True)
-class OT3CalibrationSettings:
+class OT3CalibrationSettings(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     z_offset: ZSenseSettings
     edge_sense: EdgeSenseSettings
     probe_length: float
 
 
-@dataclass
-class OT3Config:
+class OT3Config(BaseModel):
     model: Literal["OT-3 Standard"]
     name: str
     version: int

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import datetime
 import json
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from enum import Enum
 from functools import lru_cache
 from logging import getLogger
@@ -315,10 +315,12 @@ async def find_slot_center_binary(
     estimated_center = estimated_center._replace(y=plus_y_edge.y - EDGES["top"].y)
 
     # since we have a good idea where the edges are now we can reduce the second set of sweeps
-    fast_edge_settings = replace(
-        edge_settings,
-        search_initial_tolerance_mm=edge_settings.search_initial_tolerance_mm / 4,
-        search_iteration_limit=edge_settings.search_iteration_limit - 2,
+    fast_edge_settings = edge_settings.model_copy(
+        update={
+            "search_initial_tolerance_mm": edge_settings.search_initial_tolerance_mm
+            / 4,
+            "search_iteration_limit": edge_settings.search_iteration_limit - 2,
+        }
     )
     minus_x_edge = await find_edge_binary(
         hcapi,

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -1893,7 +1893,7 @@ class OT3API(
 
     async def update_config(self, **kwargs: Any) -> None:
         """Update values of the robot's configuration."""
-        self._config = self._config.model_copy(update={**kwargs})
+        self._config = self._config.model_copy(update=kwargs)
 
     @property
     def hardware_feature_flags(self) -> HardwareFeatureFlags:

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -147,6 +147,7 @@ from opentrons.util.pyro.pyro_synchronous_adapter import (
     convert_result_to_proxy,
     convert_result_to_wrapped_dict,
     convert_type_to_instance,
+    debug_attribute,
     pyro_behavior,
 )
 
@@ -2690,11 +2691,14 @@ class OT3API(
             module_type, serial_number
         )
 
+    # CASEY NOTE REPLACE WITH NON DEBUG BEHAVIOR
+    @pyro_behavior(specialty_func=debug_attribute, apply_local=False)
     def get_attached_pipette(
         self, mount: Union[top_types.Mount, OT3Mount]
     ) -> PipetteDict:
         return self._pipette_handler.get_attached_instrument(OT3Mount.from_mount(mount))
 
+    @pyro_behavior(specialty_func=debug_attribute, apply_local=False)
     def get_attached_instrument(
         self, mount: Union[top_types.Mount, OT3Mount]
     ) -> PipetteDict:
@@ -2757,6 +2761,8 @@ class OT3API(
             OT3Mount.from_mount(mount), aspirate, dispense, blow_out
         )
 
+    # CASEY NOTE REMOVE DEBUG ATTRIBUTE HERE
+    @pyro_behavior(debug_attribute, False)
     def get_instrument_max_height(
         self,
         mount: Union[top_types.Mount, OT3Mount],

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -4,7 +4,6 @@ import logging
 from collections import OrderedDict
 from concurrent.futures import Future
 from copy import deepcopy
-from dataclasses import replace
 from functools import lru_cache, partial, wraps
 from typing import (
     Any,
@@ -1894,7 +1893,7 @@ class OT3API(
 
     async def update_config(self, **kwargs: Any) -> None:
         """Update values of the robot's configuration."""
-        self._config = replace(self._config, **kwargs)
+        self._config = self._config.model_copy(update={**kwargs})
 
     @property
     def hardware_feature_flags(self) -> HardwareFeatureFlags:
@@ -2706,7 +2705,8 @@ class OT3API(
         self, mount: Union[top_types.Mount, OT3Mount]
     ) -> PipetteDict:
         # Warning: don't use this in new code, used `get_attached_pipette` instead
-        return self.get_attached_pipette(mount)
+        pipette_dict: PipetteDict = self.get_attached_pipette(mount)
+        return pipette_dict
 
     @property
     @pyro_behavior(specialty_func=convert_result_to_wrapped_dict, apply_local=False)

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -146,8 +146,8 @@ from opentrons.hardware_control.modules.module_calibration import (
 from opentrons.util.pyro.pyro_synchronous_adapter import (
     convert_result_to_proxy,
     convert_result_to_wrapped_dict,
+    convert_result_to_wrapped_typed_dict,
     convert_type_to_instance,
-    debug_attribute,
     pyro_behavior,
 )
 
@@ -2691,14 +2691,17 @@ class OT3API(
             module_type, serial_number
         )
 
-    # CASEY NOTE REPLACE WITH NON DEBUG BEHAVIOR
-    @pyro_behavior(specialty_func=debug_attribute, apply_local=False)
+    @pyro_behavior(
+        specialty_func=convert_result_to_wrapped_typed_dict, apply_local=False
+    )
     def get_attached_pipette(
         self, mount: Union[top_types.Mount, OT3Mount]
     ) -> PipetteDict:
         return self._pipette_handler.get_attached_instrument(OT3Mount.from_mount(mount))
 
-    @pyro_behavior(specialty_func=debug_attribute, apply_local=False)
+    @pyro_behavior(
+        specialty_func=convert_result_to_wrapped_typed_dict, apply_local=False
+    )
     def get_attached_instrument(
         self, mount: Union[top_types.Mount, OT3Mount]
     ) -> PipetteDict:
@@ -2761,8 +2764,6 @@ class OT3API(
             OT3Mount.from_mount(mount), aspirate, dispense, blow_out
         )
 
-    # CASEY NOTE REMOVE DEBUG ATTRIBUTE HERE
-    @pyro_behavior(debug_attribute, False)
     def get_instrument_max_height(
         self,
         mount: Union[top_types.Mount, OT3Mount],

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -22,8 +22,7 @@ import opentrons.hardware_control.types
 import opentrons.types
 from opentrons.util.pyro.pyro_serialization import (
     OpentronsPyroSerializer,
-    SpecialDictWrapper,
-    _serpent_enum_serializer,
+    TypedDictWrapper,
     find_enums_in_packages,
     find_pydantic_classes_in_packages,
     find_typed_dict_classes_in_packages,
@@ -173,12 +172,14 @@ def _PipetteOffsetSummary_class_to_dict(obj) -> Dict:  # type: ignore
         "reasonability_check_failures": None,  # todo(chb: 04-09-2026): These are skipped for integration simplicity, they should be handled by automatic process
     }
 
-# CASEY TODO: the special dict wrapper should include a __class__ name and here we should check it with an if statement, and have a handler function that does the pipette dict stuff
+
+# Type Dict registration handlers
 
 
-def _special_dict_wrapper_dict_dict_to_class(  # type: ignore
+def _pipetted_dict_dict_to_class(  # type: ignore
     classname, d
 ) -> opentrons.hardware_control.dev_types.PipetteDict:
+    """Reconstruction handler for PipetteDict TypedDicts."""
     dictionary = d["dictionary"]
 
     converted_supported_tips: Dict[
@@ -197,18 +198,19 @@ def _special_dict_wrapper_dict_dict_to_class(  # type: ignore
         opentrons_shared_data.pipette.pipette_definition.PipetteLiquidPropertiesDefinition,
     ] = {}
 
-
     for liquid_class, props in dictionary["available_volume_modes"].items():
-        liquid_class_enum = opentrons_shared_data.pipette.types.LiquidClasses(int(liquid_class))
-        print(f"LQ PROPS: {props}")
-        props["supportedTips"] = {f"t{key}": value for key, value in props["supportedTips"].items()}
+        liquid_class_enum = opentrons_shared_data.pipette.types.LiquidClasses(
+            int(liquid_class)
+        )
+        props["supportedTips"] = {
+            f"t{key}": value for key, value in props["supportedTips"].items()
+        }
         prop_model = opentrons_shared_data.pipette.pipette_definition.PipetteLiquidPropertiesDefinition.model_validate(
             props
         )
         converted_available_volume_modes[liquid_class_enum] = prop_model
 
-
-    new_dict = opentrons.hardware_control.dev_types.PipetteDict(
+    return opentrons.hardware_control.dev_types.PipetteDict(
         display_name=str(dictionary["display_name"]),
         name=dictionary["name"],  # TODO take a look at it
         model=opentrons_shared_data.pipette.types.PipetteModel(dictionary["model"]),
@@ -261,7 +263,16 @@ def _special_dict_wrapper_dict_dict_to_class(  # type: ignore
         ),
         available_volume_modes=converted_available_volume_modes,
     )
-    return new_dict
+
+
+def _typed_dict_dict_to_class(classname, d) -> Any:
+    """This is a unique serializaiton handler that can be expanded to support TypedDicts that need reconstruction."""
+    if d["typed_dict_name"] == "opentrons.hardware_control.dev_types.PipetteDict":
+        return _pipetted_dict_dict_to_class(classname, d)
+    else:
+        raise ValueError(
+            f"No registration handler available for classname: {classname}"
+        )
 
 
 # numpy float serialization
@@ -363,7 +374,7 @@ def register_hardware_types() -> None:
         class_to_dict=_estop_overall_status_class_to_dict,
     )
 
-    # todo(chb: 04-09-2026): These are termporary direct serializations to support the initial robot server intergration, replace with automated solution
+    # todo(chb: 04-09-2026): These are direct serializations to support the initial robot server intergration, replace with automated solution where approprite
     # gripper calibration
     register_type_to_serpent(
         class_type=opentrons.hardware_control.instruments.ot3.instrument_calibration.GripperCalibrationOffset,
@@ -392,9 +403,5 @@ def register_hardware_types() -> None:
         class_to_dict=_point_class_to_dict,
     )
 
-    # handle special dicts
-    register_type_to_serpent(
-        class_type=SpecialDictWrapper,
-        dict_to_class=_special_dict_wrapper_dict_dict_to_class,
-        class_to_dict=OpentronsPyroSerializer._pydantic_class_to_dict,
-    )
+    # handle Typed Dicts for the hardware controller
+    OpentronsPyroSerializer.register_opentrons_typed_dicts(_typed_dict_dict_to_class)

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -1,16 +1,29 @@
 """Registry for use with a Pyro Daemon client and server to allow serialization of Opentrons Hardware types and classes."""
 
 import datetime
-from typing import Dict
+from importlib import util
+from typing import Any, Dict, cast
+
+import numpy
+import Pyro5.api as pyro
+import serpent
+from numpy import float64
+from pydantic import BaseModel
+
+import opentrons_shared_data.pipette.pipette_definition
+import opentrons_shared_data.pipette.types
 
 import opentrons.config.types
 import opentrons.hardware_control.dev_types
 import opentrons.hardware_control.instruments.ot3.instrument_calibration
+import opentrons.hardware_control.nozzle_manager
 import opentrons.hardware_control.protocols.types
 import opentrons.hardware_control.types
 import opentrons.types
 from opentrons.util.pyro.pyro_serialization import (
     OpentronsPyroSerializer,
+    SpecialDictWrapper,
+    _serpent_enum_serializer,
     find_enums_in_packages,
     find_pydantic_classes_in_packages,
     find_typed_dict_classes_in_packages,
@@ -160,6 +173,128 @@ def _PipetteOffsetSummary_class_to_dict(obj) -> Dict:  # type: ignore
         "reasonability_check_failures": None,  # todo(chb: 04-09-2026): These are skipped for integration simplicity, they should be handled by automatic process
     }
 
+# CASEY TODO: the special dict wrapper should include a __class__ name and here we should check it with an if statement, and have a handler function that does the pipette dict stuff
+
+
+def _special_dict_wrapper_dict_dict_to_class(  # type: ignore
+    classname, d
+) -> opentrons.hardware_control.dev_types.PipetteDict:
+    dictionary = d["dictionary"]
+
+    converted_supported_tips: Dict[
+        opentrons_shared_data.pipette.types.PipetteTipType,
+        opentrons_shared_data.pipette.pipette_definition.SupportedTipsDefinition,
+    ] = {}
+    for tip in dictionary["supported_tips"].keys():
+        converted_supported_tips[
+            opentrons_shared_data.pipette.types.PipetteTipType(value=int(tip))
+        ] = opentrons_shared_data.pipette.pipette_definition.SupportedTipsDefinition.model_validate(
+            dictionary["supported_tips"][tip]
+        )
+
+    converted_available_volume_modes: Dict[
+        opentrons_shared_data.pipette.types.LiquidClasses,
+        opentrons_shared_data.pipette.pipette_definition.PipetteLiquidPropertiesDefinition,
+    ] = {}
+
+
+    for liquid_class, props in dictionary["available_volume_modes"].items():
+        liquid_class_enum = opentrons_shared_data.pipette.types.LiquidClasses(int(liquid_class))
+        print(f"LQ PROPS: {props}")
+        props["supportedTips"] = {f"t{key}": value for key, value in props["supportedTips"].items()}
+        prop_model = opentrons_shared_data.pipette.pipette_definition.PipetteLiquidPropertiesDefinition.model_validate(
+            props
+        )
+        converted_available_volume_modes[liquid_class_enum] = prop_model
+
+
+    new_dict = opentrons.hardware_control.dev_types.PipetteDict(
+        display_name=str(dictionary["display_name"]),
+        name=dictionary["name"],  # TODO take a look at it
+        model=opentrons_shared_data.pipette.types.PipetteModel(dictionary["model"]),
+        back_compat_names=dictionary["back_compat_names"],
+        pipette_id=str(dictionary["pipette_id"]),
+        min_volume=float(dictionary["min_volume"]),
+        max_volume=float(dictionary["max_volume"]),
+        channels=dictionary["channels"],  # TODO here too
+        aspirate_flow_rate=float(dictionary["aspirate_flow_rate"]),
+        dispense_flow_rate=float(dictionary["dispense_flow_rate"]),
+        blow_out_flow_rate=float(dictionary["blow_out_flow_rate"]),
+        aspirate_speed=float(dictionary["aspirate_speed"]),
+        dispense_speed=float(dictionary["dispense_speed"]),
+        blow_out_speed=float(dictionary["blow_out_speed"]),
+        current_volume=float(dictionary["current_volume"]),
+        tip_length=float(dictionary["tip_length"]),
+        working_volume=float(dictionary["working_volume"]),
+        tip_overlap=dictionary["tip_overlap"],
+        versioned_tip_overlap=dictionary["versioned_tip_overlap"],
+        available_volume=float(dictionary["available_volume"]),
+        return_tip_height=float(dictionary["return_tip_height"]),
+        default_aspirate_flow_rates=dictionary["default_aspirate_flow_rates"],
+        default_dispense_flow_rates=dictionary["default_dispense_flow_rates"],
+        default_blow_out_flow_rates=dictionary["default_blow_out_flow_rates"],
+        default_aspirate_speeds=dictionary["default_aspirate_speeds"],
+        default_dispense_speeds=dictionary["default_dispense_speeds"],
+        default_blow_out_speeds=dictionary["default_blow_out_speeds"],
+        ready_to_aspirate=bool(dictionary["ready_to_aspirate"]),
+        has_tip=bool(dictionary["has_tip"]),
+        default_push_out_volume=None
+        if dictionary["default_push_out_volume"] is None
+        else float(dictionary["default_push_out_volume"]),
+        supported_tips=converted_supported_tips,
+        pipette_bounding_box_offsets=opentrons_shared_data.pipette.pipette_definition.PipetteBoundingBoxOffsetDefinition.model_validate(
+            dictionary["pipette_bounding_box_offsets"]
+        ),
+        current_nozzle_map=opentrons.hardware_control.nozzle_manager.NozzleMap.model_validate(
+            dictionary["current_nozzle_map"]
+        ),
+        lld_settings=None
+        if dictionary["lld_settings"] is None
+        else dictionary["lld_settings"],
+        plunger_positions=dictionary["plunger_positions"],
+        shaft_ul_per_mm=float(dictionary["shaft_ul_per_mm"]),
+        available_sensors=opentrons_shared_data.pipette.pipette_definition.AvailableSensorDefinition.model_validate(
+            dictionary["available_sensors"]
+        ),
+        volume_mode=opentrons_shared_data.pipette.types.LiquidClasses(
+            dictionary["volume_mode"]
+        ),
+        available_volume_modes=converted_available_volume_modes,
+    )
+    return new_dict
+
+
+# numpy float serialization
+def _numpy_float_class_to_dict(obj) -> Dict:
+    return {"__class__": "numpy.float64", "value": float(obj)}
+
+
+def _numpy_float_dict_to_class(classname, d) -> float64:
+    return float64(d["value"])
+
+
+# point named tuple
+def _point_class_to_dict(obj) -> Dict:
+    return {
+        "__class__": ".".join((obj.__module__, obj.__class__.__name__)),
+        "x": obj.x,
+        "y": obj.y,
+        "z": obj.z,
+    }
+
+
+def _point_dict_to_class(clasname, d) -> opentrons.types.Point:
+    x_data = d["x"]
+    y_data = d["y"]
+    z_data = d["z"]
+    if isinstance(x_data, dict):
+        x_data = x_data["value"]
+    if isinstance(y_data, dict):
+        y_data = y_data["value"]
+    if isinstance(z_data, dict):
+        z_data = z_data["value"]
+    return opentrons.types.Point(x=float(x_data), y=float(y_data), z=float(z_data))
+
 
 # Robot type registry - of note, this is meant to return a "pure" type
 def _robot_type_class_to_dict(obj) -> Dict:  # type: ignore
@@ -183,6 +318,8 @@ def register_hardware_types() -> None:
             opentrons.config.types,
             opentrons.hardware_control.types,
             opentrons.hardware_control.dev_types,
+            opentrons_shared_data.pipette.pipette_definition,
+            opentrons_shared_data.pipette.types,
         ]
     )
 
@@ -196,6 +333,8 @@ def register_hardware_types() -> None:
             opentrons.config.types,
             opentrons.hardware_control.types,
             opentrons.hardware_control.protocols.types,
+            opentrons_shared_data.pipette.pipette_definition,
+            opentrons.hardware_control.nozzle_manager,
         ]
     )
     for pydantic_type in opentrons_pydantic_types:
@@ -237,4 +376,25 @@ def register_hardware_types() -> None:
         class_type=opentrons.hardware_control.instruments.ot3.instrument_calibration.PipetteOffsetSummary,
         dict_to_class=_PipetteOffsetSummary_dict_to_class,
         class_to_dict=_PipetteOffsetSummary_class_to_dict,
+    )
+
+    # numpy registration
+    register_type_to_serpent(
+        class_type=float64,
+        dict_to_class=_numpy_float_dict_to_class,
+        class_to_dict=_numpy_float_class_to_dict,
+    )
+
+    # point registration
+    register_type_to_serpent(
+        class_type=opentrons.types.Point,
+        dict_to_class=_point_dict_to_class,
+        class_to_dict=_point_class_to_dict,
+    )
+
+    # handle special dicts
+    register_type_to_serpent(
+        class_type=SpecialDictWrapper,
+        dict_to_class=_special_dict_wrapper_dict_dict_to_class,
+        class_to_dict=OpentronsPyroSerializer._pydantic_class_to_dict,
     )

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -1,14 +1,9 @@
 """Registry for use with a Pyro Daemon client and server to allow serialization of Opentrons Hardware types and classes."""
 
 import datetime
-from importlib import util
-from typing import Any, Dict, cast
+from typing import Any, Dict
 
-import numpy
-import Pyro5.api as pyro
-import serpent
 from numpy import float64
-from pydantic import BaseModel
 
 import opentrons_shared_data.pipette.pipette_definition
 import opentrons_shared_data.pipette.types
@@ -22,7 +17,6 @@ import opentrons.hardware_control.types
 import opentrons.types
 from opentrons.util.pyro.pyro_serialization import (
     OpentronsPyroSerializer,
-    TypedDictWrapper,
     find_enums_in_packages,
     find_pydantic_classes_in_packages,
     find_typed_dict_classes_in_packages,
@@ -265,7 +259,7 @@ def _pipetted_dict_dict_to_class(  # type: ignore
     )
 
 
-def _typed_dict_dict_to_class(classname, d) -> Any:
+def _typed_dict_dict_to_class(classname, d) -> Any:  # type: ignore
     """This is a unique serializaiton handler that can be expanded to support TypedDicts that need reconstruction."""
     if d["typed_dict_name"] == "opentrons.hardware_control.dev_types.PipetteDict":
         return _pipetted_dict_dict_to_class(classname, d)
@@ -276,16 +270,16 @@ def _typed_dict_dict_to_class(classname, d) -> Any:
 
 
 # numpy float serialization
-def _numpy_float_class_to_dict(obj) -> Dict:
+def _numpy_float_class_to_dict(obj) -> Dict:  # type: ignore
     return {"__class__": "numpy.float64", "value": float(obj)}
 
 
-def _numpy_float_dict_to_class(classname, d) -> float64:
+def _numpy_float_dict_to_class(classname, d) -> float64:  # type: ignore
     return float64(d["value"])
 
 
 # point named tuple
-def _point_class_to_dict(obj) -> Dict:
+def _point_class_to_dict(obj) -> Dict:  # type: ignore
     return {
         "__class__": ".".join((obj.__module__, obj.__class__.__name__)),
         "x": obj.x,
@@ -294,7 +288,7 @@ def _point_class_to_dict(obj) -> Dict:
     }
 
 
-def _point_dict_to_class(clasname, d) -> opentrons.types.Point:
+def _point_dict_to_class(clasname, d) -> opentrons.types.Point:  # type: ignore
     x_data = d["x"]
     y_data = d["y"]
     z_data = d["z"]

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -206,13 +206,13 @@ def _pipetted_dict_dict_to_class(  # type: ignore
 
     return opentrons.hardware_control.dev_types.PipetteDict(
         display_name=str(dictionary["display_name"]),
-        name=dictionary["name"],  # TODO take a look at it
+        name=dictionary["name"],
         model=opentrons_shared_data.pipette.types.PipetteModel(dictionary["model"]),
         back_compat_names=dictionary["back_compat_names"],
         pipette_id=str(dictionary["pipette_id"]),
         min_volume=float(dictionary["min_volume"]),
         max_volume=float(dictionary["max_volume"]),
-        channels=dictionary["channels"],  # TODO here too
+        channels=dictionary["channels"],
         aspirate_flow_rate=float(dictionary["aspirate_flow_rate"]),
         dispense_flow_rate=float(dictionary["dispense_flow_rate"]),
         blow_out_flow_rate=float(dictionary["blow_out_flow_rate"]),
@@ -278,7 +278,7 @@ def _numpy_float_dict_to_class(classname, d) -> float64:  # type: ignore
     return float64(d["value"])
 
 
-# point named tuple
+# Point type serialization
 def _point_class_to_dict(obj) -> Dict:  # type: ignore
     return {
         "__class__": ".".join((obj.__module__, obj.__class__.__name__)),
@@ -368,7 +368,7 @@ def register_hardware_types() -> None:
         class_to_dict=_estop_overall_status_class_to_dict,
     )
 
-    # todo(chb: 04-09-2026): These are direct serializations to support the initial robot server intergration, replace with automated solution where approprite
+    # todo(chb: 04-09-2026): These are direct serializations to support the initial robot server intergration, replace with automated solution where appropriate
     # gripper calibration
     register_type_to_serpent(
         class_type=opentrons.hardware_control.instruments.ot3.instrument_calibration.GripperCalibrationOffset,

--- a/api/src/opentrons/util/pyro/pyro_daemon_utility.py
+++ b/api/src/opentrons/util/pyro/pyro_daemon_utility.py
@@ -13,13 +13,7 @@ from opentrons.util.pyro.pyro_synchronous_adapter import (
     PyroSynchronousObject,
 )
 
-# CASEY NOTE CLEAN UP THIS LOGGER STUFF
-os.environ["PYRO_LOGFILE"] = "pyro.log"
-os.environ["PYRO_LOGLEVEL"] = "DEBUG"
-
 log = logging.getLogger(__name__)
-logging.getLogger("Pyro5").setLevel(logging.DEBUG)
-logging.getLogger("Pyro5.core").setLevel(logging.DEBUG)
 
 PYRO_TIMEOUT = 100
 

--- a/api/src/opentrons/util/pyro/pyro_daemon_utility.py
+++ b/api/src/opentrons/util/pyro/pyro_daemon_utility.py
@@ -1,7 +1,6 @@
 """Pyro related utilities for daemons and request handling."""
 
 import logging
-import os
 import socket
 from typing import Any, Callable
 

--- a/api/src/opentrons/util/pyro/pyro_daemon_utility.py
+++ b/api/src/opentrons/util/pyro/pyro_daemon_utility.py
@@ -1,6 +1,7 @@
 """Pyro related utilities for daemons and request handling."""
 
 import logging
+import os
 import socket
 from typing import Any, Callable
 
@@ -12,7 +13,13 @@ from opentrons.util.pyro.pyro_synchronous_adapter import (
     PyroSynchronousObject,
 )
 
+# CASEY NOTE CLEAN UP THIS LOGGER STUFF
+os.environ["PYRO_LOGFILE"] = "pyro.log"
+os.environ["PYRO_LOGLEVEL"] = "DEBUG"
+
 log = logging.getLogger(__name__)
+logging.getLogger("Pyro5").setLevel(logging.DEBUG)
+logging.getLogger("Pyro5.core").setLevel(logging.DEBUG)
 
 PYRO_TIMEOUT = 100
 

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -13,8 +13,14 @@ from Pyro5 import api as pyro
 from typing_extensions import TypedDict, is_typeddict
 
 
-class SpecialDictWrapper(BaseModel):
+class TypedDictWrapper(BaseModel):
+    """This is a specialty model create to safely wrap TypedDicts like PipetteDict.
+
+    Each typed dict requires custom handling in their native serializer.
+    """
+
     dictionary: dict[Any, Any]
+    typed_dict_name: str
 
 
 class UnhashableDictWrapper(BaseModel):
@@ -161,6 +167,18 @@ class OpentronsPyroSerializer:
         """Registered a TypedDict type to the OpentronsPyroSerializer for tracking and deserialization purposes only."""
         class_name = ".".join((typed_dict.__module__, typed_dict.__qualname__))
         cls._typed_dict_class_name_to_model[class_name] = typed_dict
+
+    @classmethod
+    def register_opentrons_typed_dicts(
+        cls, dict_to_class: Callable[[str, Any], Any]
+    ) -> None:
+        """Registers the specialty handler for typed dicts using TypeDictWrapper."""
+        class_name = register_type_to_serpent(
+            TypedDictWrapper,
+            dict_to_class,
+            cls._pydantic_class_to_dict,
+        )
+        cls._pydantic_class_name_to_model[class_name] = TypedDictWrapper
 
     @classmethod
     def register_unhashable_dicts(cls) -> None:

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -13,6 +13,10 @@ from Pyro5 import api as pyro
 from typing_extensions import TypedDict, is_typeddict
 
 
+class SpecialDictWrapper(BaseModel):
+    dictionary: dict[Any, Any]
+
+
 class UnhashableDictWrapper(BaseModel):
     """This is a specialty model created to safely wrap dictionaries with mutable elements provided by Opentrons APIs.
 

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -6,12 +6,11 @@ import inspect
 from types import FunctionType, MethodType
 from typing import Any, Callable, Dict, Iterator, Optional, ParamSpec, TypeVar
 
-import numpy
 from pydantic import BaseModel
 from Pyro5 import api as pyro
 
 from opentrons.util.pyro.pyro_serialization import (
-    SpecialDictWrapper,
+    TypedDictWrapper,
     UnhashableDictWrapper,
 )
 
@@ -486,32 +485,44 @@ def convert_type_to_instance(
     return wrapper  # type: ignore
 
 
-# CASEY NOTE: REMOVE AND REPLACE FUNCTIONALITY
-def debug_attribute(
+def convert_result_to_wrapped_typed_dict(
     utility: DaemonUtility, core_obj: Any, name: str, attr: Callable[P, T]
 ) -> Callable[P, T]:
+    """Wrapper that ensures a result of a method call through Pyro is a wrapped Typed Dict.
+
+    The result of this is later deserialzed by serpent using special registries for TypedDictWrapper. This
+    is useful for complex Typed Dictionaries such as PipetteDict that require reconstruction.
+    """
+
     @functools.wraps(attr)
     def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:
         if inspect.iscoroutinefunction(attr):
             sync_func = synchronous(attr)
             bound_method = MethodType(sync_func, core_obj)
             result = bound_method(*args, **kwargs)
+            return_type = attr.__annotations__["return"]
         elif isinstance(attr, FunctionType):
             bound_method = MethodType(attr, core_obj)
             result = bound_method(*args, **kwargs)
+            return_type = attr.__annotations__["return"]
         elif isinstance(attr, property):
             result = getattr(core_obj, name)
+            return_type = attr.fget.__annotations__["return"]
         else:
             raise ValueError(
                 "Provided base attribute must be a Property, a Method or an Async method."
             )
-        # log some useful things!
-        print(f"type of result: {type(result)}")
         if isinstance(result, dict):
-            print("WE GOT A DICT")
-            return SpecialDictWrapper(dictionary=result)
-
-        return result
+            return TypedDictWrapper(
+                dictionary=result,
+                typed_dict_name=".".join(
+                    (return_type.__module__, return_type.__qualname__)
+                ),
+            )
+        else:
+            raise ValueError(
+                "Pyro behavior for Typed Dict wrapping is only available for use with dictionaries."
+            )
 
     return wrapper  # type: ignore
 

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -6,10 +6,14 @@ import inspect
 from types import FunctionType, MethodType
 from typing import Any, Callable, Dict, Iterator, Optional, ParamSpec, TypeVar
 
+import numpy
 from pydantic import BaseModel
 from Pyro5 import api as pyro
 
-from opentrons.util.pyro.pyro_serialization import UnhashableDictWrapper
+from opentrons.util.pyro.pyro_serialization import (
+    SpecialDictWrapper,
+    UnhashableDictWrapper,
+)
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -478,6 +482,36 @@ def convert_type_to_instance(
             raise ValueError(
                 "Pyro behavior for type to instance conversion is only available for use with pure types."
             )
+
+    return wrapper  # type: ignore
+
+
+# CASEY NOTE: REMOVE AND REPLACE FUNCTIONALITY
+def debug_attribute(
+    utility: DaemonUtility, core_obj: Any, name: str, attr: Callable[P, T]
+) -> Callable[P, T]:
+    @functools.wraps(attr)
+    def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:
+        if inspect.iscoroutinefunction(attr):
+            sync_func = synchronous(attr)
+            bound_method = MethodType(sync_func, core_obj)
+            result = bound_method(*args, **kwargs)
+        elif isinstance(attr, FunctionType):
+            bound_method = MethodType(attr, core_obj)
+            result = bound_method(*args, **kwargs)
+        elif isinstance(attr, property):
+            result = getattr(core_obj, name)
+        else:
+            raise ValueError(
+                "Provided base attribute must be a Property, a Method or an Async method."
+            )
+        # log some useful things!
+        print(f"type of result: {type(result)}")
+        if isinstance(result, dict):
+            print("WE GOT A DICT")
+            return SpecialDictWrapper(dictionary=result)
+
+        return result
 
     return wrapper  # type: ignore
 

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
@@ -261,5 +261,7 @@ async def test_pyro_behavior_ot3api_unhashable_dicts(
     value = ot3api.get_robot_type()
     assert isinstance(value, type)
 
+    assert ot3api.get_attached_instruments() == managed_obj.get_attached_instruments()
+
     # Clean up client resources.
     ot3_proxy._pyroRelease()  # type: ignore

--- a/api/tests/opentrons/hardware_control/test_ot3_calibration.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_calibration.py
@@ -2,7 +2,6 @@
 
 import copy
 import json
-from dataclasses import replace
 from math import isclose
 from typing import Any, AsyncIterator, Iterator, Literal, Tuple
 
@@ -136,7 +135,7 @@ def mock_data_analysis() -> Iterator[Mock]:
 def _update_edge_sense_config(
     old: OT3CalibrationSettings, **new_edge_sense_settings: Any
 ) -> OT3CalibrationSettings:
-    return replace(old, edge_sense=replace(old.edge_sense, **new_edge_sense_settings))
+    return old.model_copy(update={**new_edge_sense_settings})
 
 
 @pytest.fixture

--- a/api/tests/opentrons/hardware_control/test_ot3_calibration.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_calibration.py
@@ -1,6 +1,5 @@
 """Tests for OT3 calibration."""
 
-import copy
 import json
 from math import isclose
 from typing import Any, AsyncIterator, Iterator, Literal, Tuple
@@ -135,14 +134,15 @@ def mock_data_analysis() -> Iterator[Mock]:
 def _update_edge_sense_config(
     old: OT3CalibrationSettings, **new_edge_sense_settings: Any
 ) -> OT3CalibrationSettings:
-    return old.model_copy(update={**new_edge_sense_settings})
+    edge_sense = old.edge_sense.model_copy(update=new_edge_sense_settings)
+    return old.model_copy(update={"edge_sense": edge_sense})
 
 
 @pytest.fixture
 async def override_cal_config(
     ot3_hardware: ThreadManager[OT3API],
 ) -> AsyncIterator[None]:
-    old_calibration = copy.deepcopy(ot3_hardware.config.calibration)
+    old_calibration = ot3_hardware.config.calibration
     await ot3_hardware.update_config(
         calibration=_update_edge_sense_config(
             old_calibration,

--- a/api/tests/opentrons/protocol_engine/execution/test_gantry_mover.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_gantry_mover.py
@@ -10,6 +10,8 @@ from decoy import Decoy
 
 from opentrons_shared_data.errors.exceptions import PositionUnknownError
 
+from opentrons.config.robot_configs import build_config_ot3
+from opentrons.config.types import OT3Config
 from opentrons.hardware_control import API as HardwareAPI
 from opentrons.hardware_control.types import (
     Axis as HardwareAxis,
@@ -49,6 +51,12 @@ def mock_hardware_api(decoy: Decoy) -> HardwareAPI:
 def mock_state_view(decoy: Decoy) -> StateView:
     """Get a mock in the shape of a StateView."""
     return decoy.mock(cls=StateView)
+
+
+@pytest.fixture
+def mock_config() -> OT3Config:
+    """Get a mock in the shape of a OT3Config."""
+    return build_config_ot3({})
 
 
 @pytest.fixture
@@ -516,6 +524,7 @@ async def test_home_z(
 async def test_move_axes(
     decoy: Decoy,
     ot3_hardware_api: OT3API,
+    mock_config: OT3Config,
     mock_state_view: StateView,
     axis_map: Dict[MotorAxis, float],
     critical_point: Optional[Dict[MotorAxis, float]],
@@ -550,13 +559,10 @@ async def test_move_axes(
         await ot3_hardware_api.current_position(expected_mount, refresh=True)
     ).then_do(_current_position)
 
-    decoy.when(ot3_hardware_api.config.left_mount_offset).then_return(Point(1, 1, 1))
-    decoy.when(ot3_hardware_api.config.right_mount_offset).then_return(
-        Point(10, 10, 10)
-    )
-    decoy.when(ot3_hardware_api.config.gripper_mount_offset).then_return(
-        Point(0.5, 0.5, 0.5)
-    )
+    decoy.when(ot3_hardware_api.config).then_return(mock_config)
+    mock_config.left_mount_offset = Point(1, 1, 1)
+    mock_config.right_mount_offset = Point(10, 10, 10)
+    mock_config.gripper_mount_offset = Point(0.5, 0.5, 0.5)
 
     decoy.when(ot3_hardware_api.get_deck_from_machine(curr_pos)).then_return(curr_pos)
 
@@ -567,7 +573,6 @@ async def test_move_axes(
         decoy.when(ot3_hardware_api.critical_point_for(expected_mount)).then_return(
             Point(1, 1, 1)
         )
-
     pos = await subject.move_axes(axis_map, critical_point, 100, relative_move)
     decoy.verify(
         await ot3_hardware_api.move_axes(

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -17,6 +17,7 @@ from opentrons.config import (
 from opentrons.config import (
     reset as reset_util,
 )
+from opentrons.config.types import OT3Config
 from opentrons.hardware_control import (
     API,
     HardwareControlAPI,
@@ -385,6 +386,8 @@ async def post_settings_reset_options(
 async def get_robot_settings(
     hardware: Annotated[HardwareControlAPI, Depends(get_hardware)],
 ) -> RobotConfigs:
+    if isinstance(hardware.config, OT3Config):
+        return hardware.config.model_dump()
     return asdict(hardware.config)
 
 


### PR DESCRIPTION
# Overview
In order to get a basic run working via Pyro we needed to serialize the PipetteDict and OT3Config, alongside implementing some related infrastructure. 
This enables:

- Pipette Attach Flow
- Pipette Detatch
- Pipette calibration
- Basic run with load instrument, pick up and drop tip

## Test Plan and Hands on Testing
AFTER DISABLING DOOR WATCHER:

- [x] Run a basic protocol on Flex
- [x] Test attached/detacht/calibrate flows through app
- [x] Write unit tests to enforce serialization of PipetteDict and OT3Config
- [x] Run test on Flex AGAIN after all these changes

## Changelog

New pyro behavior to facilitate handling typed dicts like PipetteDict, converted OT3Config to pydantic BaseModel, etc

## Review requests


## Risk assessment
Low - needed to enable pyro communication