### PR TITLE
refactor(app): Fix type error

### DIFF
--- a/app/src/organisms/ODD/QuickTransferFlow/utils/getMatchingTipLiquidSpecsFromSpec.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/getMatchingTipLiquidSpecsFromSpec.ts
@@ -15,7 +15,7 @@ export function getMatchingTipLiquidSpecsFromSpec(
   const pipetteName = getPipetteNameFromSpecs(pipetteSpecs)
 
   console.assert(
-    matchingLabwareDef,
+    matchingLabwareDef != null,
     `expected to find a matching labware def with tiprack ${tiprackUri} but could not`
   )
 
@@ -48,7 +48,7 @@ export function getMatchingTipLiquidSpecsFromSpec(
   })[0]
 
   console.assert(
-    matchingTipLiquidSpecs,
+    matchingTipLiquidSpecs != null,
     `expected to find the tip liquid specs but could not with pipette tiprack displayname ${
       matchingLabwareDef?.metadata.displayName ?? 'unknown displayname'
     }`

--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -12,6 +12,7 @@ const emptyRemote: Remote = {} as any
 export const remote: Remote = new Proxy(emptyRemote, {
   get(_target, propName: string): unknown {
     console.assert(
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       (global as any).APP_SHELL_REMOTE,
       'Expected APP_SHELL_REMOTE to be attached to global scope; is app-shell/src/preload.ts properly configured?'
     )


### PR DESCRIPTION
## Overview

This fixes a small type error that was failing `make check-js`. I think it was just a merge conflict with #18571.

## Test Plan and Hands on Testing

* [ ] CI passes.

## Review requests

None.

## Risk assessment

Very low.