### PR TITLE
fix(app): fix instruments screen spacing issue

### DIFF
--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupInstruments/ProtocolSetupInstruments.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupInstruments/ProtocolSetupInstruments.tsx
@@ -1,15 +1,5 @@
 import { useTranslation } from 'react-i18next'
-import styled from 'styled-components'
 
-import {
-  ALIGN_CENTER,
-  COLORS,
-  DIRECTION_COLUMN,
-  Flex,
-  JUSTIFY_SPACE_BETWEEN,
-  SPACING,
-  TYPOGRAPHY,
-} from '@opentrons/components'
 import { useInstrumentsQuery } from '@opentrons/react-api-client'
 
 import { ODDBackButton } from '/app/molecules/ODDBackButton'
@@ -18,6 +8,8 @@ import { PipetteRecalibrationODDWarning } from '/app/organisms/ODD/PipetteRecali
 import { isGripperInCommands } from '/app/resources/protocols/utils'
 import { useMostRecentCompletedAnalysis } from '/app/resources/runs'
 import { getShowPipetteCalibrationWarning } from '/app/transformations/instruments'
+
+import styles from './protocolsetupinstruments.module.css'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { GripperData, PipetteData } from '@opentrons/api-client'
@@ -48,32 +40,26 @@ export function ProtocolSetupInstruments({
     : null
 
   return (
-    <Flex
-      flexDirection={DIRECTION_COLUMN}
-      width="100%"
-      gridGap={SPACING.spacing8}
-    >
-      <ODDBackButton
-        label={t('instruments')}
-        onClick={() => {
-          setSetupScreen('prepare to run')
-        }}
-      />
+    <div className={styles.instruments_container}>
+      <div className={styles.back_button_container}>
+        <ODDBackButton
+          label={t('instruments')}
+          onClick={() => {
+            setSetupScreen('prepare to run')
+          }}
+        />
+      </div>
       {getShowPipetteCalibrationWarning(attachedInstruments) && (
-        <Flex paddingBottom={SPACING.spacing16}>
+        <div className={styles.warning_container}>
           <PipetteRecalibrationODDWarning />
-        </Flex>
+        </div>
       )}
-      <Flex
-        justifyContent={JUSTIFY_SPACE_BETWEEN}
-        alignItems={ALIGN_CENTER}
-        paddingX={SPACING.spacing24}
-      >
-        <ColumnLabel>{t('location')}</ColumnLabel>
-        <ColumnLabel>
+      <div className={styles.header_container}>
+        <p className={styles.column_label}>{t('location')}</p>
+        <p className={styles.column_label}>
           {i18n.format(t('calibration_status'), 'sentenceCase')}
-        </ColumnLabel>
-      </Flex>
+        </p>
+      </div>
       {(mostRecentAnalysis?.pipettes ?? []).map(loadedPipette => {
         const attachedPipetteMatch =
           (attachedInstruments?.data ?? []).find(
@@ -102,14 +88,6 @@ export function ProtocolSetupInstruments({
           attachedInstrument={attachedGripperMatch}
         />
       ) : null}
-    </Flex>
+    </div>
   )
 }
-
-const ColumnLabel = styled.p`
-  flex: 1;
-  font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
-  font-size: ${TYPOGRAPHY.fontSize22};
-  line-height: ${TYPOGRAPHY.lineHeight28};
-  color: ${COLORS.grey60};
-`

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupInstruments/protocolsetupinstruments.module.css
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupInstruments/protocolsetupinstruments.module.css
@@ -1,0 +1,29 @@
+.instruments_container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-8);
+}
+
+.back_button_container {
+  padding-bottom: var(--spacing-32);
+}
+
+.warning_container {
+  display: flex;
+  padding-bottom: var(--spacing-16);
+}
+
+.header_container {
+  display: flex;
+  justify-content: space-between;
+  padding-right: var(--spacing-24);
+  padding-left: var(--spacing-24);
+}
+
+.column_label {
+  flex: 1;
+  color: var(--grey-60);
+  font-size: var(--font-size-22);
+  font-weight: var(--font-weight-semi-bold);
+  line-height: var(--line-height-28);
+}


### PR DESCRIPTION
fix instruments screen spacing issue

close AUTH-2681

# Overview
fix instruments screen spacing issue and switch `styled-components` to `CSS Modules`

<img width="1293" height="764" alt="Screenshot 2026-04-30 at 1 26 49 PM" src="https://github.com/user-attachments/assets/e8bd5b73-87da-45c5-a36f-e32682d2e159" />

Mel approved the change already.

close AUTH-2681

## Test Plan and Hands on Testing
- set up a protocol
- tap instruments in protocol setup sceeen

## Changelog
- fix spacing issue of ODDBackButton
- introduce CSS Modules

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment
low
