### PR TITLE
fix(protocol-designer): check safety of all pipette configurations and add check with labware

### DIFF
--- a/protocol-designer/src/assets/localization/en/well_selection.json
+++ b/protocol-designer/src/assets/localization/en/well_selection.json
@@ -14,7 +14,7 @@
   "inaccessible": {
     "collision": "Selection will cause a collision",
     "partial_tip": "Blocked by existing selection",
-    "labware_well_spacing": "Nozzle configuration does not match wells"
+    "labware_well_spacing": "Incompatible nozzle configuration for this labware"
   },
   "all_pickups_selected": "All wells selected"
 }

--- a/protocol-designer/src/assets/localization/en/well_selection.json
+++ b/protocol-designer/src/assets/localization/en/well_selection.json
@@ -13,7 +13,8 @@
   },
   "inaccessible": {
     "collision": "Selection will cause a collision",
-    "partial_tip": "Blocked by existing selection"
+    "partial_tip": "Blocked by existing selection",
+    "labware_well_spacing": "Nozzle configuration does not match wells"
   },
   "all_pickups_selected": "All wells selected"
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -28,12 +28,16 @@ import { getInvariantContext } from '/protocol-designer/step-forms/selectors'
 import { getRobotStateAtActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 import { getCollidingWells } from '/protocol-designer/utils/index'
 
+import { canPipetteUseLabware } from '../../../../../../utils'
 import { BaseDeckTipSelection } from '../TipSelectionWizard/BaseDeckTipSelection'
 import { INACCESSIBLE_COLLISION } from '../TipSelectionWizard/constants'
 import { PipetteShadow } from '../TipSelectionWizard/PipetteShadows/PipetteShadow'
 import { SelectionLegend } from '../TipSelectionWizard/SelectionLegend'
 import { getViewboxFromSelectedLabware } from '../TipSelectionWizard/utils'
-import { INACCESSIBLE_PARTIAL_TIP } from './constants'
+import {
+  INACCESSIBLE_PARTIAL_TIP,
+  INACCESSIBLE_WELL_SPACING_MISMATCH,
+} from './constants'
 import { getAllWellsSafetyStatus } from './getAllWellsSafetyStatus'
 import styles from './nozzleandwellwizard.module.css'
 import {
@@ -53,6 +57,7 @@ import type {
 import type { GenericRect } from '/protocol-designer/collision-types'
 import type { FieldProps } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/types'
 import type { AllTemporalPropertiesForTimelineFrame } from '/protocol-designer/step-forms'
+import type { InaccessibleReason } from '../../PipetteFields/TipSelectionWizard/types'
 import type { FieldPropsByName } from '../../types'
 
 interface WellSelectorProps {
@@ -396,12 +401,20 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
           return allWellsWithState[w] !== SELECTED_ERROR
         })
       : true
-
-    const inaccessibleReason =
+    let inaccessibleReason: InaccessibleReason
+    if (
       inaccessiblePartialWells.filter(well => hoveredWells?.includes(well))
         .length > 0
-        ? INACCESSIBLE_PARTIAL_TIP
-        : INACCESSIBLE_COLLISION
+    ) {
+      inaccessibleReason = INACCESSIBLE_PARTIAL_TIP
+    } else if (
+      !canPipetteUseLabware(pipetteSpecs, nozzleConfiguration, labwareDef)
+    ) {
+      inaccessibleReason = INACCESSIBLE_WELL_SPACING_MISMATCH
+    } else {
+      inaccessibleReason = INACCESSIBLE_COLLISION
+    }
+
     const is96Channel = channels === 96
 
     const labwarePositionProps = isLabwareOnModule

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/__tests__/getAllWellsSafetyStatus.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/__tests__/getAllWellsSafetyStatus.test.ts
@@ -1,19 +1,50 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { COLUMN, ROW } from '@opentrons/shared-data'
+import {
+  COLUMN,
+  fixture96Plate,
+  fixtureP100096V2Specs,
+  fixtureTiprack1000ul,
+  getLabwareDefURI,
+  ROW,
+} from '@opentrons/shared-data'
 import { getIsSafePipetteMovement } from '@opentrons/step-generation'
 
 import { getAllWellsSafetyStatus } from '../getAllWellsSafetyStatus'
+
+import type { LabwareDefinition } from '@opentrons/shared-data'
 
 vi.mock('@opentrons/step-generation', () => ({
   getIsSafePipetteMovement: vi.fn(),
 }))
 
 describe('getAllWellsSafetyStatus', () => {
-  const mockInvariantContext = {} as any
-  const mockRobotState = {} as any
   const pipetteId = 'pipette-id'
   const labwareId = 'labware-id'
+
+  const mockInvariantContext = {
+    pipetteEntities: {
+      [pipetteId]: {
+        name: 'p1000_96',
+        id: pipetteId,
+        tiprackDefURI: [
+          getLabwareDefURI(fixtureTiprack1000ul as LabwareDefinition),
+        ],
+        tiprackLabwareDef: [fixtureTiprack1000ul],
+        spec: fixtureP100096V2Specs,
+        pythonName: 'mock_pipette_p1000_96',
+      },
+    },
+    labwareEntities: {
+      [labwareId]: {
+        id: labwareId,
+        pythonName: 'mock_source_plate',
+        labwareDefURI: getLabwareDefURI(fixture96Plate as LabwareDefinition),
+        def: fixture96Plate,
+      },
+    },
+  } as any
+  const mockRobotState = {} as any
   const primaryNozzle = 'A1' as any
   const singleNozzle = 'SINGLE' as any
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/constants.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/constants.ts
@@ -1,4 +1,5 @@
 export const INACCESSIBLE_PARTIAL_TIP: 'partial_tip' = 'partial_tip'
-
+export const INACCESSIBLE_WELL_SPACING_MISMATCH: 'labware_well_spacing' =
+  'labware_well_spacing'
 export const PLURAL_COLUMNS: 'columns' = 'columns'
 export const PLURAL_ROWS: 'rows' = 'rows'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
@@ -1,5 +1,7 @@
-import { COLUMN, ROW } from '@opentrons/shared-data'
+import { ALL, COLUMN, ROW } from '@opentrons/shared-data'
 import { getIsSafePipetteMovement } from '@opentrons/step-generation'
+
+import { canPipetteUseLabware } from '../../../../../../utils'
 
 import type {
   NozzleConfigurationStyle,
@@ -31,7 +33,21 @@ export function getAllWellsSafetyStatus(
   } = args
 
   const allWellsWithStatus: Record<string, number> = {}
-
+  const pipetteSpec = invariantContext.pipetteEntities[pipetteId].spec
+  const labwareDef = invariantContext.labwareEntities[labwareId].def
+  const channels = pipetteSpec.channels
+  const pipetteCanUseLabware = canPipetteUseLabware(
+    pipetteSpec,
+    nozzleConfiguration,
+    labwareDef
+  )
+  if (!pipetteCanUseLabware) {
+    Object.assign(
+      allWellsWithStatus,
+      Object.fromEntries(allWells.map(well => [well, 1]))
+    )
+    return allWellsWithStatus
+  }
   if (nozzleConfiguration === ROW) {
     // ROW mode: each row = 12 wells across
     const numRows = allWells[0].length
@@ -54,7 +70,10 @@ export function getAllWellsSafetyStatus(
         allWellsWithStatus[column[rowIndex]] = safe ? 0 : 1
       })
     }
-  } else if (nozzleConfiguration === COLUMN) {
+  } else if (
+    nozzleConfiguration === COLUMN ||
+    (channels === 8 && nozzleConfiguration === ALL)
+  ) {
     // COLUMN mode: each column = 8 wells
     for (let colIndex = 0; colIndex < allWells.length; colIndex++) {
       const column = allWells[colIndex]
@@ -75,6 +94,22 @@ export function getAllWellsSafetyStatus(
         allWellsWithStatus[wellName] = safe ? 0 : 1
       })
     }
+  } else if (nozzleConfiguration === ALL && channels === 96) {
+    // ALL 96 Nozzles: only check the first well
+    const safe = robotState
+      ? getIsSafePipetteMovement({
+          robotState,
+          invariantContext,
+          pipetteId,
+          labwareId,
+          wellTargetName: allWells[0][0],
+          primaryNozzle,
+          nozzleConfiguration,
+        })
+      : true
+    allWells.flat().forEach(wellName => {
+      allWellsWithStatus[wellName] = safe ? 0 : 1
+    })
   } else {
     // SINGLE nozzle: check every well individually
     allWells.flat().forEach(wellName => {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -35,7 +35,10 @@ import { getRobotStateAtActiveItem } from '/protocol-designer/top-selectors/labw
 import { getLabwareNicknamesById } from '/protocol-designer/ui/labware/selectors'
 import { getCollidingWells } from '/protocol-designer/utils/index'
 
-import { INACCESSIBLE_PARTIAL_TIP } from '../NozzleAndWellSelectionModal/constants'
+import {
+  INACCESSIBLE_PARTIAL_TIP,
+  INACCESSIBLE_WELL_SPACING_MISMATCH,
+} from '../NozzleAndWellSelectionModal/constants'
 import { getEntireWellSelection } from '../NozzleAndWellSelectionModal/utils'
 import { BaseDeckTipSelection } from './BaseDeckTipSelection'
 import {
@@ -142,6 +145,7 @@ export function SelectTips(
     INACCESSIBLE_INCOMPLETE,
     INACCESSIBLE_TOO_MANY_PICKUPS,
     INACCESSIBLE_PARTIAL_TIP,
+    INACCESSIBLE_WELL_SPACING_MISMATCH,
   ]
 
   const hoveredWellsInaccessibilityStatus =

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/types.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/types.ts
@@ -6,7 +6,10 @@ import type {
   PrimaryNozzleConfigurationStyle,
 } from '@opentrons/shared-data'
 import type { AllTemporalPropertiesForTimelineFrame } from '/protocol-designer/step-forms/types'
-import type { INACCESSIBLE_PARTIAL_TIP } from '../NozzleAndWellSelectionModal/constants'
+import type {
+  INACCESSIBLE_PARTIAL_TIP,
+  INACCESSIBLE_WELL_SPACING_MISMATCH,
+} from '../NozzleAndWellSelectionModal/constants'
 import type {
   INACCESSIBLE_COLLISION,
   INACCESSIBLE_INCOMPLETE,
@@ -50,6 +53,7 @@ export type InaccessibleReason =
   | typeof INACCESSIBLE_INCOMPLETE
   | typeof INACCESSIBLE_TOO_MANY_PICKUPS
   | typeof INACCESSIBLE_PARTIAL_TIP
+  | typeof INACCESSIBLE_WELL_SPACING_MISMATCH
 
 export interface AccessibilityStatus {
   isAccessible: boolean

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -122,6 +122,7 @@ export const aspirate: CommandCreator<ExtendedAspirateParams> = (
 
   if (
     isMultiChannelPipette &&
+    pipetteSpec &&
     !getIsSafePipetteMovement({
       robotState: prevRobotState,
       invariantContext,

--- a/step-generation/src/commandCreators/atomic/moveToWell.ts
+++ b/step-generation/src/commandCreators/atomic/moveToWell.ts
@@ -185,9 +185,9 @@ export const moveToWell: CommandCreator<MoveToWellParams> = (
   }
   const isMultiChannelPipette =
     invariantContext.pipetteEntities[pipetteId]?.spec.channels !== 1
-
+  const pipetteSpecs = invariantContext.pipetteEntities[pipetteId]?.spec
   if (
-    isMultiChannelPipette &&
+    isMultiChannelPipette && pipetteSpecs &&
     !getIsSafePipetteMovement({
       robotState: prevRobotState,
       invariantContext,

--- a/step-generation/src/commandCreators/atomic/moveToWell.ts
+++ b/step-generation/src/commandCreators/atomic/moveToWell.ts
@@ -187,7 +187,8 @@ export const moveToWell: CommandCreator<MoveToWellParams> = (
     invariantContext.pipetteEntities[pipetteId]?.spec.channels !== 1
   const pipetteSpecs = invariantContext.pipetteEntities[pipetteId]?.spec
   if (
-    isMultiChannelPipette && pipetteSpecs &&
+    isMultiChannelPipette &&
+    pipetteSpecs &&
     !getIsSafePipetteMovement({
       robotState: prevRobotState,
       invariantContext,

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -352,8 +352,7 @@ export const getIsSafePipetteMovement = (args: {
 
   const pipetteEntity = pipetteEntities[pipetteId]
 
-  const { spec: pipetteSpecs } = pipetteEntity ?? {}
-  if (pipetteSpecs === undefined) return false
+  const { spec: pipetteSpecs } = pipetteEntity
 
   // NOTE: I don't like this, but step-generation is currently blind to robot type, so we'll infer from the pipette specs
   const displayCategory = pipetteSpecs?.displayCategory

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -361,11 +361,7 @@ export const getIsSafePipetteMovement = (args: {
   const deckDefinition = getDeckDefFromRobotType(robotType)
 
   //  early exit if labwareId is a trashBin or wasteChute or if no nozzle is provided
-  if (
-    labwareEntities[labwareId] == null ||
-    wellTargetName == null ||
-    nozzleConfiguration === ALL
-  ) {
+  if (labwareEntities[labwareId] == null || wellTargetName == null) {
     return true
   }
 

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -353,6 +353,7 @@ export const getIsSafePipetteMovement = (args: {
   const pipetteEntity = pipetteEntities[pipetteId]
 
   const { spec: pipetteSpecs } = pipetteEntity ?? {}
+  if (pipetteSpecs === undefined) return false
 
   // NOTE: I don't like this, but step-generation is currently blind to robot type, so we'll infer from the pipette specs
   const displayCategory = pipetteSpecs?.displayCategory
@@ -403,7 +404,7 @@ export const getIsSafePipetteMovement = (args: {
     pipetteHasTip
   )
 
-  const { channels } = pipetteEntity.spec
+  const { channels } = pipetteSpecs
 
   const tipOverlapOnNozzle =
     tiprackEntity != null

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -360,7 +360,7 @@ export const getIsSafePipetteMovement = (args: {
   const robotType = isFlexPipette ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE
   const deckDefinition = getDeckDefFromRobotType(robotType)
 
-  //  early exit if labwareId is a trashBin or wasteChute or if no nozzle is provided
+  //  early exit if labwareId is a trashBin or wasteChute or if no well name is provided
   if (labwareEntities[labwareId] == null || wellTargetName == null) {
     return true
   }


### PR DESCRIPTION
# Overview

Use util `canPipetteUseLabware` when determining well safety status.

This will prevent users from using 96ch or 8ch pipettes with labware with uneven spacing (ie 24 well labware)

## Test Plan and Hands on Testing

smoke tested with protocol attached to ticket
<img width="887" height="687" alt="Screenshot 2026-04-15 at 5 05 08 PM" src="https://github.com/user-attachments/assets/391191bc-71dc-426c-8bdf-dcc4751a331b" />

## Changelog

- check well safety for `ALL` configuration to account for labware compatibility
- use util `canPipetteUseLabware` to determine if nozzles used are compatible with the number of wells per column
- added new error message `INACCESSIBLE_WELL_SPACING_MISMATCH` to let the user know that the nozzle configuration does not match wells

## Review requests
- error message makes sense - approved by Sue - Incompatible nozzle configuration for this labware

## Risk assessment

medium - changes some safety logic

Closes RQA-5326