### PR TITLE
refactor(api): Reduce Pyro connection churn

### DIFF
--- a/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
@@ -1,6 +1,7 @@
 """Class wrapper that ingests a PyroSynchronousObject and maps 'synchronized' async functions to awaitable methods."""
 
 import asyncio
+import threading
 from typing import Any, Iterator, ParamSpec, TypeVar
 
 import Pyro5.api
@@ -13,6 +14,9 @@ P = ParamSpec("P")
 
 class _ACPO:
     pass
+
+
+_thread_local = threading.local()
 
 
 def AsyncClientPyroObject(pyro_synchronous_object: Pyro5.api.Proxy) -> _ACPO:
@@ -80,6 +84,22 @@ def _get_async_methods(proxy: Pyro5.api.Proxy) -> dict[str, dict[str, Any]]:
     return result
 
 
+def _get_thread_proxy(proxy: Pyro5.api.Proxy) -> Pyro5.api.Proxy:
+    """Get or create a thread-local proxy for the given URI, reconnecting if needed."""
+    existing = getattr(_thread_local, "proxy", None)
+    if existing is not None and existing._pyroUri == proxy._pyroUri:  # type: ignore[comparison-overlap]
+        if existing._pyroConnection is not None:  # type: ignore
+            return existing
+        else:  # Connection was lost, proxy needs reconnect
+            existing._pyroReconnect()  # type: ignore
+            return existing
+
+    new_proxy = Pyro5.api.Proxy(proxy._pyroUri)  # type: ignore
+    _thread_local.proxy = new_proxy
+
+    return new_proxy
+
+
 def wrap_as_async(method_metadata: dict[str, Any]) -> Any:
     """Wrapper to make a callable element on a PyroSynchronousObject into an awaitable element on a AsyncClientPyroObject."""
 
@@ -90,13 +110,12 @@ def wrap_as_async(method_metadata: dict[str, Any]) -> Any:
             *args: P.args,  # type: ignore
             **kwargs: P.kwargs,  # type: ignore
         ) -> Any:
-            # This must be done because Pyro only accepts proxy calls from the thread that owns the proxy
-            thread_proxy = Pyro5.api.Proxy(proxy._pyroUri)  # type: ignore
+            thread_proxy = _get_thread_proxy(proxy)
             func = getattr(thread_proxy, func_name)
             validated_func = wrap_parameter_validation(func)
+            
             return validated_func(self, *args, **kwargs)
 
-        # Return a Coroutine that may be awaited, it will execute the `_thread_call` when called
         return await asyncio.to_thread(
             _thread_call, self._proxy, method_metadata["__name__"], *args, **kwargs
         )

--- a/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
@@ -86,15 +86,16 @@ def _get_async_methods(proxy: Pyro5.api.Proxy) -> dict[str, dict[str, Any]]:
 
 def _get_thread_proxy(proxy: Pyro5.api.Proxy) -> Pyro5.api.Proxy:
     """Get or create a thread-local proxy for the given URI, reconnecting if needed."""
-    existing = getattr(_thread_local, "proxy", None)
-    if existing is not None and existing._pyroUri == proxy._pyroUri:  # type: ignore[comparison-overlap]
-        if existing._pyroConnection is not None:  # type: ignore
+    existing: Pyro5.api.Proxy | None = getattr(_thread_local, "proxy", None)
+
+    if existing is not None and existing._pyroUri == proxy._pyroUri:
+        if existing._pyroConnection is not None:
             return existing
         else:  # Connection was lost, proxy needs reconnect
-            existing._pyroReconnect()  # type: ignore
+            existing._pyroReconnect()  # type: ignore[no-untyped-call]
             return existing
 
-    new_proxy = Pyro5.api.Proxy(proxy._pyroUri)  # type: ignore
+    new_proxy = Pyro5.api.Proxy(proxy._pyroUri)  # type: ignore[no-untyped-call]
     _thread_local.proxy = new_proxy
 
     return new_proxy

--- a/api/tests/opentrons/util/test_pyro_async_client_adapter.py
+++ b/api/tests/opentrons/util/test_pyro_async_client_adapter.py
@@ -3,7 +3,8 @@
 import asyncio
 import socket
 import threading
-from typing import cast
+from typing import Any, cast
+from unittest.mock import patch
 
 import pytest
 from decoy import Decoy
@@ -100,4 +101,78 @@ async def test_client_async_on_ot3api(decoy: Decoy, managed_obj: OT3API) -> None
     assert estop_state is hw_types.EstopState.DISENGAGED
 
     # Clean up client resources.
+    ot3_proxy._pyroRelease()  # type: ignore
+
+
+async def test_thread_local_proxy_reuses_connections(
+    managed_obj: OT3API,
+) -> None:
+    """Test that async calls reuse proxies instead of creating a new one per call."""
+    sock = socket.socket()
+    sock.bind(("localhost", 0))
+    host, port = sock.getsockname()
+    sock.close()
+
+    pyro.config.NS_HOST = host
+    pyro.config.NS_PORT = port
+
+    name_server_ready = threading.Event()
+
+    def _nameserver_loop() -> None:
+        _, ns_daemon, _ = nameserver.start_ns(host=host, port=port)  # type: ignore
+        name_server_ready.set()
+        ns_daemon.requestLoop()
+
+    def _pyro_daemon() -> None:
+        name_server_ready.wait(timeout=PYRO_TIMEOUT)
+        create_pyro_daemon("OT3API", managed_obj, register_hardware_types)
+
+    ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
+    server_thread = threading.Thread(target=_pyro_daemon, daemon=True)
+
+    ns_thread.start()
+    server_thread.start()
+
+    register_hardware_types()
+    name_server_ready.wait(timeout=PYRO_TIMEOUT)
+    ns = pyro.locate_ns()
+
+    retries_counter = 0
+    while ns.count() < 2:
+        await asyncio.sleep(0.01)
+        retries_counter += 1
+        if retries_counter > 10:
+            raise TimeoutError("TEST FAILURE ON PYRO NAMESERVER.")
+
+    uri = pyro.resolve(uri="PYRONAME:OT3API")
+    ot3_proxy = pyro.Proxy(uri)  # type: ignore
+    casted_ot3api = cast(HardwareControlAPI, AsyncClientPyroObject(ot3_proxy))
+
+    original_proxy_init = pyro.Proxy.__init__
+    proxy_creation_count = 0
+
+    def counting_proxy_init(
+        self_instance: pyro.Proxy, *args: Any, **kwargs: Any
+    ) -> None:
+        nonlocal proxy_creation_count
+        proxy_creation_count += 1
+        
+        return original_proxy_init(self_instance, *args, **kwargs)
+
+    call_count = 20
+    with patch.object(pyro.Proxy, "__init__", counting_proxy_init):
+        for _ in range(call_count):
+            await casted_ot3api.home()
+
+    # Without thread-local proxy reuse, each call creates a new Proxy inside
+    # _thread_call, so we'd expect proxy_creation_count == call_count.
+    # With thread-local reuse, we'd expect far fewer (roughly one per worker
+    # thread in asyncio's thread pool).
+    # The assertion threshold leaves generous room for the thread pool size
+    # while still catching the "new proxy every call" antipattern.
+    assert proxy_creation_count < call_count, (
+        f"Expected proxy reuse but got {proxy_creation_count} proxy creations "
+        f"for {call_count} calls."
+    )
+
     ot3_proxy._pyroRelease()  # type: ignore

--- a/api/tests/opentrons/util/test_pyro_async_client_adapter.py
+++ b/api/tests/opentrons/util/test_pyro_async_client_adapter.py
@@ -156,8 +156,7 @@ async def test_thread_local_proxy_reuses_connections(
     ) -> None:
         nonlocal proxy_creation_count
         proxy_creation_count += 1
-        
-        return original_proxy_init(self_instance, *args, **kwargs)
+        original_proxy_init(self_instance, *args, **kwargs)  # type: ignore[no-untyped-call]
 
     call_count = 20
     with patch.object(pyro.Proxy, "__init__", counting_proxy_init):


### PR DESCRIPTION
Works toward [EXEC-2535](https://opentrons.atlassian.net/browse/EXEC-2535)

# Overview

Inter-process Pyro5 calls between the robot-server and hardware API processes would intermittently fail with `Pyro5.errors.ConnectionClosedError: receiving: not enough data`.  This error occurs when the server closes a TCP connection before the client finishes reading the response. Critically, this error does not indicate whether the original command was received and executed by the server, only that the response was lost.

Digging into the internals of pyro, the Proxy lifecycle in `AsyncAdapter` is roughly the following:

1. Create a new Proxy object
2. Lazily open a new TCP connection to the Pyro daemon
3. Perform a full connection handshake
4. Execute the remote call
5. Close the connection when the proxy is garbage collected

Connection churn creates undue load, potentially causing the daemon to drop connections mid-response. To fix, we introduce a thread-local proxy cache. Each worker thread from the pool now gets one persistent Proxy that is reused across all calls on that thread. The cache also handles stale connections: if the thread-local proxy's connection has been dropped, we re-established connection without re-invoking any request (ie, no side-effects produced on reconnection).

It's difficult to say whether this refactor will eliminate the problem entirely, however, this is likely a positive addition that we want regardless.

## Test Plan and Hands on Testing

- TDD approach taken here. b6de8dacdcf5387aef6f345316162f477daf1ee9 adds the test that is used to validate that we create a new Proxy with each request. 036c18cf8c00f6913f760178ed4e5bc7c0b4bab4 serves as the fix that causes the test to pass.

## Risk assessment

- low, change is auditable and validated well through new testing


[EXEC-2535]: https://opentrons.atlassian.net/browse/EXEC-2535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ