### PR TITLE
feat(api): add labware containment to enable loading the vacuum module collar on the dock

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13cc2361a9][Flex_S_v2_25_P50_P200_stacker_all_parts].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13cc2361a9][Flex_S_v2_25_P50_P200_stacker_all_parts].json
@@ -32050,6 +32050,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -32264,6 +32268,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -36176,6 +36184,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -36317,6 +36329,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -40067,6 +40083,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -40191,6 +40211,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -41662,6 +41686,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -41882,6 +41910,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -42413,6 +42445,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -42632,6 +42668,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -47247,6 +47287,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -52078,6 +52122,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -52223,6 +52271,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -52754,6 +52806,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -53067,6 +53123,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -63942,6 +64002,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -64171,6 +64235,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -64977,6 +65045,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -65051,6 +65123,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -65280,6 +65356,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -67643,6 +67723,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -68042,6 +68126,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -69330,6 +69418,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -69548,6 +69640,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -70834,6 +70930,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -70979,6 +71079,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -72255,6 +72359,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -72400,6 +72508,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -72749,6 +72861,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -72990,6 +73106,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -73646,6 +73766,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -74252,6 +74376,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -74471,6 +74599,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -75764,6 +75896,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -75911,6 +76047,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -77204,6 +77344,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -77351,6 +77495,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -77692,6 +77840,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -78027,6 +78179,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -79998,6 +80154,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -80212,6 +80372,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -80369,6 +80533,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -80559,6 +80727,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -80700,6 +80872,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -82750,6 +82926,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -85143,6 +85323,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -85286,6 +85470,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1baf3666f4][Flex_X_v2_18_Illumina_Stranded_total_RNA_Ribo_Zero].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[1baf3666f4][Flex_X_v2_18_Illumina_Stranded_total_RNA_Ribo_Zero].json
@@ -4916,6 +4916,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutA3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[26d6478878][Flex_S_2_17_MPL_sigdx_part2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[26d6478878][Flex_S_2_17_MPL_sigdx_part2].json
@@ -15844,6 +15844,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutC3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -42977,6 +42981,10 @@
           {
             "addressableAreaName": "C4",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutC3",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2aceb4fe25][Flex_S_v2_18_PL_Illumina-Stranded_total_RNA_Ribo-Zero].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2aceb4fe25][Flex_S_v2_18_PL_Illumina-Stranded_total_RNA_Ribo-Zero].json
@@ -4916,6 +4916,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutA3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -40334,6 +40338,10 @@
           {
             "addressableAreaName": "A4",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutA3",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[2b866b03f3][Flex_S_v2_21_P1000_96_GRIP_HS_MB_TC_TM_Smoke].json
@@ -373,6 +373,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutA3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -552,6 +556,10 @@
           {
             "addressableAreaName": "A4",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutA3",
@@ -737,6 +745,10 @@
           {
             "addressableAreaName": "A4",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutA3",
@@ -926,6 +938,10 @@
           {
             "addressableAreaName": "A4",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutA3",
@@ -1119,6 +1135,10 @@
           {
             "addressableAreaName": "A4",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutA3",
@@ -13480,6 +13500,10 @@
           {
             "addressableAreaName": "A4",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutA3",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[58f4fdb80f][Flex_S_2_18_MPL_96_ch_demo_rtp_with_hs].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[58f4fdb80f][Flex_S_2_18_MPL_96_ch_demo_rtp_with_hs].json
@@ -12486,6 +12486,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8d7ad02701][Flex_S_2_17_MPL_EM_seq_48Samples_AllSteps_Edits_150].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[8d7ad02701][Flex_S_2_17_MPL_EM_seq_48Samples_AllSteps_Edits_150].json
@@ -18377,6 +18377,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutC3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -45707,6 +45711,10 @@
           {
             "addressableAreaName": "C4",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutC3",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[94cd467de4][Flex_X_v2_19_Illumina_Stranded_total_RNA_Ribo_Zero].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[94cd467de4][Flex_X_v2_19_Illumina_Stranded_total_RNA_Ribo_Zero].json
@@ -4916,6 +4916,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutA3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b2b1925b81][Flex_S_2_7_P200_96_GRIP_HS_MB_TC_TM_SmokeTestWith2Stackers].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b2b1925b81][Flex_S_2_7_P200_96_GRIP_HS_MB_TC_TM_SmokeTestWith2Stackers].json
@@ -2942,6 +2942,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutA3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -3186,6 +3190,10 @@
               "kind": "onAddressableArea"
             },
             {
+              "kind": "onModule",
+              "moduleId": "UUID"
+            },
+            {
               "cutoutId": "cutoutA3",
               "kind": "onCutoutFixture",
               "possibleCutoutFixtureIds": [
@@ -3212,68 +3220,8 @@
               "kind": "onAddressableArea"
             },
             {
-              "cutoutId": "cutoutA3",
-              "kind": "onCutoutFixture",
-              "possibleCutoutFixtureIds": [
-                "stagingAreaRightSlot",
-                "stagingAreaSlotWithMagneticBlockV1"
-              ]
-            }
-          ],
-          [
-            {
-              "kind": "onLabware",
-              "labwareId": "UUID"
-            },
-            {
-              "kind": "onLabware",
-              "labwareId": "UUID"
-            },
-            {
-              "kind": "onLabware",
-              "labwareId": "UUID"
-            },
-            {
-              "kind": "onLabware",
-              "labwareId": "UUID"
-            },
-            {
-              "addressableAreaName": "A4",
-              "kind": "onAddressableArea"
-            },
-            {
-              "cutoutId": "cutoutA3",
-              "kind": "onCutoutFixture",
-              "possibleCutoutFixtureIds": [
-                "stagingAreaRightSlot",
-                "stagingAreaSlotWithMagneticBlockV1"
-              ]
-            }
-          ],
-          [
-            {
-              "kind": "onLabware",
-              "labwareId": "UUID"
-            },
-            {
-              "kind": "onLabware",
-              "labwareId": "UUID"
-            },
-            {
-              "kind": "onLabware",
-              "labwareId": "UUID"
-            },
-            {
-              "kind": "onLabware",
-              "labwareId": "UUID"
-            },
-            {
-              "kind": "onLabware",
-              "labwareId": "UUID"
-            },
-            {
-              "addressableAreaName": "A4",
-              "kind": "onAddressableArea"
+              "kind": "onModule",
+              "moduleId": "UUID"
             },
             {
               "cutoutId": "cutoutA3",
@@ -3302,6 +3250,36 @@
               "labwareId": "UUID"
             },
             {
+              "addressableAreaName": "A4",
+              "kind": "onAddressableArea"
+            },
+            {
+              "kind": "onModule",
+              "moduleId": "UUID"
+            },
+            {
+              "cutoutId": "cutoutA3",
+              "kind": "onCutoutFixture",
+              "possibleCutoutFixtureIds": [
+                "stagingAreaRightSlot",
+                "stagingAreaSlotWithMagneticBlockV1"
+              ]
+            }
+          ],
+          [
+            {
+              "kind": "onLabware",
+              "labwareId": "UUID"
+            },
+            {
+              "kind": "onLabware",
+              "labwareId": "UUID"
+            },
+            {
+              "kind": "onLabware",
+              "labwareId": "UUID"
+            },
+            {
               "kind": "onLabware",
               "labwareId": "UUID"
             },
@@ -3312,6 +3290,52 @@
             {
               "addressableAreaName": "A4",
               "kind": "onAddressableArea"
+            },
+            {
+              "kind": "onModule",
+              "moduleId": "UUID"
+            },
+            {
+              "cutoutId": "cutoutA3",
+              "kind": "onCutoutFixture",
+              "possibleCutoutFixtureIds": [
+                "stagingAreaRightSlot",
+                "stagingAreaSlotWithMagneticBlockV1"
+              ]
+            }
+          ],
+          [
+            {
+              "kind": "onLabware",
+              "labwareId": "UUID"
+            },
+            {
+              "kind": "onLabware",
+              "labwareId": "UUID"
+            },
+            {
+              "kind": "onLabware",
+              "labwareId": "UUID"
+            },
+            {
+              "kind": "onLabware",
+              "labwareId": "UUID"
+            },
+            {
+              "kind": "onLabware",
+              "labwareId": "UUID"
+            },
+            {
+              "kind": "onLabware",
+              "labwareId": "UUID"
+            },
+            {
+              "addressableAreaName": "A4",
+              "kind": "onAddressableArea"
+            },
+            {
+              "kind": "onModule",
+              "moduleId": "UUID"
             },
             {
               "cutoutId": "cutoutA3",
@@ -3332,6 +3356,10 @@
           {
             "addressableAreaName": "A4",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutA3",
@@ -9513,6 +9541,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -9787,6 +9819,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -10866,6 +10902,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -13589,6 +13629,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutA3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -13727,6 +13771,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -14620,6 +14668,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -14750,6 +14802,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -14958,6 +15014,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3b37eae0f][Flex_S_v2_25_P200_stacker_2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3b37eae0f][Flex_S_v2_25_P200_stacker_2].json
@@ -26045,6 +26045,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -27470,6 +27474,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -28944,6 +28952,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -31432,6 +31444,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -31785,6 +31801,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -31932,6 +31952,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -32597,6 +32621,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -32687,6 +32715,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -32771,6 +32803,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -32959,6 +32995,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -34756,6 +34796,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -34830,6 +34874,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -34973,6 +35021,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -35942,6 +35994,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -36061,6 +36117,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -41111,6 +41171,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -41958,6 +42022,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -42105,6 +42173,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -42179,6 +42251,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -46474,6 +46550,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -46615,6 +46695,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -47186,6 +47270,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -47305,6 +47393,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -52391,6 +52483,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -52975,6 +53071,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -53191,6 +53291,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -53541,6 +53645,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -55036,6 +55144,10 @@
             "kind": "onAddressableArea"
           },
           {
+            "kind": "onModule",
+            "moduleId": "UUID"
+          },
+          {
             "cutoutId": "cutoutD3",
             "kind": "onCutoutFixture",
             "possibleCutoutFixtureIds": [
@@ -55379,6 +55491,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",
@@ -56664,6 +56780,10 @@
           {
             "addressableAreaName": "gripperWasteChute",
             "kind": "onAddressableArea"
+          },
+          {
+            "kind": "onModule",
+            "moduleId": "UUID"
           },
           {
             "cutoutId": "cutoutD3",

--- a/api/src/opentrons/legacy_commands/helpers.py
+++ b/api/src/opentrons/legacy_commands/helpers.py
@@ -4,7 +4,7 @@ from opentrons.protocol_api._types import OffDeckType
 from opentrons.protocol_api.disposal_locations import TrashBin, WasteChute
 from opentrons.protocol_api.labware import Labware, Well
 from opentrons.protocol_api.module_contexts import ModuleContext
-from opentrons.types import DeckLocation, Location
+from opentrons.types import DeckLocation, Location, ModuleFixtureLocation
 
 CommandLocation = Union[Location, Well]
 
@@ -107,7 +107,13 @@ def stringify_well_list(
 
 def _stringify_labware_movement_location(
     location: Union[
-        DeckLocation, OffDeckType, Labware, ModuleContext, WasteChute, TrashBin
+        DeckLocation,
+        OffDeckType,
+        Labware,
+        ModuleContext,
+        ModuleFixtureLocation,
+        WasteChute,
+        TrashBin,
     ],
 ) -> str:
     if isinstance(location, (int, str)):
@@ -116,7 +122,7 @@ def _stringify_labware_movement_location(
         return "off-deck"
     elif isinstance(location, Labware):
         return location.name
-    elif isinstance(location, ModuleContext):
+    elif isinstance(location, (ModuleContext, ModuleFixtureLocation)):
         return str(location)
     elif isinstance(location, WasteChute):
         return "Waste Chute"
@@ -127,7 +133,13 @@ def _stringify_labware_movement_location(
 def stringify_labware_movement_command(
     source_labware: Labware,
     destination: Union[
-        DeckLocation, OffDeckType, Labware, ModuleContext, WasteChute, TrashBin
+        DeckLocation,
+        OffDeckType,
+        Labware,
+        ModuleContext,
+        ModuleFixtureLocation,
+        WasteChute,
+        TrashBin,
     ],
     use_gripper: bool,
 ) -> str:

--- a/api/src/opentrons/motion_planning/deck_conflict.py
+++ b/api/src/opentrons/motion_planning/deck_conflict.py
@@ -116,6 +116,11 @@ class FlexStackerModuleKindaButSomethingElseReally(_Module):
     original_item: "DeckItem"
 
 
+@dataclass
+class VacuumModule(_Module):
+    """A Vacuum Module."""
+
+
 DeckItem = Union[
     Labware,
     HeaterShakerModule,
@@ -125,6 +130,7 @@ DeckItem = Union[
     TrashBin,
     FlexStackerModule,
     FlexStackerModuleKindaButSomethingElseReally,
+    VacuumModule,
 ]
 
 

--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -247,12 +247,13 @@ def _map_labware(
     location_from_engine = engine_state.labware.get_location(labware_id=labware_id)
     if isinstance(location_from_engine, AddressableAreaLocation):
         area_name = location_from_engine.addressableAreaName
-        # If this is our custom module dock, it's not a standard deck slot.
-        # We skip standard conflict mapping because the geometry engine
-        # handles this 1:n space.
-        if "VACUUMMODULE" in area_name.upper() and "DOCK" in area_name.upper():
-            area_name = area_name[:-2]
-            return None
+        # NOTE(ba, 2026-05-1): Some labware like the vacuum module collar
+        # are loaded onto custom addressable areas like `vacuumModuleV1DockV4`.
+        # Currently this does not map well to our convention of everything is
+        # either a DeckSlotName or StagingSlotName. So we need to take the
+        # last 2 characters to convert properly, we should find a better way
+        # of doing this like working with addressableAreaLocation directly.
+        area_name = area_name if len(area_name) == 2 else area_name[-2:]
 
         # This will be guaranteed to be either deck slot name or staging slot name
         slot: Union[DeckSlotName, StagingSlotName]
@@ -365,6 +366,14 @@ def _map_module(
         return (
             mapped_location,
             wrapped_deck_conflict.FlexStackerModule(
+                name_for_errors=name_for_errors,
+                highest_z_including_labware=highest_z_including_labware,
+            ),
+        )
+    elif module_type == ModuleType.VACUUM_MODULE:
+        return (
+            mapped_location,
+            wrapped_deck_conflict.VacuumModule(
                 name_for_errors=name_for_errors,
                 highest_z_including_labware=highest_z_including_labware,
             ),

--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -246,14 +246,20 @@ def _map_labware(
 ]:
     location_from_engine = engine_state.labware.get_location(labware_id=labware_id)
     if isinstance(location_from_engine, AddressableAreaLocation):
+        area_name = location_from_engine.addressableAreaName
+        # If this is our custom module dock, it's not a standard deck slot.
+        # We skip standard conflict mapping because the geometry engine
+        # handles this 1:n space.
+        if "VACUUMMODULE" in area_name.upper() and "DOCK" in area_name.upper():
+            area_name = area_name[:-2]
+            return None
+
         # This will be guaranteed to be either deck slot name or staging slot name
         slot: Union[DeckSlotName, StagingSlotName]
         try:
-            slot = DeckSlotName.from_primitive(location_from_engine.addressableAreaName)
+            slot = DeckSlotName.from_primitive(area_name)
         except ValueError:
-            slot = StagingSlotName.from_primitive(
-                location_from_engine.addressableAreaName
-            )
+            slot = StagingSlotName.from_primitive(area_name)
         return (
             slot,
             wrapped_deck_conflict.Labware(

--- a/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
+++ b/api/src/opentrons/protocol_api/core/engine/deck_conflict.py
@@ -11,6 +11,7 @@ from typing import (
     Optional,
     Tuple,
     Union,
+    cast,
     overload,
 )
 
@@ -246,23 +247,8 @@ def _map_labware(
 ]:
     location_from_engine = engine_state.labware.get_location(labware_id=labware_id)
     if isinstance(location_from_engine, AddressableAreaLocation):
-        area_name = location_from_engine.addressableAreaName
-        # NOTE(ba, 2026-05-1): Some labware like the vacuum module collar
-        # are loaded onto custom addressable areas like `vacuumModuleV1DockV4`.
-        # Currently this does not map well to our convention of everything is
-        # either a DeckSlotName or StagingSlotName. So we need to take the
-        # last 2 characters to convert properly, we should find a better way
-        # of doing this like working with addressableAreaLocation directly.
-        area_name = area_name if len(area_name) == 2 else area_name[-2:]
-
-        # This will be guaranteed to be either deck slot name or staging slot name
-        slot: Union[DeckSlotName, StagingSlotName]
-        try:
-            slot = DeckSlotName.from_primitive(area_name)
-        except ValueError:
-            slot = StagingSlotName.from_primitive(area_name)
         return (
-            slot,
+            _addressable_area_to_slot(location_from_engine),
             wrapped_deck_conflict.Labware(
                 name_for_errors=engine_state.labware.get_load_name(
                     labware_id=labware_id
@@ -404,6 +390,35 @@ def _map_disposal_location(
 
 def _deck_slot_to_int(deck_slot_location: DeckSlotLocation) -> int:
     return deck_slot_location.slotName.as_int()
+
+
+def _addressable_area_to_slot(
+    location: AddressableAreaLocation,
+) -> Union[DeckSlotName, StagingSlotName]:
+    """Takes an AddressableAreaLocation and converts to DeckSlotName or StagingSlotName.
+
+    Tries the full name first, then falls back to the last two characters
+    for special areas (e.g. vacuumModuleV1DockA4 -> A4).
+    """
+    # NOTE(ba, 2026-05-1): Some labware like the vacuum module collar
+    # are loaded onto custom addressable areas like `vacuumModuleV1DockV4`.
+    # Currently this does not map well to our convention of everything is
+    # either a DeckSlotName or StagingSlotName. So we need to take the
+    # last 2 characters to convert properly, we should find a better way
+    # of doing this like working with addressableAreaLocation directly.
+    area_name = location.addressableAreaName
+    names = (area_name, area_name[-2:].upper())
+    for name, slot_type in itertools.product(names, (DeckSlotName, StagingSlotName)):
+        try:
+            return cast(Union[DeckSlotName, StagingSlotName], slot_type).from_primitive(
+                name
+            )
+        except ValueError:
+            continue
+
+    raise ValueError(
+        f"Cannot convert area name '{area_name}' to DeckSlotName or StagingSlotName."
+    )
 
 
 def _get_module_highest_z_including_labware(

--- a/api/src/opentrons/protocol_api/core/engine/protocol.py
+++ b/api/src/opentrons/protocol_api/core/engine/protocol.py
@@ -87,6 +87,7 @@ from opentrons.protocols.api_support.util import AxisMaxSpeeds
 from opentrons.types import (
     DeckSlotName,
     Location,
+    ModuleFixtureLocation,
     Mount,
     MountType,
     Point,
@@ -227,6 +228,7 @@ class ProtocolCore(
             StagingSlotName,
             LabwareCore,
             ModuleCore,
+            ModuleFixtureLocation,
             NonConnectedModuleCore,
             OffDeckType,
         ],
@@ -302,6 +304,7 @@ class ProtocolCore(
             StagingSlotName,
             ModuleCore,
             NonConnectedModuleCore,
+            ModuleFixtureLocation,
             OffDeckType,
         ],
         namespace: Optional[str],
@@ -309,7 +312,6 @@ class ProtocolCore(
     ) -> LabwareCore:
         """Load an adapter using its identifying parameters"""
         load_location = self._get_non_stacked_location(location=location)
-
         custom_labware_params = (
             self._engine_client.state.labware.find_custom_labware_load_params()
         )
@@ -325,6 +327,7 @@ class ProtocolCore(
             ),
             command_annotations=self._annotation_ids,
         )
+
         # FIXME(jbl, 2023-08-14) validating after loading the object issue
         validation.ensure_definition_is_adapter(load_result.definition)
 
@@ -1311,6 +1314,7 @@ class ProtocolCore(
             StagingSlotName,
             LabwareCore,
             ModuleCore,
+            ModuleFixtureLocation,
             NonConnectedModuleCore,
             OffDeckType,
             WasteChute,
@@ -1328,6 +1332,7 @@ class ProtocolCore(
             DeckSlotName,
             StagingSlotName,
             ModuleCore,
+            ModuleFixtureLocation,
             NonConnectedModuleCore,
             OffDeckType,
             WasteChute,
@@ -1349,3 +1354,7 @@ class ProtocolCore(
             return AddressableAreaLocation(addressableAreaName="gripperWasteChute")
         elif isinstance(location, TrashBin):
             return AddressableAreaLocation(addressableAreaName=location.area_name)
+        elif isinstance(location, ModuleFixtureLocation):
+            return AddressableAreaLocation(
+                addressableAreaName=location.addressable_area_name
+            )

--- a/api/src/opentrons/protocol_api/core/engine/stringify.py
+++ b/api/src/opentrons/protocol_api/core/engine/stringify.py
@@ -7,6 +7,7 @@ from opentrons.protocol_engine.types import (
     ModuleLocation,
     OnLabwareLocation,
 )
+from opentrons.types import ModuleFixtureLocation
 
 
 def well(engine_client: SyncClient, well_name: str, labware_id: str) -> str:
@@ -27,7 +28,7 @@ def _module_in_location_string(module_id: str, engine_client: SyncClient) -> str
     return f"{module_name} on {module_on_string}"
 
 
-def _labware_location_string(
+def _labware_location_string(  # noqa: C901
     engine_client: SyncClient, location: LabwareLocation
 ) -> str:
     if isinstance(location, DeckSlotLocation):
@@ -49,6 +50,10 @@ def _labware_location_string(
     elif isinstance(location, AddressableAreaLocation):
         # In practice this will always be a deck slot or staging slot
         return f"slot {location.addressableAreaName}"
+
+    elif isinstance(location, ModuleFixtureLocation):
+        # In practice this will always be a deck slot or staging slot
+        return f"slot {location.addressable_area_name}"
 
     elif location == "offDeck":
         return "[off-deck]"

--- a/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
+++ b/api/src/opentrons/protocol_api/core/legacy/legacy_protocol_core.py
@@ -29,6 +29,7 @@ from opentrons.protocols.api_support.util import APIVersionError, AxisMaxSpeeds
 from opentrons.types import (
     DeckSlotName,
     Location,
+    ModuleFixtureLocation,
     Mount,
     Point,
     StagingSlotName,
@@ -173,6 +174,7 @@ class LegacyProtocolCore(
             LegacyLabwareCore,
             legacy_module_core.LegacyModuleCore,
             StagingSlotName,
+            ModuleFixtureLocation,
             OffDeckType,
         ],
         label: Optional[str],
@@ -192,6 +194,10 @@ class LegacyProtocolCore(
         elif isinstance(location, StagingSlotName):
             raise APIVersionError(
                 api_element="Using a staging deck slot", until_version="2.16"
+            )
+        elif isinstance(location, ModuleFixtureLocation):
+            raise APIVersionError(
+                api_element="Using a module addressable area", until_version="2.28"
             )
 
         deck_slot = (
@@ -272,6 +278,7 @@ class LegacyProtocolCore(
             StagingSlotName,
             legacy_module_core.LegacyModuleCore,
             OffDeckType,
+            ModuleFixtureLocation,
         ],
         namespace: Optional[str],
         version: Optional[int],

--- a/api/src/opentrons/protocol_api/core/protocol.py
+++ b/api/src/opentrons/protocol_api/core/protocol.py
@@ -25,6 +25,7 @@ from opentrons.protocols.api_support.util import AxisMaxSpeeds
 from opentrons.types import (
     DeckSlotName,
     Location,
+    ModuleFixtureLocation,
     Mount,
     Point,
     StagingSlotName,
@@ -77,7 +78,12 @@ class AbstractProtocol(
         self,
         load_name: str,
         location: Union[
-            DeckSlotName, StagingSlotName, LabwareCoreType, ModuleCoreType, OffDeckType
+            DeckSlotName,
+            StagingSlotName,
+            LabwareCoreType,
+            ModuleCoreType,
+            ModuleFixtureLocation,
+            OffDeckType,
         ],
         label: Optional[str],
         namespace: Optional[str],
@@ -90,7 +96,13 @@ class AbstractProtocol(
     def load_adapter(
         self,
         load_name: str,
-        location: Union[DeckSlotName, StagingSlotName, ModuleCoreType, OffDeckType],
+        location: Union[
+            DeckSlotName,
+            StagingSlotName,
+            ModuleCoreType,
+            ModuleFixtureLocation,
+            OffDeckType,
+        ],
         namespace: Optional[str],
         version: Optional[int],
     ) -> LabwareCoreType:

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -42,6 +42,7 @@ from opentrons.protocols.api_support.util import (
     UnsupportedAPIError,
     requires_version,
 )
+from opentrons.types import ModuleFixtureLocation
 
 from . import (
     validation,
@@ -1864,3 +1865,42 @@ class VacuumModuleContext(ModuleContext):
     def serial_number(self) -> str:
         """Get the module's unique hardware serial number."""
         return self._core.get_serial_number()
+
+    @property
+    @requires_version(2, 28)
+    def manifold_dock(self) -> ModuleFixtureLocation:
+        base_slot = self._core.get_deck_slot().id
+        area_name = f"{self.model}Dock{base_slot[0]}4"
+        return ModuleFixtureLocation(addressable_area_name=area_name)
+
+    @requires_version(2, 28)
+    def load_adapter_to_dock(
+        self,
+        name: str,
+        namespace: Optional[str] = None,
+        version: Optional[int] = None,
+    ) -> Labware:
+        """Load a collar adapter to the vacuum module dock."""
+
+        labware_core = self._protocol_core.load_adapter(
+            load_name=name,
+            namespace=namespace,
+            version=version,
+            location=self.manifold_dock,
+        )
+
+        if isinstance(self._core, LegacyModuleCore) and isinstance(
+            labware_core, LegacyLabwareCore
+        ):
+            adapter = self._core.add_labware_core(labware_core)
+        else:
+            adapter = Labware(
+                core=labware_core,
+                api_version=self._api_version,
+                protocol_core=self._protocol_core,
+                core_map=self._core_map,
+            )
+
+        self._core_map.add(labware_core, adapter)
+
+        return adapter

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -96,7 +96,14 @@ from opentrons.protocols.api_support.util import (
     UnsupportedAPIError,
     requires_version,
 )
-from opentrons.types import DeckLocation, DeckSlotName, Location, Mount, StagingSlotName
+from opentrons.types import (
+    DeckLocation,
+    DeckSlotName,
+    Location,
+    ModuleFixtureLocation,
+    Mount,
+    StagingSlotName,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -412,7 +419,7 @@ class ProtocolContext(CommandPublisher):
     def load_labware(  # noqa: C901
         self,
         load_name: str,
-        location: Union[DeckLocation, OffDeckType],
+        location: Union[DeckLocation, OffDeckType, ModuleFixtureLocation],
         label: Optional[str] = None,
         namespace: Optional[str] = None,
         version: Optional[int] = None,
@@ -545,7 +552,13 @@ class ProtocolContext(CommandPublisher):
                 )
 
         load_name = validation.ensure_lowercase_name(load_name)
-        load_location: Union[OffDeckType, DeckSlotName, StagingSlotName, LabwareCore]
+        load_location: Union[
+            OffDeckType,
+            DeckSlotName,
+            StagingSlotName,
+            LabwareCore,
+            ModuleFixtureLocation,
+        ]
         if adapter is not None:
             if self._api_version < APIVersion(2, 15):
                 raise APIVersionError(
@@ -571,7 +584,7 @@ class ProtocolContext(CommandPublisher):
                 version=checked_adapter_version,
             )
             load_location = loaded_adapter._core
-        elif isinstance(location, OffDeckType):
+        elif isinstance(location, (OffDeckType, ModuleFixtureLocation)):
             load_location = location
         else:
             load_location = validation.ensure_and_convert_deck_slot(
@@ -709,7 +722,7 @@ class ProtocolContext(CommandPublisher):
     def load_adapter(
         self,
         load_name: str,
-        location: Union[DeckLocation, OffDeckType],
+        location: Union[DeckLocation, OffDeckType, ModuleFixtureLocation],
         namespace: Optional[str] = None,
         version: Optional[int] = None,
     ) -> Labware:
@@ -728,7 +741,7 @@ class ProtocolContext(CommandPublisher):
                 You can find the `load_name` for any standard adapter on the Opentrons
                 [Labware Library](https://labware.opentrons.com).
 
-            location (Union[int, str, OffDeckType]): Either a
+            location (Union[int, str, OffDeckType, ModuleFixtureLocation]): Either a
                 [deck slot](../deck-slots.md), like `1`, `"1"`, or `"D1"`, or the special value
                 [`OFF_DECK`][opentrons.protocol_api.OFF_DECK].
 
@@ -747,8 +760,10 @@ class ProtocolContext(CommandPublisher):
                 leave this unspecified to let `load_adapter()` choose a version automatically.
         """
         load_name = validation.ensure_lowercase_name(load_name)
-        load_location: Union[OffDeckType, DeckSlotName, StagingSlotName]
-        if isinstance(location, OffDeckType):
+        load_location: Union[
+            OffDeckType, DeckSlotName, StagingSlotName, ModuleFixtureLocation
+        ]
+        if isinstance(location, (OffDeckType, ModuleFixtureLocation)):
             load_location = location
         else:
             load_location = validation.ensure_and_convert_deck_slot(
@@ -808,7 +823,12 @@ class ProtocolContext(CommandPublisher):
         self,
         labware: Labware,
         new_location: Union[
-            DeckLocation, Labware, ModuleTypes, OffDeckType, WasteChute, TrashBin
+            DeckLocation,
+            Labware,
+            ModuleTypes,
+            OffDeckType,
+            WasteChute,
+            TrashBin,
         ],
         use_gripper: bool = False,
         pick_up_offset: Optional[Mapping[str, float]] = None,
@@ -871,6 +891,7 @@ class ProtocolContext(CommandPublisher):
             OffDeckType,
             DeckSlotName,
             StagingSlotName,
+            ModuleFixtureLocation,
             TrashBin,
         ]
         if isinstance(new_location, (Labware, ModuleContext)):

--- a/api/src/opentrons/protocol_engine/commands/load_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/load_labware.py
@@ -18,7 +18,6 @@ from ..types import (
     AddressableAreaLocation,
     DeckSlotLocation,
     LoadableLabwareLocation,
-    LoadedModule,
     ModuleLocation,
     ModuleModel,
     OnLabwareLocation,
@@ -97,11 +96,17 @@ class LoadLabwareImplementation(
     def _is_loading_to_module(
         self, location: LoadableLabwareLocation, module_model: ModuleModel
     ) -> TypeGuard[ModuleLocation]:
-        if not isinstance(location, ModuleLocation):
+        if not isinstance(location, (ModuleLocation, AddressableAreaLocation)):
             return False
 
-        module: LoadedModule = self._state_view.modules.get(location.moduleId)
-        return module.model == module_model
+        if isinstance(location, AddressableAreaLocation):
+            slot = self._state_view.addressable_areas.get_addressable_area_base_slot(
+                location.addressableAreaName
+            )
+            module = self._state_view.modules.get_by_slot(slot)
+        else:
+            module = self._state_view.modules.get(location.moduleId)
+        return module is not None and module.model == module_model
 
     async def execute(
         self, params: LoadLabwareParams
@@ -126,6 +131,7 @@ class LoadLabwareImplementation(
             if not (
                 fixture_validation.is_deck_slot(params.location.addressableAreaName)
                 or fixture_validation.is_abs_reader(params.location.addressableAreaName)
+                or fixture_validation.is_vac_dock(params.location.addressableAreaName)
             ):
                 raise LabwareIsNotAllowedInLocationError(
                     f"Cannot load {params.loadName} onto addressable area {area_name}"
@@ -140,24 +146,18 @@ class LoadLabwareImplementation(
             )
             state_update.set_addressable_area_used(params.location.slotName.id)
 
-        verified_location = self._state_view.geometry.ensure_location_not_occupied(
-            params.location
-        )
-
-        loaded_labware = await self._equipment.load_labware(
+        definition, definition_uri = await self._equipment.load_definition_for_details(
             load_name=params.loadName,
             namespace=params.namespace,
             version=params.version,
-            location=verified_location,
-            labware_id=params.labwareId,
         )
 
-        state_update.set_loaded_labware(
-            labware_id=loaded_labware.labware_id,
-            offset_id=loaded_labware.offsetId,
-            definition=loaded_labware.definition,
-            location=verified_location,
-            display_name=params.displayName,
+        verified_location = self._state_view.geometry.ensure_location_not_occupied(
+            params.location, None, definition
+        )
+
+        loaded_labware = await self._equipment._load_labware_from_def_and_uri(
+            definition, definition_uri, verified_location, params.labwareId, None
         )
 
         if isinstance(verified_location, OnLabwareLocation):
@@ -166,7 +166,7 @@ class LoadLabwareImplementation(
                 bottom_labware_id=verified_location.labwareId,
             )
 
-        # Validate labware for the absorbance reader
+        # Validate labware for different modules
         if self._is_loading_to_module(
             params.location, ModuleModel.ABSORBANCE_READER_V1
         ):
@@ -174,8 +174,21 @@ class LoadLabwareImplementation(
                 loaded_labware.definition
             )
 
+        elif self._is_loading_to_module(params.location, ModuleModel.VACUUM_MODULE_V1):
+            self._state_view.labware.raise_if_labware_incompatible_with_vacuum_module_dock(
+                verified_location, loaded_labware.definition
+            )
+
         self._state_view.labware.raise_if_labware_cannot_be_ondeck(
             location=params.location, labware_definition=loaded_labware.definition
+        )
+
+        state_update.set_loaded_labware(
+            labware_id=loaded_labware.labware_id,
+            offset_id=loaded_labware.offsetId,
+            definition=loaded_labware.definition,
+            location=verified_location,
+            display_name=params.displayName,
         )
 
         return SuccessData(

--- a/api/src/opentrons/protocol_engine/resources/fixture_validation.py
+++ b/api/src/opentrons/protocol_engine/resources/fixture_validation.py
@@ -66,3 +66,8 @@ def is_stacker_shuttle(addressable_area_name: str) -> bool:
         "flexStackerModuleV1C4",
         "flexStackerModuleV1D4",
     ]
+
+
+def is_vac_dock(addressable_area_name: str) -> bool:
+    """Check if an addressable area is an vacuum module dock area."""
+    return "vacuumModuleV1Dock" in addressable_area_name

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -92,6 +92,7 @@ from ..types.liquid_level_detection import LiquidTrackingType, SimulatedProbeRes
 from ._well_math import nozzles_per_well, wells_covered_by_pipette_configuration
 from .addressable_areas import AddressableAreaView
 from .config import Config
+from .containment_utils import is_fully_contained
 from .inner_well_math_utils import (
     find_height_inner_well_geometry,
     find_height_user_defined_volumes,
@@ -110,6 +111,7 @@ from .wells import WellView
 from opentrons.types import (
     DeckSlotName,
     MeniscusTrackingTarget,
+    ModuleFixtureLocation,
     MountType,
     Point,
     StagingSlotName,
@@ -383,7 +385,9 @@ class GeometryView:
             return self._normalize_module_calibration_offset(
                 module_location, offset_data
             )
-        elif isinstance(location, (DeckSlotLocation, AddressableAreaLocation)):
+        elif isinstance(
+            location, (DeckSlotLocation, AddressableAreaLocation, ModuleFixtureLocation)
+        ):
             # TODO we might want to do a check here to make sure addressable area location is a standard deck slot
             #   and raise if its not (or maybe we don't actually care since modules will never be loaded elsewhere)
             return Point(x=0, y=0, z=0)
@@ -878,15 +882,14 @@ class GeometryView:
         original_display_name = self._labware.get_display_name(labware_id)
 
         # Track visited IDs to truly detect cycles (A nested on B nested on A)
-        seen: Set[str] = {labware_id}
+        seen: Set[str] = set((labware_id,))
 
         while isinstance(labware.location, OnLabwareLocation):
             parent_id = labware.location.labwareId
             if parent_id in seen:
                 raise InvalidLabwarePositionError(
-                    f"Cycle detected in labware positioning for {original_display_name}. "
+                    f"Cycle detected in labware positioning for {original_display_name}"
                 )
-
             seen.add(parent_id)
             labware = self._labware.get(parent_id)
 
@@ -927,6 +930,8 @@ class GeometryView:
             return current_loc.slotName.id
         elif isinstance(current_loc, AddressableAreaLocation):
             return current_loc.addressableAreaName
+        elif isinstance(current_loc, ModuleFixtureLocation):
+            return current_loc.addressable_area_name
         elif isinstance(current_loc, ModuleLocation):
             return self._modules.get_provided_addressable_area(current_loc.moduleId)
 
@@ -936,10 +941,11 @@ class GeometryView:
                 details={"terminal-location": repr(current_loc)},
             )
 
-    def ensure_location_not_occupied(
+    def ensure_location_not_occupied(  # noqa: C901
         self,
         location: _LabwareLocation,
         desired_addressable_area: Optional[str] = None,
+        labware_definition: Optional[LabwareDefinition] = None,
     ) -> _LabwareLocation:
         """Ensure that the location does not already have either Labware or a Module in it."""
         # Collect set of existing fixtures, if any
@@ -972,7 +978,6 @@ class GeometryView:
                 )
             ):
                 self._labware.raise_if_labware_in_location(location)
-
             else:
                 self._modules.raise_if_module_in_location(location)
 
@@ -987,7 +992,53 @@ class GeometryView:
                     AddressableAreaLocation,
                 ),
             ):
-                self._labware.raise_if_labware_in_location(location)
+                # Check if sibling labware have a 'containedSpace' variable
+                # in their definition to do a containment occupancy check.
+                # This lets us determine if the empty space (containedSpace) of
+                # a labware is able to fit other labware inside of it.
+                if labware_definition is not None and isinstance(
+                    labware_definition, LabwareDefinition2
+                ):
+                    children = []
+                    for lw in self._labware.get_all():
+                        if lw.location == location:
+                            children.append(lw)
+
+                    new_labware_def = labware_definition
+                    new_contained = new_labware_def.containedSpace
+
+                    # if we have children check if either siblings have 'containedSpace'
+                    for child in children:
+                        child_def = self._labware.get_definition(child.id)
+                        if not isinstance(child_def, LabwareDefinition2):
+                            continue
+                        existing_contained = child_def.containedSpace
+
+                        # Standard Nesting: Loading a resident into an existing container
+                        if existing_contained is not None:
+                            if not is_fully_contained(
+                                resident_def=new_labware_def,
+                                boundary_space=existing_contained,
+                            ):
+                                raise errors.LabwareIsNotAllowedInLocationError(
+                                    f"Labware {new_labware_def.parameters.loadName} does not fit within the "
+                                    f"containedSpace of existing {child.loadName}."
+                                )
+                        # Contained Logic: Loading a container over an existing resident
+                        elif new_contained is not None:
+                            if not is_fully_contained(
+                                resident_def=child_def, boundary_space=new_contained
+                            ):
+                                raise errors.LocationIsOccupiedError(
+                                    f"Cannot contain {child.loadName}; it is too large for the "
+                                    f"internal volume of {new_labware_def.parameters.loadName}."
+                                )
+                        # Strict Occupancy: Neither has a volume
+                        else:
+                            self._labware.raise_if_labware_in_location(location)
+
+                else:
+                    self._labware.raise_if_labware_in_location(location)
 
             area = (
                 location.slotName.id
@@ -998,6 +1049,7 @@ class GeometryView:
                     else None
                 )
             )
+
             if area is not None and (
                 existing_fixtures is None
                 or not any(
@@ -1015,7 +1067,6 @@ class GeometryView:
                             )
                         )
                     )
-
         return location
 
     def _get_potential_fixtures_for_location_occupation(

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -1696,7 +1696,8 @@ class GeometryView:
         # If the labware is loaded on an AA that is a module, we want to respect the convention
         # of giving it an OnModuleLocation.
         possible_module = self._modules.get_by_addressable_area(
-            labware_location.addressableAreaName
+            labware_location.addressableAreaName,
+            self._addressable_areas.deck_definition,
         )
         if possible_module is not None:
             return building + [

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -424,6 +424,17 @@ class LabwareView:
             "There is no labware loaded on this Module"
         )
 
+    def get_labware_on_module(self, module_id: str) -> List[str]:
+        """Return all ID's of labware loaded directly on the given module."""
+        on_module: List[str] = []
+        for labware in self._state.labware_by_id.values():
+            if (
+                isinstance(labware.location, ModuleLocation)
+                and labware.location.moduleId == module_id
+            ):
+                on_module.append(labware.id)
+        return on_module
+
     def get_id_by_labware(self, labware_id: str) -> str:
         """Return the ID of the labware loaded on the given labware."""
         for labware in self._state.labware_by_id.values():

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1160,7 +1160,7 @@ class LabwareView:
             ):
                 raise errors.LabwareIsNotAllowedInLocationError(
                     f'Labware "{labware_definition.parameters.loadName}" is not compatible with '
-                    f"the vacuum module dock ({location.addressableAreaName})."
+                    f"the vacuum module dock {location.addressableAreaName}."
                 )
 
         return True

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1140,6 +1140,31 @@ class LabwareView:
             )
         return True
 
+    def raise_if_labware_incompatible_with_vacuum_module_dock(
+        self,
+        location: LabwareLocation,
+        labware_definition: LabwareDefinition,
+    ) -> bool:
+        """Raise an error if the labware is not compatible with the vacuum module dock.
+
+        Returns True if it does not raise.
+        """
+        if isinstance(location, AddressableAreaLocation):
+            # If the module is a Vacuum Module and we are loading
+            # a compatible adapter into its designated staging dock,
+            # do NOT raise.
+            if not (
+                location.addressableAreaName[-1] == "4"
+                and labware_definition.parameters.quirks is not None
+                and "vacuumModuleDock" in labware_definition.parameters.quirks
+            ):
+                raise errors.LabwareIsNotAllowedInLocationError(
+                    f'Labware "{labware_definition.parameters.loadName}" is not compatible with '
+                    f"the vacuum module dock ({location.addressableAreaName})."
+                )
+
+        return True
+
     def raise_if_stacker_labware_pool_is_not_valid(
         self,
         primary_labware_definition: LabwareDefinition,

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -1507,17 +1507,6 @@ class ModuleView:
         )
         return lid_dock_area
 
-    def vacuum_module_dock_location(self, module_id: str) -> AddressableAreaLocation:
-        """Get the addressable area for the vacuum module dock."""
-        reader_slot = self.get_location(module_id)
-        lid_doc_slot = get_adjacent_staging_slot(reader_slot.slotName)
-        self.get_provided_addressable_area(module_id)
-        assert lid_doc_slot is not None
-        lid_dock_area = AddressableAreaLocation(
-            addressableAreaName="VacuumModuleV1LidDock" + lid_doc_slot.value
-        )
-        return lid_dock_area
-
     def get_stacker_max_fill_height(self, module_id: str) -> float:
         """Get the maximum fill height for the Flex Stacker."""
         definition = self.get_definition(module_id)

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -21,6 +21,8 @@ from numpy import array, dot
 from numpy import double as npdouble
 from numpy.typing import NDArray
 
+from opentrons_shared_data.deck.types import DeckDefinitionV5
+
 from .. import errors
 from ..actions import (
     Action,
@@ -741,12 +743,18 @@ class ModuleView:
         return None
 
     def get_by_addressable_area(
-        self, addressable_area_name: str
+        self, addressable_area_name: str, deck_definition: DeckDefinitionV5
     ) -> Optional[LoadedModule]:
         """Get the module associated with this addressable area, if any."""
         for module_id in self._state.load_location_by_module_id.keys():
-            if addressable_area_name == self.get_provided_addressable_area(module_id):
-                return self.get(module_id)
+            module_addressable_area = self.get_provided_addressable_area(module_id)
+            cutout_fixtures = deck_configuration_provider.get_potential_cutout_fixtures(
+                module_addressable_area, deck_definition
+            )
+            for fixture in cutout_fixtures[1]:
+                if addressable_area_name in fixture.provided_addressable_areas:
+                    return self.get(module_id)
+
         return None
 
     def _get_module_substate(

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -868,7 +868,7 @@ class ModuleView:
         )
 
     def get_vacuum_module_substate(self, module_id: str) -> VacuumModuleSubState:
-        """Return a `VacuumModululeSubState` for the given Vacuum Module.
+        """Return a `VacuumModuleSubState` for the given Vacuum Module.
 
         Raises:
            ModuleNotLoadedError: If module_id has not been loaded.
@@ -1496,6 +1496,17 @@ class ModuleView:
         assert lid_doc_slot is not None
         lid_dock_area = AddressableAreaLocation(
             addressableAreaName="absorbanceReaderV1LidDock" + lid_doc_slot.value
+        )
+        return lid_dock_area
+
+    def vacuum_module_dock_location(self, module_id: str) -> AddressableAreaLocation:
+        """Get the addressable area for the vacuum module dock."""
+        reader_slot = self.get_location(module_id)
+        lid_doc_slot = get_adjacent_staging_slot(reader_slot.slotName)
+        self.get_provided_addressable_area(module_id)
+        assert lid_doc_slot is not None
+        lid_dock_area = AddressableAreaLocation(
+            addressableAreaName="VacuumModuleV1LidDock" + lid_doc_slot.value
         )
         return lid_dock_area
 

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import enum
+from dataclasses import dataclass
 from math import isclose, sqrt
 from typing import (
     TYPE_CHECKING,
@@ -521,6 +522,21 @@ class StagingSlotName(enum.Enum):
         For explicitness, prefer using `.id` instead.
         """
         return self.id
+
+
+@dataclass(frozen=True)
+class ModuleFixtureLocation:
+    """A special location (dock, fixture, collar, holder, etc.) that is paired
+    with a specific module.
+
+    Used when a module has associated positions in the staging area or elsewhere
+    that are not standard deck slots.
+    """
+
+    addressable_area_name: str
+
+    def __str__(self) -> str:
+        return self.addressable_area_name
 
 
 class TransferTipPolicy(enum.Enum):

--- a/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_deck_conflict.py
@@ -310,6 +310,11 @@ def test_maps_different_module_models(
                 name_for_errors=expected_name_for_errors,
                 highest_z_including_labware=3.14159,
             )
+        elif module_model is ModuleModel.VACUUM_MODULE_V1:
+            return wrapped_deck_conflict.VacuumModule(
+                name_for_errors=expected_name_for_errors,
+                highest_z_including_labware=3.14159,
+            )
         else:
             return wrapped_deck_conflict.OtherModule(
                 name_for_errors=expected_name_for_errors,

--- a/api/tests/opentrons/protocol_api/test_vacuum_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_vacuum_module_context.py
@@ -1,0 +1,145 @@
+"""Tests for Protocol API Vacuum Module contexts."""
+
+import pytest
+from decoy import Decoy
+
+from . import versions_at_or_above
+from opentrons.hardware_control.modules.types import VacuumModuleModel
+from opentrons.legacy_broker import LegacyBroker
+from opentrons.protocol_api import Labware, VacuumModuleContext
+from opentrons.protocol_api.core.common import (
+    LabwareCore,
+    ProtocolCore,
+    VacuumModuleCore,
+)
+from opentrons.protocol_api.core.core_map import LoadedCoreMap
+from opentrons.protocols.api_support.types import APIVersion
+from opentrons.types import DeckSlotName, ModuleFixtureLocation
+
+
+@pytest.fixture
+def mock_core(decoy: Decoy) -> VacuumModuleCore:
+    """Get a mock module implementation core."""
+    core = decoy.mock(cls=VacuumModuleCore)
+    decoy.when(core.get_display_name()).then_return("mock vacuum core")
+    decoy.when(core.get_deck_slot()).then_return(DeckSlotName.SLOT_A3)
+    decoy.when(core.get_model()).then_return(VacuumModuleModel.VACUUM_MODULE_V1)
+    return core
+
+
+@pytest.fixture
+def mock_protocol_core(decoy: Decoy) -> ProtocolCore:
+    """Get a mock protocol implementation core."""
+    return decoy.mock(cls=ProtocolCore)
+
+
+@pytest.fixture
+def mock_labware_core(decoy: Decoy) -> LabwareCore:
+    """Get a mock labware implementation core."""
+    mock_core = decoy.mock(cls=LabwareCore)
+    decoy.when(mock_core.get_well_columns()).then_return([])
+    return mock_core
+
+
+@pytest.fixture
+def mock_core_map(decoy: Decoy) -> LoadedCoreMap:
+    """Get a mock LoadedCoreMap."""
+    return decoy.mock(cls=LoadedCoreMap)
+
+
+@pytest.fixture
+def mock_broker(decoy: Decoy) -> LegacyBroker:
+    """Get a mock command message broker."""
+    return decoy.mock(cls=LegacyBroker)
+
+
+@pytest.fixture
+def subject(
+    api_version: APIVersion,
+    mock_core: VacuumModuleCore,
+    mock_protocol_core: ProtocolCore,
+    mock_core_map: LoadedCoreMap,
+    mock_broker: LegacyBroker,
+) -> VacuumModuleContext:
+    """Get a vacuum module context with its dependencies mocked out."""
+    return VacuumModuleContext(
+        core=mock_core,
+        protocol_core=mock_protocol_core,
+        core_map=mock_core_map,
+        broker=mock_broker,
+        api_version=api_version,
+    )
+
+
+@pytest.mark.parametrize(
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 28))
+)
+def test_get_serial_number(
+    decoy: Decoy, mock_core: VacuumModuleCore, subject: VacuumModuleContext
+) -> None:
+    """It should get the serial number from the core."""
+    decoy.when(mock_core.get_serial_number()).then_return("12345")
+    result = subject.serial_number
+    assert result == "12345"
+
+
+@pytest.mark.parametrize(
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 28))
+)
+def test_vacuum_module_manifold_dock_property(
+    subject: VacuumModuleContext,
+) -> None:
+    """The manifold_dock property should return correct ModuleFixtureLocation."""
+    assert isinstance(subject.manifold_dock, ModuleFixtureLocation)
+    assert "vacuumModuleV1Dock" in str(subject.manifold_dock)
+
+
+@pytest.mark.parametrize(
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 28))
+)
+def test_vacuum_module_load_adapter_to_dock(
+    decoy: Decoy,
+    subject: VacuumModuleContext,
+    mock_protocol_core: ProtocolCore,
+) -> None:
+    """It should successfully load a compatible collar onto the vacuum module dock."""
+    collar_name = "millipore_vacuum_manifold_collar_tall"
+    dock_location = ModuleFixtureLocation(addressable_area_name="vacuumModuleV1DockA4")
+
+    # Mock the LabwareCore that will be returned
+    mock_labware_core = decoy.mock(cls=LabwareCore)
+
+    # Set up what load_adapter should return
+    decoy.when(
+        mock_protocol_core.load_adapter(
+            load_name=collar_name,
+            location=dock_location,
+            namespace=None,
+            version=None,
+        )
+    ).then_return(mock_labware_core)
+
+    # Mock the properties that Labware wrapper accesses
+    decoy.when(mock_labware_core.load_name).then_return(collar_name)
+    decoy.when(mock_labware_core.get_name()).then_return(
+        "Millipore Vacuum Manifold Collar Tall"
+    )
+    decoy.when(mock_labware_core.get_well_columns()).then_return([])
+
+    # Act
+    result = subject.load_adapter_to_dock(collar_name)
+
+    # Assert
+    assert isinstance(result, Labware)
+    assert result.load_name == collar_name
+    assert result.name == "Millipore Vacuum Manifold Collar Tall"
+
+    # Verify the core call was made with correct ModuleFixtureLocation
+    decoy.verify(
+        mock_protocol_core.load_adapter(
+            load_name=collar_name,
+            location=dock_location,
+            namespace=None,
+            version=None,
+        )
+    )

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -35,6 +35,11 @@ from opentrons.protocol_engine.types import (
     OnLabwareLocation,
     OnLabwareLocationSequenceComponent,
 )
+from opentrons.protocol_engine.types.location import (
+    ModuleLocation,
+    OnCutoutFixtureLocationSequenceComponent,
+    OnModuleLocationSequenceComponent,
+)
 from opentrons.types import DeckSlotName
 
 
@@ -295,3 +300,453 @@ async def test_load_labware_raises_if_location_occupied(
 
     with pytest.raises(LocationIsOccupiedError):
         await subject.execute(data)
+
+
+@pytest.mark.parametrize("display_name", ["My custom collar", None])
+async def test_load_labware_on_vacuum_module_dock(
+    decoy: Decoy,
+    well_plate_def: LabwareDefinition,
+    equipment: EquipmentHandler,
+    state_view: StateView,
+    display_name: Optional[str],
+) -> None:
+    """Loading a labware (collar) onto a vacuum module dock should work via ModuleFixtureLocation."""
+    subject = LoadLabwareImplementation(equipment=equipment, state_view=state_view)
+
+    dock_location = AddressableAreaLocation(addressableAreaName="vacuumModuleV1DockA4")
+
+    data = LoadLabwareParams(
+        location=dock_location,
+        loadName="millipore_vacuum_manifold_collar_tall",
+        namespace="opentrons-test",
+        version=1,
+        displayName=display_name,
+    )
+
+    decoy.when(
+        state_view.geometry.get_predicted_location_sequence(dock_location)
+    ).then_return(
+        [
+            OnAddressableAreaLocationSequenceComponent(
+                addressableAreaName="vacuumModuleV1DockA4"
+            ),
+            OnModuleLocationSequenceComponent(moduleId="module-id"),
+            OnCutoutFixtureLocationSequenceComponent(
+                cutoutId="cutoutA4", possibleCutoutFixtureIds=["vacuumModuleV1"]
+            ),
+        ]
+    )
+
+    decoy.when(
+        await equipment.load_definition_for_details(
+            load_name="millipore_vacuum_manifold_collar_tall",
+            namespace="opentrons-test",
+            version=1,
+        )
+    ).then_return(
+        (well_plate_def, "opentrons-test/millipore_vacuum_manifold_collar_tall/1")
+    )
+
+    decoy.when(
+        state_view.geometry.ensure_location_not_occupied(
+            dock_location, None, well_plate_def
+        )
+    ).then_return(dock_location)
+
+    decoy.when(
+        await equipment._load_labware_from_def_and_uri(
+            well_plate_def,
+            "opentrons-test/millipore_vacuum_manifold_collar_tall/1",
+            dock_location,
+            None,
+            None,
+        )
+    ).then_return(
+        LoadedLabwareData(
+            labware_id="labware-id",
+            definition=well_plate_def,
+            offsetId=None,
+        )
+    )
+
+    decoy.when(
+        labware_validation.validate_definition_is_labware(well_plate_def)
+    ).then_return(True)
+
+    result = await subject.execute(data)
+
+    assert result == SuccessData(
+        public=LoadLabwareResult(
+            labwareId="labware-id",
+            definition=well_plate_def,
+            offsetId=None,
+            locationSequence=[
+                OnAddressableAreaLocationSequenceComponent(
+                    addressableAreaName="vacuumModuleV1DockA4"
+                ),
+                OnModuleLocationSequenceComponent(moduleId="module-id"),
+                OnCutoutFixtureLocationSequenceComponent(
+                    cutoutId="cutoutA4", possibleCutoutFixtureIds=["vacuumModuleV1"]
+                ),
+            ],
+        ),
+        state_update=StateUpdate(
+            loaded_labware=LoadedLabwareUpdate(
+                labware_id="labware-id",
+                definition=well_plate_def,
+                offset_id=None,
+                new_location=dock_location,
+                display_name=display_name,
+            ),
+            addressable_area_used=AddressableAreaUsedUpdate(
+                addressable_area_name="vacuumModuleV1DockA4"
+            ),
+        ),
+    )
+
+
+async def test_load_second_collar_on_first_collar_raises(
+    decoy: Decoy,
+    well_plate_def: LabwareDefinition,
+    equipment: EquipmentHandler,
+    state_view: StateView,
+) -> None:
+    """Stacking two collars (adapter on adapter) on the vacuum dock is not allowed."""
+    subject = LoadLabwareImplementation(equipment=equipment, state_view=state_view)
+
+    data = LoadLabwareParams(
+        location=OnLabwareLocation(labwareId="first-collar-id"),
+        loadName="millipore_vacuum_manifold_collar_tall",
+        namespace="opentrons-test",
+        version=1,
+        displayName=None,
+    )
+
+    decoy.when(
+        await equipment.load_definition_for_details(
+            load_name="millipore_vacuum_manifold_collar_tall",
+            namespace="opentrons-test",
+            version=1,
+        )
+    ).then_return(
+        (well_plate_def, "opentrons-test/millipore_vacuum_manifold_collar_tall/1")
+    )
+
+    decoy.when(
+        state_view.geometry.ensure_location_not_occupied(
+            OnLabwareLocation(labwareId="first-collar-id"), None, well_plate_def
+        )
+    ).then_raise(
+        LabwareIsNotAllowedInLocationError(
+            "Cannot stack two collars on the vacuum module dock"
+        )
+    )
+
+    with pytest.raises(LabwareIsNotAllowedInLocationError):
+        await subject.execute(data)
+
+
+async def test_load_labware_on_vacuum_dock_raises_if_incompatible(
+    decoy: Decoy,
+    well_plate_def: LabwareDefinition,
+    equipment: EquipmentHandler,
+    state_view: StateView,
+) -> None:
+    """It should raise when trying to load an incompatible labware on the vacuum dock."""
+    subject = LoadLabwareImplementation(equipment=equipment, state_view=state_view)
+
+    dock_location = AddressableAreaLocation(addressableAreaName="vacuumModuleV1DockA4")
+
+    data = LoadLabwareParams(
+        location=dock_location,
+        loadName="invitroven_filter_plate",
+        namespace="opentrons",
+        version=1,
+        displayName=None,
+    )
+
+    decoy.when(
+        await equipment.load_definition_for_details(
+            load_name="invitroven_filter_plate",
+            namespace="opentrons",
+            version=1,
+        )
+    ).then_return((well_plate_def, "opentrons-test/invitroven_filter_plate/1"))
+
+    decoy.when(
+        state_view.geometry.ensure_location_not_occupied(
+            dock_location, None, well_plate_def
+        )
+    ).then_raise(
+        LabwareIsNotAllowedInLocationError(
+            "This labware is not allowed on the vacuum module dock"
+        )
+    )
+
+    decoy.when(
+        await equipment._load_labware_from_def_and_uri(
+            well_plate_def,
+            "opentrons-test/invitroven_filter_plate/1",
+            dock_location,
+            None,
+            None,
+        )
+    ).then_return(
+        LoadedLabwareData(
+            labware_id="filter-id", definition=well_plate_def, offsetId=None
+        )
+    )
+
+    with pytest.raises(LabwareIsNotAllowedInLocationError):
+        await subject.execute(data)
+
+
+async def test_load_filter_plate_on_collar_which_is_on_vacuum_dock(
+    decoy: Decoy,
+    well_plate_def: LabwareDefinition,
+    equipment: EquipmentHandler,
+    state_view: StateView,
+) -> None:
+    """Loading a labware (filter plate) on top of a collar that is on the vacuum dock."""
+    subject = LoadLabwareImplementation(equipment=equipment, state_view=state_view)
+
+    collar_location = OnLabwareLocation(labwareId="collar-id")
+
+    data = LoadLabwareParams(
+        location=collar_location,
+        loadName="invitroven_filter_plate",
+        namespace="opentrons-test",
+        version=1,
+        displayName=None,
+    )
+
+    decoy.when(
+        state_view.geometry.get_predicted_location_sequence(collar_location)
+    ).then_return(
+        [
+            OnLabwareLocationSequenceComponent(labwareId="collar-id", lidId=None),
+            OnAddressableAreaLocationSequenceComponent(
+                addressableAreaName="vacuumModuleV1DockA4"
+            ),
+            OnModuleLocationSequenceComponent(moduleId="module-id"),
+            OnCutoutFixtureLocationSequenceComponent(
+                cutoutId="cutoutA4", possibleCutoutFixtureIds=["vacuumModuleV1"]
+            ),
+        ]
+    )
+
+    decoy.when(
+        await equipment.load_definition_for_details(
+            load_name="invitroven_filter_plate",
+            namespace="opentrons-test",
+            version=1,
+        )
+    ).then_return((well_plate_def, "opentrons-test/invitroven_filter_plate/1"))
+
+    decoy.when(
+        state_view.geometry.ensure_location_not_occupied(
+            collar_location, None, well_plate_def
+        )
+    ).then_return(OnLabwareLocation(labwareId="collar-id"))
+
+    decoy.when(
+        await equipment._load_labware_from_def_and_uri(
+            well_plate_def,
+            "opentrons-test/invitroven_filter_plate/1",
+            OnLabwareLocation(labwareId="collar-id"),
+            None,
+            None,
+        )
+    ).then_return(
+        LoadedLabwareData(
+            labware_id="filter-id", definition=well_plate_def, offsetId=None
+        )
+    )
+
+    decoy.when(
+        labware_validation.validate_definition_is_labware(well_plate_def)
+    ).then_return(True)
+
+    result = await subject.execute(data)
+
+    assert result == SuccessData(
+        public=LoadLabwareResult(
+            labwareId="filter-id",
+            definition=well_plate_def,
+            offsetId=None,
+            locationSequence=[
+                OnLabwareLocationSequenceComponent(labwareId="collar-id", lidId=None),
+                OnAddressableAreaLocationSequenceComponent(
+                    addressableAreaName="vacuumModuleV1DockA4"
+                ),
+                OnModuleLocationSequenceComponent(moduleId="module-id"),
+                OnCutoutFixtureLocationSequenceComponent(
+                    cutoutId="cutoutA4", possibleCutoutFixtureIds=["vacuumModuleV1"]
+                ),
+            ],
+        ),
+        state_update=StateUpdate(
+            loaded_labware=LoadedLabwareUpdate(
+                labware_id="filter-id",
+                definition=well_plate_def,
+                offset_id=None,
+                new_location=OnLabwareLocation(labwareId="collar-id"),
+                display_name=None,
+            )
+        ),
+    )
+
+
+async def test_load_black_plate_contained_inside_collar_on_same_vacuum_module(
+    decoy: Decoy,
+    well_plate_def: LabwareDefinition,
+    equipment: EquipmentHandler,
+    state_view: StateView,
+) -> None:
+    """Both the collar and the black plate are loaded directly on the vacuum module.
+
+    The plate is physically contained inside the collar's containedSpace.
+    Both share the same parent (the vacuum module).
+    """
+    subject = LoadLabwareImplementation(equipment=equipment, state_view=state_view)
+
+    module_location = ModuleLocation(moduleId="module-id")
+
+    data = LoadLabwareParams(
+        location=module_location,
+        loadName="corning_96_wellplate_360ul_flat",
+        namespace="opentrons",
+        version=1,
+        displayName=None,
+    )
+
+    # Expected location sequence for the plate (on module, contained by collar)
+    decoy.when(
+        state_view.geometry.get_predicted_location_sequence(module_location)
+    ).then_return(
+        [
+            OnModuleLocationSequenceComponent(moduleId="module-id"),
+            OnCutoutFixtureLocationSequenceComponent(
+                cutoutId="cutoutA4", possibleCutoutFixtureIds=["vacuumModuleV1"]
+            ),
+        ]
+    )
+
+    decoy.when(
+        await equipment.load_definition_for_details(
+            load_name="corning_96_wellplate_360ul_flat",
+            namespace="opentrons",
+            version=1,
+        )
+    ).then_return((well_plate_def, "opentrons/corning_96_wellplate_360ul_flat/1"))
+
+    decoy.when(
+        state_view.geometry.ensure_location_not_occupied(
+            module_location, None, well_plate_def
+        )
+    ).then_return(module_location)
+
+    decoy.when(
+        await equipment._load_labware_from_def_and_uri(
+            well_plate_def,
+            "opentrons/corning_96_wellplate_360ul_flat/1",
+            module_location,
+            None,
+            None,
+        )
+    ).then_return(
+        LoadedLabwareData(
+            labware_id="plate-id", definition=well_plate_def, offsetId=None
+        )
+    )
+
+    decoy.when(
+        labware_validation.validate_definition_is_labware(well_plate_def)
+    ).then_return(True)
+
+    result = await subject.execute(data)
+
+    assert result.public.labwareId == "plate-id"
+    assert result.public.locationSequence is not None
+    assert isinstance(result.public.locationSequence, OnModuleLocationSequenceComponent)
+    assert result.public.locationSequence[0].moduleId == "module-id"
+
+
+async def test_load_filter_plate_contained_inside_collar_on_vacuum_module(
+    decoy: Decoy,
+    well_plate_def: LabwareDefinition,
+    equipment: EquipmentHandler,
+    state_view: StateView,
+) -> None:
+    """Loading a labware contained inside a collar that is loaded directly on the vacuum module."""
+    subject = LoadLabwareImplementation(equipment=equipment, state_view=state_view)
+
+    # The plate is loaded on the collar
+    collar_location = OnLabwareLocation(labwareId="collar-id")
+
+    data = LoadLabwareParams(
+        location=collar_location,
+        loadName="invitroven_filter_plate",
+        namespace="opentrons-test",
+        version=1,
+        displayName=None,
+    )
+
+    # Expected location sequence: plate -> collar -> module -> cutout
+    decoy.when(
+        state_view.geometry.get_predicted_location_sequence(collar_location)
+    ).then_return(
+        [
+            OnLabwareLocationSequenceComponent(labwareId="collar-id", lidId=None),
+            OnModuleLocationSequenceComponent(moduleId="module-id"),
+            OnCutoutFixtureLocationSequenceComponent(
+                cutoutId="cutoutA4", possibleCutoutFixtureIds=["vacuumModuleV1"]
+            ),
+        ]
+    )
+
+    decoy.when(
+        await equipment.load_definition_for_details(
+            load_name="invitroven_filter_plate",
+            namespace="opentrons-test",
+            version=1,
+        )
+    ).then_return((well_plate_def, "opentrons-test/invitroven_filter_plate/1"))
+
+    decoy.when(
+        state_view.geometry.ensure_location_not_occupied(
+            collar_location, None, well_plate_def
+        )
+    ).then_return(collar_location)
+
+    decoy.when(
+        await equipment._load_labware_from_def_and_uri(
+            well_plate_def,
+            "opentrons-test/invitroven_filter_plate/1",
+            collar_location,
+            None,
+            None,
+        )
+    ).then_return(
+        LoadedLabwareData(
+            labware_id="filter-id", definition=well_plate_def, offsetId=None
+        )
+    )
+
+    decoy.when(
+        labware_validation.validate_definition_is_labware(well_plate_def)
+    ).then_return(True)
+
+    result = await subject.execute(data)
+
+    assert result.public.labwareId == "filter-id"
+
+    # Verify containment chain: plate is on collar, both share vacuum module as parent
+    sequence = result.public.locationSequence
+    assert sequence is not None
+    assert isinstance(sequence[0], OnLabwareLocationSequenceComponent)
+    assert sequence[0].labwareId == "collar-id"  # plate is on collar
+    assert isinstance(sequence[1], ModuleLocation)
+    assert sequence[1].moduleId == "module-id"  # collar and plate are on module
+    assert isinstance(sequence[2], OnCutoutFixtureLocationSequenceComponent)
+    assert sequence[2].cutoutId == "cutoutA4"  # module on cutout

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -668,7 +668,9 @@ async def test_load_black_plate_contained_inside_collar_on_same_vacuum_module(
 
     assert result.public.labwareId == "plate-id"
     assert result.public.locationSequence is not None
-    assert isinstance(result.public.locationSequence, OnModuleLocationSequenceComponent)
+    assert isinstance(
+        result.public.locationSequence[0], OnModuleLocationSequenceComponent
+    )
     assert result.public.locationSequence[0].moduleId == "module-id"
 
 
@@ -746,7 +748,7 @@ async def test_load_filter_plate_contained_inside_collar_on_vacuum_module(
     assert sequence is not None
     assert isinstance(sequence[0], OnLabwareLocationSequenceComponent)
     assert sequence[0].labwareId == "collar-id"  # plate is on collar
-    assert isinstance(sequence[1], ModuleLocation)
+    assert isinstance(sequence[1], OnModuleLocationSequenceComponent)
     assert sequence[1].moduleId == "module-id"  # collar and plate are on module
     assert isinstance(sequence[2], OnCutoutFixtureLocationSequenceComponent)
     assert sequence[2].cutoutId == "cutoutA4"  # module on cutout

--- a/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_load_labware.py
@@ -86,16 +86,25 @@ async def test_load_labware_on_slot_or_addressable_area(
         ]
     )
 
-    decoy.when(state_view.geometry.ensure_location_not_occupied(location)).then_return(
-        sentinel.validated_empty_location
-    )
     decoy.when(
-        await equipment.load_labware(
-            location=sentinel.validated_empty_location,
+        await equipment.load_definition_for_details(
             load_name="some-load-name",
             namespace="opentrons-test",
             version=1,
-            labware_id=None,
+        )
+    ).then_return((well_plate_def, "opentrons-test/some-load-name/1"))
+
+    decoy.when(
+        state_view.geometry.ensure_location_not_occupied(location, None, well_plate_def)
+    ).then_return(sentinel.validated_empty_location)
+
+    decoy.when(
+        await equipment._load_labware_from_def_and_uri(
+            well_plate_def,
+            "opentrons-test/some-load-name/1",
+            sentinel.validated_empty_location,
+            None,
+            None,
         )
     ).then_return(
         LoadedLabwareData(
@@ -177,17 +186,26 @@ async def test_load_labware_on_labware(
     )
 
     decoy.when(
-        state_view.geometry.ensure_location_not_occupied(
-            OnLabwareLocation(labwareId="other-labware-id")
-        )
-    ).then_return(OnLabwareLocation(labwareId="another-labware-id"))
-    decoy.when(
-        await equipment.load_labware(
-            location=OnLabwareLocation(labwareId="another-labware-id"),
+        await equipment.load_definition_for_details(
             load_name="some-load-name",
             namespace="opentrons-test",
             version=1,
-            labware_id=None,
+        )
+    ).then_return((well_plate_def, "opentrons-test/some-load-name/1"))
+
+    decoy.when(
+        state_view.geometry.ensure_location_not_occupied(
+            OnLabwareLocation(labwareId="other-labware-id"), None, well_plate_def
+        )
+    ).then_return(OnLabwareLocation(labwareId="another-labware-id"))
+
+    decoy.when(
+        await equipment._load_labware_from_def_and_uri(
+            well_plate_def,
+            "opentrons-test/some-load-name/1",
+            OnLabwareLocation(labwareId="another-labware-id"),
+            None,
+            None,
         )
     ).then_return(
         LoadedLabwareData(
@@ -262,8 +280,16 @@ async def test_load_labware_raises_if_location_occupied(
     )
 
     decoy.when(
+        await equipment.load_definition_for_details(
+            load_name="some-load-name",
+            namespace="opentrons-test",
+            version=1,
+        )
+    ).then_return((well_plate_def, "opentrons-test/some-load-name/1"))
+
+    decoy.when(
         state_view.geometry.ensure_location_not_occupied(
-            DeckSlotLocation(slotName=DeckSlotName.SLOT_3)
+            DeckSlotLocation(slotName=DeckSlotName.SLOT_3), None, well_plate_def
         )
     ).then_raise(LocationIsOccupiedError("Get your own spot!"))
 

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -16,6 +16,7 @@ from opentrons_shared_data.errors.exceptions import (
 from opentrons_shared_data.gripper.constants import GRIPPER_PADDLE_WIDTH
 from opentrons_shared_data.labware.labware_definition import (
     Dimensions,
+    LabwareDefinition,
     LabwareDefinition2,
     Parameters2,
 )
@@ -92,6 +93,7 @@ def subject(
 )
 async def test_manual_move_labware_implementation(
     decoy: Decoy,
+    well_plate_def: LabwareDefinition,
     subject: MoveLabwareImplementation,
     equipment: EquipmentHandler,
     state_view: StateView,
@@ -116,9 +118,13 @@ async def test_manual_move_labware_implementation(
             offsetId=None,
         )
     )
+    lw_def = LabwareDefinition2.model_construct(namespace="opentrons-test")  # type: ignore[call-arg]
+    decoy.when(
+        state_view.labware.get_definition(labware_id="my-cool-labware-id")
+    ).then_return(lw_def)
     decoy.when(
         state_view.geometry.ensure_location_not_occupied(
-            location=DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
+            DeckSlotLocation(slotName=DeckSlotName.SLOT_4),
         )
     ).then_return(DeckSlotLocation(slotName=DeckSlotName.SLOT_5))
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -19,6 +19,8 @@ from opentrons_shared_data.labware import load_definition as load_labware_defini
 from opentrons_shared_data.labware.labware_definition import (
     AxisAlignedBoundingBox3D,
     ConicalFrustum,
+    ContainedSpace,
+    ContainmentShape,
     CuboidalFrustum,
     Extents,
     InnerWellGeometry,
@@ -5021,3 +5023,643 @@ def test_get_parent_from_location_raises_when_not_on_deck(
 
     with pytest.raises(errors.LabwareNotOnDeckError):
         subject.get_parent_from_location(SYSTEM_LOCATION)
+
+
+@pytest.mark.parametrize("use_mocks", [False])
+def test_ensure_location_not_occupied_containment_success_collar_and_plate_on_module(
+    labware_store: LabwareStore,
+    module_store: ModuleStore,
+    addressable_area_store: AddressableAreaStore,
+    subject: GeometryView,
+    vacuum_module_v1_def: ModuleDefinition,
+    nice_labware_definition: LabwareDefinition,
+) -> None:
+    """Plate fits inside collar's containedSpace when both are on the same vacuum module."""
+    load_module = load_module_action(
+        module_id="mod-1",
+        module_def=vacuum_module_v1_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
+        used_addressable_area="vacuumModuleV1A3",
+    )
+
+    collar_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "millipore_vacuum_manifold_collar_tall"}
+            ),
+            "containedSpace": ContainedSpace(
+                shape=ContainmentShape.rectangular,
+                origin=Vector3D(x=0, y=0, z=0),
+                dimensions=LabwareDimensions(
+                    xDimension=90, yDimension=60, zDimension=20
+                ),
+            ),
+        }
+    )
+
+    load_collar = load_labware_action(
+        labware_id="collar-id",
+        labware_def=collar_def,
+        location=ModuleLocation(moduleId="mod-1"),
+    )
+
+    plate_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "corning_96_wellplate_360ul_flat"}
+            ),
+            "dimensions": LabwareDimensions(
+                xDimension=85, yDimension=55, zDimension=15
+            ),
+        }
+    )
+
+    module_store.handle_action(load_module)
+    addressable_area_store.handle_action(load_module)
+    labware_store.handle_action(load_collar)
+
+    # Should succeed because plate fits inside collar's containedSpace
+    result = subject.ensure_location_not_occupied(
+        location=ModuleLocation(moduleId="mod-1"),
+        labware_definition=plate_def,
+    )
+
+    assert result == ModuleLocation(moduleId="mod-1")
+
+
+@pytest.mark.parametrize("use_mocks", [False])
+def test_ensure_location_not_occupied_containment_failure_plate_too_big(
+    labware_store: LabwareStore,
+    module_store: ModuleStore,
+    addressable_area_store: AddressableAreaStore,
+    subject: GeometryView,
+    vacuum_module_v1_def: ModuleDefinition,
+    nice_labware_definition: LabwareDefinition,
+) -> None:
+    """Raise if plate does not fit inside collar's containedSpace on the same module."""
+    load_module = load_module_action(
+        module_id="mod-1",
+        module_def=vacuum_module_v1_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
+        used_addressable_area="vacuumModuleV1A3",
+    )
+
+    collar_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "millipore_vacuum_manifold_collar_tall"}
+            ),
+            "containedSpace": ContainedSpace(
+                shape=ContainmentShape.rectangular,
+                origin=Vector3D(x=0, y=0, z=0),
+                dimensions=LabwareDimensions(
+                    xDimension=80, yDimension=50, zDimension=10
+                ),
+            ),
+        }
+    )
+
+    load_collar = load_labware_action(
+        labware_id="collar-id",
+        labware_def=collar_def,
+        location=ModuleLocation(moduleId="mod-1"),
+    )
+
+    big_plate_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "corning_96_wellplate_360ul_flat"}
+            ),
+            "dimensions": LabwareDimensions(
+                xDimension=85, yDimension=55, zDimension=15
+            ),
+        }
+    )
+
+    module_store.handle_action(load_module)
+    addressable_area_store.handle_action(load_module)
+    labware_store.handle_action(load_collar)
+
+    with pytest.raises(errors.LabwareIsNotAllowedInLocationError, match="does not fit"):
+        subject.ensure_location_not_occupied(
+            location=ModuleLocation(moduleId="mod-1"),
+            labware_definition=big_plate_def,
+        )
+
+
+@pytest.mark.parametrize("use_mocks", [False])
+def test_ensure_location_not_occupied_containment_no_siblings(
+    labware_store: LabwareStore,
+    module_store: ModuleStore,
+    addressable_area_store: AddressableAreaStore,
+    subject: GeometryView,
+    vacuum_module_v1_def: ModuleDefinition,
+    nice_labware_definition: LabwareDefinition,
+) -> None:
+    """No error when loading on module with no siblings (standard case)."""
+    load_module = load_module_action(
+        module_id="mod-1",
+        module_def=vacuum_module_v1_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
+        used_addressable_area="vacuumModuleV1A3",
+    )
+
+    plate_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "test-plate"}
+            )
+        }
+    )
+
+    module_store.handle_action(load_module)
+    addressable_area_store.handle_action(load_module)
+
+    result = subject.ensure_location_not_occupied(
+        location=ModuleLocation(moduleId="mod-1"),
+        labware_definition=plate_def,
+    )
+
+    assert result == ModuleLocation(moduleId="mod-1")
+
+
+@pytest.mark.parametrize("use_mocks", [False])
+def test_ensure_location_not_occupied_containment_stacked_success_plate_inside_collar(
+    labware_store: LabwareStore,
+    module_store: ModuleStore,
+    addressable_area_store: AddressableAreaStore,
+    subject: GeometryView,
+    vacuum_module_v1_def: ModuleDefinition,
+    nice_labware_definition: LabwareDefinition,
+) -> None:
+    """Plate is loaded directly on the same bottom labware as a collar (stacked siblings).
+
+    The plate fits inside the collar's containedSpace → success.
+    """
+    load_module = load_module_action(
+        module_id="mod-1",
+        module_def=vacuum_module_v1_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
+        used_addressable_area="vacuumModuleV1A3",
+    )
+
+    collar_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "millipore_vacuum_manifold_collar_tall"}
+            ),
+            "containedSpace": ContainedSpace(
+                shape=ContainmentShape.rectangular,
+                origin=Vector3D(x=0, y=0, z=0),
+                dimensions=LabwareDimensions(
+                    xDimension=90, yDimension=60, zDimension=20
+                ),
+            ),
+        }
+    )
+
+    # Bottom labware that both collar and plate will stack on
+    bottom_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "bottom-plate"}
+            )
+        }
+    )
+    load_bottom = load_labware_action(
+        labware_id="bottom-id",
+        labware_def=bottom_def,
+        location=ModuleLocation(moduleId="mod-1"),
+    )
+
+    load_collar = load_labware_action(
+        labware_id="collar-id",
+        labware_def=collar_def,
+        location=OnLabwareLocation(labwareId="bottom-id"),
+    )
+
+    plate_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "corning_96_wellplate_360ul_flat"}
+            ),
+            "dimensions": LabwareDimensions(
+                xDimension=85, yDimension=55, zDimension=15
+            ),
+        }
+    )
+
+    module_store.handle_action(load_module)
+    addressable_area_store.handle_action(load_module)
+    labware_store.handle_action(load_bottom)
+    labware_store.handle_action(load_collar)
+
+    # Plate loaded on same parent as collar → sibling containment check
+    result = subject.ensure_location_not_occupied(
+        location=OnLabwareLocation(labwareId="bottom-id"),
+        labware_definition=plate_def,
+    )
+
+    assert result == OnLabwareLocation(labwareId="bottom-id")
+
+
+@pytest.mark.parametrize("use_mocks", [False])
+def test_ensure_location_not_occupied_containment_stacked_failure_plate_too_big_for_collar(
+    labware_store: LabwareStore,
+    module_store: ModuleStore,
+    addressable_area_store: AddressableAreaStore,
+    subject: GeometryView,
+    vacuum_module_v1_def: ModuleDefinition,
+    nice_labware_definition: LabwareDefinition,
+) -> None:
+    """Plate is too big for the collar's containedSpace when both are stacked on the same bottom labware."""
+    load_module = load_module_action(
+        module_id="mod-1",
+        module_def=vacuum_module_v1_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
+        used_addressable_area="vacuumModuleV1A3",
+    )
+
+    collar_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "millipore_vacuum_manifold_collar_tall"}
+            ),
+            "containedSpace": ContainedSpace(
+                shape=ContainmentShape.rectangular,
+                origin=Vector3D(x=0, y=0, z=0),
+                dimensions=LabwareDimensions(
+                    xDimension=80, yDimension=50, zDimension=10
+                ),
+            ),
+        }
+    )
+
+    bottom_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "bottom-plate"}
+            )
+        }
+    )
+    load_bottom = load_labware_action(
+        labware_id="bottom-id",
+        labware_def=bottom_def,
+        location=ModuleLocation(moduleId="mod-1"),
+    )
+
+    load_collar = load_labware_action(
+        labware_id="collar-id",
+        labware_def=collar_def,
+        location=OnLabwareLocation(labwareId="bottom-id"),
+    )
+
+    big_plate_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "corning_96_wellplate_360ul_flat"}
+            ),
+            "dimensions": LabwareDimensions(
+                xDimension=85, yDimension=55, zDimension=15
+            ),
+        }
+    )
+
+    module_store.handle_action(load_module)
+    addressable_area_store.handle_action(load_module)
+    labware_store.handle_action(load_bottom)
+    labware_store.handle_action(load_collar)
+
+    with pytest.raises(errors.LabwareIsNotAllowedInLocationError, match="does not fit"):
+        subject.ensure_location_not_occupied(
+            location=OnLabwareLocation(labwareId="bottom-id"),
+            labware_definition=big_plate_def,
+        )
+
+
+@pytest.mark.parametrize("use_mocks", [False])
+def test_ensure_location_not_occupied_containment_stacked_no_siblings(
+    labware_store: LabwareStore,
+    subject: GeometryView,
+    nice_labware_definition: LabwareDefinition,
+) -> None:
+    """Standard stacking case with no siblings — no containment check needed."""
+    bottom_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "bottom-plate"}
+            )
+        }
+    )
+    load_bottom = load_labware_action(
+        labware_id="bottom-id",
+        labware_def=bottom_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_C2),
+    )
+
+    plate_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "test-plate"}
+            )
+        }
+    )
+
+    labware_store.handle_action(load_bottom)
+
+    result = subject.ensure_location_not_occupied(
+        location=OnLabwareLocation(labwareId="bottom-id"),
+        labware_definition=plate_def,
+    )
+
+    assert result == OnLabwareLocation(labwareId="bottom-id")
+
+
+@pytest.mark.parametrize("use_mocks", [False])
+def test_ensure_location_not_occupied_containment_true_stacking_plate_on_collar(
+    labware_store: LabwareStore,
+    module_store: ModuleStore,
+    addressable_area_store: AddressableAreaStore,
+    subject: GeometryView,
+    vacuum_module_v1_def: ModuleDefinition,
+    nice_labware_definition: LabwareDefinition,
+) -> None:
+    """Plate is stacked directly ON the collar (true OnLabwareLocation stacking).
+
+    The plate fits inside the collar's containedSpace → success.
+    """
+    load_module = load_module_action(
+        module_id="mod-1",
+        module_def=vacuum_module_v1_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
+        used_addressable_area="vacuumModuleV1A3",
+    )
+
+    collar_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "millipore_vacuum_manifold_collar_tall"}
+            ),
+            "containedSpace": ContainedSpace(
+                shape=ContainmentShape.rectangular,
+                origin=Vector3D(x=0, y=0, z=0),
+                dimensions=LabwareDimensions(
+                    xDimension=90, yDimension=60, zDimension=20
+                ),
+            ),
+        }
+    )
+
+    load_collar = load_labware_action(
+        labware_id="collar-id",
+        labware_def=collar_def,
+        location=ModuleLocation(moduleId="mod-1"),
+    )
+
+    plate_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "corning_96_wellplate_360ul_flat"}
+            ),
+            "dimensions": LabwareDimensions(
+                xDimension=85, yDimension=55, zDimension=15
+            ),
+        }
+    )
+
+    module_store.handle_action(load_module)
+    addressable_area_store.handle_action(load_module)
+    labware_store.handle_action(load_collar)
+
+    # Plate is now stacked directly on the collar
+    result = subject.ensure_location_not_occupied(
+        location=OnLabwareLocation(labwareId="collar-id"),
+        labware_definition=plate_def,
+    )
+
+    assert result == OnLabwareLocation(labwareId="collar-id")
+
+
+@pytest.mark.parametrize("use_mocks", [False])
+def test_ensure_location_not_occupied_containment_container_over_resident(
+    labware_store: LabwareStore,
+    module_store: ModuleStore,
+    addressable_area_store: AddressableAreaStore,
+    subject: GeometryView,
+    vacuum_module_v1_def: ModuleDefinition,
+    nice_labware_definition: LabwareDefinition,
+) -> None:
+    """Loading a collar (container) over an existing plate (resident) on the same module.
+
+    The resident must fit inside the new container's containedSpace.
+    """
+    load_module = load_module_action(
+        module_id="mod-1",
+        module_def=vacuum_module_v1_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
+        used_addressable_area="vacuumModuleV1A3",
+    )
+
+    plate_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "corning_96_wellplate_360ul_flat"}
+            ),
+            "dimensions": LabwareDimensions(
+                xDimension=85, yDimension=55, zDimension=15
+            ),
+        }
+    )
+    load_plate = load_labware_action(
+        labware_id="plate-id",
+        labware_def=plate_def,
+        location=ModuleLocation(moduleId="mod-1"),
+    )
+
+    collar_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "millipore_vacuum_manifold_collar_tall"}
+            ),
+            "containedSpace": ContainedSpace(
+                shape=ContainmentShape.rectangular,
+                origin=Vector3D(x=0, y=0, z=0),
+                dimensions=LabwareDimensions(
+                    xDimension=90, yDimension=60, zDimension=20
+                ),
+            ),
+        }
+    )
+
+    module_store.handle_action(load_module)
+    addressable_area_store.handle_action(load_module)
+    labware_store.handle_action(load_plate)
+
+    # Collar is the new container being loaded over the existing resident plate
+    result = subject.ensure_location_not_occupied(
+        location=ModuleLocation(moduleId="mod-1"),
+        labware_definition=collar_def,
+    )
+
+    assert result == ModuleLocation(moduleId="mod-1")
+
+
+@pytest.mark.parametrize("use_mocks", [False])
+def test_ensure_location_not_occupied_containment_no_contained_space_fallback(
+    labware_store: LabwareStore,
+    subject: GeometryView,
+    nice_labware_definition: LabwareDefinition,
+) -> None:
+    """Standard stacking on deck slot with no containedSpace involved (falls back to normal occupancy check)."""
+    bottom_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "bottom-plate"}
+            )
+        }
+    )
+    load_bottom = load_labware_action(
+        labware_id="bottom-id",
+        labware_def=bottom_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_C2),
+    )
+
+    plate_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "test-plate"}
+            )
+        }
+    )
+
+    labware_store.handle_action(load_bottom)
+
+    result = subject.ensure_location_not_occupied(
+        location=OnLabwareLocation(labwareId="bottom-id"),
+        labware_definition=plate_def,
+    )
+
+    assert result == OnLabwareLocation(labwareId="bottom-id")
+
+
+@pytest.mark.parametrize("use_mocks", [False])
+def test_ensure_location_not_occupied_containment_non_zero_origin_success(
+    labware_store: LabwareStore,
+    module_store: ModuleStore,
+    addressable_area_store: AddressableAreaStore,
+    subject: GeometryView,
+    vacuum_module_v1_def: ModuleDefinition,
+    nice_labware_definition: LabwareDefinition,
+) -> None:
+    """ContainedSpace can have a non-zero origin. The resident must fit inside the offset box."""
+    load_module = load_module_action(
+        module_id="mod-1",
+        module_def=vacuum_module_v1_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
+        used_addressable_area="vacuumModuleV1A3",
+    )
+
+    # Collar with containedSpace offset from local (0,0,0)
+    collar_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "millipore_vacuum_manifold_collar_tall"}
+            ),
+            "containedSpace": ContainedSpace(
+                shape=ContainmentShape.rectangular,
+                origin=Vector3D(x=5.0, y=8.0, z=2.0),  # non-zero origin
+                dimensions=LabwareDimensions(
+                    xDimension=85, yDimension=55, zDimension=18
+                ),
+            ),
+        }
+    )
+
+    load_collar = load_labware_action(
+        labware_id="collar-id",
+        labware_def=collar_def,
+        location=ModuleLocation(moduleId="mod-1"),
+    )
+
+    # Plate that fits inside the *offset* contained space
+    plate_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "corning_96_wellplate_360ul_flat"}
+            ),
+            "dimensions": LabwareDimensions(
+                xDimension=78, yDimension=48, zDimension=14
+            ),
+        }
+    )
+
+    module_store.handle_action(load_module)
+    addressable_area_store.handle_action(load_module)
+    labware_store.handle_action(load_collar)
+
+    result = subject.ensure_location_not_occupied(
+        location=ModuleLocation(moduleId="mod-1"),
+        labware_definition=plate_def,
+    )
+
+    assert result == ModuleLocation(moduleId="mod-1")
+
+
+@pytest.mark.parametrize("use_mocks", [False])
+def test_ensure_location_not_occupied_containment_non_zero_origin_failure(
+    labware_store: LabwareStore,
+    module_store: ModuleStore,
+    addressable_area_store: AddressableAreaStore,
+    subject: GeometryView,
+    vacuum_module_v1_def: ModuleDefinition,
+    nice_labware_definition: LabwareDefinition,
+) -> None:
+    """Plate does not fit inside containedSpace when origin is non-zero."""
+    load_module = load_module_action(
+        module_id="mod-1",
+        module_def=vacuum_module_v1_def,
+        location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A3),
+        used_addressable_area="vacuumModuleV1A3",
+    )
+
+    collar_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "millipore_vacuum_manifold_collar_tall"}
+            ),
+            "containedSpace": ContainedSpace(
+                shape=ContainmentShape.rectangular,
+                origin=Vector3D(x=5.0, y=8.0, z=2.0),  # non-zero origin
+                dimensions=LabwareDimensions(
+                    xDimension=80, yDimension=50, zDimension=10
+                ),
+            ),
+        }
+    )
+
+    load_collar = load_labware_action(
+        labware_id="collar-id",
+        labware_def=collar_def,
+        location=ModuleLocation(moduleId="mod-1"),
+    )
+
+    big_plate_def = nice_labware_definition.model_copy(
+        update={
+            "parameters": nice_labware_definition.parameters.model_copy(
+                update={"loadName": "corning_96_wellplate_360ul_flat"}
+            ),
+            "dimensions": LabwareDimensions(
+                xDimension=85, yDimension=55, zDimension=15
+            ),
+        }
+    )
+
+    module_store.handle_action(load_module)
+    addressable_area_store.handle_action(load_module)
+    labware_store.handle_action(load_collar)
+
+    with pytest.raises(errors.LabwareIsNotAllowedInLocationError, match="does not fit"):
+        subject.ensure_location_not_occupied(
+            location=ModuleLocation(moduleId="mod-1"),
+            labware_definition=big_plate_def,
+        )

--- a/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_geometry_view.py
@@ -2839,9 +2839,20 @@ def test_ensure_location_not_occupied_raises(
     """It should raise error when labware is present in given location."""
     slot_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_4)
     # Shouldn't raise if neither labware nor module in location
+    decoy.when(mock_labware_view.get_all()).then_return([])
     assert subject.ensure_location_not_occupied(location=slot_location) == slot_location
 
     # Raise if labware in location
+    decoy.when(mock_labware_view.get_all()).then_return(
+        [
+            LoadedLabware(
+                id="some-id",
+                loadName="some-name",
+                definitionUri="1234",
+                location=slot_location,
+            )
+        ]
+    )
     decoy.when(
         mock_labware_view.raise_if_labware_in_location(slot_location)
     ).then_raise(errors.LocationIsOccupiedError("Woops!"))


### PR DESCRIPTION
# Overview

Pr had to be re-created, I accidentally closed the original [Opentrons/opentrons#21299](https://github.com/Opentrons/opentrons/pull/21299)

This PR adds initial support in the load_labware protocol engine command for loading the Millipore vacuum manifold collar onto the vacuum module’s private staging dock. It introduces the foundational labware containment functionality needed to support nested workflows with the vacuum module.

### The vacuumModuleV1 provides two distinct addressable areas:

- vacuumModuleV1A3 — the main module base area
- vacuumModuleV1DockA4 — the private staging dock

This design allows labware to be loaded or moved to either location independently. With the new labware containment feature, an addressable area can hold multiple pieces of labware as long as their geometries do not collide. There are two kinds of relationships:

Parent relationship (-->) — normal loading/stacking (labware is placed on something)
Contained relationship (-.->) — geometric containment via `containedSpace` (labware sits inside another labware)

In the example below, you can see
- On the left, `Collar1` is loaded on the main module area (`vacuumModuleV1`). It contains the `plate` Labware inside its `containedSpace`, while also having `filter_plate1` Labware stacked on top of it at the same time.
- On the right, `Collar2` is loaded on the (`vacuumModuleV1DockA4`) addressable area, and then `filter_plate2` is loaded on top of the `Collar2` adapter.
- Both of these share the `vacuumModuleV1` Module and `CutoutFixture` parent location.

```mermaid
graph TD;

    Labware:filter_plate2-->|parent|Adapter:Collar2;
    Adapter:Collar2-->|parent|AddressableArea:vacuumModuleV1DockA4;
    Labware:filter_plate1-->|parent|Adapter:Collar1;
    Labware:plate-.->|contained|Adapter:Collar1;
    Labware:plate-->|parent|AddressableArea:vacuumModuleV1A3;
    Adapter:Collar1-->|parent|AddressableArea:vacuumModuleV1A3;
    AddressableArea:vacuumModuleV1A3-->|parent|Module:vacuumModuleV1;
    AddressableArea:vacuumModuleV1DockA4-->|parent|Module:vacuumModuleV1;
    Module:vacuumModuleV1-->|parent|CutoutFixture;
```

## Test Plan and Hands on Testing

The following protocol should simulate

```python
from opentrons.protocol_api import ProtocolContext

"""Load Vacuum Module."""

metadata = {
    "protocolName": "Vacuum Module API",
    "author": "Opentrons <protocols@opentrons.com>",
}
requirements = {
    "robotType": "Flex",
    "apiLevel": "2.28",
}

def run(ctx: ProtocolContext) -> None:
    """Protocol."""

    vm_mod = ctx.load_module( module_name="vacuumModuleV1", location="A3")
    black_flat_plate = vm_mod.load_labware("corning_96_wellplate_360ul_flat")
    manifold_collar = vm_mod.load_adapter('millipore_vacuum_manifold_collar_tall')
    white_filter_plate = manifold_collar.load_labware("invitroven_filter_plate")

```

## Changelog

- Added load_adapter_to_dock() method on VacuumModuleContext to conveniently load compatible adapters (such as the manifold collar) directly onto the dock.
- Introduced early labware containment support in the API layer to allow loading labware inside adapters that define `containedSpace`.
- Enabled loading the `millipore_vacuum_manifold_collar_tall` onto the vacuum module dock (location "A4" on Flex).
- Updated protocol execution flow to support collar + filter plate nesting scenarios.
- Minor updates to labware loading logic to handle the new dock addressable area.

## Review requests
## Risk assessment
