### PR TITLE
fix(protocol-designer): only check the primary well of a partial column selection

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
@@ -17,7 +17,6 @@ import { getAllWellsSafetyStatus } from './getAllWellsSafetyStatus'
 import { NozzleAndWellSelectionModal } from './NozzleAndWellSelectionModal'
 import styles from './nozzleandwellwizard.module.css'
 import {
-  getEntireWellSelection,
   getNozzleText,
   getWellGroupLength,
 } from './utils'
@@ -87,7 +86,7 @@ export function ExtendedPartialTipField(
     labwareId: string,
     selectedWells: string[] | undefined,
     fieldKey: keyof FieldPropsByName
-  ) => {
+  ): void => {
     const wells =
       invariantContext.labwareEntities[labwareId]?.def.ordering ?? []
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
@@ -73,7 +73,8 @@ export function ExtendedPartialTipField(
   }
   // if deck setup changes and selected wells are now inaccessible - unselect them so that an error is raised
   interface WellCheckConfig {
-    wells: string[]
+    wells: string[][]
+    selectedWells: string[]
     labwareId: string | null
     fieldKey: keyof FieldPropsByName
   }
@@ -81,23 +82,35 @@ export function ExtendedPartialTipField(
   const wellConfigs: WellCheckConfig[] = []
 
   if (stepType === 'mix') {
+    const mixLabwareId = propsForFields.labware.value as string
+    const allMixLabwareWells =
+      invariantContext.labwareEntities[mixLabwareId].def.ordering
     wellConfigs.push({
-      wells: (propsForFields.wells?.value as string[]) ?? [],
-      labwareId: propsForFields.labware.value as string,
+      wells: allMixLabwareWells,
+      selectedWells: (propsForFields.wells?.value as string[]) ?? [],
+      labwareId: mixLabwareId,
       fieldKey: 'wells',
     })
   }
 
   if (stepType === 'transfer') {
+    const aspLabwareId = propsForFields.aspirate_labware.value as string
+    const allAspLabwareWells =
+      invariantContext.labwareEntities[aspLabwareId].def.ordering
     wellConfigs.push({
-      wells: (propsForFields.aspirate_wells?.value as string[]) ?? [],
-      labwareId: propsForFields.aspirate_labware.value as string,
+      wells: allAspLabwareWells,
+      selectedWells: (propsForFields.aspirate_wells?.value as string[]) ?? [],
+      labwareId: aspLabwareId,
       fieldKey: 'aspirate_wells',
     })
+    const dspLabwareId = propsForFields.dispense_labware.value as string
+    const allDspLabwareWells =
+      invariantContext.labwareEntities[dspLabwareId].def.ordering
 
     wellConfigs.push({
-      wells: (propsForFields.dispense_wells?.value as string[]) ?? [],
-      labwareId: propsForFields.dispense_labware.value as string,
+      wells: allDspLabwareWells,
+      selectedWells: (propsForFields.dispense_wells?.value as string[]) ?? [],
+      labwareId: dspLabwareId,
       fieldKey: 'dispense_wells',
     })
   }
@@ -113,7 +126,7 @@ export function ExtendedPartialTipField(
       }
 
       const status = getAllWellsSafetyStatus({
-        allWells: [config.wells],
+        allWells: config.wells,
         robotState,
         invariantContext,
         pipetteId: propsForFields.pipette.value as string,
@@ -123,7 +136,9 @@ export function ExtendedPartialTipField(
         tiprackId,
       })
 
-      const hasInaccessibleWell = config.wells.some(well => status[well] !== 0)
+      const hasInaccessibleWell = config.selectedWells.some(
+        well => status[well] !== 0
+      )
 
       return hasInaccessibleWell ? config.fieldKey : null
     })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
@@ -16,7 +16,11 @@ import { PLURAL_COLUMNS, PLURAL_ROWS } from './constants'
 import { getAllWellsSafetyStatus } from './getAllWellsSafetyStatus'
 import { NozzleAndWellSelectionModal } from './NozzleAndWellSelectionModal'
 import styles from './nozzleandwellwizard.module.css'
-import { getNozzleText, getWellGroupLength } from './utils'
+import {
+  getEntireWellSelection,
+  getNozzleText,
+  getWellGroupLength,
+} from './utils'
 
 import type {
   ActiveNozzleNumber,
@@ -78,44 +82,42 @@ export function ExtendedPartialTipField(
     labwareId: string | null
     fieldKey: keyof FieldPropsByName
   }
-
   const wellConfigs: WellCheckConfig[] = []
+  const addWellConfig = (
+    labwareId: string,
+    selectedWells: string[] | undefined,
+    fieldKey: keyof FieldPropsByName
+  ) => {
+    const wells =
+      invariantContext.labwareEntities[labwareId]?.def.ordering ?? []
 
-  if (stepType === 'mix') {
-    const mixLabwareId = propsForFields.labware.value as string
-    const allMixLabwareWells =
-      invariantContext.labwareEntities[mixLabwareId].def.ordering
     wellConfigs.push({
-      wells: allMixLabwareWells,
-      selectedWells: (propsForFields.wells?.value as string[]) ?? [],
-      labwareId: mixLabwareId,
-      fieldKey: 'wells',
+      wells,
+      selectedWells: selectedWells ?? [],
+      labwareId,
+      fieldKey,
     })
   }
-
+  if (stepType === 'mix') {
+    addWellConfig(
+      propsForFields.labware.value as string,
+      propsForFields.wells?.value as string[],
+      'wells'
+    )
+  }
   if (stepType === 'transfer') {
-    const aspLabwareId = propsForFields.aspirate_labware.value as string
-    const allAspLabwareWells =
-      invariantContext.labwareEntities[aspLabwareId].def.ordering
-    wellConfigs.push({
-      wells: allAspLabwareWells,
-      selectedWells: (propsForFields.aspirate_wells?.value as string[]) ?? [],
-      labwareId: aspLabwareId,
-      fieldKey: 'aspirate_wells',
-    })
-    const dspLabwareId = propsForFields.dispense_labware.value as string
-    const allDspLabwareWells =
-      invariantContext.labwareEntities[dspLabwareId].def.ordering
-
-    wellConfigs.push({
-      wells: allDspLabwareWells,
-      selectedWells: (propsForFields.dispense_wells?.value as string[]) ?? [],
-      labwareId: dspLabwareId,
-      fieldKey: 'dispense_wells',
-    })
+    addWellConfig(
+      propsForFields.aspirate_labware.value as string,
+      propsForFields.aspirate_wells?.value as string[],
+      'aspirate_wells'
+    )
+    addWellConfig(
+      propsForFields.dispense_labware.value as string,
+      propsForFields.dispense_wells?.value as string[],
+      'dispense_wells'
+    )
   }
   const tiprackLabwareDefURI = propsForFields.tipRack.value as string
-
   const tiprackId = Object.values(deckSetup.labware).find(
     labware => labware.labwareDefURI === tiprackLabwareDefURI
   )?.id

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
@@ -16,10 +16,7 @@ import { PLURAL_COLUMNS, PLURAL_ROWS } from './constants'
 import { getAllWellsSafetyStatus } from './getAllWellsSafetyStatus'
 import { NozzleAndWellSelectionModal } from './NozzleAndWellSelectionModal'
 import styles from './nozzleandwellwizard.module.css'
-import {
-  getNozzleText,
-  getWellGroupLength,
-} from './utils'
+import { getNozzleText, getWellGroupLength } from './utils'
 
 import type {
   ActiveNozzleNumber,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -236,21 +236,24 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
       }
       return acc
     }, {})
-  const inaccessiblePartialWells = useMemo(
-    () => {
-      if (!isPartialNozzle || selectedWells.length === 0) return []
+  const inaccessiblePartialWells = useMemo(() => {
+    if (!isPartialNozzle || selectedWells.length === 0) {
+      return []
+    }
 
-      return getInaccessibleWellsForPartialNozzleRowMap(
-        selectedWells,
-        labwareDef.ordering,
-        allWellsWithState,
-        PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
-      )
-    },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedWells, isPartialNozzle, primaryNozzle, labwareDef.ordering]
-  )
+    return getInaccessibleWellsForPartialNozzleRowMap(
+      selectedWells,
+      labwareDef.ordering,
+      allWellsWithState,
+      PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
+    )
+  }, [
+    selectedWells,
+    isPartialNozzle,
+    primaryNozzle,
+    labwareDef.ordering,
+    allWellsWithState,
+  ])
 
   const deckDef = getDeckDefFromRobotType(robotType)
   const viewBox = getViewboxFromSelectedLabware(
@@ -283,7 +286,6 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
     }
     return highlightedWells
   }
-
   const handleSelectionMove: (e: MouseEvent, rect: GenericRect) => void = (
     e,
     rect
@@ -308,7 +310,6 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
         const allAlreadySelected = wellsUnderRect.every(group =>
           group.every(well => selectedFlat.has(well))
         )
-
         let updated: string[][]
         // Remove all wells if the entire selection is already selected
         if (allAlreadySelected) {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/__tests__/getAllWellsSafetyStatus.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/__tests__/getAllWellsSafetyStatus.test.ts
@@ -1,12 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  A1_NOZZLE,
+  B1_NOZZLE,
+  C1_NOZZLE,
   COLUMN,
+  D1_NOZZLE,
+  E1_NOZZLE,
+  F1_NOZZLE,
   fixture96Plate,
   fixtureP100096V2Specs,
   fixtureTiprack1000ul,
+  G1_NOZZLE,
   getLabwareDefURI,
+  PARTIAL_COLUMN,
   ROW,
+  SINGLE,
 } from '@opentrons/shared-data'
 import { getIsSafePipetteMovement } from '@opentrons/step-generation'
 
@@ -45,8 +54,8 @@ describe('getAllWellsSafetyStatus', () => {
     },
   } as any
   const mockRobotState = {} as any
-  const primaryNozzle = 'A1' as any
-  const singleNozzle = 'SINGLE' as any
+  const primaryNozzle = A1_NOZZLE
+  const singleNozzle = SINGLE
 
   const allWells = [
     ['A1', 'B1', 'C1'],
@@ -183,5 +192,44 @@ describe('getAllWellsSafetyStatus', () => {
 
       expect(getIsSafePipetteMovement).toHaveBeenCalledTimes(6)
     })
+  })
+  describe('PARTIAL COLUMN mode', () => {
+    const column = ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1']
+
+    const cases = [
+      { nozzle: B1_NOZZLE, tipCount: 2 },
+      { nozzle: C1_NOZZLE, tipCount: 3 },
+      { nozzle: D1_NOZZLE, tipCount: 4 },
+      { nozzle: E1_NOZZLE, tipCount: 5 },
+      { nozzle: F1_NOZZLE, tipCount: 6 },
+      { nozzle: G1_NOZZLE, tipCount: 7 },
+    ]
+
+    it.each(cases)(
+      'handles partial column mode with $tipCount tips ($nozzle)',
+      ({ nozzle, tipCount }) => {
+        ;(getIsSafePipetteMovement as any).mockReturnValue(true)
+
+        const result = getAllWellsSafetyStatus({
+          allWells: [column],
+          robotState: mockRobotState,
+          invariantContext: mockInvariantContext,
+          pipetteId,
+          labwareId,
+          primaryNozzle: nozzle,
+          nozzleConfiguration: PARTIAL_COLUMN,
+        })
+
+        // Assert correct block is marked safe
+        for (let i = 0; i < tipCount; i++) {
+          expect(result[column[i]]).toBe(0)
+        }
+
+        // Assert remaining wells are still present in output
+        for (let i = tipCount; i < column.length; i++) {
+          expect(result[column[i]]).toBeDefined()
+        }
+      }
+    )
   })
 })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
@@ -159,9 +159,9 @@ export function getAllWellsSafetyStatus(
               tiprackId,
             })
           : true
-
         const canFitBlock = i <= column.length - totalSelectionLength
-        if (safe && canFitBlock) {
+        const labwareHasOneRow = labwareDef.ordering[0].length === 1
+        if (safe && (canFitBlock || labwareHasOneRow)) {
           // 1. Mark the valid block (e.g., A1–E1)
           for (let j = 0; j < totalSelectionLength; j++) {
             const well = column[i + j]

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
@@ -2,6 +2,7 @@ import {
   ALL,
   COLUMN,
   PARTIAL_COLUMN,
+  PARTIAL_NOZZLE_MAP,
   ROW,
   SINGLE,
 } from '@opentrons/shared-data'
@@ -11,6 +12,7 @@ import { canPipetteUseLabware } from '../../../../../../utils'
 
 import type {
   NozzleConfigurationStyle,
+  PartialPrimaryNozzles,
   PrimaryNozzleConfigurationStyle,
 } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '@opentrons/step-generation'
@@ -121,11 +123,7 @@ export function getAllWellsSafetyStatus(
     allWells.flat().forEach(wellName => {
       allWellsWithStatus[wellName] = safe ? 0 : 1
     })
-  } else if (
-    (nozzleConfiguration === SINGLE ||
-      nozzleConfiguration === PARTIAL_COLUMN) &&
-    channels !== 1
-  ) {
+  } else if (nozzleConfiguration === SINGLE && channels !== 1) {
     // SINGLE nozzle for 8ch and 96ch: check every well individually
     allWells.flat().forEach(wellName => {
       const safe = robotState
@@ -142,12 +140,63 @@ export function getAllWellsSafetyStatus(
         : true
       allWellsWithStatus[wellName] = safe ? 0 : 1
     })
+  } else if (nozzleConfiguration === PARTIAL_COLUMN) {
+    const totalSelectionLength =
+      PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
+    for (let colIndex = 0; colIndex < allWells.length; colIndex++) {
+      const column = allWells[colIndex]
+      for (let i = 0; i < column.length; i++) {
+        const wellToTest = column[i]
+        const safe = robotState
+          ? getIsSafePipetteMovement({
+              robotState,
+              invariantContext,
+              pipetteId,
+              labwareId,
+              wellTargetName: wellToTest,
+              primaryNozzle,
+              nozzleConfiguration,
+              tiprackId,
+            })
+          : true
+
+        const canFitBlock = i <= column.length - totalSelectionLength
+        if (safe && canFitBlock) {
+          // 1. Mark the valid block (e.g., A1–E1)
+          for (let j = 0; j < totalSelectionLength; j++) {
+            const well = column[i + j]
+            allWellsWithStatus[well] = 0
+          }
+          // 2. Continue checking the remaining wells (e.g., F1–H1)
+          for (let k = i + totalSelectionLength; k < column.length; k++) {
+            const remainingWell = column[k]
+            const remainingSafe = robotState
+              ? getIsSafePipetteMovement({
+                  robotState,
+                  invariantContext,
+                  pipetteId,
+                  labwareId,
+                  wellTargetName: remainingWell,
+                  primaryNozzle,
+                  nozzleConfiguration,
+                  tiprackId,
+                })
+              : true
+
+            allWellsWithStatus[remainingWell] = remainingSafe ? 0 : 1
+          }
+          // Done with this column
+          break
+        }
+        // Mark unsafe if not usable as a starting point
+        allWellsWithStatus[wellToTest] = 1
+      }
+    }
   } else {
     // remaining case - single channel pipettes - assume all wells can be safely accessed
     allWells.flat().forEach(wellName => {
       allWellsWithStatus[wellName] = 0
     })
   }
-
   return allWellsWithStatus
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
@@ -63,18 +63,18 @@ export function getAllWellsSafetyStatus(
     const numRows = allWells[0].length
     for (let rowIndex = 0; rowIndex < numRows; rowIndex++) {
       const firstWell = allWells[0][rowIndex]
-      const safe = robotState
-        ? getIsSafePipetteMovement({
-            robotState,
-            invariantContext,
-            pipetteId,
-            labwareId,
-            wellTargetName: firstWell,
-            primaryNozzle,
-            nozzleConfiguration,
-            tiprackId,
-          })
-        : true
+      const safe =
+        robotState === null ||
+        getIsSafePipetteMovement({
+          robotState,
+          invariantContext,
+          pipetteId,
+          labwareId,
+          wellTargetName: firstWell,
+          primaryNozzle,
+          nozzleConfiguration,
+          tiprackId,
+        })
 
       // mark all wells in this row
       allWells.forEach(column => {
@@ -89,18 +89,18 @@ export function getAllWellsSafetyStatus(
     for (let colIndex = 0; colIndex < allWells.length; colIndex++) {
       const column = allWells[colIndex]
       const firstWell = column[0]
-      const safe = robotState
-        ? getIsSafePipetteMovement({
-            robotState,
-            invariantContext,
-            pipetteId,
-            labwareId,
-            wellTargetName: firstWell,
-            primaryNozzle,
-            nozzleConfiguration,
-            tiprackId,
-          })
-        : true
+      const safe =
+        robotState === null ||
+        getIsSafePipetteMovement({
+          robotState,
+          invariantContext,
+          pipetteId,
+          labwareId,
+          wellTargetName: firstWell,
+          primaryNozzle,
+          nozzleConfiguration,
+          tiprackId,
+        })
 
       column.forEach(wellName => {
         allWellsWithStatus[wellName] = safe ? 0 : 1
@@ -108,36 +108,38 @@ export function getAllWellsSafetyStatus(
     }
   } else if (nozzleConfiguration === ALL && channels === 96) {
     // ALL 96 Nozzles: only check the first well
-    const safe = robotState
-      ? getIsSafePipetteMovement({
-          robotState,
-          invariantContext,
-          pipetteId,
-          labwareId,
-          wellTargetName: allWells[0][0],
-          primaryNozzle,
-          nozzleConfiguration,
-          tiprackId,
-        })
-      : true
+    const safe =
+      robotState === null ||
+      getIsSafePipetteMovement({
+        robotState,
+        invariantContext,
+        pipetteId,
+        labwareId,
+        wellTargetName: allWells[0][0],
+        primaryNozzle,
+        nozzleConfiguration,
+        tiprackId,
+      })
+
     allWells.flat().forEach(wellName => {
       allWellsWithStatus[wellName] = safe ? 0 : 1
     })
   } else if (nozzleConfiguration === SINGLE && channels !== 1) {
     // SINGLE nozzle for 8ch and 96ch: check every well individually
     allWells.flat().forEach(wellName => {
-      const safe = robotState
-        ? getIsSafePipetteMovement({
-            robotState,
-            invariantContext,
-            pipetteId,
-            labwareId,
-            wellTargetName: wellName,
-            primaryNozzle,
-            nozzleConfiguration,
-            tiprackId,
-          })
-        : true
+      const safe =
+        robotState === null ||
+        getIsSafePipetteMovement({
+          robotState,
+          invariantContext,
+          pipetteId,
+          labwareId,
+          wellTargetName: wellName,
+          primaryNozzle,
+          nozzleConfiguration,
+          tiprackId,
+        })
+
       allWellsWithStatus[wellName] = safe ? 0 : 1
     })
   } else if (nozzleConfiguration === PARTIAL_COLUMN) {
@@ -147,18 +149,19 @@ export function getAllWellsSafetyStatus(
       const column = allWells[colIndex]
       for (let i = 0; i < column.length; i++) {
         const wellToTest = column[i]
-        const safe = robotState
-          ? getIsSafePipetteMovement({
-              robotState,
-              invariantContext,
-              pipetteId,
-              labwareId,
-              wellTargetName: wellToTest,
-              primaryNozzle,
-              nozzleConfiguration,
-              tiprackId,
-            })
-          : true
+        const safe =
+          robotState === null ||
+          getIsSafePipetteMovement({
+            robotState,
+            invariantContext,
+            pipetteId,
+            labwareId,
+            wellTargetName: wellToTest,
+            primaryNozzle,
+            nozzleConfiguration,
+            tiprackId,
+          })
+
         const canFitBlock = i <= column.length - totalSelectionLength
         const labwareHasOneRow = labwareDef.ordering[0].length === 1
         if (safe && (canFitBlock || labwareHasOneRow)) {
@@ -170,18 +173,18 @@ export function getAllWellsSafetyStatus(
           // 2. Continue checking the remaining wells (e.g., F1–H1)
           for (let k = i + totalSelectionLength; k < column.length; k++) {
             const remainingWell = column[k]
-            const remainingSafe = robotState
-              ? getIsSafePipetteMovement({
-                  robotState,
-                  invariantContext,
-                  pipetteId,
-                  labwareId,
-                  wellTargetName: remainingWell,
-                  primaryNozzle,
-                  nozzleConfiguration,
-                  tiprackId,
-                })
-              : true
+            const remainingSafe =
+              robotState === null ||
+              getIsSafePipetteMovement({
+                robotState,
+                invariantContext,
+                pipetteId,
+                labwareId,
+                wellTargetName: remainingWell,
+                primaryNozzle,
+                nozzleConfiguration,
+                tiprackId,
+              })
 
             allWellsWithStatus[remainingWell] = remainingSafe ? 0 : 1
           }


### PR DESCRIPTION
# Overview

We should only check the primary well of a partial column selection. If the primary well is accessible, we can assume that the wells underneath are accessible as well because this indicates that those wells are within the bounds of the labware.

## Test Plan and Hands on Testing

- wrote units tests
- smoke tested with 2 - 7 tip pick up with a 96 well plate and with 12 well and 1 well reservoir
[Blocking_Buffer_Test.py](https://github.com/user-attachments/files/27281714/Blocking_Buffer_Test.py)

## Changelog

- added additional logic to `getAllWellsSafetyStatus` - if the first well is found to be accessible, it skips down to the next well that is there after the group selection.
- adjusted ExtendedPartialTipField to ensure the entire labware definition was passed in rather than what is selected. In order for partial column collision detection to work, you need to have the entire well map

## Review requests


## Risk assessment

- medium -changes partial collision detection 
Closes RQA-5347