### PR TITLE
fix(step-generation): omit all 1ch pipettes from collision detection

### DIFF
--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -350,11 +350,11 @@ export const getIsSafePipetteMovement = (args: {
   const robotType = isFlexPipette ? FLEX_ROBOT_TYPE : OT2_ROBOT_TYPE
 
   const deckDefinition = getDeckDefFromRobotType(robotType)
-  //  early exit if labwareId is a trashBin or wasteChute or if no well name is provided or if 1ch OT-2 pipette
+  //  early exit if labwareId is a trashBin or wasteChute or if no well name is provided or if 1ch pipette
   if (
     labwareEntities[labwareId] == null ||
     wellTargetName == null ||
-    (channels === 1 && robotType === OT2_ROBOT_TYPE)
+    (channels === 1)
   ) {
     return true
   }

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -354,7 +354,7 @@ export const getIsSafePipetteMovement = (args: {
   if (
     labwareEntities[labwareId] == null ||
     wellTargetName == null ||
-    (channels === 1)
+    channels === 1
   ) {
     return true
   }


### PR DESCRIPTION
# Overview

Remove collision detection for 1ch pipettes. This reverts back to original behavior, where if the pipette was using all of its nozzles, we would not check if it was going to collide with anything.

## Test Plan and Hands on Testing

smoke tested using protocol and no collision risk was detected
[bingo.py](https://github.com/user-attachments/files/27209640/bingo.py)

## Changelog

- remove special casing for OT-2 pipette

## Review requests

## Risk assessment
- low - goes back to original behavior
Riskier for if at sometime point in the future we add a really big single channel pipette