### PR TITLE
feat(app): Add robot search bar

### DIFF
--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -11,6 +11,7 @@
   "__dev_internal__quickTransferProtocolContentsLog": "Enable QT Protocol Contents Logging",
   "__dev_internal__reactQueryDevtools": "Enable React Query Devtools",
   "__dev_internal__reactScan": "Enable React Scan",
+  "__dev_internal__robotSearchBar": "Adds a robot search bar on select pages",
   "add_folder_button": "Add labware source folder",
   "add_ip_button": "Add",
   "add_ip_error": "Enter an IP Address or Hostname",

--- a/app/src/assets/localization/en/devices_landing.json
+++ b/app/src/assets/localization/en/devices_landing.json
@@ -44,5 +44,6 @@
   "update_robot_software": "Update robot software",
   "use_usb_cable_for_new_robot": "When setting up a new robot, use the included USB cable to connect for the first time.",
   "wait_after_connecting": "Wait for a minute after connecting the robot to the computer",
-  "why_is_this_robot_unavailable": "Why is this robot unavailable?"
+  "why_is_this_robot_unavailable": "Why is this robot unavailable?",
+  "search_robots": "Search robots"
 }

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
@@ -1,4 +1,11 @@
-import { Fragment, useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import {
+  Fragment,
+  useCallback,
+  useEffect,
+  useReducer,
+  useRef,
+  useState,
+} from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { NavLink } from 'react-router-dom'
@@ -213,12 +220,17 @@ export function ChooseRobotSlideout(
       if (query === '') {
         return robots
       } else {
-        return robots.filter(
-          robot =>
-            robot.displayName.toLowerCase().includes(query) ||
-            robot.name.toLowerCase().includes(query) ||
-            robot.robotModel.toLowerCase().includes(query)
-        )
+        return robots.filter(robot => {
+          const displayName = robot.displayName.toLowerCase()
+          const name = robot.name.toLowerCase()
+          const model = robot.robotModel.toLowerCase()
+
+          return (
+            displayName.includes(query) ||
+            name.includes(query) ||
+            model.includes(query)
+          )
+        })
       }
     },
     [searchQuery]
@@ -274,9 +286,7 @@ export function ChooseRobotSlideout(
           onChange={e => {
             setSearchQuery(e.target.value)
           }}
-          leftElement={
-            <Icon name="search" size="1rem" color={COLORS.grey50} />
-          }
+          leftElement={<Icon name="search" size="1rem" color={COLORS.grey50} />}
           size="small"
         />
       ) : null}

--- a/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useReducer, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useReducer, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { NavLink } from 'react-router-dom'
@@ -43,6 +43,7 @@ import { ToggleButton } from '/app/atoms/buttons'
 import { Slideout } from '/app/atoms/Slideout'
 import { MultiSlideout } from '/app/atoms/Slideout/MultiSlideout'
 import { UploadInput } from '/app/molecules/UploadInput'
+import { useFeatureFlag } from '/app/redux/config'
 import {
   getConnectableRobots,
   getReachableRobots,
@@ -203,10 +204,32 @@ export function ChooseRobotSlideout(
     {}
   )
 
-  const reducerAvailableRobots = healthyReachableRobots.filter(robot =>
+  const showSearchBar = useFeatureFlag('robotSearchBar')
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const filterRobots = useCallback(
+    (robots: Robot[]): Robot[] => {
+      const query = searchQuery.toLowerCase().trim()
+      if (query === '') {
+        return robots
+      } else {
+        return robots.filter(
+          robot =>
+            robot.displayName.toLowerCase().includes(query) ||
+            robot.name.toLowerCase().includes(query) ||
+            robot.robotModel.toLowerCase().includes(query)
+        )
+      }
+    },
+    [searchQuery]
+  )
+
+  const filteredHealthy = filterRobots(healthyReachableRobots)
+
+  const reducerAvailableRobots = filteredHealthy.filter(robot =>
     showIdleOnly ? !robotBusyStatusByName[robot.name] : robot
   )
-  const reducerBusyCount = healthyReachableRobots.filter(
+  const reducerBusyCount = filteredHealthy.filter(
     robot => robotBusyStatusByName[robot.name]
   ).length
 
@@ -244,6 +267,19 @@ export function ChooseRobotSlideout(
       {isAnalysisStale ? (
         <Banner type="warning">{t('protocol_outdated_app_analysis')}</Banner>
       ) : null}
+      {showSearchBar ? (
+        <InputField
+          placeholder={t('search_robots', { ns: 'devices_landing' })}
+          value={searchQuery}
+          onChange={e => {
+            setSearchQuery(e.target.value)
+          }}
+          leftElement={
+            <Icon name="search" size="1rem" color={COLORS.grey50} />
+          }
+          size="small"
+        />
+      ) : null}
       <Flex alignSelf={ALIGN_FLEX_END} marginY={SPACING.spacing4}>
         {isScanning ? (
           <Flex flexDirection={DIRECTION_ROW} alignItems={ALIGN_CENTER}>
@@ -267,7 +303,7 @@ export function ChooseRobotSlideout(
           </Link>
         )}
       </Flex>
-      {!isScanning && healthyReachableRobots.length === 0 ? (
+      {!isScanning && filteredHealthy.length === 0 ? (
         <Flex
           css={css`
             ${CARD_OUTLINE_BORDER_STYLE}
@@ -290,7 +326,7 @@ export function ChooseRobotSlideout(
           </LegacyStyledText>
         </Flex>
       ) : (
-        healthyReachableRobots.map(robot => {
+        filteredHealthy.map(robot => {
           const isSelected =
             selectedRobot != null && selectedRobot.ip === robot.ip
           return (

--- a/app/src/pages/Desktop/Devices/DevicesLanding/index.tsx
+++ b/app/src/pages/Desktop/Devices/DevicesLanding/index.tsx
@@ -1,15 +1,18 @@
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import partition from 'lodash/partition'
 
 import {
   ALIGN_CENTER,
+  ALIGN_END,
   Box,
   COLORS,
   DIRECTION_COLUMN,
   DISPLAY_FLEX,
   Flex,
   Icon,
+  InputField,
   JUSTIFY_SPACE_BETWEEN,
   LegacyStyledText,
   Link,
@@ -24,6 +27,7 @@ import { Divider } from '/app/atoms/structure'
 import { CollapsibleSection } from '/app/molecules/CollapsibleSection'
 import { DevicesEmptyState } from '/app/organisms/Desktop/Devices/DevicesEmptyState'
 import { RobotCard } from '/app/organisms/Desktop/Devices/RobotCard'
+import { useFeatureFlag } from '/app/redux/config'
 import {
   getConnectableRobots,
   getReachableRobots,
@@ -35,6 +39,7 @@ import { appShellUSBRequestor } from '/app/redux/shell/remote'
 
 import { NewRobotSetupHelp } from './NewRobotSetupHelp'
 
+import type { DiscoveredRobot } from '/app/redux/discovery/types'
 import type { State } from '/app/redux/types'
 
 export const TROUBLESHOOTING_CONNECTION_PROBLEMS_URL =
@@ -42,6 +47,7 @@ export const TROUBLESHOOTING_CONNECTION_PROBLEMS_URL =
 
 export function DevicesLanding(): JSX.Element {
   const { t } = useTranslation('devices_landing')
+  const showSearchBar = useFeatureFlag('robotSearchBar')
 
   const isScanning = useSelector((state: State) => getScanning(state))
   const healthyReachableRobots = useSelector((state: State) =>
@@ -59,12 +65,36 @@ export function DevicesLanding(): JSX.Element {
     robot => robot.healthStatus === 'ok'
   )
 
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const filterRobots = useCallback(
+    (robots: DiscoveredRobot[]): DiscoveredRobot[] => {
+      const query = searchQuery.toLowerCase().trim()
+      if (query === '') {
+        return robots
+      } else {
+        return robots.filter(
+          robot =>
+            robot.displayName.toLowerCase().includes(query) ||
+            robot.name.toLowerCase().includes(query) ||
+            robot.robotModel.toLowerCase().includes(query)
+        )
+      }
+    },
+    [searchQuery]
+  )
+
+  const filteredHealthy = filterRobots(healthyReachableRobots)
+  const filteredUnhealthy = filterRobots(unhealthyReachableRobots)
+  const filteredRecentlySeen = filterRobots(recentlySeenRobots)
+  const filteredUnreachable = filterRobots(unreachableRobots)
+
   const noRobots =
     [
-      ...healthyReachableRobots,
-      ...recentlySeenRobots,
-      ...unhealthyReachableRobots,
-      ...unreachableRobots,
+      ...filteredHealthy,
+      ...filteredRecentlySeen,
+      ...filteredUnhealthy,
+      ...filteredUnreachable,
     ].length === 0
 
   return (
@@ -80,6 +110,26 @@ export function DevicesLanding(): JSX.Element {
         </LegacyStyledText>
         <NewRobotSetupHelp />
       </Flex>
+      {showSearchBar ? (
+        <Flex
+          justifyContent={JUSTIFY_SPACE_BETWEEN}
+          alignItems={ALIGN_END}
+          width="33%"
+          marginLeft={SPACING.spacingAuto}
+        >
+          <InputField
+            placeholder={t('search_robots')}
+            value={searchQuery}
+            onChange={e => {
+              setSearchQuery(e.target.value)
+            }}
+            leftElement={
+              <Icon name="search" size="1rem" color={COLORS.grey50} />
+            }
+            size="small"
+          />
+        </Flex>
+      ) : null}
       {isScanning && noRobots ? <DevicesLoadingState /> : null}
       {!isScanning && noRobots ? <DevicesEmptyState /> : null}
       {!noRobots ? (
@@ -88,11 +138,10 @@ export function DevicesLanding(): JSX.Element {
             gridGap={SPACING.spacing4}
             marginY={SPACING.spacing8}
             title={t('available', {
-              count: [...healthyReachableRobots, ...unhealthyReachableRobots]
-                .length,
+              count: [...filteredHealthy, ...filteredUnhealthy].length,
             })}
           >
-            {healthyReachableRobots.map(robot => (
+            {filteredHealthy.map(robot => (
               <ApiHostProvider
                 key={robot.name}
                 hostname={robot.ip ?? null}
@@ -103,7 +152,7 @@ export function DevicesLanding(): JSX.Element {
                 <RobotCard robot={robot} />
               </ApiHostProvider>
             ))}
-            {unhealthyReachableRobots.map(robot => (
+            {filteredUnhealthy.map(robot => (
               <ApiHostProvider
                 key={robot.name}
                 hostname={robot.ip ?? null}
@@ -120,14 +169,14 @@ export function DevicesLanding(): JSX.Element {
             gridGap={SPACING.spacing4}
             marginY={SPACING.spacing16}
             title={t('not_available', {
-              count: [...recentlySeenRobots, ...unreachableRobots].length,
+              count: [...filteredRecentlySeen, ...filteredUnreachable].length,
             })}
-            isExpandedInitially={healthyReachableRobots.length === 0}
+            isExpandedInitially={filteredHealthy.length === 0}
           >
-            {recentlySeenRobots.map(robot => (
+            {filteredRecentlySeen.map(robot => (
               <RobotCard key={robot.name} robot={{ ...robot, local: null }} />
             ))}
-            {unreachableRobots.map(robot => (
+            {filteredUnreachable.map(robot => (
               <RobotCard key={robot.name} robot={robot} />
             ))}
           </CollapsibleSection>

--- a/app/src/pages/Desktop/Devices/DevicesLanding/index.tsx
+++ b/app/src/pages/Desktop/Devices/DevicesLanding/index.tsx
@@ -73,12 +73,17 @@ export function DevicesLanding(): JSX.Element {
       if (query === '') {
         return robots
       } else {
-        return robots.filter(
-          robot =>
-            robot.displayName.toLowerCase().includes(query) ||
-            robot.name.toLowerCase().includes(query) ||
-            robot.robotModel.toLowerCase().includes(query)
-        )
+        return robots.filter(robot => {
+          const displayName = robot.displayName.toLowerCase()
+          const name = robot.name.toLowerCase()
+          const model = robot.robotModel.toLowerCase()
+
+          return (
+            displayName.includes(query) ||
+            name.includes(query) ||
+            model.includes(query)
+          )
+        })
       }
     },
     [searchQuery]

--- a/app/src/redux/config/constants.ts
+++ b/app/src/redux/config/constants.ts
@@ -11,6 +11,7 @@ export const DEV_INTERNAL_FLAGS: DevInternalFlag[] = [
   'quickTransferProtocolContentsLog',
   'ignoreOT2App',
   'accessControlMode',
+  'robotSearchBar',
 ]
 
 // action type constants

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -19,6 +19,7 @@ export type DevInternalFlag =
   | 'quickTransferProtocolContentsLog'
   | 'ignoreOT2App'
   | 'accessControlMode'
+  | 'robotSearchBar'
 
 export type FeatureFlags = Partial<Record<DevInternalFlag, boolean | undefined>>
 


### PR DESCRIPTION
# Overview

Adds a robot search bar, behind a feature flag, to the Devices page and the robot slideout.


https://github.com/user-attachments/assets/752491ea-8464-4dc5-b427-1e6f7b7c81e5

## Test Plan and Hands on Testing

- See video

## Changelog

- Adds a developer only search bar to filter robots on the Desktop app's devices page and the robot slideout.

## Risk assessment

- very low, this does touch the robot list props before forwarding them onwards, but it does so in an auditable way.
