### PR TITLE
fix(app, shared-data): fix VM deck configuration

### DIFF
--- a/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
@@ -31,9 +31,11 @@ import {
   getCutoutDisplayName,
   getDeckDefFromRobotType,
   getFixtureDisplayName,
+  getJoinedVisualSlotDisplayNamesForFixture,
   getVisualSlotIdForAA,
   replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA,
   SINGLE_SLOT_FIXTURES,
+  VACUUM_MODULE_V1_FIXTURE,
 } from '@opentrons/shared-data'
 
 import { useIsRobotViewable } from '/app/redux-resources/robots'
@@ -138,6 +140,22 @@ export function DeviceDetailsDeckConfiguration({
             displayList: [...acc.displayList, { displayLocation, displayName }],
             groupedCutoutIds: [...acc.groupedCutoutIds, ...groupedCutoutIds],
           }
+        }
+      }
+      if (cutoutFixtureId === VACUUM_MODULE_V1_FIXTURE) {
+        return {
+          ...acc,
+          displayList: [
+            ...acc.displayList,
+            {
+              displayLocation: getJoinedVisualSlotDisplayNamesForFixture(
+                deckDef,
+                cutoutFixtureId,
+                cutoutId
+              ),
+              displayName,
+            },
+          ],
         }
       }
       const vsId = getVisualSlotIdForAA(

--- a/shared-data/js/helpers/__tests__/deckConfiguration/getFixtureFrom.test.ts
+++ b/shared-data/js/helpers/__tests__/deckConfiguration/getFixtureFrom.test.ts
@@ -18,6 +18,7 @@ import {
   STAGING_AREA_SLOT_WITH_MAGNETIC_BLOCK_V1_FIXTURE,
   STAGING_AREA_SLOT_WITH_WASTE_CHUTE_RIGHT_ADAPTER_COVERED_FIXTURE,
   STAGING_AREA_SLOT_WITH_WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE,
+  VACUUM_MODULE_V1_FIXTURE,
   WASTE_CHUTE_RIGHT_ADAPTER_COVERED_FIXTURE,
   WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE,
 } from '../../../constants'
@@ -124,6 +125,16 @@ describe('getReplacementFixtureForFixtureRemoval', () => {
     )
 
     expect(result).toEqual(STAGING_AREA_RIGHT_SLOT_FIXTURE)
+  })
+
+  it('Should return SINGLE_RIGHT_SLOT_FIXTURE when removing vacuum module from A3', () => {
+    const result = getReplacementFixtureForFixtureRemoval(
+      VACUUM_MODULE_V1_FIXTURE,
+      'cutoutA3',
+      'vacuumModuleV1A3'
+    )
+
+    expect(result).toEqual(SINGLE_RIGHT_SLOT_FIXTURE)
   })
 })
 

--- a/shared-data/js/helpers/deckConfiguration/getFixtureFrom.ts
+++ b/shared-data/js/helpers/deckConfiguration/getFixtureFrom.ts
@@ -21,6 +21,7 @@ import {
   SINGLE_RIGHT_CUTOUTS,
   SINGLE_RIGHT_SLOT_FIXTURE,
   STAGING_AREA_RIGHT_SLOT_FIXTURE,
+  VACUUM_MODULE_V1_FIXTURE,
   WASTE_CHUTE_FIXTURES,
   WASTE_CHUTE_FLEX_STACKER_FIXTURES,
   WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE,
@@ -165,6 +166,17 @@ export const replaceFixtureToFakeFixtureAndTransformCutoutFixturesToAA = (
           cutoutFixtureId: cutoutFixtureReplacment,
         })
       }
+    } else if (obj.cutoutFixtureId === VACUUM_MODULE_V1_FIXTURE) {
+      const vacuumModuleAA = aaPerCutoutFixture?.find(
+        aa => getAAByAAId(aa, deckDef).areaType === 'vacuumModule'
+      )
+      if (vacuumModuleAA != null) {
+        acc.push({
+          ...obj,
+          addressableAreaId: vacuumModuleAA,
+          cutoutFixtureId: cutoutFixtureReplacment,
+        })
+      }
     } else {
       aaPerCutoutFixture?.forEach(item => {
         acc.push({
@@ -216,6 +228,10 @@ export const replaceCutoutFixtureForFixtureRemoval = (
       return WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE
     }
   } else if (cutoutFixtureRemoved === ABSORBANCE_READER_V1_FIXTURE) {
+    return SINGLE_RIGHT_SLOT_FIXTURE
+  } else if (cutoutFixtureRemoved === VACUUM_MODULE_V1_FIXTURE) {
+    // Vacuum spans two AAs on one cutout; the generic matcher below cannot
+    // resolve to singleRightSlot (only provides A3), so removal must be explicit.
     return SINGLE_RIGHT_SLOT_FIXTURE
   } else if (cutoutFixtureRemoved === FLEX_STACKER_V1_FIXTURE) {
     return SINGLE_RIGHT_SLOT_FIXTURE

--- a/shared-data/js/helpers/deckConfiguration/getJoinedVisualSlotDisplayNamesForFixture.ts
+++ b/shared-data/js/helpers/deckConfiguration/getJoinedVisualSlotDisplayNamesForFixture.ts
@@ -1,0 +1,24 @@
+import { getSlotDisplayNameFromAAWithFakes } from './getVisualSlotFrom'
+
+import type { CutoutFixtureId, CutoutId } from '../../../deck'
+import type { DeckDefinition } from '../../types'
+
+/**
+ * Visual slot labels for a cutout fixture mounted on a cutout, joined with " + "
+ * when the fixture spans multiple slots on one cutout (e.g. vacuum module A3 + A4).
+ *
+ * Values come from `providesAddressableAreas` on the deck definition fixture.
+ */
+export function getJoinedVisualSlotDisplayNamesForFixture(
+  deckDef: DeckDefinition,
+  cutoutFixtureId: CutoutFixtureId,
+  cutoutId: CutoutId
+): string {
+  const fixtureDef = deckDef.cutoutFixtures.find(
+    cf => cf.id === cutoutFixtureId
+  )
+  const areaIds = fixtureDef?.providesAddressableAreas[cutoutId] ?? []
+  return areaIds
+    .map(aaId => getSlotDisplayNameFromAAWithFakes(aaId))
+    .join(' + ')
+}

--- a/shared-data/js/helpers/deckConfiguration/index.ts
+++ b/shared-data/js/helpers/deckConfiguration/index.ts
@@ -1,3 +1,4 @@
 export * from './getAddressableAreaFrom'
 export * from './getFixtureFrom'
+export * from './getJoinedVisualSlotDisplayNamesForFixture'
 export * from './getVisualSlotFrom'


### PR DESCRIPTION
# Overview

This PR fixes a few bugs noticed in deck configuration:
1. The display location for the vacuum module should read "A3 + A4"
2. Clicking the configured VM should remove it from deck config.


### 1. Display location in Device Details

#### Before

<img width="681" height="703" alt="Screenshot 2026-04-21 at 12 01 36 PM" src="https://github.com/user-attachments/assets/bd18791b-0936-4c08-a827-418d9753c82e" />

#### After

<img width="696" height="681" alt="Screenshot 2026-04-21 at 11 59 24 AM" src="https://github.com/user-attachments/assets/d756ae1d-a7f0-434e-8548-e5907bc01f25" />

### 2. Removal of configured VM

#### Before

https://github.com/user-attachments/assets/659a9fed-994b-4701-b8d9-fe8826f72f71

#### After

https://github.com/user-attachments/assets/70d1d1bc-0835-4683-aca4-2bc71b49dddb


## Test Plan and Hands on Testing

#### On robot
- connected a vacuum module to a robot
- configured the vacuum in either A3 or A4 (both point to cutout A3 for the VM)
- inspected the device list in the desktop app > device details > deck configuration, and verified that the VM shows only one item in "A3 + A4"
- clicked the deck config VM item, and verified it was removed from deck config
- repeated the above point on the ODD

#### In code
- unit testing for new utilities

## Changelog

- updated logic for removing a vacuum module from deck config
- added new logic for building the vacuum module display location ("A3 + A4")

## Review requests

- see test plan

## Risk assessment

low