### PR TITLE
fix(app-shell): fix make -C app dev errors

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-ignore-scripts=true

--- a/app-shell-odd/package.json
+++ b/app-shell-odd/package.json
@@ -30,7 +30,7 @@
     "@opentrons/app": "link:../app",
     "@types/node-fetch": "2.6.11",
     "@types/yargs-parser": "^21.0.3",
-    "is-ip": "3.1.0",
+    "is-ip": "5.0.1",
     "postcss-apply": "0.12.0",
     "postcss-color-mod-function": "3.0.3",
     "postcss-import": "16.0.0",

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -62,6 +62,7 @@
     "get-stream": "5.1.0",
     "lodash": "4.18.1",
     "merge-options": "1.0.1",
+    "mdns-js": "1.0.1",
     "mqtt": "4.3.8",
     "node-fetch": "2.6.7",
     "node-stream-zip": "1.8.2",

--- a/app-shell/vite.config.mts
+++ b/app-shell/vite.config.mts
@@ -34,6 +34,9 @@ export default defineConfig(async (): Promise<UserConfig> => {
         formats: ['cjs'],
       },
     },
+    ssr: {
+      external: ['mdns-js'],
+    },
     plugins: [
       sentryVitePlugin({
         org: 'opentrons-sw',

--- a/app/package.json
+++ b/app/package.json
@@ -42,7 +42,7 @@
     "file-saver": "2.0.1",
     "history": "4.7.2",
     "hls.js": "1.6.11",
-    "is-ip": "3.1.0",
+    "is-ip": "5.0.1",
     "jszip": "3.2.2",
     "lodash": "4.18.1",
     "mixpanel-browser": "2.22.1",

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -1,4 +1,4 @@
-import isIp from 'is-ip'
+import { isIPv6 } from 'is-ip'
 import concat from 'lodash/concat'
 import find from 'lodash/find'
 import head from 'lodash/head'
@@ -55,7 +55,7 @@ const isLocal = (ip: string): boolean => {
   )
 }
 
-const ipToHostname = (ip: string): string => (isIp.v6(ip) ? `[${ip}]` : ip)
+const ipToHostname = (ip: string): string => (isIPv6(ip) ? `[${ip}]` : ip)
 
 const makeRobotModel = (
   healthModel: string | null,

--- a/discovery-client/package.json
+++ b/discovery-client/package.json
@@ -24,7 +24,7 @@
     "@types/node-fetch": "2.6.11",
     "@types/yargs": "17.0.32",
     "escape-string-regexp": "1.0.5",
-    "is-ip": "3.1.0",
+    "is-ip": "5.0.1",
     "lodash": "4.18.1",
     "mdns-js": "1.0.1",
     "node-fetch": "2.6.7",

--- a/discovery-client/src/store/selectors.ts
+++ b/discovery-client/src/store/selectors.ts
@@ -1,4 +1,4 @@
-import isIp from 'is-ip'
+import { isIP } from 'is-ip'
 import unionBy from 'lodash/unionBy'
 import { createSelector } from 'reselect'
 
@@ -99,7 +99,7 @@ export function compareHostsByConnectability(
   if (ipSort !== 0) return ipSort
 
   // prefer ip hostname
-  const isIpSort = isIp(b.ip) ? 1 : -1
+  const isIpSort = isIP(b.ip) ? 1 : -1
 
   return isIpSort
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,8 +441,8 @@ importers:
         specifier: 1.6.11
         version: 1.6.11
       is-ip:
-        specifier: 3.1.0
-        version: 3.1.0
+        specifier: 5.0.1
+        version: 5.0.1
       jszip:
         specifier: 3.2.2
         version: 3.2.2
@@ -660,6 +660,9 @@ importers:
       merge-options:
         specifier: 1.0.1
         version: 1.0.1
+      mdns-js:
+        specifier: 1.0.1
+        version: 1.0.1
       mqtt:
         specifier: 4.3.8
         version: 4.3.8
@@ -822,8 +825,8 @@ importers:
         specifier: ^21.0.3
         version: 21.0.3
       is-ip:
-        specifier: 3.1.0
-        version: 3.1.0
+        specifier: 5.0.1
+        version: 5.0.1
       postcss-apply:
         specifier: 0.12.0
         version: 0.12.0
@@ -925,8 +928,8 @@ importers:
         specifier: 1.0.5
         version: 1.0.5
       is-ip:
-        specifier: 3.1.0
-        version: 3.1.0
+        specifier: 5.0.1
+        version: 5.0.1
       lodash:
         specifier: 4.18.1
         version: 4.18.1
@@ -5934,6 +5937,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clone-regexp@3.0.0:
+    resolution: {integrity: sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==}
+    engines: {node: '>=12'}
+
   clone-response@1.0.2:
     resolution: {integrity: sha512-yjLXh88P599UOyPTFX0POsd7WxnbsVsGohcwzHOLspIhhpalPw1BcqED8NblyZLKcGrL8dTgMlcaZxV2jAD41Q==}
 
@@ -6166,6 +6173,10 @@ packages:
     resolution: {integrity: sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==}
     engines: {node: '>=10'}
     hasBin: true
+
+  convert-hrtime@5.0.0:
+    resolution: {integrity: sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==}
+    engines: {node: '>=12'}
 
   convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
@@ -7709,6 +7720,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  function-timeout@0.1.1:
+    resolution: {integrity: sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg==}
+    engines: {node: '>=14.16'}
+
   function.prototype.name@1.1.8:
     resolution: {integrity: sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==}
     engines: {node: '>= 0.4'}
@@ -8311,9 +8326,9 @@ packages:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
 
-  ip-regex@4.3.0:
-    resolution: {integrity: sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==}
-    engines: {node: '>=8'}
+  ip-regex@5.0.0:
+    resolution: {integrity: sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -8471,9 +8486,9 @@ packages:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
 
-  is-ip@3.1.0:
-    resolution: {integrity: sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==}
-    engines: {node: '>=8'}
+  is-ip@5.0.1:
+    resolution: {integrity: sha512-FCsGHdlrOnZQcp0+XT5a+pYowf33itBalCl+7ovNXC/7o5BhIpG14M3OrpPPdBSIQJCm+0M5+9mO7S9VVTTCFw==}
+    engines: {node: '>=14.16'}
 
   is-lambda@1.0.1:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
@@ -8553,6 +8568,10 @@ packages:
   is-regexp@1.0.0:
     resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
     engines: {node: '>=0.10.0'}
+
+  is-regexp@3.1.0:
+    resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
+    engines: {node: '>=12'}
 
   is-relative-path@1.0.2:
     resolution: {integrity: sha512-i1h+y50g+0hRbBD+dbnInl3JlJ702aar58snAeX+MxBAPvzXGej7sYoPMhlnykabt0ZzCJNBEyzMlekuQZN7fA==}
@@ -11752,6 +11771,10 @@ packages:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
 
+  super-regex@0.2.0:
+    resolution: {integrity: sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw==}
+    engines: {node: '>=14.16'}
+
   supercluster@7.1.5:
     resolution: {integrity: sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==}
 
@@ -11908,6 +11931,10 @@ packages:
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  time-span@5.1.0:
+    resolution: {integrity: sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==}
+    engines: {node: '>=12'}
 
   timed-out@4.0.1:
     resolution: {integrity: sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==}
@@ -18674,6 +18701,10 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clone-regexp@3.0.0:
+    dependencies:
+      is-regexp: 3.1.0
+
   clone-response@1.0.2:
     dependencies:
       mimic-response: 1.0.1
@@ -18955,6 +18986,8 @@ snapshots:
       meow: 8.1.2
       split2: 3.2.2
       through2: 4.0.2
+
+  convert-hrtime@5.0.0: {}
 
   convert-source-map@1.9.0: {}
 
@@ -21033,6 +21066,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  function-timeout@0.1.1: {}
+
   function.prototype.name@1.1.8:
     dependencies:
       call-bind: 1.0.8
@@ -21807,7 +21842,7 @@ snapshots:
 
   ip-address@10.1.0: {}
 
-  ip-regex@4.3.0: {}
+  ip-regex@5.0.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -21958,9 +21993,10 @@ snapshots:
 
   is-interactive@1.0.0: {}
 
-  is-ip@3.1.0:
+  is-ip@5.0.1:
     dependencies:
-      ip-regex: 4.3.0
+      ip-regex: 5.0.0
+      super-regex: 0.2.0
 
   is-lambda@1.0.1: {}
 
@@ -22016,6 +22052,8 @@ snapshots:
       hasown: 2.0.2
 
   is-regexp@1.0.0: {}
+
+  is-regexp@3.1.0: {}
 
   is-relative-path@1.0.2: {}
 
@@ -25924,6 +25962,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  super-regex@0.2.0:
+    dependencies:
+      clone-regexp: 3.0.0
+      function-timeout: 0.1.1
+      time-span: 5.1.0
+
   supercluster@7.1.5:
     dependencies:
       kdbush: 3.0.0
@@ -26117,6 +26161,10 @@ snapshots:
       readable-stream: 3.6.2
 
   through@2.3.8: {}
+
+  time-span@5.1.0:
+    dependencies:
+      convert-hrtime: 5.0.0
 
   timed-out@4.0.1: {}
 


### PR DESCRIPTION


# Overview
fix make -C app dev errors

```shell
[shell] error during build:
[shell] ../discovery-client/src/store/selectors.ts (1:7): "default" is not exported by "../node_modules/.pnpm/is-ip@3.1.0/node_modules/is-ip/index.js", imported by "../discovery-client/src/store/selectors.ts".
[shell] file: /Users/koji/Desktop/test_test_test/opentrons/discovery-client/src/store/selectors.ts:1:7
[shell]
[shell] 1: import isIp from 'is-ip'
[shell]           ^
[shell] 2: import unionBy from 'lodash/unionBy'
[shell] 3: import { createSelector } from 'reselect'
[shell]
[shell]     at getRollupError (file:///Users/koji/Desktop/test_test_test/opentrons/node_modules/.pnpm/rollup@4.55.1/node_modules/rollup/dist/es/shared/parseAst.js:401:41)
[shell]     at error (file:///Users/koji/Desktop/test_test_test/opentrons/node_modules/.pnpm/rollup@4.55.1/node_modules/rollup/dist/es/shared/parseAst.js:397:42)
```

```shell
[shell] App threw an error during load
[shell] Error: Cannot find module './package.json'
[shell] Require stack:
[shell] - /Users/koji/Desktop/test_test_test/opentrons/app-shell/lib/main.js
[shell]     at Module._resolveFilename (node:internal/modules/cjs/loader:1390:15)
[shell]     at s._resolveFilename (node:electron/js2c/browser_init:2:130410)
[shell]     at defaultResolveImpl (node:internal/modules/cjs/loader:1032:19)
[shell]     at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1037:22)
```



## Test Plan and Hands on Testing
- make teardown-js && make setup-js
- make -C app dev

## Changelog
- update packages
- modify vite config

## Review requests


## Risk assessment
low
