### PR TITLE
docs: remove link to GitHub issues in manuals

### DIFF
--- a/docs/flex/docs/open-source.md
+++ b/docs/flex/docs/open-source.md
@@ -3,74 +3,43 @@ title: "Opentrons Flex: Open-Source Software"
 description: "GitHub, releases, contributing, and other resources for Flex software."
 ---
 
-Opentrons believes that open-source software and hardware make science
-better. That's why we make our code available on GitHub and welcome
-contributions from the open-source community.
+Opentrons believes that open-source software and hardware make science better. That's why we make our code available on GitHub and welcome contributions from the open-source community.
 
-This appendix covers various ways to use Opentrons open-source resources
-and describes the structure of our repositories.
+This appendix covers various ways to use Opentrons open-source resources and describes the structure of our repositories.
 
 ## Opentrons on GitHub
 
-The Opentrons GitHub organization can be found at <https://github.com/Opentrons>. All of our publicly
-hosted code resides there, including the Flex robot software, the
-Opentrons App, and our Python and HTTP APIs.
+The Opentrons GitHub organization can be found at <https://github.com/Opentrons>. All of our publicly hosted code resides there, including the Flex robot software, the Opentrons App, and our Python and HTTP APIs.
 
-Our GitHub site has several useful resources for Flex users, and you can
-participate in our community even if you're not a coder.
+Our GitHub site has several useful resources for Flex users, and you can participate in our community even if you're not a coder.
 
 !!! note
     As you browse our GitHub repositories, you will encounter references to `ot3`, which is a model identifier for Opentrons Flex. If you're having trouble finding something when searching for "Flex", try searching for "ot3" or "OT-3" instead.
 
 ### Releases
 
-Whenever we create a new version of the robot software and Opentrons
-App, we publish it on GitHub as a release. Past releases of Opentrons
-software are kept at <https://github.com/Opentrons/opentrons/releases>.
+Whenever we create a new version of the robot software and Opentrons App, we publish it on GitHub as a release. Past releases of Opentrons software are kept at <https://github.com/Opentrons/opentrons/releases>.
 
-Opentrons recommends running the latest version of our software.
-However, we recognize that some users need access to previous versions
-(e.g., for validation or compliance purposes). Download previous
-versions of the Opentrons App or robot software under the **Assets**
-section of each release entry on GitHub.
+Opentrons recommends running the latest version of our software. However, we recognize that some users need access to previous versions (e.g., for validation or compliance purposes). Download previous versions of the Opentrons App or robot software under the **Assets** section of each release entry on GitHub.
 
 ### Opening issues
 
-Contact Opentrons Support first if you're having a problem with your
-robot. Before opening an issue, search through [existing issues](https://github.com/Opentrons/opentrons/issues) to prevent creating a
-duplicate.
-
-We accept two types of issue reports: bugs and feature requests. Each
-has its own issue template. Fill out all parts of the template with as
-much detail as possible to help us address your issue completely and
-quickly.
+Contact [Opentrons Support](https://opentrons.com/opentrons-support) for technical assistance with your robot. We are unable to accept support requests submitted via the GitHub Issues tab.
 
 ### Contributing code
 
-Get started working with Opentrons code by following the [development environment setup instructions](https://github.com/Opentrons/opentrons/blob/edge/DEV_SETUP.md). Work on your
-code in your own fork and then create a pull request to contribute to
-our codebase. For additional details on creating pull requests,
-including testing requirements, see the [contributing guide](https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md).
+Get started working with Opentrons code by following the [development environment setup instructions](https://github.com/Opentrons/opentrons/blob/edge/DEV_SETUP.md). Work on your code in your own fork and then create a pull request to contribute to
+our codebase. For additional details on creating pull requests, including testing requirements, see the [contributing guide](https://github.com/Opentrons/opentrons/blob/edge/CONTRIBUTING.md).
 
 ### Open-source licenses
 
-Most Opentrons repositories are licensed under the Apache License 2.0,
-but some use other licenses. Consult the license on each repository
-before using or modifying the code it contains. Keep in mind that any
-code you contribute will be governed by the license in place on the
-corresponding repository.
+Most Opentrons repositories are licensed under the Apache License 2.0, but some use other licenses. Consult the license on each repository before using or modifying the code it contains. Keep in mind that any code you contribute will be governed by the license in place on the corresponding repository.
 
 ## Opentrons monorepo
 
-Most of our software is in the [Opentrons/opentrons](https://github.com/Opentrons/opentrons) *monorepo*: a single repository that
-contains multiple software projects, each in its own directory. The
-`README.md` file in each directory describes the project and gives advice
-on working with the code. The default branch in the monorepo is called
-`edge`.
+Most of our software is in the [Opentrons/opentrons](https://github.com/Opentrons/opentrons) *monorepo*: a single repository that contains multiple software projects, each in its own directory. The `README.md` file in each directory describes the project and gives advice on working with the code. The default branch in the monorepo is called `edge`.
 
-The following (non-exhaustive) list of directories, subdirectories, and
-files can help you navigate the monorepo and find code relevant to using
-Flex.
+The following (non-exhaustive) list of directories, subdirectories, and files can help you navigate the monorepo and find code relevant to using Flex.
 
 | Path {width="25%"} | Description |
 |------|-------------|
@@ -90,8 +59,7 @@ Flex.
 
 ## Other repositories
 
-Opentrons also maintains software outside of the monorepo. A few key
-repositories include:
+Opentrons also maintains software outside of the monorepo. A few key repositories include:
 
 | Repository {width="25%"} | Description |
 |---|---|


### PR DESCRIPTION
# Overview

Re: https://github.com/Opentrons/opentrons/pull/21254 

We no longer accept customer issues via GitHub. Update a section in the Flex manual to include this change.

RTC-981

## Test Plan and Hands on Testing

n/a

## Changelog

Revising a small H3 section in `open-source.md`. We could either go with the revision in this PR or remove the subsection completely. The manual pushes people to support links throughout.

## Review requests

- I don't think this is in the OT-2 manual. Am I missing other locations?

## Risk assessment

- Below sea level.
