### PR TITLE
feat(protocol-designer) improve landing page accessibility 

### DIFF
--- a/protocol-designer/src/ProtocolRoutes/index.tsx
+++ b/protocol-designer/src/ProtocolRoutes/index.tsx
@@ -1,8 +1,6 @@
 import { ErrorBoundary } from 'react-error-boundary'
 import { Navigate, Route, Routes, useNavigate } from 'react-router-dom'
 
-import { Box } from '@opentrons/components'
-
 import {
   FileUploadMessagesModal,
   GateModal,
@@ -10,7 +8,7 @@ import {
   Kitchen,
   LabwareUploadModal,
   Navigation,
-} from './components/organisms'
+} from '../components/organisms'
 import {
   Designer,
   Hardware,
@@ -19,10 +17,11 @@ import {
   Onboarding,
   ProtocolOverview,
   Settings,
-} from './pages'
-import { ProtocolDesignerAppFallback } from './resources/ProtocolDesignerAppFallback'
+} from '../pages'
+import { ProtocolDesignerAppFallback } from '../resources/ProtocolDesignerAppFallback'
+import styles from './protocolroutes.module.css'
 
-import type { RouteProps } from './types'
+import type { RouteProps } from '../types'
 
 const pdRoutes: RouteProps[] = [
   {
@@ -83,7 +82,7 @@ export function ProtocolRoutes(): JSX.Element {
     >
       <Navigation />
       <Kitchen>
-        <Box width="100%" height="100%">
+        <main className={styles.main_contaienr}>
           <GateModal />
           <LabwareUploadModal />
           <FileUploadMessagesModal />
@@ -94,7 +93,7 @@ export function ProtocolRoutes(): JSX.Element {
             })}
             <Route path="*" element={<Navigate to={landingPage.path} />} />
           </Routes>
-        </Box>
+        </main>
       </Kitchen>
     </ErrorBoundary>
   )

--- a/protocol-designer/src/ProtocolRoutes/protocolroutes.module.css
+++ b/protocol-designer/src/ProtocolRoutes/protocolroutes.module.css
@@ -1,0 +1,4 @@
+.main_container {
+  width: 100%;
+  height: 100%;
+}

--- a/protocol-designer/src/components/molecules/EndUserAgreementFooter/enduseragreementfooter.module.css
+++ b/protocol-designer/src/components/molecules/EndUserAgreementFooter/enduseragreementfooter.module.css
@@ -1,0 +1,27 @@
+.footer_container {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--spacing-24);
+  background-color: var(--grey-10);
+  gap: var(--spacing-8);
+}
+
+.link_button {
+  color: var(--black-90);
+
+  &:hover {
+    color: var(--blue-50);
+  }
+
+  &:focus-visible {
+    color: var(--blue-50);
+    outline: 2px solid var(--blue-50);
+    outline-offset: 0.25rem;
+  }
+
+  &:disabled {
+    color: var(--grey40);
+  }
+}

--- a/protocol-designer/src/components/molecules/EndUserAgreementFooter/index.tsx
+++ b/protocol-designer/src/components/molecules/EndUserAgreementFooter/index.tsx
@@ -1,18 +1,8 @@
 import { Trans, useTranslation } from 'react-i18next'
 
-import {
-  ALIGN_CENTER,
-  COLORS,
-  DIRECTION_COLUMN,
-  Flex,
-  Link,
-  SPACING,
-  StyledText,
-  TYPOGRAPHY,
-} from '@opentrons/components'
+import { Link, StyledText, TYPOGRAPHY } from '@opentrons/components'
 
-import { LINK_BUTTON_STYLE } from '/protocol-designer/components/atoms'
-
+import styles from './enduseragreementfooter.module.css'
 import { getYearFromDate } from './utils'
 
 const PRIVACY_POLICY_URL = 'https://opentrons.com/privacy-policy'
@@ -21,41 +11,36 @@ const EULA_URL = 'https://opentrons.com/eula'
 export function EndUserAgreementFooter(): JSX.Element {
   const { t } = useTranslation('shared')
   return (
-    <Flex
-      backgroundColor={COLORS.grey10}
-      padding={SPACING.spacing24}
-      width="100%"
-      alignItems={ALIGN_CENTER}
-      flexDirection={DIRECTION_COLUMN}
-      gridGap={SPACING.spacing8}
-    >
-      <StyledText desktopStyle="captionRegular">
-        <Trans
-          i18nKey="privacy_policy"
-          t={t}
-          components={{
-            privacyPolicyLink: (
-              <Link
-                external
-                href={PRIVACY_POLICY_URL}
-                textDecoration={TYPOGRAPHY.textDecorationUnderline}
-                css={LINK_BUTTON_STYLE}
-              />
-            ),
-            EULALink: (
-              <Link
-                external
-                href={EULA_URL}
-                textDecoration={TYPOGRAPHY.textDecorationUnderline}
-                css={LINK_BUTTON_STYLE}
-              />
-            ),
-          }}
-        />
-      </StyledText>
-      <StyledText desktopStyle="captionRegular">
-        {t('copyright', { year: getYearFromDate() })}
-      </StyledText>
-    </Flex>
+    <footer>
+      <div className={styles.footer_container}>
+        <StyledText desktopStyle="captionRegular">
+          <Trans
+            i18nKey="privacy_policy"
+            t={t}
+            components={{
+              privacyPolicyLink: (
+                <Link
+                  external
+                  href={PRIVACY_POLICY_URL}
+                  textDecoration={TYPOGRAPHY.textDecorationUnderline}
+                  className={styles.link_button}
+                />
+              ),
+              EULALink: (
+                <Link
+                  external
+                  href={EULA_URL}
+                  textDecoration={TYPOGRAPHY.textDecorationUnderline}
+                  className={styles.link_button}
+                />
+              ),
+            }}
+          />
+        </StyledText>
+        <StyledText desktopStyle="captionRegular">
+          {t('copyright', { year: getYearFromDate() })}
+        </StyledText>
+      </div>
+    </footer>
   )
 }

--- a/protocol-designer/src/components/organisms/Navigation/index.tsx
+++ b/protocol-designer/src/components/organisms/Navigation/index.tsx
@@ -3,11 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { useLocation, useNavigate } from 'react-router-dom'
 
-import {
-  BasicButton,
-  COLORS,
-  StyledText,
-} from '@opentrons/components'
+import { BasicButton, COLORS, StyledText } from '@opentrons/components'
 
 import { ACCEPTED_PROTOCOL_FILE_TYPES } from '/protocol-designer/constants'
 import { actions as loadFileActions } from '/protocol-designer/load-file'

--- a/protocol-designer/src/components/organisms/Navigation/index.tsx
+++ b/protocol-designer/src/components/organisms/Navigation/index.tsx
@@ -2,16 +2,10 @@ import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { useLocation, useNavigate } from 'react-router-dom'
-import styled from 'styled-components'
 
 import {
-  ALIGN_CENTER,
   BasicButton,
   COLORS,
-  CURSOR_POINTER,
-  Flex,
-  JUSTIFY_SPACE_BETWEEN,
-  SPACING,
   StyledText,
 } from '@opentrons/components'
 
@@ -21,6 +15,7 @@ import { getHasUnsavedChanges } from '/protocol-designer/load-file/selectors'
 import { toggleNewProtocolModal } from '/protocol-designer/navigation/actions'
 
 import { SettingsIcon } from '../SettingsIcon'
+import styles from './navigation.module.css'
 
 import type { ChangeEvent } from 'react'
 import type { ThunkDispatch } from '/protocol-designer/types'
@@ -57,39 +52,32 @@ export function Navigation(): JSX.Element | null {
   }
 
   return (
-    <Flex
-      justifyContent={JUSTIFY_SPACE_BETWEEN}
-      padding={`${SPACING.spacing12} ${SPACING.spacing40}`}
-    >
-      <Flex gridGap={SPACING.spacing8} alignItems={ALIGN_CENTER}>
-        <StyledText desktopStyle="bodyLargeSemiBold">
-          {t('opentrons')}
-        </StyledText>
-        <StyledText desktopStyle="bodyLargeSemiBold" color={COLORS.purple50}>
-          {t('protocol_designer')}
-        </StyledText>
-      </Flex>
-      <Flex gridGap={SPACING.spacing40} alignItems={ALIGN_CENTER}>
-        <BasicButton onClick={handleCreateNew}>{t('create_new')}</BasicButton>
-        <StyledLabel>
-          <BasicButton onClick={handleImport}>{t('import')}</BasicButton>
-          <input
-            type="file"
-            onChange={loadFile}
-            aria-label={`${t('import')}_from_navigation`}
-            ref={fileInputRef}
-            accept={ACCEPTED_PROTOCOL_FILE_TYPES}
-          />
-        </StyledLabel>
-        {location.pathname === '/createNew' ? null : <SettingsIcon />}
-      </Flex>
-    </Flex>
+    <nav>
+      <div className={styles.nav_container}>
+        <div className={styles.nav_title_container}>
+          <StyledText desktopStyle="bodyLargeSemiBold">
+            {t('opentrons')}
+          </StyledText>
+          <StyledText desktopStyle="bodyLargeSemiBold" color={COLORS.purple50}>
+            {t('protocol_designer')}
+          </StyledText>
+        </div>
+        <div className={styles.nav_button_container}>
+          <BasicButton onClick={handleCreateNew}>{t('create_new')}</BasicButton>
+          <label className={styles.import_label}>
+            <BasicButton onClick={handleImport}>{t('import')}</BasicButton>
+            <input
+              className={styles.hidden_input}
+              type="file"
+              onChange={loadFile}
+              aria-label={`${t('import')}_from_navigation`}
+              ref={fileInputRef}
+              accept={ACCEPTED_PROTOCOL_FILE_TYPES}
+            />
+          </label>
+          {location.pathname === '/createNew' ? null : <SettingsIcon />}
+        </div>
+      </div>
+    </nav>
   )
 }
-
-const StyledLabel = styled.label`
-  cursor: ${CURSOR_POINTER};
-  input[type='file'] {
-    display: none;
-  }
-`

--- a/protocol-designer/src/components/organisms/Navigation/navigation.module.css
+++ b/protocol-designer/src/components/organisms/Navigation/navigation.module.css
@@ -1,0 +1,25 @@
+.nav_container {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--spacing-12) var(--spacing-40);
+}
+
+.nav_title_container {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-8);
+}
+
+.nav_button_container {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-40);
+}
+
+.import_label {
+  cursor: pointer;
+}
+
+.hidden_input {
+  display: none;
+}

--- a/protocol-designer/src/pages/Landing/index.tsx
+++ b/protocol-designer/src/pages/Landing/index.tsx
@@ -143,7 +143,7 @@ export function Landing(): JSX.Element {
             gridGap={SPACING.spacing8}
             alignItems={ALIGN_CENTER}
           >
-            <StyledText desktopStyle="headingLargeBold">
+            <StyledText desktopStyle="headingLargeBold" as="h1">
               {t('welcome')}
             </StyledText>
             <StyledText


### PR DESCRIPTION
# Overview
improve accessibility + switch from styled-components to CSS Modules.

use axe devtools
https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd

### before
<img width="1124" height="2014" alt="Screenshot 2026-04-29 at 12 07 45 AM" src="https://github.com/user-attachments/assets/cdeafdf7-0fcb-4d04-be89-1e0b62858145" />

### after
<img width="1125" height="778" alt="Screenshot 2026-04-29 at 12 09 00 AM" src="https://github.com/user-attachments/assets/7b25d0fb-80a4-4b4d-a8a4-9d166ef3d14f" />


## Test Plan and Hands on Testing



## Changelog
- add main tag to the main content part
- add nav to the navigation component
- add footer to the footer component
- switch from styled-components to CSS Modules

## Review requests



## Risk assessment

