### PR TITLE
fix(app): fix whitescreen error and commandAnnotations filtering issue

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -92,19 +92,26 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [isValidRobotSideAnalysis]
   )
-  const commandIndexById = useMemo(
+  const filteredCommands = useMemo(
     () =>
-      new Map(analysis.commands.map((command, index) => [command.id, index])),
+      analysis.commands.filter(
+        command =>
+          !command.commandType.includes('load') &&
+          command.commandType !== 'home'
+      ),
     [analysis.commands]
   )
+  const currentCommandId =
+    currentCommandIndex != null
+      ? (filteredCommands[currentCommandIndex]?.id ?? null)
+      : null
   const groupedCommandsHighlightedInfo = useMemo(
     () =>
       groupedCommands?.map(node => {
         if ('annotationId' in node) {
           const updatedSubCommands = node.subCommands.map(subNode => ({
             ...subNode,
-            isHighlighted:
-              currentCommandIndex === commandIndexById.get(subNode.command.id),
+            isHighlighted: currentCommandId === subNode.command.id,
           }))
 
           return {
@@ -117,50 +124,34 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
         }
         return {
           ...node,
-          isHighlighted:
-            currentCommandIndex === commandIndexById.get(node.command.id),
+          isHighlighted: currentCommandId === node.command.id,
         }
       }),
-    [groupedCommands, currentCommandIndex, commandIndexById]
-  )
-  const filteredCommands = useMemo(
-    () =>
-      analysis.commands.filter(
-        command =>
-          !command.commandType.includes('load') &&
-          command.commandType !== 'home'
-      ),
-    [analysis.commands]
+    [groupedCommands, currentCommandId]
   )
 
   useEffect(() => {
-    if (currentCommandIndex == null) return
-    if (groupedCommands != null) {
+    if (currentCommandId == null) return
+    if (groupedCommands != null && groupedCommands.length > 0) {
       const flatCommands = groupedCommands.flatMap(node =>
         'subCommands' in node ? node.subCommands : [node]
       )
 
       const targetNode = flatCommands.find(
-        node => commandIndexById.get(node.command.id) === currentCommandIndex
+        node => node.command.id === currentCommandId
       )
+      const targetCommandId = targetNode?.command.id ?? null
 
-      if (targetNode?.command.id && scrollTargetId !== targetNode.command.id) {
-        setScrollTargetId(targetNode.command.id)
+      if (targetCommandId != null && scrollTargetId !== targetCommandId) {
+        setScrollTargetId(targetCommandId)
       }
       return
     }
 
-    const targetCommand = filteredCommands[currentCommandIndex]
-    if (targetCommand?.id && scrollTargetId !== targetCommand.id) {
-      setScrollTargetId(targetCommand.id)
+    if (scrollTargetId !== currentCommandId) {
+      setScrollTargetId(currentCommandId)
     }
-  }, [
-    groupedCommands,
-    currentCommandIndex,
-    scrollTargetId,
-    commandIndexById,
-    filteredCommands,
-  ])
+  }, [groupedCommands, currentCommandId, scrollTargetId])
 
   const { rows, rowIndexByCommandId } = useMemo(() => {
     const nextRows: AnnotatedStepsRow[] = []

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -95,6 +95,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
   const filteredCommands = useMemo(
     () =>
       analysis.commands.filter(
+        // ToDo: the following condition will be updated for phase 2
         command =>
           !command.commandType.includes('load') &&
           command.commandType !== 'home'

--- a/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/LabwareSlotContainer/index.tsx
@@ -114,10 +114,16 @@ export function LabwareSlotContainer(
     pipetteTemporalProperties != null
       ? pipetteTemporalProperties[1].wellName
       : null
-  const selectedWellName =
+  const rawSelectedWellName =
     commandLabwareId === topLabwareOnSlotId && commandWellName != null
       ? commandWellName
       : activeWellName
+
+  const selectedWellName =
+    rawSelectedWellName != null && labwareDef.wells[rawSelectedWellName] != null
+      ? rawSelectedWellName
+      : null
+
   const shouldShowWellContainer =
     selectedWellName != null &&
     !HIDE_WELL_CONTAINER_COMMAND_TYPES.includes(commandType)

--- a/app/src/pages/Desktop/Protocols/ProtocolVisualization/index.tsx
+++ b/app/src/pages/Desktop/Protocols/ProtocolVisualization/index.tsx
@@ -30,9 +30,10 @@ export function ProtocolVisualization(): JSX.Element {
   const mostRecentAnalysis = storedProtocol?.mostRecentAnalysis ?? null
   const groupedCommands = useMemo(
     () =>
-      mostRecentAnalysis != null
+      mostRecentAnalysis?.commandAnnotations != null &&
+      mostRecentAnalysis.commandAnnotations.length > 0
         ? getGroupedCommands(mostRecentAnalysis)
-        : null,
+        : [],
     [mostRecentAnalysis]
   )
 


### PR DESCRIPTION


# Overview
fix the white screen 

#21331 made it so that ‎`getGroupedCommands()` is called even when ‎`commandAnnotations` is empty. As a result, it would enter the grouped path that includes ‎`home/load`, and because the highlight logic was comparing the “index after filtering” with the “unfiltered commands index,” clicking a step would jump to an unintended step.

clsoe RESC-565

## Test Plan and Hands on Testing
- run the app from this branch
- import the protocol that attached to RESC-565
- play the visualization


## Changelog
- fix filtering part
- add additional check to wells 

## Review requests

## Risk assessment
low
