### PR TITLE
fix(robot-server): address non-critical tracebacks during runs in subprocess mode

### DIFF
--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -1,5 +1,6 @@
 """Registry for use with a Pyro Daemon client and server to allow serialization of Opentrons Hardware types and classes."""
 
+import dataclasses
 import datetime
 from typing import Any, Dict
 
@@ -8,6 +9,7 @@ from numpy import float64
 import opentrons_shared_data.pipette.pipette_definition
 import opentrons_shared_data.pipette.types
 
+import opentrons.calibration_storage.types
 import opentrons.config.types
 import opentrons.hardware_control.dev_types
 import opentrons.hardware_control.instruments.ot3.instrument_calibration
@@ -278,20 +280,18 @@ def _numpy_float_dict_to_class(classname, d) -> float64:  # type: ignore
     return float64(d["value"])
 
 
-# Point type serialization
-def _point_class_to_dict(obj) -> Dict:  # type: ignore
+def _point_to_dict(point: opentrons.types.Point) -> Dict:  # type: ignore
     return {
-        "__class__": ".".join((obj.__module__, obj.__class__.__name__)),
-        "x": obj.x,
-        "y": obj.y,
-        "z": obj.z,
+        "x": point.x,
+        "y": point.y,
+        "z": point.z,
     }
 
 
-def _point_dict_to_class(clasname, d) -> opentrons.types.Point:  # type: ignore
-    x_data = d["x"]
-    y_data = d["y"]
-    z_data = d["z"]
+def _dict_to_point(point_dict: Dict) -> opentrons.types.Point:  # type: ignore
+    x_data = point_dict["x"]
+    y_data = point_dict["y"]
+    z_data = point_dict["z"]
     if isinstance(x_data, dict):
         x_data = x_data["value"]
     if isinstance(y_data, dict):
@@ -299,6 +299,82 @@ def _point_dict_to_class(clasname, d) -> opentrons.types.Point:  # type: ignore
     if isinstance(z_data, dict):
         z_data = z_data["value"]
     return opentrons.types.Point(x=float(x_data), y=float(y_data), z=float(z_data))
+
+
+# Point type serialization
+def _point_class_to_dict(obj) -> Dict:  # type: ignore
+    _point_dict = _point_to_dict(obj)
+    _point_dict["__class__"] = ".".join((obj.__module__, obj.__class__.__name__))
+    return _point_dict
+
+
+def _point_dict_to_class(classname, d) -> opentrons.types.Point:  # type: ignore
+    return _dict_to_point(d)
+
+
+def _ot3_transforms_class_to_dict(
+    obj: opentrons.hardware_control.ot3_calibration.OT3Transforms,
+) -> Dict:  # type: ignore
+    transform_dict = dataclasses.asdict(obj)
+    transform_dict["deck_calibration"]["source"] = obj.deck_calibration.source.value
+    transform_dict["deck_calibration"]["status"] = {
+        "markedBad": obj.deck_calibration.status.markedBad,
+        "source": obj.deck_calibration.status.source.value
+        if obj.deck_calibration.status.source is not None
+        else None,
+        "markedAt": obj.deck_calibration.status.markedAt.isoformat()
+        if obj.deck_calibration.status.markedAt is not None
+        else None,
+    }
+    transform_dict["deck_calibration"]["last_modified"] = (
+        obj.deck_calibration.last_modified.isoformat()
+        if obj.deck_calibration.last_modified is not None
+        else None
+    )
+
+    transform_dict["carriage_offset"] = _point_to_dict(obj.carriage_offset)
+    transform_dict["left_mount_offset"] = _point_to_dict(obj.left_mount_offset)
+    transform_dict["right_mount_offset"] = _point_to_dict(obj.right_mount_offset)
+    transform_dict["gripper_mount_offset"] = _point_to_dict(obj.gripper_mount_offset)
+    transform_dict["__class__"] = (
+        "opentrons.hardware_control.ot3_calibration.OT3Transforms"
+    )
+    return transform_dict
+
+
+def _ot3_transforms_dict_to_class(
+    classname: str, d: Any
+) -> opentrons.hardware_control.ot3_calibration.OT3Transforms:
+    status_source = d["deck_calibration"]["status"]["source"]
+    status_marked_at = d["deck_calibration"]["status"]["markedAt"]
+    last_modified = d["deck_calibration"]["last_modified"]
+    return opentrons.hardware_control.ot3_calibration.OT3Transforms(
+        deck_calibration=opentrons.hardware_control.robot_calibration.DeckCalibration(
+            attitude=d["deck_calibration"]["attitude"],
+            source=opentrons.calibration_storage.types.SourceType(
+                d["deck_calibration"]["source"]
+            ),
+            status=opentrons.calibration_storage.types.CalibrationStatus(
+                markedBad=d["deck_calibration"]["status"]["markedBad"],
+                source=opentrons.calibration_storage.types.SourceType(status_source)
+                if status_source is not None
+                else None,
+                markedAt=datetime.datetime.fromisoformat(status_marked_at)
+                if status_marked_at is not None
+                else None,
+            ),
+            belt_attitude=d["deck_calibration"]["belt_attitude"],
+            last_modified=datetime.datetime.fromisoformat(last_modified)
+            if last_modified is not None
+            else None,
+            pipette_calibrated_with=d["deck_calibration"]["pipette_calibrated_with"],
+            tiprack=d["deck_calibration"]["tiprack"],
+        ),
+        carriage_offset=_dict_to_point(d["carriage_offset"]),
+        left_mount_offset=_dict_to_point(d["left_mount_offset"]),
+        right_mount_offset=_dict_to_point(d["right_mount_offset"]),
+        gripper_mount_offset=_dict_to_point(d["gripper_mount_offset"]),
+    )
 
 
 # Robot type registry - of note, this is meant to return a "pure" type
@@ -381,6 +457,13 @@ def register_hardware_types() -> None:
         class_type=opentrons.hardware_control.instruments.ot3.instrument_calibration.PipetteOffsetSummary,
         dict_to_class=_PipetteOffsetSummary_dict_to_class,
         class_to_dict=_PipetteOffsetSummary_class_to_dict,
+    )
+
+    # OT3 Transforms
+    register_type_to_serpent(
+        class_type=opentrons.hardware_control.ot3_calibration.OT3Transforms,
+        dict_to_class=_ot3_transforms_dict_to_class,
+        class_to_dict=_ot3_transforms_class_to_dict,
     )
 
     # numpy registration

--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -348,7 +348,11 @@ def get_ot2_hardware(
     thread_manager: Annotated[ThreadManagedHardware, Depends(get_hardware_resource)],
 ) -> "API":
     """Get an OT2 hardware controller."""
-    if not thread_manager.wraps_instance(API):
+    if not isinstance(
+        # If this isn't a thread manager, it's an Async Pyro object and this is on OT-3
+        thread_manager,
+        ThreadManager,
+    ) or not thread_manager.wraps_instance(API):
         raise NotSupportedOnFlex(
             detail="This route is only available on an OT-2."
         ).as_error(status.HTTP_403_FORBIDDEN)

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -391,11 +391,8 @@ class RunOrchestratorStore:
             raise RunConflictError("Another run is currently active.")
 
         # "Run orchestrator" here is a proxy of a directed run process
-        self._run_orchestrator = (
-            await self._run_process_pyro_provider.wait_for_run_proxy()
-        )
-
-        await self._run_orchestrator.create(
+        run_orchestrator = await self._run_process_pyro_provider.wait_for_run_proxy()
+        await run_orchestrator.create(
             run_id=run_id,
             labware_offsets=labware_offsets,
             deck_configuration=deck_configuration,
@@ -403,7 +400,10 @@ class RunOrchestratorStore:
             run_time_param_values=run_time_param_values,
             run_time_param_paths=run_time_param_paths,
         )
-        return self._run_orchestrator.get_state_summary()
+
+        summary = run_orchestrator.get_state_summary()
+        self._run_orchestrator = run_orchestrator
+        return summary
 
     async def clear_pyro(self) -> RunResult:
         """End the pyro protocol subprocess and remove the pyro proxy from the nameserver."""

--- a/robot-server/robot_server/runs/run_process.py
+++ b/robot-server/robot_server/runs/run_process.py
@@ -159,6 +159,8 @@ class DirectedRunProcess(AbstractRunCoordinator):
         run_time_param_paths: Optional[CSVRuntimeParamPaths] = None,
     ) -> None:
         """Create a run orchestrator and protocol engine for a given run."""
+        self._run_id = run_id
+
         if protocol is not None:
             load_fixed_trash = should_load_fixed_trash(protocol.source.config)
         else:
@@ -209,7 +211,6 @@ class DirectedRunProcess(AbstractRunCoordinator):
             orchestrator.add_labware_offset(offset)
 
         self._run_orchestrator = orchestrator
-        self._run_id = run_id
 
     @property
     def run_id(self) -> Optional[str]:

--- a/robot-server/robot_server/runs/run_process.py
+++ b/robot-server/robot_server/runs/run_process.py
@@ -159,8 +159,6 @@ class DirectedRunProcess(AbstractRunCoordinator):
         run_time_param_paths: Optional[CSVRuntimeParamPaths] = None,
     ) -> None:
         """Create a run orchestrator and protocol engine for a given run."""
-        self._run_id = run_id
-
         if protocol is not None:
             load_fixed_trash = should_load_fixed_trash(protocol.source.config)
         else:
@@ -211,6 +209,7 @@ class DirectedRunProcess(AbstractRunCoordinator):
             orchestrator.add_labware_offset(offset)
 
         self._run_orchestrator = orchestrator
+        self._run_id = run_id
 
     @property
     def run_id(self) -> Optional[str]:


### PR DESCRIPTION
# Overview

When using subprocess mode, there were a few Pyro5 related tracebacks that would appear that weren't interfering with the protocol running and succeeding, but causing log spam and interfering with identifying real critical errors. This PR addresses three that would occur in all situations (there are still some that must be addressed when modules are connected).

The first had to do with `get_ot2_hardware`. This would fail with an error along the lines of `AttributeError: 'AsyncClientPyroObject_Proxy_547894261952' object has no attribute 'wraps_instance'`. This was occurring since when in hardware subprocess mode, `get_hardware_resource` returns an AsyncClient proxy wrapped API and not a ThreadManager. To fix this, we check that the object is a thread manager, which it will never not be on an OT-2, and if so short-circuit the second test and raise the expected error.

The second was simply not serializing `OT3Transforms`. This was fixed by registering the type with pyro serialization.

Lastly, the third error had to do with the light task failing on `self._run_orchestrator_store.get_status()`. This was being caused by a concurrency error, where we were setting the `RunOrchestratorStore` run orchestrator before it was fully initialized and ready. Now we are modeling the behavior in the non-subprocess `create` where we don't set `_run_orchestrator` until after the run has been set up and the summary has been obtained.

## Test Plan and Hands on Testing

On-robot testing that protocols still run as expected and checking the logs for absence of these errors

## Changelog

- Fixed the source of a few pyro tracebacks

## Review requests

The only part of this I'm not fully sure on is the check in `get_ot2_hardware`. If there's a better way of preventing this error, or if catching the exception would be better, I'm all ears.

## Risk assessment

Low-medium, really only for the `get_ot2_hardware` change, the rest are all low risk and improvements.