### PR TITLE
docs(api): update concurrent command examples

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -747,24 +747,23 @@ class ThermocyclerContext(ModuleContext):
     ) -> Task:
         """Sets the target temperature for the Thermocycler Module's well block, in °C.
 
-                Returns a [`Task`][opentrons.protocol_api.Task] object that represents concurrent heating.
-                Pass the task object to [`ProtocolContext.wait_for_tasks()`][opentrons.protocol_api.ProtocolContext.wait_for_tasks]
-                to wait for the preheat to complete.
+        Returns a [`Task`][opentrons.protocol_api.Task] object that represents concurrent heating.
+        Pass the task object to [`ProtocolContext.wait_for_tasks()`][opentrons.protocol_api.ProtocolContext.wait_for_tasks]
+        to wait for the preheat to complete.
 
-                Args:
-                    temperature: A value between 4 and 99, representing the target
-                        temperature in °C.
-                    block_max_volume: The greatest volume of liquid contained in any
-                        individual well of the loaded labware, in µL. If not specified,
-                        the default is 25 µL.
-                    ramp_rate: The rate to heat or cool the Thermocycler Module's block,
-                        in °C/second. The acceptable range is 0.01–2 °C/second
-                        to cool the block, and 0.01–4.25 °C/second to heat the block. If not specified,
-                        the block will heat or cool as quickly as possible to reach the set temperature.
+        Args:
+            temperature: A value between 4 and 99, representing the target
+                temperature in °C.
+            block_max_volume: The greatest volume of liquid contained in any
+                individual well of the loaded labware, in µL. If not specified,
+                the default is 25 µL.
+            ramp_rate: The rate to heat or cool the Thermocycler Module's block,
+                in °C/second. The acceptable range is 0.01–2 °C/second
+                to cool the block, and 0.01–4.25 °C/second to heat the block. If not specified,
+                the block will heat or cool as quickly as possible to reach the set temperature.
 
-                *Changed in version 2.27:* In API version
-                2.27 and newer, the API will first attempt to use the liquid tracking in labware, then default to 25 µL if the protocol lacks probed or loaded
-                liquid information.
+        *Changed in version 2.27:* In API version 2.27 and newer, the API will first attempt to use the liquid tracking in labware, then default to 25 µL if the protocol lacks probed or loaded
+        liquid information.
 
         *Changed in version 2.28:* Use the optional `ramp_rate` parameter to control how quickly
         the block heats or cools.

--- a/docs/python-api/docs/modules/heater-shaker.md
+++ b/docs/python-api/docs/modules/heater-shaker.md
@@ -132,7 +132,7 @@ The examples below use a blocking or concurrent command to set the Heater-Shaker
 
 === "Blocking"
     ```python
-    hs_mod.set_and_wait_for_temperature(75)
+    hs_mod.set_and_wait_for_temperature(celsius=75)
     pipette.pick_up_tip()
     pipette.aspirate(50, plate["A1"])
     pipette.dispense(50, plate["B1"])
@@ -146,7 +146,7 @@ The examples below use a blocking or concurrent command to set the Heater-Shaker
 
 === "Concurrent"
     ```python
-    hs_mod.set_target_temperature(75)
+    hs_mod.set_target_temperature(celsius=75)
     pipette.pick_up_tip()   
     pipette.aspirate(50, plate["A1"])
     pipette.dispense(50, plate["B1"])
@@ -165,7 +165,7 @@ If you want the robot to continue pipetting while the module heats to prepare fo
 
 ```python
 # set target temperature
-heat_task = hs_mod.set_target_temperature(75)
+heat_task = hs_mod.set_target_temperature(celsius=75)
 
 # pipette while the module heats
 pipette.pick_up_tip()
@@ -176,7 +176,7 @@ pipette.dispense(50, plate["B1"])
 protocol.wait_for_tasks([heat_task])
 
 # set and hold for a sample incubation 
-incubation_timer = create_timer(seconds=120)
+incubation_timer = protocol.create_timer(seconds=120)
 protocol.wait_for_tasks([incubation_timer])
 hs_mod.deactivate_heater()
 ```

--- a/docs/python-api/docs/modules/thermocycler.md
+++ b/docs/python-api/docs/modules/thermocycler.md
@@ -117,7 +117,7 @@ You can optionally instruct the Thermocycler to hold its block temperature for a
 === "Concurrent"
     ```python
     # set block temperature
-    cool_task = tc_mod.start_set_block_temperature(celsius=4)
+    cool_task = tc_mod.start_set_block_temperature(temperature=4)
     # complete pipetting actions while the block cools
     pipette.pick_up_tip()
     pipette.aspirate(50, plate["A1"])
@@ -126,7 +126,7 @@ You can optionally instruct the Thermocycler to hold its block temperature for a
     # wait for the block to reach the target temperature
     protocol.wait_for_tasks([cool_task])
     # hold samples on the block at target temperature
-    block_timer = create_timer(seconds=255)
+    block_timer = protocol.create_timer(seconds=255)
     protocol.wait_for_tasks([block_timer])
     ```
 


### PR DESCRIPTION
# Overview

I wrote a protocol using the concurrent command examples from the docs and found errors and areas for improvement: 

- code block error when using `protocol.create_timer()`
- `start_set_block_temperature()`'s API ref was in a code block 
- consistently stating the parameter for different module temperature commands. some accept `celsius` and some accept `temperature`. one change here was to fix an error. the rest are just to more explicitly state which param each command accepts. 

## Test Plan and Hands on Testing

[sandbox](https://sandbox.docs.opentrons.com/docs-concurrent-fix/)

## Changelog

see above ^

## Review requests

Does everything look right? 

## Risk assessment

low. 
