### PR TITLE
feat(app): Add an account icon to the ODD navigation menu

### DIFF
--- a/app/src/assets/localization/en/top_navigation.json
+++ b/app/src/assets/localization/en/top_navigation.json
@@ -1,4 +1,5 @@
 {
+  "account": "Account",
   "app_settings": "App Settings",
   "attached_pipettes_do_not_match": "Attached pipettes do not match pipettes specified in loaded protocol",
   "calibrate_deck_to_proceed": "Calibrate your deck to proceed",

--- a/app/src/organisms/ODD/Navigation/__tests__/Navigation.test.tsx
+++ b/app/src/organisms/ODD/Navigation/__tests__/Navigation.test.tsx
@@ -10,14 +10,16 @@ import { mockConnectedRobot } from '/app/redux/discovery/__fixtures__'
 import { useNetworkConnection } from '/app/resources/networking/hooks/useNetworkConnection'
 
 import { Navigation } from '..'
+import { useAccountIconInitial } from '../hooks/useAccountIconInitial'
 import { NavigationMenu } from '../NavigationMenu'
 
 import type { ComponentProps } from 'react'
 
+vi.mock('/app/local-resources/dom-utils')
 vi.mock('/app/resources/networking/hooks/useNetworkConnection')
 vi.mock('/app/redux/discovery')
+vi.mock('../hooks/useAccountIconInitial')
 vi.mock('../NavigationMenu')
-vi.mock('/app/local-resources/dom-utils')
 
 mockConnectedRobot.name = '12345678901234567'
 
@@ -35,6 +37,7 @@ describe('Navigation', () => {
   beforeEach(() => {
     props = {}
     vi.mocked(getLocalRobot).mockReturnValue(mockConnectedRobot)
+    vi.mocked(useAccountIconInitial).mockReturnValue(null)
     vi.mocked(NavigationMenu).mockReturnValue(<div>mock NavigationMenu</div>)
     vi.mocked(useNetworkConnection).mockReturnValue({
       isEthernetConnected: false,
@@ -91,5 +94,22 @@ describe('Navigation', () => {
     )
     screen.getByText('mock NavigationMenu')
     expect(props.setNavMenuIsOpened).toHaveBeenCalled()
+  })
+  describe('account icon', () => {
+    const linkName = 'Account'
+    it('should not render the account control when logged out', () => {
+      vi.mocked(useAccountIconInitial).mockReturnValue(null)
+      render(props)
+      expect(
+        screen.queryByRole('link', { name: linkName })
+      ).not.toBeInTheDocument()
+    })
+    it('should render the account initial and link to settings when logged in', () => {
+      vi.mocked(useAccountIconInitial).mockReturnValue('T')
+      render(props)
+      const accountLink = screen.getByRole('link', { name: linkName })
+      expect(accountLink).toHaveAttribute('href', '/robot-settings')
+      expect(accountLink).toHaveTextContent('T')
+    })
   })
 })

--- a/app/src/organisms/ODD/Navigation/hooks/useAccountIconInitial.ts
+++ b/app/src/organisms/ODD/Navigation/hooks/useAccountIconInitial.ts
@@ -1,0 +1,21 @@
+import { useSelector } from 'react-redux'
+
+import { getLocalRobotAuthState } from '/app/redux/robot-auth'
+
+import type { State } from '/app/redux/types'
+
+/**
+ * Returns the initial to show in the account icon.
+ *
+ * If the user isn't currently logged in, returns `null`.
+ */
+export function useAccountIconInitial(): string | null {
+  // todo(mm, 2026-04-29): This should be based on the legal name, not the username.
+  // To do that, a user needs to be able to fetch `GET /auth/users/{username}` for
+  // their own username, but that's currently an admin-only endpoint.`
+  const currentUsername = useSelector(
+    (state: State) => getLocalRobotAuthState(state)?.username ?? null
+  )
+  const firstChar = currentUsername?.[0]
+  return firstChar != null ? firstChar.toLocaleUpperCase() : null
+}

--- a/app/src/organisms/ODD/Navigation/index.tsx
+++ b/app/src/organisms/ODD/Navigation/index.tsx
@@ -10,6 +10,7 @@ import { useScrollPosition } from '/app/local-resources/dom-utils'
 import { getLocalRobot } from '/app/redux/discovery'
 import { useNetworkConnection } from '/app/resources/networking/hooks/useNetworkConnection'
 
+import { useAccountIconInitial } from './hooks/useAccountIconInitial'
 import styles from './navigation.module.css'
 import { NavigationMenu } from './NavigationMenu'
 
@@ -33,11 +34,15 @@ interface NavigationProps {
 }
 export function Navigation(props: NavigationProps): JSX.Element {
   const { setNavMenuIsOpened, longPressModalIsOpened } = props
+
   const { t } = useTranslation('top_navigation')
+
   const location = useLocation()
+  const accountIconInitial = useAccountIconInitial()
   const localRobot = useSelector(getLocalRobot)
-  const [showNavMenu, setShowNavMenu] = useState<boolean>(false)
   const robotName = localRobot?.name != null ? localRobot.name : 'no name'
+
+  const [showNavMenu, setShowNavMenu] = useState<boolean>(false)
 
   // We need to display an icon for what type of network connection (if any)
   // is active next to the robot's name. The designs call for it to change color
@@ -125,6 +130,15 @@ export function Navigation(props: NavigationProps): JSX.Element {
             ))}
           </div>
         </div>
+        {accountIconInitial && (
+          <NavLink
+            to="/robot-settings"
+            className={clsx(styles.account_icon, styles.cursor_default)}
+            aria-label={t('account')}
+          >
+            {accountIconInitial}
+          </NavLink>
+        )}
         <button
           type="button"
           className={clsx(styles.icon_button, styles.cursor_default)}

--- a/app/src/organisms/ODD/Navigation/navigation.module.css
+++ b/app/src/organisms/ODD/Navigation/navigation.module.css
@@ -31,6 +31,7 @@
 
 .carousel_scroll_container {
   display: flex;
+  flex: 1;
   flex-direction: row;
   align-items: flex-start;
   mask-image: linear-gradient(
@@ -45,6 +46,21 @@
 
 .carousel_scroll_container::-webkit-scrollbar {
   display: none;
+}
+
+.account_icon {
+  width: 3.75rem;
+  height: 3.75rem;
+  flex: none;
+  align-content: center;
+  border-radius: var(--border-radius-200);
+  background-color: var(--black-90);
+  color: var(--white);
+  font-size: var(--font-size-28);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--line-height-36);
+  text-align: center;
+  text-decoration: none;
 }
 
 .touch_nav_link {

--- a/app/src/organisms/ODD/Navigation/navigation.module.css
+++ b/app/src/organisms/ODD/Navigation/navigation.module.css
@@ -34,7 +34,7 @@
   flex: 1;
   flex-direction: row;
   align-items: flex-start;
-  mask-image: linear-gradient(to left, transparent 0%, black 100px, black 100%);
+  mask-image: linear-gradient(to left, transparent, black 6.25rem, black 100%);
   overflow-x: scroll;
 }
 

--- a/app/src/organisms/ODD/Navigation/navigation.module.css
+++ b/app/src/organisms/ODD/Navigation/navigation.module.css
@@ -34,13 +34,7 @@
   flex: 1;
   flex-direction: row;
   align-items: flex-start;
-  mask-image: linear-gradient(
-    to right,
-    transparent 0%,
-    black 0%,
-    black 96.5%,
-    transparent 100%
-  );
+  mask-image: linear-gradient(to left, transparent 0%, black 100px, black 100%);
   overflow-x: scroll;
 }
 

--- a/app/src/redux/robot-auth/__tests__/selectors.test.ts
+++ b/app/src/redux/robot-auth/__tests__/selectors.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
-import { getAuthStateForRobot } from '../slice'
+import {
+  getAuthStateForRobot,
+  getIsLoggedInToLocalRobot,
+  getLocalRobotAuthState,
+} from '../slice'
 
+import type {
+  DiscoveryClientRobot,
+  DiscoveryClientRobotAddress,
+} from '@opentrons/discovery-client'
 import type { State } from '../../types'
 
 describe('robot auth selectors', () => {
@@ -30,6 +38,73 @@ describe('robot auth selectors', () => {
         refreshToken: null,
         expiresAt: 1234,
       })
+    })
+  })
+
+  describe('local robot selectors', () => {
+    const localRobot: DiscoveryClientRobot = {
+      addresses: [
+        {
+          ip: 'localhost',
+        } satisfies Partial<DiscoveryClientRobotAddress> as DiscoveryClientRobotAddress,
+      ],
+      health: {} as any,
+      name: 'testRobot',
+      serverHealth: {} as any,
+    }
+    const authState = {
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: 1234,
+      username: 'george_clooney',
+    }
+
+    it('returns data when the local robot has auth state', () => {
+      const state = {
+        discovery: {
+          scanning: false,
+          robotsByName: {
+            [localRobot.name]: localRobot,
+          },
+        },
+        robotAuth: {
+          [localRobot.name]: authState,
+        },
+      } satisfies Partial<State> as State
+
+      expect(getLocalRobotAuthState(state)).toStrictEqual(
+        state.robotAuth[localRobot.name]
+      )
+      expect(getIsLoggedInToLocalRobot(state)).toStrictEqual(true)
+    })
+
+    it('returns null when there is no local robot', () => {
+      const state = {
+        discovery: {
+          scanning: false,
+          robotsByName: {},
+        },
+        robotAuth: {
+          [localRobot.name]: authState,
+        },
+      } satisfies Partial<State> as State
+
+      expect(getLocalRobotAuthState(state)).toStrictEqual(null)
+      expect(getIsLoggedInToLocalRobot(state)).toStrictEqual(false)
+    })
+    it('returns null when the local robot has no auth state', () => {
+      const state = {
+        discovery: {
+          scanning: false,
+          robotsByName: {
+            [localRobot.name]: localRobot,
+          },
+        },
+        robotAuth: {},
+      } satisfies Partial<State> as State
+
+      expect(getLocalRobotAuthState(state)).toStrictEqual(null)
+      expect(getIsLoggedInToLocalRobot(state)).toStrictEqual(false)
     })
   })
 })

--- a/app/src/redux/robot-auth/slice.ts
+++ b/app/src/redux/robot-auth/slice.ts
@@ -80,16 +80,33 @@ export function getAuthStateForRobot(
 }
 
 /**
+ * On the on-device display, this returns info for the current login, if the user
+ * is currently logged in. This should not be used in the desktop app.
+ *
+ * This only considers client-side state. Robot-side state, like whether access control
+ * is enabled at all, needs to be fetched separately.
+ */
+export const getLocalRobotAuthState = createSelector(
+  (state: State) => state,
+  (state: State) => getLocalRobot(state)?.name ?? null,
+  (state: State, localRobotName: string | null): PerRobotAuthState | null => {
+    if (localRobotName == null) {
+      return null
+    } else {
+      return getAuthStateForRobot(state, localRobotName)
+    }
+  }
+)
+
+/**
  * On the on-device display, this returns whether we're currently logged in to the
- * local robot. On the desktop app, this is not meaningful.
+ * local robot. This should not be used in the desktop app.
  *
  * This only considers client-side state. Robot-side state, like whether access control
  * is enabled at all, needs to be fetched separately.
  */
 export const getIsLoggedInToLocalRobot = createSelector(
-  (state: State) => state,
-  (state: State) => getLocalRobot(state)?.name ?? null,
-  (state: State, localRobotName: string | null): boolean =>
-    localRobotName != null &&
-    getAuthStateForRobot(state, localRobotName) != null
+  getLocalRobotAuthState,
+  (localRobotAuthState: PerRobotAuthState | null): boolean =>
+    localRobotAuthState != null
 )


### PR DESCRIPTION
# Overview

This closes EXEC-2601. See there for a link to the Figma designs.

## Test Plan and Hands on Testing


https://github.com/user-attachments/assets/bb878348-dad0-4fdd-a1ba-6a44ac2a5989

## Changelog

* When the user is logged in, we now show an account icon with the first letter of their username.
  * It should be the first letter of their *legal* name, but we need HTTP API changes for that, so I'm just doing the username for now.
  * It should link to an account page, but that doesn't exist yet (EXEC-2602), so it links to the settings page for now.
* A small tweak to the navigation menu's fadeout gradient, to make sure its width always matches the designs regardless of how many items are in the menu.

## Review requests

None in particular.

## Risk assessment

Low.