### PR TITLE
docs: update Ubuntu minimum requirement to 22.04

### DIFF
--- a/docs/flex/docs/opentrons-app/install.md
+++ b/docs/flex/docs/opentrons-app/install.md
@@ -7,7 +7,7 @@ Start here for step-by-step instructions for downloading, installing, and mainta
 
 ## App installation
 
-Download the Opentrons App from <https://opentrons.com/ot-app/>. The latest version of the app requires Windows 10, macOS 11, or Ubuntu 20.04 or later. The app may run on other Linux distributions, but Opentrons does not officially support them.
+Download the Opentrons App from <https://opentrons.com/ot-app/>. The latest version of the app requires Windows 10, macOS 11, or Ubuntu 22.04 or later. The app may run on other Linux distributions, but Opentrons does not officially support them.
 
 ### Windows
 

--- a/docs/flex/docs/system-description/specs.md
+++ b/docs/flex/docs/system-description/specs.md
@@ -23,7 +23,7 @@ description: "Dimensions, weight, deck slots, connectivity, and power specificat
 | **Frame composition**    | Rigid steel and CNC aluminum design |
 | **Window composition**   | Removable polycarbonate side windows and front door |
 | **Ventilation requirements** | At least 20 cm / 8 in between the unit and a wall |
-| **Connected PC requirements** | The latest version of the Opentrons App runs on: <ul><li>Windows 10 or later</li><li>macOS 11 or later</li><li>Ubuntu 20.04 or later</li></ul> |
+| **Connected PC requirements** | The latest version of the Opentrons App runs on: <ul><li>Windows 10 or later</li><li>macOS 11 or later</li><li>Ubuntu 22.04 or later</li></ul> |
 
 ## Environmental specifications
 

--- a/docs/ot-2/docs/opentrons-app/installation.md
+++ b/docs/ot-2/docs/opentrons-app/installation.md
@@ -7,7 +7,7 @@ Start here for step-by-step instructions for downloading, installing, and updati
 
 ## App installation { #app-installation-ot2 }
 
-Download the Opentrons App from [opentrons.com/ot-app](https://opentrons.com/ot-app/). The latest version of the app requires Windows 10, macOS 11, or Ubuntu 20.04 or later. The app may run on other Linux distributions, but Opentrons does not officially support them.
+Download the Opentrons App from [opentrons.com/ot-app](https://opentrons.com/ot-app/). The latest version of the app requires Windows 10, macOS 11, or Ubuntu 22.04 or later. The app may run on other Linux distributions, but Opentrons does not officially support them.
 
 ### Windows
 

--- a/docs/ot-2/docs/system-description/specs.md
+++ b/docs/ot-2/docs/system-description/specs.md
@@ -76,7 +76,7 @@ description: "Dimensions, weight, deck slots, connectivity, and power specificat
             <ul>
                 <li>Windows 10 or later</li>
                 <li>macOS 11 (Big Sur) or later</li>
-                <li>Ubuntu 20.04 or later</li>
+                <li>Ubuntu 22.04 or later</li>
             </ul>
         </td>
     </tr>


### PR DESCRIPTION
# Overview

We're bumping our minimum Ubuntu version from 20.04 -> 22.04

## Test Plan and Hands on Testing

Check the sandbox.

## Changelog

4 occurrences of this, 2x each in Flex and OT-2 manual.

## Review requests

got em all, yeah?

## Risk assessment

v v low