### PR TITLE
fix(monorepo): update uuid version to use the same version in the monorepo

### DIFF
--- a/app-shell-odd/package.json
+++ b/app-shell-odd/package.json
@@ -44,7 +44,6 @@
     "@types/fs-extra": "9.0.13",
     "@types/lodash": "4.17.24",
     "@types/pump": "^1.1.0",
-    "@types/uuid": "^3.4.7",
     "ajv": "6.12.3",
     "dateformat": "3.0.3",
     "electron-devtools-installer": "4.0.0",
@@ -62,7 +61,7 @@
     "pump": "3.0.0",
     "semver": "5.7.2",
     "tempy": "1.0.1",
-    "uuid": "3.2.1",
+    "uuid": "14.0.0",
     "winston": "3.15.0",
     "winston-transport": "^4.9.0",
     "yargs-parser": "13.1.2"

--- a/app-shell-odd/src/config/__tests__/migrate.test.ts
+++ b/app-shell-odd/src/config/__tests__/migrate.test.ts
@@ -1,5 +1,5 @@
 // config migration tests
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -23,14 +23,16 @@ import {
 } from '../__fixtures__'
 import { migrate } from '../migrate'
 
-vi.mock('uuid/v4')
+vi.mock('uuid', () => ({
+  v4: vi.fn(),
+}))
 
 const NEWEST_VERSION = 28
 const NEWEST_MOCK_CONFIG = MOCK_CONFIG_V28
 
 describe('config migration', () => {
   beforeEach(() => {
-    vi.mocked(uuid).mockReturnValue('MOCK_UUIDv4')
+    vi.mocked(uuid).mockImplementation((() => 'MOCK_UUIDv4') as typeof uuid)
   })
 
   it('should migrate version 12 to latest', () => {

--- a/app-shell-odd/src/config/migrate.ts
+++ b/app-shell-odd/src/config/migrate.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { app } from 'electron'
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 
 import type {
   Config,

--- a/app-shell/package.json
+++ b/app-shell/package.json
@@ -43,7 +43,6 @@
     "@types/fs-extra": "9.0.13",
     "@types/lodash": "4.17.24",
     "@types/pump": "^1.1.0",
-    "@types/uuid": "^3.4.7",
     "agent-base": "6.0.2",
     "ajv": "6.12.3",
     "axios": "^0.21.1",
@@ -75,7 +74,7 @@
     "tempy": "1.0.1",
     "to-regex": "3.0.2",
     "usb": "^2.11.0",
-    "uuid": "3.2.1",
+    "uuid": "14.0.0",
     "winston": "3.15.0",
     "winston-transport": "^4.9.0",
     "yargs-parser": "13.1.2"

--- a/app-shell/src/config/__tests__/migrate.test.ts
+++ b/app-shell/src/config/__tests__/migrate.test.ts
@@ -1,5 +1,5 @@
 // config migration tests
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -35,14 +35,16 @@ import {
 } from '../../__fixtures__'
 import { migrate } from '../migrate'
 
-vi.mock('uuid/v4')
+vi.mock('uuid', () => ({
+  v4: vi.fn(),
+}))
 
 const NEWEST_VERSION = 28
 const NEWEST_MOCK_CONFIG = MOCK_CONFIG_V28
 
 describe('config migration', () => {
   beforeEach(() => {
-    vi.mocked(uuid).mockReturnValue('MOCK_UUIDv4')
+    vi.mocked(uuid).mockImplementation((() => 'MOCK_UUIDv4') as typeof uuid)
   })
 
   it('should migrate version 0 to latest', () => {

--- a/app-shell/src/config/migrate.ts
+++ b/app-shell/src/config/migrate.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { app } from 'electron'
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 
 import type {
   Config,

--- a/app-shell/src/protocol-analysis/writeFailedAnalysis.ts
+++ b/app-shell/src/protocol-analysis/writeFailedAnalysis.ts
@@ -1,5 +1,5 @@
 import { writeFile } from 'fs/promises'
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 

--- a/app-shell/src/protocol-storage/__tests__/file-system.test.ts
+++ b/app-shell/src/protocol-storage/__tests__/file-system.test.ts
@@ -19,9 +19,8 @@ import {
   shouldMigrateToNotOt2Directory,
 } from '../file-system'
 
-vi.mock('uuid/v4', () => ({
-  __esModule: true,
-  default: vi.fn(),
+vi.mock('uuid', () => ({
+  v4: vi.fn(),
 }))
 vi.mock('electron')
 vi.mock('electron-store')
@@ -228,8 +227,8 @@ describe('protocol storage directory utilities', () => {
 
   describe('addProtocolFile', () => {
     it('writes a protocol file to a new directory', async () => {
-      const { default: uuid } = await import('uuid/v4')
-      vi.mocked(uuid).mockReturnValue('0abc123')
+      const { v4: uuid } = await import('uuid')
+      vi.mocked(uuid).mockImplementation((() => '0abc123') as typeof uuid)
       const sourceDir = makeEmptyDir()
       const destDir = makeEmptyDir()
       const sourceName = path.join(sourceDir, 'source.py')

--- a/app-shell/src/protocol-storage/file-system.ts
+++ b/app-shell/src/protocol-storage/file-system.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { app, shell } from 'electron'
 import fs from 'fs-extra'
-import uuid from 'uuid/v4'
+import { v4 as uuid } from 'uuid'
 
 import { OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 

--- a/app/package.json
+++ b/app/package.json
@@ -33,7 +33,6 @@
     "@reduxjs/toolkit": "2.11.2",
     "@sentry/electron": "7.5.0",
     "@thi.ng/paths": "5.1.63",
-    "@types/uuid": "^3.4.7",
     "builder-util-runtime": "^9.3.1",
     "classnames": "2.2.5",
     "connected-react-router": "6.9.3",
@@ -68,7 +67,7 @@
     "simple-keyboard-layouts": "3.4.41",
     "styled-components": "5.3.6",
     "typeface-open-sans": "0.0.75",
-    "uuid": "3.2.1"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@tanstack/react-query-devtools": "5.59.16",

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -1,5 +1,5 @@
 import intersection from 'lodash/intersection'
-import uuidv1 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 
 import {
   ALL,
@@ -45,7 +45,7 @@ export type MoveLiquidStepArgs =
   | TransferArgs
   | null
 
-const uuid: () => string = uuidv1
+const uuid: () => string = uuidv4
 const adapter96ChannelDefUri = 'opentrons/opentrons_flex_96_tiprack_adapter/1'
 
 function getOrderedWells(

--- a/app/src/organisms/ODD/RobotSettingsDashboard/LanguageSetting.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/LanguageSetting.tsx
@@ -2,7 +2,7 @@ import { Fragment, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components'
-import uuidv1 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 
 import {
   BORDERS,
@@ -45,7 +45,7 @@ interface LanguageSettingProps {
   setCurrentOption: SetSettingOption
 }
 
-const uuid: () => string = uuidv1
+const uuid: () => string = uuidv4
 
 export function LanguageSetting({
   setCurrentOption,

--- a/app/src/pages/Desktop/AppSettings/GeneralSettings.tsx
+++ b/app/src/pages/Desktop/AppSettings/GeneralSettings.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import uuidv1 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 
 import {
   ALIGN_CENTER,
@@ -57,7 +57,7 @@ const GITHUB_LINK =
   'https://github.com/Opentrons/opentrons/blob/edge/app-shell/build/release-notes.md'
 
 const ENABLE_APP_UPDATE_NOTIFICATIONS = 'Enable app update notifications'
-const uuid: () => string = uuidv1
+const uuid: () => string = uuidv4
 
 export function GeneralSettings(): JSX.Element {
   const { t } = useTranslation(['app_settings', 'shared', 'branded'])

--- a/opentrons-ai-client/package.json
+++ b/opentrons-ai-client/package.json
@@ -35,7 +35,7 @@
     "mixpanel-browser": "2.22.1",
     "react-router-dom": "6.24.1",
     "react-transition-group": "4.4.5",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "engines": {
     "node": ">=18.19.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,9 +368,6 @@ importers:
       '@thi.ng/paths':
         specifier: 5.1.63
         version: 5.1.63
-      '@types/uuid':
-        specifier: ^3.4.7
-        version: 3.4.13
       builder-util-runtime:
         specifier: ^9.3.1
         version: 9.5.1
@@ -474,8 +471,8 @@ importers:
         specifier: 0.0.75
         version: 0.0.75
       uuid:
-        specifier: 3.2.1
-        version: 3.2.1
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@tanstack/react-query-devtools':
         specifier: 5.59.16
@@ -555,9 +552,6 @@ importers:
       '@types/pump':
         specifier: ^1.1.0
         version: 1.1.3
-      '@types/uuid':
-        specifier: ^3.4.7
-        version: 3.4.13
       agent-base:
         specifier: 6.0.2
         version: 6.0.2
@@ -652,8 +646,8 @@ importers:
         specifier: ^2.11.0
         version: 2.16.0
       uuid:
-        specifier: 3.2.1
-        version: 3.2.1
+        specifier: 14.0.0
+        version: 14.0.0
       winston:
         specifier: 3.15.0
         version: 3.15.0
@@ -700,9 +694,6 @@ importers:
       '@types/pump':
         specifier: ^1.1.0
         version: 1.1.3
-      '@types/uuid':
-        specifier: ^3.4.7
-        version: 3.4.13
       ajv:
         specifier: 6.12.3
         version: 6.12.3
@@ -755,8 +746,8 @@ importers:
         specifier: 1.0.1
         version: 1.0.1
       uuid:
-        specifier: 3.2.1
-        version: 3.2.1
+        specifier: 14.0.0
+        version: 14.0.0
       winston:
         specifier: 3.15.0
         version: 3.15.0
@@ -1114,8 +1105,8 @@ importers:
         specifier: 5.3.6
         version: 5.3.6(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
       uuid:
-        specifier: 11.1.0
-        version: 11.1.0
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@types/lodash':
         specifier: 4.17.24
@@ -1180,9 +1171,6 @@ importers:
       '@types/ua-parser-js':
         specifier: 0.7.36
         version: 0.7.36
-      '@types/uuid':
-        specifier: 8.3.0
-        version: 8.3.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.10.0
         version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.3.3))(eslint@8.57.1)(typescript@5.3.3)
@@ -1292,8 +1280,8 @@ importers:
         specifier: ^0.7.23
         version: 0.7.41
       uuid:
-        specifier: 3.3.2
-        version: 3.3.2
+        specifier: 14.0.0
+        version: 14.0.0
       vite-bundle-analyzer:
         specifier: ^1.2.2
         version: 1.3.2
@@ -1390,8 +1378,8 @@ importers:
         specifier: 4.18.1
         version: 4.18.1
       uuid:
-        specifier: 3.3.2
-        version: 3.3.2
+        specifier: 14.0.0
+        version: 14.0.0
     devDependencies:
       '@types/lodash':
         specifier: 4.17.24
@@ -4698,12 +4686,6 @@ packages:
 
   '@types/use-sync-external-store@0.0.3':
     resolution: {integrity: sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==}
-
-  '@types/uuid@3.4.13':
-    resolution: {integrity: sha512-pAeZeUbLE4Z9Vi9wsWV2bYPTweEHeJJy0G4pEjOA/FSvy1Ad5U5Km8iDV6TKre1mjBiVNfAdVHKruP8bAh4Q5A==}
-
-  '@types/uuid@8.3.0':
-    resolution: {integrity: sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==}
 
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
@@ -12081,13 +12063,8 @@ packages:
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
-
-  uuid@3.2.1:
-    resolution: {integrity: sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   uuid@3.3.2:
@@ -16591,10 +16568,6 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.3': {}
-
-  '@types/uuid@3.4.13': {}
-
-  '@types/uuid@8.3.0': {}
 
   '@types/verror@1.10.11':
     optional: true
@@ -25698,9 +25671,7 @@ snapshots:
       is-typed-array: 1.1.15
       which-typed-array: 1.1.19
 
-  uuid@11.1.0: {}
-
-  uuid@3.2.1: {}
+  uuid@14.0.0: {}
 
   uuid@3.3.2: {}
 

--- a/protocol-designer/package.json
+++ b/protocol-designer/package.json
@@ -30,7 +30,6 @@
     "@types/redux-actions": "2.6.1",
     "@types/styled-components": "^5.1.26",
     "@types/ua-parser-js": "0.7.36",
-    "@types/uuid": "8.3.0",
     "@typescript-eslint/eslint-plugin": "^6.10.0",
     "@typescript-eslint/parser": "^6.10.0",
     "@uiw/react-color": "2.9.5",
@@ -67,7 +66,7 @@
     "styled-components": "5.3.6",
     "tslib": "^2.8.1",
     "ua-parser-js": "^0.7.23",
-    "uuid": "3.3.2",
+    "uuid": "14.0.0",
     "vite-bundle-analyzer": "^1.2.2",
     "vite-plugin-node-polyfills": "^0.25.0",
     "yup": "1.3.3"

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -1,5 +1,5 @@
 import snakeCase from 'lodash/snakeCase'
-import uuidv1 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 
 import {
   FLEX_ROBOT_TYPE,
@@ -45,7 +45,7 @@ import type {
   ModuleEntities,
 } from '../step-forms'
 
-export const uuid: () => string = uuidv1
+export const uuid: () => string = uuidv4
 // Collision detection for SelectionRect / SelectableLabware
 export const rectCollision = (
   rect1: BoundingRect,

--- a/protocol-designer/typings/uuid.d.ts
+++ b/protocol-designer/typings/uuid.d.ts
@@ -1,5 +1,0 @@
-declare module 'uuid/v4' {
-  const uuidv1: any
-  // eslint-disable-next-line import/no-default-export
-  export default uuidv1
-}

--- a/step-generation/package.json
+++ b/step-generation/package.json
@@ -35,7 +35,7 @@
     "core-js": "3.2.1",
     "immer": "^10.1.3",
     "lodash": "4.18.1",
-    "uuid": "3.3.2"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@types/lodash": "4.17.24"

--- a/step-generation/src/utils/index.ts
+++ b/step-generation/src/utils/index.ts
@@ -1,4 +1,4 @@
-import uuidv4 from 'uuid/v4'
+import { v4 as uuidv4 } from 'uuid'
 
 import { absorbanceReaderCollision } from './absorbanceReaderCollision'
 import { commandCreatorsTimeline } from './commandCreatorsTimeline'

--- a/step-generation/typings/global.d.ts
+++ b/step-generation/typings/global.d.ts
@@ -1,5 +1,0 @@
-declare module 'uuid/v4' {
-  const uuidv4: any
-  // eslint-disable-next-line import/no-default-export
-  export default uuidv4
-}

--- a/step-generation/vite.config.mts
+++ b/step-generation/vite.config.mts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite'
 
 function isExternal(id: string): boolean {
   // Keep shared-data external (separate package). Bundle lodash/immer/uuid so Node ESM
-  // can load the entry without extensionless subpath imports (lodash/min, uuid/v4).
+  // can load the entry without legacy extensionless subpath imports.
   return (
     id === '@opentrons/shared-data' || id.startsWith('@opentrons/shared-data/')
   )


### PR DESCRIPTION
# Overview
update uuid version to use the same version in the monorepo

close AUTH-2895


## Test Plan and Hands on Testing

## Changelog
- update the uuid version to 14.0.0

## Review requests


## Risk assessment
low
