### PR TITLE
perf(discovery-client): Ignore updates to robot filesystem usage

### DIFF
--- a/discovery-client/src/__tests__/health-poller.test.ts
+++ b/discovery-client/src/__tests__/health-poller.test.ts
@@ -227,6 +227,38 @@ describe('health poller', () => {
     })
   })
 
+  it('should strip unrecognized fields from responses', () => {
+    const healthWithExtraFields = {
+      ...Fixtures.mockLegacyHealthResponse,
+      extraField: 'extra value',
+    }
+    const serverHealthWithExtraFields = {
+      ...Fixtures.mockLegacyServerHealthResponse,
+      extraField: 'extra value',
+    }
+
+    stubFetchOnce('http://127.0.0.1:31950/health')(
+      makeMockJsonResponse(healthWithExtraFields)
+    )
+    stubFetchOnce('http://127.0.0.1:31950/server/update/health')(
+      makeMockJsonResponse(serverHealthWithExtraFields)
+    )
+
+    poller.start({ list: [HOST_1], interval: 1000 })
+    vi.advanceTimersByTime(1000)
+
+    return flush().then(() => {
+      expect(onPollResult).toHaveBeenCalledWith({
+        ip: '127.0.0.1',
+        port: 31950,
+        health: Fixtures.mockLegacyHealthResponse, // Should exclude the extra fields.
+        serverHealth: Fixtures.mockLegacyServerHealthResponse, // Should exclude the extra fields.
+        healthError: null,
+        serverHealthError: null,
+      })
+    })
+  })
+
   it('should map partially successful fetch responses to onPollResult', () => {
     stubFetchOnce('http://127.0.0.1:31950/health')(
       makeMockJsonResponse({ message: 'some error' }, false, 400)

--- a/discovery-client/src/health-poller.ts
+++ b/discovery-client/src/health-poller.ts
@@ -1,7 +1,7 @@
 import net from 'net'
-import { pick } from 'lodash'
 import intersectionBy from 'lodash/intersectionBy'
 import isEqual from 'lodash/isEqual'
+import pick from 'lodash/pick'
 import unionBy from 'lodash/unionBy'
 import xorWith from 'lodash/xorWith'
 import fetch from 'node-fetch'

--- a/discovery-client/src/health-poller.ts
+++ b/discovery-client/src/health-poller.ts
@@ -1,4 +1,5 @@
 import net from 'net'
+import { pick } from 'lodash'
 import intersectionBy from 'lodash/intersectionBy'
 import isEqual from 'lodash/isEqual'
 import unionBy from 'lodash/unionBy'
@@ -9,6 +10,7 @@ import {
   ROBOT_SERVER_HEALTH_PATH,
   UPDATE_SERVER_HEALTH_PATH,
 } from './constants'
+import { HEALTH_RESPONSE_KEYS, SERVER_HEALTH_RESPONSE_KEYS } from './types'
 
 import type { Agent } from 'http'
 import type { RequestInit } from 'node-fetch'
@@ -209,8 +211,10 @@ async function pollHealth({
   return {
     ip,
     port,
-    health: healthResp.ok ? healthResp.body : null,
-    serverHealth: serverHealthResp.ok ? serverHealthResp.body : null,
+    health: healthResp.ok ? trimHealthResponse(healthResp.body) : null,
+    serverHealth: serverHealthResp.ok
+      ? trimServerHealthResponse(serverHealthResp.body)
+      : null,
     healthError: !healthResp.ok
       ? { status: healthResp.status, body: healthResp.body }
       : null,
@@ -218,4 +222,20 @@ async function pollHealth({
       ? { status: serverHealthResp.status, body: serverHealthResp.body }
       : null,
   }
+}
+
+/**
+ * To avoid unnecessary client updates, this removes any extra fields that the
+ * server might have returned but that aren't relevant for robot discovery purposes.
+ * Especially fields that change over time, like disk usage.
+ */
+function trimHealthResponse(response: HealthResponse): HealthResponse {
+  return pick(response, HEALTH_RESPONSE_KEYS)
+}
+
+/** Like trimHealthResponse(), but for ServerHealthResponse. */
+function trimServerHealthResponse(
+  response: ServerHealthResponse
+): ServerHealthResponse {
+  return pick(response, SERVER_HEALTH_RESPONSE_KEYS)
 }

--- a/discovery-client/src/health-poller.ts
+++ b/discovery-client/src/health-poller.ts
@@ -181,7 +181,7 @@ function fetchAndParse<SuccessBody>(
  * Poll both /heath and /server/update/health of an IP address and combine the
  * responses into a single result object
  */
-function pollHealth({
+async function pollHealth({
   ip,
   port,
   agent,
@@ -201,19 +201,21 @@ function pollHealth({
     `http://${urlIp}:${port}${UPDATE_SERVER_HEALTH_PATH}`,
     { agent }
   )
+  const [healthResp, serverHealthResp] = await Promise.all([
+    healthReq,
+    serverHealthReq,
+  ])
 
-  return Promise.all([healthReq, serverHealthReq]).then(
-    ([healthResp, serverHealthResp]) => ({
-      ip,
-      port,
-      health: healthResp.ok ? healthResp.body : null,
-      serverHealth: serverHealthResp.ok ? serverHealthResp.body : null,
-      healthError: !healthResp.ok
-        ? { status: healthResp.status, body: healthResp.body }
-        : null,
-      serverHealthError: !serverHealthResp.ok
-        ? { status: serverHealthResp.status, body: serverHealthResp.body }
-        : null,
-    })
-  )
+  return {
+    ip,
+    port,
+    health: healthResp.ok ? healthResp.body : null,
+    serverHealth: serverHealthResp.ok ? serverHealthResp.body : null,
+    healthError: !healthResp.ok
+      ? { status: healthResp.status, body: healthResp.body }
+      : null,
+    serverHealthError: !serverHealthResp.ok
+      ? { status: serverHealthResp.status, body: serverHealthResp.body }
+      : null,
+  }
 }

--- a/discovery-client/src/types.ts
+++ b/discovery-client/src/types.ts
@@ -8,7 +8,6 @@ import type {
 
 export type { RobotState, HostState, HealthStatus, Address }
 
-// TODO(mc, 2018-10-03): figure out what to do with duplicate type in app
 export interface HealthResponse {
   name: string
   api_version: string
@@ -20,7 +19,25 @@ export interface HealthResponse {
   maximum_protocol_api_version?: [number, number]
   robot_model?: string
   robot_serial?: string | null
+  // Note: To avoid unnecessary client updates, this should omit fields that change over
+  // time and aren't helpful for robot discovery, such as filesystem usage. The client
+  // can always do its own fetch outside of discovery-client, if it cares about those
+  // fields.
 }
+
+// This should contain all the keys in the HealthResponse type above.
+export const HEALTH_RESPONSE_KEYS = [
+  'name',
+  'api_version',
+  'fw_version',
+  'system_version',
+  'logs',
+  'protocol_api_version',
+  'minimum_protocol_api_version',
+  'maximum_protocol_api_version',
+  'robot_model',
+  'robot_serial',
+] as const satisfies Array<keyof HealthResponse>
 
 export type Capability =
   | 'bootstrap'
@@ -44,14 +61,30 @@ export interface ServerHealthResponse {
   capabilities?: CapabilityMap
   bootId?: string
   robotModel?: string
+  // Note: To avoid unnecessary client updates, this should omit fields that change over
+  // time and aren't helpful for robot discovery, such as filesystem usage. The client
+  // can always do its own fetch outside of discovery-client, if it cares about those
+  // fields.
 }
+
+// This should contain all the keys in the ServerHealthResponse type above.
+export const SERVER_HEALTH_RESPONSE_KEYS = [
+  'name',
+  'apiServerVersion',
+  'updateServerVersion',
+  'serialNumber',
+  'smoothieVersion',
+  'systemVersion',
+  'capabilities',
+  'bootId',
+  'robotModel',
+] as const satisfies Array<keyof ServerHealthResponse>
 
 export interface HealthErrorResponse {
   status: number
   body: string | { [property: string]: unknown }
 }
 
-// TODO(mc, 2018-07-26): grab common logger type from app and app-shell
 export type LogLevel =
   | 'error'
   | 'warn'


### PR DESCRIPTION
## Overview

The backend returns the robot's current filesystem usage in every `/health` request (#19912). This has accidentally been causing a lot of spurious updates from discovery-client. The filesystem usage would creep up a little bit between `/health` polls, which meant that the health details "changed" on every poll, so basically every `/health` poll for every robot would always trigger its own update.

This PR fixes it by making discovery-client throw away any fields that it doesn't care about, which includes `systemAvailableMb`. This has no adverse effect on the frontend because the frontend uses other, more deliberate mechanisms to fetch `systemAvailableMb`.

My main motivation is to clean up the logs and Redux dev tools, but there's probably some performance benefit, too (reducing React renders).

## Test Plan and Hands on Testing

* [x] Robot discovery still works.
* [x] There's less spam now in the Redux dev tools.

## Review requests

None in particular.

## Risk assessment

I've tried to make only minimal low-risk changes, but this is definitely a touchy area. We need to be careful to preserve the existing error-handling semantics, for example, since the "robot is unreachable" UX copy depends on it.
