### PR TITLE
fix(protocol-designer): simplify collision logic for single channel pipettes

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
@@ -110,7 +110,7 @@ export function getAllWellsSafetyStatus(
     allWells.flat().forEach(wellName => {
       allWellsWithStatus[wellName] = safe ? 0 : 1
     })
-  } else if (nozzleConfiguration === SINGLE) {
+  } else if (nozzleConfiguration === SINGLE && channels !== 1) {
     // SINGLE nozzle for 8ch and 96ch: check every well individually
     allWells.flat().forEach(wellName => {
       const safe = robotState

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
@@ -111,7 +111,7 @@ export function getAllWellsSafetyStatus(
       allWellsWithStatus[wellName] = safe ? 0 : 1
     })
   } else if (nozzleConfiguration === SINGLE) {
-    // SINGLE nozzle configuration: check every well individually
+    // SINGLE nozzle for 8ch and 96ch: check every well individually
     allWells.flat().forEach(wellName => {
       const safe = robotState
         ? getIsSafePipetteMovement({

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
@@ -1,4 +1,4 @@
-import { ALL, COLUMN, ROW } from '@opentrons/shared-data'
+import { ALL, COLUMN, ROW, SINGLE } from '@opentrons/shared-data'
 import { getIsSafePipetteMovement } from '@opentrons/step-generation'
 
 import { canPipetteUseLabware } from '../../../../../../utils'
@@ -110,8 +110,8 @@ export function getAllWellsSafetyStatus(
     allWells.flat().forEach(wellName => {
       allWellsWithStatus[wellName] = safe ? 0 : 1
     })
-  } else {
-    // SINGLE nozzle: check every well individually
+  } else if (nozzleConfiguration === SINGLE) {
+    // SINGLE nozzle configuration: check every well individually
     allWells.flat().forEach(wellName => {
       const safe = robotState
         ? getIsSafePipetteMovement({
@@ -125,6 +125,11 @@ export function getAllWellsSafetyStatus(
           })
         : true
       allWellsWithStatus[wellName] = safe ? 0 : 1
+    })
+  } else {
+    // remaining case - single channel pipettes - assume all wells can be safely accessed
+    allWells.flat().forEach(wellName => {
+      allWellsWithStatus[wellName] = 0
     })
   }
 

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -81,7 +81,7 @@ export const getCutoutIdFromSlot = (slotInfo: SlotInfo): CutoutId | null => {
   return null
 }
 
-// return pipette bounds at a sepcific position
+// return pipette bounds at a specific position
 // note that this calculation is pessimistic to mirror behavior on protocol engine
 // the returned plane is defined by the z-height of the empty nozzles (lowest case scenario)
 // and the x-y bounds defined by the outer-most bounds of the pipette


### PR DESCRIPTION
# Overview

Don't use single channel pipette bounding box for collision detection.

The bounding box for single channel pipettes is used for collision detection and this is not needed because the pipette won't ever be in a position will occur since it is always directly above the well in labware / tip in tip rack.

## Test Plan and Hands on Testing

- smoke tested on protocol attached to ticket RQA-5331 and no collision was detected. also created an OT-2 protocol to ensure no collisions were detected

<img width="913" height="715" alt="Screenshot 2026-04-27 at 3 26 48 PM" src="https://github.com/user-attachments/assets/21aac9a1-e8bd-4678-ae8c-b835259ede15" />
<img width="931" height="713" alt="Screenshot 2026-04-27 at 3 27 38 PM" src="https://github.com/user-attachments/assets/cee4f80c-8591-4889-a835-41019ed4f207" />

## Changelog

- getAllWellsSafetyStatus assumes all wells are safe if the pipette is a 1ch. 

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment

- low, this reverts back to previous working behavior.
Closes RQA-5331