### PR TITLE
fix(app): fix protocol overflow menu for an invalid protocol

### DIFF
--- a/app/src/organisms/Desktop/ProtocolsLanding/ProtocolCard.tsx
+++ b/app/src/organisms/Desktop/ProtocolsLanding/ProtocolCard.tsx
@@ -75,6 +75,11 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
   instruments or modules from a future version of Opentrons software. Please update
   the app to the most recent version to run this protocol.`
 
+  const invalidRobotType =
+    mostRecentAnalysis?.errors.some(error =>
+      error.detail.includes(INVALID_ROBOT_TYPE_ERROR)
+    ) ?? false
+
   const UnknownAttachmentError = (
     <ProtocolAnalysisFailure
       protocolKey={protocolKey}
@@ -108,6 +113,7 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
           protocolDisplayName={protocolDisplayName}
           isAnalyzing={isAnalyzing}
           modified={modified}
+          invalidRobotType={invalidRobotType}
         />
       </ErrorBoundary>
       <Box
@@ -119,6 +125,7 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element | null {
           handleRunProtocol={handleRunProtocol}
           handleSendProtocolToFlex={handleSendProtocolToFlex}
           storedProtocolData={storedProtocolData}
+          invalidRobotType={invalidRobotType}
         />
       </Box>
     </Box>
@@ -130,6 +137,7 @@ interface AnalysisInfoProps {
   protocolDisplayName: string
   modified: number
   isAnalyzing: boolean
+  invalidRobotType: boolean
   mostRecentAnalysis?: ProtocolAnalysisOutput | null
 }
 function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
@@ -138,6 +146,7 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
     protocolDisplayName,
     isAnalyzing,
     mostRecentAnalysis,
+    invalidRobotType,
     modified,
   } = props
   const dispatch = useDispatch<Dispatch>()
@@ -156,11 +165,6 @@ function AnalysisInfo(props: AnalysisInfoProps): JSX.Element {
 
   const hasPeripherals =
     mostRecentAnalysis?.commandPreconditions?.isCameraUsed ?? false
-
-  const invalidRobotType =
-    mostRecentAnalysis?.errors.some(error =>
-      error.detail.includes(INVALID_ROBOT_TYPE_ERROR)
-    ) ?? false
 
   // If OT-2 app is installed, OT-2 app will be opened.
   // If OT-2 app isn't installed, a web browser will open the OT-2 app download page

--- a/app/src/organisms/Desktop/ProtocolsLanding/ProtocolOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/ProtocolsLanding/ProtocolOverflowMenu.tsx
@@ -42,13 +42,18 @@ interface ProtocolOverflowMenuProps extends StyleProps {
   handleRunProtocol: (storedProtocolData: StoredProtocolData) => void
   handleSendProtocolToFlex: (storedProtocolData: StoredProtocolData) => void
   storedProtocolData: StoredProtocolData
+  invalidRobotType?: boolean
 }
 
 export function ProtocolOverflowMenu(
   props: ProtocolOverflowMenuProps
 ): JSX.Element {
-  const { storedProtocolData, handleRunProtocol, handleSendProtocolToFlex } =
-    props
+  const {
+    storedProtocolData,
+    handleRunProtocol,
+    handleSendProtocolToFlex,
+    invalidRobotType,
+  } = props
   const { mostRecentAnalysis, protocolKey } = storedProtocolData
   const { t } = useTranslation(['protocol_list', 'shared'])
   const {
@@ -131,23 +136,26 @@ export function ProtocolOverflowMenu(
           right="0"
           flexDirection={DIRECTION_COLUMN}
         >
-          <MenuItem
-            onClick={handleClickRun}
-            data-testid="ProtocolOverflowMenu_run"
-            css={css`
-              border-radius: ${BORDERS.borderRadius8} ${BORDERS.borderRadius8} 0
-                0;
-            `}
-          >
-            {t('start_setup')}
-          </MenuItem>
+          {!invalidRobotType ? (
+            <MenuItem
+              onClick={handleClickRun}
+              data-testid="ProtocolOverflowMenu_run"
+              css={css`
+                border-radius: ${BORDERS.borderRadius8} ${BORDERS.borderRadius8}
+                  0 0;
+              `}
+            >
+              {t('start_setup')}
+            </MenuItem>
+          ) : null}
+
           <MenuItem
             onClick={handleClickReanalyze}
             data-testid="ProtocolOverflowMenu_reanalyze"
           >
             {t('shared:reanalyze')}
           </MenuItem>
-          {robotType !== 'OT-2 Standard' ? (
+          {robotType !== 'OT-2 Standard' && !invalidRobotType ? (
             <MenuItem
               onClick={handleClickSendToOT3}
               data-testid="ProtocolOverflowMenu_sendToOT3"


### PR DESCRIPTION


# Overview
fix protocol overflow menu for an invalid protocol

<img width="927" height="292" alt="Screenshot 2026-04-22 at 3 49 18 PM" src="https://github.com/user-attachments/assets/72880b2b-7dbe-47ef-b972-a85648148656" />
<img width="930" height="234" alt="Screenshot 2026-04-22 at 3 49 26 PM" src="https://github.com/user-attachments/assets/364b0a59-4197-4285-b465-797febe6f17e" />



close EXEC-2565


## Test Plan and Hands on Testing
- import an OT-2 protocol and click overflow menu
- import a Flex protocol and click overflow menu

## Changelog
- pass invalidRobotType to overflow menu to hide `setup` and `send to`

## Review requests


## Risk assessment
low
