### PR TITLE
docs: update 20 ul tip accuracy data in flex manual

### DIFF
--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -48,7 +48,7 @@ Flex 1-channel pipettes meet the following accuracy and precision specifications
     <th>Pipette Type</th>
     <th>Tip Size</th>
     <th>Volume (µL)</th>
-    <th>Random Error<br>(%&nbsp;CV)</th>
+    <th>Random Error<br>(% CV)</th>
     <th>Systematic Error<br>(% D)</th>
   </tr>
 </thead>

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -43,18 +43,18 @@ The following tables list the accuracy and precision specifications for Opentron
 Flex 1-channel pipettes meet the following accuracy and precision specifications.
 
 <table>
-  <thead>
-    <tr>
-      <th>Pipette Type</th>
-      <th>Tip Size</th>
-      <th>Volume (µL)</th>
-      <th>Random Error (% CV)</th>
-      <th>Systematic Error (% D)</th>
-    </tr>
-  </thead>
+<thead>
+  <tr>
+    <th>Pipette Type</th>
+    <th>Tip Size</th>
+    <th>Volume (µL)</th>
+    <th>Random Error<br>(%&nbsp;CV)</th>
+    <th>Systematic Error<br>(%&nbsp;D)</th>
+  </tr>
+</thead>
   <tbody>
     <tr>
-      <td rowspan="5"><b>1-Channel (1–50 µL)</b></td>
+      <td rowspan="5"><b>1–50 µL</b></td>
       <td>20 µL</td>
       <td>1</td>
       <td>3.50%</td>
@@ -85,7 +85,7 @@ Flex 1-channel pipettes meet the following accuracy and precision specifications
       <td>±1.25%</td>
     </tr>
     <tr>
-      <td rowspan="4"><b>1-Channel (5–1000 µL)</b></td>
+      <td rowspan="4"><b>5–1000 µL</b></td>
       <td>50 µL</td>
       <td>5</td>
       <td>2.50%</td>
@@ -117,59 +117,71 @@ Flex 1-channel pipettes meet the following accuracy and precision specifications
 Flex 8-channel pipettes meet the following accuracy and precision specifications.
 
 <table>
-  <thead>
-    <tr>
-      <th>Pipette Capacity</th>
-      <th>Tip Capacity</th>
-      <th>Tested Volume</th>
-      <th>Accuracy %D</th>
-      <th>Precision %CV</th>
-    </tr>
-  </thead>
+<thead>
+  <tr>
+    <th>Pipette Type</th>
+    <th>Tip Size</th>
+    <th>Volume (µL)</th>
+    <th>Random Error<br>(%&nbsp;CV)</th>
+    <th>Systematic Error<br>(%&nbsp;D)</th>
+  </tr>
+</thead>
   <tbody>
     <tr>
-      <td rowspan="3"><b>1–50 µL</b></td>
-      <td>50 µL</td>
-      <td>1 µL</td>
+      <td rowspan="5"><b>1–50 µL</b></td>
+      <td>20 µL</td>
+      <td>1</td>
+      <td>6.00%</td>
       <td>±10.00%</td>
+    </tr>
+    <tr>
+      <td>50 µL</td>
+      <td>1</td>
       <td>8.00%</td>
+      <td>±10.00%</td>
     </tr>
     <tr>
-      <td>50 µL</td>
-      <td>10 µL</td>
-      <td>±2.50%</td>
+      <td>20 µL</td>
+      <td>5</td>
       <td>1.00%</td>
+      <td>±2.50%</td>
     </tr>
     <tr>
       <td>50 µL</td>
+      <td>10</td>
+      <td>1.00%</td>
+      <td>±2.50%</td>
+    </tr>
+    <tr>
       <td>50 µL</td>
-      <td>±1.25%</td>
+      <td>50</td>
       <td>0.60%</td>
+      <td>±1.25%</td>
     </tr>
     <tr>
       <td rowspan="4"><b>5–1000 µL</b></td>
       <td>50 µL</td>
-      <td>5 µL</td>
+      <td>5</td>
+      <td>4.00%</td>
       <td>±8.00%</td>
-      <td>4%</td>
     </tr>
     <tr>
       <td>50 µL</td>
-      <td>50 µL</td>
-      <td>±2.50%</td>
+      <td>50</td>
       <td>0.60%</td>
+      <td>±2.50%</td>
     </tr>
     <tr>
       <td>200 µL</td>
-      <td>200 µL</td>
-      <td>±1.00%</td>
+      <td>200</td>
       <td>0.25%</td>
+      <td>±1.00%</td>
     </tr>
     <tr>
       <td>1000 µL</td>
-      <td>1000 µL</td>
-      <td>±0.70%</td>
+      <td>1000</td>
       <td>0.15%</td>
+      <td>±0.70%</td>
     </tr>
   </tbody>
 </table>
@@ -179,66 +191,73 @@ Flex 8-channel pipettes meet the following accuracy and precision specifications
 Flex 96-channel pipettes meet the following accuracy and precision specifications.
 
 <table>
-  <thead>
-    <tr>
-      <th>Pipette Capacity</th>
-      <th>Tip Capacity</th>
-      <th>Tested Volume</th>
-      <th>Accuracy %D</th>
-      <th>Precision %CV</th>
-    </tr>
-  </thead>
+<thead>
+  <tr>
+    <th>Pipette Type</th>
+    <th>Tip Size</th>
+    <th>Volume (µL)</th>
+    <th>Random Error<br>(%&nbsp;CV)</th>
+    <th>Systematic Error<br>(%&nbsp;D)</th>
+  </tr>
+</thead>
   <tbody>
     <tr>
-      <td rowspan="4"><b>1–200 µL</b></td>
-      <td>50 µL</td>
-      <td>1 µL</td>
-      <td>±10%</td>
-      <td>6%</td>
+      <td rowspan="5"><b>1–200 µL</b></td>
+      <td>20 µL</td>
+      <td>1</td>
+      <td>3.00%</td>
+      <td>±10.00%</td>
     </tr>
     <tr>
       <td>50 µL</td>
-      <td>5 µL</td>
-      <td>±4%</td>
-      <td>2%</td>
+      <td>1</td>
+      <td>6.00%</td>
+      <td>±10.00%</td>
+    </tr>
+    <tr>
+      <td>20 µL</td>
+      <td>5</td>
+      <td>1.00%</td>
+      <td>±4.00%</td>
     </tr>
     <tr>
       <td>50 µL</td>
-      <td>50 µL</td>
-      <td>±1.5%</td>
-      <td>1%</td>
+      <td>50</td>
+      <td>1.00%</td>
+      <td>±1.50%</td>
     </tr>
     <tr>
       <td>200 µL</td>
-      <td>200 µL</td>
-      <td>±1%</td>
-      <td>1%</td>
+      <td>200</td>
+      <td>1.00%</td>
+      <td>±1.00%</td>
     </tr>
     <tr>
       <td rowspan="4"><b>5–1000 µL</b></td>
       <td>50 µL</td>
-      <td>5 µL</td>
-      <td>±10%</td>
-      <td>5%</td>
+      <td>5</td>
+      <td>5.00%</td>
+      <td>±10.00%</td>
     </tr>
     <tr>
       <td>50 µL</td>
-      <td>50 µL</td>
-      <td>±2.5%</td>
+      <td>50</td>
       <td>1.25%</td>
+      <td>±2.50%</td>
     </tr>
     <tr>
       <td>200 µL</td>
-      <td>200 µL</td>
-      <td>±1.5%</td>
+      <td>200</td>
       <td>1.25%</td>
+      <td>±1.50%</td>
     </tr>
     <tr>
       <td>1000 µL</td>
-      <td>1000 µL</td>
-      <td>±1.5%</td>
-      <td>1.5%</td>
+      <td>1000</td>
+      <td>1.50%</td>
+      <td>±1.50%</td>
     </tr>
+  </tbody>
 </table>
 
 ## Pipette calibration

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -49,7 +49,6 @@ Flex 1-channel pipettes meet the following accuracy and precision specifications
     <th>Tip Size</th>
     <th>Volume (µL)</th>
     <th>Random Error<br>(%&nbsp;CV)</th>
-    <th>Random Error<br>(% CV)</th>
     <th>Systematic Error<br>(% D)</th>
   </tr>
 </thead>

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -49,7 +49,8 @@ Flex 1-channel pipettes meet the following accuracy and precision specifications
     <th>Tip Size</th>
     <th>Volume (µL)</th>
     <th>Random Error<br>(%&nbsp;CV)</th>
-    <th>Systematic Error<br>(%&nbsp;D)</th>
+    <th>Random Error<br>(% CV)</th>
+    <th>Systematic Error<br>(% D)</th>
   </tr>
 </thead>
   <tbody>

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -45,57 +45,69 @@ Flex 1-channel pipettes meet the following accuracy and precision specifications
 <table>
   <thead>
     <tr>
-      <th>Pipette Capacity</th>
-      <th>Tip Capacity</th>
-      <th>Tested Volume</th>
-      <th>Accuracy %D</th>
-      <th>Precision %CV</th>
+      <th>Pipette Type</th>
+      <th>Tip Size</th>
+      <th>Volume (µL)</th>
+      <th>Random Error (% CV)</th>
+      <th>Systematic Error (% D)</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td rowspan="3"><b>1–50 µL</b></td>
-      <td>50 µL</td>
-      <td>1 µL</td>
+      <td rowspan="5"><b>1-Channel (1–50 µL)</b></td>
+      <td>20 µL</td>
+      <td>1</td>
+      <td>3.50%</td>
       <td>±8.00%</td>
+    </tr>
+    <tr>
+      <td>50 µL</td>
+      <td>1</td>
       <td>7.00%</td>
+      <td>±8.00%</td>
     </tr>
     <tr>
-      <td>50 µL</td>
-      <td>10 µL</td>
+      <td>20 µL</td>
+      <td>5</td>
+      <td>0.75%</td>
       <td>±1.50%</td>
+    </tr>
+    <tr>
+      <td>50 µL</td>
+      <td>10</td>
       <td>0.50%</td>
+      <td>±1.00%</td>
     </tr>
     <tr>
       <td>50 µL</td>
-      <td>50 µL</td>
-      <td>±1.25%</td>
+      <td>50</td>
       <td>0.40%</td>
+      <td>±1.25%</td>
     </tr>
     <tr>
-      <td rowspan="4"><b>5–1000 µL</b></td>
+      <td rowspan="4"><b>1-Channel (5–1000 µL)</b></td>
       <td>50 µL</td>
-      <td>5 µL</td>
-      <td>±5.00%</td>
+      <td>5</td>
       <td>2.50%</td>
+      <td>±5.00%</td>
     </tr>
     <tr>
       <td>50 µL</td>
-      <td>50 µL</td>
-      <td>±0.50%</td>
+      <td>50</td>
       <td>0.30%</td>
+      <td>±0.50%</td>
     </tr>
     <tr>
       <td>200 µL</td>
-      <td>200 µL</td>
-      <td>±0.50%</td>
+      <td>200</td>
       <td>0.15%</td>
+      <td>±0.50%</td>
     </tr>
     <tr>
       <td>1000 µL</td>
-      <td>1000 µL</td>
-      <td>±0.50%</td>
+      <td>1000</td>
       <td>0.15%</td>
+      <td>±0.50%</td>
     </tr>
   </tbody>
 </table>

--- a/docs/flex/docs/system-description/pipettes.md
+++ b/docs/flex/docs/system-description/pipettes.md
@@ -122,8 +122,8 @@ Flex 8-channel pipettes meet the following accuracy and precision specifications
     <th>Pipette Type</th>
     <th>Tip Size</th>
     <th>Volume (µL)</th>
-    <th>Random Error<br>(%&nbsp;CV)</th>
-    <th>Systematic Error<br>(%&nbsp;D)</th>
+    <th>Random Error<br>(% CV)</th>
+    <th>Systematic Error<br>(% D)</th>
   </tr>
 </thead>
   <tbody>
@@ -196,8 +196,8 @@ Flex 96-channel pipettes meet the following accuracy and precision specification
     <th>Pipette Type</th>
     <th>Tip Size</th>
     <th>Volume (µL)</th>
-    <th>Random Error<br>(%&nbsp;CV)</th>
-    <th>Systematic Error<br>(%&nbsp;D)</th>
+    <th>Random Error<br>(% CV)</th>
+    <th>Systematic Error<br>(% D)</th>
   </tr>
 </thead>
   <tbody>


### PR DESCRIPTION
# Overview

New accuracy and precision specs are available for the 20 uL pipette. This updates the "Pipette specifications" section in the Flex manual: System Description > Pipettes with new data.

**Sandbox:**  [Pipette specifications](https://sandbox.docs.opentrons.com/20-ul-tip-accuracy-flex-manual/flex/system-description/pipettes/#pipette-specifications)

RTC-982

## Test Plan and Hands on Testing

—

## Changelog

Couple 'o changes:
- Revise the table headers in Flex manual to match the marketing PDF
- Revise the specs order in Flex manual to match the marketing PDF
- Changes [outlined in JIRA here](https://opentrons.atlassian.net/browse/RTC-982?focusedCommentId=149794).

## Review requests

There are a lot of items in these tables. Please spot check for mistakes, typos, transcription errors.

## Risk assessment

- Low, docs changes only.
