### PR TITLE
feat(robot-server): allow async methods to be called on run process

### DIFF
--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -62,6 +62,7 @@ from opentrons.protocol_runner import (
 from opentrons.protocol_runner.run_coordinator import ParseMode
 from opentrons.protocols.api_support.deck_type import should_load_fixed_trash
 from opentrons.types import NozzleMapInterface
+from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
 from opentrons_shared_data.errors.exceptions import ModuleNotPresent
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.labware.types import LabwareUri
@@ -391,7 +392,9 @@ class RunOrchestratorStore:
         with Pyro5.api.locate_ns() as ns:
             while time.monotonic() - start_time < 60:
                 if "ot-protocol" in ns.list():
-                    proxy = Pyro5.api.Proxy(ns.list()["ot-protocol"])  # type: ignore[no-untyped-call]
+                    proxy = AsyncClientPyroObject(
+                        Pyro5.api.Proxy(ns.list()["ot-protocol"])  # type: ignore[no-untyped-call]
+                    )
                     self._run_orchestrator = cast(
                         DirectedRunProcess, cast(object, proxy)
                     )
@@ -402,7 +405,7 @@ class RunOrchestratorStore:
                 ns.remove("ot-protocol")
                 raise ValueError("Can't find process")
 
-        proxy.create(run_id)
+        self._run_orchestrator.create(run_id)
         return self._run_orchestrator.get_state_summary()
 
     async def clear_pyro(self) -> RunResult:

--- a/robot-server/robot_server/runs/run_process.py
+++ b/robot-server/robot_server/runs/run_process.py
@@ -1,5 +1,6 @@
 """A wrapper for a protocol run that lives as a proxy in its own process."""
 
+import asyncio
 from datetime import datetime
 from typing import Any, Dict, List, Mapping, Optional, Tuple, cast, get_args
 
@@ -102,6 +103,18 @@ class DirectedRunProcess(AbstractRunCoordinator):
         self._robot_type = robot_type
         self._deck_type = deck_type
         self._run_id: Optional[str] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    @property
+    def loop(self) -> asyncio.AbstractEventLoop:
+        """Event loop for use in allowing async methods via Pyro."""
+        assert self._loop is not None
+        return self._loop
+
+    @loop.setter
+    def loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Set an abstract event loop."""
+        self._loop = loop
 
     def create(self, run_id: str) -> None:
         """Create a run orchestrator and protocol engine for a given run."""

--- a/robot-server/robot_server/runs/run_process_entry_point.py
+++ b/robot-server/robot_server/runs/run_process_entry_point.py
@@ -1,24 +1,60 @@
 """This file is run directly in its own process and encapsulates a run."""
 
+import asyncio
+import threading
+from typing import Any
+
 from opentrons.protocol_engine import DeckType
 from opentrons.util.pyro.pyro_daemon_utility import create_pyro_daemon
-from opentrons_shared_data.robot.types import RobotType
 
 from robot_server.runs.run_process import DirectedRunProcess, register_process_types
 
 
-def create_directed_run_process(
-    robot_type: RobotType,
-    deck_type: DeckType,
-) -> None:
-    """Build an instance of the DirectedRunProcess and provide it to Pyro Daemon Factory as a resource."""
-    directed_run_process = DirectedRunProcess(robot_type, deck_type)
-    try:
-        create_pyro_daemon("ot-protocol", directed_run_process, register_process_types)
-    finally:
-        pass
+def initialize_run_process() -> threading.Thread:
+    """Build an instance of the DirectedRunProcess, create a thread to run it, and return a pyro daemon thread."""
+
+    def _start_and_run_process(process: DirectedRunProcess) -> None:
+        process.loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(process.loop)
+            process.loop.run_forever()
+        except Exception as e:
+            raise e
+        finally:
+            process.loop.close()
+
+    def _start_and_run_pyro_daemon(
+        pyroname: str, process: DirectedRunProcess, registry: Any
+    ) -> None:
+        create_pyro_daemon(pyroname=pyroname, resource=process, registry=registry)
+
+    # TODO hard coding this for now since it's only gonna be on Flex
+    run_process = DirectedRunProcess("OT-3 Standard", DeckType.OT3_STANDARD)
+
+    process_resource_thread = threading.Thread(
+        target=_start_and_run_process,
+        name="RunProcessThread",
+        args=(),
+        kwargs={"process": run_process},
+        daemon=True,
+    )
+    process_resource_thread.start()
+
+    pyro_daemon_thread = threading.Thread(
+        target=_start_and_run_pyro_daemon,
+        name="RunProcessThread",
+        args=(),
+        kwargs={
+            "pyroname": "ot-protocol",
+            "process": run_process,
+            "registry": register_process_types,
+        },
+        daemon=True,
+    )
+    return pyro_daemon_thread
 
 
 if __name__ == "__main__":
-    # TODO hard coding this for now since it's only gonna be on Flex
-    create_directed_run_process("OT-3 Standard", DeckType.OT3_STANDARD)
+    pyro_thread = initialize_run_process()
+    pyro_thread.start()
+    pyro_thread.join()

--- a/robot-server/tests/runs/test_run_process.py
+++ b/robot-server/tests/runs/test_run_process.py
@@ -1,0 +1,68 @@
+"""Tests for run process."""
+
+import asyncio
+import socket
+import threading
+from typing import cast
+
+from Pyro5 import api as pyro
+from Pyro5 import nameserver
+
+from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
+from opentrons.util.pyro.pyro_daemon_utility import PYRO_TIMEOUT
+
+from robot_server.runs.run_process import DirectedRunProcess, register_process_types
+from robot_server.runs.run_process_entry_point import initialize_run_process
+
+
+async def test_run_process_proxy() -> None:
+    """Test the run process pyro creation and a proxy can be created that returns data and async commands can be called."""
+    sock = socket.socket()
+    sock.bind(("localhost", 0))
+    host, port = sock.getsockname()
+    sock.close()
+
+    pyro.config.NS_HOST = host
+    pyro.config.NS_PORT = port
+
+    name_server_ready = threading.Event()
+
+    def _nameserver_loop() -> None:
+        # start_ns returns (nameserver, daemon, uri)
+        _, ns_daemon, _ = nameserver.start_ns(host=host, port=port)  # type: ignore
+        name_server_ready.set()
+        # Run until the test process exits; thread is marked daemon=True.
+        ns_daemon.requestLoop()
+
+    ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
+    ns_thread.start()
+
+    pyro_thread = initialize_run_process()
+    pyro_thread.start()
+
+    # Client-side requests below
+    register_process_types()
+    name_server_ready.wait(timeout=PYRO_TIMEOUT)
+    ns = pyro.locate_ns()
+
+    retries_counter = 0
+    while ns.count() < 2:
+        # Wait and try again, the resource isnt registered yet
+        await asyncio.sleep(0.01)
+        retries_counter += 1
+        if retries_counter > 10:
+            # Stop waiting for the nameserver, will fail on pyro.resolve (something is wrong with nameserver and/or daemon)
+            raise TimeoutError("TEST FAILURE ON PYRO NAMESERVER.")
+
+    uri = pyro.resolve(uri="PYRONAME:ot-protocol")
+    protocol_proxy = pyro.Proxy(uri)  # type: ignore
+    protocol_async = AsyncClientPyroObject(protocol_proxy)
+    run_process = cast(DirectedRunProcess, cast(object, protocol_async))
+
+    # TODO when these aren't stubs things will have to be mocked or changed
+    result = run_process.get_loaded_labware_definitions()
+    assert result == []
+    await run_process.finish()
+
+    # Clean up client resources.
+    protocol_proxy._pyroRelease()  # type: ignore


### PR DESCRIPTION
# Overview

The run process, created in #21131, has some asynchornous methods that will need to be able to be called via the proxy. Pyro does not natively support this, but #21058 added the `AsyncClientPyroObject` which can wrap a proxy and allow async methods to be called with no changes to the method signature.

To allow this though, the run process needed an asyncio event loop to be created. This has been added to the run process object. In the entry point, we now create that loop and in a thread run it. We then create another thread to run the pyro daemon with that run process, which is then returned. In the entry point, we then `start` and `join` on that thread which will run as it's own subprocess. Using this, we can now wrap the proxy in `AsyncClientPyroObject` and call async methods.

## Test Plan and Hands on Testing

On robot testing and a unit test added.

## Changelog

- Add an `asyncio.AbstractEventLoop` to `DirectedRunProcess`
- Refactor `run_process_entry_point.py` to create a thread running the above loop and the pyro daemon, creating it and starting and waiting on it when run as main
- Wrap pyro protocol proxy as an `AsyncClientPyroObject`

## Review requests

## Risk assessment

Low-medium, code added to new feature-flag gated code, but we're adding more threads and complexity to this code.