### PR TITLE
fix(app): fix camera_setup_step undefined issue

### DIFF
--- a/app/src/redux/protocol-runs/selectors/setup.ts
+++ b/app/src/redux/protocol-runs/selectors/setup.ts
@@ -102,7 +102,7 @@ export const getCameraImageSettings = (
   cameraId: CameraId
 ): CameraImageSettings | null => {
   const cameraStep =
-    state.protocolRuns[runId]?.setup[Constants.CAMERA_SETUP_STEP_KEY]
+    state.protocolRuns[runId]?.setup?.[Constants.CAMERA_SETUP_STEP_KEY]
   if (cameraStep == null) {
     return null
   } else {


### PR DESCRIPTION

# Overview
fix camera_setup_step undefined issue

```
Apr 21 08:19:29.403638 e7e78d opentrons-robot-app.sh[697]: 08:19:29.401 [systemUpdate/from-web/provider] info: Could not fetch manifest: FetchError: request to https://builds.opentrons.com/ot3-oe/releases.json failed, reason: getaddrinfo EAI_AGAIN builds.opentrons.com, falling back to cached
Apr 21 08:19:39.245166 e7e78d opentrons-robot-app.sh[697]: restarting app: Cannot read properties of undefined (reading 'camera_setup_step')
Apr 21 08:19:39.276792 e7e78d opentrons-robot-app.sh[697]: /bin/systemd-notify --status=restarting app: Cannot read properties of undefined (reading 'camera_setup_step') failed: 2: Command failed: /bin/systemd-notify --status=restarting app: Cannot read properties of undefined (reading 'camera_setup_step')
```

close EXEC-2597


## Test Plan and Hands on Testing


## Changelog
- add optional

## Review requests


## Risk assessment
low
