### PR TITLE
fix(e2e-testing): correct applitools baseline

### DIFF
--- a/.github/workflows/pd-e2e-test.yaml
+++ b/.github/workflows/pd-e2e-test.yaml
@@ -71,6 +71,7 @@ jobs:
       - name: "Run E2E tests against local build"
         working-directory: e2e-testing
         env:
+          APPLITOOLS_BRANCH: ${{ github.base_ref || github.ref_name }}
           APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
         run: make test-pd-local
 


### PR DESCRIPTION
this is applying PR #21317's fix to pd 8.10.1 to reduce mergeback complexity
