### PR TITLE
feat(api): Proxy and Callback wrappers for AsyncClientPyroObjects

### DIFF
--- a/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from typing import Any, Iterator, ParamSpec, TypeVar
+from collections.abc import Iterable
 
 import Pyro5.api
 
@@ -10,6 +11,19 @@ from opentrons.util.pyro.pyro_serialization import UnhashableDictWrapper
 T = TypeVar("T")
 P = ParamSpec("P")
 
+class AsyncPyroFunctionWrapper:
+    """Wrapper class to make Proxy response objects callable."""
+    def __init__(
+        self,
+        proxy: Pyro5.api.Proxy,
+    ):
+        self.proxy = proxy
+    
+    def __call__(self, *args, **kwargs) -> Any:
+        # Overload client-side call references with proxy-safe callable reference
+        threadsafe_proxy = Pyro5.api.Proxy(self.proxy._pyroUri)  # type: ignore
+        return threadsafe_proxy.call(*args, **kwargs)
+    
 
 class _ACPO:
     pass
@@ -60,7 +74,7 @@ def _build_classdict(
             yield (method, async_method)
         else:
             # For standard method calls forward the direct call to the method on the PSO Proxy.
-            yield (method, wrap_parameter_validation(attribute))
+            yield (method, wrap_parameter_validation(pso, method, attribute))
     # Attach PSO exposed attributes to the AsyncClientPyroObject
     for attr in pso._pyroAttrs:
         # For property attributes we use to attach a wrapped `getattr` call for that attribute.
@@ -93,7 +107,7 @@ def wrap_as_async(method_metadata: dict[str, Any]) -> Any:
             # This must be done because Pyro only accepts proxy calls from the thread that owns the proxy
             thread_proxy = Pyro5.api.Proxy(proxy._pyroUri)  # type: ignore
             func = getattr(thread_proxy, func_name)
-            validated_func = wrap_parameter_validation(func)
+            validated_func = wrap_parameter_validation(proxy, func_name, func)
             return validated_func(self, *args, **kwargs)
 
         # Return a Coroutine that may be awaited, it will execute the `_thread_call` when called
@@ -113,10 +127,13 @@ def wrap_as_async(method_metadata: dict[str, Any]) -> Any:
 
 def wrap_property(proxy: Pyro5.api.Proxy, attr: str) -> Any:
     """Wrapper to produce a call forward to a specified attribute of a Proxy object."""
-    return lambda self, current_attr=attr: getattr(proxy, current_attr)
+    return lambda self, current_attr=attr: wrap_result_validation(proxy, attr, getattr(proxy, current_attr))
 
 
-def wrap_parameter_validation(attr: Any) -> Any:
+### Parameter Validations
+
+
+def wrap_parameter_validation(proxy: Pyro5.api.Proxy, func_name: str, attr: Any) -> Any:
     """Validate outbound parameter requests before allowing serialization."""
 
     def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:  # type: ignore
@@ -124,6 +141,7 @@ def wrap_parameter_validation(attr: Any) -> Any:
         def _validations(arg: Any) -> Any:
             # NOTE: Extend this as further validations are needed
             arg = _validate_hashable(arg)
+            arg = _validate_outbound_callback(arg)
             return arg
 
         validated_args = tuple()  # type: ignore
@@ -133,7 +151,8 @@ def wrap_parameter_validation(attr: Any) -> Any:
         # Validate each keyword argument and reconstruct the kwargs dictionary
         kwargs = {key: _validations(kwargs[key]) for key in kwargs.keys()}
 
-        return attr(*validated_args, **kwargs)
+        result = attr(*validated_args, **kwargs)
+        return wrap_result_validation(proxy, func_name, result)
 
     return wrapper
 
@@ -167,3 +186,46 @@ def _validate_hashable(arg: Any) -> Any:
                 value_type=".".join((value_type.__module__, value_type.__qualname__)),
             )
     return arg
+
+def _validate_outbound_callback(arg: Any) -> Any:
+    """Handle an argument which is a remote callback in an AsyncPyroFunctionWrapper.
+    
+    For roundtrip functions, which may be sent across multiple processes, we only want to perserve the inner Proxy.
+    """
+    if isinstance(arg, AsyncPyroFunctionWrapper):
+        arg = arg.proxy
+
+    return arg
+
+
+### Result Validations
+
+def wrap_result_validation(proxy: Pyro5.api.Proxy, func_name: str, result: Any):
+    """Validate incoming result format before returning from a remote call.
+    
+    This is not to be confused with serialization. The validation process can be used to reformat
+    result data into more client-acceptable shapes. For example, autowrapping of Proxy responses
+    as AsyncClientPyroObjects.
+    """
+
+    validated_result = result
+    threadsafe_proxy = Pyro5.api.Proxy(proxy._pyroUri)  # type: ignore
+    attributes_with_proxy_result: list[str] = getattr(threadsafe_proxy, "get_pyro_attributes_with_proxy_result", [])
+    if func_name in attributes_with_proxy_result:
+        # Check if the result is a list of proxies or singular entity
+        try:
+            if result.is_callable:
+                validated_result = AsyncPyroFunctionWrapper(result)
+
+        except:
+            if isinstance(result, Iterable):
+                validated_result = []
+                for r in result:
+                    assert isinstance(r, Pyro5.api.Proxy)
+                    validated_result.append(AsyncClientPyroObject(r))
+            else:
+                assert isinstance(result, Pyro5.api.Proxy)
+                validated_result = AsyncClientPyroObject(result)
+
+    return validated_result
+

--- a/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
@@ -1,8 +1,8 @@
 """Class wrapper that ingests a PyroSynchronousObject and maps 'synchronized' async functions to awaitable methods."""
 
 import asyncio
-from typing import Any, Iterator, ParamSpec, TypeVar
 from collections.abc import Iterable
+from typing import Any, Iterator, ParamSpec, TypeVar
 
 import Pyro5.api
 
@@ -11,19 +11,21 @@ from opentrons.util.pyro.pyro_serialization import UnhashableDictWrapper
 T = TypeVar("T")
 P = ParamSpec("P")
 
+
 class AsyncPyroFunctionWrapper:
     """Wrapper class to make Proxy response objects callable."""
+
     def __init__(
         self,
         proxy: Pyro5.api.Proxy,
     ):
         self.proxy = proxy
-    
+
     def __call__(self, *args, **kwargs) -> Any:
         # Overload client-side call references with proxy-safe callable reference
         threadsafe_proxy = Pyro5.api.Proxy(self.proxy._pyroUri)  # type: ignore
         return threadsafe_proxy.call(*args, **kwargs)
-    
+
 
 class _ACPO:
     pass
@@ -127,7 +129,9 @@ def wrap_as_async(method_metadata: dict[str, Any]) -> Any:
 
 def wrap_property(proxy: Pyro5.api.Proxy, attr: str) -> Any:
     """Wrapper to produce a call forward to a specified attribute of a Proxy object."""
-    return lambda self, current_attr=attr: wrap_result_validation(proxy, attr, getattr(proxy, current_attr))
+    return lambda self, current_attr=attr: wrap_result_validation(
+        proxy, attr, getattr(proxy, current_attr)
+    )
 
 
 ### Parameter Validations
@@ -187,9 +191,10 @@ def _validate_hashable(arg: Any) -> Any:
             )
     return arg
 
+
 def _validate_outbound_callback(arg: Any) -> Any:
     """Handle an argument which is a remote callback in an AsyncPyroFunctionWrapper.
-    
+
     For roundtrip functions, which may be sent across multiple processes, we only want to perserve the inner Proxy.
     """
     if isinstance(arg, AsyncPyroFunctionWrapper):
@@ -200,9 +205,10 @@ def _validate_outbound_callback(arg: Any) -> Any:
 
 ### Result Validations
 
+
 def wrap_result_validation(proxy: Pyro5.api.Proxy, func_name: str, result: Any):
     """Validate incoming result format before returning from a remote call.
-    
+
     This is not to be confused with serialization. The validation process can be used to reformat
     result data into more client-acceptable shapes. For example, autowrapping of Proxy responses
     as AsyncClientPyroObjects.
@@ -210,7 +216,9 @@ def wrap_result_validation(proxy: Pyro5.api.Proxy, func_name: str, result: Any):
 
     validated_result = result
     threadsafe_proxy = Pyro5.api.Proxy(proxy._pyroUri)  # type: ignore
-    attributes_with_proxy_result: list[str] = getattr(threadsafe_proxy, "get_pyro_attributes_with_proxy_result", [])
+    attributes_with_proxy_result: list[str] = getattr(
+        threadsafe_proxy, "get_pyro_attributes_with_proxy_result", []
+    )
     if func_name in attributes_with_proxy_result:
         # Check if the result is a list of proxies or singular entity
         try:
@@ -228,4 +236,3 @@ def wrap_result_validation(proxy: Pyro5.api.Proxy, func_name: str, result: Any):
                 validated_result = AsyncClientPyroObject(result)
 
     return validated_result
-

--- a/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
@@ -1,7 +1,6 @@
 """Class wrapper that ingests a PyroSynchronousObject and maps 'synchronized' async functions to awaitable methods."""
 
 import asyncio
-from collections.abc import Iterable
 from typing import Any, Iterator, ParamSpec, TypeVar
 
 import Pyro5.api
@@ -226,12 +225,13 @@ def wrap_result_validation(proxy: Pyro5.api.Proxy, func_name: str, result: Any) 
                 validated_result = AsyncPyroFunctionWrapper(result)
 
         except AttributeError:
-            if isinstance(result, Iterable):
+            try:
+                iter(result)
                 validated_result = []
                 for r in result:
                     assert isinstance(r, Pyro5.api.Proxy)
                     validated_result.append(AsyncClientPyroObject(r))
-            else:
+            except AttributeError:
                 assert isinstance(result, Pyro5.api.Proxy)
                 validated_result = AsyncClientPyroObject(result)
 

--- a/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
@@ -18,11 +18,11 @@ class AsyncPyroFunctionWrapper:
     def __init__(
         self,
         proxy: Pyro5.api.Proxy,
-    ):
+    ) -> None:
         self.proxy = proxy
 
-    def __call__(self, *args, **kwargs) -> Any:
-        # Overload client-side call references with proxy-safe callable reference
+    def __call__(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:  # type: ignore
+        """Overload client-side call references with proxy-safe callable reference."""
         threadsafe_proxy = Pyro5.api.Proxy(self.proxy._pyroUri)  # type: ignore
         return threadsafe_proxy.call(*args, **kwargs)
 
@@ -206,26 +206,26 @@ def _validate_outbound_callback(arg: Any) -> Any:
 ### Result Validations
 
 
-def wrap_result_validation(proxy: Pyro5.api.Proxy, func_name: str, result: Any):
+def wrap_result_validation(proxy: Pyro5.api.Proxy, func_name: str, result: Any) -> Any:
     """Validate incoming result format before returning from a remote call.
 
     This is not to be confused with serialization. The validation process can be used to reformat
     result data into more client-acceptable shapes. For example, autowrapping of Proxy responses
     as AsyncClientPyroObjects.
     """
-
     validated_result = result
     threadsafe_proxy = Pyro5.api.Proxy(proxy._pyroUri)  # type: ignore
     attributes_with_proxy_result: list[str] = getattr(
         threadsafe_proxy, "get_pyro_attributes_with_proxy_result", []
     )
+
     if func_name in attributes_with_proxy_result:
         # Check if the result is a list of proxies or singular entity
         try:
             if result.is_callable:
                 validated_result = AsyncPyroFunctionWrapper(result)
 
-        except:
+        except AttributeError:
             if isinstance(result, Iterable):
                 validated_result = []
                 for r in result:

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -1,9 +1,9 @@
 """Synchronous class wrapper and functions for creating Pyro compatible objects."""
 
 import asyncio
+import enum
 import functools
 import inspect
-import enum
 from types import FunctionType, MethodType
 from typing import Any, Callable, Dict, Iterator, Optional, ParamSpec, TypeVar
 
@@ -62,25 +62,29 @@ class DaemonUtility:
         # This could trigger inside a wrapper pyro_behavior function on a PSO call for example.
         return self._daemon.proxyFor(pso)  # type: ignore
 
+
 class PyroFunctionWrapper:
     """Wrapper class to safely wrap callable responses as Proxy objects.."""
+
     def __init__(
         self,
         callable: Callable,
     ):
         self.callable = callable
-    
+
     @property
     def is_callable(self) -> bool:
         return True
-    
+
     def call(self, *args, **kwargs) -> Any:
         """Remote deployable function call."""
         return self.callable(*args, **kwargs)
-    
+
+
 class ResultMeta(enum.Enum):
     PROXY = enum.auto()
     UNKNOWN = enum.auto()
+
 
 class _PyroSpecialBehavior(BaseModel):
     specialty_function: Callable[[DaemonUtility, Any, str, Any], Any]
@@ -267,8 +271,10 @@ def _build_classdict(  # noqa: C901
                 if inspect.iscoroutinefunction(attr):
                     async_metadata = _build_metadata_dictionary(attr)
                     async_methods[name] = async_metadata
-                
-                result_meta = _determine_attribute_result_metadata(specialty_behavior.specialty_function)
+
+                result_meta = _determine_attribute_result_metadata(
+                    specialty_behavior.specialty_function
+                )
                 # NOTE: extend this further as needed for custom result types
                 if result_meta is ResultMeta.PROXY:
                     proxy_attributes.append(name)
@@ -316,10 +322,12 @@ def _build_classdict(  # noqa: C901
     # Attach the known async methods list to the PSO as a private member and expose a getter method
     yield ("_pyro_async_methods", async_methods)
     yield ("get_pyro_async_methods", pyro.expose(property(get_pyro_async_methods)))  # type: ignore
-    # Attach an initially empty proxy-providing methods list to the PSO as a private member and expose a getter method
+    # Attach an proxy-providing methods list to the PSO as a private member and expose a getter method
     yield ("_pyro_attributes_with_proxy_results", proxy_attributes)
-    yield( "get_pyro_attributes_with_proxy_result", pyro.expose(property(get_pyro_attributes_with_proxy_result)))  # type: ignore
-
+    yield (
+        "get_pyro_attributes_with_proxy_result",
+        pyro.expose(property(get_pyro_attributes_with_proxy_result)),
+    )  # type: ignore
 
     # Attach the `core_obj` instance as a private member for internal tracking
     try:
@@ -364,6 +372,7 @@ def get_pyro_async_methods(self: Any) -> dict[str, dict[str, Any]]:
     """Helper function to access the dictionary of known async method metadata on a PyroSynchronousObject."""
     result: dict[str, dict[str, Any]] = self._pyro_async_methods
     return result
+
 
 def get_pyro_attributes_with_proxy_result(self) -> list[str]:
     """Helper function to access the list of known methods that provide their results as Proxies."""

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -68,20 +68,23 @@ class PyroFunctionWrapper:
 
     def __init__(
         self,
-        callable: Callable,
-    ):
+        callable: Callable[P, T],
+    ) -> None:
         self.callable = callable
 
     @property
     def is_callable(self) -> bool:
+        """Callable status for validation of a wrapped function, always true."""
         return True
 
-    def call(self, *args, **kwargs) -> Any:
+    def call(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:  # type: ignore
         """Remote deployable function call."""
         return self.callable(*args, **kwargs)
 
 
-class ResultMeta(enum.Enum):
+class _ResultMeta(enum.Enum):
+    """Result type metadata for attributes that are wrapped in special PyroBehaviors."""
+
     PROXY = enum.auto()
     UNKNOWN = enum.auto()
 
@@ -276,7 +279,7 @@ def _build_classdict(  # noqa: C901
                     specialty_behavior.specialty_function
                 )
                 # NOTE: extend this further as needed for custom result types
-                if result_meta is ResultMeta.PROXY:
+                if result_meta is _ResultMeta.PROXY:
                     proxy_attributes.append(name)
 
                 exposed = pyro.expose(
@@ -326,8 +329,8 @@ def _build_classdict(  # noqa: C901
     yield ("_pyro_attributes_with_proxy_results", proxy_attributes)
     yield (
         "get_pyro_attributes_with_proxy_result",
-        pyro.expose(property(get_pyro_attributes_with_proxy_result)),
-    )  # type: ignore
+        pyro.expose(property(get_pyro_attributes_with_proxy_result)),  # type: ignore
+    )
 
     # Attach the `core_obj` instance as a private member for internal tracking
     try:
@@ -350,12 +353,12 @@ def _build_metadata_dictionary(attr: Any) -> Dict[str, Any]:
     }
 
 
-def _determine_attribute_result_metadata(specialty_func: Any) -> ResultMeta:
+def _determine_attribute_result_metadata(specialty_func: Any) -> _ResultMeta:
     # Determines the result metadata for an attribute wrapped in a speciality function
     if specialty_func.__name__ == "convert_result_to_proxy":
-        return ResultMeta.PROXY
+        return _ResultMeta.PROXY
     # NOTE: extend this further as needed in the future for other custom return types
-    return ResultMeta.UNKNOWN
+    return _ResultMeta.UNKNOWN
 
 
 def _get_specialty_behavior(func: Any, name: str) -> _PyroSpecialBehavior | None:
@@ -374,7 +377,7 @@ def get_pyro_async_methods(self: Any) -> dict[str, dict[str, Any]]:
     return result
 
 
-def get_pyro_attributes_with_proxy_result(self) -> list[str]:
+def get_pyro_attributes_with_proxy_result(self: Any) -> list[str]:
     """Helper function to access the list of known methods that provide their results as Proxies."""
     result: list[str] = self._pyro_attributes_with_proxy_results
     return result

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -10,11 +10,14 @@ from typing import Any, Callable, Dict, Iterator, Optional, ParamSpec, TypeVar
 from pydantic import BaseModel
 from Pyro5 import api as pyro
 
+from opentrons.util.pyro.pyro_client_async_adapter import (
+    AsyncClientPyroObject,
+    AsyncPyroFunctionWrapper,
+)
 from opentrons.util.pyro.pyro_serialization import (
     TypedDictWrapper,
     UnhashableDictWrapper,
 )
-from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject, AsyncPyroFunctionWrapper
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -295,12 +298,12 @@ def _build_classdict(  # noqa: C901
                 async_methods[name] = async_metadata
 
                 bound_method = MethodType(exposed, core_obj)
-                yield (name, bound_method)
+                yield (name, parameter_validation_wrapper(bound_method))
             elif isinstance(attr, FunctionType):
                 # Expose standard functions and bound the exposed function to the original instance
                 exposed = pyro.expose(attr)
                 bound_method = MethodType(exposed, core_obj)
-                yield (name, bound_method)
+                yield (name, parameter_validation_wrapper(bound_method))
             elif isinstance(attr, property):
                 # Bound property to the original instance and expose the bounded property
                 # Accepts the functional arguments (Callables) of a property to rebind
@@ -383,25 +386,29 @@ def get_pyro_attributes_with_proxy_result(self: Any) -> list[str]:
     result: list[str] = self._pyro_attributes_with_proxy_results
     return result
 
-# Validators
-# CASEY NOTE: This won't be called on non-pyro behavior functions. Maybe those need to be checked too.
-def _validated_parameters(*args: P.args, **kwargs: P.kwargs) -> tuple[tuple, dict]:
-        def _validations(arg: Any) -> Any:
-            # NOTE: Extend this as further validations are needed
-            arg = _validate_inbound_proxy(arg)
-            return arg
 
-        validated_args = tuple()  # type: ignore
-        for arg in args:
-            # Validate each non-keyword argument and reconstruct the argument tuple
-            validated_args = (*validated_args, _validations(arg))
-        # Validate each keyword argument and reconstruct the kwargs dictionary
-        kwargs = {key: _validations(kwargs[key]) for key in kwargs.keys()}
-        return (validated_args, kwargs)
+# Validators
+
+
+def _validated_parameters(*args: P.args, **kwargs: P.kwargs) -> tuple[tuple, dict]:  # type: ignore
+    def _validations(arg: Any) -> Any:
+        # NOTE: Extend this as further validations are needed
+        arg = _validate_inbound_proxy(arg)
+        return arg
+
+    validated_args = tuple()  # type: ignore
+    for arg in args:
+        # Validate each non-keyword argument and reconstruct the argument tuple
+        validated_args = (*validated_args, _validations(arg))
+    # Validate each keyword argument and reconstruct the kwargs dictionary
+    kwargs = {key: _validations(kwargs[key]) for key in kwargs.keys()}
+    return (validated_args, kwargs)
+
 
 def _validate_inbound_proxy(arg: Any) -> Any:
     """Handle an argument which is a remote Proxy that may have been forwarded through multiple processes."""
     if isinstance(arg, pyro.Proxy):
+        # NOTE: Cases like this are the result of multi-process callback forwarding
         try:
             if arg.is_callable:
                 arg = AsyncPyroFunctionWrapper(proxy=arg)
@@ -416,7 +423,18 @@ def _validate_inbound_proxy(arg: Any) -> Any:
                 arg = AsyncClientPyroObject(arg)
     return arg
 
-# CASEY NOTE: put some kind of generic "validator wrapper" here? is there even a usecase where non-pso decorated functions get these? maybe create() for protocol engine
+
+def parameter_validation_wrapper(attr: Callable[P, T]) -> Callable[P, T]:
+    """Validate incoming parameters on any generically generated PSO bound method function call."""
+
+    @functools.wraps(attr)
+    def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:  # noqa: C901
+        # Of note, the wrapper passes self to terminate the self instance passed by the PSO
+        args, kwargs = _validated_parameters(*args, **kwargs)  # type: ignore
+        return attr(*args, **kwargs)
+
+    return wrapper  # type: ignore
+
 
 ### Specialty Functions for use with the `pyro_behavior` decorator ###
 
@@ -436,8 +454,7 @@ def convert_result_to_proxy(  # noqa: C901
     @functools.wraps(attr)
     def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:  # noqa: C901
         # Of note, the wrapper passes self to terminate the self instance passed by the PSO
-        args, kwargs = _validated_parameters(*args, **kwargs)
-        print(f"HERE WITH: {args} --- {kwargs}")
+        args, kwargs = _validated_parameters(*args, **kwargs)  # type: ignore
         if inspect.iscoroutinefunction(attr):
             sync_func = synchronous(attr)
             bound_method = MethodType(sync_func, core_obj)
@@ -495,7 +512,7 @@ def convert_result_to_wrapped_dict(  # noqa: C901
     @functools.wraps(attr)
     def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:
         # Of note, the wrapper passes self to terminate the self instance passed by the PSO
-        args, kwargs = _validated_parameters(*args, **kwargs)
+        args, kwargs = _validated_parameters(*args, **kwargs)  # type: ignore
         if inspect.iscoroutinefunction(attr):
             sync_func = synchronous(attr)
             bound_method = MethodType(sync_func, core_obj)
@@ -561,7 +578,7 @@ def convert_type_to_instance(
 
     @functools.wraps(attr)
     def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:
-        args, kwargs = _validated_parameters(*args, **kwargs)
+        args, kwargs = _validated_parameters(*args, **kwargs)  # type: ignore
         if inspect.iscoroutinefunction(attr):
             sync_func = synchronous(attr)
             result = sync_func(self, *args, **kwargs)
@@ -594,7 +611,7 @@ def convert_result_to_wrapped_typed_dict(
 
     @functools.wraps(attr)
     def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:
-        args, kwargs = _validated_parameters(*args, **kwargs)
+        args, kwargs = _validated_parameters(*args, **kwargs)  # type: ignore
         if inspect.iscoroutinefunction(attr):
             sync_func = synchronous(attr)
             bound_method = MethodType(sync_func, core_obj)

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -14,6 +14,7 @@ from opentrons.util.pyro.pyro_serialization import (
     TypedDictWrapper,
     UnhashableDictWrapper,
 )
+from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject, AsyncPyroFunctionWrapper
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -382,6 +383,40 @@ def get_pyro_attributes_with_proxy_result(self: Any) -> list[str]:
     result: list[str] = self._pyro_attributes_with_proxy_results
     return result
 
+# Validators
+# CASEY NOTE: This won't be called on non-pyro behavior functions. Maybe those need to be checked too.
+def _validated_parameters(*args: P.args, **kwargs: P.kwargs) -> tuple[tuple, dict]:
+        def _validations(arg: Any) -> Any:
+            # NOTE: Extend this as further validations are needed
+            arg = _validate_inbound_proxy(arg)
+            return arg
+
+        validated_args = tuple()  # type: ignore
+        for arg in args:
+            # Validate each non-keyword argument and reconstruct the argument tuple
+            validated_args = (*validated_args, _validations(arg))
+        # Validate each keyword argument and reconstruct the kwargs dictionary
+        kwargs = {key: _validations(kwargs[key]) for key in kwargs.keys()}
+        return (validated_args, kwargs)
+
+def _validate_inbound_proxy(arg: Any) -> Any:
+    """Handle an argument which is a remote Proxy that may have been forwarded through multiple processes."""
+    if isinstance(arg, pyro.Proxy):
+        try:
+            if arg.is_callable:
+                arg = AsyncPyroFunctionWrapper(proxy=arg)
+        except AttributeError:
+            try:
+                iter(arg)
+                validated_arg = []
+                for r in arg:
+                    validated_arg.append(AsyncClientPyroObject(r))
+                arg = validated_arg
+            except AttributeError:
+                arg = AsyncClientPyroObject(arg)
+    return arg
+
+# CASEY NOTE: put some kind of generic "validator wrapper" here? is there even a usecase where non-pso decorated functions get these? maybe create() for protocol engine
 
 ### Specialty Functions for use with the `pyro_behavior` decorator ###
 
@@ -401,6 +436,8 @@ def convert_result_to_proxy(  # noqa: C901
     @functools.wraps(attr)
     def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:  # noqa: C901
         # Of note, the wrapper passes self to terminate the self instance passed by the PSO
+        args, kwargs = _validated_parameters(*args, **kwargs)
+        print(f"HERE WITH: {args} --- {kwargs}")
         if inspect.iscoroutinefunction(attr):
             sync_func = synchronous(attr)
             bound_method = MethodType(sync_func, core_obj)
@@ -458,6 +495,7 @@ def convert_result_to_wrapped_dict(  # noqa: C901
     @functools.wraps(attr)
     def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:
         # Of note, the wrapper passes self to terminate the self instance passed by the PSO
+        args, kwargs = _validated_parameters(*args, **kwargs)
         if inspect.iscoroutinefunction(attr):
             sync_func = synchronous(attr)
             bound_method = MethodType(sync_func, core_obj)
@@ -523,6 +561,7 @@ def convert_type_to_instance(
 
     @functools.wraps(attr)
     def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:
+        args, kwargs = _validated_parameters(*args, **kwargs)
         if inspect.iscoroutinefunction(attr):
             sync_func = synchronous(attr)
             result = sync_func(self, *args, **kwargs)
@@ -555,6 +594,7 @@ def convert_result_to_wrapped_typed_dict(
 
     @functools.wraps(attr)
     def wrapper(self: Any, *args: P.args, **kwargs: P.kwargs) -> Any:
+        args, kwargs = _validated_parameters(*args, **kwargs)
         if inspect.iscoroutinefunction(attr):
             sync_func = synchronous(attr)
             bound_method = MethodType(sync_func, core_obj)

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -3,6 +3,7 @@
 import asyncio
 import functools
 import inspect
+import enum
 from types import FunctionType, MethodType
 from typing import Any, Callable, Dict, Iterator, Optional, ParamSpec, TypeVar
 
@@ -61,6 +62,25 @@ class DaemonUtility:
         # This could trigger inside a wrapper pyro_behavior function on a PSO call for example.
         return self._daemon.proxyFor(pso)  # type: ignore
 
+class PyroFunctionWrapper:
+    """Wrapper class to safely wrap callable responses as Proxy objects.."""
+    def __init__(
+        self,
+        callable: Callable,
+    ):
+        self.callable = callable
+    
+    @property
+    def is_callable(self) -> bool:
+        return True
+    
+    def call(self, *args, **kwargs) -> Any:
+        """Remote deployable function call."""
+        return self.callable(*args, **kwargs)
+    
+class ResultMeta(enum.Enum):
+    PROXY = enum.auto()
+    UNKNOWN = enum.auto()
 
 class _PyroSpecialBehavior(BaseModel):
     specialty_function: Callable[[DaemonUtility, Any, str, Any], Any]
@@ -216,6 +236,7 @@ def _build_classdict(  # noqa: C901
     core_obj: Any, utility: DaemonUtility
 ) -> Iterator[tuple[str, Any]]:
     async_methods: dict[str, dict[str, Any]] = {}
+    proxy_attributes: list[str] = []
     for name, attr in inspect.getmembers(core_obj.__class__):
         if "__" not in name and not name.startswith("_"):
             specialty_behavior = _get_specialty_behavior(attr, name)
@@ -246,6 +267,12 @@ def _build_classdict(  # noqa: C901
                 if inspect.iscoroutinefunction(attr):
                     async_metadata = _build_metadata_dictionary(attr)
                     async_methods[name] = async_metadata
+                
+                result_meta = _determine_attribute_result_metadata(specialty_behavior.specialty_function)
+                # NOTE: extend this further as needed for custom result types
+                if result_meta is ResultMeta.PROXY:
+                    proxy_attributes.append(name)
+
                 exposed = pyro.expose(
                     specialty_behavior.specialty_function(utility, core_obj, name, attr)
                 )
@@ -289,6 +316,10 @@ def _build_classdict(  # noqa: C901
     # Attach the known async methods list to the PSO as a private member and expose a getter method
     yield ("_pyro_async_methods", async_methods)
     yield ("get_pyro_async_methods", pyro.expose(property(get_pyro_async_methods)))  # type: ignore
+    # Attach an initially empty proxy-providing methods list to the PSO as a private member and expose a getter method
+    yield ("_pyro_attributes_with_proxy_results", proxy_attributes)
+    yield( "get_pyro_attributes_with_proxy_result", pyro.expose(property(get_pyro_attributes_with_proxy_result)))  # type: ignore
+
 
     # Attach the `core_obj` instance as a private member for internal tracking
     try:
@@ -311,6 +342,14 @@ def _build_metadata_dictionary(attr: Any) -> Dict[str, Any]:
     }
 
 
+def _determine_attribute_result_metadata(specialty_func: Any) -> ResultMeta:
+    # Determines the result metadata for an attribute wrapped in a speciality function
+    if specialty_func.__name__ == "convert_result_to_proxy":
+        return ResultMeta.PROXY
+    # NOTE: extend this further as needed in the future for other custom return types
+    return ResultMeta.UNKNOWN
+
+
 def _get_specialty_behavior(func: Any, name: str) -> _PyroSpecialBehavior | None:
     if inspect.iscoroutinefunction(func) or isinstance(func, FunctionType):
         if hasattr(func, "_pyro_specialty_behavior"):
@@ -324,6 +363,11 @@ def _get_specialty_behavior(func: Any, name: str) -> _PyroSpecialBehavior | None
 def get_pyro_async_methods(self: Any) -> dict[str, dict[str, Any]]:
     """Helper function to access the dictionary of known async method metadata on a PyroSynchronousObject."""
     result: dict[str, dict[str, Any]] = self._pyro_async_methods
+    return result
+
+def get_pyro_attributes_with_proxy_result(self) -> list[str]:
+    """Helper function to access the list of known methods that provide their results as Proxies."""
+    result: list[str] = self._pyro_attributes_with_proxy_results
     return result
 
 
@@ -372,6 +416,9 @@ def convert_result_to_proxy(  # noqa: C901
                 proxy_list.append(utility.proxy_for(pyro_synchronous_obj))
             return proxy_list
         except TypeError:
+            if isinstance(result, FunctionType):
+                # Wrap callable result in Proxy-safe format
+                result = PyroFunctionWrapper(result)
             pyro_synchronous_obj = utility.find_PSO(result)
             if pyro_synchronous_obj is None:
                 if not hasattr(result, "_loop"):

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
@@ -27,12 +27,20 @@ from opentrons.hardware_control.poller import Poller
 from opentrons.hardware_control.pyro_utils.serpent_type_registry import (
     register_hardware_types,
 )
-from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
+from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject, AsyncPyroFunctionWrapper
 from opentrons.util.pyro.pyro_daemon_utility import PYRO_TIMEOUT, create_pyro_daemon
 from opentrons.util.pyro.pyro_synchronous_adapter import (
     DaemonUtility,
     PyroSynchronousObject,
+    pyro_behavior,
+    convert_result_to_proxy
 )
+from mock import AsyncMock
+from opentrons.drivers.thermocycler import driver
+from opentrons.drivers.asyncio.communication.serial_connection import (
+    AsyncResponseSerialConnection,
+)
+from opentrons.hardware_control.types import DoorStateNotification, HardwareEvent, HardwareEventHandler
 
 
 @pytest.fixture
@@ -96,6 +104,17 @@ async def st_reader_mocked_driver(
     """A reader with a mocked driver."""
     return modules.flex_stacker.FlexStackerReader(driver=mock_driver)  # type: ignore
 
+
+@pytest.fixture
+def connection() -> AsyncMock:
+    return AsyncMock(spec=AsyncResponseSerialConnection)
+
+
+
+@pytest.fixture
+def mock_thermo_driver(connection: AsyncMock) -> driver.ThermocyclerDriverV2:
+    connection.send_command.return_value = ""
+    return driver.ThermocyclerDriverV2(connection)
 
 async def test_pyro_behavior_on_modules(
     ot3_hardware: ThreadManager[OT3API],
@@ -265,3 +284,116 @@ async def test_pyro_behavior_ot3api_unhashable_dicts(
 
     # Clean up client resources.
     ot3_proxy._pyroRelease()  # type: ignore
+
+async def test_pyro_async_wrapped_calls(
+    ot3_hardware: ThreadManager[OT3API],
+    mock_driver: SimulatingDriver,
+    decoy: Decoy,
+    tc_reader_mocked_driver: modules.thermocycler.ThermocyclerReader,
+    mock_thermo_driver: driver.ThermocyclerDriverV2
+) -> None:
+    """Test the pyro behavior for callback and asynchronous module calls through an automatically wrapped proxy child."""
+    sock = socket.socket()
+    sock.bind(("localhost", 0))
+    host, port = sock.getsockname()
+    sock.close()
+
+    pyro.config.NS_HOST = host
+    pyro.config.NS_PORT = port
+
+    name_server_ready = threading.Event()
+
+    # Module mocks
+    api = ot3_hardware.wrapped()
+    api._backend.module_controls = decoy.mock(cls=AttachedModulesControl)
+    tc = decoy.mock(cls=Thermocycler)
+    decoy.when(api._backend.module_controls.available_modules).then_return(
+        [tc]
+    )
+    tc._loop = ot3_hardware.managed_obj._loop
+    for mod in api._backend.module_controls.available_modules:
+        decoy.when(mod._driver).then_return(mock_driver)  # type: ignore
+
+    decoy.when(tc._poller).then_return(Poller(tc_reader_mocked_driver, interval=0.01))
+
+    def _nameserver_loop() -> None:
+        # start_ns returns (nameserver, daemon, uri)
+        _, ns_daemon, _ = nameserver.start_ns(host=host, port=port)  # type: ignore
+        name_server_ready.set()
+        # Run until the test process exits; thread is marked daemon=True.
+        ns_daemon.requestLoop()
+
+    def _pyro_daemon() -> None:
+        # Wait for the nameserver to be ready so locate_ns can succeed.
+        name_server_ready.wait(timeout=PYRO_TIMEOUT)
+        create_pyro_daemon("OT3API", ot3_hardware, register_hardware_types)
+
+    class cool_door_class:
+        def __init__(
+            self,
+            loop: bool
+        ):
+            self._loop = loop # placeholder dummy - never used by this object
+
+        @pyro_behavior(convert_result_to_proxy, False)
+        def cool_hardware_event(self) -> HardwareEventHandler:
+            print("IN THIS")
+            def run_handler(
+                event: HardwareEvent,
+            ) -> None:
+                if isinstance(event, DoorStateNotification):
+                    return None
+
+            return run_handler
+
+    def _door_daemon() -> None:
+        cool_door_instance = cool_door_class(True)
+        # Wait for the nameserver to be ready so locate_ns can succeed.
+        name_server_ready.wait(timeout=PYRO_TIMEOUT)
+        create_pyro_daemon("cool_door", cool_door_instance, register_hardware_types)
+
+    ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
+    server_thread = threading.Thread(target=_pyro_daemon, daemon=True)
+    door_thead = threading.Thread(target=_door_daemon, daemon=True)
+
+    ns_thread.start()
+    server_thread.start()
+    door_thead.start()
+
+    # Client-side requests below
+    register_hardware_types()
+    name_server_ready.wait(timeout=PYRO_TIMEOUT)
+    ns = pyro.locate_ns()
+
+    retries_counter = 0
+    while ns.count() < 2:
+        # Wait and try again, the resource isnt registered yet
+        await asyncio.sleep(0.01)
+        retries_counter += 1
+        if retries_counter > 10:
+            # Stop waiting for the nameserver, will fail on pyro.resolve (something is wrong with nameserver and/or daemon)
+            raise TimeoutError("TEST FAILURE ON PYRO NAMESERVER.")
+
+    uri = pyro.resolve(uri="PYRONAME:OT3API")
+    ot3_proxy = pyro.Proxy(uri)  # type: ignore
+    ot3_async = AsyncClientPyroObject(ot3_proxy)
+    ot3api = cast(OT3API, ot3_async)
+    door_uri = pyro.resolve(uri="PYRONAME:cool_door")
+    door_proxy = pyro.Proxy(door_uri)  # type: ignore
+    door_async = AsyncClientPyroObject(door_proxy)
+
+    await ot3api.home()
+
+    # Ensure that functions which provide proxies also are wrapped asynchronously
+    async_remote_tc = ot3api.attached_modules[0]
+    decoy.when(tc._driver).then_return(mock_thermo_driver)
+    # Verify that async calls work on the thermocycler right away
+    assert await async_remote_tc.open() == "open"
+
+    # Test registering an outbound function from one remote resource with another remote resouce
+    result = ot3api.register_callback(cb=door_async.cool_hardware_event())
+
+    # Verify the resulting callback proxy (which is wrapped automagically) is wrapped and callable
+    assert isinstance(result, AsyncPyroFunctionWrapper)
+    result()
+

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
@@ -7,10 +7,15 @@ from typing import Dict, cast
 
 import pytest
 from decoy import Decoy
+from mock import AsyncMock
 from Pyro5 import api as pyro
 from Pyro5 import nameserver
 
+from opentrons.drivers.asyncio.communication.serial_connection import (
+    AsyncResponseSerialConnection,
+)
 from opentrons.drivers.heater_shaker.simulator import SimulatingDriver
+from opentrons.drivers.thermocycler import driver
 from opentrons.hardware_control import ThreadManager, modules
 from opentrons.hardware_control import types as hw_types
 from opentrons.hardware_control.module_control import AttachedModulesControl
@@ -27,20 +32,22 @@ from opentrons.hardware_control.poller import Poller
 from opentrons.hardware_control.pyro_utils.serpent_type_registry import (
     register_hardware_types,
 )
-from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject, AsyncPyroFunctionWrapper
+from opentrons.hardware_control.types import (
+    DoorStateNotification,
+    HardwareEvent,
+    HardwareEventHandler,
+)
+from opentrons.util.pyro.pyro_client_async_adapter import (
+    AsyncClientPyroObject,
+    AsyncPyroFunctionWrapper,
+)
 from opentrons.util.pyro.pyro_daemon_utility import PYRO_TIMEOUT, create_pyro_daemon
 from opentrons.util.pyro.pyro_synchronous_adapter import (
     DaemonUtility,
     PyroSynchronousObject,
+    convert_result_to_proxy,
     pyro_behavior,
-    convert_result_to_proxy
 )
-from mock import AsyncMock
-from opentrons.drivers.thermocycler import driver
-from opentrons.drivers.asyncio.communication.serial_connection import (
-    AsyncResponseSerialConnection,
-)
-from opentrons.hardware_control.types import DoorStateNotification, HardwareEvent, HardwareEventHandler
 
 
 @pytest.fixture
@@ -110,11 +117,11 @@ def connection() -> AsyncMock:
     return AsyncMock(spec=AsyncResponseSerialConnection)
 
 
-
 @pytest.fixture
 def mock_thermo_driver(connection: AsyncMock) -> driver.ThermocyclerDriverV2:
     connection.send_command.return_value = ""
     return driver.ThermocyclerDriverV2(connection)
+
 
 async def test_pyro_behavior_on_modules(
     ot3_hardware: ThreadManager[OT3API],
@@ -285,12 +292,13 @@ async def test_pyro_behavior_ot3api_unhashable_dicts(
     # Clean up client resources.
     ot3_proxy._pyroRelease()  # type: ignore
 
+
 async def test_pyro_async_wrapped_calls(
     ot3_hardware: ThreadManager[OT3API],
     mock_driver: SimulatingDriver,
     decoy: Decoy,
     tc_reader_mocked_driver: modules.thermocycler.ThermocyclerReader,
-    mock_thermo_driver: driver.ThermocyclerDriverV2
+    mock_thermo_driver: driver.ThermocyclerDriverV2,
 ) -> None:
     """Test the pyro behavior for callback and asynchronous module calls through an automatically wrapped proxy child."""
     sock = socket.socket()
@@ -307,9 +315,7 @@ async def test_pyro_async_wrapped_calls(
     api = ot3_hardware.wrapped()
     api._backend.module_controls = decoy.mock(cls=AttachedModulesControl)
     tc = decoy.mock(cls=Thermocycler)
-    decoy.when(api._backend.module_controls.available_modules).then_return(
-        [tc]
-    )
+    decoy.when(api._backend.module_controls.available_modules).then_return([tc])
     tc._loop = ot3_hardware.managed_obj._loop
     for mod in api._backend.module_controls.available_modules:
         decoy.when(mod._driver).then_return(mock_driver)  # type: ignore
@@ -329,15 +335,11 @@ async def test_pyro_async_wrapped_calls(
         create_pyro_daemon("OT3API", ot3_hardware, register_hardware_types)
 
     class cool_door_class:
-        def __init__(
-            self,
-            loop: bool
-        ):
-            self._loop = loop # placeholder dummy - never used by this object
+        def __init__(self, loop: bool):
+            self._loop = loop  # placeholder dummy - never used by this object
 
         @pyro_behavior(convert_result_to_proxy, False)
         def cool_hardware_event(self) -> HardwareEventHandler:
-            print("IN THIS")
             def run_handler(
                 event: HardwareEvent,
             ) -> None:
@@ -396,4 +398,3 @@ async def test_pyro_async_wrapped_calls(
     # Verify the resulting callback proxy (which is wrapped automagically) is wrapped and callable
     assert isinstance(result, AsyncPyroFunctionWrapper)
     result()
-

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
@@ -293,7 +293,7 @@ async def test_pyro_behavior_ot3api_unhashable_dicts(
     ot3_proxy._pyroRelease()  # type: ignore
 
 
-async def test_pyro_async_wrapped_calls(
+async def test_pyro_async_wrapped_calls(  # noqa: C901
     ot3_hardware: ThreadManager[OT3API],
     mock_driver: SimulatingDriver,
     decoy: Decoy,
@@ -316,7 +316,7 @@ async def test_pyro_async_wrapped_calls(
     api._backend.module_controls = decoy.mock(cls=AttachedModulesControl)
     tc = decoy.mock(cls=Thermocycler)
     decoy.when(api._backend.module_controls.available_modules).then_return([tc])
-    tc._loop = ot3_hardware.managed_obj._loop
+    tc._loop = ot3_hardware.managed_obj._loop  # type: ignore
     for mod in api._backend.module_controls.available_modules:
         decoy.when(mod._driver).then_return(mock_driver)  # type: ignore
 
@@ -393,7 +393,7 @@ async def test_pyro_async_wrapped_calls(
     assert await async_remote_tc.open() == "open"
 
     # Test registering an outbound function from one remote resource with another remote resouce
-    result = ot3api.register_callback(cb=door_async.cool_hardware_event())
+    result = ot3api.register_callback(cb=door_async.cool_hardware_event())  # type: ignore
 
     # Verify the resulting callback proxy (which is wrapped automagically) is wrapped and callable
     assert isinstance(result, AsyncPyroFunctionWrapper)

--- a/robot-server/tests/service/pyro_utils/test_pyro_resource.py
+++ b/robot-server/tests/service/pyro_utils/test_pyro_resource.py
@@ -25,7 +25,10 @@ from opentrons.protocol_engine.resources.file_provider import (
     FileProvider,
     UserDefinedCSVCmdFileNameMetadata,
 )
-from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
+from opentrons.util.pyro.pyro_client_async_adapter import (
+    AsyncClientPyroObject,
+    AsyncPyroFunctionWrapper,
+)
 from opentrons.util.pyro.pyro_daemon_utility import PYRO_TIMEOUT, create_pyro_daemon
 from opentrons_shared_data.data_files import DataFileInfo, MimeType
 from opentrons_shared_data.robot.types import RobotTypeEnum
@@ -165,7 +168,7 @@ async def test_run_hardware_event_callback(
         robot_server_resource.create_run_hardware_event_callback()
     )
 
-    assert isinstance(result, pyro.Proxy)
+    assert isinstance(result, AsyncPyroFunctionWrapper)
 
 
 async def test_maintenance_run_hardware_event_callback(
@@ -201,7 +204,7 @@ async def test_maintenance_run_hardware_event_callback(
         robot_server_resource.create_maintenance_run_hardware_event_callback()
     )
 
-    assert isinstance(result, pyro.Proxy)
+    assert isinstance(result, AsyncPyroFunctionWrapper)
 
 
 async def test_camera_provider(
@@ -222,11 +225,10 @@ async def test_camera_provider(
         mock_app_state, empty_cam_provider
     )
 
-    camera_proxy = robot_server_resource.get_camera_provider()
+    # NOTE: The camera proxy should comeback already wrapped as an AsyncClientPyroObject
+    camera_proxy_async = robot_server_resource.get_camera_provider()
 
-    # todo(chb: 04-10-2026): When AsyncClientPyroObjects start auto-wrapping child proxies as async this can simplify
-    async_cam = AsyncClientPyroObject(camera_proxy)
-    cam_provider = cast(CameraProvider, async_cam)
+    cam_provider = cast(CameraProvider, camera_proxy_async)
     settings = await cam_provider.get_camera_settings()
 
     # Empty Camera settings defaults all to True, assert the proxy gave us that
@@ -253,11 +255,10 @@ async def test_file_provider(
         mock_app_state, empty_file_provider
     )
 
-    file_proxy = robot_server_resource.get_file_provider()
+    # NOTE: The camera proxy should comeback already wrapped as an AsyncClientPyroObject
+    file_proxy_async = robot_server_resource.get_file_provider()
 
-    # todo(chb: 04-10-2026): When AsyncClientPyroObjects start auto-wrapping child proxies as async this can simplify
-    async_file = AsyncClientPyroObject(file_proxy)
-    file_provider = cast(FileProvider, async_file)
+    file_provider = cast(FileProvider, file_proxy_async)
     results = await file_provider.write_file(
         data=bytes([1, 2, 3]),
         mime_type=MimeType("text/csv"),


### PR DESCRIPTION
# Overview
Covers EXEC-2523

In order to fully support roundtrip callbacks we needed a way to safely wrap them for transport between client and servers, this is where the server side `PyroFunctionWrapper` and client side `AsyncPyroFunctionWrapper` come in to play! At either end of our remote calls, the callback results of a given attribute will be neatly packaged on either end, to ensure everything is callable as expected and maintained in a threadsafe fashion (woohoo!).

As an extension of this, Proxy results which represent non-function class types will also be automatically wrapped as AsyncClientPyroObjects so they are fully awaitable upon unpacking. This means child PyroSynchronousObjects are automagically prepared for use on client callers.
Example:
```
...
ot3_async = AsyncClientPyroObject(ot3_proxy_object)
# Assume the thermocycler is our first module
thermo = ot3_async.attached_modules[0]
# Despite being a child Proxy of an OT3API Proxy, the thermocycler can be awaited! Thanks ACPO!
await thermo.open()
```

## Test Plan and Hands on Testing

- [x] Unit test coverage for OT3API register callback behavior
- [x] Unit test coverage for async module calls
- [ ] Test on Flex with subprocess run


## Changelog
Extended the PyroSynchronousObject and AsyncClientPyroObject to support bi-directional callback transfer and automatic Proxy async wrapping.

## Review requests
Do we have any async callbacks I need to worry about here? Will those just work? Do we even do that?

## Risk assessment
Medium - this ones pretty important to get all of our gears turning on the business logic of a full system run.