### PR TITLE
fix(protocol-designer): show error message for both tip tracking options

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipTrackingField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipTrackingField.tsx
@@ -210,7 +210,7 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
           </ListButton>
         </Flex>
       ) : null}
-      {formData.tip_tracking === MANUAL && !hasValidTiprackForPickup ? (
+      {!hasValidTiprackForPickup ? (
         <InlineNotification
           type="error"
           heading={t('tip_selection:no_valid_tips_available.title')}


### PR DESCRIPTION
# Overview

If there are no tip racks or tips available, an inline notification will appear for both tip tracking options. 

This gives the user more clarity on what could be causing a collision. 

## Test Plan and Hands on Testing
smoke tested with protocol attached in RQA-5342
<img width="1489" height="808" alt="Screenshot 2026-04-30 at 3 00 56 PM" src="https://github.com/user-attachments/assets/7c5a228a-d0cd-466d-8827-5b8f5d9b8f6f" />

## Changelog

- removed conditional statement that made the notification only appear if the tip selection mode was manual


## Risk assessment
low

Closes RQA-5342