### PR TITLE
feat(api): add labware containment to enable loading the vacuum module collar on the dock

### DIFF
--- a/api/src/opentrons/legacy_commands/helpers.py
+++ b/api/src/opentrons/legacy_commands/helpers.py
@@ -4,7 +4,7 @@ from opentrons.protocol_api._types import OffDeckType
 from opentrons.protocol_api.disposal_locations import TrashBin, WasteChute
 from opentrons.protocol_api.labware import Labware, Well
 from opentrons.protocol_api.module_contexts import ModuleContext
-from opentrons.types import DeckLocation, Location
+from opentrons.types import DeckLocation, Location, ModuleFixtureLocation
 
 CommandLocation = Union[Location, Well]
 
@@ -107,7 +107,13 @@ def stringify_well_list(
 
 def _stringify_labware_movement_location(
     location: Union[
-        DeckLocation, OffDeckType, Labware, ModuleContext, WasteChute, TrashBin
+        DeckLocation,
+        OffDeckType,
+        Labware,
+        ModuleContext,
+        ModuleFixtureLocation,
+        WasteChute,
+        TrashBin,
     ],
 ) -> str:
     if isinstance(location, (int, str)):
@@ -116,7 +122,7 @@ def _stringify_labware_movement_location(
         return "off-deck"
     elif isinstance(location, Labware):
         return location.name
-    elif isinstance(location, ModuleContext):
+    elif isinstance(location, (ModuleContext, ModuleFixtureLocation)):
         return str(location)
     elif isinstance(location, WasteChute):
         return "Waste Chute"
@@ -127,7 +133,13 @@ def _stringify_labware_movement_location(
 def stringify_labware_movement_command(
     source_labware: Labware,
     destination: Union[
-        DeckLocation, OffDeckType, Labware, ModuleContext, WasteChute, TrashBin
+        DeckLocation,
+        OffDeckType,
+        Labware,
+        ModuleContext,
+        ModuleFixtureLocation,
+        WasteChute,
+        TrashBin,
     ],
     use_gripper: bool,
 ) -> str:

--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -246,6 +246,13 @@ def _map_labware(
 ]:
     location_from_engine = engine_state.labware.get_location(labware_id=labware_id)
     if isinstance(location_from_engine, AddressableAreaLocation):
+        area_name = location_from_engine.addressableAreaName
+        # If this is our custom module dock, it's not a standard deck slot.
+        # We skip standard conflict mapping because the geometry engine
+        # handles this 1:n space.
+        if "VACUUMMODULE" in area_name.upper() and "DOCK" in area_name.upper():
+            return None
+
         # This will be guaranteed to be either deck slot name or staging slot name
         slot: Union[DeckSlotName, StagingSlotName]
         try:

--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -251,16 +251,15 @@ def _map_labware(
         # We skip standard conflict mapping because the geometry engine
         # handles this 1:n space.
         if "VACUUMMODULE" in area_name.upper() and "DOCK" in area_name.upper():
+            area_name = area_name[:-2]
             return None
 
         # This will be guaranteed to be either deck slot name or staging slot name
         slot: Union[DeckSlotName, StagingSlotName]
         try:
-            slot = DeckSlotName.from_primitive(location_from_engine.addressableAreaName)
+            slot = DeckSlotName.from_primitive(area_name)
         except ValueError:
-            slot = StagingSlotName.from_primitive(
-                location_from_engine.addressableAreaName
-            )
+            slot = StagingSlotName.from_primitive(area_name)
         return (
             slot,
             wrapped_deck_conflict.Labware(

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -87,6 +87,7 @@ from opentrons.protocols.api_support.util import AxisMaxSpeeds
 from opentrons.types import (
     DeckSlotName,
     Location,
+    ModuleFixtureLocation,
     Mount,
     MountType,
     Point,
@@ -227,6 +228,7 @@ class ProtocolCore(
             StagingSlotName,
             LabwareCore,
             ModuleCore,
+            ModuleFixtureLocation,
             NonConnectedModuleCore,
             OffDeckType,
         ],
@@ -302,6 +304,7 @@ class ProtocolCore(
             StagingSlotName,
             ModuleCore,
             NonConnectedModuleCore,
+            ModuleFixtureLocation,
             OffDeckType,
         ],
         namespace: Optional[str],
@@ -309,7 +312,6 @@ class ProtocolCore(
     ) -> LabwareCore:
         """Load an adapter using its identifying parameters"""
         load_location = self._get_non_stacked_location(location=location)
-
         custom_labware_params = (
             self._engine_client.state.labware.find_custom_labware_load_params()
         )
@@ -325,6 +327,7 @@ class ProtocolCore(
             ),
             command_annotations=self._annotation_ids,
         )
+
         # FIXME(jbl, 2023-08-14) validating after loading the object issue
         validation.ensure_definition_is_adapter(load_result.definition)
 
@@ -1311,6 +1314,7 @@ class ProtocolCore(
             StagingSlotName,
             LabwareCore,
             ModuleCore,
+            ModuleFixtureLocation,
             NonConnectedModuleCore,
             OffDeckType,
             WasteChute,
@@ -1328,6 +1332,7 @@ class ProtocolCore(
             DeckSlotName,
             StagingSlotName,
             ModuleCore,
+            ModuleFixtureLocation,
             NonConnectedModuleCore,
             OffDeckType,
             WasteChute,
@@ -1349,3 +1354,7 @@ class ProtocolCore(
             return AddressableAreaLocation(addressableAreaName="gripperWasteChute")
         elif isinstance(location, TrashBin):
             return AddressableAreaLocation(addressableAreaName=location.area_name)
+        elif isinstance(location, ModuleFixtureLocation):
+            return AddressableAreaLocation(
+                addressableAreaName=location.addressable_area_name
+            )

--- a/api/src/opentrons/protocol_api/core/engine/stringify.py
+++ b/api/src/opentrons/protocol_api/core/engine/stringify.py
@@ -7,6 +7,7 @@ from opentrons.protocol_engine.types import (
     ModuleLocation,
     OnLabwareLocation,
 )
+from opentrons.types import ModuleFixtureLocation
 
 
 def well(engine_client: SyncClient, well_name: str, labware_id: str) -> str:
@@ -27,7 +28,7 @@ def _module_in_location_string(module_id: str, engine_client: SyncClient) -> str
     return f"{module_name} on {module_on_string}"
 
 
-def _labware_location_string(
+def _labware_location_string(  # noqa: C901
     engine_client: SyncClient, location: LabwareLocation
 ) -> str:
     if isinstance(location, DeckSlotLocation):
@@ -49,6 +50,10 @@ def _labware_location_string(
     elif isinstance(location, AddressableAreaLocation):
         # In practice this will always be a deck slot or staging slot
         return f"slot {location.addressableAreaName}"
+
+    elif isinstance(location, ModuleFixtureLocation):
+        # In practice this will always be a deck slot or staging slot
+        return f"slot {location.addressable_area_name}"
 
     elif location == "offDeck":
         return "[off-deck]"

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -29,6 +29,7 @@ from opentrons.protocols.api_support.util import APIVersionError, AxisMaxSpeeds
 from opentrons.types import (
     DeckSlotName,
     Location,
+    ModuleFixtureLocation,
     Mount,
     Point,
     StagingSlotName,
@@ -173,6 +174,7 @@ class LegacyProtocolCore(
             LegacyLabwareCore,
             legacy_module_core.LegacyModuleCore,
             StagingSlotName,
+            ModuleFixtureLocation,
             OffDeckType,
         ],
         label: Optional[str],
@@ -192,6 +194,10 @@ class LegacyProtocolCore(
         elif isinstance(location, StagingSlotName):
             raise APIVersionError(
                 api_element="Using a staging deck slot", until_version="2.16"
+            )
+        elif isinstance(location, ModuleFixtureLocation):
+            raise APIVersionError(
+                api_element="Using a module addressable area", until_version="2.28"
             )
 
         deck_slot = (
@@ -272,6 +278,7 @@ class LegacyProtocolCore(
             StagingSlotName,
             legacy_module_core.LegacyModuleCore,
             OffDeckType,
+            ModuleFixtureLocation,
         ],
         namespace: Optional[str],
         version: Optional[int],

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -25,6 +25,7 @@ from opentrons.protocols.api_support.util import AxisMaxSpeeds
 from opentrons.types import (
     DeckSlotName,
     Location,
+    ModuleFixtureLocation,
     Mount,
     Point,
     StagingSlotName,
@@ -77,7 +78,12 @@ class AbstractProtocol(
         self,
         load_name: str,
         location: Union[
-            DeckSlotName, StagingSlotName, LabwareCoreType, ModuleCoreType, OffDeckType
+            DeckSlotName,
+            StagingSlotName,
+            LabwareCoreType,
+            ModuleCoreType,
+            ModuleFixtureLocation,
+            OffDeckType,
         ],
         label: Optional[str],
         namespace: Optional[str],
@@ -90,7 +96,13 @@ class AbstractProtocol(
     def load_adapter(
         self,
         load_name: str,
-        location: Union[DeckSlotName, StagingSlotName, ModuleCoreType, OffDeckType],
+        location: Union[
+            DeckSlotName,
+            StagingSlotName,
+            ModuleCoreType,
+            ModuleFixtureLocation,
+            OffDeckType,
+        ],
         namespace: Optional[str],
         version: Optional[int],
     ) -> LabwareCoreType:

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -42,6 +42,7 @@ from opentrons.protocols.api_support.util import (
     UnsupportedAPIError,
     requires_version,
 )
+from opentrons.types import ModuleFixtureLocation
 
 from . import (
     validation,
@@ -1865,3 +1866,42 @@ class VacuumModuleContext(ModuleContext):
     def serial_number(self) -> str:
         """Get the module's unique hardware serial number."""
         return self._core.get_serial_number()
+
+    @property
+    @requires_version(2, 28)
+    def manifold_dock(self) -> ModuleFixtureLocation:
+        base_slot = self._core.get_deck_slot().id
+        area_name = f"{self.model}Dock{base_slot[0]}4"
+        return ModuleFixtureLocation(addressable_area_name=area_name)
+
+    @requires_version(2, 28)
+    def load_adapter_to_dock(
+        self,
+        name: str,
+        namespace: Optional[str] = None,
+        version: Optional[int] = None,
+    ) -> Labware:
+        """Load a collar adapter to the vacuum module dock."""
+
+        labware_core = self._protocol_core.load_adapter(
+            load_name=name,
+            namespace=namespace,
+            version=version,
+            location=self.manifold_dock,
+        )
+
+        if isinstance(self._core, LegacyModuleCore) and isinstance(
+            labware_core, LegacyLabwareCore
+        ):
+            adapter = self._core.add_labware_core(labware_core)
+        else:
+            adapter = Labware(
+                core=labware_core,
+                api_version=self._api_version,
+                protocol_core=self._protocol_core,
+                core_map=self._core_map,
+            )
+
+        self._core_map.add(labware_core, adapter)
+
+        return adapter

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -96,7 +96,14 @@ from opentrons.protocols.api_support.util import (
     UnsupportedAPIError,
     requires_version,
 )
-from opentrons.types import DeckLocation, DeckSlotName, Location, Mount, StagingSlotName
+from opentrons.types import (
+    DeckLocation,
+    DeckSlotName,
+    Location,
+    ModuleFixtureLocation,
+    Mount,
+    StagingSlotName,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -412,7 +419,7 @@ class ProtocolContext(CommandPublisher):
     def load_labware(  # noqa: C901
         self,
         load_name: str,
-        location: Union[DeckLocation, OffDeckType],
+        location: Union[DeckLocation, OffDeckType, ModuleFixtureLocation],
         label: Optional[str] = None,
         namespace: Optional[str] = None,
         version: Optional[int] = None,
@@ -545,7 +552,13 @@ class ProtocolContext(CommandPublisher):
                 )
 
         load_name = validation.ensure_lowercase_name(load_name)
-        load_location: Union[OffDeckType, DeckSlotName, StagingSlotName, LabwareCore]
+        load_location: Union[
+            OffDeckType,
+            DeckSlotName,
+            StagingSlotName,
+            LabwareCore,
+            ModuleFixtureLocation,
+        ]
         if adapter is not None:
             if self._api_version < APIVersion(2, 15):
                 raise APIVersionError(
@@ -571,7 +584,7 @@ class ProtocolContext(CommandPublisher):
                 version=checked_adapter_version,
             )
             load_location = loaded_adapter._core
-        elif isinstance(location, OffDeckType):
+        elif isinstance(location, (OffDeckType, ModuleFixtureLocation)):
             load_location = location
         else:
             load_location = validation.ensure_and_convert_deck_slot(
@@ -709,7 +722,7 @@ class ProtocolContext(CommandPublisher):
     def load_adapter(
         self,
         load_name: str,
-        location: Union[DeckLocation, OffDeckType],
+        location: Union[DeckLocation, OffDeckType, ModuleFixtureLocation],
         namespace: Optional[str] = None,
         version: Optional[int] = None,
     ) -> Labware:
@@ -728,7 +741,7 @@ class ProtocolContext(CommandPublisher):
                 You can find the `load_name` for any standard adapter on the Opentrons
                 [Labware Library](https://labware.opentrons.com).
 
-            location (Union[int, str, OffDeckType]): Either a
+            location (Union[int, str, OffDeckType, ModuleFixtureLocation]): Either a
                 [deck slot](../deck-slots.md), like `1`, `"1"`, or `"D1"`, or the special value
                 [`OFF_DECK`][opentrons.protocol_api.OFF_DECK].
 
@@ -747,8 +760,10 @@ class ProtocolContext(CommandPublisher):
                 leave this unspecified to let `load_adapter()` choose a version automatically.
         """
         load_name = validation.ensure_lowercase_name(load_name)
-        load_location: Union[OffDeckType, DeckSlotName, StagingSlotName]
-        if isinstance(location, OffDeckType):
+        load_location: Union[
+            OffDeckType, DeckSlotName, StagingSlotName, ModuleFixtureLocation
+        ]
+        if isinstance(location, (OffDeckType, ModuleFixtureLocation)):
             load_location = location
         else:
             load_location = validation.ensure_and_convert_deck_slot(
@@ -808,7 +823,12 @@ class ProtocolContext(CommandPublisher):
         self,
         labware: Labware,
         new_location: Union[
-            DeckLocation, Labware, ModuleTypes, OffDeckType, WasteChute, TrashBin
+            DeckLocation,
+            Labware,
+            ModuleTypes,
+            OffDeckType,
+            WasteChute,
+            TrashBin,
         ],
         use_gripper: bool = False,
         pick_up_offset: Optional[Mapping[str, float]] = None,
@@ -871,6 +891,7 @@ class ProtocolContext(CommandPublisher):
             OffDeckType,
             DeckSlotName,
             StagingSlotName,
+            ModuleFixtureLocation,
             TrashBin,
         ]
         if isinstance(new_location, (Labware, ModuleContext)):

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -18,7 +18,6 @@ from ..types import (
     AddressableAreaLocation,
     DeckSlotLocation,
     LoadableLabwareLocation,
-    LoadedModule,
     ModuleLocation,
     ModuleModel,
     OnLabwareLocation,
@@ -97,11 +96,17 @@ class LoadLabwareImplementation(
     def _is_loading_to_module(
         self, location: LoadableLabwareLocation, module_model: ModuleModel
     ) -> TypeGuard[ModuleLocation]:
-        if not isinstance(location, ModuleLocation):
+        if not isinstance(location, (ModuleLocation, AddressableAreaLocation)):
             return False
 
-        module: LoadedModule = self._state_view.modules.get(location.moduleId)
-        return module.model == module_model
+        if isinstance(location, AddressableAreaLocation):
+            slot = self._state_view.addressable_areas.get_addressable_area_base_slot(
+                location.addressableAreaName
+            )
+            module = self._state_view.modules.get_by_slot(slot)
+        else:
+            module = self._state_view.modules.get(location.moduleId)
+        return module is not None and module.model == module_model
 
     async def execute(
         self, params: LoadLabwareParams
@@ -126,6 +131,7 @@ class LoadLabwareImplementation(
             if not (
                 fixture_validation.is_deck_slot(params.location.addressableAreaName)
                 or fixture_validation.is_abs_reader(params.location.addressableAreaName)
+                or fixture_validation.is_vac_dock(params.location.addressableAreaName)
             ):
                 raise LabwareIsNotAllowedInLocationError(
                     f"Cannot load {params.loadName} onto addressable area {area_name}"
@@ -140,24 +146,18 @@ class LoadLabwareImplementation(
             )
             state_update.set_addressable_area_used(params.location.slotName.id)
 
-        verified_location = self._state_view.geometry.ensure_location_not_occupied(
-            params.location
-        )
-
-        loaded_labware = await self._equipment.load_labware(
+        definition, definition_uri = await self._equipment.load_definition_for_details(
             load_name=params.loadName,
             namespace=params.namespace,
             version=params.version,
-            location=verified_location,
-            labware_id=params.labwareId,
         )
 
-        state_update.set_loaded_labware(
-            labware_id=loaded_labware.labware_id,
-            offset_id=loaded_labware.offsetId,
-            definition=loaded_labware.definition,
-            location=verified_location,
-            display_name=params.displayName,
+        verified_location = self._state_view.geometry.ensure_location_not_occupied(
+            params.location, None, definition
+        )
+
+        loaded_labware = await self._equipment._load_labware_from_def_and_uri(
+            definition, definition_uri, verified_location, params.labwareId, None
         )
 
         if isinstance(verified_location, OnLabwareLocation):
@@ -166,7 +166,7 @@ class LoadLabwareImplementation(
                 bottom_labware_id=verified_location.labwareId,
             )
 
-        # Validate labware for the absorbance reader
+        # Validate labware for different modules
         if self._is_loading_to_module(
             params.location, ModuleModel.ABSORBANCE_READER_V1
         ):
@@ -174,8 +174,21 @@ class LoadLabwareImplementation(
                 loaded_labware.definition
             )
 
+        elif self._is_loading_to_module(params.location, ModuleModel.VACUUM_MODULE_V1):
+            self._state_view.labware.raise_if_labware_incompatible_with_vacuum_module_dock(
+                verified_location, loaded_labware.definition
+            )
+
         self._state_view.labware.raise_if_labware_cannot_be_ondeck(
             location=params.location, labware_definition=loaded_labware.definition
+        )
+
+        state_update.set_loaded_labware(
+            labware_id=loaded_labware.labware_id,
+            offset_id=loaded_labware.offsetId,
+            definition=loaded_labware.definition,
+            location=verified_location,
+            display_name=params.displayName,
         )
 
         return SuccessData(

--- a/api/src/opentrons/protocol_engine/resources/fixture_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/fixture_validation.py
@@ -66,3 +66,8 @@ def is_stacker_shuttle(addressable_area_name: str) -> bool:
         "flexStackerModuleV1C4",
         "flexStackerModuleV1D4",
     ]
+
+
+def is_vac_dock(addressable_area_name: str) -> bool:
+    """Check if an addressable area is an vacuum module dock area."""
+    return "vacuumModuleV1Dock" in addressable_area_name

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -111,6 +111,7 @@ from .wells import WellView
 from opentrons.types import (
     DeckSlotName,
     MeniscusTrackingTarget,
+    ModuleFixtureLocation,
     MountType,
     Point,
     StagingSlotName,
@@ -384,7 +385,9 @@ class GeometryView:
             return self._normalize_module_calibration_offset(
                 module_location, offset_data
             )
-        elif isinstance(location, (DeckSlotLocation, AddressableAreaLocation)):
+        elif isinstance(
+            location, (DeckSlotLocation, AddressableAreaLocation, ModuleFixtureLocation)
+        ):
             # TODO we might want to do a check here to make sure addressable area location is a standard deck slot
             #   and raise if its not (or maybe we don't actually care since modules will never be loaded elsewhere)
             return Point(x=0, y=0, z=0)
@@ -879,15 +882,14 @@ class GeometryView:
         original_display_name = self._labware.get_display_name(labware_id)
 
         # Track visited IDs to truly detect cycles (A nested on B nested on A)
-        seen: Set[str] = {labware_id}
+        seen: Set[str] = set((labware_id,))
 
         while isinstance(labware.location, OnLabwareLocation):
             parent_id = labware.location.labwareId
             if parent_id in seen:
                 raise InvalidLabwarePositionError(
-                    f"Cycle detected in labware positioning for {original_display_name}. "
+                    f"Cycle detected in labware positioning for {original_display_name}"
                 )
-
             seen.add(parent_id)
             labware = self._labware.get(parent_id)
 
@@ -928,6 +930,8 @@ class GeometryView:
             return current_loc.slotName.id
         elif isinstance(current_loc, AddressableAreaLocation):
             return current_loc.addressableAreaName
+        elif isinstance(current_loc, ModuleFixtureLocation):
+            return current_loc.addressable_area_name
         elif isinstance(current_loc, ModuleLocation):
             return self._modules.get_provided_addressable_area(current_loc.moduleId)
 
@@ -972,10 +976,11 @@ class GeometryView:
             and res_max_z <= bound_max_z
         )
 
-    def ensure_location_not_occupied(
+    def ensure_location_not_occupied(  # noqa: C901
         self,
         location: _LabwareLocation,
         desired_addressable_area: Optional[str] = None,
+        labware_definition: Optional[LabwareDefinition] = None,
     ) -> _LabwareLocation:
         """Ensure that the location does not already have either Labware or a Module in it."""
         # Collect set of existing fixtures, if any
@@ -1008,7 +1013,6 @@ class GeometryView:
                 )
             ):
                 self._labware.raise_if_labware_in_location(location)
-
             else:
                 self._modules.raise_if_module_in_location(location)
 
@@ -1023,7 +1027,49 @@ class GeometryView:
                     AddressableAreaLocation,
                 ),
             ):
-                self._labware.raise_if_labware_in_location(location)
+                # Check if sibling labware have a 'containedSpace' variable
+                # in their definition to do a containment occupancy check.
+                # This lets us determine if the empty space (containedSpace) of
+                # a labware is able to fit other labware inside of it.
+                if labware_definition is not None:
+                    children = []
+                    for lw in self._labware.get_all():
+                        if lw.location == location:
+                            children.append(lw)
+
+                    new_labware_def = labware_definition
+                    new_contained = new_labware_def.containedSpace
+
+                    # if we have children check if either siblings have 'containedSpace'
+                    for child in children:
+                        child_def = self._labware.get_definition(child.id)
+                        existing_contained = child_def.containedSpace
+
+                        # Standard Nesting: Loading a resident into an existing container
+                        if existing_contained is not None:
+                            if not self._is_fully_contained(
+                                resident_def=new_labware_def,
+                                boundary_space=existing_contained,
+                            ):
+                                raise errors.LabwareIsNotAllowedInLocationError(
+                                    f"Labware {new_labware_def.parameters.loadName} does not fit within the "
+                                    f"containedSpace of existing {child.loadName}."
+                                )
+                        # Contained Logic: Loading a container over an existing resident
+                        elif new_contained is not None:
+                            if not self._is_fully_contained(
+                                resident_def=child_def, boundary_space=new_contained
+                            ):
+                                raise errors.LocationIsOccupiedError(
+                                    f"Cannot contain {child.loadName}; it is too large for the "
+                                    f"internal volume of {new_labware_def.parameters.loadName}."
+                                )
+                        # Strict Occupancy: Neither has a volume
+                        else:
+                            self._labware.raise_if_labware_in_location(location)
+
+                else:
+                    self._labware.raise_if_labware_in_location(location)
 
             area = (
                 location.slotName.id
@@ -1034,6 +1080,7 @@ class GeometryView:
                     else None
                 )
             )
+
             if area is not None and (
                 existing_fixtures is None
                 or not any(
@@ -1051,7 +1098,6 @@ class GeometryView:
                             )
                         )
                     )
-
         return location
 
     def _get_potential_fixtures_for_location_occupation(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -996,7 +996,9 @@ class GeometryView:
                 # in their definition to do a containment occupancy check.
                 # This lets us determine if the empty space (containedSpace) of
                 # a labware is able to fit other labware inside of it.
-                if labware_definition is not None:
+                if labware_definition is not None and isinstance(
+                    labware_definition, LabwareDefinition2
+                ):
                     children = []
                     for lw in self._labware.get_all():
                         if lw.location == location:
@@ -1008,6 +1010,8 @@ class GeometryView:
                     # if we have children check if either siblings have 'containedSpace'
                     for child in children:
                         child_def = self._labware.get_definition(child.id)
+                        if not isinstance(child_def, LabwareDefinition2):
+                            continue
                         existing_contained = child_def.containedSpace
 
                         # Standard Nesting: Loading a resident into an existing container

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1140,6 +1140,28 @@ class LabwareView:
             )
         return True
 
+    def raise_if_labware_incompatible_with_vacuum_module_dock(
+        self,
+        location: LabwareLocation,
+        labware_definition: LabwareDefinition,
+    ) -> bool:
+        """Raise an error if the labware is not compatible with the vacuum module dock.
+
+        Returns True if it does not raise.
+        """
+        if isinstance(location, AddressableAreaLocation):
+            # If the module is a Vacuum Module and we are loading
+            # a compatible adapter into its designated staging dock,
+            # do NOT raise.
+            if not (
+                location.addressableAreaName[-1] == "4"
+                and labware_definition.parameters.quirks is not None
+                and "vacuumModuleDock" in labware_definition.parameters.quirks
+            ):
+                raise ValueError("Labware not compatible with vacuum module dock")
+
+        return True
+
     def raise_if_stacker_labware_pool_is_not_valid(
         self,
         primary_labware_definition: LabwareDefinition,

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -868,7 +868,7 @@ class ModuleView:
         )
 
     def get_vacuum_module_substate(self, module_id: str) -> VacuumModuleSubState:
-        """Return a `VacuumModululeSubState` for the given Vacuum Module.
+        """Return a `VacuumModuleSubState` for the given Vacuum Module.
 
         Raises:
            ModuleNotLoadedError: If module_id has not been loaded.
@@ -1496,6 +1496,17 @@ class ModuleView:
         assert lid_doc_slot is not None
         lid_dock_area = AddressableAreaLocation(
             addressableAreaName="absorbanceReaderV1LidDock" + lid_doc_slot.value
+        )
+        return lid_dock_area
+
+    def vacuum_module_dock_location(self, module_id: str) -> AddressableAreaLocation:
+        """Get the addressable area for the vacuum module dock."""
+        reader_slot = self.get_location(module_id)
+        lid_doc_slot = get_adjacent_staging_slot(reader_slot.slotName)
+        self.get_provided_addressable_area(module_id)
+        assert lid_doc_slot is not None
+        lid_dock_area = AddressableAreaLocation(
+            addressableAreaName="VacuumModuleV1LidDock" + lid_doc_slot.value
         )
         return lid_dock_area
 

--- a/api/src/opentrons/protocol_engine/types/deck_configuration.py
+++ b/api/src/opentrons/protocol_engine/types/deck_configuration.py
@@ -45,6 +45,7 @@ class AreaType(Enum):
     MAGNETICBLOCK = "magneticBlock"
     ABSORBANCE_READER = "absorbanceReader"
     FLEX_STACKER = "flexStacker"
+    VACUUM_MODULE = "vacuumModule"
     LID_DOCK = "lidDock"
 
 

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+from dataclasses import dataclass
 from math import isclose, sqrt
 from typing import (
     TYPE_CHECKING,
@@ -521,6 +522,21 @@ class StagingSlotName(enum.Enum):
         For explicitness, prefer using `.id` instead.
         """
         return self.id
+
+
+@dataclass(frozen=True)
+class ModuleFixtureLocation:
+    """A special location (dock, fixture, collar, holder, etc.) that is paired
+    with a specific module.
+
+    Used when a module has associated positions in the staging area or elsewhere
+    that are not standard deck slots.
+    """
+
+    addressable_area_name: str
+
+    def __str__(self) -> str:
+        return self.addressable_area_name
 
 
 class TransferTipPolicy(enum.Enum):

--- a/api/tests/opentrons/protocol_api/test_vacuum_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_vacuum_module_context.py
@@ -1,0 +1,149 @@
+"""Tests for Protocol API Vacuum Module contexts."""
+
+from unittest.mock import sentinel
+
+from opentrons.protocol_engine.types.module import ModuleDefinition
+import pytest
+from decoy import Decoy, matchers
+
+from . import versions_at_or_above, versions_between
+from opentrons.legacy_broker import LegacyBroker
+from opentrons.protocol_api import VacuumModuleContext, Labware
+from opentrons.protocol_api.core.common import (
+    ModuleCore,
+    VacuumModuleCore,
+    LabwareCore,
+    ProtocolCore,
+)
+from opentrons.protocol_api.core.core_map import LoadedCoreMap
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.api_support.util import APIVersionError
+from opentrons.types import DeckSlotName, ModuleFixtureLocation
+from opentrons.hardware_control.modules.types import VacuumModuleModel
+
+
+@pytest.fixture
+def mock_core(decoy: Decoy) -> VacuumModuleCore:
+    """Get a mock module implementation core."""
+    core = decoy.mock(cls=VacuumModuleCore)
+    decoy.when(core.get_display_name()).then_return("mock vacuum core")
+    decoy.when(core.get_deck_slot()).then_return(DeckSlotName.SLOT_A3)
+    decoy.when(core.get_model()).then_return(VacuumModuleModel.VACUUM_MODULE_V1)
+    return core
+
+
+@pytest.fixture
+def mock_protocol_core(decoy: Decoy) -> ProtocolCore:
+    """Get a mock protocol implementation core."""
+    return decoy.mock(cls=ProtocolCore)
+
+
+@pytest.fixture
+def mock_labware_core(decoy: Decoy) -> LabwareCore:
+    """Get a mock labware implementation core."""
+    mock_core = decoy.mock(cls=LabwareCore)
+    decoy.when(mock_core.get_well_columns()).then_return([])
+    return mock_core
+
+
+@pytest.fixture
+def mock_core_map(decoy: Decoy) -> LoadedCoreMap:
+    """Get a mock LoadedCoreMap."""
+    return decoy.mock(cls=LoadedCoreMap)
+
+
+@pytest.fixture
+def mock_broker(decoy: Decoy) -> LegacyBroker:
+    """Get a mock command message broker."""
+    return decoy.mock(cls=LegacyBroker)
+
+
+@pytest.fixture
+def subject(
+    api_version: APIVersion,
+    mock_core: VacuumModuleCore,
+    mock_protocol_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    mock_broker: LegacyBroker,
+) -> VacuumModuleContext:
+    """Get a vacuum module context with its dependencies mocked out."""
+    return VacuumModuleContext(
+        core=mock_core,
+        protocol_core=mock_protocol_core,
+        core_map=mock_core_map,
+        broker=mock_broker,
+        api_version=api_version,
+    )
+
+
+@pytest.mark.parametrize(
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 28))
+)
+def test_get_serial_number(
+    decoy: Decoy, mock_core: VacuumModuleCore, subject: VacuumModuleContext
+) -> None:
+    """It should get the serial number from the core."""
+    decoy.when(mock_core.get_serial_number()).then_return("12345")
+    result = subject.serial_number
+    assert result == "12345"
+
+
+@pytest.mark.parametrize(
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 28))
+)
+def test_vacuum_module_manifold_dock_property(
+    subject: VacuumModuleContext,
+) -> None:
+    """The manifold_dock property should return correct ModuleFixtureLocation."""
+    assert isinstance(subject.manifold_dock, ModuleFixtureLocation)
+    assert "vacuumModuleV1Dock" in str(subject.manifold_dock)
+
+
+@pytest.mark.parametrize(
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 28))
+)
+def test_vacuum_module_load_adapter_to_dock(
+    decoy: Decoy,
+    subject: VacuumModuleContext,
+    mock_protocol_core: ProtocolCore,
+) -> None:
+    """It should successfully load a compatible collar onto the vacuum module dock."""
+    collar_name = "millipore_vacuum_manifold_collar_tall"
+    dock_location = ModuleFixtureLocation(addressable_area_name="vacuumModuleV1DockA4")
+
+    # Mock the LabwareCore that will be returned
+    mock_labware_core = decoy.mock(cls=LabwareCore)
+
+    # Set up what load_adapter should return
+    decoy.when(
+        mock_protocol_core.load_adapter(
+            load_name=collar_name,
+            location=dock_location,
+            namespace=None,
+            version=None,
+        )
+    ).then_return(mock_labware_core)
+
+    # Mock the properties that Labware wrapper accesses
+    decoy.when(mock_labware_core.load_name).then_return(collar_name)
+    decoy.when(mock_labware_core.get_name()).then_return("Millipore Vacuum Manifold Collar Tall")
+    decoy.when(mock_labware_core.get_well_columns()).then_return([])
+
+    # Act
+    result = subject.load_adapter_to_dock(collar_name)
+
+    # Assert
+    assert isinstance(result, Labware)
+    assert result.load_name == collar_name
+    assert result.name == "Millipore Vacuum Manifold Collar Tall"
+
+    # Verify the core call was made with correct ModuleFixtureLocation
+    decoy.verify(
+        mock_protocol_core.load_adapter(
+            load_name=collar_name,
+            location=dock_location,
+            namespace=None,
+            version=None,
+        )
+    )
+

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -86,16 +86,25 @@ async def test_load_labware_on_slot_or_addressable_area(
         ]
     )
 
-    decoy.when(state_view.geometry.ensure_location_not_occupied(location)).then_return(
-        sentinel.validated_empty_location
-    )
     decoy.when(
-        await equipment.load_labware(
-            location=sentinel.validated_empty_location,
+        await equipment.load_definition_for_details(
             load_name="some-load-name",
             namespace="opentrons-test",
             version=1,
-            labware_id=None,
+        )
+    ).then_return((well_plate_def, "opentrons-test/some-load-name/1"))
+
+    decoy.when(
+        state_view.geometry.ensure_location_not_occupied(location, None, well_plate_def)
+    ).then_return(sentinel.validated_empty_location)
+
+    decoy.when(
+        await equipment._load_labware_from_def_and_uri(
+            well_plate_def,
+            "opentrons-test/some-load-name/1",
+            sentinel.validated_empty_location,
+            None,
+            None,
         )
     ).then_return(
         LoadedLabwareData(
@@ -177,17 +186,26 @@ async def test_load_labware_on_labware(
     )
 
     decoy.when(
-        state_view.geometry.ensure_location_not_occupied(
-            OnLabwareLocation(labwareId="other-labware-id")
-        )
-    ).then_return(OnLabwareLocation(labwareId="another-labware-id"))
-    decoy.when(
-        await equipment.load_labware(
-            location=OnLabwareLocation(labwareId="another-labware-id"),
+        await equipment.load_definition_for_details(
             load_name="some-load-name",
             namespace="opentrons-test",
             version=1,
-            labware_id=None,
+        )
+    ).then_return((well_plate_def, "opentrons-test/some-load-name/1"))
+
+    decoy.when(
+        state_view.geometry.ensure_location_not_occupied(
+            OnLabwareLocation(labwareId="other-labware-id"), None, well_plate_def
+        )
+    ).then_return(OnLabwareLocation(labwareId="another-labware-id"))
+
+    decoy.when(
+        await equipment._load_labware_from_def_and_uri(
+            well_plate_def,
+            "opentrons-test/some-load-name/1",
+            OnLabwareLocation(labwareId="another-labware-id"),
+            None,
+            None,
         )
     ).then_return(
         LoadedLabwareData(
@@ -262,8 +280,16 @@ async def test_load_labware_raises_if_location_occupied(
     )
 
     decoy.when(
+        await equipment.load_definition_for_details(
+            load_name="some-load-name",
+            namespace="opentrons-test",
+            version=1,
+        )
+    ).then_return((well_plate_def, "opentrons-test/some-load-name/1"))
+
+    decoy.when(
         state_view.geometry.ensure_location_not_occupied(
-            DeckSlotLocation(slotName=DeckSlotName.SLOT_3)
+            DeckSlotLocation(slotName=DeckSlotName.SLOT_3), None, well_plate_def
         )
     ).then_raise(LocationIsOccupiedError("Get your own spot!"))
 

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -16,6 +16,7 @@ from opentrons_shared_data.errors.exceptions import (
 from opentrons_shared_data.gripper.constants import GRIPPER_PADDLE_WIDTH
 from opentrons_shared_data.labware.labware_definition import (
     Dimensions,
+    LabwareDefinition,
     LabwareDefinition2,
     Parameters2,
 )
@@ -92,6 +93,7 @@ def subject(
 )
 async def test_manual_move_labware_implementation(
     decoy: Decoy,
+    well_plate_def: LabwareDefinition,
     subject: MoveLabwareImplementation,
     equipment: EquipmentHandler,
     state_view: StateView,
@@ -116,9 +118,13 @@ async def test_manual_move_labware_implementation(
             offsetId=None,
         )
     )
+    lw_def = LabwareDefinition2.model_construct(namespace="opentrons-test")  # type: ignore[call-arg]
+    decoy.when(
+        state_view.labware.get_definition(labware_id="my-cool-labware-id")
+    ).then_return(lw_def)
     decoy.when(
         state_view.geometry.ensure_location_not_occupied(
-            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
+            DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
         )
     ).then_return(DeckSlotLocation(slotName=DeckSlotName.SLOT_5))
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/conftest.py
+++ b/api/tests/opentrons/protocol_engine/conftest.py
@@ -278,6 +278,13 @@ def flex_stacker_v1_def() -> ModuleDefinition:
 
 
 @pytest.fixture(scope="session")
+def vacuum_module_v1_def() -> ModuleDefinition:
+    """Get the definition of a V1 vacuum module."""
+    definition = load_shared_data("module/definitions/3/vacuumModuleV1.json")
+    return ModuleDefinition.model_validate_json(definition)
+
+
+@pytest.fixture(scope="session")
 def supported_tip_fixture() -> pipette_definition.SupportedTipsDefinition:
     """Get a mock supported tip definition."""
     return pipette_definition.SupportedTipsDefinition(

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -161,6 +161,7 @@ from opentrons.protocol_engine.types.liquid_level_detection import (
 from opentrons.types import (
     DeckSlotName,
     MeniscusTrackingTarget,
+    ModuleFixtureLocation,
     MountType,
     Point,
     StagingSlotName,
@@ -4857,12 +4858,12 @@ def test_get_ancestor_addressable_area_name_on_module(
     addressable_area_store: AddressableAreaStore,
     subject: GeometryView,
     nice_labware_definition: LabwareDefinition,
-    tempdeck_v2_def: ModuleDefinition,
+    vacuum_module_v1_def: ModuleDefinition,
 ) -> None:
     """Labware on a module returns the module's provided addressable area."""
     load_module = load_module_action(
         module_id="mod-1",
-        module_def=tempdeck_v2_def,
+        module_def=vacuum_module_v1_def,
         location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
         used_addressable_area="vacuumModuleV1A3",
     )
@@ -5021,3 +5022,4 @@ def test_get_parent_from_location_raises_when_not_on_deck(
 
     with pytest.raises(errors.LabwareNotOnDeckError):
         subject.get_parent_from_location(SYSTEM_LOCATION)
+

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -2839,9 +2839,20 @@ def test_ensure_location_not_occupied_raises(
     """It should raise error when labware is present in given location."""
     slot_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_4)
     # Shouldn't raise if neither labware nor module in location
+    decoy.when(mock_labware_view.get_all()).then_return([])
     assert subject.ensure_location_not_occupied(location=slot_location) == slot_location
 
     # Raise if labware in location
+    decoy.when(mock_labware_view.get_all()).then_return(
+        [
+            LoadedLabware(
+                id="some-id",
+                loadName="some-name",
+                definitionUri="1234",
+                location=slot_location,
+            )
+        ]
+    )
     decoy.when(
         mock_labware_view.raise_if_labware_in_location(slot_location)
     ).then_raise(errors.LocationIsOccupiedError("Woops!"))


### PR DESCRIPTION
# Overview

This PR adds initial support in the load_labware protocol engine command for loading the Millipore vacuum manifold collar onto the vacuum module’s private staging dock. It introduces the foundational labware containment functionality needed to support nested workflows with the vacuum module.

## Test Plan and Hands on Testing

The following protocol should simulate

```python
from opentrons.protocol_api import ProtocolContext

"""Load Vacuum Module."""

metadata = {
    "protocolName": "Vacuum Module API",
    "author": "Opentrons <protocols@opentrons.com>",
}
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.28",
}

def run(ctx: ProtocolContext) -> None:
    """Protocol."""

    vm_mod = ctx.load_module( module_name="vacuumModuleV1", location="A3")
    manifold_collar = vm_mod.load_adapter_to_dock('millipore_vacuum_manifold_collar_tall')
```

## Changelog

- Added load_adapter_to_dock() method on VacuumModuleContext to conveniently load compatible adapters (such as the manifold collar) directly onto the dock.
- Introduced early labware containment support in the API layer to allow loading labware inside adapters that define `containedSpace`.
- Enabled loading the `millipore_vacuum_manifold_collar_tall` onto the vacuum module dock (location "A4" on Flex).
- Updated protocol execution flow to support collar + filter plate nesting scenarios.
- Minor updates to labware loading logic to handle the new dock addressable area.

## Review requests
## Risk assessment
