### PR TITLE
fix(protocol-designer): check safe pipette movements for PARTIAL_COLUMN configuration

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
@@ -1,4 +1,10 @@
-import { ALL, COLUMN, ROW, SINGLE } from '@opentrons/shared-data'
+import {
+  ALL,
+  COLUMN,
+  PARTIAL_COLUMN,
+  ROW,
+  SINGLE,
+} from '@opentrons/shared-data'
 import { getIsSafePipetteMovement } from '@opentrons/step-generation'
 
 import { canPipetteUseLabware } from '../../../../../../utils'
@@ -115,7 +121,11 @@ export function getAllWellsSafetyStatus(
     allWells.flat().forEach(wellName => {
       allWellsWithStatus[wellName] = safe ? 0 : 1
     })
-  } else if (nozzleConfiguration === SINGLE && channels !== 1) {
+  } else if (
+    (nozzleConfiguration === SINGLE ||
+      nozzleConfiguration === PARTIAL_COLUMN) &&
+    channels !== 1
+  ) {
     // SINGLE nozzle for 8ch and 96ch: check every well individually
     allWells.flat().forEach(wellName => {
       const safe = robotState


### PR DESCRIPTION
# Overview

Whoops! PARTIAL_COLUMN configuration was not being check for safe pipette movements. Now it is and detecting unaccessible wells correctly!

## Test Plan and Hands on Testing

- smoke tested using protocol attached to ticket RQA-5341
<img width="847" height="702" alt="Screenshot 2026-04-29 at 2 50 24 PM" src="https://github.com/user-attachments/assets/2e614fee-3f11-43c9-b79b-8731ec628e6d" />
<img width="842" height="683" alt="Screenshot 2026-04-29 at 2 50 16 PM" src="https://github.com/user-attachments/assets/f3d92f69-0aa4-4548-880f-9ba31fac5107" />

## Changelog

- added PARTIAL_COLUMN into checking if statement. This will check every well.

## Risk assessment

- low

Closes RQA-5341