### PR TITLE
refactor(mono): Add curly eslint rule

### DIFF
--- a/.cursor/skills/opentrons-typescript/SKILL.md
+++ b/.cursor/skills/opentrons-typescript/SKILL.md
@@ -412,3 +412,4 @@ function AppContent({ isOnChatPage }: { isOnChatPage: boolean }) {
 - Do NOT skip `afterEach(() => vi.clearAllMocks())` in test suites
 - Do NOT use semicolons (Prettier removes them)
 - Do NOT use `console.log` or `debugger` in committed code
+- Do NOT omit curly braces for control statements — ESLint `curly` rule enforces braces for all `if`, `else`, `for`, `while`, and `do` blocks

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,7 @@ module.exports = {
   reportUnusedDisableDirectives: true,
 
   rules: {
+    curly: 'error',
     camelcase: 'off',
     'no-var': 'error',
     'prefer-const': 'error',

--- a/api-client/src/protocols/createProtocol.ts
+++ b/api-client/src/protocols/createProtocol.ts
@@ -20,18 +20,24 @@ export function createProtocol(
   files.forEach(file => {
     formData.append('files', file, file.name)
   })
-  if (protocolKind != null) formData.append('protocolKind', protocolKind)
-  if (protocolKey != null) formData.append('key', protocolKey)
-  if (runTimeParameterValues != null)
+  if (protocolKind != null) {
+    formData.append('protocolKind', protocolKind)
+  }
+  if (protocolKey != null) {
+    formData.append('key', protocolKey)
+  }
+  if (runTimeParameterValues != null) {
     formData.append(
       'runTimeParameterValues',
       JSON.stringify(runTimeParameterValues)
     )
-  if (runTimeParameterFiles != null)
+  }
+  if (runTimeParameterFiles != null) {
     formData.append(
       'runTimeParameterFiles',
       JSON.stringify(runTimeParameterFiles)
     )
+  }
 
   return request<Protocol, FormData>(POST, '/protocols', formData, config)
 }

--- a/app-shell/src/update.ts
+++ b/app-shell/src/update.ts
@@ -101,12 +101,13 @@ function downloadUpdate(dispatch: Dispatch): void {
     autoUpdater.removeListener('download-progress', onDownloading)
     autoUpdater.removeListener('update-downloaded', onDownloaded)
     autoUpdater.removeListener('error', onError)
-    if (payload.error == null)
+    if (payload.error == null) {
       dispatch({
         type: UPDATE_VALUE,
         payload: { path: 'update.hasJustUpdated', value: true },
         meta: { shell: true },
       })
+    }
     dispatch({ type: 'shell:DOWNLOAD_UPDATE_RESULT', payload })
   }
 }

--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -178,8 +178,9 @@ function RobotControlTakeover(): JSX.Element | null {
   const params = deviceRouteMatch?.params
   const robotName = params?.robotName ?? null
   const robot = useRobot(robotName)
-  if (deviceRouteMatch == null || robot == null || robotName == null)
+  if (deviceRouteMatch == null || robot == null || robotName == null) {
     return null
+  }
 
   return (
     <ApiHostProvider

--- a/app/src/molecules/LabwareOffsetSnippet/createSnippet/buildLoadCommandCopy.ts
+++ b/app/src/molecules/LabwareOffsetSnippet/createSnippet/buildLoadCommandCopy.ts
@@ -233,8 +233,9 @@ function buildLoadModuleCommandInfo(
   moduleVariableById: { [moduleId: string]: string }
   commandLines: string[]
 } {
-  if (command.result == null)
+  if (command.result == null) {
     return { moduleVariableById: currentModuleVariableById, commandLines: [] }
+  }
 
   const moduleVariable = `module_${
     Object.keys(currentModuleVariableById).length + 1

--- a/app/src/organisms/Desktop/CalibrationTaskList/index.tsx
+++ b/app/src/organisms/Desktop/CalibrationTaskList/index.tsx
@@ -67,10 +67,11 @@ export function CalibrationTaskList({
   }
 
   const runHasStarted = useRunHasStarted(runId)
-  if (runHasStarted)
+  if (runHasStarted) {
     generalTaskDisabledReason = t(
       'device_settings:some_robot_controls_are_not_available'
     )
+  }
 
   useEffect(() => {
     if (

--- a/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/ConnectModal/form-fields.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/ConnectModal/form-fields.ts
@@ -280,8 +280,9 @@ export const connectFormToConfigureRequest = (
     }
 
     if (formPsk != null) options.psk = formPsk
-    if (eapConfig != null)
+    if (eapConfig != null) {
       options.eapConfig = { ...eapConfig, ...formEapConfig }
+    }
     return options
   }
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
@@ -95,8 +95,9 @@ export function RobotUpdateProgressModal({
     setShowFileSelect(false)
   }
   useEffect(() => {
-    if (showFileSelect && installFromFileRef.current)
+    if (showFileSelect && installFromFileRef.current) {
       installFromFileRef.current.click()
+    }
   }, [showFileSelect])
 
   const robotInitStatus = useRobotInitializationStatus()
@@ -207,11 +208,11 @@ function SuccessOrError({ errorMessage }: SuccessOrErrorProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const IMAGE_ALT = 'Welcome screen background image'
   let renderedImg: JSX.Element
-  if (!errorMessage)
+  if (!errorMessage) {
     renderedImg = (
       <img alt={IMAGE_ALT} src={successIcon} height="208px" width="250px" />
     )
-  else
+  } else {
     renderedImg = (
       <Icon
         name="ot-alert"
@@ -220,6 +221,7 @@ function SuccessOrError({ errorMessage }: SuccessOrErrorProps): JSX.Element {
         margin={SPACING.spacing24}
       />
     )
+  }
 
   return (
     <>

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/UpdateRobotModal.tsx
@@ -89,9 +89,11 @@ export function UpdateRobotModal({
   const updateDisabled = updateFromFileDisabledReason !== null || isRobotBusy
 
   let disabledReason: string = ''
-  if (updateFromFileDisabledReason)
+  if (updateFromFileDisabledReason) {
     disabledReason = t(updateFromFileDisabledReason)
-  else if (isRobotBusy) disabledReason = t('robot_busy_protocol')
+  } else if (isRobotBusy) {
+    disabledReason = t('robot_busy_protocol')
+  }
 
   useEffect(
     () => {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/ViewUpdateModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/ViewUpdateModal.tsx
@@ -57,7 +57,7 @@ export function ViewUpdateModal(
   let releaseNotes = ''
   if (updateInfo?.releaseNotes != null) releaseNotes = updateInfo.releaseNotes
 
-  if (availableAppUpdateVersion && showAppUpdateModal)
+  if (availableAppUpdateVersion && showAppUpdateModal) {
     return createPortal(
       <UpdateAppModal
         closeModal={() => {
@@ -66,6 +66,7 @@ export function ViewUpdateModal(
       />,
       getTopPortalEl()
     )
+  }
 
   if (showMigrationWarning) {
     return (
@@ -79,7 +80,7 @@ export function ViewUpdateModal(
     )
   }
 
-  if (robotSystemType != null)
+  if (robotSystemType != null) {
     return (
       <UpdateRobotModal
         robotName={robotName}
@@ -89,6 +90,7 @@ export function ViewUpdateModal(
         closeModal={closeModal}
       />
     )
+  }
 
   return null
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/index.tsx
@@ -36,8 +36,9 @@ const UpdateBuildroot = NiceModal.create(
     const robotName = useRef<string>(robot?.name ?? '')
     const dispatch = useDispatch<Dispatch>()
     const session = useSelector(getRobotUpdateSession)
-    if (!hasSeenSessionOnce.current && session)
+    if (!hasSeenSessionOnce.current && session) {
       hasSeenSessionOnce.current = true
+    }
 
     useEffect(
       () => {
@@ -62,7 +63,7 @@ const UpdateBuildroot = NiceModal.create(
       [robotName, close]
     )
 
-    if (hasSeenSessionOnce.current)
+    if (hasSeenSessionOnce.current) {
       return (
         <ApiHostProvider
           hostname={robot?.ip ?? null}
@@ -78,7 +79,7 @@ const UpdateBuildroot = NiceModal.create(
           />
         </ApiHostProvider>
       )
-    else if (robot != null && robot.status !== UNREACHABLE)
+    } else if (robot != null && robot.status !== UNREACHABLE) {
       return (
         <ViewUpdateModal
           robotName={robotName.current}
@@ -86,6 +87,8 @@ const UpdateBuildroot = NiceModal.create(
           closeModal={ignoreUpdate}
         />
       )
-    else return null
+    } else {
+      return null
+    }
   }
 )

--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveSlotForLabwareDetails.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveSlotForLabwareDetails.ts
@@ -21,10 +21,11 @@ const getSlotFromPipetteLocation = (
     return trashBinEntities[entityUnderPipette].location.split('cutout')[1]
   } else if (wasteChuteEntities[entityUnderPipette] != null) {
     return wasteChuteEntities[entityUnderPipette].location.split('cutout')[1]
-  } else
+  } else {
     console.warn(
       `expected to find slot assosciated with piette location ${entityUnderPipette} but could not`
     )
+  }
   return null
 }
 

--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveSlotForTiprackDetails.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveSlotForTiprackDetails.ts
@@ -21,10 +21,11 @@ const getSlotFromPipetteLocation = (
     return trashBinEntities[entityUnderPipette].location.split('cutout')[1]
   } else if (wasteChuteEntities[entityUnderPipette] != null) {
     return wasteChuteEntities[entityUnderPipette].location.split('cutout')[1]
-  } else
+  } else {
     console.warn(
       `expected to find slot assosciated with piette location ${entityUnderPipette} but could not`
     )
+  }
   return null
 }
 

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/RobotSettingsPipetteOffsetCalibration.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/RobotSettingsPipetteOffsetCalibration.tsx
@@ -51,8 +51,9 @@ export function RobotSettingsPipetteOffsetCalibration({
     isFlex &&
     (ot3AttachedLeftPipetteOffsetCal != null ||
       ot3AttachedRightPipetteOffsetCal != null)
-  )
+  ) {
     showPipetteOffsetCalItems = true
+  }
 
   return (
     <Flex

--- a/app/src/organisms/Desktop/UpdateAppModal/index.tsx
+++ b/app/src/organisms/Desktop/UpdateAppModal/index.tsx
@@ -108,8 +108,9 @@ export function UpdateAppModal(props: UpdateAppModalProps): JSX.Element {
   const { removeActiveAppUpdateToast } = useRemoveActiveAppUpdateToast()
   const availableAppUpdateVersion = useSelector(getAvailableShellUpdate) ?? ''
 
-  if (downloaded)
+  if (downloaded) {
     setTimeout(() => dispatch(applyShellUpdate()), RESTART_APP_AFTER_TIME)
+  }
 
   const handleRemindMeLaterClick = (): void => {
     navigate('/app-settings/general')

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
@@ -396,7 +396,7 @@ function routeAlternativelyIfNoPipette(props: RecoveryContentProps): void {
     MANUAL_FILL_AND_RETRY_NEW_TIPS,
   } = RECOVERY_MAP
 
-  if (tipStatusUtils.aPipetteWithTip == null)
+  if (tipStatusUtils.aPipetteWithTip == null) {
     switch (selectedRecoveryOption) {
       case RETRY_NEW_TIPS.ROUTE: {
         proceedToRouteAndStep(
@@ -430,4 +430,5 @@ function routeAlternativelyIfNoPipette(props: RecoveryContentProps): void {
         proceedToRouteAndStep(OPTION_SELECTION.ROUTE)
       }
     }
+  }
 }

--- a/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
@@ -129,12 +129,13 @@ export const BeforeBeginning = (
     return { loadName, displayName, subtitle }
   })
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return (
       <SimpleWizardInProgressBody
         description={t('shared:stand_back_robot_is_in_motion')}
       />
     )
+  }
   return errorMessage != null ? (
     <SimpleWizardBody
       isSuccess={false}

--- a/app/src/organisms/GripperWizardFlows/ExitConfirmation.tsx
+++ b/app/src/organisms/GripperWizardFlows/ExitConfirmation.tsx
@@ -40,12 +40,13 @@ export function ExitConfirmation(props: ExitConfirmationProps): JSX.Element {
   const flowTitle: string = titleFlowType[flowType]
   const isOnDevice = useSelector(getIsOnDevice)
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return (
       <SimpleWizardInProgressBody
         description={t('shared:stand_back_robot_is_in_motion')}
       />
     )
+  }
 
   return (
     <SimpleWizardBody

--- a/app/src/organisms/GripperWizardFlows/MountGripper.tsx
+++ b/app/src/organisms/GripperWizardFlows/MountGripper.tsx
@@ -86,12 +86,13 @@ export const MountGripper = (
       })
   }
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return (
       <SimpleWizardInProgressBody
         description={t('shared:stand_back_robot_is_in_motion')}
       />
     )
+  }
   return showUnableToDetect ? (
     <SimpleWizardBody
       header={t('unable_to_detect_gripper')}

--- a/app/src/organisms/GripperWizardFlows/MovePin.tsx
+++ b/app/src/organisms/GripperWizardFlows/MovePin.tsx
@@ -235,7 +235,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
     prepImage,
     inProgressImage,
   } = infoByMovement[movement]
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return (
       <SimpleWizardInProgressBody
         description={
@@ -253,6 +253,7 @@ export const MovePin = (props: MovePinProps): JSX.Element | null => {
         }
       />
     )
+  }
 
   return errorMessage != null ? (
     <SimpleWizardBody

--- a/app/src/organisms/GripperWizardFlows/Success.tsx
+++ b/app/src/organisms/GripperWizardFlows/Success.tsx
@@ -73,12 +73,13 @@ export const Success = (
   }
   const { header, buttonText } = infoByAction[successfulAction]
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return (
       <SimpleWizardInProgressBody
         description={t('shared:stand_back_robot_is_in_motion')}
       />
     )
+  }
 
   return (
     <SimpleWizardBody

--- a/app/src/organisms/GripperWizardFlows/UnmountGripper.tsx
+++ b/app/src/organisms/GripperWizardFlows/UnmountGripper.tsx
@@ -94,12 +94,13 @@ export const UnmountGripper = (
       })
   }
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return (
       <SimpleWizardInProgressBody
         description={t('shared:stand_back_robot_is_in_motion')}
       />
     )
+  }
   return showGripperStillDetected ? (
     <SimpleWizardBody
       iconColor={COLORS.red50}

--- a/app/src/organisms/InterventionModal/StackerEmptyInterventionContent.tsx
+++ b/app/src/organisms/InterventionModal/StackerEmptyInterventionContent.tsx
@@ -62,8 +62,9 @@ export function StackerEmptyInterventionContent({
     moduleLocation?.slotName == null ||
     labwareName == null ||
     flexStacker == null
-  )
+  ) {
     return null
+  }
 
   const infoProps: ComponentProps<typeof InterventionInfo> = {
     layout: 'default',

--- a/app/src/organisms/LegacyApplyHistoricOffsets/hooks/getLegacyLabwareLocationCombos.ts
+++ b/app/src/organisms/LegacyApplyHistoricOffsets/hooks/getLegacyLabwareLocationCombos.ts
@@ -35,8 +35,9 @@ export function getLegacyLabwareLocationCombos(
         if (
           command.result?.definition == null ||
           command.result.definition.parameters.format === 'trash'
-        )
+        ) {
           return acc
+        }
         const definitionUri = getLabwareDefURI(command.result.definition)
         if (locationIsOffDeck(command.params.location)) {
           return acc

--- a/app/src/organisms/LegacyApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis.ts
+++ b/app/src/organisms/LegacyApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis.ts
@@ -29,8 +29,9 @@ export function useOffsetCandidatesForAnalysis(
     { enabled: !isFlex }
   )
   // don't attempt to scrape offsets on the Flex ever.
-  if (allHistoricOffsets.length === 0 || analysisOutput == null || isFlex)
+  if (allHistoricOffsets.length === 0 || analysisOutput == null || isFlex) {
     return []
+  }
   const { commands, labware, modules = [] } = analysisOutput
   const labwareLocationCombos = getLegacyLabwareLocationCombos(
     commands,

--- a/app/src/organisms/LegacyLabwarePositionCheck/AttachProbe.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/AttachProbe.tsx
@@ -162,11 +162,11 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
       })
   }
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return (
       <RobotMotionLoader header={t('shared:stand_back_robot_is_in_motion')} />
     )
-  else if (showUnableToDetect)
+  } else if (showUnableToDetect) {
     return (
       <ProbeNotAttached
         handleOnClick={handleProbeAttached}
@@ -174,6 +174,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
         isOnDevice={isOnDevice}
       />
     )
+  }
 
   return (
     <GenericWizardTile

--- a/app/src/organisms/LegacyLabwarePositionCheck/CheckItem.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/CheckItem.tsx
@@ -166,8 +166,9 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
     [moduleId]
   )
 
-  if (pipetteName == null || labwareDef == null || pipetteMount == null)
+  if (pipetteName == null || labwareDef == null || pipetteMount == null) {
     return null
+  }
 
   const labwareDefs = getLabwareDefinitionsFromCommands(protocolData.commands)
   const pipetteZMotorAxis: 'leftZ' | 'rightZ' =
@@ -477,10 +478,11 @@ export const CheckItem = (props: CheckItemProps): JSX.Element | null => {
       location
     )?.vector ?? IDENTITY_VECTOR
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return (
       <RobotMotionLoader header={t('shared:stand_back_robot_is_in_motion')} />
     )
+  }
   return (
     <Flex flexDirection={DIRECTION_COLUMN} minHeight="29.5rem">
       {initialPosition != null ? (

--- a/app/src/organisms/LegacyLabwarePositionCheck/DetachProbe.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/DetachProbe.tsx
@@ -136,10 +136,11 @@ export const DetachProbe = (props: DetachProbeProps): JSX.Element | null => {
       })
   }
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return (
       <RobotMotionLoader header={t('shared:stand_back_robot_is_in_motion')} />
     )
+  }
 
   return (
     <GenericWizardTile

--- a/app/src/organisms/LegacyLabwarePositionCheck/PickUpTip.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/PickUpTip.tsx
@@ -103,8 +103,9 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
   const pipette = protocolData.pipettes.find(p => p.id === pipetteId)
   const pipetteName = pipette?.pipetteName
   const pipetteMount = pipette?.mount
-  if (pipetteName == null || labwareDef == null || pipetteMount == null)
+  if (pipetteName == null || labwareDef == null || pipetteMount == null) {
     return null
+  }
   const pipetteZMotorAxis: 'leftZ' | 'rightZ' =
     pipetteMount === 'left' ? 'leftZ' : 'rightZ'
 
@@ -424,10 +425,11 @@ export const PickUpTip = (props: PickUpTipProps): JSX.Element | null => {
       location
     )?.vector ?? IDENTITY_VECTOR
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return (
       <RobotMotionLoader header={t('shared:stand_back_robot_is_in_motion')} />
     )
+  }
   return showTipConfirmation ? (
     <TipConfirmation
       invalidateTip={handleInvalidateTip}

--- a/app/src/organisms/LegacyLabwarePositionCheck/ReturnTip.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/ReturnTip.tsx
@@ -214,10 +214,11 @@ export const ReturnTip = (props: ReturnTipProps): JSX.Element | null => {
       })
   }
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return (
       <RobotMotionLoader header={t('shared:stand_back_robot_is_in_motion')} />
     )
+  }
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
       <PrepareSpace

--- a/app/src/organisms/LegacyLabwarePositionCheck/index.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/index.tsx
@@ -91,7 +91,7 @@ class ErrorBoundary extends Component<
     const { ErrorComponent, children, shouldUseMetalProbe, isOnDevice } =
       this.props
     const { error } = this.state
-    if (error != null)
+    if (error != null) {
       return (
         <ErrorComponent
           errorMessage={error.message}
@@ -100,6 +100,7 @@ class ErrorBoundary extends Component<
           isOnDevice={isOnDevice}
         />
       )
+    }
     // Normally, just render children
     return children
   }

--- a/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/ModuleWizardFlows/AttachProbe.tsx
@@ -113,7 +113,7 @@ export function AttachProbe(props: AttachProbeProps): JSX.Element {
       })
   }
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return (
       <SimpleWizardInProgressBody
         // TODO ND: 9/6/23 use spinner until animations are made
@@ -121,52 +121,52 @@ export function AttachProbe(props: AttachProbeProps): JSX.Element {
         description={t('stand_back')}
       />
     )
+  }
   // TODO: add calibration loading screen and error screen
-  else
-    return (
-      <GenericWizardTile
-        header={i18n.format(t('attach_probe'), 'capitalize')}
-        rightHandBody={
-          <Flex height="13.25rem" paddingTop={SPACING.spacing4}>
-            <AnimationVideo
-              css={css`
-                max-width: 100%;
-                max-height: 100%;
-              `}
-            >
-              <source src={pipetteAttachProbeVideoSource} />
-            </AnimationVideo>
-          </Flex>
-        }
-        bodyText={
-          <>
-            <LegacyStyledText css={BODY_STYLE}>
-              <Trans
-                t={t}
-                i18nKey="pipette_wizard_flows:install_probe"
-                values={{ location: probeLocation }}
-                components={{
-                  bold: <strong />,
-                }}
-              />
-            </LegacyStyledText>
+  return (
+    <GenericWizardTile
+      header={i18n.format(t('attach_probe'), 'capitalize')}
+      rightHandBody={
+        <Flex height="13.25rem" paddingTop={SPACING.spacing4}>
+          <AnimationVideo
+            css={css`
+              max-width: 100%;
+              max-height: 100%;
+            `}
+          >
+            <source src={pipetteAttachProbeVideoSource} />
+          </AnimationVideo>
+        </Flex>
+      }
+      bodyText={
+        <>
+          <LegacyStyledText css={BODY_STYLE}>
+            <Trans
+              t={t}
+              i18nKey="pipette_wizard_flows:install_probe"
+              values={{ location: probeLocation }}
+              components={{
+                bold: <strong />,
+              }}
+            />
+          </LegacyStyledText>
 
-            {wasteChuteConflictWith96Channel && (
-              <Banner
-                type={isWasteChuteOnDeck ? 'error' : 'warning'}
-                size={isOnDevice ? '1.5rem' : '1rem'}
-                marginTop={isOnDevice ? SPACING.spacing24 : SPACING.spacing16}
-              >
-                {isWasteChuteOnDeck
-                  ? t('pipette_wizard_flows:waste_chute_error')
-                  : t('pipette_wizard_flows:waste_chute_warning')}
-              </Banner>
-            )}
-          </>
-        }
-        proceedButtonText={t('begin_calibration')}
-        proceed={handleBeginCalibration}
-        back={goBack}
-      />
-    )
+          {wasteChuteConflictWith96Channel && (
+            <Banner
+              type={isWasteChuteOnDeck ? 'error' : 'warning'}
+              size={isOnDevice ? '1.5rem' : '1rem'}
+              marginTop={isOnDevice ? SPACING.spacing24 : SPACING.spacing16}
+            >
+              {isWasteChuteOnDeck
+                ? t('pipette_wizard_flows:waste_chute_error')
+                : t('pipette_wizard_flows:waste_chute_warning')}
+            </Banner>
+          )}
+        </>
+      }
+      proceedButtonText={t('begin_calibration')}
+      proceed={handleBeginCalibration}
+      back={goBack}
+    />
+  )
 }

--- a/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
+++ b/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
@@ -211,13 +211,13 @@ export function PlaceAdapter(props: PlaceAdapterProps): JSX.Element {
     )
   }
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return (
       <SimpleWizardInProgressBody
         description={t('shared:stand_back_robot_is_in_motion')}
       />
     )
-  else {
+  } else {
     return (
       <GenericWizardTile
         header={

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/utils.ts
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/utils.ts
@@ -29,8 +29,9 @@ export function getUnmatchedModulesForProtocol(
       (acc, module) => {
         const { model, compatibleWith } = module.moduleDef
         // Skip matching any modules that don't require an electronic robot connection
-        if (NON_CONNECTING_MODULE_TYPES.includes(getModuleType(model)))
+        if (NON_CONNECTING_MODULE_TYPES.includes(getModuleType(model))) {
           return acc
+        }
         // for this required module, find a remaining (unmatched) attached module of the requested model
         const moduleTypeMatchIndex = acc.remainingAttachedModules.findIndex(
           attachedModule => {

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/BaseSettings.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/BaseSettings.tsx
@@ -66,8 +66,9 @@ export function BaseSettings(props: BaseSettingsProps): JSX.Element | null {
       value: pipettePath,
       enabled: state.transferType !== 'transfer',
       onClick: () => {
-        if (state.transferType !== 'transfer')
+        if (state.transferType !== 'transfer') {
           setSelectedSetting('pipette_path')
+        }
       },
     },
   ]

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/index.tsx
@@ -43,8 +43,9 @@ export function RunFailedModal({
   if (
     (errors == null || errors.length === 0) &&
     (commandErrorList == null || commandErrorList.data.length === 0)
-  )
+  ) {
     return null
+  }
   const modalHeader: OddModalHeaderBaseProps = {
     title:
       commandErrorList == null || commandErrorList?.data.length === 0

--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -110,7 +110,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
     </Flex>
   )
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return (
       <SimpleWizardInProgressBody
         alternativeSpinner={isExiting ? null : pipetteProbeVid}
@@ -131,7 +131,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
         )}
       </SimpleWizardInProgressBody>
     )
-  else if (showUnableToDetect)
+  } else if (showUnableToDetect) {
     return (
       <ProbeNotAttached
         handleOnClick={
@@ -143,6 +143,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
         isOnDevice={isOnDevice ?? false}
       />
     )
+  }
 
   return errorMessage != null ? (
     <SimpleWizardBody

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -105,8 +105,9 @@ export const BeforeBeginning = (
   if (
     pipetteId == null &&
     (flowType === FLOWS.CALIBRATE || flowType === FLOWS.DETACH)
-  )
+  ) {
     return null
+  }
 
   let equipmentList = [CALIBRATION_PROBE]
   const proceedButtonText = t('move_gantry_to_front')
@@ -249,8 +250,9 @@ export const BeforeBeginning = (
       })
   }
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return <SimpleWizardInProgressBody description={t('stand_back')} />
+  }
 
   return errorMessage != null ? (
     <SimpleWizardBody

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -192,8 +192,9 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
     )
   }
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return <SimpleWizardInProgressBody description={t('stand_back')} />
+  }
   if (showPipetteStillAttached) {
     return (
       <SimpleWizardBody

--- a/app/src/organisms/PipetteWizardFlows/DetachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachProbe.tsx
@@ -28,8 +28,9 @@ export const DetachProbe = (props: DetachProbeProps): JSX.Element => {
   const pipetteWizardStep = { mount, flowType, section: SECTIONS.DETACH_PROBE }
   const channel = attachedPipettes[mount]?.data.channels
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return <SimpleWizardInProgressBody description={t('stand_back')} />
+  }
   return (
     <GenericWizardTile
       header={i18n.format(t('remove_cal_probe'), 'capitalize')}

--- a/app/src/organisms/PipetteWizardFlows/ExitModal.tsx
+++ b/app/src/organisms/PipetteWizardFlows/ExitModal.tsx
@@ -43,8 +43,9 @@ export function ExitModal(props: ExitModalProps): JSX.Element {
       break
     }
   }
-  if (Boolean(isRobotMoving))
+  if (Boolean(isRobotMoving)) {
     return <SimpleWizardInProgressBody description={t('stand_back')} />
+  }
 
   return (
     <SimpleWizardBody

--- a/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
@@ -52,8 +52,9 @@ export const MountingPlate = (
       })
   }
 
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return <SimpleWizardInProgressBody description={t('stand_back')} />
+  }
   return errorMessage != null ? (
     <SimpleWizardBody
       iconColor={COLORS.red50}

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -305,8 +305,9 @@ export const Results = (props: ResultsProps): JSX.Element => {
       </>
     )
   }
-  if (isRobotMoving)
+  if (isRobotMoving) {
     return <SimpleWizardInProgressBody description={t('stand_back')} />
+  }
   if (errorMessage != null) {
     return (
       <SimpleWizardBody

--- a/app/src/pages/Desktop/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength.tsx
+++ b/app/src/pages/Desktop/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength.tsx
@@ -189,8 +189,9 @@ export function useDashboardCalibrateTipLength(
       tipLengthCalibrationSession != null ||
       showCalBlockModal != null
     )
-  )
+  ) {
     Wizard = null
+  }
 
   return [handleStartDashboardTipLengthCalSession, Wizard]
 }

--- a/app/src/pages/Desktop/Devices/ProtocolRunDetails/index.tsx
+++ b/app/src/pages/Desktop/Devices/ProtocolRunDetails/index.tsx
@@ -347,8 +347,9 @@ const ModuleControlsTab = (
   )}`
 
   useEffect(() => {
-    if (disabled && protocolRunDetailsTab === 'module-controls')
+    if (disabled && protocolRunDetailsTab === 'module-controls') {
       navigate(`/devices/${robotName}/protocol-runs/${runId}/run-preview`)
+    }
   }, [disabled, navigate, protocolRunDetailsTab, robotName, runId])
 
   return isEmpty(moduleRenderInfoForProtocolById) ? null : (

--- a/app/src/redux/analytics/epic.ts
+++ b/app/src/redux/analytics/epic.ts
@@ -66,8 +66,9 @@ const optIntoAnalyticsEpic: Epic = (_, state$) => {
         getAnalyticsOptedIn(prevState) !== getAnalyticsOptedIn(nextState)
     ),
     tap(([_, state]: [State, State]) => {
-      if (state.config?.analytics != null)
+      if (state.config?.analytics != null) {
         setMixpanelTracking(state.config?.analytics, state.config?.isOnDevice)
+      }
     }),
     ignoreElements() as OperatorFunction<[State, State], never>
   )

--- a/app/src/redux/robot-admin/epic/resetConfigEpic.ts
+++ b/app/src/redux/robot-admin/epic/resetConfigEpic.ts
@@ -40,8 +40,9 @@ function mapActionToRequests(
 
   const requests: RobotApiRequestOptions[] = []
   requests.push(settingsResetRequest)
-  if (deleteLabwareOffsetsRequest !== null)
+  if (deleteLabwareOffsetsRequest !== null) {
     requests.push(deleteLabwareOffsetsRequest)
+  }
   return requests
 }
 

--- a/app/src/resources/deck_configuration/utils.ts
+++ b/app/src/resources/deck_configuration/utils.ts
@@ -157,8 +157,9 @@ export const getFilteredDeckConfigFixtureCompatibility = (
           if (
             compatabilityItem.cutoutFixtureId !== FLEX_STACKER_V1_FIXTURE &&
             compatabilityItem.cutoutFixtureId !== SINGLE_RIGHT_SLOT_FIXTURE
-          )
+          ) {
             acc.push(rightSlotRequirement)
+          }
           return acc
         } else {
           acc.push(compatabilityItem)

--- a/app/src/resources/runs/hooks.ts
+++ b/app/src/resources/runs/hooks.ts
@@ -144,8 +144,9 @@ export function useCreateTargetedMaintenanceRunMutation(
       createMaintenanceRunMutation
         .createMaintenanceRun(variables, ...options)
         .then(res => {
-          if (isOnDevice)
+          if (isOnDevice) {
             setOddRunIds({ currentRunId: res.data.id, oddRunId: res.data.id })
+          }
           return Promise.resolve(res)
         })
         .catch(error => error),

--- a/app/src/resources/runs/useRunCalibrationStatus.ts
+++ b/app/src/resources/runs/useRunCalibrationStatus.ts
@@ -70,8 +70,9 @@ function getFlexRunCalibrationStatus(
     )
     return pipetteOnThisMount?.instrumentName !== speccedPipette.pipetteName
   })
-  if (wrongPipettesAttached)
+  if (wrongPipettesAttached) {
     return { complete: false, reason: 'attach_pipette_failure_reason' }
+  }
 
   const pipettesNotCalibrated = requiredPipettes.some(speccedPipette => {
     const pipetteMatch = instrumentsQueryData?.data.find(
@@ -83,8 +84,9 @@ function getFlexRunCalibrationStatus(
     )
     return pipetteMatch?.data.calibratedOffset?.last_modified == null
   })
-  if (pipettesNotCalibrated)
+  if (pipettesNotCalibrated) {
     return { complete: false, reason: 'calibrate_pipette_failure_reason' }
+  }
 
   const protocolRequiresGripper = isGripperInCommands(
     robotAnalysis?.commands ?? storedAnalysis?.commands ?? []

--- a/components/src/hooks/useSelectDeckLocation/index.tsx
+++ b/components/src/hooks/useSelectDeckLocation/index.tsx
@@ -157,9 +157,12 @@ export function DeckLocationSelect({
             )?.cutoutFixtureId ?? null
           const isSelected = isEqual(selectedLocation, slotLocation)
           let fill = theme === 'default' ? COLORS.purple35 : COLORS.grey35
-          if (isSelected)
+          if (isSelected) {
             fill = theme === 'default' ? COLORS.purple50 : COLORS.grey50
-          if (isDisabled) fill = COLORS.grey30
+          }
+          if (isDisabled) {
+            fill = COLORS.grey30
+          }
           if (isSelected && slot.id === 'B1' && isThermocycler) {
             return (
               <g key="thermocyclerSelectionArea">
@@ -201,8 +204,9 @@ export function DeckLocationSelect({
                     fixtureBaseColor={fill}
                     slotClipColor={COLORS.white}
                     onClick={() => {
-                      if (!isDisabled && setSelectedLocation != null)
+                      if (!isDisabled && setSelectedLocation != null) {
                         setSelectedLocation(slotLocation)
+                      }
                     }}
                     cursor={
                       setSelectedLocation == null || isDisabled || isSelected
@@ -228,8 +232,9 @@ export function DeckLocationSelect({
                   slotName={slot.id}
                   slotClipColor={COLORS.white}
                   onClick={() => {
-                    if (!isDisabled && setSelectedLocation != null)
+                    if (!isDisabled && setSelectedLocation != null) {
                       setSelectedLocation(slotLocation)
+                    }
                   }}
                   cursor={
                     setSelectedLocation == null || isDisabled || isSelected

--- a/components/src/molecules/DropdownMenu/index.tsx
+++ b/components/src/molecules/DropdownMenu/index.tsx
@@ -168,8 +168,9 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
         !dropDownMenuWrapperRef.current ||
         !showDropdownMenu ||
         !menuItemsContainerRef.current
-      )
+      ) {
         return
+      }
       const currentTriggerRect =
         dropDownMenuWrapperRef.current.getBoundingClientRect()
       const currentMenuHeight = menuItemsContainerRef.current.scrollHeight
@@ -181,11 +182,14 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
       if (menuPlacement === 'auto') {
         const currentFitsBelow = currentSpaceBelow >= currentMenuHeight
         const currentFitsAbove = currentSpaceAbove >= currentMenuHeight
-        if (currentFitsBelow) determinedPosition = 'bottom'
-        else if (currentFitsAbove) determinedPosition = 'top'
-        else
+        if (currentFitsBelow) {
+          determinedPosition = 'bottom'
+        } else if (currentFitsAbove) {
+          determinedPosition = 'top'
+        } else {
           determinedPosition =
             currentSpaceBelow >= currentSpaceAbove ? 'bottom' : 'top'
+        }
       } else {
         determinedPosition = menuPlacement
       }

--- a/components/src/organisms/ProtocolDeck/index.tsx
+++ b/components/src/organisms/ProtocolDeck/index.tsx
@@ -56,8 +56,9 @@ export function ProtocolDeck(props: ProtocolDeckProps): JSX.Element | null {
       getLabwareDefinitionsByURIForProtocol(protocolAnalysis?.commands ?? []),
     [protocolAnalysis]
   )
-  if (protocolAnalysis == null || (protocolAnalysis?.errors ?? []).length > 0)
+  if (protocolAnalysis == null || (protocolAnalysis?.errors ?? []).length > 0) {
     return null
+  }
   const robotType = protocolAnalysis.robotType ?? FLEX_ROBOT_TYPE
   const deckDef = getDeckDefFromRobotType(robotType)
   const deckConfig = getSimplestDeckConfigForProtocol(protocolAnalysis)

--- a/components/src/utils/truncateString.ts
+++ b/components/src/utils/truncateString.ts
@@ -16,7 +16,7 @@ export function truncateString(
   breakPoint?: number
 ): string {
   const dots = '...'
-  if (text.length > maxLength)
+  if (text.length > maxLength) {
     if (breakPoint != null) {
       return `${text.substring(0, breakPoint)}${dots}${text.slice(
         breakPoint - maxLength + dots.length
@@ -24,5 +24,7 @@ export function truncateString(
     } else {
       return `${text.slice(0, maxLength - dots.length)}${dots}`
     }
-  else return text
+  } else {
+    return text
+  }
 }

--- a/opentrons-ai-client/src/components/molecules/ChatDisplay/index.tsx
+++ b/opentrons-ai-client/src/components/molecules/ChatDisplay/index.tsx
@@ -149,10 +149,11 @@ export function ChatDisplay({ chat, chatId }: ChatDisplayProps): JSX.Element {
   }
 
   useEffect(() => {
-    if (isCopied)
+    if (isCopied) {
       delay(() => {
         setIsCopied(false)
       }, 2000)
+    }
   }, [isCopied])
 
   const protocolName =

--- a/opentrons-ai-client/src/pages/Chat/index.tsx
+++ b/opentrons-ai-client/src/pages/Chat/index.tsx
@@ -58,12 +58,13 @@ export function Chat(): JSX.Element | null {
   )
 
   useEffect(() => {
-    if (scrollRef.current != null)
+    if (scrollRef.current != null) {
       scrollRef.current.scrollIntoView({
         behavior: 'smooth',
         block: 'nearest',
         inline: 'nearest',
       })
+    }
   }, [chatData.length, scrollToBottom])
 
   return (

--- a/protocol-designer/src/file-data/selectors/fileCreator.ts
+++ b/protocol-designer/src/file-data/selectors/fileCreator.ts
@@ -36,8 +36,9 @@ import type {
 import type { PDPythonFile, PythonDesignerApplication } from '../../file-types'
 import type { LabwareDefByDefURI } from '../../labware-defs'
 
-if (isEmpty(_OT_PD_VERSION_))
+if (isEmpty(_OT_PD_VERSION_)) {
   console.warn('Could not find application version!')
+}
 const applicationVersion: string = _OT_PD_VERSION_ || ''
 // Internal release date: this should never be read programatically,
 // it just helps us humans quickly identify what build a user was using

--- a/protocol-designer/src/load-file/migration/1_1_0.ts
+++ b/protocol-designer/src/load-file/migration/1_1_0.ts
@@ -338,8 +338,9 @@ export function replaceTCDStepsWithMoveLiquidStep(
   const savedStepForms = fileData['designer-application'].data.savedStepForms
   const migratedStepForms = mapValues(savedStepForms, formData => {
     const { stepType } = formData
-    if (!['transfer', 'consolidate', 'distribute'].includes(stepType))
+    if (!['transfer', 'consolidate', 'distribute'].includes(stepType)) {
       return formData
+    }
     const pathMap = {
       transfer: 'single',
       consolidate: 'multiAspirate',

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -670,8 +670,9 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
         if (
           allModules.some(m => labware.stack.includes(m.id)) ||
           getSlotInLocationStack(labware.stack) === 'offDeck'
-        )
+        ) {
           return null
+        }
         if (
           deckDef.locations.addressableAreas.some(addressableArea =>
             labware.stack.includes(addressableArea.id)

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/SlotControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/SlotControls.tsx
@@ -147,8 +147,9 @@ export const SlotControls = (props: SlotControlsProps): JSX.Element | null => {
     slotPosition == null ||
     terminalItemId !== START_TERMINAL_ITEM_ID ||
     isSelected
-  )
+  ) {
     return null
+  }
 
   const draggedDef = draggedItem?.labwareOnDeck?.def
   // when dragging labware over a slot many times quickly

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/SlotOverlay.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/SlotOverlay.tsx
@@ -70,8 +70,9 @@ export function SlotOverlay(props: SlotOverlayProps): JSX.Element | null {
     }
   }, [slotFillOpacity])
 
-  if (slotPosition === null || (hasTCOnSlot && tcSlots.includes(slotId)))
+  if (slotPosition === null || (hasTCOnSlot && tcSlots.includes(slotId))) {
     return null
+  }
 
   const { width, height, x, y } =
     robotType === FLEX_ROBOT_TYPE

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/SecondStepsMoveLiquidTools.tsx
@@ -113,8 +113,9 @@ export const SecondStepsMoveLiquidTools = ({
         ? formData.liquidClass
         : WATER_LIQUID_CLASS_NAME
     ]
-  if (!liquidClassDef)
+  if (!liquidClassDef) {
     throw new Error(`Liquid class '${formData.liquidClass}' does not exist`)
+  }
   const stubbedByTipValues = liquidClassDef.byPipette
     .find(
       ({ pipetteModel }) => pipetteModel === getFlexNameConversion(pipetteSpecs)

--- a/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
@@ -72,8 +72,9 @@ export function SlotHover(props: SlotHoverProps): JSX.Element | null {
     ) ?? 'cutoutD1'
 
   //  return null for TC slots
-  if (slotPosition === null || (hasTCOnSlot && tcSlots.includes(slotId)))
+  if (slotPosition === null || (hasTCOnSlot && tcSlots.includes(slotId))) {
     return null
+  }
 
   const hoverOpacity = hover != null && hover === slotId ? 1 : 0
   const slotFill = (

--- a/protocol-designer/src/step-forms/selectors/index.ts
+++ b/protocol-designer/src/step-forms/selectors/index.ts
@@ -567,8 +567,9 @@ export const _hasFormLevelErrors = (
       invariantContext.moduleEntities,
       invariantContext.labwareEntities
     ).length > 0
-  )
+  ) {
     return true
+  }
 
   if (
     hydratedForm.stepType === 'thermocycler' &&

--- a/protocol-designer/src/step-forms/test/reducers.test.ts
+++ b/protocol-designer/src/step-forms/test/reducers.test.ts
@@ -1094,16 +1094,18 @@ describe('savedStepForms reducer: initial deck setup step', () => {
         it(testName, () => {
           const result = savedStepForms(prevRootStateWithMagAndTCSteps, action)
           // @ts-expect-error(sa, 2021-6-14): null check
-          if (action.payload.type)
+          if (action.payload.type) {
             expect(result.mag_step_form_id.moduleId).toBe(expectedModuleId)
+          }
         })
       })
       TCStepCases.forEach(({ testName, action, expectedModuleId }) => {
         it(testName, () => {
           const result = savedStepForms(prevRootStateWithMagAndTCSteps, action)
           // @ts-expect-error(sa, 2021-6-14): null check
-          if (action.payload.type)
+          if (action.payload.type) {
             expect(result.TC_step_form_id.moduleId).toBe(expectedModuleId)
+          }
         })
       })
     })

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -788,8 +788,9 @@ export const wellRatioMoveLiquid = (
     dispenseLabware != null
       ? dispenseLabware === 'wasteChute' || dispenseLabware === 'trashBin'
       : false
-  if (!aspirate_wells || (!isDispensingIntoTrash && !dispense_wells))
+  if (!aspirate_wells || (!isDispensingIntoTrash && !dispense_wells)) {
     return null
+  }
   const wellRatioFormError = isDispensingIntoTrash
     ? WELL_RATIO_MOVE_LIQUID_INTO_WASTE_CHUTE
     : WELL_RATIO_MOVE_LIQUID

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/dependentFieldsUpdateMoveLiquid.ts
@@ -300,8 +300,9 @@ const clampAspirateAirGapVolume = (
       minAirGapVolume,
       maxAirGapVolume
     )
-    if (clampedAirGapVolume === Number(patchedAspirateAirgapVolume))
+    if (clampedAirGapVolume === Number(patchedAspirateAirgapVolume)) {
       return patch
+    }
     return { ...patch, aspirate_airGap_volume: String(clampedAirGapVolume) }
   }
 

--- a/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
+++ b/protocol-designer/src/steplist/formLevel/handleFormChange/utils.ts
@@ -258,8 +258,9 @@ export function getDefaultWells(args: GetDefaultWellsArgs): string[] {
     !labwareEntities[labwareId] ||
     !pipetteId ||
     !pipetteEntities[pipetteId]
-  )
+  ) {
     return []
+  }
   const labwareDef = labwareEntities[labwareId].def
   const pipetteCanUseLabware = canPipetteUseLabware(
     pipetteEntities[pipetteId].spec,

--- a/protocol-designer/src/steplist/formLevel/moveLabwareFormErrors.ts
+++ b/protocol-designer/src/steplist/formLevel/moveLabwareFormErrors.ts
@@ -24,8 +24,9 @@ const getMoveLabwareError = (
     newLocation == null ||
     locationIsOffDeck(newLocation) ||
     !getLabwareDefIsStandard(labware?.def)
-  )
+  ) {
     return null
+  }
   if ('moduleId' in newLocation) {
     const moduleType =
       invariantContext.moduleEntities[newLocation.moduleId].type

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -351,13 +351,14 @@ export const getDeckSetupForActiveItem: Selector<AllTemporalPropertiesForTimelin
     getLabwareEntities,
 
     (robotState, initialDeckSetup, labwareEntities) => {
-      if (robotState == null)
+      if (robotState == null) {
         return {
           pipettes: {},
           labware: {},
           modules: {},
           additionalEquipmentOnDeck: {},
         }
+      }
       const { pipettes, modules, additionalEquipmentOnDeck } = initialDeckSetup
       return {
         pipettes: mapValues(pipettes, (pipEntity, pipId) => ({

--- a/protocol-designer/src/top-selectors/substep-highlight.ts
+++ b/protocol-designer/src/top-selectors/substep-highlight.ts
@@ -273,8 +273,9 @@ function _getSelectedWellsForSubstep(
             activeTips &&
             activeTips.labwareId === labwareId &&
             activeTips.wellName
-          )
+          ) {
             tipWellSet = [activeTips.wellName]
+          }
         }
       } else {
         // single-channel
@@ -283,8 +284,9 @@ function _getSelectedWellsForSubstep(
           activeTips &&
           activeTips.labwareId === labwareId &&
           activeTips.wellName
-        )
+        ) {
           tipWellSet = [activeTips.wellName]
+        }
       }
     }
     wells.push(...tipWellSet)

--- a/protocol-designer/src/top-selectors/well-contents/index.ts
+++ b/protocol-designer/src/top-selectors/well-contents/index.ts
@@ -83,17 +83,19 @@ export const getSelectedWellsCommonValues = createSelector(
   labwareIngredSelectors.getSelectedLabwareId,
   labwareIngredSelectors.getLiquidsByLabwareId,
   (selectedWells, labwareId, allIngreds): CommonWellValues => {
-    if (!labwareId)
+    if (!labwareId) {
       return {
         ingredientId: null,
         volume: null,
       }
+    }
     const ingredsInLabware = allIngreds[labwareId]
-    if (!ingredsInLabware || isEmpty(selectedWells))
+    if (!ingredsInLabware || isEmpty(selectedWells)) {
       return {
         ingredientId: null,
         volume: null,
       }
+    }
     const initialWellContents:
       | StepGeneration.LocationLiquidState
       | null

--- a/protocol-designer/src/ui/steps/selectors.ts
+++ b/protocol-designer/src/ui/steps/selectors.ts
@@ -46,14 +46,16 @@ const getSelectedItem: Selector<SelectableItem> = createSelector(
       // (or the initial selected item, if there are no more saved steps).
       // Ideally this would happen in the selectedItem reducer itself,
       // but it's not easy to feed orderedStepIds into that reducer.
-      if (orderedStepIds.length > 0)
+      if (orderedStepIds.length > 0) {
         return {
           selectionType: SINGLE_STEP_SELECTION_TYPE,
           // This non-null assertion is safe because the length is checked above.
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           id: last(orderedStepIds)!,
         }
-      else return initialSelectedItemState
+      } else {
+        return initialSelectedItemState
+      }
     }
   }
 )

--- a/shared-data/js/helpers/parseProtocolCommands.ts
+++ b/shared-data/js/helpers/parseProtocolCommands.ts
@@ -395,11 +395,14 @@ export function parseLiquidsInLoadOrder(
 
     // Track well-to-liquid mapping for mixed liquids
     const labwareId = cmd.params.labwareId
-    if (!wellToLiquids[labwareId]) wellToLiquids[labwareId] = {}
+    if (!wellToLiquids[labwareId]) {
+      wellToLiquids[labwareId] = {}
+    }
 
     for (const well of Object.keys(cmd.params.volumeByWell)) {
-      if (!wellToLiquids[labwareId][well])
+      if (!wellToLiquids[labwareId][well]) {
         wellToLiquids[labwareId][well] = new Set()
+      }
       wellToLiquids[labwareId][well].add(liquidId)
     }
   })

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -405,10 +405,11 @@ export const distribute: CommandCreator<DistributeArgs> = (
       })
     )
   }
-  if (errors.length > 0)
+  if (errors.length > 0) {
     return {
       errors,
     }
+  }
   const { tipracks } = getNextTiprack(
     pipette,
     tiprackURI,

--- a/step-generation/src/commandCreators/compound/replaceTip.ts
+++ b/step-generation/src/commandCreators/compound/replaceTip.ts
@@ -132,7 +132,7 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
   const isFlexPipette =
     (pipetteSpec?.displayCategory === 'FLEX' || channels === 96) ?? false
 
-  if (!pipetteSpec)
+  if (!pipetteSpec) {
     return {
       errors: [
         errorCreators.pipetteDoesNotExist({
@@ -140,6 +140,7 @@ export const replaceTip: CommandCreator<ReplaceTipArgs> = (
         }),
       ],
     }
+  }
   const labwareDef =
     invariantContext.labwareEntities[nextTiprack.tiprackId]?.def
 


### PR DESCRIPTION
# Overview

Our codebase doesn't enforce braces around conditional statements, but [we really should. ](https://eslint.org/docs/latest/rules/curly)

49b9e143303c4bedd66883408f43b661533e27e3 - Adds the eslint rule
775e52ec6103bfef9b9b4a0fe828547d7482d989 - Updates the cursor typescript rule

Any additional commit(s) will address current violations of the rule in our codebase.

## Test Plan and Hands on Testing

- CI is sufficient. 

## Risk assessment

- Effectively none
