### PR TITLE
fix(step-generation): correct cutoutId util to accurately translate the slot to a cutout id

### DIFF
--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -72,9 +72,9 @@ interface SlotInfo {
   position: CoordinateTuple | null
 }
 
-export const getCutoutIdFromSlot = (slotInfo: SlotInfo): CutoutId | null => {
+export const getCutoutFromSlot = (slotInfo: SlotInfo): CutoutId | null => {
   if (slotInfo.addressableArea?.areaType === 'slot') {
-    const testCutoutId = `cutoutId${slotInfo.addressableArea?.id}`
+    const testCutoutId = `cutout${slotInfo.addressableArea?.id}`
     if (testCutoutId as CutoutId) {
       return testCutoutId as CutoutId
     }
@@ -186,7 +186,7 @@ const getHighestZInSlot = (
       moduleId => modules[moduleId].slot === slotId
     )
     const wasteChuteInSlot = Object.values(wasteChuteEntities).find(
-      wasteChute => wasteChute.location === getCutoutIdFromSlot(slotInfo)
+      wasteChute => wasteChute.location === getCutoutFromSlot(slotInfo)
     )
     // if slot has waste chute
     if (wasteChuteInSlot) {
@@ -243,12 +243,14 @@ const getSlotHasPotentialCollidingObject = (
       y: slotPosition[1],
       z: slotPosition[2],
     }
-    // Check for overlapping rectangles and pipette z-coordinate if slot overlaps with pipette bounds
-    if (
-      getHasOverlappingRectangles(
+    const willCollide =  getHasOverlappingRectangles(
         [pipetteBounds[0], pipetteBounds[1]],
         [backLeftCoords, frontRightCoords]
-      ) &&
+      )
+    console.log("🚀 ~ getSlotHasPotentialCollidingObject ~ willCollide:", willCollide)
+    // Check for overlapping rectangles and pipette z-coordinate if slot overlaps with pipette bounds
+    if (
+      willCollide &&
       pipetteBounds[0].z != null
     ) {
       const highestZInSurroundingSlot = getHighestZInSlot(
@@ -257,6 +259,7 @@ const getSlotHasPotentialCollidingObject = (
         slot,
         robotType
       )
+      console.log("🚀 ~ getSlotHasPotentialCollidingObject ~ highestZInSurroundingSlot:", highestZInSurroundingSlot)
 
       if (highestZInSurroundingSlot >= pipetteBounds[0]?.z) {
         return true

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -243,13 +243,12 @@ const getSlotHasPotentialCollidingObject = (
       y: slotPosition[1],
       z: slotPosition[2],
     }
-    const willCollide =  getHasOverlappingRectangles(
-        [pipetteBounds[0], pipetteBounds[1]],
-        [backLeftCoords, frontRightCoords]
-      )
     // Check for overlapping rectangles and pipette z-coordinate if slot overlaps with pipette bounds
     if (
-      willCollide &&
+      getHasOverlappingRectangles(
+        [pipetteBounds[0], pipetteBounds[1]],
+        [backLeftCoords, frontRightCoords]
+      ) &&
       pipetteBounds[0].z != null
     ) {
       const highestZInSurroundingSlot = getHighestZInSlot(

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -247,7 +247,6 @@ const getSlotHasPotentialCollidingObject = (
         [pipetteBounds[0], pipetteBounds[1]],
         [backLeftCoords, frontRightCoords]
       )
-    console.log("🚀 ~ getSlotHasPotentialCollidingObject ~ willCollide:", willCollide)
     // Check for overlapping rectangles and pipette z-coordinate if slot overlaps with pipette bounds
     if (
       willCollide &&
@@ -259,7 +258,6 @@ const getSlotHasPotentialCollidingObject = (
         slot,
         robotType
       )
-      console.log("🚀 ~ getSlotHasPotentialCollidingObject ~ highestZInSurroundingSlot:", highestZInSurroundingSlot)
 
       if (highestZInSurroundingSlot >= pipetteBounds[0]?.z) {
         return true


### PR DESCRIPTION
# Overview

Fixes `getCutoutFromSlot` to accurately produce a cutout id. This was creating in issue in determining if the waste chute was in the slot.

## Test Plan and Hands on Testing

- smoke tested with this protocol  and ensured that inaccessible wells were marked: 
[8ch_test.py](https://github.com/user-attachments/files/27212105/8ch_test.py)
<img width="741" height="800" alt="Screenshot 2026-04-29 at 1 44 43 PM" src="https://github.com/user-attachments/assets/d1e5c437-6249-4a01-99d8-ade83063ce95" />

## Changelog

- changed string from `cutoutId` to `cutout` and renamed util appropriately. This matches the syntax pattern of type `CutoutId`

## Risk assessment

- low. this util is only used once in this file