### PR TITLE
feat(app): Introduce Redux Toolkit and add a slice for robot auth

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -29,6 +29,7 @@
     "@opentrons/react-api-client": "link:../react-api-client",
     "@opentrons/shared-data": "link:../shared-data",
     "@opentrons/step-generation": "link:../step-generation",
+    "@reduxjs/toolkit": "2.11.2",
     "@sentry/electron": "7.5.0",
     "@thi.ng/paths": "5.1.63",
     "@types/uuid": "^3.4.7",

--- a/app/src/redux/ActionTypesFromSlice.ts
+++ b/app/src/redux/ActionTypesFromSlice.ts
@@ -1,0 +1,15 @@
+/**
+ * A utility for extracting action types from a Redux Toolkit slice.
+ *
+ * For example:
+ *
+ *   const fooSlice = createSlice(...)
+ *   export type FooAction = ActionTypesFromSlice<typeof fooSlice.actions>
+ */
+export type ActionTypesFromSlice<ActionsObject> = {
+  [Key in keyof ActionsObject]: ActionsObject[Key] extends (
+    ...args: any[]
+  ) => infer Return
+    ? Return
+    : never
+}[keyof ActionsObject]

--- a/app/src/redux/reducer.ts
+++ b/app/src/redux/reducer.ts
@@ -22,6 +22,8 @@ import { protocolStorageReducer } from './protocol-storage/reducer'
 import { robotAdminReducer } from './robot-admin/reducer'
 // api state
 import { robotApiReducer } from './robot-api/reducer'
+// robot auth state
+import { robotAuthReducer } from './robot-auth/slice'
 // robot controls state
 import { robotControlsReducer } from './robot-controls/reducer'
 // robot settings state
@@ -43,8 +45,9 @@ export const rootReducer: Reducer<State, Action> = (
   action: Action
 ): State => {
   const combinedReducer = combineReducers({
-    robotApi: robotApiReducer,
     robotAdmin: robotAdminReducer,
+    robotApi: robotApiReducer,
+    robotAuth: robotAuthReducer,
     robotControls: robotControlsReducer,
     robotSettings: robotSettingsReducer,
     robotUpdate: robotUpdateReducer,

--- a/app/src/redux/robot-auth/__tests__/reducer.test.ts
+++ b/app/src/redux/robot-auth/__tests__/reducer.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  INITIAL_ROBOT_AUTH_STATE,
+  logInOrRefresh,
+  logOutOrTimeOut,
+  robotAuthReducer,
+} from '../slice'
+
+import type { RobotAuthState } from '../slice'
+
+describe('robotAuthReducer', () => {
+  it('uses empty object as initial state', () => {
+    expect(
+      robotAuthReducer(undefined, { type: 'not-handled' } as any)
+    ).toStrictEqual({})
+  })
+
+  it('handles logins and login refreshes', () => {
+    let state: RobotAuthState = INITIAL_ROBOT_AUTH_STATE
+
+    // Log in to first robot:
+    state = robotAuthReducer(
+      INITIAL_ROBOT_AUTH_STATE,
+      logInOrRefresh({
+        robotName: 'testRobotNameA',
+        username: 'testUserA',
+        accessToken: 'testAccessTokenA',
+        refreshToken: 'testRefreshTokenA',
+        expiresAt: 1234,
+      })
+    )
+    expect(state).toStrictEqual({
+      testRobotNameA: {
+        username: 'testUserA',
+        accessToken: 'testAccessTokenA',
+        refreshToken: 'testRefreshTokenA',
+        expiresAt: 1234,
+      },
+    })
+
+    // Log in to second robot:
+    state = robotAuthReducer(
+      state,
+      logInOrRefresh({
+        robotName: 'testRobotNameB',
+        username: 'testUserB',
+        accessToken: 'testAccessTokenB',
+        refreshToken: null,
+        expiresAt: 5678,
+      })
+    )
+    expect(state).toStrictEqual({
+      testRobotNameA: {
+        username: 'testUserA',
+        accessToken: 'testAccessTokenA',
+        refreshToken: 'testRefreshTokenA',
+        expiresAt: 1234,
+      },
+      testRobotNameB: {
+        username: 'testUserB',
+        accessToken: 'testAccessTokenB',
+        refreshToken: null,
+        expiresAt: 5678,
+      },
+    })
+
+    // Refresh login for first robot:
+    state = robotAuthReducer(
+      state,
+      logInOrRefresh({
+        robotName: 'testRobotNameA',
+        username: 'testUserARefreshed',
+        accessToken: 'testAccessTokenARefreshed',
+        refreshToken: 'testRefreshTokenARefreshed',
+        expiresAt: 4321,
+      })
+    )
+    expect(state).toStrictEqual({
+      testRobotNameA: {
+        username: 'testUserARefreshed',
+        accessToken: 'testAccessTokenARefreshed',
+        refreshToken: 'testRefreshTokenARefreshed',
+        expiresAt: 4321,
+      },
+      testRobotNameB: {
+        username: 'testUserB',
+        accessToken: 'testAccessTokenB',
+        refreshToken: null,
+        expiresAt: 5678,
+      },
+    })
+  })
+
+  it('handles logouts', () => {
+    const initialState: RobotAuthState = {
+      testRobotNameA: {
+        username: 'testUserA',
+        accessToken: 'testAccessTokenA',
+        refreshToken: 'testRefreshTokenA',
+        expiresAt: 1234,
+      },
+      testRobotNameB: {
+        username: 'testUserB',
+        accessToken: 'testAccessTokenB',
+        refreshToken: 'testRefreshTokenB',
+        expiresAt: 5678,
+      },
+    }
+
+    const newState = robotAuthReducer(
+      initialState,
+      logOutOrTimeOut({
+        robotName: 'testRobotNameB',
+      })
+    )
+    expect(newState).toStrictEqual({
+      testRobotNameA: initialState.testRobotNameA,
+    })
+  })
+})

--- a/app/src/redux/robot-auth/__tests__/selectors.test.ts
+++ b/app/src/redux/robot-auth/__tests__/selectors.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { getAuthStateForRobot } from '../slice'
+
+import type { State } from '../../types'
+
+describe('robot auth selectors', () => {
+  const stateWithRobotA = {
+    robotAuth: {
+      robotA: {
+        username: 'alice',
+        accessToken: 'token-a',
+        refreshToken: null,
+        expiresAt: 1234,
+      },
+    },
+  } as unknown as State
+
+  const emptyRobotAuthState = { robotAuth: {} } as unknown as State
+
+  describe('getAuthStateForRobot', () => {
+    it('returns null when robot is not in state', () => {
+      expect(getAuthStateForRobot(emptyRobotAuthState, 'robotA')).toEqual(null)
+    })
+
+    it('returns per-robot auth when present', () => {
+      expect(getAuthStateForRobot(stateWithRobotA, 'robotA')).toEqual({
+        username: 'alice',
+        accessToken: 'token-a',
+        refreshToken: null,
+        expiresAt: 1234,
+      })
+    })
+  })
+})

--- a/app/src/redux/robot-auth/hooks.ts
+++ b/app/src/redux/robot-auth/hooks.ts
@@ -1,9 +1,0 @@
-import { useSelector } from 'react-redux'
-
-import { getRobotToken } from './slice'
-
-import type { State } from '/app/redux/types'
-
-export function useRobotToken(robotName: string | null): string | null {
-  return useSelector((state: State) => getRobotToken(state, robotName))
-}

--- a/app/src/redux/robot-auth/hooks.ts
+++ b/app/src/redux/robot-auth/hooks.ts
@@ -1,0 +1,9 @@
+import { useSelector } from 'react-redux'
+
+import { getRobotToken } from './slice'
+
+import type { State } from '/app/redux/types'
+
+export function useRobotToken(robotName: string | null): string | null {
+  return useSelector((state: State) => getRobotToken(state, robotName))
+}

--- a/app/src/redux/robot-auth/index.ts
+++ b/app/src/redux/robot-auth/index.ts
@@ -1,0 +1,1 @@
+export * from './slice'

--- a/app/src/redux/robot-auth/slice.ts
+++ b/app/src/redux/robot-auth/slice.ts
@@ -2,7 +2,7 @@
 
 import { createSlice } from '@reduxjs/toolkit'
 
-import { type ActionTypesFromSlice } from '../actionTypesFromSlice'
+import { type ActionTypesFromSlice } from '../ActionTypesFromSlice'
 
 import type { PayloadAction } from '@reduxjs/toolkit'
 import type { State } from '/app/redux/types'

--- a/app/src/redux/robot-auth/slice.ts
+++ b/app/src/redux/robot-auth/slice.ts
@@ -1,0 +1,79 @@
+/** The Redux slice for authorization and authentication. */
+
+import { createSlice } from '@reduxjs/toolkit'
+
+import { type ActionTypesFromSlice } from '../actionTypesFromSlice'
+
+import type { PayloadAction } from '@reduxjs/toolkit'
+import type { State } from '/app/redux/types'
+
+export interface RobotAuthState {
+  [robotName: string]: PerRobotAuthState | undefined
+}
+
+interface PerRobotAuthState {
+  /** The username that we're currently logged in as. */
+  username: string
+
+  /** The OAuth 2 access token, for making robot API requests. */
+  accessToken: string
+
+  /**
+   * The OAuth 2 refresh token, if the server issued one,
+   * for refreshing the access token.
+   */
+  refreshToken: string | null
+
+  /**
+   * When the access token expires, as milliseconds since epoch,
+   * if the server supplied this information.
+   */
+  expiresAt: number | null
+}
+
+export const INITIAL_ROBOT_AUTH_STATE: RobotAuthState = {}
+
+/** Stores the result of logging in to a robot, of refreshing an existing login. */
+interface LogInOrRefreshPayload {
+  robotName: string
+  username: string
+  accessToken: string
+  refreshToken: string | null
+  expiresAt: number | null
+}
+
+/** Stores the result of logging out of a robot, or of a login naturally timing out. */
+interface LogOutOrTimeOutPayload {
+  robotName: string
+}
+
+const robotAuthSlice = createSlice({
+  name: 'robotAuth',
+  initialState: INITIAL_ROBOT_AUTH_STATE,
+  reducers: {
+    logInOrRefresh(state, action: PayloadAction<LogInOrRefreshPayload>) {
+      const { robotName, ...robotAuthState } = action.payload
+      state[robotName] = robotAuthState
+    },
+    logOutOrTimeOut(state, action: PayloadAction<LogOutOrTimeOutPayload>) {
+      // dynamic-delete is normal and fine with Immer and Redux.
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete state[action.payload.robotName]
+    },
+  },
+})
+
+export const robotAuthReducer = robotAuthSlice.reducer
+
+export const { logInOrRefresh, logOutOrTimeOut } = robotAuthSlice.actions
+
+export type RobotAuthAction = ActionTypesFromSlice<
+  typeof robotAuthSlice.actions
+>
+
+export function getAuthStateForRobot(
+  state: State,
+  robotName: string
+): PerRobotAuthState | null {
+  return state.robotAuth?.[robotName] ?? null
+}

--- a/app/src/redux/types.ts
+++ b/app/src/redux/types.ts
@@ -23,6 +23,7 @@ import type {
 } from './protocol-storage/types'
 import type { RobotAdminAction, RobotAdminState } from './robot-admin/types'
 import type { RobotApiAction, RobotApiState } from './robot-api/types'
+import type { RobotAuthAction, RobotAuthState } from './robot-auth'
 import type {
   RobotControlsAction,
   RobotControlsState,
@@ -42,6 +43,7 @@ import type { SystemInfoAction, SystemInfoState } from './system-info/types'
 
 export interface State {
   readonly robotApi: RobotApiState
+  readonly robotAuth: RobotAuthState
   readonly robotAdmin: RobotAdminState
   readonly robotControls: RobotControlsState
   readonly robotSettings: RobotSettingsState
@@ -63,6 +65,7 @@ export interface State {
 export type Action =
   | RobotApiAction
   | RobotAdminAction
+  | RobotAuthAction
   | RobotControlsAction
   | RobotSettingsAction
   | RobotUpdateAction

--- a/yarn.lock
+++ b/yarn.lock
@@ -3935,6 +3935,7 @@
     "@opentrons/react-api-client" "link:react-api-client"
     "@opentrons/shared-data" "link:shared-data"
     "@opentrons/step-generation" "link:step-generation"
+    "@reduxjs/toolkit" "2.11.2"
     "@sentry/electron" "7.5.0"
     "@thi.ng/paths" "5.1.63"
     "@types/uuid" "^3.4.7"
@@ -4428,6 +4429,18 @@
     "@react-spring/core" "~9.6.1"
     "@react-spring/shared" "~9.6.1"
     "@react-spring/types" "~9.6.1"
+
+"@reduxjs/toolkit@2.11.2":
+  version "2.11.2"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-2.11.2.tgz#582225acea567329ca6848583e7dd72580d38e82"
+  integrity sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==
+  dependencies:
+    "@standard-schema/spec" "^1.0.0"
+    "@standard-schema/utils" "^0.3.0"
+    immer "^11.0.0"
+    redux "^5.0.1"
+    redux-thunk "^3.1.0"
+    reselect "^5.1.0"
 
 "@remix-run/router@1.17.1":
   version "1.17.1"
@@ -5440,6 +5453,16 @@
     "@smithy/abort-controller" "^3.0.0"
     "@smithy/types" "^3.0.0"
     tslib "^2.6.2"
+
+"@standard-schema/spec@^1.0.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/spec/-/spec-1.1.0.tgz#a79b55dbaf8604812f52d140b2c9ab41bc150bb8"
+  integrity sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==
+
+"@standard-schema/utils@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/utils/-/utils-0.3.0.tgz#3d5e608f16c2390c10528e98e59aef6bf73cae7b"
+  integrity sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==
 
 "@storybook/addon-actions@7.6.21":
   version "7.6.21"
@@ -13318,6 +13341,11 @@ immer@^10.1.3:
   resolved "https://registry.yarnpkg.com/immer/-/immer-10.1.3.tgz#e38a0b97db59949d31d9b381b04c2e441b1c3747"
   integrity sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==
 
+immer@^11.0.0:
+  version "11.1.4"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-11.1.4.tgz#37aee86890b134a8f1a2fadd44361fb86c6ae67e"
+  integrity sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==
+
 "immutable@^3.8.1 || ^4.0.0":
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.5.tgz#f8b436e66d59f99760dc577f5c99a4fd2a5cc5a0"
@@ -18126,12 +18154,12 @@ redux-observable@1.1.0:
   resolved "https://registry.yarnpkg.com/redux-observable/-/redux-observable-1.1.0.tgz#323a8fe53e89fdb519be2807b55f08e21c13e6f1"
   integrity sha512-G0nxgmTZwTK3Z3KoQIL8VQu9n0YCUwEP3wc3zxKQ8zAZm+iYkoZvBqAnBJfLi4EsD1E64KR4s4jFH/dFXpV9Og==
 
-redux-thunk@3.1.0:
+redux-thunk@3.1.0, redux-thunk@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-3.1.0.tgz#94aa6e04977c30e14e892eae84978c1af6058ff3"
   integrity sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==
 
-redux@5.0.1:
+redux@5.0.1, redux@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/redux/-/redux-5.0.1.tgz#97fa26881ce5746500125585d5642c77b6e9447b"
   integrity sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==
@@ -18448,7 +18476,7 @@ resedit@^1.7.0:
   dependencies:
     pe-library "^0.4.1"
 
-reselect@5.1.1:
+reselect@5.1.1, reselect@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-5.1.1.tgz#c766b1eb5d558291e5e550298adb0becc24bb72e"
   integrity sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==


### PR DESCRIPTION
## Overview

This introduces some more modern Redux patterns (going towards EXEC-1475 and EXEC-1476), and takes a first pass at implementing the client-side state for access control mode (going generally towards EXEC-1792).

## Changelog

* Install Redux Toolkit. As discussed in Slack, this is how we want to use Redux going forward. In this case, it reduces the boilerplate by like 4x. It really is so much better.
* Using Redux Toolkit, take a first pass at the client-side state for access control mode. Nothing uses this yet.

## Test Plan and Hands on Testing

* [x] Unit tests.
* [x] Smoke-test the desktop app to make sure I didn't flagrantly break anything in the top-level wireup.

## Review requests

This is the first code that's using Redux toolkit, which means it's going to be copied a lot as we adopt it further. So let's put some care and thought into the patterns that we're setting up. File layout, testing strategies, and so on.

I wouldn't put too much thought into the actual auth-specific logic. It's certainly going to evolve in the future as we start actually wiring this up to the UI. Treat this less as an "add robot auth" PR, more as an "introduce Redux Toolkit" PR.

## Risk assessment

Low.
