### PR TITLE
refactor(api): update relelvant simulate tests to utilize Flex robot

### DIFF
--- a/api/tests/opentrons/data/flex_bug_aspirate_tip.py
+++ b/api/tests/opentrons/data/flex_bug_aspirate_tip.py
@@ -1,0 +1,18 @@
+from opentrons import protocol_api
+
+metadata = {
+    "protocolName": "Bug 7552 - Flex",
+    "author": "Opentrons <engineering@opentrons.com>",
+    "description": "Simulation allows aspirating and dispensing on a tip rack",
+}
+
+requirements = {"robotType": "Flex", "apiLevel": "2.16"}
+
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    protocol.load_trash_bin("A3")
+    plate = protocol.load_labware("opentrons_flex_96_tiprack_50ul", "D1")
+
+    pipette = protocol.load_instrument("flex_1channel_50", "left", tip_racks=[plate])
+
+    pipette.transfer(5, plate.wells_by_name()["A1"], plate.wells_by_name()["B1"])

--- a/api/tests/opentrons/data/flex_drop_tip.py
+++ b/api/tests/opentrons/data/flex_drop_tip.py
@@ -1,0 +1,12 @@
+from opentrons import protocol_api
+
+requirements = {"robotType": "Flex", "apiLevel": "2.16"}
+
+
+def run(ctx: protocol_api.ProtocolContext) -> None:
+    ctx.load_trash_bin("A3")
+    tipracks = [ctx.load_labware("opentrons_flex_96_tiprack_1000ul", "D1")]
+    m1000 = ctx.load_instrument("flex_8channel_1000", "right", tipracks)
+
+    m1000.pick_up_tip()
+    m1000.drop_tip()

--- a/api/tests/opentrons/data/flex_testosaur.py
+++ b/api/tests/opentrons/data/flex_testosaur.py
@@ -1,0 +1,21 @@
+from opentrons import protocol_api
+
+metadata = {
+    "protocolName": "Flex Testosaur",
+    "author": "Opentrons <engineering@opentrons.com>",
+    "description": 'A Flex variant on "Dinosaur" for testing',
+    "source": "Opentrons Repository",
+}
+
+requirements = {"robotType": "Flex", "apiLevel": "2.16"}
+
+
+def run(ctx: protocol_api.ProtocolContext) -> None:
+    ctx.load_trash_bin("A3")
+    tr = ctx.load_labware("opentrons_flex_96_tiprack_1000ul", "D1")
+    right = ctx.load_instrument("flex_1channel_1000", "right", tip_racks=[tr])
+    lw = ctx.load_labware("corning_96_wellplate_360ul_flat", "D2")
+    right.pick_up_tip()
+    right.aspirate(100, lw.wells()[0].bottom())
+    right.dispense(100, lw.wells()[1].bottom())
+    right.drop_tip()

--- a/api/tests/opentrons/test_simulate.py
+++ b/api/tests/opentrons/test_simulate.py
@@ -6,22 +6,21 @@ import io
 import json
 import textwrap
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Generator, List, TextIO, cast
+from typing import TYPE_CHECKING, Generator, List, TextIO, cast
 
 import pytest
 from _pytest.fixtures import SubRequest
 
 from opentrons_shared_data import get_shared_data_root, load_shared_data
 
-from opentrons import protocols, simulate
+from opentrons import simulate
 from opentrons.protocols.api_support.definitions import MIN_SUPPORTED_VERSION_FOR_FLEX
 from opentrons.protocols.api_support.types import APIVersion
-from opentrons.protocols.execution.errors import ExceptionInProtocolError
 from opentrons.protocols.types import ApiDeprecationError
 from opentrons.util import entrypoint_util
 
 if TYPE_CHECKING:
-    from tests.opentrons.conftest import Bundle, Protocol
+    from tests.opentrons.conftest import Protocol
 
 
 HERE = Path(__file__).parent
@@ -37,133 +36,44 @@ def api_version(request: SubRequest) -> APIVersion:
     return cast(APIVersion, request.param)
 
 
-# TODO(jh, 04-07-2026): A lot of these tests are irrelevant now that the OT-2 is no longer supported in the monorepo.
-#  Out of the skipped tests, identify which to modify & keep and which to remove.
-@pytest.mark.skip(reason="OT-2 protocols are no longer supported by simulate()")
-@pytest.mark.parametrize(
-    "protocol_file",
-    [
-        "testosaur_v2.py",
-        pytest.param(
-            "testosaur_v2_14.py",
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    "We can't currently get bundle contents"
-                    " from protocols run through Protocol Engine."
-                ),
-            ),
-        ),
-    ],
-)
-def test_simulate_function_apiv2_bundle(
-    protocol: Protocol,
-    protocol_file: str,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Test that `simulate()` returns the expected bundle contents from a Python file."""
-    monkeypatch.setenv("OT_API_FF_allowBundleCreation", "1")
-    _, bundle_contents = simulate.simulate(protocol.filelike, protocol.filename)
-    assert isinstance(bundle_contents, protocols.types.BundleContents)
-
-
-@pytest.mark.skip(reason="OT-2 protocols are no longer supported by simulate()")
 @pytest.mark.parametrize("protocol_file", ["testosaur_v2.py", "testosaur_v2_14.py"])
-def test_simulate_without_filename(protocol: Protocol, protocol_file: str) -> None:
-    """`simulate()` should accept a protocol without a filename."""
-    simulate.simulate(protocol.filelike)  # Should not raise.
+def test_simulate_without_filename_rejects_ot2(
+    protocol: Protocol, protocol_file: str
+) -> None:
+    """`simulate()` should reject OT-2 protocols."""
+    with pytest.raises(RuntimeError, match="OT-2"):
+        simulate.simulate(protocol.filelike)
 
 
-@pytest.mark.skip(reason="OT-2 protocols are no longer supported by simulate()")
 @pytest.mark.parametrize(
     ("protocol_file", "expected_entries"),
     [
         (
-            "testosaur_v2.py",
+            "flex_testosaur.py",
             [
-                "Picking up tip from A1 of Opentrons OT-2 96 Tip Rack 1000 µL on 1",
-                "Aspirating 100.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on 2 at 500.0 uL/sec",
-                "Dispensing 100.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on 2 at 1000.0 uL/sec",
-                "Dropping tip into H12 of Opentrons OT-2 96 Tip Rack 1000 µL on 1",
+                "Picking up tip from A1 of Opentrons Flex 96 Tip Rack 1000 µL on slot D1",
+                "Aspirating 100.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on slot D2 at 716.0 uL/sec",
+                "Dispensing 100.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on slot D2 at 716.0 uL/sec",
+                "Dropping tip into Trash Bin on slot A3",
             ],
         ),
         (
-            "testosaur_v2_14.py",
+            "flex_drop_tip.py",
             [
-                "Picking up tip from A1 of Opentrons OT-2 96 Tip Rack 1000 µL on slot 1",
-                "Aspirating 100.0 uL from A1 of Corning 96 Well Plate 360 µL Flat on slot 2 at 500.0 uL/sec",
-                "Dispensing 100.0 uL into B1 of Corning 96 Well Plate 360 µL Flat on slot 2 at 1000.0 uL/sec",
-                "Dropping tip into H12 of Opentrons OT-2 96 Tip Rack 1000 µL on slot 1",
-            ],
-        ),
-        (
-            "ot2_drop_tip.py",
-            [
-                "Picking up tip from A1 of Opentrons OT-2 96 Tip Rack 300 µL on slot 5",
-                "Dropping tip into Trash Bin on slot 12",
+                "Picking up tip from A1 of Opentrons Flex 96 Tip Rack 1000 µL on slot D1",
+                "Dropping tip into Trash Bin on slot A3",
             ],
         ),
     ],
 )
-def test_simulate_function_apiv2_run_log(
+def test_simulate_function_flex_run_log(
     protocol: Protocol,
     protocol_file: str,
     expected_entries: List[str],
 ) -> None:
-    """Test that `simulate()` returns the expected run log from a Python file."""
+    """Test that `simulate()` returns the expected run log from a Flex Python file."""
     run_log, _ = simulate.simulate(protocol.filelike, protocol.filename)
     assert [item["payload"]["text"] for item in run_log] == expected_entries
-
-
-@pytest.mark.skip(reason="OT-2 protocols are no longer supported by simulate()")
-def test_simulate_function_json(
-    get_json_protocol_fixture: Callable[[str, str, bool], str],
-) -> None:
-    """Test `simulate()` with a JSON file."""
-    jp = get_json_protocol_fixture("3", "simple", False)
-    filelike = io.StringIO(jp)
-    runlog, bundle = simulate.simulate(filelike, "simple.json")
-    assert bundle is None
-    assert [item["payload"]["text"] for item in runlog] == [
-        "Picking up tip from B1 of Opentrons 96 Tip Rack 10 µL on 1",
-        "Aspirating 5.0 uL from A1 of Source Plate on 2 at 3.0 uL/sec",
-        "Delaying for 0 minutes and 42.0 seconds",
-        "Dispensing 4.5 uL into B1 of Dest Plate on 3 at 2.5 uL/sec",
-        "Touching tip",
-        "Blowing out into B1 of Dest Plate on 3 at 2.0 uL/sec",
-        "Moving to 5",
-        "Dropping tip into A1 of Trash on 12",
-    ]
-
-
-@pytest.mark.skip(reason="OT-2 protocols are no longer supported by simulate()")
-def test_simulate_function_bundle_apiv2(
-    get_bundle_fixture: Callable[[str], Bundle],
-) -> None:
-    """Test `simulate()` with a .zip bundle."""
-    bundle_fixture = get_bundle_fixture("simple_bundle")
-    runlog, bundle = simulate.simulate(
-        cast(TextIO, bundle_fixture["filelike"]),
-        "simple_bundle.zip",
-    )
-    assert bundle is None
-    assert [item["payload"]["text"] for item in runlog] == [
-        "Transferring 1.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1",
-        "Picking up tip from A1 of Opentrons OT-2 96 Tip Rack 10 µL on 3",
-        "Aspirating 1.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec",
-        "Dispensing 1.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec",
-        "Dropping tip into A1 of Opentrons Fixed Trash on 12",
-        "Transferring 2.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1",
-        "Picking up tip from B1 of Opentrons OT-2 96 Tip Rack 10 µL on 3",
-        "Aspirating 2.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec",
-        "Dispensing 2.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec",
-        "Dropping tip into A1 of Opentrons Fixed Trash on 12",
-        "Transferring 3.0 from A1 of FAKE example labware on 1 to A4 of FAKE example labware on 1",
-        "Picking up tip from C1 of Opentrons OT-2 96 Tip Rack 10 µL on 3",
-        "Aspirating 3.0 uL from A1 of FAKE example labware on 1 at 5.0 uL/sec",
-        "Dispensing 3.0 uL into A4 of FAKE example labware on 1 at 10.0 uL/sec",
-        "Dropping tip into A1 of Opentrons Fixed Trash on 12",
-    ]
 
 
 @pytest.mark.parametrize("protocol_file", ["testosaur.py"])
@@ -173,16 +83,14 @@ def test_simulate_function_v1(protocol: Protocol, protocol_file: str) -> None:
         simulate.simulate(protocol.filelike, "testosaur.py")
 
 
-@pytest.mark.skip(reason="OT-2 protocols are no longer supported by simulate()")
-@pytest.mark.parametrize("protocol_file", ["bug_aspirate_tip.py"])
-def test_simulate_aspirate_tip(
+@pytest.mark.parametrize("protocol_file", ["flex_bug_aspirate_tip.py"])
+def test_simulate_aspirate_tip_flex(
     protocol: Protocol,
     protocol_file: str,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Integration test for https://github.com/opentrons/opentrons/issues/7552."""
-    with pytest.raises(ExceptionInProtocolError):
-        simulate.simulate(protocol.filelike, "bug_aspirate_tip.py")
+    with pytest.raises(entrypoint_util.ProtocolEngineExecuteError):
+        simulate.simulate(protocol.filelike, "flex_bug_aspirate_tip.py")
 
 
 class TestSimulatePythonLabware:


### PR DESCRIPTION
Closes [EXEC-2519](https://opentrons.atlassian.net/browse/EXEC-2519)

# Overview

When we introduced [OT-2 protocols failing simulation](https://github.com/Opentrons/opentrons/pull/21204), we marked several of the simulation tests as skippable, since they required some thought as to whether or not they are necessary to keep.

This PR attempts to do that thinking, creating Flex-equivalent protocols when necessary and deleting tests that no longer apply, since they were truly OT-2 specific. 

## Test Plan and Hands on Testing

- Does CI pass? 

## Risk assessment

- none, just testing cleanup

[EXEC-2519]: https://opentrons.atlassian.net/browse/EXEC-2519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ