### PR TITLE
fix(app): fix parameter button text warp

### DIFF
--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupStep/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupStep/index.tsx
@@ -9,9 +9,9 @@ import {
   Flex,
   Icon,
   JUSTIFY_END,
-  LegacyStyledText,
   NO_WRAP,
   SPACING,
+  StyledText,
   truncateString,
   TYPOGRAPHY,
 } from '@opentrons/components'
@@ -140,21 +140,25 @@ export function ProtocolSetupStep({
           flexDirection={DIRECTION_COLUMN}
           textAlign={TYPOGRAPHY.textAlignLeft}
         >
-          <LegacyStyledText
-            forwardedAs="h4"
-            fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+          <StyledText
+            oddStyle="level4HeaderSemiBold"
             color={disabled ? COLORS.grey50 : COLORS.black90}
           >
             {title}
-          </LegacyStyledText>
+          </StyledText>
           {description != null ? (
-            <LegacyStyledText
-              forwardedAs="h4"
+            <StyledText
+              oddStyle="level4HeaderRegular"
               color={disabled ? COLORS.grey50 : COLORS.grey60}
               maxWidth="35rem"
+              style={{
+                overflowWrap: 'anywhere',
+                whiteSpace: 'normal',
+                wordBreak: 'normal',
+              }}
             >
               {description}
-            </LegacyStyledText>
+            </StyledText>
           ) : null}
         </Flex>
         <Flex
@@ -164,8 +168,8 @@ export function ProtocolSetupStep({
             isToggle ? `${SPACING.spacing12} ${SPACING.spacing10}` : 'undefined'
           }
         >
-          <LegacyStyledText
-            as={fontSize as keyof JSX.IntrinsicElements}
+          <StyledText
+            oddStyle="level4HeaderSemiBold"
             textAlign={TYPOGRAPHY.textAlignRight}
             color={interactionDisabled ? COLORS.grey50 : COLORS.black90}
             maxWidth="20rem"
@@ -176,7 +180,7 @@ export function ProtocolSetupStep({
               : detail}
             {subDetail != null && detail != null ? <br /> : null}
             {subDetail}
-          </LegacyStyledText>
+          </StyledText>
         </Flex>
         {interactionDisabled || !hasRightIcon ? null : (
           <Icon


### PR DESCRIPTION


# Overview
fix parameter button text warp

<img width="706" height="529" alt="IMG_2080" src="https://github.com/user-attachments/assets/64506a8b-5397-4ad9-a86b-67a612603260" />



close EXEC-2596

## Test Plan and Hands on Testing
- push this branch to a Flex
- upload the protocol and labwares in [the thread](https://opentrons.slack.com/archives/C03TM47CW/p1777046877308019)

## Changelog
- replace LegacyStyledText with StyledText
- add styles to wrap text

## Review requests

## Risk assessment
low
