### PR TITLE
fix(protocol-designer): check if selected wells are accessible at beginning of transfer step form

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
@@ -6,9 +6,14 @@ import { COLORS, ListButton, StyledText } from '@opentrons/components'
 import { ALL, COLUMN, PARTIAL_NOZZLE_MAP, ROW } from '@opentrons/shared-data'
 import { getDefaultPrimaryNozzle } from '@opentrons/step-generation'
 
-import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
+import {
+  getInitialDeckSetup,
+  getInvariantContext,
+} from '/protocol-designer/step-forms/selectors'
+import { getRobotStateAtActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 
 import { PLURAL_COLUMNS, PLURAL_ROWS } from './constants'
+import { getAllWellsSafetyStatus } from './getAllWellsSafetyStatus'
 import { NozzleAndWellSelectionModal } from './NozzleAndWellSelectionModal'
 import styles from './nozzleandwellwizard.module.css'
 import { getNozzleText, getWellGroupLength } from './utils'
@@ -34,6 +39,8 @@ export function ExtendedPartialTipField(
   const { pipetteSpecs, propsForFields, stepType } = props
   const { t } = useTranslation('protocol_steps')
   const deckSetup = useSelector(getInitialDeckSetup)
+  const invariantContext = useSelector(getInvariantContext)
+  const robotState = useSelector(getRobotStateAtActiveItem)
   const { channels } = pipetteSpecs
   const [isNozzleAndWellModalOpen, setIsNozzleAndWellModalOpen] =
     useState<boolean>(false)
@@ -64,6 +71,69 @@ export function ExtendedPartialTipField(
 
       break
   }
+  // if deck setup changes and selected wells are now inaccessible - unselect them so that an error is raised
+  interface WellCheckConfig {
+    wells: string[]
+    labwareId: string | null
+    fieldKey: keyof FieldPropsByName
+  }
+
+  const wellConfigs: WellCheckConfig[] = []
+
+  if (stepType === 'mix') {
+    wellConfigs.push({
+      wells: (propsForFields.wells?.value as string[]) ?? [],
+      labwareId: propsForFields.labware.value as string,
+      fieldKey: 'wells',
+    })
+  }
+
+  if (stepType === 'transfer') {
+    wellConfigs.push({
+      wells: (propsForFields.aspirate_wells?.value as string[]) ?? [],
+      labwareId: propsForFields.aspirate_labware.value as string,
+      fieldKey: 'aspirate_wells',
+    })
+
+    wellConfigs.push({
+      wells: (propsForFields.dispense_wells?.value as string[]) ?? [],
+      labwareId: propsForFields.dispense_labware.value as string,
+      fieldKey: 'dispense_wells',
+    })
+  }
+  const tiprackLabwareDefURI = propsForFields.tipRack.value as string
+
+  const tiprackId = Object.values(deckSetup.labware).find(
+    labware => labware.labwareDefURI === tiprackLabwareDefURI
+  )?.id
+  const inaccessibleFields = wellConfigs
+    .map(config => {
+      if (!config.labwareId || config.wells.length === 0) {
+        return null
+      }
+
+      const status = getAllWellsSafetyStatus({
+        allWells: [config.wells],
+        robotState,
+        invariantContext,
+        pipetteId: propsForFields.pipette.value as string,
+        labwareId: config.labwareId,
+        primaryNozzle: primaryNozzle,
+        nozzleConfiguration: nozzleConfiguration,
+        tiprackId,
+      })
+
+      const hasInaccessibleWell = config.wells.some(well => status[well] !== 0)
+
+      return hasInaccessibleWell ? config.fieldKey : null
+    })
+    .filter(Boolean) as Array<keyof FieldPropsByName>
+  useEffect(() => {
+    inaccessibleFields.forEach(fieldKey => {
+      propsForFields[fieldKey]?.updateValue([])
+    })
+  }, [inaccessibleFields, propsForFields])
+
   const dspWells = propsForFields.dispense_wells
     ? (propsForFields.dispense_wells.value as [])
     : []
@@ -107,7 +177,11 @@ export function ExtendedPartialTipField(
       (channels === 8 && nozzleConfiguration === ALL) ||
       nozzleConfiguration === COLUMN
     const isRow = nozzleConfiguration === ROW
-    if (!nozzleText || aspWellsLength === 0) {
+    if (
+      !nozzleText ||
+      aspWellsLength === 0 ||
+      (isTransfer && dspWellsLength === 0)
+    ) {
       return t('no_nozzles_and_wells_selected')
     }
     let positionType: string = 'wells'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/FirstStepMoveLiquidTools.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/__tests__/FirstStepMoveLiquidTools.test.tsx
@@ -1,7 +1,12 @@
 import { screen } from '@testing-library/react'
 import { beforeEach, describe, it, vi } from 'vitest'
 
-import { fixture96Plate } from '@opentrons/shared-data'
+import {
+  fixture96Plate,
+  fixtureP100096V2Specs,
+  fixtureTiprack1000ul,
+  getLabwareDefURI,
+} from '@opentrons/shared-data'
 
 import formDataForSingleStep from '/protocol-designer/__fixtures__/formDataForSingleStep.json'
 import propsForFieldsForSingleStep from '/protocol-designer/__fixtures__/propsForFieldsForSingleStep.json'
@@ -10,9 +15,11 @@ import { i18n } from '/protocol-designer/assets/localization'
 import {
   getAdditionalEquipmentEntities,
   getInitialDeckSetup,
+  getInvariantContext,
   getLabwareEntities,
   getPipetteEntities,
 } from '/protocol-designer/step-forms/selectors'
+import { getRobotStateAtActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 
 import {
   ChangeTipField,
@@ -28,13 +35,19 @@ import {
 import { FirstStepMoveLiquidTools } from '../FirstStepMoveLiquidTools'
 
 import type { ComponentProps } from 'react'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type {
+  LabwareDefinition,
+  LabwareDefinition2,
+} from '@opentrons/shared-data'
 import type { AllTemporalPropertiesForTimelineFrame } from '/protocol-designer/step-forms'
 
 vi.mock('/protocol-designer/step-forms/selectors')
 vi.mock('../../../PipetteFields')
 vi.mock('/protocol-designer/feature-flags/selectors')
-
+vi.mock('/protocol-designer/file-data/selectors')
+vi.mock('/protocol-designer/ui/labware/selectors')
+vi.mock('/protocol-designer/ui/modules/selectors')
+vi.mock('/protocol-designer/top-selectors/labware-locations')
 const labwareId =
   '4d7e45e2-b962-45ca-8ace-8a5a683591d5:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/2'
 const dispenseLabwareId =
@@ -46,7 +59,45 @@ const render = (props: ComponentProps<typeof FirstStepMoveLiquidTools>) => {
     i18nInstance: i18n,
   })
 }
+const DEFAULT_ROBOT_STATE = {
+  tipState: { pipettes: { pipetteId: {} } },
+  labware: {
+    [labwareId]: { stack: [labwareId, 'C1'] },
+    [dispenseLabwareId]: { stack: [dispenseLabwareId, 'C2'] },
+  },
+} as any
+const mockInvariantContext = {
+  pipetteEntities: {
+    [pipetteId]: {
+      name: 'p1000_96',
+      id: pipetteId,
+      tiprackDefURI: [
+        getLabwareDefURI(fixtureTiprack1000ul as LabwareDefinition),
+      ],
+      tiprackLabwareDef: [fixtureTiprack1000ul],
+      spec: fixtureP100096V2Specs,
+      pythonName: 'mock_pipette_p1000_96',
+    },
+  },
+  labwareEntities: {
+    [labwareId]: {
+      id: labwareId,
+      pythonName: 'mock_source_plate',
+      labwareDefURI: getLabwareDefURI(fixture96Plate as LabwareDefinition),
+      def: fixture96Plate,
+    },
+    [dispenseLabwareId]: {
+      id: dispenseLabwareId,
+      labwareDefURI: 'mockUri',
+      pythonName: 'aspirate_labware',
+      def: fixture96Plate as LabwareDefinition2,
+    },
+  },
 
+  stagingAreaEntities: {},
+  moduleEntities: {},
+} as any
+vi.mocked(getInvariantContext).mockReturnValue(mockInvariantContext)
 describe('FirstStepMoveLiquidTools', () => {
   let props: ComponentProps<typeof FirstStepMoveLiquidTools>
   beforeEach(() => {
@@ -54,6 +105,7 @@ describe('FirstStepMoveLiquidTools', () => {
       propsForFields: propsForFieldsForSingleStep as any,
       formData: formDataForSingleStep as any,
     }
+    vi.mocked(getRobotStateAtActiveItem).mockReturnValue(DEFAULT_ROBOT_STATE)
     vi.mocked(getInitialDeckSetup).mockReturnValue({
       modules: {},
       labware: {
@@ -95,7 +147,6 @@ describe('FirstStepMoveLiquidTools', () => {
       },
     })
     vi.mocked(getAdditionalEquipmentEntities).mockReturnValue({})
-
     vi.mocked(PipetteField).mockReturnValue(<div>mock PipetteField</div>)
     vi.mocked(TiprackField).mockReturnValue(<div>mock TiprackField</div>)
     vi.mocked(LabwareField).mockReturnValue(<div>mock LabwareField</div>)


### PR DESCRIPTION
# Overview

Ensure wells are accessible when the transfer step form is opened. If some wells are not accessible, then unselect them. This was added to handle changes in deck configuration that would make previously selected wells unaccessible.

## Test Plan and Hands on Testing
- upload protocol: 
[GbS_5_plaques_pooling_5ul_tubes_5ml.py](https://github.com/user-attachments/files/27249562/GbS_5_plaques_pooling_5ul_tubes_5ml.py)

- move tiprack into slot A1 or A2 to make selected wells unaccessible
- confirm that those wells were unselected in the well selection modal
<img width="1215" height="747" alt="Screenshot 2026-04-30 at 11 45 49 AM" src="https://github.com/user-attachments/assets/efcaa247-79a1-46da-8d3e-002b81c1c24b" />

## Changelog

- added use of `getAllWellsSafetyStatus` in `ExtendedPartialTipField` 
- update well values when propsforfields or accessibility status changes

## Risk assessment

medium

Closes RQA-5344