### PR TITLE
fix(app): Fix spacing in the ODD nav menu

### DIFF
--- a/app/src/organisms/ODD/Navigation/index.tsx
+++ b/app/src/organisms/ODD/Navigation/index.tsx
@@ -125,23 +125,21 @@ export function Navigation(props: NavigationProps): JSX.Element {
             ))}
           </div>
         </div>
-        <div className={styles.overflow_button_wrap}>
-          <button
-            type="button"
-            className={clsx(styles.icon_button, styles.cursor_default)}
-            aria-label="overflow menu button"
-            onClick={() => {
-              handleMenu(true)
-            }}
-          >
-            <Icon
-              name="overflow-btn-touchscreen"
-              height="3.75rem"
-              width="3rem"
-              color={COLORS.grey60}
-            />
-          </button>
-        </div>
+        <button
+          type="button"
+          className={clsx(styles.icon_button, styles.cursor_default)}
+          aria-label="overflow menu button"
+          onClick={() => {
+            handleMenu(true)
+          }}
+        >
+          <Icon
+            name="overflow-btn-touchscreen"
+            height="3.75rem"
+            width="3rem"
+            color={COLORS.grey60}
+          />
+        </button>
       </nav>
       {showNavMenu && (
         <NavigationMenu

--- a/app/src/organisms/ODD/Navigation/index.tsx
+++ b/app/src/organisms/ODD/Navigation/index.tsx
@@ -94,39 +94,35 @@ export function Navigation(props: NavigationProps): JSX.Element {
           isScrolled && styles.nav_bar_scrolled
         )}
       >
-        <div className={styles.nav_content_row}>
-          <div className={styles.carousel_wrapper}>
-            <div className={styles.carousel_inner}>
-              <div
-                ref={
-                  location.pathname === '/dashboard' ? navBarScrollRef : null
-                }
-              >
-                <NavigationLink
-                  to="/dashboard"
-                  name={truncateString(
-                    robotName,
-                    iconName != null ? CHAR_LIMIT_WITH_ICON : CHAR_LIMIT_NO_ICON
-                  )}
-                />
-              </div>
-              {iconName != null ? (
-                <Icon
-                  aria-label="network icon"
-                  name={iconName}
-                  size="2.5rem"
-                  color={COLORS.grey60}
-                />
-              ) : null}
-              {NAV_LINKS.map(path => (
-                <div
-                  ref={path === location.pathname ? navBarScrollRef : null}
-                  key={path}
-                >
-                  <NavigationLink to={path} name={getPathDisplayName(path)} />
-                </div>
-              ))}
+        <div className={styles.carousel_scroll_container}>
+          <div className={styles.carousel_contents}>
+            <div
+              ref={location.pathname === '/dashboard' ? navBarScrollRef : null}
+            >
+              <NavigationLink
+                to="/dashboard"
+                name={truncateString(
+                  robotName,
+                  iconName != null ? CHAR_LIMIT_WITH_ICON : CHAR_LIMIT_NO_ICON
+                )}
+              />
             </div>
+            {iconName != null ? (
+              <Icon
+                aria-label="network icon"
+                name={iconName}
+                size="2.5rem"
+                color={COLORS.grey60}
+              />
+            ) : null}
+            {NAV_LINKS.map(path => (
+              <div
+                ref={path === location.pathname ? navBarScrollRef : null}
+                key={path}
+              >
+                <NavigationLink to={path} name={getPathDisplayName(path)} />
+              </div>
+            ))}
           </div>
         </div>
         <div className={styles.overflow_button_wrap}>

--- a/app/src/organisms/ODD/Navigation/navigation.module.css
+++ b/app/src/organisms/ODD/Navigation/navigation.module.css
@@ -29,14 +29,8 @@
   gap: var(--spacing-32);
 }
 
-.overflow_button_wrap {
-  position: absolute;
-  right: var(--spacing-16);
-}
-
 .carousel_scroll_container {
   display: flex;
-  width: 56.75rem;
   flex-direction: row;
   align-items: flex-start;
   mask-image: linear-gradient(
@@ -81,6 +75,7 @@
 
 .icon_button {
   max-height: 100%;
+  flex: none;
   border-radius: var(--border-radius-8);
   background-color: var(--white);
 

--- a/app/src/organisms/ODD/Navigation/navigation.module.css
+++ b/app/src/organisms/ODD/Navigation/navigation.module.css
@@ -39,7 +39,6 @@
 .overflow_button_wrap {
   position: absolute;
   right: var(--spacing-16);
-  margin-top: calc(-1 * var(--spacing-12));
 }
 
 .carousel_wrapper {

--- a/app/src/organisms/ODD/Navigation/navigation.module.css
+++ b/app/src/organisms/ODD/Navigation/navigation.module.css
@@ -22,14 +22,7 @@
   z-index: 0;
 }
 
-.nav_content_row {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: var(--spacing-32);
-}
-
-.carousel_inner {
+.carousel_contents {
   display: flex;
   flex-direction: row;
   margin-right: var(--spacing-24);
@@ -41,7 +34,7 @@
   right: var(--spacing-16);
 }
 
-.carousel_wrapper {
+.carousel_scroll_container {
   display: flex;
   width: 56.75rem;
   flex-direction: row;
@@ -56,7 +49,7 @@
   overflow-x: scroll;
 }
 
-.carousel_wrapper::-webkit-scrollbar {
+.carousel_scroll_container::-webkit-scrollbar {
   display: none;
 }
 

--- a/app/src/organisms/ODD/Navigation/navigation.module.css
+++ b/app/src/organisms/ODD/Navigation/navigation.module.css
@@ -63,12 +63,12 @@
 
 .touch_nav_link {
   display: flex;
-  height: 3.5rem;
   flex-direction: column;
   align-items: center;
   color: var(--grey-50);
   font-size: var(--font-size-32);
   font-weight: var(--font-weight-semi-bold);
+  gap: var(--spacing-8);
   line-height: var(--line-height-42);
   white-space: nowrap;
 


### PR DESCRIPTION
## Overview

In preparation for adding an account icon to the nav menu (EXEC-2601), this makes the spacing match the latest designs.

## Changelog

To match the designs:

* Add more vertical space between the text in the menu and the purple underline.
* Vertically center the overflow button.
* Add more space to the right of the overflow button.

## Test Plan and Hands on Testing

Before (with lengthened text to demonstrate the fade-out):

<img width="1024" height="600" alt="Screenshot 2026-04-29 at 3 43 42 PM" src="https://github.com/user-attachments/assets/37d61fd4-039c-470d-a64f-c8302120ef76" />

After:

<img width="1024" height="600" alt="Screenshot 2026-04-29 at 3 43 31 PM" src="https://github.com/user-attachments/assets/bd603335-90e2-4284-8217-060d74c0129d" />

## Review requests

None in particular.

The commits are broken up so that they can be looked at individually, if that makes it clearer how things changed.

## Risk assessment

Low.