### PR TITLE
fix(protocol-designer): unselect labware when discarding step

### DIFF
--- a/protocol-designer/src/steplist/actions/actions.ts
+++ b/protocol-designer/src/steplist/actions/actions.ts
@@ -94,10 +94,19 @@ export interface CancelStepFormAction {
   type: 'CANCEL_STEP_FORM'
   payload: null
 }
-export const cancelStepForm = (): CancelStepFormAction => ({
-  type: 'CANCEL_STEP_FORM',
-  payload: null,
-})
+
+export const cancelStepForm = () => (dispatch: any) => {
+  const clearSelectedItemAction: ClearSelectedItemAction = {
+    type: 'CLEAR_SELECTED_ITEM',
+  }
+
+  dispatch(clearSelectedItemAction)
+
+  dispatch({
+    type: 'CANCEL_STEP_FORM',
+    payload: null,
+  })
+}
 
 export interface ReorderStepsAction {
   type: 'REORDER_STEPS'


### PR DESCRIPTION
# Overview

When discarding a step, unselect all selected labware.

This fixes a bug where the labware would stay selected after canceling the form, which prevented you from using the edit labware state that appears upon hovering over it in the starting deck setup.

## Test Plan and Hands on Testing

- smoke tested following steps in ticket AUTH-2887 and confirmed that when the step is discarded all labware are unselected.

https://github.com/user-attachments/assets/016578cb-4fdb-42cd-8cad-81461b2db7b7

## Changelog

- added `clearSelectedItemAction` to the `cancelStepFormAction`

## Review requests
- anywhere else this is needed?

## Risk assessment

- low, if you are cancelling a step I don't think there is any reason to keep the labware associated with the slot selected but correct me if that is a wrong assumption.