### PR TITLE
feat(app): add certificate storage to disk

### DIFF
--- a/app-shell/src/certs.ts
+++ b/app-shell/src/certs.ts
@@ -53,23 +53,38 @@ async function getCertDir(): Promise<string> {
   return certDir
 }
 
+async function writeFile(path: string, contents: Buffer): Promise<void> {
+  const certFile = await open(path, 'w')
+  try {
+    await certFile.writeFile(contents)
+  } finally {
+    await certFile.close()
+  }
+}
+
 async function saveCertificateToDisk(
   certificate: X509Certificate
 ): Promise<void> {
   const certDir = await getCertDir()
-
   const certPath = join(certDir, `${certificate.fingerprint256}.cer`)
-  const certFile = await open(certPath, 'w')
-  await certFile.writeFile(certificate.raw)
+  await writeFile(certPath, certificate.raw)
   log.info(`Saved certificate to ${certPath}`)
   addCertificateToMap(certificate)
+}
+
+async function readFile(path: string): Promise<Buffer> {
+  const handle = await open(path, 'r')
+  try {
+    return await handle.readFile()
+  } finally {
+    await handle.close()
+  }
 }
 
 async function tryLoadCertificate(
   path: string
 ): Promise<X509Certificate | null> {
-  const handle = await open(path, 'r')
-  const contents = await handle.readFile()
+  const contents = await readFile(path)
   try {
     return new X509Certificate(contents)
   } catch (err: any) {
@@ -233,7 +248,7 @@ async function certInstallListener(
   )
   const certificate = new X509Certificate(certDER)
   log.silly(`got cert, ca: ${certificate.ca} signer: ${certificate.issuer}`)
-  saveCertificateToDisk(certificate)
+  await saveCertificateToDisk(certificate)
   return true
 }
 

--- a/app-shell/src/certs.ts
+++ b/app-shell/src/certs.ts
@@ -1,4 +1,6 @@
 import { pbkdf2, subtle, X509Certificate } from 'crypto'
+import { mkdir, open, readdir, rm, stat } from 'fs/promises'
+import { join } from 'path'
 import { promisify } from 'util'
 import { app, ipcMain } from 'electron'
 
@@ -18,13 +20,95 @@ const CERT_DECRYPTION_TTL_NOT_RECENT_S = 10 * 365 * 24 * 60 * 60
 const CERT_DECRYPTION_FORWARD_CLOCK_SKEW_NEAR_S = 24 * 60 * 60
 const CERT_DECRYPTION_FORWARD_CLOCK_SKEW_FAR_S = 10 * 365 * 24 * 60 * 60
 
+const CERT_SUBDIR = 'robot-certificates'
+
+const log = createLogger('certs')
+
+async function wrappedStat(
+  path: string
+): Promise<Awaited<ReturnType<typeof stat>> | null> {
+  try {
+    return await stat(path)
+  } catch (_: any) {
+    return null
+  }
+}
+
+async function ensureDir(path: string): Promise<void> {
+  const dirstat = await wrappedStat(path)
+  if (dirstat == null) {
+    log.info(`${path} does not exist, making directory`)
+    await mkdir(path, { recursive: true })
+  } else if (!dirstat.isDirectory()) {
+    log.warn(`${path} exists as a non-directory, removing`)
+    await rm(path)
+    await mkdir(path, { recursive: true })
+  }
+}
+
+async function getCertDir(): Promise<string> {
+  const basePath = app.getPath('userData')
+  const certDir = join(basePath, CERT_SUBDIR)
+  await ensureDir(certDir)
+  return certDir
+}
+
+async function saveCertificateToDisk(
+  certificate: X509Certificate
+): Promise<void> {
+  const certDir = await getCertDir()
+
+  const certPath = join(certDir, `${certificate.fingerprint256}.cer`)
+  const certFile = await open(certPath, 'w')
+  await certFile.writeFile(certificate.raw)
+  log.info(`Saved certificate to ${certPath}`)
+  addCertificateToMap(certificate)
+}
+
+async function tryLoadCertificate(
+  path: string
+): Promise<X509Certificate | null> {
+  const handle = await open(path, 'r')
+  const contents = await handle.readFile()
+  try {
+    return new X509Certificate(contents)
+  } catch (err: any) {
+    log.warning(`Invalid certificate: ${err}`)
+    return null
+  }
+}
+
+async function loadCertificatesFromDisk(): Promise<void> {
+  const certDir = await getCertDir()
+  log.info(`Reading robot certificates from ${certDir}`)
+  const certs = await readdir(certDir, {
+    withFileTypes: true,
+    encoding: 'utf8',
+  })
+  for (const possibleCert of certs) {
+    if (!possibleCert.isFile()) {
+      continue
+    }
+    if (!possibleCert.name.endsWith('.cer')) {
+      continue
+    }
+    const loaded = await tryLoadCertificate(join(certDir, possibleCert.name))
+    if (loaded == null) {
+      continue
+    }
+    if (!loaded.ca || loaded.issuer === 'Opentrons') {
+      continue
+    }
+    addCertificateToMap(loaded)
+  }
+}
+
 function addCertificateToMap(certificate: X509Certificate): void {
   const sha256Fingerprint = certificate.fingerprint256
   knownCertificates.set(sha256Fingerprint, certificate)
-  log.silly(`added certificate at ${sha256Fingerprint}`)
+  log.info(`added certificate at ${sha256Fingerprint}`)
 }
 
-const log = createLogger('certs')
 /**
  * An implementation of the Fernet cryptosystem (https://github.com/fernet/spec)
  * decode side only tuned to our requirements.
@@ -149,12 +233,11 @@ async function certInstallListener(
   )
   const certificate = new X509Certificate(certDER)
   log.silly(`got cert, ca: ${certificate.ca} signer: ${certificate.issuer}`)
-  addCertificateToMap(certificate)
-  log.info(`added cert to known certificates, have ${knownCertificates.size}`)
+  saveCertificateToDisk(certificate)
   return true
 }
 
-export function registerCertIPC(): void {
+export async function registerCertIPC(): Promise<void> {
   ipcMain.handle('robot-cert:install', certInstallListener)
   app.on(
     'certificate-error',
@@ -174,4 +257,5 @@ export function registerCertIPC(): void {
       log.info('no sign match for cert, denying')
     }
   )
+  await loadCertificatesFromDisk()
 }

--- a/app-shell/src/certs.ts
+++ b/app-shell/src/certs.ts
@@ -111,9 +111,6 @@ async function loadCertificatesFromDisk(): Promise<void> {
     if (loaded == null) {
       continue
     }
-    if (!loaded.ca || loaded.issuer === 'Opentrons') {
-      continue
-    }
     addCertificateToMap(loaded)
   }
 }

--- a/app-shell/src/main.ts
+++ b/app-shell/src/main.ts
@@ -82,7 +82,7 @@ app
   .whenReady()
   .then(async () => {
     app.setAsDefaultProtocolClient(PROTOCOL_NAME)
-    startUp()
+    await startUp()
 
     if (config.devtools) {
       await installDevtools()
@@ -168,7 +168,7 @@ function getOrCreateHandlerSet(window: BrowserWindow): HandlerSet | null {
   return handlerSet ?? null
 }
 
-function startUp(): void {
+async function startUp(): Promise<void> {
   log.info('Starting App')
   process.on('uncaughtException', error => log.error('Uncaught: ', { error }))
   process.on('unhandledRejection', reason =>
@@ -224,7 +224,7 @@ function startUp(): void {
       )
     }
   })
-  registerCertIPC()
+  await registerCertIPC()
 
   log.silly('Global references', { mainWindow, rendererLogger })
 }


### PR DESCRIPTION
We need to store CA certificates in between app launches, so put them in the configuration directory. Their filenames don't matter beyond being unique to the cert, so we can use the fingerprint of the cert. We just load everything when we boot.

This is entirely fs integrations so I'm not quite sure what we could unit test, but suggest something!

Testing:
- [x] dev robots store their certs
- [x] real robot stores its certs

Closes EXEC-2603
