### PR TITLE
fix(step-generation, protocol-designer): determine well accessibility for liquid steps with tip attached to pipette

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -78,7 +78,10 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
     .value as PrimaryNozzleConfigurationStyle
   const pipetteId = propsForFields.pipette.value as string
   const isPartialNozzle = nozzleConfiguration === PARTIAL_COLUMN
-
+  const tiprackLabwareDefURI = propsForFields.tipRack.value as string
+  const tiprackId = Object.values(deckSetup.labware).find(
+    labware => labware.labwareDefURI === tiprackLabwareDefURI
+  )?.id
   const robotState = useSelector(getRobotStateAtActiveItem)
   const invariantContext = useSelector(getInvariantContext)
 
@@ -193,27 +196,27 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
     setWellShadow(hovered[0])
   }
 
-  const allWellsWithStatus = useMemo(
-    () =>
-      getAllWellsSafetyStatus({
-        allWells,
-        robotState,
-        invariantContext,
-        pipetteId,
-        labwareId,
-        primaryNozzle,
-        nozzleConfiguration,
-      }),
-    [
+  const allWellsWithStatus = useMemo(() => {
+    return getAllWellsSafetyStatus({
       allWells,
-      primaryNozzle,
-      nozzleConfiguration,
-      pipetteId,
-      labwareId,
       robotState,
       invariantContext,
-    ]
-  )
+      pipetteId,
+      labwareId,
+      primaryNozzle,
+      nozzleConfiguration,
+      tiprackId,
+    })
+  }, [
+    allWells,
+    primaryNozzle,
+    nozzleConfiguration,
+    pipetteId,
+    labwareId,
+    robotState,
+    invariantContext,
+    tiprackId,
+  ])
   const allWellsWithState = allWells
     .flat()
     .reduce<Record<string, WellType>>((acc, wellName) => {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
@@ -15,6 +15,7 @@ interface GetWellSafetyArgs {
   invariantContext: InvariantContext
   pipetteId: string
   labwareId: string
+  tiprackId?: string
   primaryNozzle: PrimaryNozzleConfigurationStyle
   nozzleConfiguration: NozzleConfigurationStyle
 }
@@ -28,6 +29,7 @@ export function getAllWellsSafetyStatus(
     invariantContext,
     pipetteId,
     labwareId,
+    tiprackId,
     primaryNozzle,
     nozzleConfiguration,
   } = args
@@ -62,6 +64,7 @@ export function getAllWellsSafetyStatus(
             wellTargetName: firstWell,
             primaryNozzle,
             nozzleConfiguration,
+            tiprackId,
           })
         : true
 
@@ -87,6 +90,7 @@ export function getAllWellsSafetyStatus(
             wellTargetName: firstWell,
             primaryNozzle,
             nozzleConfiguration,
+            tiprackId,
           })
         : true
 
@@ -105,6 +109,7 @@ export function getAllWellsSafetyStatus(
           wellTargetName: allWells[0][0],
           primaryNozzle,
           nozzleConfiguration,
+          tiprackId,
         })
       : true
     allWells.flat().forEach(wellName => {
@@ -122,6 +127,7 @@ export function getAllWellsSafetyStatus(
             wellTargetName: wellName,
             primaryNozzle,
             nozzleConfiguration,
+            tiprackId,
           })
         : true
       allWellsWithStatus[wellName] = safe ? 0 : 1

--- a/step-generation/src/utils/__tests__/getPipetteCriticalPoint.test.ts
+++ b/step-generation/src/utils/__tests__/getPipetteCriticalPoint.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  ALL,
   COLUMN,
   fixture12Trough,
   fixture96Plate,
@@ -24,17 +25,23 @@ describe('getPipetteCriticalPoint', () => {
     H12: [70, 110, 0],
   }
 
-  const mockPipetteEntity = {
+  const mock96chPipetteEntity = {
     spec: {
       nozzleMap: mockNozzleMap,
     },
     channels: 96,
   } as unknown as PipetteEntity
+  const mock8chPipetteEntity = {
+    spec: {
+      nozzleMap: mockNozzleMap,
+    },
+    channels: 8,
+  } as unknown as PipetteEntity
 
   it('returns center point for COLUMN configuration when labware has one row', () => {
     const result = getPipetteCriticalPoint(
       COLUMN as NozzleConfigurationStyle,
-      mockPipetteEntity,
+      mock96chPipetteEntity,
       'A1' as PrimaryNozzleConfigurationStyle,
       fixture12Trough as LabwareDefinition
     )
@@ -46,7 +53,7 @@ describe('getPipetteCriticalPoint', () => {
   it('returns center point for ROW configuration when labware has one row', () => {
     const result = getPipetteCriticalPoint(
       ROW as NozzleConfigurationStyle,
-      mockPipetteEntity,
+      mock96chPipetteEntity,
       'A1' as PrimaryNozzleConfigurationStyle,
       fixture12Trough as LabwareDefinition
     )
@@ -58,7 +65,7 @@ describe('getPipetteCriticalPoint', () => {
   it('uses primary nozzle as backLeftPoint correctly for different nozzle', () => {
     const result = getPipetteCriticalPoint(
       COLUMN as NozzleConfigurationStyle,
-      mockPipetteEntity,
+      mock96chPipetteEntity,
       'A12' as PrimaryNozzleConfigurationStyle,
       fixture12Trough as LabwareDefinition
     )
@@ -70,7 +77,7 @@ describe('getPipetteCriticalPoint', () => {
   it('returns default position when labware has more than one column', () => {
     const result = getPipetteCriticalPoint(
       COLUMN as NozzleConfigurationStyle,
-      mockPipetteEntity,
+      mock96chPipetteEntity,
       'A1' as PrimaryNozzleConfigurationStyle,
       fixture96Plate as LabwareDefinition
     )
@@ -81,11 +88,21 @@ describe('getPipetteCriticalPoint', () => {
   it('returns default position when nozzle configuration is neither ROW nor COLUMN', () => {
     const result = getPipetteCriticalPoint(
       'SINGLE' as NozzleConfigurationStyle,
-      mockPipetteEntity,
+      mock96chPipetteEntity,
       'H12' as PrimaryNozzleConfigurationStyle,
       fixture12Trough as LabwareDefinition
     )
 
     expect(result).toEqual({ x: 70, y: 110, z: 0 })
+  })
+  it('returns the top point for 8ch ALL configuration when labware has one row', () => {
+    const result = getPipetteCriticalPoint(
+      ALL as NozzleConfigurationStyle,
+      mock8chPipetteEntity,
+      'A1' as PrimaryNozzleConfigurationStyle,
+      fixture12Trough as LabwareDefinition
+    )
+
+    expect(result).toEqual({ x: 0, y: 0, z: 0 })
   })
 })

--- a/step-generation/src/utils/getPipetteCriticalPoint.ts
+++ b/step-generation/src/utils/getPipetteCriticalPoint.ts
@@ -1,4 +1,4 @@
-import { COLUMN, ROW } from '@opentrons/shared-data'
+import { ALL, COLUMN, ROW } from '@opentrons/shared-data'
 
 import type {
   LabwareDefinition,
@@ -15,7 +15,9 @@ export const getPipetteCriticalPoint = (
 ): Point => {
   const { spec } = pipetteEntity
   const isRow = nozzleConfiguration === ROW
-  const isColumn = nozzleConfiguration === COLUMN
+  const isColumn =
+    nozzleConfiguration === COLUMN ||
+    (nozzleConfiguration === ALL && spec.channels === 8)
   const labwareHasOneRow = labwareDefinition.ordering[0].length === 1
   if ((isColumn || isRow) && labwareHasOneRow) {
     // return the XY CENTER

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -350,11 +350,15 @@ export const getIsSafePipetteMovement = (args: {
   if (labwareEntities[labwareId] == null || wellTargetName == null) {
     return true
   }
-  // if tiprackId is passed in, assume a tip is on the pipette
+  // If tiprackId is explicitly provided, assume the pipette currently has a tip attached.
+  // This is used in WellSelector.ts / getAllWellsSafetyStatus to force "tip present"
+  // during collision detection scenarios.
   const pipetteHasTip = tiprackId
     ? true
     : (tipState.pipettes[pipetteId]?.hasTip ?? false)
-  // if a specific tip rack id is passed in, use that instead
+
+  // Use the provided tiprackId if available; otherwise fall back to the
+  // tiprack recorded in tipState for this pipette.
   const confirmedTiprackId =
     tiprackId ?? tipState.pipettes[pipetteId]?.tiprackURI
   const tiprackEntity =

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -315,6 +315,7 @@ export const getIsSafePipetteMovement = (args: {
   labwareId: string
   wellLocationOffset?: Point
   wellTargetName?: string
+  tiprackId?: string
   primaryNozzle: PrimaryNozzleConfigurationStyle
   nozzleConfiguration: NozzleConfigurationStyle
 }): boolean => {
@@ -327,6 +328,7 @@ export const getIsSafePipetteMovement = (args: {
     wellTargetName,
     primaryNozzle,
     nozzleConfiguration,
+    tiprackId,
   } = args
   const {
     pipetteEntities,
@@ -339,7 +341,6 @@ export const getIsSafePipetteMovement = (args: {
   const pipetteEntity = pipetteEntities[pipetteId]
 
   const { spec: pipetteSpecs } = pipetteEntity
-
   // NOTE: I don't like this, but step-generation is currently blind to robot type, so we'll infer from the pipette specs
   const displayCategory = pipetteSpecs?.displayCategory
   const isFlexPipette = displayCategory === 'FLEX'
@@ -349,15 +350,21 @@ export const getIsSafePipetteMovement = (args: {
   if (labwareEntities[labwareId] == null || wellTargetName == null) {
     return true
   }
-
-  const tiprackId = tipState.pipettes[pipetteId]?.tiprackURI
-  const tiprackEntity = tiprackId != null ? labwareEntities[tiprackId] : null
+  // if tiprackId is passed in, assume a tip is on the pipette
+  const pipetteHasTip = tiprackId
+    ? true
+    : (tipState.pipettes[pipetteId]?.hasTip ?? false)
+  // if a specific tip rack id is passed in, use that instead
+  const confirmedTiprackId =
+    tiprackId ?? tipState.pipettes[pipetteId]?.tiprackURI
+  const tiprackEntity =
+    confirmedTiprackId != null ? labwareEntities[confirmedTiprackId] : null
   const tiprackTipLength =
     tiprackEntity != null ? tiprackEntity.def.parameters.tipLength : 0
   const stagingAreaSlots = Object.values(stagingAreaEntities).map(
     stagingArea => stagingArea.location as string
   )
-  const pipetteHasTip = tipState.pipettes[pipetteId]?.hasTip ?? false
+
   // account for tip length if picking up tip
   const tipLength = pipetteHasTip ? (tiprackTipLength ?? 0) : 0
   const labwareSlot = getSlotInLocationStack(labwareState[labwareId].stack)


### PR DESCRIPTION
# Overview

Assume the pipette has a tip attached when determining well accessibility status for move liquid steps.

This fixes RQA-5336, where collisions were being raised unnecessarily because it was treating the pipette like it had no tip attached. Technically at the time of selecting wells, this is true but for collision detection we want to it to reflect accessibility at the time of the transfer or mix action.

## Test Plan and Hands on Testing

- smoke tested with protocol attached to the ticket and ensure the left side of the labware was only inaccessible if a very tall labware was in the adjacent spot

tiprack vs 
<img width="888" height="589" alt="Screenshot 2026-04-28 at 12 55 06 PM" src="https://github.com/user-attachments/assets/2a86632c-ae1f-4c65-9431-f76dd0095a8b" />
shorter labware
<img width="850" height="605" alt="Screenshot 2026-04-28 at 12 54 49 PM" src="https://github.com/user-attachments/assets/d798aabc-15ad-424f-a1bc-a7750a19cb94" />

- logged pipette bounds to ensure the z height had increased based off the tip length

## Changelog

- added optional tiprack id parameter to be passed into `getIsSafePipetteMovement`. If this value is passed in, the function will assume a tip is attached and use the tiprack id passed in to determine the length rather than using the current robotState
- ensured collision detection assumes that an 8ch ALL nozzle configuration goes to the top of the well rather than its center

## Review requests

- okay to make the tiprackId arg optional?

## Risk assessment

- medium - changes collision detection utility

Closes RQA-5336