### PR TITLE
fix(protocol-designer): correct which wells to check for collision based on nozzle configuration AND channels

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -39,7 +39,10 @@ import {
   INACCESSIBLE_PARTIAL_TIP,
   INACCESSIBLE_WELL_SPACING_MISMATCH,
 } from '../NozzleAndWellSelectionModal/constants'
-import { getEntireWellSelection } from '../NozzleAndWellSelectionModal/utils'
+import {
+  getEntireWellSelection,
+  getWellNameAtClientPoint,
+} from '../NozzleAndWellSelectionModal/utils'
 import { BaseDeckTipSelection } from './BaseDeckTipSelection'
 import {
   INACCESSIBLE_COLLISION,
@@ -106,7 +109,7 @@ export function SelectTips(
   } = props
   const labwareName = labwareNicknamesById[selectedTiprackId ?? '']
   const robotState = useSelector(getRobotStateAtActiveItem)
-
+  const [wellShadow, setWellShadow] = useState<string | null>(null)
   const viewBox =
     selectedTiprackId != null
       ? getViewboxFromSelectedLabware(
@@ -283,7 +286,7 @@ export function SelectTips(
       leaveTimeoutRef.current = null
     }
     setHoveredWells(allHoveredWells)
-    currentHoveredWellRef.current = allHoveredWells
+    setWellShadow(allHoveredWells[0])
   }
 
   const handleLeaveWell = (_: WellMouseEvent): void => {
@@ -312,6 +315,10 @@ export function SelectTips(
       const wellsUnderRect = _getWellsFromRect(rect)
       const flat = [...new Set(wellsUnderRect.flat())]
       setHoveredWells(flat)
+      const wellUnderMouse = getWellNameAtClientPoint(e.clientX, e.clientY)
+      if (wellUnderMouse) {
+        setWellShadow(wellUnderMouse)
+      }
     }
   }
   const handleSelectionDone = (e: MouseEvent, rect: GenericRect): void => {
@@ -420,17 +427,17 @@ export function SelectTips(
           borderStroke={COLORS.yellow40}
           ignoreMissingTips
         />
-        {hoveredWells != null ? (
+        {wellShadow ? (
           <PipetteShadow
             robotType={robotType}
             pipetteSpec={pipetteSpecs}
             slotPosition={slotPosition}
-            hoveredWell={hoveredWells[0]}
+            hoveredWell={wellShadow ?? ''}
             selectedLabwareId={selectedTiprackId}
             labwareState={activeDeckSetup.labware}
             isHoveredWellSelected={selectedTips
               .flat()
-              .some(tip => tip === hoveredWells[0])}
+              .some(tip => tip === wellShadow)}
             hasPickupsRemaining={hasPickupsRemaining}
             isAccessible={hoveredWellsInaccessibilityStatus == null}
             inaccessibleReason={hoveredWellsInaccessibilityStatus ?? null}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
@@ -1,13 +1,7 @@
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 
-import {
-  ALL,
-  COLUMN,
-  PARTIAL_COLUMN,
-  ROW,
-  SINGLE,
-} from '@opentrons/shared-data'
+import { ALL, COLUMN, ROW } from '@opentrons/shared-data'
 import {
   getIsSafePickupWithinTiprack,
   getIsSafePipetteMovement,
@@ -25,6 +19,7 @@ import {
 } from '../constants'
 
 import type {
+  ActiveNozzleNumber,
   NozzleConfigurationStyle,
   PipetteV2Specs,
   PrimaryNozzleConfigurationStyle,
@@ -33,19 +28,18 @@ import type { AccessibilityStatus, InaccessibleReason } from '../types'
 
 export const getWellsToCheck = (
   nozzles: NozzleConfigurationStyle,
-  wellOrdering: string[][]
+  wellOrdering: string[][],
+  channels: ActiveNozzleNumber
 ): string[] => {
-  switch (nozzles) {
-    case ROW:
-      return wellOrdering[0]
-    case COLUMN:
-      return wellOrdering.map(row => row[0])
-    case ALL:
-    case SINGLE:
-    case PARTIAL_COLUMN:
-      return wellOrdering.flat()
+  if (channels === 96 && nozzles === ALL) {
+    return [wellOrdering.flat()[0]]
+  } else if (nozzles === ROW) {
+    return wellOrdering[0]
+  } else if (nozzles === COLUMN || (channels === 8 && nozzles === ALL)) {
+    return wellOrdering.map(row => row[0])
+  } else {
+    return wellOrdering.flat()
   }
-  return []
 }
 
 /**
@@ -102,7 +96,11 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
           return acc
         }
         const pipetteChannels = pipetteSpecs.channels
-        const wellNamesToCheck = getWellsToCheck(nozzles, def.ordering)
+        const wellNamesToCheck = getWellsToCheck(
+          nozzles,
+          def.ordering,
+          pipetteChannels
+        )
         return {
           ...acc,
           [id]: wellNamesToCheck.reduce((acc, wellName) => {


### PR DESCRIPTION
# Overview

`getWellsToCheck` should take channels into account to determine what wells it should check for collisions.

Ex: for ALL configuration in an 1ch you should check ALL wells, for ALL configuration for the 8ch you should check the first well of the column, and for ALL 96ch you should only check the first well in the tip rack.

This was causing a bug where it thought some wells were inaccessible because it was mapping the nozzle to every single one.

## Test Plan and Hands on Testing

- smoke tested with protocols attached to ticket RQA-5345 and then also created this protocol with a few more steps:
[96ch_partial_smoketest.py](https://github.com/user-attachments/files/27260879/96ch_partial_smoketest.py)

## Changelog
- reworked `getWellsToCheck` to include consideration of number of channels
- adjusted hovered well to reflect the well that the selection rectangle was hovered over.
## Risk assessment

medium
Closes RQA-5345