### PR TITLE
refactor(robot-server): start the run subprocess eagerly

### DIFF
--- a/robot-server/robot_server/app_setup.py
+++ b/robot-server/robot_server/app_setup.py
@@ -30,6 +30,7 @@ from .persistence.fastapi_dependencies import (
 from .router import router
 from .runs.dependencies import (
     mark_light_control_startup_finished,
+    set_up_run_process_pyro_provider,
     start_light_control_task,
 )
 from .service.logging import initialize_logging
@@ -109,6 +110,9 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
         # Always make an empty Robot Server Pyro Resource, and populate if appropriate
         start_initializing_pyro_resource(app_state=app.state)
+
+        # Start the run process pyro provider so a process is ready when a run starts
+        exit_stack.enter_context(set_up_run_process_pyro_provider(app.state))
 
         yield  # Start handling HTTP requests.
 

--- a/robot-server/robot_server/app_setup.py
+++ b/robot-server/robot_server/app_setup.py
@@ -112,7 +112,9 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         start_initializing_pyro_resource(app_state=app.state)
 
         # Start the run process pyro provider so a process is ready when a run starts
-        exit_stack.enter_context(set_up_run_process_pyro_provider(app.state))
+        await exit_stack.enter_async_context(
+            set_up_run_process_pyro_provider(app.state)
+        )
 
         yield  # Start handling HTTP requests.
 

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -1,6 +1,7 @@
 """Run router dependency-injection wire-up."""
 
-from typing import Annotated
+import contextlib
+from typing import Annotated, Generator
 
 from fastapi import Depends, status
 from sqlalchemy.engine import Engine as SQLEngine
@@ -20,6 +21,7 @@ from .light_control_task import LightController, run_light_task
 from .run_auto_deleter import RunAutoDeleter
 from .run_data_manager import RunDataManager
 from .run_orchestrator_store import NoRunOrchestrator, RunOrchestratorStore
+from .run_process_pyro_provider import RunProcessPyroProvider
 from .run_store import RunStore
 from robot_server.camera.settings.store import (
     CameraSettingStore,
@@ -59,6 +61,9 @@ _run_orchestrator_store_accessor = AppStateAccessor[RunOrchestratorStore](
 )
 _run_data_manager_accessor = AppStateAccessor[RunDataManager]("run_data_manager")
 _light_control_accessor = AppStateAccessor[LightController]("light_controller")
+_run_process_pyro_provider_accessor = AppStateAccessor[RunProcessPyroProvider](
+    "run_process_pyro_provider"
+)
 
 
 async def get_run_store(
@@ -127,12 +132,44 @@ async def get_light_controller(
     return controller
 
 
+@contextlib.contextmanager
+def set_up_run_process_pyro_provider(
+    app_state: Annotated[AppState, Depends(get_app_state)],
+) -> Generator[None, None, None]:
+    """Set up the server's singleton `RunProcessPyroProvider`."""
+    run_process_pyro_provider = RunProcessPyroProvider()
+    _run_process_pyro_provider_accessor.set_on(app_state, run_process_pyro_provider)
+    # TODO(2026-04-21) We might want to wrap this into a try/except if this causes local issues
+    run_process_pyro_provider.initialize()
+
+    try:
+        yield
+    finally:
+        run_process_pyro_provider.teardown()
+
+
+async def get_run_process_pyro_provider(
+    app_state: Annotated[AppState, Depends(get_app_state)],
+) -> RunProcessPyroProvider:
+    """Get a run process pyro provider as a dependency."""
+    run_process_pyro_provider = _run_process_pyro_provider_accessor.get_from(
+        app_state=app_state
+    )
+    assert run_process_pyro_provider is not None, (
+        "Forgot to initialize run process pyro provider as part of server startup?"
+    )
+    return run_process_pyro_provider
+
+
 async def get_run_orchestrator_store(
     app_state: Annotated[AppState, Depends(get_app_state)],
     hardware_api: Annotated[HardwareControlAPI, Depends(get_hardware)],
     robot_type: Annotated[RobotType, Depends(get_robot_type)],
     deck_type: Annotated[DeckType, Depends(get_deck_type)],
     light_controller: Annotated[LightController, Depends(get_light_controller)],
+    run_process_pyro_provider: Annotated[
+        RunProcessPyroProvider, Depends(get_run_process_pyro_provider)
+    ],
 ) -> RunOrchestratorStore:
     """Get a singleton EngineStore to keep track of created engines / runners."""
     run_orchestrator_store = _run_orchestrator_store_accessor.get_from(app_state)
@@ -142,6 +179,7 @@ async def get_run_orchestrator_store(
             hardware_api=hardware_api,
             robot_type=robot_type,
             deck_type=deck_type,
+            run_process_pyro_provider=run_process_pyro_provider,
         )
         _run_orchestrator_store_accessor.set_on(app_state, run_orchestrator_store)
         # Handle remote hardware registry, if needed

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -1,7 +1,7 @@
 """Run router dependency-injection wire-up."""
 
 import contextlib
-from typing import Annotated, Generator
+from typing import Annotated, AsyncGenerator
 
 from fastapi import Depends, status
 from sqlalchemy.engine import Engine as SQLEngine
@@ -132,10 +132,10 @@ async def get_light_controller(
     return controller
 
 
-@contextlib.contextmanager
-def set_up_run_process_pyro_provider(
+@contextlib.asynccontextmanager
+async def set_up_run_process_pyro_provider(
     app_state: Annotated[AppState, Depends(get_app_state)],
-) -> Generator[None, None, None]:
+) -> AsyncGenerator[None, None]:
     """Set up the server's singleton `RunProcessPyroProvider`."""
     run_process_pyro_provider = RunProcessPyroProvider()
     _run_process_pyro_provider_accessor.set_on(app_state, run_process_pyro_provider)
@@ -145,7 +145,7 @@ def set_up_run_process_pyro_provider(
     try:
         yield
     finally:
-        run_process_pyro_provider.teardown()
+        await run_process_pyro_provider.teardown()
 
 
 async def get_run_process_pyro_provider(

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -87,6 +87,14 @@ class NoRunOrchestrator(RuntimeError):
     """Raised if you try to get the current run orchestrator while there is none."""
 
 
+class RunProcessRunningError(RuntimeError):
+    """Raised if a run process is attempted to be opened when one is already running."""
+
+
+class NoRunProcessRunningError(RuntimeError):
+    """Raised if a run process is attempted to be closed when one is not running."""
+
+
 async def _do_handle_hardware_event(  # noqa: C901
     run_orchestrator_store: "RunOrchestratorStore", event: HardwareEvent
 ) -> None:
@@ -196,6 +204,7 @@ class RunOrchestratorStore:
         self._run_process: Optional[subprocess.Popen[bytes]] = None
         if feature_flags.protocol_subprocess_enabled():
             register_process_types()
+            self._start_run_process()
         if not feature_flags.hardware_subprocess_enabled():
             hardware_api.register_callback(_get_hardware_listener(self))
 
@@ -212,6 +221,25 @@ class RunOrchestratorStore:
         return (
             self.run_orchestrator.run_id if self._run_orchestrator is not None else None
         )
+
+    def _start_run_process(self) -> None:
+        """Starts a protocol run process in the background if one hasn't been created already."""
+        if self._run_process is not None:
+            raise RunProcessRunningError("Protocol run process already running.")
+
+        self._run_process = subprocess.Popen(
+            args=[sys.executable, "-m", run_process_entry_point.__name__],
+            env={k: v for k, v in os.environ.items()},
+            # user="ot-protocol"  # TODO how do we make sure this works locally?
+        )
+
+    def _end_run_process(self) -> None:
+        if self._run_process is None:
+            raise NoRunProcessRunningError("No protocol run process currently running.")
+        self._run_process.terminate()
+        self._run_process = None
+        with Pyro5.api.locate_ns() as ns:
+            ns.remove("ot-protocol")
 
     # TODO(mc, 2022-03-21): this resource locking is insufficient;
     # come up with something more sophisticated without race condition holes.
@@ -381,19 +409,16 @@ class RunOrchestratorStore:
         run_id: str,
     ) -> StateSummary:
         """Eventually this will replace create and make a run process that does the whole run, right now it's a stub."""
-        if self._run_process is not None:
+        if self._run_orchestrator is not None:
             raise RunConflictError("Another run is currently active.")
 
-        self._run_process = subprocess.Popen(
-            args=[sys.executable, "-m", run_process_entry_point.__name__],
-            env={k: v for k, v in os.environ.items()},
-            # user="ot-protocol"  # TODO how do we make sure this works locally?
-        )
+        if self._run_process is None:
+            self._start_run_process()
 
         # TODO This timeout sucks
         start_time = time.monotonic()
         with Pyro5.api.locate_ns() as ns:
-            while time.monotonic() - start_time < 60:
+            while time.monotonic() - start_time < 30:
                 if "ot-protocol" in ns.list():
                     proxy = AsyncClientPyroObject(
                         Pyro5.api.Proxy(ns.list()["ot-protocol"])  # type: ignore[no-untyped-call]
@@ -404,10 +429,8 @@ class RunOrchestratorStore:
                     break
                 time.sleep(0.01)
             else:
-                self._run_process.terminate()
-                self._run_process = None
-                ns.remove("ot-protocol")
-                raise ValueError("Can't find process")
+                self._end_run_process()
+                raise RuntimeError("Can't resolve pyro proxy 'ot-protocol'")
 
         self._run_orchestrator.create(run_id)
         return self._run_orchestrator.get_state_summary()
@@ -425,12 +448,9 @@ class RunOrchestratorStore:
 
         run_data = self.run_orchestrator.get_state_summary()
 
-        assert self._run_process is not None
-        self._run_process.terminate()
-        self._run_process = None
+        self._end_run_process()
         self._run_orchestrator = None
-        with Pyro5.api.locate_ns() as ns:
-            ns.remove("ot-protocol")
+        self._start_run_process()
 
         return RunResult(
             state_summary=run_data,

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -80,14 +80,6 @@ class NoRunOrchestrator(RuntimeError):
     """Raised if you try to get the current run orchestrator while there is none."""
 
 
-class RunProcessRunningError(RuntimeError):
-    """Raised if a run process is attempted to be opened when one is already running."""
-
-
-class NoRunProcessRunningError(RuntimeError):
-    """Raised if a run process is attempted to be closed when one is not running."""
-
-
 async def _do_handle_hardware_event(  # noqa: C901
     run_orchestrator_store: "RunOrchestratorStore", event: HardwareEvent
 ) -> None:

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -387,7 +387,9 @@ class RunOrchestratorStore:
             raise RunConflictError("Another run is currently active.")
 
         # "Run orchestrator" here is a proxy of a directed run process
-        self._run_orchestrator = self._run_process_pyro_provider.wait_for_run_proxy()
+        self._run_orchestrator = (
+            await self._run_process_pyro_provider.wait_for_run_proxy()
+        )
 
         self._run_orchestrator.create(run_id)
         return self._run_orchestrator.get_state_summary()
@@ -405,7 +407,7 @@ class RunOrchestratorStore:
 
         run_data = self.run_orchestrator.get_state_summary()
 
-        self._run_process_pyro_provider.refresh()
+        await self._run_process_pyro_provider.refresh()
 
         self._run_orchestrator = None
 

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -2,13 +2,7 @@
 
 import asyncio
 import logging
-import os
-import subprocess
-import sys
-import time
-from typing import Callable, Dict, List, Mapping, Optional, Sequence, Union, cast
-
-import Pyro5.api
+from typing import Callable, Dict, List, Mapping, Optional, Sequence, Union
 
 from opentrons.config import feature_flags
 from opentrons.hardware_control import HardwareControlAPI
@@ -62,14 +56,13 @@ from opentrons.protocol_runner import (
 from opentrons.protocol_runner.run_coordinator import ParseMode
 from opentrons.protocols.api_support.deck_type import should_load_fixed_trash
 from opentrons.types import NozzleMapInterface
-from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
 from opentrons_shared_data.errors.exceptions import ModuleNotPresent
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
 from opentrons_shared_data.labware.types import LabwareUri
 from opentrons_shared_data.robot.types import RobotType, RobotTypeEnum
 
-from . import run_process_entry_point
-from .run_process import DirectedRunProcess, register_process_types
+from .run_process import DirectedRunProcess
+from .run_process_pyro_provider import RunProcessPyroProvider
 from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.service.legacy.models.settings import CameraCaptureImageSettings
 
@@ -184,6 +177,7 @@ class RunOrchestratorStore:
         hardware_api: HardwareControlAPI,
         robot_type: RobotType,
         deck_type: DeckType,
+        run_process_pyro_provider: RunProcessPyroProvider,
     ) -> None:
         """Initialize a run orchestrator storage interface.
 
@@ -192,6 +186,8 @@ class RunOrchestratorStore:
                 construction.
             robot_type: Passed along to `opentrons.protocol_engine.Config`.
             deck_type: Passed along to `opentrons.protocol_engine.Config`.
+            run_process_pyro_provider: If in protocol subprocess mode, provides
+                the run process proxy when running a protocol.
         """
         self._hardware_api = hardware_api
         self._robot_type = robot_type
@@ -201,10 +197,7 @@ class RunOrchestratorStore:
             None
         )
         self._default_run_orchestrator: Optional[RunOrchestrator] = None
-        self._run_process: Optional[subprocess.Popen[bytes]] = None
-        if feature_flags.protocol_subprocess_enabled():
-            register_process_types()
-            self._start_run_process()
+        self._run_process_pyro_provider = run_process_pyro_provider
         if not feature_flags.hardware_subprocess_enabled():
             hardware_api.register_callback(_get_hardware_listener(self))
 
@@ -221,25 +214,6 @@ class RunOrchestratorStore:
         return (
             self.run_orchestrator.run_id if self._run_orchestrator is not None else None
         )
-
-    def _start_run_process(self) -> None:
-        """Starts a protocol run process in the background if one hasn't been created already."""
-        if self._run_process is not None:
-            raise RunProcessRunningError("Protocol run process already running.")
-
-        self._run_process = subprocess.Popen(
-            args=[sys.executable, "-m", run_process_entry_point.__name__],
-            env={k: v for k, v in os.environ.items()},
-            # user="ot-protocol"  # TODO how do we make sure this works locally?
-        )
-
-    def _end_run_process(self) -> None:
-        if self._run_process is None:
-            raise NoRunProcessRunningError("No protocol run process currently running.")
-        self._run_process.terminate()
-        self._run_process = None
-        with Pyro5.api.locate_ns() as ns:
-            ns.remove("ot-protocol")
 
     # TODO(mc, 2022-03-21): this resource locking is insufficient;
     # come up with something more sophisticated without race condition holes.
@@ -412,25 +386,8 @@ class RunOrchestratorStore:
         if self._run_orchestrator is not None:
             raise RunConflictError("Another run is currently active.")
 
-        if self._run_process is None:
-            self._start_run_process()
-
-        # TODO This timeout sucks
-        start_time = time.monotonic()
-        with Pyro5.api.locate_ns() as ns:
-            while time.monotonic() - start_time < 30:
-                if "ot-protocol" in ns.list():
-                    proxy = AsyncClientPyroObject(
-                        Pyro5.api.Proxy(ns.list()["ot-protocol"])  # type: ignore[no-untyped-call]
-                    )
-                    self._run_orchestrator = cast(
-                        DirectedRunProcess, cast(object, proxy)
-                    )
-                    break
-                time.sleep(0.01)
-            else:
-                self._end_run_process()
-                raise RuntimeError("Can't resolve pyro proxy 'ot-protocol'")
+        # "Run orchestrator" here is a proxy of a directed run process
+        self._run_orchestrator = self._run_process_pyro_provider.wait_for_run_proxy()
 
         self._run_orchestrator.create(run_id)
         return self._run_orchestrator.get_state_summary()
@@ -448,9 +405,9 @@ class RunOrchestratorStore:
 
         run_data = self.run_orchestrator.get_state_summary()
 
-        self._end_run_process()
+        self._run_process_pyro_provider.refresh()
+
         self._run_orchestrator = None
-        self._start_run_process()
 
         return RunResult(
             state_summary=run_data,

--- a/robot-server/robot_server/runs/run_process_pyro_provider.py
+++ b/robot-server/robot_server/runs/run_process_pyro_provider.py
@@ -1,5 +1,6 @@
 """Manages protocol run subprocesses and provides Pyro proxies to communicate with them."""
 
+import asyncio
 import logging
 import os
 import subprocess
@@ -22,14 +23,6 @@ _RUN_PROXY_TIMEOUT = 30  # seconds
 _RUN_PROCESS_TERMINATE_TIMEOUT = 10  # seconds
 
 
-class RunProcessRunningError(RuntimeError):
-    """Raised if a run process is attempted to be opened when one is already running."""
-
-
-class NoRunProcessRunningError(RuntimeError):
-    """Raised if a run process is attempted to be closed when one is not running."""
-
-
 class RunProcessPyroProvider:
     """A provider for run subprocesses and pyro run process proxies."""
 
@@ -47,25 +40,25 @@ class RunProcessPyroProvider:
             register_process_types()
             self._start_run_process()
 
-    def teardown(self) -> None:
+    async def teardown(self) -> None:
         """Called when server ends.
 
         If feature flag is on for protocol subprocess, ends the process and removes
         the run process proxy name from the nameserver.
         """
         if feature_flags.protocol_subprocess_enabled():
-            self._end_run_process()
+            await self._end_run_process()
             with Pyro5.api.locate_ns() as ns:
                 ns.remove(_RUN_PROXY_NAME)
 
-    def refresh(self) -> None:
+    async def refresh(self) -> None:
         """Ends the currently running process and starts a new one."""
-        self._end_run_process()
+        await self._end_run_process()
         with Pyro5.api.locate_ns() as ns:
             ns.remove(_RUN_PROXY_NAME)
         self._start_run_process()
 
-    def wait_for_run_proxy(self) -> DirectedRunProcess:
+    async def wait_for_run_proxy(self) -> DirectedRunProcess:
         """Returns a proxy for the run process.
 
         Depending on how recently it started, this may take up to around 25 seconds to resolve.
@@ -81,25 +74,25 @@ class RunProcessPyroProvider:
                         Pyro5.api.Proxy(ns.list()[_RUN_PROXY_NAME])  # type: ignore[no-untyped-call]
                     )
                     return cast(DirectedRunProcess, cast(object, proxy))
-                time.sleep(0.01)
+                await asyncio.sleep(0.01)
             else:
-                self._end_run_process()
+                await self._end_run_process()
                 self._start_run_process()
                 raise RuntimeError("Can't resolve pyro proxy 'ot-protocol'")
 
     def _start_run_process(self) -> None:
         if self._run_process is not None:
-            raise RunProcessRunningError("Protocol run process already running.")
+            return
 
         self._run_process = subprocess.Popen(
             args=[sys.executable, "-m", run_process_entry_point.__name__],
             env={k: v for k, v in os.environ.items()},
-            # user="ot-protocol"  # TODO how do we make sure this works locally?
+            # user="ot-protocol"
         )
 
-    def _end_run_process(self) -> None:
+    async def _end_run_process(self) -> None:
         if self._run_process is None:
-            raise NoRunProcessRunningError("No protocol run process currently running.")
+            return
 
         self._run_process.terminate()
         start_time = time.monotonic()
@@ -107,7 +100,7 @@ class RunProcessPyroProvider:
             self._run_process.poll() is None
             and time.monotonic() - start_time < _RUN_PROCESS_TERMINATE_TIMEOUT
         ):
-            time.sleep(0.01)
+            await asyncio.sleep(0.01)
         else:
             self._run_process.kill()
 

--- a/robot-server/robot_server/runs/run_process_pyro_provider.py
+++ b/robot-server/robot_server/runs/run_process_pyro_provider.py
@@ -1,0 +1,114 @@
+"""Manages protocol run subprocesses and provides Pyro proxies to communicate with them."""
+
+import logging
+import os
+import subprocess
+import sys
+import time
+from typing import Optional, cast
+
+import Pyro5.api
+
+from opentrons.config import feature_flags
+from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
+
+from . import run_process_entry_point
+from .run_process import DirectedRunProcess, register_process_types
+
+_log = logging.getLogger(__name__)
+
+_RUN_PROXY_NAME = "ot-protocol"
+_RUN_PROXY_TIMEOUT = 30  # seconds
+_RUN_PROCESS_TERMINATE_TIMEOUT = 10  # seconds
+
+
+class RunProcessRunningError(RuntimeError):
+    """Raised if a run process is attempted to be opened when one is already running."""
+
+
+class NoRunProcessRunningError(RuntimeError):
+    """Raised if a run process is attempted to be closed when one is not running."""
+
+
+class RunProcessPyroProvider:
+    """A provider for run subprocesses and pyro run process proxies."""
+
+    def __init__(self) -> None:
+        self._run_process: Optional[subprocess.Popen[bytes]] = None
+
+    def initialize(self) -> None:
+        """Called when server first starts up.
+
+        If feature flag is on for protocol subprocess, registers the process types
+        for pyro serialization, then starts a run process in the background ready to
+        be used by a run.
+        """
+        if feature_flags.protocol_subprocess_enabled():
+            register_process_types()
+            self._start_run_process()
+
+    def teardown(self) -> None:
+        """Called when server ends.
+
+        If feature flag is on for protocol subprocess, ends the process and removes
+        the run process proxy name from the nameserver.
+        """
+        if feature_flags.protocol_subprocess_enabled():
+            self._end_run_process()
+            with Pyro5.api.locate_ns() as ns:
+                ns.remove(_RUN_PROXY_NAME)
+
+    def refresh(self) -> None:
+        """Ends the currently running process and starts a new one."""
+        self._end_run_process()
+        with Pyro5.api.locate_ns() as ns:
+            ns.remove(_RUN_PROXY_NAME)
+        self._start_run_process()
+
+    def wait_for_run_proxy(self) -> DirectedRunProcess:
+        """Returns a proxy for the run process.
+
+        Depending on how recently it started, this may take up to around 25 seconds to resolve.
+        """
+        if self._run_process is None:
+            self._start_run_process()
+
+        start_time = time.monotonic()
+        with Pyro5.api.locate_ns() as ns:
+            while time.monotonic() - start_time < _RUN_PROXY_TIMEOUT:
+                if _RUN_PROXY_NAME in ns.list():
+                    proxy = AsyncClientPyroObject(
+                        Pyro5.api.Proxy(ns.list()[_RUN_PROXY_NAME])  # type: ignore[no-untyped-call]
+                    )
+                    return cast(DirectedRunProcess, cast(object, proxy))
+                time.sleep(0.01)
+            else:
+                self._end_run_process()
+                self._start_run_process()
+                raise RuntimeError("Can't resolve pyro proxy 'ot-protocol'")
+
+    def _start_run_process(self) -> None:
+        if self._run_process is not None:
+            raise RunProcessRunningError("Protocol run process already running.")
+
+        self._run_process = subprocess.Popen(
+            args=[sys.executable, "-m", run_process_entry_point.__name__],
+            env={k: v for k, v in os.environ.items()},
+            # user="ot-protocol"  # TODO how do we make sure this works locally?
+        )
+
+    def _end_run_process(self) -> None:
+        if self._run_process is None:
+            raise NoRunProcessRunningError("No protocol run process currently running.")
+
+        self._run_process.terminate()
+        start_time = time.monotonic()
+        while (
+            self._run_process.poll() is None
+            and time.monotonic() - start_time < _RUN_PROCESS_TERMINATE_TIMEOUT
+        ):
+            time.sleep(0.01)
+        else:
+            self._run_process.kill()
+
+        self._run_process = None

--- a/robot-server/tests/runs/test_run_orchestrator_store.py
+++ b/robot-server/tests/runs/test_run_orchestrator_store.py
@@ -37,6 +37,7 @@ from robot_server.runs.run_orchestrator_store import (
     RunOrchestratorStore,
     handle_hardware_event,
 )
+from robot_server.runs.run_process_pyro_provider import RunProcessPyroProvider
 
 
 def mock_notify_publishers() -> None:
@@ -45,8 +46,16 @@ def mock_notify_publishers() -> None:
 
 
 @pytest.fixture
+def mock_run_process_pyro_provider(decoy: Decoy) -> RunProcessPyroProvider:
+    """A mock RunProcessPyroProvider."""
+    return decoy.mock(cls=RunProcessPyroProvider)
+
+
+@pytest.fixture
 async def subject(
-    decoy: Decoy, hardware_api: HardwareControlAPI
+    decoy: Decoy,
+    hardware_api: HardwareControlAPI,
+    mock_run_process_pyro_provider: RunProcessPyroProvider,
 ) -> RunOrchestratorStore:
     """Get a EngineStore test subject."""
     return RunOrchestratorStore(
@@ -55,6 +64,7 @@ async def subject(
         # construct their own EngineStore.
         robot_type="OT-2 Standard",
         deck_type=pe_types.DeckType.OT2_SHORT_TRASH,
+        run_process_pyro_provider=mock_run_process_pyro_provider,
     )
 
 
@@ -108,14 +118,20 @@ async def test_create_engine(decoy: Decoy, subject: RunOrchestratorStore) -> Non
 @pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
 @pytest.mark.parametrize("deck_type", pe_types.DeckType)
 async def test_create_engine_uses_robot_type(
-    decoy: Decoy, robot_type: RobotType, deck_type: pe_types.DeckType
+    decoy: Decoy,
+    robot_type: RobotType,
+    deck_type: pe_types.DeckType,
+    mock_run_process_pyro_provider: RunProcessPyroProvider,
 ) -> None:
     """It should create ProtocolEngines with the given robot and deck type."""
     # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
     # should pass in some sort of actual, valid HardwareAPI instead of a mock
     hardware_api = decoy.mock(cls=API)
     subject = RunOrchestratorStore(
-        hardware_api=hardware_api, robot_type=robot_type, deck_type=deck_type
+        hardware_api=hardware_api,
+        robot_type=robot_type,
+        deck_type=deck_type,
+        run_process_pyro_provider=mock_run_process_pyro_provider,
     )
 
     await subject.create(
@@ -297,7 +313,10 @@ async def test_get_default_orchestrator_idempotent(
 @pytest.mark.parametrize("robot_type", ["OT-2 Standard", "OT-3 Standard"])
 @pytest.mark.parametrize("deck_type", pe_types.DeckType)
 async def test_get_default_orchestrator_robot_type(
-    decoy: Decoy, robot_type: RobotType, deck_type: pe_types.DeckType
+    decoy: Decoy,
+    robot_type: RobotType,
+    deck_type: pe_types.DeckType,
+    mock_run_process_pyro_provider: RunProcessPyroProvider,
 ) -> None:
     """It should create default ProtocolEngines with the given robot and deck type."""
     # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
@@ -307,6 +326,7 @@ async def test_get_default_orchestrator_robot_type(
         hardware_api=hardware_api,
         robot_type=robot_type,
         deck_type=deck_type,
+        run_process_pyro_provider=mock_run_process_pyro_provider,
     )
 
     result = await subject.get_default_orchestrator()

--- a/robot-server/tests/service/pyro_utils/test_pyro_resource.py
+++ b/robot-server/tests/service/pyro_utils/test_pyro_resource.py
@@ -37,6 +37,7 @@ from robot_server.maintenance_runs.maintenance_run_orchestrator_store import (
 from robot_server.runs.run_orchestrator_store import (
     RunOrchestratorStore,
 )
+from robot_server.runs.run_process_pyro_provider import RunProcessPyroProvider
 from robot_server.service.pyro_utils import (
     pyro_resource,
     resource_utilities,
@@ -73,6 +74,12 @@ def ot3_hardware_api(decoy: Decoy, request: pytest.FixtureRequest) -> OT3API:
 def mock_app_state(decoy: Decoy) -> AppState:
     """Get a mock DataFilesStore."""
     return decoy.mock(cls=AppState)
+
+
+@pytest.fixture
+def mock_run_process_pyro_provider(decoy: Decoy) -> RunProcessPyroProvider:
+    """A mock RunProcessPyroProvider."""
+    return decoy.mock(cls=RunProcessPyroProvider)
 
 
 async def _host_pyro_nameserver_and_ot3api(
@@ -136,6 +143,7 @@ async def test_run_hardware_event_callback(
     ot3_hardware_api: OT3API,
     mock_app_state: AppState,
     mock_feature_flags: None,
+    mock_run_process_pyro_provider: RunProcessPyroProvider,
     decoy: Decoy,
 ) -> None:
     """Enforce that the RobotServerPyroResource provides a proxy of a callback.
@@ -155,6 +163,7 @@ async def test_run_hardware_event_callback(
         hardware_api=ot3api,
         robot_type="OT-3 Standard",
         deck_type=DeckType("ot3_standard"),
+        run_process_pyro_provider=mock_run_process_pyro_provider,
     )
 
     resource_utilities.register_run_orchestrator_store_to_pyro_resource(


### PR DESCRIPTION
# Overview

For Pyro execution, we now run all code related to loading and running arbitrary protocol code in its own subprocess. Due to import load times, this takes about 24 seconds from starting the process to the Pyro proxy being available.

Previous in #21131 which introduced this, we'd only create the subprocess when a run was created. This meant that the user would have to wait this time *every* time they started a run.

To mitigate this, we now will always have a run process started in the background, ready to start a run. There is now a singleton class for the server, `RunProcessPyroProvider` in charge of managing the run process and providing the proxy for the `DirectedRunProcess` class that is running in the separate process. When the server initializes, we start this process for the first time if the feature flag is on. This run process, after it is loaded and the proxy is available, is essentially idling at this point waiting for a run to start. When one does, we use it to load and run the run, and when the run is finished, we use the `RunProcessPyroProvider` to end the current process and start a new one.

This reduces the time from 24 seconds to 24 - *time since boot or last protocol ended*. The worst case will be encountered if restarting a run after the first has finished (but has not been cleared).

There is still room for further improvement, but this is the first step in reducing the pain point of waiting for the run to start.

## Test Plan and Hands on Testing

On-robot testing.

## Changelog

- Switched from starting the run subprocess from on run creation to always having one running in the background.

## Review requests


## Risk assessment

Low-medium. We now always have a subprocess running or initializing in the background, but this is still gated by a feature flag and if a run hasn't started the process is idling with no proxy communicating with it.