### PR TITLE
fix(app-shell-odd): Configure discovery-client for localhost in dev mode

### DIFF
--- a/app-shell-odd/Makefile
+++ b/app-shell-odd/Makefile
@@ -31,6 +31,7 @@ electron := yarn electron . \
 	--disable_ui.webPreferences.webSecurity \
 	--ui.url.protocol="http:" \
 	--ui.url.path="localhost:$(PORT)" \
+	--discovery.candidates=localhost \
 
 OPENTRONS_PROJECT ?= robot-stack
 


### PR DESCRIPTION
## Overview

For historical reasons, the ODD app requires a full-fledged robot discovery client, configured to find a robot at `localhost`. Without this, various things are subtly broken. We should try to disentangle this—the app should simply know that there's a robot available at `localhost`, it shouldn't need to "discover" anything—but for now, this is the case.

On actual Flex robots, the configuration for `localhost` happens [here](https://github.com/Opentrons/oe-core/blob/58d9b1a6bbff31fa53b09d6ec9730ea0ad7c30f6/layers/meta-opentrons/recipes-robot/opentrons-robot-app/files/opentrons-robot-app.sh#L18-L19). We've been missing something equivalent for local development with `make -C app-shell-odd`.

This PR adds the missing `--discovery.candidates` line. It does *not* add the missing `discovery.ipFilter` line, because as far as I can tell, nothing reads it and it doesn't do anything.

## Test Plan and Hands on Testing

* [x] If you launch `make -C app dev-odd` along with `make dev-backend-flex`, you should now see "opentrons-dev" as the robot name instead of "no name."
* [x] In some in-progress work that doesn't have a PR yet, logging in now successfully updates Redux state.

## Review requests

None in particular.

## Risk assessment

Low.