### PR TITLE
chore(ci): Pin pnpm/action-setup to a Git SHA

### DIFF
--- a/.github/actions/js/setup/action.yml
+++ b/.github/actions/js/setup/action.yml
@@ -14,7 +14,7 @@ runs:
 
     # must install pnpm directly before setup-node
     - name: Install pnpm
-      uses: pnpm/action-setup@v4
+      uses: 'pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
       with:
         version: 10.32.1
 

--- a/.github/workflows/g-code-testing-lint-test.yaml
+++ b/.github/workflows/g-code-testing-lint-test.yaml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: 'pnpm/action-setup@v4'
+      - uses: 'pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
         with:
           version: 10.32.1
       - name: 'install udev'

--- a/.github/workflows/gh-actions-security-zizmor.yaml
+++ b/.github/workflows/gh-actions-security-zizmor.yaml
@@ -4,6 +4,9 @@ on:
   push:
     paths:
       - .github/**
+  pull_request:
+    paths:
+      - .github/**
   workflow_dispatch: {}
 
 permissions: {}

--- a/.github/workflows/npm-packages-scan.yaml
+++ b/.github/workflows/npm-packages-scan.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: 'pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320' # v4.4.0
         with:
           version: 10.32.1
 


### PR DESCRIPTION
## Overview

This fixes some straggling conflicts between #21196 and #18571. Since #21196, our GitHub Actions dependencies need to be pinned by Git SHA.

## Test Plan and Hands on Testing

* [x] The Zizmor workflow should run and pass on this PR.

## Changelog

* Make sure some straggling GitHub Action dependencies are pinned by SHA, to resolve Zizmor failures.
* The Zizmor workflow now runs on `pull_request`, not just on `push`.

  There have been a couple instances of this workflow not running on a PR that it should have, and failing only after the PR has been merged into `edge`. I suspect this is because those PRs were branched off of old `edge` commits that didn't have the Zizmor workflow. This is intended to fix that, as well as similar hazards in the future whenever we modify the Zizmor workflow to add more rules.

## Review requests

None.

## Risk assessment

Low.
