### PR TITLE
fix(app): fix labware offset screen spacing issue

### DIFF
--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/SetupOffsetsHeader.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/SetupOffsetsHeader.tsx
@@ -1,13 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { css } from 'styled-components'
 
-import {
-  Chip,
-  Flex,
-  JUSTIFY_SPACE_BETWEEN,
-  SPACING,
-} from '@opentrons/components'
+import { Chip, SPACING } from '@opentrons/components'
 
 import { SmallButton } from '/app/atoms/buttons'
 import { ODDBackButton } from '/app/molecules/ODDBackButton'
@@ -17,6 +11,8 @@ import {
   selectIsAnyNecessaryDefaultOffsetMissing,
 } from '/app/redux/protocol-runs'
 import { useUpdateClientLPC } from '/app/resources/client_data'
+
+import styles from './setupoffsetsheader.module.css'
 
 import type { ProtocolSetupOffsetsProps } from '/app/organisms/ODD/ProtocolSetup'
 
@@ -42,7 +38,7 @@ export function SetupOffsetsHeader({
   }
 
   return (
-    <Flex css={CONTAINER_STYLE}>
+    <div className={styles.header_container}>
       <ODDBackButton
         label={t('labware_offsets')}
         onClick={() => {
@@ -67,11 +63,6 @@ export function SetupOffsetsHeader({
           padding={`${SPACING.spacing16} ${SPACING.spacing24}`}
         />
       )}
-    </Flex>
+    </div>
   )
 }
-
-const CONTAINER_STYLE = css`
-  justify-content: ${JUSTIFY_SPACE_BETWEEN};
-  padding: ${SPACING.spacing32} ${SPACING.spacing40};
-`

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/SetupOffsetsTable.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/SetupOffsetsTable.tsx
@@ -1,13 +1,6 @@
-import { css } from 'styled-components'
-
-import {
-  ALIGN_CENTER,
-  Flex,
-  JUSTIFY_CENTER,
-  SPACING,
-} from '@opentrons/components'
-
 import { LabwareOffsetsTable } from '/app/organisms/LabwareOffsetsTable'
+
+import styles from './setupoffsetstable.module.css'
 
 import type { ProtocolSetupOffsetsProps } from '/app/organisms/ODD/ProtocolSetup'
 
@@ -15,14 +8,8 @@ export function SetupOffsetsTable(
   props: ProtocolSetupOffsetsProps
 ): JSX.Element {
   return (
-    <Flex css={TABLE_CONTAINER_STYLE}>
+    <div className={styles.table_container}>
       <LabwareOffsetsTable {...props} />
-    </Flex>
+    </div>
   )
 }
-
-const TABLE_CONTAINER_STYLE = css`
-  padding: ${SPACING.spacing32} ${SPACING.spacing60};
-  align-items: ${ALIGN_CENTER};
-  justify-content: ${JUSTIFY_CENTER};
-`

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/index.tsx
@@ -1,11 +1,10 @@
 import { useTranslation } from 'react-i18next'
 
-import { DIRECTION_COLUMN, Flex } from '@opentrons/components'
-
 import { FloatingActionButton } from '/app/atoms/buttons'
 import { LPCFlows } from '/app/organisms/LabwarePositionCheck'
 import { useToaster } from '/app/organisms/ToasterOven'
 
+import styles from './protocolsetupoffsets.module.css'
 import { SetupOffsetsHeader } from './SetupOffsetsHeader'
 import { SetupOffsetsTable } from './SetupOffsetsTable'
 
@@ -44,7 +43,7 @@ export function ProtocolSetupOffsets(
       {showLPC ? (
         <LPCFlows {...lpcProps} />
       ) : (
-        <Flex flexDirection={DIRECTION_COLUMN} width="98vw">
+        <div className={styles.setup_offset_container}>
           <SetupOffsetsHeader {...props} />
           <SetupOffsetsTable {...props} />
           <FloatingActionButton
@@ -52,7 +51,7 @@ export function ProtocolSetupOffsets(
             iconName="reticle"
             onClick={onLPCLaunchClick}
           />
-        </Flex>
+        </div>
       )}
     </>
   )

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/protocolsetupoffsets.module.css
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/protocolsetupoffsets.module.css
@@ -1,0 +1,5 @@
+.setup_offset_container {
+  display: flex;
+  width: 98vw;
+  flex-direction: column;
+}

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/setupoffsetsheader.module.css
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/setupoffsetsheader.module.css
@@ -1,0 +1,5 @@
+.header_container {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--spacing-32) var(--spacing-40);
+}

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/setupoffsetstable.module.css
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupOffsets/setupoffsetstable.module.css
@@ -1,0 +1,6 @@
+.table_container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 var(--spacing-60) var(--spacing-32);
+}


### PR DESCRIPTION
# Overview
fix labware offset screen spacing issue and remove `styled-components`

design
https://www.figma.com/design/0kuPeCi1t2Auu2GPMnqRb2/Primary--Flex?node-id=26925-22616&m=dev

## before
<img width="1295" height="759" alt="Screenshot 2026-04-29 at 12 59 29 PM" src="https://github.com/user-attachments/assets/7c9ba073-bbe5-4e52-8b81-3e60401aa8b3" />


## after
<img width="1296" height="764" alt="Screenshot 2026-04-29 at 1 35 32 PM" src="https://github.com/user-attachments/assets/7dbfda14-2bda-4820-84c2-7f1aa8660694" />


close AUTH-2683

## Test Plan and Hands on Testing
- push this branch to a Flex
- set up a protocol and tap `Labware offsets`

or access to authorship via devloper-helper extension

## Changelog
- modify the padding to align with the desing
- switch from styled-components to CSS Modules

## Review requests

## Risk assessment
low