### PR TITLE
fix(app): fix spacing issues in protocol details page

### DIFF
--- a/app/src/pages/ODD/ProtocolDetails/Hardware.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/Hardware.tsx
@@ -10,6 +10,7 @@ import {
   ModuleIcon,
   RobotInfoLabel,
   SPACING,
+  StyledText,
   TYPOGRAPHY,
   WRAP,
 } from '@opentrons/components'
@@ -44,11 +45,10 @@ const Table = styled('table')`
   table-layout: auto;
   width: 100%;
   border-spacing: 0 ${SPACING.spacing8};
-  margin: ${SPACING.spacing16} 0;
   text-align: ${TYPOGRAPHY.textAlignLeft};
 `
 const TableHeader = styled('th')`
-  padding: ${SPACING.spacing4};
+  padding: 0 ${SPACING.spacing24} 0 ${SPACING.spacing24};
 `
 
 const TableRow = styled('tr')`
@@ -193,24 +193,22 @@ export const Hardware = (props: { protocolId: string }): JSX.Element => {
       <thead>
         <tr>
           <TableHeader>
-            <LegacyStyledText
-              fontSize={TYPOGRAPHY.fontSize20}
+            <StyledText
               color={COLORS.grey60}
-              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               paddingLeft={SPACING.spacing24}
+              oddStyle="smallBodyTextSemiBold"
             >
               {i18n.format(t('location'), 'capitalize')}
-            </LegacyStyledText>
+            </StyledText>
           </TableHeader>
           <TableHeader>
-            <LegacyStyledText
-              fontSize={TYPOGRAPHY.fontSize20}
+            <StyledText
               color={COLORS.grey60}
-              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
               paddingLeft={SPACING.spacing24}
+              oddStyle="smallBodyTextSemiBold"
             >
               {i18n.format(t('hardware'), 'capitalize')}
-            </LegacyStyledText>
+            </StyledText>
           </TableHeader>
         </tr>
       </thead>

--- a/app/src/pages/ODD/ProtocolDetails/Labware.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/Labware.tsx
@@ -57,7 +57,7 @@ const TableDatum = styled('td')`
   }
   &:last-child {
     padding-right: ${SPACING.spacing24};
-    text-align: ${TYPOGRAPHY.textAlignRight};
+    text-align: ${TYPOGRAPHY.textAlignCenter};
     border-top-right-radius: ${BORDERS.borderRadius16};
     border-bottom-right-radius: ${BORDERS.borderRadius16};
   }
@@ -131,10 +131,7 @@ export const Labware = (props: { protocolId: string }): JSX.Element => {
                 </Flex>
               </TableDatum>
               <TableDatum>
-                <StyledText
-                  oddStyle="bodyTextSemiBold"
-                  textAlign={TYPOGRAPHY.textAlignCenter}
-                >
+                <StyledText oddStyle="bodyTextSemiBold">
                   {labware.quantity}
                 </StyledText>
               </TableDatum>

--- a/app/src/pages/ODD/ProtocolDetails/Labware.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/Labware.tsx
@@ -22,15 +22,23 @@ import { EmptySection } from './EmptySection'
 
 const Table = styled('table')`
   ${TYPOGRAPHY.labelRegular}
-  border-collapse: separate
+  border-collapse: separate;
   table-layout: auto;
   width: 100%;
   border-spacing: 0 ${SPACING.spacing8};
-  margin: ${SPACING.spacing16} 0;
   text-align: ${TYPOGRAPHY.textAlignLeft};
 `
 const TableHeader = styled('th')`
-  padding: ${SPACING.spacing4};
+  padding: 0 0 0 ${SPACING.spacing24};
+
+  &:first-child {
+    width: 100%;
+  }
+
+  &:last-child {
+    padding: 0 ${SPACING.spacing24} 0 0;
+    text-align: ${TYPOGRAPHY.textAlignRight};
+  }
 `
 
 const TableRow = styled('tr')`
@@ -48,6 +56,8 @@ const TableDatum = styled('td')`
     border-bottom-left-radius: ${BORDERS.borderRadius16};
   }
   &:last-child {
+    padding-right: ${SPACING.spacing24};
+    text-align: ${TYPOGRAPHY.textAlignRight};
     border-top-right-radius: ${BORDERS.borderRadius16};
     border-bottom-right-radius: ${BORDERS.borderRadius16};
   }
@@ -65,24 +75,12 @@ export const Labware = (props: { protocolId: string }): JSX.Element => {
       <thead>
         <tr>
           <TableHeader>
-            <StyledText
-              color={COLORS.grey60}
-              fontSize={TYPOGRAPHY.fontSize20}
-              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-              paddingLeft={SPACING.spacing24}
-            >
+            <StyledText color={COLORS.grey60} oddStyle="smallBodyTextSemiBold">
               {i18n.format(t('labware_name'), 'titleCase')}
             </StyledText>
           </TableHeader>
           <TableHeader>
-            <StyledText
-              alignItems={ALIGN_CENTER}
-              color={COLORS.grey60}
-              fontSize={TYPOGRAPHY.fontSize20}
-              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-              paddingRight={SPACING.spacing12}
-              textAlign={TYPOGRAPHY.textAlignCenter}
-            >
+            <StyledText color={COLORS.grey60} oddStyle="smallBodyTextSemiBold">
               {i18n.format(t('quantity'), 'sentenceCase')}
             </StyledText>
           </TableHeader>
@@ -135,7 +133,6 @@ export const Labware = (props: { protocolId: string }): JSX.Element => {
               <TableDatum>
                 <StyledText
                   oddStyle="bodyTextSemiBold"
-                  alignItems={ALIGN_CENTER}
                   textAlign={TYPOGRAPHY.textAlignCenter}
                 >
                   {labware.quantity}

--- a/app/src/pages/ODD/ProtocolDetails/Liquids.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/Liquids.tsx
@@ -26,7 +26,6 @@ const Table = styled('table')`
   table-layout: ${SPACING.spacingAuto};
   width: 100%;
   border-spacing: 0 ${BORDERS.borderRadius8};
-  margin: ${SPACING.spacing16} 0;
   text-align: ${TYPOGRAPHY.textAlignLeft};
 `
 const TableHeader = styled('th')`

--- a/app/src/pages/ODD/ProtocolDetails/Parameters.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/Parameters.tsx
@@ -5,8 +5,8 @@ import {
   BORDERS,
   COLORS,
   Flex,
-  LegacyStyledText,
   SPACING,
+  StyledText,
   TYPOGRAPHY,
   WRAP,
 } from '@opentrons/components'
@@ -33,7 +33,7 @@ const Table = styled('table')`
 const TableHeader = styled('th')`
   font-size: ${TYPOGRAPHY.fontSize20};
   font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
-  padding: 0 ${SPACING.spacing4} 0 ${SPACING.spacing4};
+  padding: 0 ${SPACING.spacing24} 0 ${SPACING.spacing24};
   color: ${COLORS.grey60};
 `
 
@@ -100,19 +100,28 @@ export const Parameters = (props: { protocolId: string }): JSX.Element => {
       <thead>
         <tr>
           <TableHeader>
-            <LegacyStyledText paddingLeft={SPACING.spacing24}>
+            <StyledText
+              oddStyle="smallBodyTextSemiBold"
+              paddingLeft={SPACING.spacing24}
+            >
               {i18n.format(t('name'), 'capitalize')}
-            </LegacyStyledText>
+            </StyledText>
           </TableHeader>
           <TableHeader>
-            <LegacyStyledText paddingLeft={SPACING.spacing24}>
+            <StyledText
+              oddStyle="smallBodyTextSemiBold"
+              paddingLeft={SPACING.spacing24}
+            >
               {i18n.format(t('default_value'), 'capitalize')}
-            </LegacyStyledText>
+            </StyledText>
           </TableHeader>
           <TableHeader>
-            <LegacyStyledText paddingLeft={SPACING.spacing24}>
+            <StyledText
+              oddStyle="smallBodyTextSemiBold"
+              paddingLeft={SPACING.spacing24}
+            >
               {i18n.format(t('range'), 'capitalize')}
-            </LegacyStyledText>
+            </StyledText>
           </TableHeader>
         </tr>
       </thead>

--- a/app/src/pages/ODD/ProtocolDetails/index.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/index.tsx
@@ -295,7 +295,6 @@ const ProtocolSectionContent = ({
   }
   return (
     <Flex
-      paddingTop={SPACING.spacing32}
       justifyContent={currentOption === 'deck' ? JUSTIFY_CENTER : undefined}
     >
       {protocolSection}
@@ -494,7 +493,11 @@ export function ProtocolDetails(): JSX.Element | null {
           isScrolled={isScrolled}
           isProtocolFetching={isProtocolFetching}
         />
-        <Flex flexDirection={DIRECTION_COLUMN} paddingTop={SPACING.spacing6}>
+        <Flex
+          flexDirection={DIRECTION_COLUMN}
+          paddingTop={SPACING.spacing6}
+          gap={SPACING.spacing32}
+        >
           <ProtocolSectionTabs
             currentOption={currentOption}
             setCurrentOption={setCurrentOption}
@@ -508,36 +511,36 @@ export function ProtocolDetails(): JSX.Element | null {
           ) : (
             <ProtocolDetailsSectionContentSkeleton />
           )}
-          <Flex
-            flexDirection={DIRECTION_ROW}
-            gridGap={SPACING.spacing8}
-            justifyContent={JUSTIFY_SPACE_BETWEEN}
-            paddingTop={
-              // Skeleton is large. Better UX not to scroll to see buttons while loading.
-              !isProtocolFetching ? SPACING.spacing60 : SPACING.spacing24
+        </Flex>
+        <Flex
+          flexDirection={DIRECTION_ROW}
+          gridGap={SPACING.spacing8}
+          justifyContent={JUSTIFY_SPACE_BETWEEN}
+          paddingTop={
+            // Skeleton is large. Better UX not to scroll to see buttons while loading.
+            !isProtocolFetching ? SPACING.spacing60 : SPACING.spacing24
+          }
+        >
+          <MediumButton
+            buttonText={
+              pinned
+                ? t('protocol_info:unpin_protocol')
+                : t('protocol_info:pin_protocol')
             }
-          >
-            <MediumButton
-              buttonText={
-                pinned
-                  ? t('protocol_info:unpin_protocol')
-                  : t('protocol_info:pin_protocol')
-              }
-              buttonType="secondary"
-              iconName="pin"
-              onClick={handlePinClick}
-              width="100%"
-            />
-            <MediumButton
-              buttonText={t('protocol_info:delete_protocol')}
-              buttonType="alertSecondary"
-              iconName="trash"
-              onClick={() => {
-                setShowConfirmationDeleteProtocol(true)
-              }}
-              width="100%"
-            />
-          </Flex>
+            buttonType="secondary"
+            iconName="pin"
+            onClick={handlePinClick}
+            width="100%"
+          />
+          <MediumButton
+            buttonText={t('protocol_info:delete_protocol')}
+            buttonType="alertSecondary"
+            iconName="trash"
+            onClick={() => {
+              setShowConfirmationDeleteProtocol(true)
+            }}
+            width="100%"
+          />
         </Flex>
       </Flex>
     </>


### PR DESCRIPTION
# Overview
Unfortunately, this is not a comprehensive fix since I suspect that a base component was copied and then modified according to the design, but the issues that existed at the time of copying have propagated to other components. As a result, even the components that were later modified are now being forcibly adjusted to match the design, so I’ve concluded that it’s no longer meaningful to spend more time on this in its current state. (Also I need to started working on fork project so no bandwidth to solve this issue.)

As we move forward with the CSS Modules migration, we need to create a unified layout and significantly rethink the table design as well.

https://github.com/user-attachments/assets/eb37c570-9db4-4e3d-bd08-7cc9ad3f89d8

close AUTH-2680

## Test Plan and Hands on Testing
- import a protocol
- tap the protocol

## Changelog
- update components spacing in protocol details page

## Review requests


## Risk assessment
low
