### PR TITLE
fix(app): fix protocol visualization performance issue

### DIFF
--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/index.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useParams } from 'react-router-dom'
 
@@ -6,11 +6,8 @@ import { COLORS, Icon } from '@opentrons/components'
 import { ApiHostProvider } from '@opentrons/react-api-client'
 
 import { useRobot } from '/app/redux-resources/robots'
-import {
-  fetchProtocols,
-  getStoredProtocol,
-  getStoredProtocolGroupedCommands,
-} from '/app/redux/protocol-storage'
+import { fetchProtocols, getStoredProtocol } from '/app/redux/protocol-storage'
+import { getGroupedCommands } from '/app/redux/protocol-storage/utils'
 
 import { VisualizerContainer } from '../../../../organisms/Desktop/ProtocolVisualization/VisualizerContainer'
 import styles from './visualization.module.css'
@@ -30,8 +27,13 @@ export function ProtocolVisualization(): JSX.Element {
 
   // this is used for step grouping which won't be introduced until
   // PV phase 2
-  const groupedCommands = useSelector((state: State) =>
-    getStoredProtocolGroupedCommands(state, protocolKey)
+  const mostRecentAnalysis = storedProtocol?.mostRecentAnalysis ?? null
+  const groupedCommands = useMemo(
+    () =>
+      mostRecentAnalysis != null
+        ? getGroupedCommands(mostRecentAnalysis)
+        : null,
+    [mostRecentAnalysis]
   )
 
   useEffect(() => {
@@ -39,13 +41,13 @@ export function ProtocolVisualization(): JSX.Element {
   }, [dispatch])
 
   const visualizer =
-    storedProtocol != null && storedProtocol.mostRecentAnalysis != null ? (
+    mostRecentAnalysis != null ? (
       <VisualizerContainer
-        analysisOutput={storedProtocol.mostRecentAnalysis}
+        analysisOutput={mostRecentAnalysis}
         runId={runId}
         groupedCommands={groupedCommands}
         protocolKey={protocolKey}
-        srcFileNames={storedProtocol.srcFileNames}
+        srcFileNames={storedProtocol?.srcFileNames ?? []}
       />
     ) : (
       <LoadingIcon />


### PR DESCRIPTION


# Overview
#20911 removed `useMemo` and it causes the performance issue on protocol visualization page.
add useMemo to solve the issue.


[before]

https://github.com/user-attachments/assets/defcc0b2-1d97-47a7-a604-09a5819f7a95


[after]


https://github.com/user-attachments/assets/d0842b26-2ab0-49b9-bb2c-edf391ae2eea


close AUTH-2880

## Test Plan and Hands on Testing
- run this branch
- import a Flex protocol and visualize
- click play button
check that the current step is moving every 2 sec and auto-scrolling works when the current step is reaching to the bottom

## Changelog
- add useMemo

## Review requests

## Risk assessment
low
