### PR TITLE
feat(shared-data): Add containedSpace to labware schema V2.

### DIFF
--- a/shared-data/labware/schemas/2.json
+++ b/shared-data/labware/schemas/2.json
@@ -764,7 +764,7 @@
       "type": ["object"],
       "description": "The extents and dimensions of the geometrical space within a labware that can house other labware.",
       "additionalProperties": false,
-      "required": ["type", "origin", "dimensions"],
+      "required": ["shape", "origin", "dimensions"],
       "properties": {
         "shape": {
           "type": "string",

--- a/shared-data/labware/schemas/2.json
+++ b/shared-data/labware/schemas/2.json
@@ -466,6 +466,23 @@
           }
         }
       }
+    },
+    "dimensions": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Dimensions in mm (x, y, z)",
+      "required": ["xDimension", "yDimension", "zDimension"],
+      "properties": {
+        "yDimension": {
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "zDimension": {
+          "$ref": "#/definitions/positiveNumber"
+        },
+        "xDimension": {
+          "$ref": "#/definitions/positiveNumber"
+        }
+      }
     }
   },
   "type": "object",
@@ -577,6 +594,11 @@
           "type": "boolean",
           "default": true
         },
+        "isMovableAdapter": {
+          "description": "Flag marking whether this adapter can be moved by the gripper, defaults to false",
+          "type": "boolean",
+          "default": false
+        },
         "magneticModuleEngageHeight": {
           "description": "Distance to move magnetic module magnets to engage",
           "$ref": "#/definitions/positiveNumber"
@@ -598,21 +620,8 @@
       "$ref": "#/definitions/vector"
     },
     "dimensions": {
-      "type": "object",
-      "additionalProperties": false,
       "description": "Outer dimensions of a labware",
-      "required": ["xDimension", "yDimension", "zDimension"],
-      "properties": {
-        "yDimension": {
-          "$ref": "#/definitions/positiveNumber"
-        },
-        "zDimension": {
-          "$ref": "#/definitions/positiveNumber"
-        },
-        "xDimension": {
-          "$ref": "#/definitions/positiveNumber"
-        }
-      }
+      "$ref": "#/definitions/dimensions"
     },
     "wells": {
       "type": "object",
@@ -749,6 +758,27 @@
             "$ref": "#/definitions/UserDefinedVolumes"
           }
         ]
+      }
+    },
+    "containedSpace": {
+      "type": ["object"],
+      "description": "The extents and dimensions of the geometrical space within a labware that can house other labware.",
+      "additionalProperties": false,
+      "required": ["type", "origin", "dimensions"],
+      "properties": {
+        "shape": {
+          "type": "string",
+          "enum": ["rectangular"],
+          "description": "The geometric shape of the contained space. Currently only 'rectangular' is supported."
+        },
+        "origin": {
+          "$ref": "#/definitions/vector",
+          "description": "The origin of the contained space, expressed as an (x, y, z) offset in mm from the bottom-left-front corner of this labware's outer bounding box."
+        },
+        "dimensions": {
+          "$ref": "#/definitions/dimensions",
+          "description": "Inner dimensions of the contained space in mm."
+        }
       }
     }
   }

--- a/shared-data/python/opentrons_shared_data/labware/labware_definition.py
+++ b/shared-data/python/opentrons_shared_data/labware/labware_definition.py
@@ -120,6 +120,10 @@ class Quirks(Enum):
     disableGeometryBasedGripCheck = "disableGeometryBasedGripCheck"
 
 
+class ContainmentShape(StrEnum):
+    rectangular = "rectangular"
+
+
 class Metadata(BaseModel):
     displayName: str
     displayCategory: DisplayCategory
@@ -136,6 +140,7 @@ class Parameters2(BaseModel):
     loadName: Annotated[str, Field(pattern=SAFE_STRING_REGEX)]
     isMagneticModuleCompatible: bool
     isDeckSlotCompatible: bool | None = None
+    isMovableAdapter: bool | None = None
     magneticModuleEngageHeight: _NonNegativeNumber | None = None
 
 
@@ -568,6 +573,12 @@ class Extents(BaseModel):
     total: AxisAlignedBoundingBox3D
 
 
+class ContainedSpace(BaseModel):
+    shape: ContainmentShape
+    origin: Vector3D
+    dimensions: Dimensions
+
+
 class LabwareDefinition2(BaseModel):
     schemaVersion: Literal[2]
     version: Annotated[int, Field(ge=1)]
@@ -591,6 +602,7 @@ class LabwareDefinition2(BaseModel):
     innerLabwareGeometry: dict[str, InnerWellGeometry | UserDefinedVolumes] | None = (
         None
     )
+    containedSpace: ContainedSpace | None = None
 
 
 class LabwareDefinition3(BaseModel):

--- a/shared-data/python/opentrons_shared_data/labware/types.py
+++ b/shared-data/python/opentrons_shared_data/labware/types.py
@@ -80,6 +80,7 @@ class LabwareParameters2(TypedDict):
     loadName: str
     isMagneticModuleCompatible: bool
     isDeckSlotCompatible: NotRequired[bool]
+    isMovableAdapter: NotRequired[bool]
     quirks: NotRequired[list[str]]
     tipLength: NotRequired[float]
     tipOverlap: NotRequired[float]


### PR DESCRIPTION
# Overview

Add two new optional properties to the Labware Definition V2:

- `containedSpace`: Defines the inner space available inside a labware/adapter for housing other labware (e.g. Vacuum Module Collar holding a collection plate).
- `isMovableAdapter`: Boolean flag (defaults to `false`) that indicates whether the gripper can pick up and move the adapter.

This enables proper support for labware containment and movable adapters.

## Test Plan and Hands on Testing
## Changelog

- Added `containedSpace` (optional rectangular inner space) and `isMovableAdapter` flag to support containment and nested labware.
- Added `dimensions` to the schemaV2 definitions key so we can reuse the object when defining the `containedSpace`. 

## Review requests
## Risk assessment
