### PR TITLE
fix(protocol-designer): should show nozzle and well text if dispense location is trash

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
@@ -180,7 +180,7 @@ export function ExtendedPartialTipField(
     if (
       !nozzleText ||
       aspWellsLength === 0 ||
-      (isTransfer && dspWellsLength === 0)
+      (isTransfer && isDispenseInLabware && dspWellsLength === 0)
     ) {
       return t('no_nozzles_and_wells_selected')
     }


### PR DESCRIPTION
# Overview

Whoops! The nozzle and well selection text should display if the dispense wells length is 0 if the dispense location is not a labware!

## Test Plan and Hands on Testing 
smoke tested
<img width="1213" height="750" alt="Screenshot 2026-04-30 at 3 59 45 PM" src="https://github.com/user-attachments/assets/8d72fd65-a913-4efe-9ab1-b900dc46c5ec" />

## Changelog

- added conditional statement to only show nothing is selected if it is a transfer step, no dispense wells, AND the dispense location is LABWARE

## Risk assessment

low

Closes RQA-5346