### PR TITLE
fix(step-generation): remove OT-2 thermocycler collision check and redundant getDefaultPrimaryNozzle

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -371,16 +371,17 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
   let controls: JSX.Element = <></>
   const modulesOnDeck = deckSetup.modules
   const moduleIds = new Set(Object.keys(modulesOnDeck))
-  const moduleLocation = labware.stack.find(loc => moduleIds.has(loc))
 
-  const moduleDef = moduleLocation
-    ? getModuleDef(modulesOnDeck[moduleLocation].model)
-    : null
-  const isLabwareOnModule = moduleDef !== null
   const defaultSlotPosition: [number, number, number] = [0, 0, 0]
 
   if (labware && robotState) {
     const activeLabware = robotState.labware[labwareId]
+    const moduleLocation =
+      activeLabware.stack.find(loc => moduleIds.has(loc)) ?? null
+    const isLabwareOnModule = moduleLocation !== null
+    const moduleDef = moduleLocation
+      ? getModuleDef(modulesOnDeck[moduleLocation].model)
+      : null
     const slot = getSlotInLocationStack(activeLabware.stack)
     const slotPosition =
       getPositionFromSlotId(slot, deckDef) ?? defaultSlotPosition

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -69,8 +69,9 @@ export const getViewboxFromSelectedLabware = (
   const moduleIds = new Set(Object.keys(modules || {}))
 
   // find the first module location
-  const moduleLocation = selectedLabware.stack?.find(loc => moduleIds.has(loc))
-
+  const moduleLocation = labwareState[selectedLabwareId].stack.find(loc =>
+    moduleIds.has(loc)
+  )
   const moduleDef = moduleLocation
     ? getModuleDef(modules[moduleLocation].model)
     : null

--- a/protocol-designer/src/steplist/test/generateSubsteps.test.ts
+++ b/protocol-designer/src/steplist/test/generateSubsteps.test.ts
@@ -214,6 +214,7 @@ describe('generateSubstepItem', () => {
         stepArgs: {
           commandCreatorFnName: 'distribute',
           sourceWell: 'A1',
+          primaryNozzle: 'A1',
           destWells: ['A1', 'A2'],
           disposalVolume: null,
           disposalLabware: null,
@@ -278,6 +279,7 @@ describe('generateSubstepItem', () => {
         testName: 'transfer command returns substep data',
         stepArgs: {
           commandCreatorFnName: 'transfer',
+          primaryNozzle: 'A1',
           sourceWells: ['A1', 'A2'],
           destWells: ['A1', 'A2'],
           blowoutLocation: null,

--- a/step-generation/src/commandCreators/atomic/pickUpTip.ts
+++ b/step-generation/src/commandCreators/atomic/pickUpTip.ts
@@ -7,7 +7,6 @@ import {
 } from '../../errorCreators'
 import {
   formatPyStr,
-  getDefaultPrimaryNozzle,
   getIsSafePickupWithinTiprack,
   getIsSafePipetteMovement,
   getSlotInLocationStack,
@@ -60,8 +59,7 @@ export const pickUpTip: CommandCreator<PickUpTipAtomicParams> = (
 
   const isSafeWithinTiprack = getIsSafePickupWithinTiprack({
     tipState: prevRobotState.tipState.tipracks[labwareId],
-    primaryNozzle:
-      primaryNozzle ?? getDefaultPrimaryNozzle({ channels, nozzles }),
+    primaryNozzle,
     channels,
     nozzleConfiguration: nozzles,
     wellName,

--- a/step-generation/src/commandCreators/compound/__tests__/consolidate.test.ts
+++ b/step-generation/src/commandCreators/compound/__tests__/consolidate.test.ts
@@ -89,7 +89,7 @@ beforeEach(() => {
     name: 'Consolidate Test',
     description: 'test blah blah',
     pipette: DEFAULT_PIPETTE,
-
+    primaryNozzle: 'A1',
     sourceWells: ['A1', 'A2', 'A3', 'A4'],
     destWell: 'B1',
     sourceLabware: SOURCE_LABWARE,

--- a/step-generation/src/commandCreators/compound/__tests__/distribute.test.ts
+++ b/step-generation/src/commandCreators/compound/__tests__/distribute.test.ts
@@ -68,6 +68,8 @@ beforeEach(() => {
     description: 'test blah blah',
     tipRack: getLabwareDefURI(fixtureTiprack300ul as LabwareDefinition2),
     pipette: DEFAULT_PIPETTE,
+    primaryNozzle: 'A1',
+
     sourceLabware: SOURCE_LABWARE,
     destLabware: DEST_LABWARE,
     stepNumber: 1,

--- a/step-generation/src/commandCreators/compound/__tests__/mix.test.ts
+++ b/step-generation/src/commandCreators/compound/__tests__/mix.test.ts
@@ -65,6 +65,8 @@ beforeEach(() => {
     description: 'test blah blah',
     tipRack: getLabwareDefURI(fixtureTiprack300ul as LabwareDefinition2),
     pipette: DEFAULT_PIPETTE,
+    primaryNozzle: 'A1',
+
     labware: SOURCE_LABWARE,
 
     blowoutLocation: null,

--- a/step-generation/src/commandCreators/compound/__tests__/transfer.test.ts
+++ b/step-generation/src/commandCreators/compound/__tests__/transfer.test.ts
@@ -49,6 +49,8 @@ beforeEach(() => {
     name: 'Transfer Test',
     description: 'test blah blah',
     pipette: DEFAULT_PIPETTE,
+    primaryNozzle: 'A1',
+
     tipRack: getLabwareDefURI(fixtureTiprack300ul as LabwareDefinition2),
     sourceLabware: SOURCE_LABWARE,
     destLabware: DEST_LABWARE,

--- a/step-generation/src/robotStateSelectors.ts
+++ b/step-generation/src/robotStateSelectors.ts
@@ -23,7 +23,7 @@ import {
 } from '@opentrons/shared-data'
 
 import { CLEAN, COLUMN_4_SLOTS } from './constants'
-import { getDefaultPrimaryNozzle, getSlotInLocationStack } from './utils'
+import { getSlotInLocationStack } from './utils'
 
 import type {
   NozzleConfigurationStyle,
@@ -85,9 +85,6 @@ export function _getNextTip(args: {
   } = args
   const pipetteChannels =
     invariantContext.pipetteEntities[pipetteId]?.spec?.channels
-  const confirmedPrimaryNozzle =
-    primaryNozzle ??
-    getDefaultPrimaryNozzle({ nozzles, channels: pipetteChannels })
   const tiprackDef = invariantContext.labwareEntities[tiprackId]?.def
   const tiprackWellsState = robotState.tipState.tipracks[tiprackId]
   if (!pipetteChannels || !tiprackDef || !tiprackWellsState) {
@@ -116,18 +113,14 @@ export function _getNextTip(args: {
   const firstFullGroupReversed = (groups: string[][]): string[] | null =>
     [...groups].reverse().find(group => group.every(hasCleanTip)) ?? null
   const is8ch1Nozzle = pipetteChannels === 8 && nozzles === SINGLE
-  const is8ch1NozzleFront = is8ch1Nozzle && confirmedPrimaryNozzle === H1_NOZZLE
-  const is8ch1NozzleBack = is8ch1Nozzle && confirmedPrimaryNozzle === A1_NOZZLE
+  const is8ch1NozzleFront = is8ch1Nozzle && primaryNozzle === H1_NOZZLE
+  const is8ch1NozzleBack = is8ch1Nozzle && primaryNozzle === A1_NOZZLE
 
   const is96ch1Nozzle = pipetteChannels === 96 && nozzles === SINGLE
-  const is96ch1NozzleFrontRight =
-    is96ch1Nozzle && confirmedPrimaryNozzle === H12_NOZZLE
-  const is96ch1NozzleBackRight =
-    is96ch1Nozzle && confirmedPrimaryNozzle === A12_NOZZLE
-  const is96ch1NozzleFrontLeft =
-    is96ch1Nozzle && confirmedPrimaryNozzle === H1_NOZZLE
-  const is96ch1NozzleBackLeft =
-    is96ch1Nozzle && confirmedPrimaryNozzle === A1_NOZZLE
+  const is96ch1NozzleFrontRight = is96ch1Nozzle && primaryNozzle === H12_NOZZLE
+  const is96ch1NozzleBackRight = is96ch1Nozzle && primaryNozzle === A12_NOZZLE
+  const is96ch1NozzleFrontLeft = is96ch1Nozzle && primaryNozzle === H1_NOZZLE
+  const is96ch1NozzleBackLeft = is96ch1Nozzle && primaryNozzle === A1_NOZZLE
 
   if (pipetteChannels === 1 || is8ch1NozzleFront || is96ch1NozzleFrontRight) {
     return firstClean(orderedWellsT2B)
@@ -162,7 +155,7 @@ export function _getNextTip(args: {
   if (nozzles === COLUMN) {
     const columns = tiprackDef.ordering
     const column =
-      confirmedPrimaryNozzle === A1_NOZZLE
+      primaryNozzle === A1_NOZZLE
         ? firstFullGroupReversed(columns)
         : firstFullGroup(columns)
     return column?.[0] ?? null
@@ -173,7 +166,7 @@ export function _getNextTip(args: {
     const rows = columns[0].map((_, i) => columns.map(col => col[i]))
 
     const row =
-      confirmedPrimaryNozzle === A1_NOZZLE
+      primaryNozzle === A1_NOZZLE
         ? firstFullGroupReversed(rows)
         : firstFullGroup(rows)
 

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -2,6 +2,7 @@ import {
   A1_NOZZLE,
   A12_NOZZLE,
   ALL,
+  B1_ADDRESSABLE_AREA,
   COLUMN,
   FLEX_ROBOT_TYPE,
   getAddressableAreaFromSlotId,
@@ -344,7 +345,6 @@ export const getIsSafePipetteMovement = (args: {
   const isFlexPipette = displayCategory === 'FLEX'
   const robotType = isFlexPipette ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE
   const deckDefinition = getDeckDefFromRobotType(robotType)
-
   //  early exit if labwareId is a trashBin or wasteChute or if no well name is provided
   if (labwareEntities[labwareId] == null || wellTargetName == null) {
     return true
@@ -361,17 +361,19 @@ export const getIsSafePipetteMovement = (args: {
   // account for tip length if picking up tip
   const tipLength = pipetteHasTip ? (tiprackTipLength ?? 0) : 0
   const labwareSlot = getSlotInLocationStack(labwareState[labwareId].stack)
-  const addressableAreaOffset = getPositionFromSlotId(
-    labwareSlot,
-    deckDefinition
-  ) ?? [0, 0, 0]
-  const isOnFlexThermocycler =
-    robotType === FLEX_ROBOT_TYPE &&
-    labwareState[labwareId].stack.some(
-      item => moduleEntities[item]?.type === THERMOCYCLER_MODULE_TYPE
-    )
-  const thermocyclerOffset = isOnFlexThermocycler
-    ? (deckDefinition.locations.addressableAreas.find(
+
+  const hasThermocycler = labwareState[labwareId].stack.some(item => {
+    return moduleEntities[item]?.type === THERMOCYCLER_MODULE_TYPE
+  })
+
+  // special logic for thermocycler addressable area offset for the OT-2
+  const flexDeckDefinition = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
+  const addressableAreaOffset = (hasThermocycler
+    ? getPositionFromSlotId(B1_ADDRESSABLE_AREA, flexDeckDefinition)
+    : getPositionFromSlotId(labwareSlot, deckDefinition)) ?? [0, 0, 0]
+
+  const thermocyclerOffset = hasThermocycler
+    ? (flexDeckDefinition.locations.addressableAreas.find(
         addressableArea => addressableArea.id === THERMOCYCLER_MODULE_V2
       )?.offsetFromCutoutFixture ?? [0, 0, 0])
     : [0, 0, 0]

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -22,7 +22,7 @@ import {
   WASTE_CHUTE_FIXTURES,
 } from '@opentrons/shared-data'
 
-import { EMPTY, OT2_TC_SLOTS } from '../constants'
+import { EMPTY } from '../constants'
 import { getPipetteCriticalPoint } from './getPipetteCriticalPoint'
 import { getFullStackFromLabwares, getSlotInLocationStack } from './misc'
 
@@ -224,24 +224,9 @@ const getSlotHasPotentialCollidingObject = (
   invariantContext: InvariantContext,
   robotType: RobotType
 ): boolean => {
-  const isThermocyclerOnDeck = Object.values(
-    invariantContext.moduleEntities
-  ).some(({ type }) => type === THERMOCYCLER_MODULE_TYPE)
-
   for (const slot of slotInfo) {
     const slotBounds = slot.addressableArea?.boundingBox
     const slotPosition = slot.position
-    // explicit OT-2 check for if the pipette will enter the space above a thermocycler-occupied slot
-    const willCollideWithThermocycler =
-      isThermocyclerOnDeck &&
-      robotType === OT2_ROBOT_TYPE &&
-      slot.addressableArea?.id != null &&
-      OT2_TC_SLOTS.includes(slot.addressableArea.id as OT2AddressableAreaName)
-
-    if (willCollideWithThermocycler) {
-      return true
-    }
-
     // If slotPosition or slotBounds is null, continue to the next iteration
     if (slotPosition == null || slotBounds == null) {
       continue
@@ -419,8 +404,7 @@ export const getIsSafePipetteMovement = (args: {
     tipLength,
     wellTargetPoint,
     labwareDefinition,
-    primaryNozzle ??
-      getDefaultPrimaryNozzle({ nozzles: nozzleConfiguration, channels }),
+    primaryNozzle,
     nozzleConfiguration,
     tipOverlapOnNozzle
   )


### PR DESCRIPTION
# Overview

Removing explicit collision check for OT2 Thermocycler. This is already captured when comparing the pipette bounds to the surrounding slot dimensions.

## Test Plan and Hands on Testing

- smoke tested using protocol attached in RQA-5334. This was failing previously because the 384 plate is in slot 6, making the surrounding slots 2,3,5,8, and 9. Slot 8 was considered a thermocycler slot so it said there was a collision, even though the thermocycler only takes up a little bit of the top left of the slot and does not come into contact with pipette moves in slot 6.

## Changelog

- removed explicit OT2 thermocycler check - this now means that moves backward into the lid will not fail - will fix in a follow up PR
- removed spots where `defaultPrimaryNozzle` was being used when primaryNozzle cannot be null. This is helpful for future debugging
- adjusted view of labware on module to use the active deck state instead of deck setup
- hard coded use of flex tc lid collision logic to also apply to ot-2 having a thermocycler as well

## Risk assessment
- medium 

Closes RQA-5334 & RQA-5330 