### PR TITLE
fix(step-generation): don't check OT-2 1ch pipette movements

### DIFF
--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -257,7 +257,16 @@ const getSlotHasPotentialCollidingObject = (
         slot,
         robotType
       )
+
       if (highestZInSurroundingSlot >= pipetteBounds[0]?.z) {
+        console.log(
+          '🚀 ~ getSlotHasPotentialCollidingObject ~ highestZInSurroundingSlot:',
+          highestZInSurroundingSlot
+        )
+        console.log(
+          '🚀 ~ getSlotHasPotentialCollidingObject ~ pipetteBounds:',
+          pipetteBounds
+        )
         return true
       }
     }
@@ -339,14 +348,23 @@ export const getIsSafePipetteMovement = (args: {
   const pipetteEntity = pipetteEntities[pipetteId]
 
   const { spec: pipetteSpecs } = pipetteEntity
+<<<<<<< Updated upstream
+=======
+  const { channels } = pipetteSpecs
+>>>>>>> Stashed changes
 
   // NOTE: I don't like this, but step-generation is currently blind to robot type, so we'll infer from the pipette specs
   const displayCategory = pipetteSpecs?.displayCategory
   const isFlexPipette = displayCategory === 'FLEX'
   const robotType = isFlexPipette ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE
+
   const deckDefinition = getDeckDefFromRobotType(robotType)
-  //  early exit if labwareId is a trashBin or wasteChute or if no well name is provided
-  if (labwareEntities[labwareId] == null || wellTargetName == null) {
+  //  early exit if labwareId is a trashBin or wasteChute or if no well name is provided or if 1ch pipette
+  if (
+    labwareEntities[labwareId] == null ||
+    wellTargetName == null ||
+    channels === 1
+  ) {
     return true
   }
 
@@ -389,8 +407,6 @@ export const getIsSafePipetteMovement = (args: {
     fullOffset as CoordinateTuple,
     pipetteHasTip
   )
-
-  const { channels } = pipetteSpecs
 
   const tipOverlapOnNozzle =
     tiprackEntity != null

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -348,10 +348,7 @@ export const getIsSafePipetteMovement = (args: {
   const pipetteEntity = pipetteEntities[pipetteId]
 
   const { spec: pipetteSpecs } = pipetteEntity
-<<<<<<< Updated upstream
-=======
   const { channels } = pipetteSpecs
->>>>>>> Stashed changes
 
   // NOTE: I don't like this, but step-generation is currently blind to robot type, so we'll infer from the pipette specs
   const displayCategory = pipetteSpecs?.displayCategory

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -259,14 +259,6 @@ const getSlotHasPotentialCollidingObject = (
       )
 
       if (highestZInSurroundingSlot >= pipetteBounds[0]?.z) {
-        console.log(
-          '🚀 ~ getSlotHasPotentialCollidingObject ~ highestZInSurroundingSlot:',
-          highestZInSurroundingSlot
-        )
-        console.log(
-          '🚀 ~ getSlotHasPotentialCollidingObject ~ pipetteBounds:',
-          pipetteBounds
-        )
         return true
       }
     }

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -350,11 +350,11 @@ export const getIsSafePipetteMovement = (args: {
   const robotType = isFlexPipette ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE
 
   const deckDefinition = getDeckDefFromRobotType(robotType)
-  //  early exit if labwareId is a trashBin or wasteChute or if no well name is provided or if 1ch pipette
+  //  early exit if labwareId is a trashBin or wasteChute or if no well name is provided or if 1ch OT-2 pipette
   if (
     labwareEntities[labwareId] == null ||
     wellTargetName == null ||
-    channels === 1
+    (channels === 1 && robotType === OT2_ROBOT_TYPE)
   ) {
     return true
   }


### PR DESCRIPTION
# Overview

Remove check for single channel pipette movements. This reverts 1ch collision detection for OT2 pipettes back to its original behavior (changed in previous [PR](https://github.com/Opentrons/opentrons/pull/21283))

There seems to be something slightly off with the OT-2 pipette bounding boxes that causes it to think it will collide with taller labware. I think we should go back to not checking it rather than going down a geometry rabbit hole. 

## Test Plan and Hands on Testing

- smoke tested using protocol attached in the ticket

## Changelog

- exit `getIsSafePipetteMovement` early if the pipette is a single channel

## Review requests

-ok fix?

## Risk assessment

- low - unless later down the road we have a new very big single channel pipette

Closes RQA-5333