### PR TITLE
chore(app-shell): modify electron-builder-config for mac

### DIFF
--- a/app-shell/electron-builder.config.js
+++ b/app-shell/electron-builder.config.js
@@ -68,6 +68,7 @@ module.exports = async () => ({
     extendInfo: HAS_MAC_ASSET_CATALOG
       ? { CFBundleIconName: 'AppIcon' }
       : undefined,
+    identity: DEV_MODE ? null : undefined,
     forceCodeSigning: !DEV_MODE,
     gatekeeperAssess: true,
     // note: notarize.teamId is passed by implicitly sending through the APPLE_TEAM_ID env var


### PR DESCRIPTION


# Overview
modify electron-builder-config for mac

avoid https://opentrons.slack.com/archives/CMGV77JP4/p1776861081408909

## Test Plan and Hands on Testing
- run make -C app dev and can open the app without any issue

## Changelog
- update mac config in electron-builder-config

## Review requests


## Risk assessment
should be low