### PR TITLE
fix(step-generation): ensure blowout location is updated if any of the fields are changed

### DIFF
--- a/step-generation/src/commandCreators/compound/__tests__/consolidate.test.ts
+++ b/step-generation/src/commandCreators/compound/__tests__/consolidate.test.ts
@@ -262,7 +262,15 @@ mock_pipette.consolidate_with_liquid_class(
                     "delay": {"enabled": False},
                     "end_position": {"offset": {}},
                     "touch_tip": {"enabled": True, "z_offset": -3.4},
-                    "blowout": {"enabled": True, "location": "destination", "flow_rate": 2.3},
+                    "blowout": {
+                        "enabled": True,
+                        "location": "destination",
+                        "flow_rate": 2.3,
+                        "blowout_position": {
+                            "offset": {"x": 0, "y": 0, "z": 3.3},
+                            "position_reference": "well-top",
+                        },
+                    },
                 },
                 "correction_by_volume": [(0, 0)],
                 "push_out_by_volume": [(0, 0)],

--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -272,17 +272,17 @@ const getBlowoutPythonLocation = (
 const getBlowoutWellPosition = (
   args: TransferArgs | ConsolidateArgs | DistributeArgs
 ): {} | null => {
-  if (args.blowoutLocation != null) {
-    return {
-      offset: {
-        x: args.blowoutXPosition ?? 0,
-        y: args.blowoutYPosition ?? 0,
-        z: args.blowoutOffsetFromTopMm ?? 1,
-      },
-      position_reference: args.blowoutPositionReference ?? 'well-top',
-    }
-  } else {
+  const location = getBlowoutPythonLocation(args.blowoutLocation)
+  if (!location || location === 'trash') {
     return null
+  }
+  return {
+    offset: {
+      x: args.blowoutXPosition ?? 0,
+      y: args.blowoutYPosition ?? 0,
+      z: args.blowoutOffsetFromTopMm ?? 1,
+    },
+    position_reference: args.blowoutPositionReference ?? 'well-top',
   }
 }
 

--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -272,19 +272,14 @@ const getBlowoutPythonLocation = (
 const getBlowoutWellPosition = (
   args: TransferArgs | ConsolidateArgs | DistributeArgs
 ): {} | null => {
-  if (
-    args.blowoutXPosition &&
-    args.blowoutYPosition &&
-    args.blowoutOffsetFromTopMm &&
-    args.blowoutPositionReference
-  ) {
+  if (args.blowoutLocation != null) {
     return {
       offset: {
-        x: args.blowoutXPosition,
-        y: args.blowoutYPosition,
-        z: args.blowoutOffsetFromTopMm,
+        x: args.blowoutXPosition ?? 0,
+        y: args.blowoutYPosition ?? 0,
+        z: args.blowoutOffsetFromTopMm ?? 1,
       },
-      position_reference: args.blowoutPositionReference,
+      position_reference: args.blowoutPositionReference ?? 'well-top',
     }
   } else {
     return null

--- a/step-generation/src/utils/liquidClassUtils.ts
+++ b/step-generation/src/utils/liquidClassUtils.ts
@@ -1,4 +1,7 @@
-import { getAllLiquidClassDefs } from '@opentrons/shared-data'
+import {
+  getAllLiquidClassDefs,
+  POSITION_REFERENCE_TOP,
+} from '@opentrons/shared-data'
 
 import {
   DEST_WELL_BLOWOUT_DESTINATION,
@@ -282,7 +285,7 @@ const getBlowoutWellPosition = (
       y: args.blowoutYPosition ?? 0,
       z: args.blowoutOffsetFromTopMm ?? 1,
     },
-    position_reference: args.blowoutPositionReference ?? 'well-top',
+    position_reference: args.blowoutPositionReference ?? POSITION_REFERENCE_TOP,
   }
 }
 


### PR DESCRIPTION
# Overview

Ensure blowout position is added if selected.

Previously the blowout position was only changed if all fields were not null. Now the blowout position will update if one of those values has changed. If the other fields are still null, a default value will be used: (0,0,1) at 'well-top'

## Test Plan and Hands on Testing

- uploaded protocol in ticket and changed each field one at a time to make sure changes were reflected upon exporting

## Changelog

- added default values to fall back on if one of the fields are null and the location is not the trash
- updated the consolidate test because the blowout z location was not included in the expected python command and this should be included

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment

- medium - the default values are hard coded here - but they are also hard coded in the shared field form, so in interest of just affecting the blowout position I think this is the best place to put this fix.

Closes RQA-5335 and RQA-5337