### PR TITLE
fix(app): Fix the idle timeout

### DIFF
--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -151,12 +151,6 @@ function getPathComponent(
   }
 }
 
-const onDeviceDisplayEvents: Array<keyof DocumentEventMap> = [
-  'mousedown',
-  'click',
-  'scroll',
-]
-
 const TURN_OFF_BACKLIGHT = '7'
 
 export const OnDeviceDisplayApp = (): JSX.Element => {
@@ -181,11 +175,7 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
     getOnDeviceDisplaySettings
   )
   const sleepTime = sleepMs ?? SLEEP_NEVER_MS
-  const options = {
-    events: onDeviceDisplayEvents,
-    initialState: false,
-  }
-  const isIdle = useScreenIdle(sleepTime, options)
+  const isIdle = useScreenIdle(sleepTime, { initialState: false })
   useEffect(() => {
     if (isIdle) {
       dispatch(updateBrightness(TURN_OFF_BACKLIGHT))

--- a/app/src/local-resources/dom-utils/hooks/__tests__/useActivityListener.test.ts
+++ b/app/src/local-resources/dom-utils/hooks/__tests__/useActivityListener.test.ts
@@ -1,4 +1,4 @@
-import { fireEvent, renderHook } from '@testing-library/react'
+import { act, fireEvent, renderHook } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
 import { useActivityListener } from '../useActivityListener'
@@ -10,10 +10,14 @@ describe('useActivityListener', () => {
       useActivityListener(onActivity, ['click'])
     })
 
-    fireEvent.click(document)
+    act(() => {
+      fireEvent.click(document)
+    })
     expect(onActivity).toHaveBeenCalledTimes(1)
 
-    fireEvent.click(document)
+    act(() => {
+      fireEvent.click(document)
+    })
     expect(onActivity).toHaveBeenCalledTimes(2)
   })
 
@@ -23,11 +27,15 @@ describe('useActivityListener', () => {
       useActivityListener(onActivity, ['click'])
     })
 
-    fireEvent.click(document)
+    act(() => {
+      fireEvent.click(document)
+    })
     expect(onActivity).toHaveBeenCalledTimes(1)
 
     unmount()
-    fireEvent.click(document)
+    act(() => {
+      fireEvent.click(document)
+    })
     expect(onActivity).toHaveBeenCalledTimes(1)
   })
 })

--- a/app/src/local-resources/dom-utils/hooks/__tests__/useActivityListener.test.ts
+++ b/app/src/local-resources/dom-utils/hooks/__tests__/useActivityListener.test.ts
@@ -1,0 +1,33 @@
+import { fireEvent, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useActivityListener } from '../useActivityListener'
+
+describe('useActivityListener', () => {
+  it('should call onActivity when a tracked event occurs', () => {
+    const onActivity = vi.fn()
+    renderHook(() => {
+      useActivityListener(onActivity, ['click'])
+    })
+
+    fireEvent.click(document)
+    expect(onActivity).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(document)
+    expect(onActivity).toHaveBeenCalledTimes(2)
+  })
+
+  it('should not call onActivity after unmount', () => {
+    const onActivity = vi.fn()
+    const { unmount } = renderHook(() => {
+      useActivityListener(onActivity, ['click'])
+    })
+
+    fireEvent.click(document)
+    expect(onActivity).toHaveBeenCalledTimes(1)
+
+    unmount()
+    fireEvent.click(document)
+    expect(onActivity).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/src/local-resources/dom-utils/hooks/__tests__/useScreenIdle.test.ts
+++ b/app/src/local-resources/dom-utils/hooks/__tests__/useScreenIdle.test.ts
@@ -1,5 +1,5 @@
-import { fireEvent, renderHook } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { SLEEP_NEVER_MS } from '/app/local-resources/dom-utils'
 
@@ -18,7 +18,11 @@ const MOCK_OPTIONS = {
 
 describe('useIdle', () => {
   beforeEach(() => {
-    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('should initially return the default initialState', () => {
@@ -39,13 +43,19 @@ describe('useIdle', () => {
 
     expect(result.current).toBe(false)
 
-    await vi.advanceTimersByTimeAsync(mockTime - 1)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(mockTime - 1)
+    })
     expect(result.current).toBe(false)
 
-    await vi.advanceTimersByTimeAsync(1)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1)
+    })
     expect(result.current).toBe(true)
 
-    fireEvent.click(document)
+    act(() => {
+      fireEvent.click(document)
+    })
     expect(result.current).toBe(false)
   })
 
@@ -53,22 +63,38 @@ describe('useIdle', () => {
     const mockTime = 1000
     const { result } = renderHook(() => useScreenIdle(mockTime, MOCK_OPTIONS))
 
-    fireEvent.click(document)
+    act(() => {
+      fireEvent.click(document)
+    })
     expect(result.current).toBe(false)
 
-    await vi.advanceTimersByTimeAsync(mockTime - 1)
-    fireEvent.click(document)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(mockTime - 1)
+    })
+    act(() => {
+      fireEvent.click(document)
+    })
     expect(result.current).toBe(false)
 
-    await vi.advanceTimersByTimeAsync(mockTime - 1)
-    fireEvent.click(document)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(mockTime - 1)
+    })
+    act(() => {
+      fireEvent.click(document)
+    })
     expect(result.current).toBe(false)
 
-    await vi.advanceTimersByTimeAsync(mockTime - 1)
-    fireEvent.click(document)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(mockTime - 1)
+    })
+    act(() => {
+      fireEvent.click(document)
+    })
     expect(result.current).toBe(false)
 
-    await vi.advanceTimersByTimeAsync(mockTime)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(mockTime)
+    })
     expect(result.current).toBe(true)
   })
 
@@ -78,7 +104,9 @@ describe('useIdle', () => {
 
     expect(result.current).toBe(false)
 
-    await vi.advanceTimersByTimeAsync(SLEEP_NEVER_MS * 2)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(SLEEP_NEVER_MS * 2)
+    })
     expect(result.current).toBe(false)
   })
 })

--- a/app/src/local-resources/dom-utils/hooks/__tests__/useScreenIdle.test.ts
+++ b/app/src/local-resources/dom-utils/hooks/__tests__/useScreenIdle.test.ts
@@ -5,14 +5,7 @@ import { SLEEP_NEVER_MS } from '/app/local-resources/dom-utils'
 
 import { useScreenIdle } from '../useScreenIdle'
 
-const MOCK_EVENTS: Array<keyof DocumentEventMap> = [
-  'mousedown',
-  'click',
-  'scroll',
-]
-
 const MOCK_OPTIONS = {
-  events: MOCK_EVENTS,
   initialState: false,
 }
 

--- a/app/src/local-resources/dom-utils/hooks/__tests__/useScreenIdle.test.ts
+++ b/app/src/local-resources/dom-utils/hooks/__tests__/useScreenIdle.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react'
+import { fireEvent, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { SLEEP_NEVER_MS } from '/app/local-resources/dom-utils'
@@ -21,60 +21,64 @@ describe('useIdle', () => {
     vi.useFakeTimers({ shouldAdvanceTime: true })
   })
 
-  it('should return the default initialState', () => {
+  it('should initially return the default initialState', () => {
     const mockTime = 1000
     const { result } = renderHook(() => useScreenIdle(mockTime))
     expect(result.current).toBe(true)
   })
 
-  it('should return the given initialState', () => {
+  it('should initially return the given initialState', () => {
     const mockTime = 1000
     const { result } = renderHook(() => useScreenIdle(mockTime, MOCK_OPTIONS))
     expect(result.current).toBe(false)
   })
 
-  it('should return true after 1000ms', () => {
+  it('should return true after the timer elapses, then false after there is user activity again', async () => {
+    const mockTime = 12345
+    const { result } = renderHook(() => useScreenIdle(mockTime, MOCK_OPTIONS))
+
+    expect(result.current).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(mockTime - 1)
+    expect(result.current).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(result.current).toBe(true)
+
+    fireEvent.click(document)
+    expect(result.current).toBe(false)
+  })
+
+  it('should return false as long as there is user activity, then true after the timer elapses', async () => {
     const mockTime = 1000
     const { result } = renderHook(() => useScreenIdle(mockTime, MOCK_OPTIONS))
+
+    fireEvent.click(document)
     expect(result.current).toBe(false)
-    setTimeout(() => {
-      expect(result.current).toBe(true)
-    }, 1001)
+
+    await vi.advanceTimersByTimeAsync(mockTime - 1)
+    fireEvent.click(document)
+    expect(result.current).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(mockTime - 1)
+    fireEvent.click(document)
+    expect(result.current).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(mockTime - 1)
+    fireEvent.click(document)
+    expect(result.current).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(mockTime)
+    expect(result.current).toBe(true)
   })
 
-  it('should return true after 180,000ms - 3min', () => {
-    const mockTime = 60 * 1000 * 3
-    const { result } = renderHook(() => useScreenIdle(mockTime, MOCK_OPTIONS))
-    expect(result.current).toBe(false)
-    setTimeout(() => {
-      expect(result.current).toBe(true)
-    }, 180001)
-  })
-
-  it('should return true after 180,0000ms - 30min', () => {
-    const mockTime = 60 * 1000 * 30
-    const { result } = renderHook(() => useScreenIdle(mockTime, MOCK_OPTIONS))
-    expect(result.current).toBe(false)
-    setTimeout(() => {
-      expect(result.current).toBe(true)
-    }, 1800001)
-  })
-
-  it('should return true after 3,600,000ms - 1 hour', () => {
-    const mockTime = 60 * 1000 * 60
-    const { result } = renderHook(() => useScreenIdle(mockTime, MOCK_OPTIONS))
-    expect(result.current).toBe(false)
-    setTimeout(() => {
-      expect(result.current).toBe(true)
-    }, 3600001)
-  })
-
-  it(`should always return false if the idle time is exactly ${SLEEP_NEVER_MS}`, () => {
+  it(`should always return false if the idle time is exactly ${SLEEP_NEVER_MS}`, async () => {
     const mockTime = SLEEP_NEVER_MS
     const { result } = renderHook(() => useScreenIdle(mockTime, MOCK_OPTIONS))
+
     expect(result.current).toBe(false)
-    setTimeout(() => {
-      expect(result.current).toBe(false)
-    }, 604800001)
+
+    await vi.advanceTimersByTimeAsync(SLEEP_NEVER_MS * 2)
+    expect(result.current).toBe(false)
   })
 })

--- a/app/src/local-resources/dom-utils/hooks/useActivityListener.ts
+++ b/app/src/local-resources/dom-utils/hooks/useActivityListener.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+
+const USER_EVENTS: Array<keyof DocumentEventMap> = [
+  'click',
+  'dblclick',
+  'keypress',
+  'mousemove',
+  'pointerover',
+  'pointerenter',
+  'pointerdown',
+  'pointermove',
+  'pointerout',
+  'pointerleave',
+  'scroll',
+  'touchmove',
+  'touchstart',
+  'mousedown',
+]
+
+/**
+ * Calls onActivity whenever there is user activity in the app.
+ */
+export function useActivityListener(
+  onActivity: () => void,
+  events: Array<keyof DocumentEventMap> = USER_EVENTS
+): void {
+  useEffect(() => {
+    events.forEach(event => {
+      document.addEventListener(event, onActivity)
+    })
+
+    return () => {
+      events.forEach(event => {
+        document.removeEventListener(event, onActivity)
+      })
+    }
+  }, [onActivity, events])
+}

--- a/app/src/local-resources/dom-utils/hooks/useScreenIdle.ts
+++ b/app/src/local-resources/dom-utils/hooks/useScreenIdle.ts
@@ -1,6 +1,8 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { SLEEP_NEVER_MS } from '/app/local-resources/dom-utils'
+
+import { useActivityListener } from './useActivityListener'
 
 const USER_EVENTS: Array<keyof DocumentEventMap> = [
   'click',
@@ -42,32 +44,35 @@ export function useScreenIdle(
   const [idle, setIdle] = useState<boolean>(initialState)
   const idleTimer = useRef<number>()
 
-  useEffect(() => {
-    const handleEvents = (): void => {
-      setIdle(false)
+  const startOrResetTimer = useCallback(() => {
+    if (idleTimer.current != null) {
+      window.clearTimeout(idleTimer.current)
+    }
+    // See RQA-3813 and associated PR.
+    if (idleTime !== SLEEP_NEVER_MS) {
+      idleTimer.current = window.setTimeout(() => {
+        setIdle(true)
+      }, idleTime)
+    }
+  }, [idleTime])
 
+  // Start the initial timer when we mount.
+  // Clear any ongoing timer when we unmount.
+  useEffect(() => {
+    startOrResetTimer()
+    return () => {
       if (idleTimer.current != null) {
         window.clearTimeout(idleTimer.current)
       }
-
-      // See RQA-3813 and associated PR.
-      if (idleTime !== SLEEP_NEVER_MS) {
-        idleTimer.current = window.setTimeout(() => {
-          setIdle(true)
-        }, idleTime)
-      }
     }
+  }, [startOrResetTimer])
 
-    events.forEach(event => {
-      document.addEventListener(event, handleEvents)
-    })
-
-    return () => {
-      events.forEach(event => {
-        document.removeEventListener(event, handleEvents)
-      })
-    }
-  }, [events, idleTime])
+  // Reset the timer whenever there's user activity.
+  const handleActivity = useCallback(() => {
+    setIdle(false)
+    startOrResetTimer()
+  }, [startOrResetTimer])
+  useActivityListener(handleActivity, events)
 
   return idle
 }

--- a/app/src/local-resources/dom-utils/hooks/useScreenIdle.ts
+++ b/app/src/local-resources/dom-utils/hooks/useScreenIdle.ts
@@ -5,24 +5,12 @@ import { SLEEP_NEVER_MS } from '/app/local-resources/dom-utils'
 import { useActivityListener } from './useActivityListener'
 
 const USER_EVENTS: Array<keyof DocumentEventMap> = [
-  'click',
-  'dblclick',
-  'keypress',
-  'mousemove',
-  'pointerover',
-  'pointerenter',
-  'pointerdown',
-  'pointermove',
-  'pointerout',
-  'pointerleave',
-  'scroll',
-  'touchmove',
-  'touchstart',
   'mousedown',
+  'click',
+  'scroll',
 ]
 
 const DEFAULT_OPTIONS = {
-  events: USER_EVENTS,
   initialState: true,
 }
 
@@ -30,17 +18,16 @@ const DEFAULT_OPTIONS = {
  * React hook to check user events
  *
  * @param {number} idleTime (idle time)
- * @param {object} options (events that the app need to check, initialState: initial state true => idle)
+ * @param {object} options (initialState: initial state true => idle)
  * @returns {boolean}
  */
 export function useScreenIdle(
   idleTime: number,
   options?: Partial<{
-    events: Array<keyof DocumentEventMap>
     initialState: boolean
   }>
 ): boolean {
-  const { events, initialState } = { ...DEFAULT_OPTIONS, ...options }
+  const { initialState } = { ...DEFAULT_OPTIONS, ...options }
   const [idle, setIdle] = useState<boolean>(initialState)
   const idleTimer = useRef<number>()
 
@@ -72,7 +59,7 @@ export function useScreenIdle(
     setIdle(false)
     startOrResetTimer()
   }, [startOrResetTimer])
-  useActivityListener(handleActivity, events)
+  useActivityListener(handleActivity, USER_EVENTS)
 
   return idle
 }


### PR DESCRIPTION
## Overview

We have a hook to show a black screen on the on-device display after a period of user inactivity. This PR refactors it so some of the logic can be reused for showing the "logged out" screen (EXEC-2179). It also fixes some bugs that I noticed while working on it.

## Changelog

* Fix the unit tests for `useScreenIdle()`. Some of them weren't actually testing anything. They were scheduling an `expect()` to run in the future, and they ended before the `expect()` actually got a chance to run.
* Fix a bug in `useScreenIdle()` (now caught by the tests). The timer would only start after the first user activity event. Now, the timer starts on mount, and restarts after each user activity event.
* Refactor: Split `useActivityListener()` from `useScreenIdle()` so we can reuse `useActivityListener()` in the logout timer (EXEC-2179).

## Test Plan and Hands on Testing

I configured the timeout to 10 seconds and tested it in `make -C app dev-odd`.

* [x] The black screen shows up 10 seconds after boot if there is no user activity
* [x] It goes away when there is user activity
* [x] It comes back if there's another 10 seconds of inactivity

## Review requests

The big `USER_EVENTS` array isn't doing anything; it's being overridden by a smaller array in `OnDeviceDisplayApp.tsx`. Do we want to delete one of them, for simplicity?

## Risk assessment

Low with the new tests.