### PR TITLE
fix(app-shell-odd): Fix React and Redux dev tools

### DIFF
--- a/app-shell-odd/src/main.ts
+++ b/app-shell-odd/src/main.ts
@@ -2,6 +2,11 @@
 import dns from 'dns'
 import path from 'path'
 import { app, ipcMain } from 'electron'
+import {
+  installExtension,
+  REACT_DEVELOPER_TOOLS,
+  REDUX_DEVTOOLS,
+} from 'electron-devtools-installer'
 import fse from 'fs-extra'
 
 import {
@@ -196,16 +201,13 @@ function createRendererLogger(): OTLogger {
 }
 
 function installDevtools(): void {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const devtools = require('electron-devtools-installer')
-  const extensions = [devtools.REACT_DEVELOPER_TOOLS, devtools.REDUX_DEVTOOLS]
-  const install = devtools.installExtensions
+  const extensions = [REACT_DEVELOPER_TOOLS, REDUX_DEVTOOLS]
   const forceReinstall = config.reinstallDevtools
 
   log.debug('Installing devtools')
 
   try {
-    install(extensions, {
+    installExtension(extensions, {
       loadExtensionOptions: { allowFileAccess: true },
       forceDownload: forceReinstall,
     })


### PR DESCRIPTION
## Overview

This fixes a bug in `app-shell-odd` where the dev tool extensions for React and Redux were not being properly installed. Their tabs did not appear in the Chrome/Electron dev tools, and there was an error in the console saying something like "install is not a function."

## Test Plan and Hands on Testing

* [x] Run `make -C app dev-odd`, open the Chrome/Electron dev tools, and make sure it now has tabs for React and Redux.

## Changelog

I think the main problem here was that the actual function is called `installExtension`, but we were trying `installExtensions`. `tsc` couldn't catch it because we were importing it via a local `require()` instead of a top-level `import` statement. This fix changes it to a top-level `import` statement, which is what `app-shell` already does.

## Review requests

Do we know of any reason why this would have been a local `require()` instead of a top-level `import`?

## Risk assessment

Low? I hope? Unless the local `require()` was load-bearing, for some reason?
