### PR TITLE
fix(step-generation): remove assert and replace it with if statement

### DIFF
--- a/step-generation/src/commandCreators/atomic/disengageMagnet.ts
+++ b/step-generation/src/commandCreators/atomic/disengageMagnet.ts
@@ -1,5 +1,3 @@
-import assert from 'assert'
-
 import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
 
 import * as errorCreators from '../../errorCreators'
@@ -24,10 +22,11 @@ export const disengageMagnet: CommandCreator<ModuleOnlyParams> = (
     }
   }
 
-  assert(
-    moduleEntities[moduleId]?.type === MAGNETIC_MODULE_TYPE,
-    `expected module ${moduleId} to be magdeck, got ${moduleEntities[moduleId]?.type}`
-  )
+  if (moduleEntities[moduleId]?.type !== MAGNETIC_MODULE_TYPE) {
+    throw new Error(
+      `expected module ${moduleId} to be magdeck, got ${moduleEntities[moduleId]?.type}`
+    )
+  }
 
   const pythonName = moduleEntities[moduleId].pythonName
 

--- a/step-generation/src/commandCreators/atomic/engageMagnet.ts
+++ b/step-generation/src/commandCreators/atomic/engageMagnet.ts
@@ -1,5 +1,3 @@
-import assert from 'assert'
-
 import { MAGNETIC_MODULE_TYPE } from '@opentrons/shared-data'
 
 import * as errorCreators from '../../errorCreators'
@@ -24,10 +22,11 @@ export const engageMagnet: CommandCreator<EngageMagnetParams> = (
     }
   }
 
-  assert(
-    moduleEntities[moduleId]?.type === MAGNETIC_MODULE_TYPE,
-    `expected module ${moduleId} to be magdeck, got ${moduleEntities[moduleId]?.type}`
-  )
+  if (moduleEntities[moduleId]?.type !== MAGNETIC_MODULE_TYPE) {
+    throw new Error(
+      `expected module ${moduleId} to be magdeck, got ${moduleEntities[moduleId]?.type}`
+    )
+  }
 
   const pythonName = moduleEntities[moduleId].pythonName
 

--- a/step-generation/src/commandCreators/atomic/heaterShakerSetTargetShakeSpeed.ts
+++ b/step-generation/src/commandCreators/atomic/heaterShakerSetTargetShakeSpeed.ts
@@ -1,5 +1,3 @@
-import assert from 'assert'
-
 import { HEATERSHAKER_MODULE_TYPE } from '@opentrons/shared-data'
 
 import * as errorCreators from '../../errorCreators'
@@ -20,10 +18,11 @@ export const heaterShakerSetTargetShakeSpeed: CommandCreator<
     }
   }
 
-  assert(
-    moduleEntities[moduleId]?.type === HEATERSHAKER_MODULE_TYPE,
-    `expected module ${moduleId} to be heaterShaker, got ${moduleEntities[moduleId]?.type}`
-  )
+  if (moduleEntities[moduleId]?.type !== HEATERSHAKER_MODULE_TYPE) {
+    throw new Error(
+      `expected module ${moduleId} to be heaterShaker, got ${moduleEntities[moduleId]?.type}`
+    )
+  }
   const pythonName = moduleEntities[moduleId].pythonName
 
   return {

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import zip from 'lodash/zip'
 
 import {
@@ -197,8 +196,7 @@ export const transfer: CommandCreator<TransferArgs> = (
   ) {
     // No assertion failure, continue with the logic
   } else {
-    assert(
-      false,
+    throw new Error(
       `Transfer command creator expected N:N source-to-dest wells ratio. Got ${sourceWells.length}:${destWells?.length} in labware`
     )
   }

--- a/step-generation/src/getNextRobotStateAndWarnings/forDropTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forDropTip.ts
@@ -1,5 +1,3 @@
-import assert from 'assert'
-
 import { ALL, COLUMN, getIsTiprack, SINGLE } from '@opentrons/shared-data'
 
 import { DIRTY } from '../constants'
@@ -30,10 +28,11 @@ export function forDropTip(
   ): string[] | undefined =>
     ordering.find(column => column.includes(targetWellName))
   const tiprackDef = invariantContext.labwareEntities[labwareId].def
-  assert(
-    tiprackDef != null && getIsTiprack(tiprackDef),
-    `forDropTip expected ${labwareId} to have definition and to be a tiprack`
-  )
+  if (tiprackDef == null || !getIsTiprack(tiprackDef)) {
+    throw new Error(
+      `forDropTip expected ${labwareId} to have definition and to be a tiprack`
+    )
+  }
 
   // TODO (nd 08/12/2025): handle tip (re)placement more elegantly depending on pipette specs and selected nozzles
   if (nozzleConfiguration === SINGLE) {

--- a/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forPickUpTip.ts
@@ -1,5 +1,3 @@
-import assert from 'assert'
-
 import {
   ALL,
   COLUMN,
@@ -27,10 +25,9 @@ export function forPickUpTip(
   const { pipetteId, labwareId, wellName } = params
   const pipetteSpec = invariantContext.pipetteEntities[pipetteId].spec
   const tiprackDef = invariantContext.labwareEntities[labwareId].def
-  assert(
-    getIsTiprack(tiprackDef),
-    `forPickUpTip expected ${labwareId} to be a tiprack`
-  )
+  if (!getIsTiprack(tiprackDef)) {
+    throw new Error(`forPickUpTip expected ${labwareId} to be a tiprack`)
+  }
   const tipState = robotStateAndWarnings.robotState.tipState
   const nozzles = robotStateAndWarnings.robotState.pipettes[pipetteId].nozzles
   const primaryNozzle =

--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -1,4 +1,3 @@
-import assert from 'assert'
 import { produce } from 'immer'
 
 import { stripNoOpCommands } from '../utils/stripNoOpCommands'
@@ -78,7 +77,9 @@ function _getNextRobotStateAndWarningsSingleCommand(
   invariantContext: InvariantContext,
   robotStateAndWarnings: RobotStateAndWarnings
 ): void {
-  assert(command, 'undefined command passed to getNextRobotStateAndWarning')
+  if (!command) {
+    throw new Error('undefined command passed to getNextRobotStateAndWarning')
+  }
   switch (command.commandType) {
     case 'aspirateWhileTracking':
     case 'aspirate':


### PR DESCRIPTION


# Overview
yarn v1 does handle this polyfill thing magically but pnpm is stricter than yarn.
we can use polyfill package but it will increase the bundle size so decided to remove assert and replace it with if statement.

close AUTH-2889

## Test Plan and Hands on Testing
- run protocol visualization 


## Changelog
- replace assert with if statement with throw Error

## Review requests


## Risk assessment
low
