### PR TITLE
refactor(components): Mark primitive components as deprecated

### DIFF
--- a/components/src/primitives/Box.tsx
+++ b/components/src/primitives/Box.tsx
@@ -5,18 +5,23 @@ import { withStyleProps } from '../hocs/withStyleProps'
 import type { ComponentProps, FC } from 'react'
 import type { StyleProps } from './types'
 
-/**
- * Simple Box atom. Renders a `div` by default and accepts all primitive styling props.
- *
- * @component
- */
-
 const BoxComponent = forwardRef<HTMLDivElement, ComponentProps<'div'>>(
   (props, ref) => (
     <div ref={ref} {...props} style={{ minWidth: 0, ...props.style }} />
   )
 )
 
+/**
+ * Simple Box atom. Renders a `div` by default and accepts all primitive styling props.
+ *
+ * @component
+ *
+ * @deprecated Layout/style primitives are deprecated. If there is a preexisting
+ *   higher-level component that does what you want (e.g. from the Helix design system,
+ *   or from your project's shared components), use that instead. If not, implement your
+ *   own layout+styling with CSS modules and the semantically appropriate native HTML
+ *   element (`<li>`, `<menu>`, `<p>`, `<div>`, etc).
+ */
 export const Box: FC<ComponentProps<'div'> & StyleProps> = withStyleProps(
   BoxComponent
 ) as FC<ComponentProps<'div'> & StyleProps>

--- a/components/src/primitives/Btn.tsx
+++ b/components/src/primitives/Btn.tsx
@@ -10,12 +10,6 @@ export const BUTTON_TYPE_SUBMIT: 'submit' = 'submit'
 export const BUTTON_TYPE_RESET: 'reset' = 'reset'
 export const BUTTON_TYPE_BUTTON: 'button' = 'button'
 
-/**
- * Button primitive
- *
- * @component
- */
-
 const BtnComponent = forwardRef<
   HTMLButtonElement,
   ComponentProps<'button'> & StyleProps
@@ -29,6 +23,17 @@ const BtnComponent = forwardRef<
 
 BtnComponent.displayName = 'BtnComponent'
 
+/**
+ * Button primitive
+ *
+ * @component
+ *
+ * @deprecated Layout/style primitives are deprecated. If there is a preexisting
+ *   higher-level component that does what you want (e.g. from the Helix design system,
+ *   or from your project's shared components), use that instead. If not, implement your
+ *   own layout+styling with CSS modules and the semantically appropriate native HTML
+ *   element (`<li>`, `<menu>`, `<p>`, `<div>`, etc).
+ */
 export const Btn: FC<ComponentProps<'button'> & StyleProps> = withStyleProps(
   BtnComponent
 ) as FC<ComponentProps<'button'> & StyleProps>

--- a/components/src/primitives/Buttons/NewPrimaryBtn.tsx
+++ b/components/src/primitives/Buttons/NewPrimaryBtn.tsx
@@ -8,6 +8,12 @@ import type { StyleProps } from '../types'
  * New primary button variant used in app
  *
  * @component
+ *
+ * @deprecated Layout/style primitives are deprecated. If there is a preexisting
+ *   higher-level component that does what you want (e.g. from the Helix design system,
+ *   or from your project's shared components), use that instead. If not, implement your
+ *   own layout+styling with CSS modules and the semantically appropriate native HTML
+ *   element (`<li>`, `<menu>`, `<p>`, `<div>`, etc).
  */
 export const NewPrimaryBtn: FC<ComponentProps<'button'> & StyleProps> = ({
   className,

--- a/components/src/primitives/Buttons/NewSecondaryBtn.tsx
+++ b/components/src/primitives/Buttons/NewSecondaryBtn.tsx
@@ -8,6 +8,12 @@ import type { StyleProps } from '../types'
  * New secondary button variant used in app
  *
  * @component
+ *
+ * @deprecated Layout/style primitives are deprecated. If there is a preexisting
+ *   higher-level component that does what you want (e.g. from the Helix design system,
+ *   or from your project's shared components), use that instead. If not, implement your
+ *   own layout+styling with CSS modules and the semantically appropriate native HTML
+ *   element (`<li>`, `<menu>`, `<p>`, `<div>`, etc).
  */
 export const NewSecondaryBtn: FC<ComponentProps<'button'> & StyleProps> = ({
   className,

--- a/components/src/primitives/Flex.tsx
+++ b/components/src/primitives/Flex.tsx
@@ -5,11 +5,6 @@ import { isntStyleProp, styleProps } from './style-props'
 import type { ComponentProps, FC } from 'react'
 import type { StyleProps } from './types'
 
-/**
- * Flex primitive
- *
- * @component
- */
 const FlexComponent = forwardRef<
   HTMLDivElement,
   ComponentProps<'div'> & StyleProps
@@ -38,5 +33,16 @@ const FlexComponent = forwardRef<
 
 FlexComponent.displayName = 'Flex'
 
+/**
+ * Flex primitive
+ *
+ * @component
+ *
+ * @deprecated Layout/style primitives are deprecated. If there is a preexisting
+ *   higher-level component that does what you want (e.g. from the Helix design system,
+ *   or from your project's shared components), use that instead. If not, implement your
+ *   own layout+styling with CSS modules and the semantically appropriate native HTML
+ *   element (`<li>`, `<menu>`, `<p>`, `<div>`, etc).
+ */
 export const Flex: FC<ComponentProps<'div'> & StyleProps> =
   FlexComponent as unknown as FC<ComponentProps<'div'> & StyleProps>

--- a/components/src/primitives/ForeignObject.tsx
+++ b/components/src/primitives/ForeignObject.tsx
@@ -10,9 +10,15 @@ export interface ForeignObjectProps {
 
 /**
  * Foreign Object styled atomic component
+ *
  * @component
+ *
+ * @deprecated Layout/style primitives are deprecated. If there is a preexisting
+ *   higher-level component that does what you want (e.g. from the Helix design system,
+ *   or from your project's shared components), use that instead. If not, implement your
+ *   own layout+styling with CSS modules and the semantically appropriate native HTML
+ *   element (`<li>`, `<menu>`, `<p>`, `<div>`, etc).
  */
-
 export const ForeignObject = ({
   width,
   height,

--- a/components/src/primitives/Link.tsx
+++ b/components/src/primitives/Link.tsx
@@ -8,12 +8,6 @@ export interface LinkProps extends StyleProps {
   external?: boolean
 }
 
-/**
- * Link primitive
- *
- * @component
- */
-
 const LinkComponent = ({
   external,
   ...props
@@ -31,6 +25,15 @@ const LinkComponent = ({
   />
 )
 
+/**
+ * Link primitive
+ *
+ * @deprecated Layout/style primitives are deprecated. If there is a preexisting
+ *   higher-level component that does what you want (e.g. from the Helix design system,
+ *   or from your project's shared components), use that instead. If not, implement your
+ *   own layout+styling with CSS modules and the semantically appropriate native HTML
+ *   element (`<li>`, `<menu>`, `<p>`, `<div>`, etc).
+ */
 export const Link: FC<ComponentProps<'a'> & LinkProps> = withStyleProps(
   LinkComponent
 ) as FC<ComponentProps<'a'> & LinkProps>

--- a/components/src/primitives/README.md
+++ b/components/src/primitives/README.md
@@ -1,5 +1,13 @@
 Primitive components are base-level components that apply very little inherent styling (usually CSS resets) and expose simple props to customize styling or behavior at a low level.
 
+> [!WARNING]
+> Primitive components are no longer our preferred approach.
+>
+> If there is a preexisting higher-level component that does what you want
+> (e.g. from the Helix design system, or from your project's shared components),
+> use that instead. If not, implement your own layout+styling with CSS modules and the
+> semantically appropriate native HTML element (`<li>`, `<menu>`, `<p>`, `<div>`, etc).
+
 ## style props
 
 Style props will pass their value directly into CSS, but for safety, try to use the value constants defined in `components/src/styles`.

--- a/components/src/primitives/Svg.tsx
+++ b/components/src/primitives/Svg.tsx
@@ -14,11 +14,6 @@ export interface SvgProps extends StyleProps {
 
 const SVG_NAMESPACE = 'http://www.w3.org/2000/svg'
 
-/**
- * SVG primitive component that supports style props
- *
- * @component
- */
 const SvgComponent = forwardRef<
   SVGSVGElement,
   SvgProps & ComponentProps<'svg'>
@@ -48,6 +43,12 @@ SvgComponent.displayName = 'Svg'
  * SVG primitive with style props support
  *
  * @component
+ *
+ * @deprecated Layout/style primitives are deprecated. If there is a preexisting
+ *   higher-level component that does what you want (e.g. from the Helix design system,
+ *   or from your project's shared components), use that instead. If not, implement your
+ *   own layout+styling with CSS modules and the semantically appropriate native HTML
+ *   element (`<li>`, `<menu>`, `<p>`, `<div>`, etc).
  */
 export const Svg: FC<ComponentProps<'svg'> & SvgProps> = withStyleProps(
   SvgComponent

--- a/components/src/primitives/Text.tsx
+++ b/components/src/primitives/Text.tsx
@@ -5,12 +5,6 @@ import { withStyleProps } from '../hocs/withStyleProps'
 import type { ComponentProps, FC } from 'react'
 import type { StyleProps } from './types'
 
-/**
- * Text primitive
- *
- * @component
- */
-
 const TextComponent = ({
   as,
   color,
@@ -28,6 +22,17 @@ const TextComponent = ({
   })
 }
 
+/**
+ * Text primitive
+ *
+ * @component
+ *
+ * @deprecated Layout/style primitives are deprecated. If there is a preexisting
+ *   higher-level component that does what you want (e.g. from the Helix design system,
+ *   or from your project's shared components), use that instead. If not, implement your
+ *   own layout+styling with CSS modules and the semantically appropriate native HTML
+ *   element (`<li>`, `<menu>`, `<p>`, `<div>`, etc).
+ */
 export const Text: FC<ComponentProps<'p'> & StyleProps & { as?: string }> =
   withStyleProps(TextComponent) as FC<
     ComponentProps<'p'> & StyleProps & { as?: string }


### PR DESCRIPTION
## Overview

In the interest of onboarding new JS devs, this marks all our React components under `components/src/primitives` as deprecated. As I understand it, we shouldn't use any of them for new code.

In VS Code (and Cursor), this crosses out the component name, like this:

<img width="309" height="71" alt="Screenshot 2026-05-01 at 2 24 39 PM" src="https://github.com/user-attachments/assets/5aac1f3b-01b0-4ca4-824e-7941c17926df" />


## Test Plan and Hands on Testing

None needed.

## Review requests

* Is my understanding correct? Do we want to deprecate *everything* under components? Or only `<Flex>` and `<Box>`?
* Is the comment clear?

## Risk assessment

No risk.
