### PR TITLE
fix(ci): Fix workflows not running due to YAML syntax errors

### DIFF
--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '22.22.0'
-      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
+      - uses: 'pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
         with:
           version: 10.32.1
       - name: 'set complex environment variables'

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -16,6 +16,7 @@ on:
       - '**.json'
       - '**.css'
       - '**.md'
+      - '.github/workflows/js-check.yaml'
   push:
     paths:
       - '**.js'
@@ -52,7 +53,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '22.22.0'
-      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320' v4.4.0
+      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
         with:
           version: 10.32.1
       - name: 'set complex environment variables'

--- a/.github/workflows/react-api-client-test.yaml
+++ b/.github/workflows/react-api-client-test.yaml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '22.22.0'
-      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320' v4.4.0
+      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
         with:
           version: 10.32.1
       - name: 'install libudev for usb-detection'

--- a/.github/workflows/react-api-client-test.yaml
+++ b/.github/workflows/react-api-client-test.yaml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '22.22.0'
-      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
+      - uses: 'pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
         with:
           version: 10.32.1
       - name: 'install libudev for usb-detection'

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320'  # v4.4.0
+      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
         with:
           version: 10.32.1
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '22.22.0'
-      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320' v4.4.0
+      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
         with:
           version: 10.32.1
       - name: 'install udev'
@@ -234,7 +234,7 @@ jobs:
         run: |
           git fetch -f origin ${{ github.ref }}:${{ github.ref }}
           git checkout ${{ github.ref }}
-      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320' v4.4.0
+      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
         with:
           version: 10.32.1
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
+      - uses: 'pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
         with:
           version: 10.32.1
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '22.22.0'
-      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
+      - uses: 'pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
         with:
           version: 10.32.1
       - name: 'install udev'
@@ -234,7 +234,7 @@ jobs:
         run: |
           git fetch -f origin ${{ github.ref }}:${{ github.ref }}
           git checkout ${{ github.ref }}
-      - uses: 'pnpm/action-setup@vfc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
+      - uses: 'pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
         with:
           version: 10.32.1
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0


### PR DESCRIPTION
## Overview

This fixes some YAML syntax errors in our GitHub Actions workflows. I think these were from the merge conflict resolution in #18571.

Unfortunately, when a workflow has a syntax error, GitHub doesn't display it in PRs, so the problem went unnoticed.

## Test Plan and Hands on Testing

* [x] The workflows edited in this PR are now running. They might not be passing, though.
* [x] I've run `yq` on all `.yml` and `.yaml` files under `.github/` to make sure there are no more syntax errors.

## Review requests

None.

## Risk assessment

Low.