### PR TITLE
fix(auth-server): reject PATCH username collision with existing user

### DIFF
--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -173,6 +173,11 @@ async def update_user(
             status_code=fastapi.status.HTTP_404_NOT_FOUND,
             detail="User not found",
         )
+    except UserAlreadyExistsError:
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_400_BAD_REQUEST,
+            detail="User already exists",
+        )
     except InvalidInputError as e:
         raise fastapi.HTTPException(
             status_code=fastapi.status.HTTP_400_BAD_REQUEST,

--- a/auth-server/auth_server/users/user_data_manager.py
+++ b/auth-server/auth_server/users/user_data_manager.py
@@ -144,6 +144,12 @@ class UserDataManager:
             full_name=new_full_name,
             account_type=new_account_type,
         )
+        if (
+            new_username is not None
+            and new_username != username_to_update
+            and self._user_store.get(new_username) is not None
+        ):
+            raise UserAlreadyExistsError(f"User {new_username!r} already exists")
         try:
             if new_locked is not None and not new_locked:
                 # Note: do this BEFORE the username is potentially changed

--- a/auth-server/tests/users/test_user_data_manager.py
+++ b/auth-server/tests/users/test_user_data_manager.py
@@ -330,6 +330,14 @@ def test_update_user_password_is_hashed(
     )
 
 
+def test_update_user_rename_to_existing_username_raises(
+    decoy: Decoy, mock_store: UserStore, manager: UserDataManager
+) -> None:
+    decoy.when(mock_store.get("alice")).then_return(_make_orm_user(username="alice"))
+    with pytest.raises(UserAlreadyExistsError):
+        manager.update_user("bob", new_username="alice", reset_password=False)
+
+
 def test_update_user_not_found_raises(
     decoy: Decoy, mock_store: UserStore, manager: UserDataManager
 ) -> None:


### PR DESCRIPTION
## Overview

**Problem:** On `edge`, renaming a user via **PATCH** `/auth/users/{userName}` to a **username that already exists** produces a **500** error instead of a clear client error.

**Change:** `UserDataManager.update_user` now checks for an existing account with the target username before mutating state, and raises **`UserAlreadyExistsError`**. The users router catches that on PATCH and returns **HTTP 400** with **`{"detail": "User already exists"}`**, matching **POST** `/auth/users` when a duplicate is created.

**Acceptance criteria**

- PATCH with `userName` set to another user’s username returns **400** and the duplicate-user detail string, not **5xx**.
- Unit coverage exists for the manager path that raises **`UserAlreadyExistsError`** on rename collision.

## Test Plan and Hands on Testing

- [An API e2e test will exist for this](https://github.com/Opentrons/opentrons/pull/21169/changes#diff-c0622083e2e6c77cb8d834da75cb3846e2fda9ebaaa2179c6afacebe7808d1f5R39-R87)

## Changelog

- **Auth-server:** **PATCH** `/auth/users/{userName}` returns **400** with **`User already exists`** when the new username is already taken by another user, aligned with duplicate **POST** user creation.
- **Tests:** Added **`test_update_user_rename_to_existing_username_raises`** in `auth-server/tests/users/test_user_data_manager.py`.

**Breaking changes:** None for well-behaved clients. Anything that assumed **5xx** for this collision should treat **400** as the correct contract.

## Review requests

- Confirm the **pre-update** `get(new_username)` check is the right place to enforce uniqueness (vs relying only on DB constraints) and does not regress valid renames (same user, no-op name change).
- Confirm **`UserAlreadyExistsError`** message vs **`detail`** string consistency with **POST** `/auth/users`.

## Risk assessment

- **Attention level:** **Medium** (user admin API and identity semantics).
- **Blast radius:** Admin UIs or automation that PATCH user renames; low if they already handle **400** from user create.
- **Mitigation:** Targeted unit test on `UserDataManager.update_user`; router mapping mirrors existing **`UserAlreadyExistsError`** handling for create.