### PR TITLE
chore(react-api-client): update lodash in react-api-client

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1347,8 +1347,8 @@ importers:
         specifier: ^0.21.1
         version: 0.21.4
       lodash:
-        specifier: 4.17.21
-        version: 4.17.21
+        specifier: 4.18.1
+        version: 4.18.1
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -8634,9 +8634,6 @@ packages:
 
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -21414,8 +21411,6 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   lodash.truncate@4.4.2: {}
-
-  lodash@4.17.21: {}
 
   lodash@4.18.1: {}
 

--- a/react-api-client/package.json
+++ b/react-api-client/package.json
@@ -13,7 +13,7 @@
     "@opentrons/api-client": "link:../api-client",
     "@opentrons/shared-data": "link:../shared-data",
     "axios": "^0.21.1",
-    "lodash": "4.17.21",
+    "lodash": "4.18.1",
     "react-query": "3.35.0"
   }
 }


### PR DESCRIPTION


# Overview

update lodash in react-api-client since i forgot to update lodash in react-api-client

close AUTH-2894

## Test Plan and Hands on Testing


## Changelog
- update lodash version to align with the other projects

## Review requests


## Risk assessment
low