### PR TITLE
chore(js-package-testing): add devDependencies to package.json

### DIFF
--- a/js-package-testing/package.json
+++ b/js-package-testing/package.json
@@ -11,20 +11,22 @@
   },
   "dependencies": {
     "@fontsource/public-sans": "5.0.3",
-    "@applitools/eyes-playwright": "1.46.2",
     "@opentrons/components": "link:pack/opentrons-components",
     "@opentrons/protocol-visualization": "link:pack/opentrons-protocol-visualization",
     "@opentrons/shared-data": "link:pack/opentrons-shared-data",
     "@opentrons/step-generation": "link:pack/opentrons-step-generation",
+    "i18next": "^19.8.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-i18next": "14.0.0"
+  },
+  "devDependencies": {
+    "@applitools/eyes-playwright": "1.46.2",
     "@playwright/test": "^1.58.2",
     "@types/react": "18.2.51",
     "@types/react-dom": "18.2.0",
     "@vitejs/plugin-react": "4.2.0",
     "dotenv": "^16.6.1",
-    "i18next": "^19.8.3",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
-    "react-i18next": "14.0.0",
     "typescript": "5.3.3",
     "vite": "7.1.11"
   },

--- a/js-package-testing/pnpm-lock.yaml
+++ b/js-package-testing/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
 
   .:
     dependencies:
-      '@applitools/eyes-playwright':
-        specifier: 1.46.2
-        version: 1.46.2(@playwright/test@1.58.2)(@types/node@18.19.130)(encoding@0.1.13)(playwright@1.58.2)(typescript@5.3.3)
       '@fontsource/public-sans':
         specifier: 5.0.3
         version: 5.0.3
@@ -32,6 +29,22 @@ importers:
       '@opentrons/step-generation':
         specifier: link:pack/opentrons-step-generation
         version: link:pack/opentrons-step-generation
+      i18next:
+        specifier: ^19.8.3
+        version: 19.9.2
+      react:
+        specifier: 18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: 18.2.0
+        version: 18.2.0(react@18.2.0)
+      react-i18next:
+        specifier: 14.0.0
+        version: 14.0.0(i18next@19.9.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    devDependencies:
+      '@applitools/eyes-playwright':
+        specifier: 1.46.2
+        version: 1.46.2(@playwright/test@1.58.2)(@types/node@18.19.130)(encoding@0.1.13)(playwright@1.58.2)(typescript@5.3.3)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -47,18 +60,6 @@ importers:
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
-      i18next:
-        specifier: ^19.8.3
-        version: 19.9.2
-      react:
-        specifier: 18.2.0
-        version: 18.2.0
-      react-dom:
-        specifier: 18.2.0
-        version: 18.2.0(react@18.2.0)
-      react-i18next:
-        specifier: 14.0.0
-        version: 14.0.0(i18next@19.9.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       typescript:
         specifier: 5.3.3
         version: 5.3.3


### PR DESCRIPTION
# Overview
add devDependencies to package.json to tweak it because adding everything to dependencies isn't a good way to manage npm packages.

## Test Plan and Hands on Testing

the following commands work without any error.
```shell
cd js-package-testing
make teardown setup dev
```
## Changelog
- add devDependencies

## Review requests


## Risk assessment
low
