### PR TITLE
fix(protocol-designer, step-generation): fix robot state updates for stacker and move labware

### DIFF
--- a/step-generation/src/getNextRobotStateAndWarnings/__tests__/forMoveLabware.test.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/__tests__/forMoveLabware.test.ts
@@ -3,9 +3,13 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import {
   fixture96Plate,
+  FLEX_STACKER_A4_ADDRESSABLE_AREA,
+  FLEX_STACKER_MODULE_TYPE,
+  FLEX_STACKER_MODULE_V1,
   MOVABLE_TRASH_A3_ADDRESSABLE_AREA,
 } from '@opentrons/shared-data'
 
+import { FLEX_STACKER_MODULE_INITIAL_STATE } from '../../constants'
 import {
   DEST_LABWARE,
   getInitialRobotStateStandard,
@@ -195,6 +199,42 @@ describe('forMoveLabware', () => {
       expect(robotState.labware.lwBig.stackedOnNode).toEqual(newLocation)
       expect(robotState.labware.lwBig.contains).toBe('lwSmall')
       expect(robotState.labware.lwSmall.contains).toBeUndefined()
+    })
+
+    it('moves labware onto flex stacker shuttle (moduleId): updates stack and shuttle stackedOnNode', () => {
+      const stackerModuleId = 'stackerModForMoveTest'
+      const ic = {
+        ...invariantContext,
+        moduleEntities: {
+          ...invariantContext.moduleEntities,
+          [stackerModuleId]: {
+            id: stackerModuleId,
+            type: FLEX_STACKER_MODULE_TYPE,
+            model: FLEX_STACKER_MODULE_V1,
+            pythonName: 'flex_stacker',
+          },
+        },
+      }
+      const rs = cloneDeep(getInitialRobotStateStandard(ic))
+      rs.modules[stackerModuleId] = {
+        slot: 'A3',
+        moduleState: cloneDeep(FLEX_STACKER_MODULE_INITIAL_STATE),
+      }
+
+      forMoveLabware(
+        {
+          labwareId: SOURCE_LABWARE,
+          newLocation: { moduleId: stackerModuleId },
+          strategy: 'usingGripper',
+        },
+        ic,
+        { robotState: rs, warnings: [] }
+      )
+
+      expect(rs.labware[SOURCE_LABWARE].stack).toEqual([SOURCE_LABWARE, 'A3'])
+      expect(rs.labware[SOURCE_LABWARE].stackedOnNode).toEqual({
+        addressableAreaName: FLEX_STACKER_A4_ADDRESSABLE_AREA,
+      })
     })
 
     it('only sets stackedOnNode on the primary moved labware id, not labware left behind in the stack', () => {

--- a/step-generation/src/getNextRobotStateAndWarnings/__tests__/stackerUpdates.test.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/__tests__/stackerUpdates.test.ts
@@ -1,19 +1,30 @@
+import cloneDeep from 'lodash/cloneDeep'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  fixture96Plate,
   FLEX_STACKER_D4_ADDRESSABLE_AREA,
   FLEX_STACKER_MODULE_TYPE,
+  FLEX_STACKER_MODULE_V1,
+  getLabwareDefURI,
   SYSTEM_LOCATION,
 } from '@opentrons/shared-data'
 
-import { HOPPER_STACKER_LOCATION } from '../../constants'
+import {
+  FLEX_STACKER_MODULE_INITIAL_STATE,
+  HOPPER_STACKER_LOCATION,
+} from '../../constants'
 import { getInitialRobotStateStandard, makeContext } from '../../fixtures'
 import { flexStackerStateGetter } from '../../robotStateSelectors'
 import {
   forFlexStackerEmpty,
+  forFlexStackerFillItems,
   forFlexStackerRetrieve,
   forFlexStackerStore,
 } from '../stackerUpdates'
+
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { FlexStackerModuleState } from '../../types'
 
 vi.mock('@opentrons/shared-data', async importOriginal => ({
   ...(await importOriginal()),
@@ -228,6 +239,90 @@ describe('flex stacker state updates forFlexStackerRetrieve', () => {
     })
     expect(robotState.labware.tiprack1Id.stack).toEqual(['tiprack1Id', 'D4'])
     warnSpy.mockRestore()
+  })
+
+  it('sets stackedOnNode chain when retrieving adapter-with-primary from hopper', () => {
+    const ic = makeContext()
+    const rs = cloneDeep(getInitialRobotStateStandard(ic))
+    const primaryUri = ic.labwareEntities.tiprack4Id.labwareDefURI
+    const adapterUri = ic.labwareEntities.tiprack4AdapterId.labwareDefURI
+    rs.modules[FLEX_STACKER_ID] = {
+      slot: 'D4',
+      moduleState: {
+        ...cloneDeep(FLEX_STACKER_MODULE_INITIAL_STATE),
+        labwareInHopper: [
+          {
+            primaryLabwareId: 'tiprack4Id',
+            adapterLabwareId: 'tiprack4AdapterId',
+            lidLabwareId: null,
+          },
+        ],
+        storedLabwareDetails: {
+          primaryLabwareURI: primaryUri,
+          adapterLabwareURI: adapterUri,
+          lidLabwareURI: null,
+        },
+        labwareOnShuttle: null,
+      } as FlexStackerModuleState,
+    }
+
+    forFlexStackerRetrieve({ moduleId: FLEX_STACKER_ID }, ic, {
+      robotState: rs,
+      warnings: [],
+    })
+
+    expect(rs.labware.tiprack4AdapterId.stackedOnNode).toEqual({
+      addressableAreaName: FLEX_STACKER_D4_ADDRESSABLE_AREA,
+    })
+    expect(rs.labware.tiprack4Id.stackedOnNode).toEqual({
+      labwareId: 'tiprack4AdapterId',
+    })
+  })
+})
+
+describe('forFlexStackerFillItems stackedOnNode', () => {
+  it('assigns hopper stackedOnNode only to real labware ids (not hopper sentinel or module id)', () => {
+    const ic = makeContext()
+    const rs = cloneDeep(getInitialRobotStateStandard(ic))
+    const moduleId = 'flexStackerFillTest'
+    const plateDef = fixture96Plate as LabwareDefinition2
+    const primaryUri = getLabwareDefURI(plateDef)
+    ic.moduleEntities[moduleId] = {
+      id: moduleId,
+      type: FLEX_STACKER_MODULE_TYPE,
+      model: FLEX_STACKER_MODULE_V1,
+      pythonName: 'flex_stacker_fill',
+    }
+    ic.labwareEntities.fillTestLw = {
+      id: 'fillTestLw',
+      labwareDefURI: primaryUri,
+      def: plateDef,
+      pythonName: 'fill_test_lw',
+    }
+    rs.modules[moduleId] = {
+      slot: 'D4',
+      moduleState: {
+        ...cloneDeep(FLEX_STACKER_MODULE_INITIAL_STATE),
+        storedLabwareDetails: {
+          primaryLabwareURI: primaryUri,
+          adapterLabwareURI: null,
+          lidLabwareURI: null,
+        },
+        labwareInHopper: [],
+        labwareOnShuttle: null,
+      } as FlexStackerModuleState,
+    }
+    rs.labware.fillTestLw = { stack: ['fillTestLw', 'offDeck'] }
+
+    forFlexStackerFillItems({ moduleId, labware: ['fillTestLw'] }, ic, {
+      robotState: rs,
+      warnings: [],
+    })
+
+    expect(rs.labware.fillTestLw.stackedOnNode).toEqual({
+      kind: 'inStackerHopper',
+      moduleId,
+    })
   })
 })
 

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -176,17 +176,6 @@ export function forMoveLabware(
       FLEX_STACKER_MODULE_TYPE
     ) {
       newLocationStack.push(modules[newLocation.moduleId].slot)
-
-      // if the new location is a flex stacker shuttle, set the stackedOnNode to the shuttle addressable area
-      const shuttleAa = getFlexStackerShuttleAddressableArea(
-        modules[newLocation.moduleId].slot
-      )
-      if (shuttleAa != null) {
-        robotState.labware[labwareId].stackedOnNode = {
-          addressableAreaName: shuttleAa,
-        }
-        return
-      }
     } else {
       newLocationStack.push(
         newLocation.moduleId,
@@ -234,7 +223,21 @@ export function forMoveLabware(
     typeof newLocation === 'object' &&
     'labwareId' in newLocation &&
     getIsPipettableLabware(labwareEntities[newLocation.labwareId].def)
-  robotState.labware[labwareId].stackedOnNode = newLocation
+  let stackedOnNodeForMovedPrimary = newLocation
+  if (
+    typeof newLocation === 'object' &&
+    newLocation !== null &&
+    'moduleId' in newLocation &&
+    modules[newLocation.moduleId].moduleState.type === FLEX_STACKER_MODULE_TYPE
+  ) {
+    const shuttleAa = getFlexStackerShuttleAddressableArea(
+      modules[newLocation.moduleId].slot
+    )
+    if (shuttleAa != null) {
+      stackedOnNodeForMovedPrimary = { addressableAreaName: shuttleAa }
+    }
+  }
+  robotState.labware[labwareId].stackedOnNode = stackedOnNodeForMovedPrimary
   if (isNewParentPipettableLabware) {
     robotState.labware[labwareId].sterility = TOUCHED_PIPETTABLE_LABWARE
   }

--- a/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/stackerUpdates.ts
@@ -277,18 +277,23 @@ export const forFlexStackerFillItems = (
       }
     }
     let prevLabwareId: string | null = null
-    for (const labwareId of bottomUpStack) {
+    for (const id of bottomUpStack) {
+      // skip non-labware ids
+      const isLabware = labwareEntities[id] != null
+      if (!isLabware) {
+        continue
+      }
       if (prevLabwareId == null) {
-        robotState.labware[labwareId].stackedOnNode = {
+        robotState.labware[id].stackedOnNode = {
           kind: 'inStackerHopper',
           moduleId,
         }
       } else {
-        robotState.labware[labwareId].stackedOnNode = {
+        robotState.labware[id].stackedOnNode = {
           labwareId: prevLabwareId,
         }
       }
-      prevLabwareId = labwareId
+      prevLabwareId = id
     }
   }
 
@@ -572,21 +577,21 @@ export const forFlexStackerRetrieve = (
       // remove the shuttle group from the hopper
       labwareInHopper.shift()
 
-      // build labware stacks on the deck
+      // build labware stacks on the deck (bottom-up pool order: adapter → primary → lid)
       const runningStack = [moduleSlot]
-      let isBottom: boolean = true
+      let prevLabwareInShuttleStack: string | null = null
       for (const labwarePoolKey of BOTTOM_UP_LABWARE_POOL_KEYS) {
-        const labwareId =
+        const pieceId =
           labwareGroupOnShuttle[
             labwarePoolKey as keyof FlexStackerStoredLabwareGroup
           ]
-        if (labwareId != null) {
-          runningStack.unshift(labwareId)
-          robotState.labware[labwareId].stack = [...runningStack]
-          if (isBottom) {
+        if (pieceId != null) {
+          runningStack.unshift(pieceId)
+          robotState.labware[pieceId].stack = [...runningStack]
+          if (prevLabwareInShuttleStack == null) {
             const shuttleAA = getFlexStackerShuttleAddressableArea(moduleSlot)
             if (shuttleAA != null) {
-              robotState.labware[labwareId].stackedOnNode = {
+              robotState.labware[pieceId].stackedOnNode = {
                 addressableAreaName: shuttleAA,
               }
             } else {
@@ -594,8 +599,12 @@ export const forFlexStackerRetrieve = (
                 `Could not find an addressable area for retrieved labware in stacker module ${moduleId} at slot ${moduleSlot}`
               )
             }
-            isBottom = false
+          } else {
+            robotState.labware[pieceId].stackedOnNode = {
+              labwareId: prevLabwareInShuttleStack,
+            }
           }
+          prevLabwareInShuttleStack = pieceId
         }
       }
     }


### PR DESCRIPTION
# Overview


Fix bugs in both stacker updates and move labware updates. Move labware incorrectly early exited if the stacker shuttle addressable area was not found (this should be moved beneath any of the legacy stack calculations), and stacker tried to interpret non-labware elements of the stack as labware, so we explicitly check the elements' presence in labware entities (yay for moving to typed stack nodes!).

## Test Plan and Hands on Testing

[test protocol](https://github.com/user-attachments/files/26795978/stacker_demo.py)

- write new unit tests
- run e2e tests with success
- manually build a flex stacker protocol with a move labware and verify that no white screen occurs, and state updates as expected

## Changelog

- fix early return in forMoveLabware
- explicitly check labware elements of bottom up stack in 

## Review requests

- please just smoke test building any stacker protocol with a retrieve and fill step

## Risk assessment

low