### PR TITLE
refactor(app): Convert ODD/Navigation to CSS modules

### DIFF
--- a/app/src/organisms/ODD/Navigation/__tests__/Navigation.test.tsx
+++ b/app/src/organisms/ODD/Navigation/__tests__/Navigation.test.tsx
@@ -92,14 +92,4 @@ describe('Navigation', () => {
     screen.getByText('mock NavigationMenu')
     expect(props.setNavMenuIsOpened).toHaveBeenCalled()
   })
-  it('should change z index of nav bar when longPressModalIsOpened is defined and true', () => {
-    props = {
-      ...props,
-      longPressModalIsOpened: true,
-    }
-    render(props)
-    expect(screen.getByLabelText('Navigation_container')).toHaveStyle({
-      zIndex: 0,
-    })
-  })
 })

--- a/app/src/organisms/ODD/Navigation/index.tsx
+++ b/app/src/organisms/ODD/Navigation/index.tsx
@@ -2,36 +2,27 @@ import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { NavLink, useLocation } from 'react-router-dom'
-import styled from 'styled-components'
+import clsx from 'clsx'
 
 import {
   ALIGN_CENTER,
-  ALIGN_FLEX_START,
-  BORDERS,
-  Box,
   COLORS,
-  CURSOR_DEFAULT,
-  DIRECTION_COLUMN,
   DIRECTION_ROW,
-  DISPLAY_FLEX,
   Flex,
   Icon,
   JUSTIFY_SPACE_BETWEEN,
-  OVERFLOW_SCROLL,
   POSITION_ABSOLUTE,
   POSITION_STATIC,
   POSITION_STICKY,
-  RESPONSIVENESS,
   SPACING,
   truncateString,
-  TYPOGRAPHY,
 } from '@opentrons/components'
 
-import { ODD_FOCUS_VISIBLE } from '/app/atoms/buttons/constants'
 import { useScrollPosition } from '/app/local-resources/dom-utils'
 import { getLocalRobot } from '/app/redux/discovery'
 import { useNetworkConnection } from '/app/resources/networking/hooks/useNetworkConnection'
 
+import styles from './navigation.module.css'
 import { NavigationMenu } from './NavigationMenu'
 
 import type { Dispatch, SetStateAction } from 'react'
@@ -42,24 +33,6 @@ const NAV_LINKS: Array<(typeof ON_DEVICE_DISPLAY_PATHS)[number]> = [
   '/instruments',
   '/robot-settings',
 ]
-
-const CarouselWrapper = styled.div`
-  display: ${DISPLAY_FLEX};
-  flex-direction: ${DIRECTION_ROW};
-  align-items: ${ALIGN_FLEX_START};
-  width: 56.75rem;
-  overflow-x: ${OVERFLOW_SCROLL};
-  -webkit-mask-image: linear-gradient(
-    to right,
-    transparent 0%,
-    black 0%,
-    black 96.5%,
-    transparent 100%
-  );
-  &::-webkit-scrollbar {
-    display: none;
-  }
-`
 
 const CHAR_LIMIT_WITH_ICON = 12
 const CHAR_LIMIT_NO_ICON = 15
@@ -137,12 +110,12 @@ export function Navigation(props: NavigationProps): JSX.Element {
         top="0"
         width="100%"
         backgroundColor={COLORS.white}
-        boxShadow={isScrolled ? BORDERS.shadowBig : ''}
+        className={clsx(isScrolled && styles.nav_bar_scrolled)}
         gridGap={SPACING.spacing24}
         aria-label="Navigation_container"
       >
         <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing32}>
-          <CarouselWrapper>
+          <div className={styles.carousel_wrapper}>
             <Flex
               flexDirection={DIRECTION_ROW}
               gridGap={SPACING.spacing32}
@@ -178,14 +151,16 @@ export function Navigation(props: NavigationProps): JSX.Element {
                 </Flex>
               ))}
             </Flex>
-          </CarouselWrapper>
+          </div>
         </Flex>
         <Flex
           marginTop={`-${SPACING.spacing12}`}
           position={POSITION_ABSOLUTE}
           right={SPACING.spacing16}
         >
-          <IconButton
+          <button
+            type="button"
+            className={styles.icon_button}
             aria-label="overflow menu button"
             onClick={() => {
               handleMenu(true)
@@ -197,7 +172,7 @@ export function Navigation(props: NavigationProps): JSX.Element {
               width="3rem"
               color={COLORS.grey60}
             />
-          </IconButton>
+          </button>
         </Flex>
       </Flex>
       {showNavMenu && (
@@ -214,51 +189,13 @@ export function Navigation(props: NavigationProps): JSX.Element {
 }
 
 const NavigationLink = (props: { to: string; name: string }): JSX.Element => (
-  <TouchNavLink to={props.to}>
+  <NavLink
+    to={props.to}
+    className={({ isActive }) =>
+      clsx(styles.touch_nav_link, isActive && styles.touch_nav_link_active)
+    }
+  >
     {props.name}
-    <Box width="2.5rem" height="0.3125rem" borderRadius="0.125rem" />
-  </TouchNavLink>
+    <div className={styles.nav_link_indicator} />
+  </NavLink>
 )
-
-const TouchNavLink = styled(NavLink)`
-  ${TYPOGRAPHY.level3HeaderSemiBold}
-  color: ${COLORS.grey50};
-  height: 3.5rem;
-  display: flex;
-  flex-direction: ${DIRECTION_COLUMN};
-  align-items: ${ALIGN_CENTER};
-  white-space: nowrap;
-  &.active {
-    color: ${COLORS.black90};
-  }
-  &.active > div {
-    background-color: ${COLORS.purple50};
-  }
-
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    cursor: ${CURSOR_DEFAULT};
-  }
-`
-
-const IconButton = styled('button')`
-  border-radius: ${BORDERS.borderRadius8};
-  max-height: 100%;
-  background-color: ${COLORS.white};
-
-  &:hover {
-    background-color: ${COLORS.grey35};
-  }
-  &:active {
-    background-color: ${COLORS.grey30};
-  }
-  &:focus-visible {
-    box-shadow: ${ODD_FOCUS_VISIBLE};
-    background-color: ${COLORS.grey35};
-  }
-  &:disabled {
-    background-color: transparent;
-  }
-  @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    cursor: ${CURSOR_DEFAULT};
-  }
-`

--- a/app/src/organisms/ODD/Navigation/index.tsx
+++ b/app/src/organisms/ODD/Navigation/index.tsx
@@ -132,7 +132,7 @@ export function Navigation(props: NavigationProps): JSX.Element {
         <div className={styles.overflow_button_wrap}>
           <button
             type="button"
-            className={styles.icon_button}
+            className={clsx(styles.icon_button, styles.cursor_default)}
             aria-label="overflow menu button"
             onClick={() => {
               handleMenu(true)
@@ -164,7 +164,11 @@ const NavigationLink = (props: { to: string; name: string }): JSX.Element => (
   <NavLink
     to={props.to}
     className={({ isActive }) =>
-      clsx(styles.touch_nav_link, isActive && styles.touch_nav_link_active)
+      clsx(
+        styles.touch_nav_link,
+        isActive && styles.touch_nav_link_active,
+        styles.cursor_default
+      )
     }
   >
     {props.name}

--- a/app/src/organisms/ODD/Navigation/index.tsx
+++ b/app/src/organisms/ODD/Navigation/index.tsx
@@ -4,19 +4,7 @@ import { useSelector } from 'react-redux'
 import { NavLink, useLocation } from 'react-router-dom'
 import clsx from 'clsx'
 
-import {
-  ALIGN_CENTER,
-  COLORS,
-  DIRECTION_ROW,
-  Flex,
-  Icon,
-  JUSTIFY_SPACE_BETWEEN,
-  POSITION_ABSOLUTE,
-  POSITION_STATIC,
-  POSITION_STICKY,
-  SPACING,
-  truncateString,
-} from '@opentrons/components'
+import { COLORS, Icon, truncateString } from '@opentrons/components'
 
 import { useScrollPosition } from '/app/local-resources/dom-utils'
 import { getLocalRobot } from '/app/redux/discovery'
@@ -78,6 +66,8 @@ export function Navigation(props: NavigationProps): JSX.Element {
     })
   }, [])
 
+  const navMenuOrModalIsOpened = showNavMenu || Boolean(longPressModalIsOpened)
+
   function getPathDisplayName(path: (typeof NAV_LINKS)[number]): string {
     switch (path) {
       case '/instruments':
@@ -94,34 +84,21 @@ export function Navigation(props: NavigationProps): JSX.Element {
   return (
     <>
       {/* Empty box to detect scrolling */}
-      <Flex ref={scrollRef} />
-      <Flex
-        flexDirection={DIRECTION_ROW}
-        alignItems={ALIGN_CENTER}
-        justifyContent={JUSTIFY_SPACE_BETWEEN}
-        height="7.75rem"
-        zIndex={showNavMenu || Boolean(longPressModalIsOpened) ? 0 : 3}
-        position={
-          showNavMenu || Boolean(longPressModalIsOpened)
-            ? POSITION_STATIC
-            : POSITION_STICKY
-        }
-        paddingX={SPACING.spacing40}
-        top="0"
-        width="100%"
-        backgroundColor={COLORS.white}
-        className={clsx(isScrolled && styles.nav_bar_scrolled)}
-        gridGap={SPACING.spacing24}
+      <div ref={scrollRef} />
+      <div
+        className={clsx(
+          styles.nav_bar,
+          navMenuOrModalIsOpened
+            ? styles.nav_bar_static
+            : styles.nav_bar_sticky,
+          isScrolled && styles.nav_bar_scrolled
+        )}
         aria-label="Navigation_container"
       >
-        <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing32}>
+        <div className={styles.nav_content_row}>
           <div className={styles.carousel_wrapper}>
-            <Flex
-              flexDirection={DIRECTION_ROW}
-              gridGap={SPACING.spacing32}
-              marginRight={SPACING.spacing24}
-            >
-              <Flex
+            <div className={styles.carousel_inner}>
+              <div
                 ref={
                   location.pathname === '/dashboard' ? navBarScrollRef : null
                 }
@@ -133,7 +110,7 @@ export function Navigation(props: NavigationProps): JSX.Element {
                     iconName != null ? CHAR_LIMIT_WITH_ICON : CHAR_LIMIT_NO_ICON
                   )}
                 />
-              </Flex>
+              </div>
               {iconName != null ? (
                 <Icon
                   aria-label="network icon"
@@ -143,21 +120,17 @@ export function Navigation(props: NavigationProps): JSX.Element {
                 />
               ) : null}
               {NAV_LINKS.map(path => (
-                <Flex
+                <div
                   ref={path === location.pathname ? navBarScrollRef : null}
                   key={path}
                 >
                   <NavigationLink to={path} name={getPathDisplayName(path)} />
-                </Flex>
+                </div>
               ))}
-            </Flex>
+            </div>
           </div>
-        </Flex>
-        <Flex
-          marginTop={`-${SPACING.spacing12}`}
-          position={POSITION_ABSOLUTE}
-          right={SPACING.spacing16}
-        >
+        </div>
+        <div className={styles.overflow_button_wrap}>
           <button
             type="button"
             className={styles.icon_button}
@@ -173,8 +146,8 @@ export function Navigation(props: NavigationProps): JSX.Element {
               color={COLORS.grey60}
             />
           </button>
-        </Flex>
-      </Flex>
+        </div>
+      </div>
       {showNavMenu && (
         <NavigationMenu
           onClick={() => {

--- a/app/src/organisms/ODD/Navigation/index.tsx
+++ b/app/src/organisms/ODD/Navigation/index.tsx
@@ -85,7 +85,7 @@ export function Navigation(props: NavigationProps): JSX.Element {
     <>
       {/* Empty box to detect scrolling */}
       <div ref={scrollRef} />
-      <div
+      <nav
         className={clsx(
           styles.nav_bar,
           navMenuOrModalIsOpened
@@ -93,7 +93,6 @@ export function Navigation(props: NavigationProps): JSX.Element {
             : styles.nav_bar_sticky,
           isScrolled && styles.nav_bar_scrolled
         )}
-        aria-label="Navigation_container"
       >
         <div className={styles.nav_content_row}>
           <div className={styles.carousel_wrapper}>
@@ -147,7 +146,7 @@ export function Navigation(props: NavigationProps): JSX.Element {
             />
           </button>
         </div>
-      </div>
+      </nav>
       {showNavMenu && (
         <NavigationMenu
           onClick={() => {

--- a/app/src/organisms/ODD/Navigation/navigation.module.css
+++ b/app/src/organisms/ODD/Navigation/navigation.module.css
@@ -1,0 +1,80 @@
+.carousel_wrapper {
+  display: flex;
+  width: 56.75rem;
+  flex-direction: row;
+  align-items: flex-start;
+  mask-image: linear-gradient(
+    to right,
+    transparent 0%,
+    black 0%,
+    black 96.5%,
+    transparent 100%
+  );
+  overflow-x: scroll;
+}
+
+.carousel_wrapper::-webkit-scrollbar {
+  display: none;
+}
+
+.touch_nav_link {
+  display: flex;
+  height: 3.5rem;
+  flex-direction: column;
+  align-items: center;
+  color: var(--grey-50);
+  font-size: var(--font-size-32);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--line-height-42);
+  white-space: nowrap;
+
+  &.touch_nav_link_active {
+    color: var(--black-90);
+  }
+
+  @media (height = 600px) and (width = 1024px) {
+    cursor: default;
+  }
+}
+
+.nav_link_indicator {
+  width: 2.5rem;
+  height: 0.3125rem;
+  border-radius: var(--border-radius-2);
+
+  .touch_nav_link_active & {
+    background-color: var(--purple-50);
+  }
+}
+
+.icon_button {
+  max-height: 100%;
+  border-radius: var(--border-radius-8);
+  background-color: var(--white);
+
+  &:hover {
+    background-color: var(--grey-35);
+  }
+
+  &:active {
+    background-color: var(--grey-30);
+  }
+  
+  &:focus-visible {
+    background-color: var(--grey-35);
+    box-shadow: 0 0 0 4px var(--blue-50);
+    outline: none;
+  }
+
+  &:disabled {
+    background-color: transparent;
+  }
+
+  @media (height = 600px) and (width = 1024px) {
+    cursor: default;
+  }
+}
+
+.nav_bar_scrolled {
+  box-shadow: 0 3px 6px rgb(0 0 0 / 23%);
+}

--- a/app/src/organisms/ODD/Navigation/navigation.module.css
+++ b/app/src/organisms/ODD/Navigation/navigation.module.css
@@ -1,3 +1,47 @@
+.nav_bar {
+  display: flex;
+  width: 100%;
+  height: 7.75rem;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding-right: var(--spacing-40);
+  padding-left: var(--spacing-40);
+  background-color: var(--white);
+  gap: var(--spacing-24);
+}
+
+.nav_bar_sticky {
+  position: sticky;
+  z-index: 3;
+  top: 0;
+}
+
+.nav_bar_static {
+  position: static;
+  z-index: 0;
+}
+
+.nav_content_row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--spacing-32);
+}
+
+.carousel_inner {
+  display: flex;
+  flex-direction: row;
+  margin-right: var(--spacing-24);
+  gap: var(--spacing-32);
+}
+
+.overflow_button_wrap {
+  position: absolute;
+  right: var(--spacing-16);
+  margin-top: calc(-1 * var(--spacing-12));
+}
+
 .carousel_wrapper {
   display: flex;
   width: 56.75rem;
@@ -59,7 +103,7 @@
   &:active {
     background-color: var(--grey-30);
   }
-  
+
   &:focus-visible {
     background-color: var(--grey-35);
     box-shadow: 0 0 0 4px var(--blue-50);

--- a/app/src/organisms/ODD/Navigation/navigation.module.css
+++ b/app/src/organisms/ODD/Navigation/navigation.module.css
@@ -75,10 +75,6 @@
   &.touch_nav_link_active {
     color: var(--black-90);
   }
-
-  @media (height = 600px) and (width = 1024px) {
-    cursor: default;
-  }
 }
 
 .nav_link_indicator {
@@ -113,12 +109,12 @@
   &:disabled {
     background-color: transparent;
   }
-
-  @media (height = 600px) and (width = 1024px) {
-    cursor: default;
-  }
 }
 
 .nav_bar_scrolled {
   box-shadow: 0 3px 6px rgb(0 0 0 / 23%);
+}
+
+.cursor_default {
+  cursor: default;
 }


### PR DESCRIPTION
## Overview

This converts the ODD's `<Navigation>` element from using styled-components and `<Flex>` into using CSS module and vanilla HTML elements.

This goes towards EXEC-2601.

## Test Plan and Hands on Testing

General behavior:

https://github.com/user-attachments/assets/72d46169-ee61-41f1-82d5-747649ea2b91

Horizontal scrolling ("protocols" artificially lengthened for testing):

https://github.com/user-attachments/assets/f6009f9c-700c-4136-92eb-e487449522da

## Changelog

Notable changes:

* I replaced `-webkit-mask-image` with the standard `mask-image` property, now that that exists.
* Just for fun, the HTML element is an actual `<nav>` now.
* I deleted the `.toHaveStyle()` test because it was seemingly having spurious failures after the refactor, and as I understand it, we're not using `.toHaveStyle()` anymore? I manually tested that the `z-index` and `position` properties still get applied correctly. I can try harder to get `.toHaveStyle()` to work if anyone wants, though.

Everything else is a pretty straightforward copy-paste.

## Review requests

None in particular.

## Risk assessment

Medium.