### PR TITLE
feat(api-client,react-api-client): Add bindings for /auth/settings/accessControlEnabled

### DIFF
--- a/api-client/src/auth/index.ts
+++ b/api-client/src/auth/index.ts
@@ -1,1 +1,2 @@
 export * from './oauth2'
+export * from './settings'

--- a/api-client/src/auth/settings/getAccessControlEnabled.ts
+++ b/api-client/src/auth/settings/getAccessControlEnabled.ts
@@ -1,0 +1,16 @@
+import { GET, request } from '../../request'
+
+import type { ResponsePromise } from '../../request'
+import type { HostConfig } from '../../types'
+import type { AccessControlEnabledSettingsResponse } from './types'
+
+export function getAccessControlEnabled(
+  config: HostConfig
+): ResponsePromise<AccessControlEnabledSettingsResponse> {
+  return request<AccessControlEnabledSettingsResponse>(
+    GET,
+    '/auth/settings/accessControlEnabled',
+    null,
+    config
+  )
+}

--- a/api-client/src/auth/settings/index.ts
+++ b/api-client/src/auth/settings/index.ts
@@ -1,0 +1,3 @@
+export * from './getAccessControlEnabled'
+export * from './patchAccessControlEnabled'
+export * from './types'

--- a/api-client/src/auth/settings/patchAccessControlEnabled.ts
+++ b/api-client/src/auth/settings/patchAccessControlEnabled.ts
@@ -1,0 +1,18 @@
+import { PATCH, request } from '../../request'
+
+import type { ResponsePromise } from '../../request'
+import type { HostConfig } from '../../types'
+import type {
+  AccessControlEnabledSettingsResponse,
+  PatchAccessControlEnabledSettingsRequest,
+} from './types'
+
+export function patchAccessControlEnabled(
+  config: HostConfig,
+  body: PatchAccessControlEnabledSettingsRequest
+): ResponsePromise<AccessControlEnabledSettingsResponse> {
+  return request<
+    AccessControlEnabledSettingsResponse,
+    PatchAccessControlEnabledSettingsRequest
+  >(PATCH, '/auth/settings/accessControlEnabled', body, config)
+}

--- a/api-client/src/auth/settings/types.ts
+++ b/api-client/src/auth/settings/types.ts
@@ -1,0 +1,11 @@
+export interface AccessControlEnabledSettingsResponse {
+  data: {
+    accessControlEnabled: boolean
+  }
+}
+
+export interface PatchAccessControlEnabledSettingsRequest {
+  data: {
+    accessControlEnabled?: true
+  }
+}

--- a/react-api-client/src/auth/index.ts
+++ b/react-api-client/src/auth/index.ts
@@ -1,1 +1,2 @@
 export * from './oauth2'
+export * from './settings'

--- a/react-api-client/src/auth/settings/index.ts
+++ b/react-api-client/src/auth/settings/index.ts
@@ -1,0 +1,2 @@
+export * from './useAccessControlEnabledQuery'
+export * from './useAccessControlEnabledMutation'

--- a/react-api-client/src/auth/settings/useAccessControlEnabledMutation.ts
+++ b/react-api-client/src/auth/settings/useAccessControlEnabledMutation.ts
@@ -1,0 +1,53 @@
+import { useMutation } from 'react-query'
+
+import { patchAccessControlEnabled } from '@opentrons/api-client'
+
+import { useHost } from '../../api'
+
+import type { AxiosError } from 'axios'
+import type {
+  UseMutateFunction,
+  UseMutationOptions,
+  UseMutationResult,
+} from 'react-query'
+import type {
+  AccessControlEnabledSettingsResponse,
+  PatchAccessControlEnabledSettingsRequest,
+} from '@opentrons/api-client'
+
+export type UseAccessControlEnabledMutationResult = UseMutationResult<
+  AccessControlEnabledSettingsResponse,
+  AxiosError,
+  PatchAccessControlEnabledSettingsRequest
+> & {
+  patchAccessControlEnabledSettings: UseMutateFunction<
+    AccessControlEnabledSettingsResponse,
+    AxiosError,
+    PatchAccessControlEnabledSettingsRequest
+  >
+}
+
+export function useAccessControlEnabledMutation(
+  options: UseMutationOptions<
+    AccessControlEnabledSettingsResponse,
+    AxiosError,
+    PatchAccessControlEnabledSettingsRequest
+  > = {}
+): UseAccessControlEnabledMutationResult {
+  const host = useHost()
+  const mutation = useMutation(
+    [host, 'auth', 'settings', 'accessControlEnabled'],
+    (body: PatchAccessControlEnabledSettingsRequest) =>
+      patchAccessControlEnabled(host!, body)
+        .then(response => response.data)
+        .catch((e: AxiosError) => {
+          throw e
+        }),
+    options
+  )
+
+  return {
+    ...mutation,
+    patchAccessControlEnabledSettings: mutation.mutateAsync,
+  }
+}

--- a/react-api-client/src/auth/settings/useAccessControlEnabledQuery.ts
+++ b/react-api-client/src/auth/settings/useAccessControlEnabledQuery.ts
@@ -1,0 +1,25 @@
+import { useQuery } from 'react-query'
+
+import { getAccessControlEnabled } from '@opentrons/api-client'
+
+import { useHost } from '../../api'
+
+import type { AxiosError } from 'axios'
+import type { UseQueryOptions, UseQueryResult } from 'react-query'
+import type { AccessControlEnabledSettingsResponse } from '@opentrons/api-client'
+
+export function useAccessControlEnabledQuery(
+  options: UseQueryOptions<
+    AccessControlEnabledSettingsResponse,
+    AxiosError
+  > = {}
+): UseQueryResult<AccessControlEnabledSettingsResponse, AxiosError> {
+  const host = useHost()
+  const query = useQuery<AccessControlEnabledSettingsResponse, AxiosError>(
+    [host, 'auth', 'settings', 'accessControlEnabled'],
+    () => getAccessControlEnabled(host!).then(response => response.data),
+    { enabled: host !== null, ...options }
+  )
+
+  return query
+}

--- a/react-api-client/src/auth/settings/useAccessControlEnabledQuery.ts
+++ b/react-api-client/src/auth/settings/useAccessControlEnabledQuery.ts
@@ -6,17 +6,23 @@ import { useHost } from '../../api'
 
 import type { AxiosError } from 'axios'
 import type { UseQueryOptions, UseQueryResult } from 'react-query'
-import type { AccessControlEnabledSettingsResponse } from '@opentrons/api-client'
+import type {
+  AccessControlEnabledSettingsResponse,
+  HostConfig,
+} from '@opentrons/api-client'
 
 export function useAccessControlEnabledQuery(
   options: UseQueryOptions<
     AccessControlEnabledSettingsResponse,
     AxiosError
-  > = {}
+  > = {},
+  hostOverride?: HostConfig | null
 ): UseQueryResult<AccessControlEnabledSettingsResponse, AxiosError> {
-  const host = useHost()
+  const contextHost = useHost()
+  const host =
+    hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
   const query = useQuery<AccessControlEnabledSettingsResponse, AxiosError>(
-    [host, 'auth', 'settings', 'accessControlEnabled'],
+    [host!, 'auth', 'settings', 'accessControlEnabled'],
     () => getAccessControlEnabled(host!).then(response => response.data),
     { enabled: host !== null, ...options }
   )


### PR DESCRIPTION
## Overview

This adds the usual boilerplate for the frontend to use the new `GET/PATCH /auth/settings/accessControlEnabled` HTTP endpoints.

This closes EXEC-2540.

## Test Plan and Hands on Testing

As part of another draft branch, I've made sure that the query actually works.

## Review requests

None in particular.

## Risk assessment

Low. Not used for anything yet.