### PR TITLE
Fix(protocol-designer) make ot-2 pd able to transfer to and from TC 

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/__tests__/getAllWellsSafetyStatus.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/__tests__/getAllWellsSafetyStatus.test.ts
@@ -1,8 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  ALL,
   COLUMN,
+  fixture384Plate,
   fixture96Plate,
+  fixtureP10MultiV2Specs,
+  fixtureP10SingleV2Specs,
   fixtureP100096V2Specs,
   fixtureTiprack1000ul,
   getLabwareDefURI,
@@ -182,6 +186,128 @@ describe('getAllWellsSafetyStatus', () => {
       })
 
       expect(getIsSafePipetteMovement).toHaveBeenCalledTimes(6)
+    })
+  })
+
+  describe('8-channel ALL on 384-well plate (staggered columns)', () => {
+    const firstColumn = fixture384Plate.ordering[0]
+    const secondColumn = fixture384Plate.ordering[1]
+
+    const mockInvariant384 = {
+      pipetteEntities: {
+        [pipetteId]: {
+          name: 'p10_multi',
+          id: pipetteId,
+          tiprackDefURI: [
+            getLabwareDefURI(fixtureTiprack1000ul as LabwareDefinition),
+          ],
+          tiprackLabwareDef: [fixtureTiprack1000ul],
+          spec: fixtureP10MultiV2Specs,
+          pythonName: 'mock_pipette_p10_multi',
+        },
+      },
+      labwareEntities: {
+        [labwareId]: {
+          id: labwareId,
+          pythonName: 'mock_384_plate',
+          labwareDefURI: getLabwareDefURI(fixture384Plate as LabwareDefinition),
+          def: fixture384Plate,
+        },
+      },
+    } as any
+
+    it('evaluates even and odd stagger rows separately per column', () => {
+      ;(getIsSafePipetteMovement as any).mockImplementation(
+        (args: { wellTargetName: string }) => {
+          if (args.wellTargetName === firstColumn[0]) return true
+          if (args.wellTargetName === firstColumn[1]) return false
+          if (args.wellTargetName === secondColumn[0]) return false
+          if (args.wellTargetName === secondColumn[1]) return true
+          return true
+        }
+      )
+
+      const allWells384 = [firstColumn, secondColumn]
+
+      const result = getAllWellsSafetyStatus({
+        allWells: allWells384,
+        robotState: mockRobotState,
+        invariantContext: mockInvariant384,
+        pipetteId,
+        labwareId,
+        primaryNozzle,
+        nozzleConfiguration: ALL,
+      })
+
+      firstColumn.forEach((wellName, rowIdx) => {
+        expect(result[wellName]).toBe(rowIdx % 2 === 0 ? 0 : 1)
+      })
+      secondColumn.forEach((wellName, rowIdx) => {
+        expect(result[wellName]).toBe(rowIdx % 2 === 0 ? 1 : 0)
+      })
+
+      expect(getIsSafePipetteMovement).toHaveBeenCalledTimes(4)
+    })
+  })
+
+  describe('1-channel ALL on 384-well plate (staggered columns)', () => {
+    const firstColumn = fixture384Plate.ordering[0]
+    const secondColumn = fixture384Plate.ordering[1]
+
+    const mockInvariant384Single = {
+      pipetteEntities: {
+        [pipetteId]: {
+          name: 'p10_single',
+          id: pipetteId,
+          tiprackDefURI: [
+            getLabwareDefURI(fixtureTiprack1000ul as LabwareDefinition),
+          ],
+          tiprackLabwareDef: [fixtureTiprack1000ul],
+          spec: fixtureP10SingleV2Specs,
+          pythonName: 'mock_pipette_p10_single',
+        },
+      },
+      labwareEntities: {
+        [labwareId]: {
+          id: labwareId,
+          pythonName: 'mock_384_plate',
+          labwareDefURI: getLabwareDefURI(fixture384Plate as LabwareDefinition),
+          def: fixture384Plate,
+        },
+      },
+    } as any
+
+    it('evaluates even and odd stagger rows separately per column', () => {
+      ;(getIsSafePipetteMovement as any).mockImplementation(
+        (args: { wellTargetName: string }) => {
+          if (args.wellTargetName === firstColumn[0]) return true
+          if (args.wellTargetName === firstColumn[1]) return false
+          if (args.wellTargetName === secondColumn[0]) return false
+          if (args.wellTargetName === secondColumn[1]) return true
+          return true
+        }
+      )
+
+      const allWells384 = [firstColumn, secondColumn]
+
+      const result = getAllWellsSafetyStatus({
+        allWells: allWells384,
+        robotState: mockRobotState,
+        invariantContext: mockInvariant384Single,
+        pipetteId,
+        labwareId,
+        primaryNozzle,
+        nozzleConfiguration: ALL,
+      })
+
+      firstColumn.forEach((wellName, rowIdx) => {
+        expect(result[wellName]).toBe(rowIdx % 2 === 0 ? 0 : 1)
+      })
+      secondColumn.forEach((wellName, rowIdx) => {
+        expect(result[wellName]).toBe(rowIdx % 2 === 0 ? 1 : 0)
+      })
+
+      expect(getIsSafePipetteMovement).toHaveBeenCalledTimes(4)
     })
   })
 })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
@@ -36,6 +36,7 @@ export function getAllWellsSafetyStatus(
   const pipetteSpec = invariantContext.pipetteEntities[pipetteId].spec
   const labwareDef = invariantContext.labwareEntities[labwareId].def
   const channels = pipetteSpec.channels
+  const is384Plate = labwareDef.ordering.flat().length === 384
   const pipetteCanUseLabware = canPipetteUseLabware(
     pipetteSpec,
     nozzleConfiguration,
@@ -72,27 +73,70 @@ export function getAllWellsSafetyStatus(
     }
   } else if (
     nozzleConfiguration === COLUMN ||
-    (channels === 8 && nozzleConfiguration === ALL)
+    (channels === 8 && nozzleConfiguration === ALL) ||
+    (channels === 1 && nozzleConfiguration === ALL && is384Plate)
   ) {
-    // COLUMN mode: each column = 8 wells
+    // 384: two vertical staggers per column. Reuse the same even/odd grouping for
+    // 8-channel ALL, COLUMN (e.g. 96ch on 384), and single-channel ALL on 384 only —
+    // PD only offers ALL for 1ch; per-well checks are overly pessimistic at tight Y pitch.
+    const use384ColumnStagger =
+      is384Plate &&
+      (nozzleConfiguration === COLUMN ||
+        (nozzleConfiguration === ALL && (channels === 1 || channels === 8)))
+
     for (let colIndex = 0; colIndex < allWells.length; colIndex++) {
       const column = allWells[colIndex]
-      const firstWell = column[0]
-      const safe = robotState
-        ? getIsSafePipetteMovement({
-            robotState,
-            invariantContext,
-            pipetteId,
-            labwareId,
-            wellTargetName: firstWell,
-            primaryNozzle,
-            nozzleConfiguration,
-          })
-        : true
 
-      column.forEach(wellName => {
-        allWellsWithStatus[wellName] = safe ? 0 : 1
-      })
+      // 384-well plates: two staggered groups per column (even / odd row index).
+      // Using only column[0] marks both groups with the same safety and can wrongly
+      // block the whole plate on OT-2 when the second stagger is actually reachable.
+      if (use384ColumnStagger) {
+        const safeEvenStagger = robotState
+          ? getIsSafePipetteMovement({
+              robotState,
+              invariantContext,
+              pipetteId,
+              labwareId,
+              wellTargetName: column[0],
+              primaryNozzle,
+              nozzleConfiguration,
+            })
+          : true
+        const safeOddStagger = robotState
+          ? getIsSafePipetteMovement({
+              robotState,
+              invariantContext,
+              pipetteId,
+              labwareId,
+              wellTargetName: column[1],
+              primaryNozzle,
+              nozzleConfiguration,
+            })
+          : true
+
+        column.forEach((wellName, rowIdx) => {
+          const safe = rowIdx % 2 === 0 ? safeEvenStagger : safeOddStagger
+          allWellsWithStatus[wellName] = safe ? 0 : 1
+        })
+      } else {
+        // COLUMN mode (96-well columns) or 8-channel ALL on 96: one pose per column.
+        const firstWell = column[0]
+        const safe = robotState
+          ? getIsSafePipetteMovement({
+              robotState,
+              invariantContext,
+              pipetteId,
+              labwareId,
+              wellTargetName: firstWell,
+              primaryNozzle,
+              nozzleConfiguration,
+            })
+          : true
+
+        column.forEach(wellName => {
+          allWellsWithStatus[wellName] = safe ? 0 : 1
+        })
+      }
     }
   } else if (nozzleConfiguration === ALL && channels === 96) {
     // ALL 96 Nozzles: only check the first well

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
@@ -158,8 +158,15 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
         }
       }, {})
     },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedTips]
+    [
+      invariantContext,
+      nozzles,
+      pipetteId,
+      pipetteSpecs,
+      primaryNozzle,
+      robotState,
+      selectedTips,
+      tiprackUri,
+    ]
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/singleChannelLabwareShadowGeometry.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/singleChannelLabwareShadowGeometry.ts
@@ -1,0 +1,56 @@
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
+
+type ShadowSizing =
+  /** One grid cell (center-to-center), e.g. aluminum block wells */
+  | { kind: 'wellPitch'; pitchXMm: number; pitchYMm: number }
+  /** Tube / well opening from definition — smaller than full rack pitch */
+  | { kind: 'circularWellDiameter' }
+
+/**
+ * Single-channel shadows: labware-accurate size, centered on the hovered well,
+ * instead of pipetteBoundingBoxOffsets (same for Flex and OT-2).
+ *
+ * Sources (shared-data labware definitions):
+ * - opentrons_6_tuberack_nest_50ml_conical: use each well’s diameter (e.g. ~28 mm).
+ * - opentrons_24_aluminumblock_generic_2ml_screwcap: 127.75 × 85.5 × 48.7 mm labware;
+ *   D1 at (20.75, 16.88); 17.25 mm X/Y center-to-center (v1–v2).
+ * - appliedbiosystemsmicroamp_384_wellplate_40ul: 127.8 × 85.5 × 9.7 mm; A1 (12.15, 76.5);
+ *   4.5 mm pitch, 3.17 mm well diameter — shadow uses diameter (see Labware Library).
+ *   https://labware.opentrons.com/#/?loadName=appliedbiosystemsmicroamp_384_wellplate_40ul
+ */
+const LABWARE_SINGLE_CHANNEL_SHADOW_BY_LOAD_NAME: Record<string, ShadowSizing> = {
+  opentrons_6_tuberack_nest_50ml_conical: { kind: 'circularWellDiameter' },
+  opentrons_24_aluminumblock_generic_2ml_screwcap: {
+    kind: 'wellPitch',
+    pitchXMm: 17.25,
+    pitchYMm: 17.25,
+  },
+  appliedbiosystemsmicroamp_384_wellplate_40ul: { kind: 'circularWellDiameter' },
+}
+
+export function tryGetLabwareSingleChannelShadowRectMm(args: {
+  labwareDef: LabwareDefinition2
+  wellName: string
+}): { leftMm: number; bottomMm: number; widthMm: number; heightMm: number } | null {
+  const { labwareDef, wellName } = args
+  const sizing = LABWARE_SINGLE_CHANNEL_SHADOW_BY_LOAD_NAME[labwareDef.parameters.loadName]
+  if (sizing == null) {
+    return null
+  }
+  const well = labwareDef.wells[wellName]
+  if (well == null || well.shape !== 'circular') {
+    return null
+  }
+
+  const widthMm =
+    sizing.kind === 'wellPitch' ? sizing.pitchXMm : well.diameter
+  const heightMm =
+    sizing.kind === 'wellPitch' ? sizing.pitchYMm : well.diameter
+
+  return {
+    leftMm: well.x - widthMm / 2,
+    bottomMm: well.y - heightMm / 2,
+    widthMm,
+    heightMm,
+  }
+}

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -231,16 +231,6 @@ const getSlotHasPotentialCollidingObject = (
   for (const slot of slotInfo) {
     const slotBounds = slot.addressableArea?.boundingBox
     const slotPosition = slot.position
-    // explicit OT-2 check for if the pipette will enter the space above a thermocycler-occupied slot
-    const willCollideWithThermocycler =
-      isThermocyclerOnDeck &&
-      robotType === OT2_ROBOT_TYPE &&
-      slot.addressableArea?.id != null &&
-      OT2_TC_SLOTS.includes(slot.addressableArea.id as OT2AddressableAreaName)
-
-    if (willCollideWithThermocycler) {
-      return true
-    }
 
     // If slotPosition or slotBounds is null, continue to the next iteration
     if (slotPosition == null || slotBounds == null) {

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -22,7 +22,7 @@ import {
   WASTE_CHUTE_FIXTURES,
 } from '@opentrons/shared-data'
 
-import { EMPTY, OT2_TC_SLOTS } from '../constants'
+import { EMPTY } from '../constants'
 import { getPipetteCriticalPoint } from './getPipetteCriticalPoint'
 import { getFullStackFromLabwares, getSlotInLocationStack } from './misc'
 
@@ -224,10 +224,6 @@ const getSlotHasPotentialCollidingObject = (
   invariantContext: InvariantContext,
   robotType: RobotType
 ): boolean => {
-  const isThermocyclerOnDeck = Object.values(
-    invariantContext.moduleEntities
-  ).some(({ type }) => type === THERMOCYCLER_MODULE_TYPE)
-
   for (const slot of slotInfo) {
     const slotBounds = slot.addressableArea?.boundingBox
     const slotPosition = slot.position


### PR DESCRIPTION
# Overview
Removed overly strict guardrails around TC transfers 
https://opentrons.atlassian.net/browse/RQA-5329
## Test Plan and Hands on Testing

1. Imported protocols that used to work and now they work
2. Tried to do unsafe transfers and they still don't work proving other guardrails sufficient 

## Changelog

Removed OT-2 specific guardrail in favor of existing work. 

## Review requests

- I might be missing something upstream that is a more smooth fix. 
- I wonder if the rectangle sizing should be different for OT-2 vs. Flex. 

## Risk assessment
- I think is now fairly low because this is now just allowing the same behavior as API and PD 8.9.1 and prior versions. 