### PR TITLE
fix(protocol-designer): only check a tip during partial tip accessibility once

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
@@ -17,7 +17,6 @@ import { getAllWellsSafetyStatus } from './getAllWellsSafetyStatus'
 import { NozzleAndWellSelectionModal } from './NozzleAndWellSelectionModal'
 import styles from './nozzleandwellwizard.module.css'
 import {
-  getEntireWellSelection,
   getNozzleText,
   getWellGroupLength,
 } from './utils'
@@ -87,7 +86,7 @@ export function ExtendedPartialTipField(
     labwareId: string,
     selectedWells: string[] | undefined,
     fieldKey: keyof FieldPropsByName
-  ) => {
+  ): void => {
     const wells =
       invariantContext.labwareEntities[labwareId]?.def.ordering ?? []
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
@@ -73,7 +73,8 @@ export function ExtendedPartialTipField(
   }
   // if deck setup changes and selected wells are now inaccessible - unselect them so that an error is raised
   interface WellCheckConfig {
-    wells: string[]
+    wells: string[][]
+    selectedWells: string[]
     labwareId: string | null
     fieldKey: keyof FieldPropsByName
   }
@@ -81,23 +82,35 @@ export function ExtendedPartialTipField(
   const wellConfigs: WellCheckConfig[] = []
 
   if (stepType === 'mix') {
+    const mixLabwareId = propsForFields.labware.value as string
+    const allMixLabwareWells =
+      invariantContext.labwareEntities[mixLabwareId].def.ordering
     wellConfigs.push({
-      wells: (propsForFields.wells?.value as string[]) ?? [],
-      labwareId: propsForFields.labware.value as string,
+      wells: allMixLabwareWells,
+      selectedWells: (propsForFields.wells?.value as string[]) ?? [],
+      labwareId: mixLabwareId,
       fieldKey: 'wells',
     })
   }
 
   if (stepType === 'transfer') {
+    const aspLabwareId = propsForFields.aspirate_labware.value as string
+    const allAspLabwareWells =
+      invariantContext.labwareEntities[aspLabwareId].def.ordering
     wellConfigs.push({
-      wells: (propsForFields.aspirate_wells?.value as string[]) ?? [],
-      labwareId: propsForFields.aspirate_labware.value as string,
+      wells: allAspLabwareWells,
+      selectedWells: (propsForFields.aspirate_wells?.value as string[]) ?? [],
+      labwareId: aspLabwareId,
       fieldKey: 'aspirate_wells',
     })
+    const dspLabwareId = propsForFields.dispense_labware.value as string
+    const allDspLabwareWells =
+      invariantContext.labwareEntities[dspLabwareId].def.ordering
 
     wellConfigs.push({
-      wells: (propsForFields.dispense_wells?.value as string[]) ?? [],
-      labwareId: propsForFields.dispense_labware.value as string,
+      wells: allDspLabwareWells,
+      selectedWells: (propsForFields.dispense_wells?.value as string[]) ?? [],
+      labwareId: dspLabwareId,
       fieldKey: 'dispense_wells',
     })
   }
@@ -113,7 +126,7 @@ export function ExtendedPartialTipField(
       }
 
       const status = getAllWellsSafetyStatus({
-        allWells: [config.wells],
+        allWells: config.wells,
         robotState,
         invariantContext,
         pipetteId: propsForFields.pipette.value as string,
@@ -123,7 +136,9 @@ export function ExtendedPartialTipField(
         tiprackId,
       })
 
-      const hasInaccessibleWell = config.wells.some(well => status[well] !== 0)
+      const hasInaccessibleWell = config.selectedWells.some(
+        well => status[well] !== 0
+      )
 
       return hasInaccessibleWell ? config.fieldKey : null
     })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
@@ -16,7 +16,11 @@ import { PLURAL_COLUMNS, PLURAL_ROWS } from './constants'
 import { getAllWellsSafetyStatus } from './getAllWellsSafetyStatus'
 import { NozzleAndWellSelectionModal } from './NozzleAndWellSelectionModal'
 import styles from './nozzleandwellwizard.module.css'
-import { getNozzleText, getWellGroupLength } from './utils'
+import {
+  getEntireWellSelection,
+  getNozzleText,
+  getWellGroupLength,
+} from './utils'
 
 import type {
   ActiveNozzleNumber,
@@ -78,44 +82,42 @@ export function ExtendedPartialTipField(
     labwareId: string | null
     fieldKey: keyof FieldPropsByName
   }
-
   const wellConfigs: WellCheckConfig[] = []
+  const addWellConfig = (
+    labwareId: string,
+    selectedWells: string[] | undefined,
+    fieldKey: keyof FieldPropsByName
+  ) => {
+    const wells =
+      invariantContext.labwareEntities[labwareId]?.def.ordering ?? []
 
-  if (stepType === 'mix') {
-    const mixLabwareId = propsForFields.labware.value as string
-    const allMixLabwareWells =
-      invariantContext.labwareEntities[mixLabwareId].def.ordering
     wellConfigs.push({
-      wells: allMixLabwareWells,
-      selectedWells: (propsForFields.wells?.value as string[]) ?? [],
-      labwareId: mixLabwareId,
-      fieldKey: 'wells',
+      wells,
+      selectedWells: selectedWells ?? [],
+      labwareId,
+      fieldKey,
     })
   }
-
+  if (stepType === 'mix') {
+    addWellConfig(
+      propsForFields.labware.value as string,
+      propsForFields.wells?.value as string[],
+      'wells'
+    )
+  }
   if (stepType === 'transfer') {
-    const aspLabwareId = propsForFields.aspirate_labware.value as string
-    const allAspLabwareWells =
-      invariantContext.labwareEntities[aspLabwareId].def.ordering
-    wellConfigs.push({
-      wells: allAspLabwareWells,
-      selectedWells: (propsForFields.aspirate_wells?.value as string[]) ?? [],
-      labwareId: aspLabwareId,
-      fieldKey: 'aspirate_wells',
-    })
-    const dspLabwareId = propsForFields.dispense_labware.value as string
-    const allDspLabwareWells =
-      invariantContext.labwareEntities[dspLabwareId].def.ordering
-
-    wellConfigs.push({
-      wells: allDspLabwareWells,
-      selectedWells: (propsForFields.dispense_wells?.value as string[]) ?? [],
-      labwareId: dspLabwareId,
-      fieldKey: 'dispense_wells',
-    })
+    addWellConfig(
+      propsForFields.aspirate_labware.value as string,
+      propsForFields.aspirate_wells?.value as string[],
+      'aspirate_wells'
+    )
+    addWellConfig(
+      propsForFields.dispense_labware.value as string,
+      propsForFields.dispense_wells?.value as string[],
+      'dispense_wells'
+    )
   }
   const tiprackLabwareDefURI = propsForFields.tipRack.value as string
-
   const tiprackId = Object.values(deckSetup.labware).find(
     labware => labware.labwareDefURI === tiprackLabwareDefURI
   )?.id

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
@@ -16,10 +16,7 @@ import { PLURAL_COLUMNS, PLURAL_ROWS } from './constants'
 import { getAllWellsSafetyStatus } from './getAllWellsSafetyStatus'
 import { NozzleAndWellSelectionModal } from './NozzleAndWellSelectionModal'
 import styles from './nozzleandwellwizard.module.css'
-import {
-  getNozzleText,
-  getWellGroupLength,
-} from './utils'
+import { getNozzleText, getWellGroupLength } from './utils'
 
 import type {
   ActiveNozzleNumber,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -236,21 +236,24 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
       }
       return acc
     }, {})
-  const inaccessiblePartialWells = useMemo(
-    () => {
-      if (!isPartialNozzle || selectedWells.length === 0) return []
+  const inaccessiblePartialWells = useMemo(() => {
+    if (!isPartialNozzle || selectedWells.length === 0) {
+      return []
+    }
 
-      return getInaccessibleWellsForPartialNozzleRowMap(
-        selectedWells,
-        labwareDef.ordering,
-        allWellsWithState,
-        PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
-      )
-    },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedWells, isPartialNozzle, primaryNozzle, labwareDef.ordering]
-  )
+    return getInaccessibleWellsForPartialNozzleRowMap(
+      selectedWells,
+      labwareDef.ordering,
+      allWellsWithState,
+      PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
+    )
+  }, [
+    selectedWells,
+    isPartialNozzle,
+    primaryNozzle,
+    labwareDef.ordering,
+    allWellsWithState,
+  ])
 
   const deckDef = getDeckDefFromRobotType(robotType)
   const viewBox = getViewboxFromSelectedLabware(
@@ -283,7 +286,6 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
     }
     return highlightedWells
   }
-
   const handleSelectionMove: (e: MouseEvent, rect: GenericRect) => void = (
     e,
     rect
@@ -308,7 +310,6 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
         const allAlreadySelected = wellsUnderRect.every(group =>
           group.every(well => selectedFlat.has(well))
         )
-
         let updated: string[][]
         // Remove all wells if the entire selection is already selected
         if (allAlreadySelected) {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/__tests__/getAllWellsSafetyStatus.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/__tests__/getAllWellsSafetyStatus.test.ts
@@ -1,12 +1,21 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  A1_NOZZLE,
+  B1_NOZZLE,
+  C1_NOZZLE,
   COLUMN,
+  D1_NOZZLE,
+  E1_NOZZLE,
+  F1_NOZZLE,
   fixture96Plate,
   fixtureP100096V2Specs,
   fixtureTiprack1000ul,
+  G1_NOZZLE,
   getLabwareDefURI,
+  PARTIAL_COLUMN,
   ROW,
+  SINGLE,
 } from '@opentrons/shared-data'
 import { getIsSafePipetteMovement } from '@opentrons/step-generation'
 
@@ -45,8 +54,8 @@ describe('getAllWellsSafetyStatus', () => {
     },
   } as any
   const mockRobotState = {} as any
-  const primaryNozzle = 'A1' as any
-  const singleNozzle = 'SINGLE' as any
+  const primaryNozzle = A1_NOZZLE
+  const singleNozzle = SINGLE
 
   const allWells = [
     ['A1', 'B1', 'C1'],
@@ -183,5 +192,44 @@ describe('getAllWellsSafetyStatus', () => {
 
       expect(getIsSafePipetteMovement).toHaveBeenCalledTimes(6)
     })
+  })
+  describe('PARTIAL COLUMN mode', () => {
+    const column = ['A1', 'B1', 'C1', 'D1', 'E1', 'F1', 'G1', 'H1']
+
+    const cases = [
+      { nozzle: B1_NOZZLE, tipCount: 2 },
+      { nozzle: C1_NOZZLE, tipCount: 3 },
+      { nozzle: D1_NOZZLE, tipCount: 4 },
+      { nozzle: E1_NOZZLE, tipCount: 5 },
+      { nozzle: F1_NOZZLE, tipCount: 6 },
+      { nozzle: G1_NOZZLE, tipCount: 7 },
+    ]
+
+    it.each(cases)(
+      'handles partial column mode with $tipCount tips ($nozzle)',
+      ({ nozzle, tipCount }) => {
+        ;(getIsSafePipetteMovement as any).mockReturnValue(true)
+
+        const result = getAllWellsSafetyStatus({
+          allWells: [column],
+          robotState: mockRobotState,
+          invariantContext: mockInvariantContext,
+          pipetteId,
+          labwareId,
+          primaryNozzle: nozzle,
+          nozzleConfiguration: PARTIAL_COLUMN,
+        })
+
+        // Assert correct block is marked safe
+        for (let i = 0; i < tipCount; i++) {
+          expect(result[column[i]]).toBe(0)
+        }
+
+        // Assert remaining wells are still present in output
+        for (let i = tipCount; i < column.length; i++) {
+          expect(result[column[i]]).toBeDefined()
+        }
+      }
+    )
   })
 })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
@@ -159,9 +159,9 @@ export function getAllWellsSafetyStatus(
               tiprackId,
             })
           : true
-
         const canFitBlock = i <= column.length - totalSelectionLength
-        if (safe && canFitBlock) {
+        const labwareHasOneRow = labwareDef.ordering[0].length === 1
+        if (safe && (canFitBlock || labwareHasOneRow)) {
           // 1. Mark the valid block (e.g., A1–E1)
           for (let j = 0; j < totalSelectionLength; j++) {
             const well = column[i + j]

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
@@ -2,6 +2,7 @@ import {
   ALL,
   COLUMN,
   PARTIAL_COLUMN,
+  PARTIAL_NOZZLE_MAP,
   ROW,
   SINGLE,
 } from '@opentrons/shared-data'
@@ -11,6 +12,7 @@ import { canPipetteUseLabware } from '../../../../../../utils'
 
 import type {
   NozzleConfigurationStyle,
+  PartialPrimaryNozzles,
   PrimaryNozzleConfigurationStyle,
 } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '@opentrons/step-generation'
@@ -121,11 +123,7 @@ export function getAllWellsSafetyStatus(
     allWells.flat().forEach(wellName => {
       allWellsWithStatus[wellName] = safe ? 0 : 1
     })
-  } else if (
-    (nozzleConfiguration === SINGLE ||
-      nozzleConfiguration === PARTIAL_COLUMN) &&
-    channels !== 1
-  ) {
+  } else if (nozzleConfiguration === SINGLE && channels !== 1) {
     // SINGLE nozzle for 8ch and 96ch: check every well individually
     allWells.flat().forEach(wellName => {
       const safe = robotState
@@ -142,12 +140,63 @@ export function getAllWellsSafetyStatus(
         : true
       allWellsWithStatus[wellName] = safe ? 0 : 1
     })
+  } else if (nozzleConfiguration === PARTIAL_COLUMN) {
+    const totalSelectionLength =
+      PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
+    for (let colIndex = 0; colIndex < allWells.length; colIndex++) {
+      const column = allWells[colIndex]
+      for (let i = 0; i < column.length; i++) {
+        const wellToTest = column[i]
+        const safe = robotState
+          ? getIsSafePipetteMovement({
+              robotState,
+              invariantContext,
+              pipetteId,
+              labwareId,
+              wellTargetName: wellToTest,
+              primaryNozzle,
+              nozzleConfiguration,
+              tiprackId,
+            })
+          : true
+
+        const canFitBlock = i <= column.length - totalSelectionLength
+        if (safe && canFitBlock) {
+          // 1. Mark the valid block (e.g., A1–E1)
+          for (let j = 0; j < totalSelectionLength; j++) {
+            const well = column[i + j]
+            allWellsWithStatus[well] = 0
+          }
+          // 2. Continue checking the remaining wells (e.g., F1–H1)
+          for (let k = i + totalSelectionLength; k < column.length; k++) {
+            const remainingWell = column[k]
+            const remainingSafe = robotState
+              ? getIsSafePipetteMovement({
+                  robotState,
+                  invariantContext,
+                  pipetteId,
+                  labwareId,
+                  wellTargetName: remainingWell,
+                  primaryNozzle,
+                  nozzleConfiguration,
+                  tiprackId,
+                })
+              : true
+
+            allWellsWithStatus[remainingWell] = remainingSafe ? 0 : 1
+          }
+          // Done with this column
+          break
+        }
+        // Mark unsafe if not usable as a starting point
+        allWellsWithStatus[wellToTest] = 1
+      }
+    }
   } else {
     // remaining case - single channel pipettes - assume all wells can be safely accessed
     allWells.flat().forEach(wellName => {
       allWellsWithStatus[wellName] = 0
     })
   }
-
   return allWellsWithStatus
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
@@ -63,18 +63,18 @@ export function getAllWellsSafetyStatus(
     const numRows = allWells[0].length
     for (let rowIndex = 0; rowIndex < numRows; rowIndex++) {
       const firstWell = allWells[0][rowIndex]
-      const safe = robotState
-        ? getIsSafePipetteMovement({
-            robotState,
-            invariantContext,
-            pipetteId,
-            labwareId,
-            wellTargetName: firstWell,
-            primaryNozzle,
-            nozzleConfiguration,
-            tiprackId,
-          })
-        : true
+      const safe =
+        robotState === null ||
+        getIsSafePipetteMovement({
+          robotState,
+          invariantContext,
+          pipetteId,
+          labwareId,
+          wellTargetName: firstWell,
+          primaryNozzle,
+          nozzleConfiguration,
+          tiprackId,
+        })
 
       // mark all wells in this row
       allWells.forEach(column => {
@@ -89,18 +89,18 @@ export function getAllWellsSafetyStatus(
     for (let colIndex = 0; colIndex < allWells.length; colIndex++) {
       const column = allWells[colIndex]
       const firstWell = column[0]
-      const safe = robotState
-        ? getIsSafePipetteMovement({
-            robotState,
-            invariantContext,
-            pipetteId,
-            labwareId,
-            wellTargetName: firstWell,
-            primaryNozzle,
-            nozzleConfiguration,
-            tiprackId,
-          })
-        : true
+      const safe =
+        robotState === null ||
+        getIsSafePipetteMovement({
+          robotState,
+          invariantContext,
+          pipetteId,
+          labwareId,
+          wellTargetName: firstWell,
+          primaryNozzle,
+          nozzleConfiguration,
+          tiprackId,
+        })
 
       column.forEach(wellName => {
         allWellsWithStatus[wellName] = safe ? 0 : 1
@@ -108,36 +108,38 @@ export function getAllWellsSafetyStatus(
     }
   } else if (nozzleConfiguration === ALL && channels === 96) {
     // ALL 96 Nozzles: only check the first well
-    const safe = robotState
-      ? getIsSafePipetteMovement({
-          robotState,
-          invariantContext,
-          pipetteId,
-          labwareId,
-          wellTargetName: allWells[0][0],
-          primaryNozzle,
-          nozzleConfiguration,
-          tiprackId,
-        })
-      : true
+    const safe =
+      robotState === null ||
+      getIsSafePipetteMovement({
+        robotState,
+        invariantContext,
+        pipetteId,
+        labwareId,
+        wellTargetName: allWells[0][0],
+        primaryNozzle,
+        nozzleConfiguration,
+        tiprackId,
+      })
+
     allWells.flat().forEach(wellName => {
       allWellsWithStatus[wellName] = safe ? 0 : 1
     })
   } else if (nozzleConfiguration === SINGLE && channels !== 1) {
     // SINGLE nozzle for 8ch and 96ch: check every well individually
     allWells.flat().forEach(wellName => {
-      const safe = robotState
-        ? getIsSafePipetteMovement({
-            robotState,
-            invariantContext,
-            pipetteId,
-            labwareId,
-            wellTargetName: wellName,
-            primaryNozzle,
-            nozzleConfiguration,
-            tiprackId,
-          })
-        : true
+      const safe =
+        robotState === null ||
+        getIsSafePipetteMovement({
+          robotState,
+          invariantContext,
+          pipetteId,
+          labwareId,
+          wellTargetName: wellName,
+          primaryNozzle,
+          nozzleConfiguration,
+          tiprackId,
+        })
+
       allWellsWithStatus[wellName] = safe ? 0 : 1
     })
   } else if (nozzleConfiguration === PARTIAL_COLUMN) {
@@ -147,18 +149,19 @@ export function getAllWellsSafetyStatus(
       const column = allWells[colIndex]
       for (let i = 0; i < column.length; i++) {
         const wellToTest = column[i]
-        const safe = robotState
-          ? getIsSafePipetteMovement({
-              robotState,
-              invariantContext,
-              pipetteId,
-              labwareId,
-              wellTargetName: wellToTest,
-              primaryNozzle,
-              nozzleConfiguration,
-              tiprackId,
-            })
-          : true
+        const safe =
+          robotState === null ||
+          getIsSafePipetteMovement({
+            robotState,
+            invariantContext,
+            pipetteId,
+            labwareId,
+            wellTargetName: wellToTest,
+            primaryNozzle,
+            nozzleConfiguration,
+            tiprackId,
+          })
+
         const canFitBlock = i <= column.length - totalSelectionLength
         const labwareHasOneRow = labwareDef.ordering[0].length === 1
         if (safe && (canFitBlock || labwareHasOneRow)) {
@@ -170,18 +173,18 @@ export function getAllWellsSafetyStatus(
           // 2. Continue checking the remaining wells (e.g., F1–H1)
           for (let k = i + totalSelectionLength; k < column.length; k++) {
             const remainingWell = column[k]
-            const remainingSafe = robotState
-              ? getIsSafePipetteMovement({
-                  robotState,
-                  invariantContext,
-                  pipetteId,
-                  labwareId,
-                  wellTargetName: remainingWell,
-                  primaryNozzle,
-                  nozzleConfiguration,
-                  tiprackId,
-                })
-              : true
+            const remainingSafe =
+              robotState === null ||
+              getIsSafePipetteMovement({
+                robotState,
+                invariantContext,
+                pipetteId,
+                labwareId,
+                wellTargetName: remainingWell,
+                primaryNozzle,
+                nozzleConfiguration,
+                tiprackId,
+              })
 
             allWellsWithStatus[remainingWell] = remainingSafe ? 0 : 1
           }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/utils.ts
@@ -172,7 +172,7 @@ export const getEntireWellSelection = (
     return []
   }
   if (nozzleConfiguration === SINGLE) return [wellName]
-  const columnIndex = wellOrdering.findIndex(column =>
+  const columnIndex = wellOrdering?.findIndex(column =>
     column.includes(wellName)
   )
   const indexInColumn = wellOrdering[columnIndex].findIndex(

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -17,15 +17,7 @@ import {
   TIP,
   USED,
 } from '@opentrons/components'
-import {
-  ALL,
-  COLUMN,
-  getPositionFromSlotId,
-  PARTIAL_COLUMN,
-  PARTIAL_NOZZLE_MAP,
-  ROW,
-  SINGLE,
-} from '@opentrons/shared-data'
+import { getPositionFromSlotId, PARTIAL_COLUMN } from '@opentrons/shared-data'
 import { EMPTY, getSlotInLocationStack } from '@opentrons/step-generation'
 
 import { LabwareOnDeck } from '/protocol-designer/components/organisms'
@@ -54,17 +46,12 @@ import { DeckOverlay } from './DeckOverlay'
 import { PipetteShadow } from './PipetteShadows/PipetteShadow'
 import { SelectionLegend } from './SelectionLegend'
 import styles from './tipselectionwizard.module.css'
-import {
-  getAllWellsInColumn,
-  getAllWellsInRow,
-  getViewboxFromSelectedLabware,
-} from './utils'
+import { getViewboxFromSelectedLabware } from './utils'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { TipType, WellMouseEvent } from '@opentrons/components'
 import type {
   NozzleConfigurationStyle,
-  PartialPrimaryNozzles,
   PipetteV2Specs,
   PrimaryNozzleConfigurationStyle,
 } from '@opentrons/shared-data'
@@ -102,7 +89,6 @@ export function SelectTips(
     selectedTips,
     setSelectedTips,
     numTotalPickups,
-    setShowErrorBanner,
     tipAccessibilityStatus,
     nozzles,
     primaryNozzle,
@@ -138,7 +124,7 @@ export function SelectTips(
 
   const areAllHoveredWellsAccessibleAndOccupied = allWellsAffectedByHover.every(
     well =>
-      tipAccessibileStatusByWellName[well].isAccessible &&
+      tipAccessibileStatusByWellName[well]?.isAccessible &&
       tipState?.[well] !== EMPTY
   )
 
@@ -153,6 +139,9 @@ export function SelectTips(
 
   const hoveredWellsInaccessibilityStatus =
     allWellsAffectedByHover.reduce<InaccessibleReason | null>((acc, well) => {
+      if (tipAccessibileStatusByWellName[well] === undefined) {
+        return null
+      }
       const { isAccessible, inaccessibleReason } =
         tipAccessibileStatusByWellName[well]
       if (isAccessible || inaccessibleReason == null) {
@@ -183,92 +172,6 @@ export function SelectTips(
       highlightedWells.push(wellSelection)
     }
     return highlightedWells
-  }
-
-  const handleUnselectWell = (unselectIndex: number): void => {
-    setSelectedTips(selectedTips.slice(0, unselectIndex))
-  }
-
-  const handleClickWell = (wellName: string): void => {
-    const prevSelectedTipsByIndex = selectedTips.reduce<Record<string, number>>(
-      (acc, tipList, index) => {
-        const innerAcc = tipList.reduce((acc, tip) => {
-          return { ...acc, [tip]: index }
-        }, {})
-        return { ...acc, ...innerAcc }
-      },
-      {}
-    )
-    if (
-      // always allow tip unselection
-      !(wellName in prevSelectedTipsByIndex) &&
-      (tipState?.[wellName] === 'EMPTY' ||
-        !tipAccessibileStatusByWellName[wellName].isAccessible ||
-        (allWellsAffectedByHover.includes(wellName) &&
-          !areAllHoveredWellsAccessibleAndOccupied))
-    ) {
-      return
-    }
-    setShowErrorBanner(false)
-
-    if (channels === 1 || nozzles === SINGLE) {
-      if (wellName in prevSelectedTipsByIndex) {
-        const indexToUnselect = prevSelectedTipsByIndex[wellName]
-        handleUnselectWell(indexToUnselect)
-      } else if (hasPickupsRemaining) {
-        setSelectedTips(prevTips => [...prevTips, [wellName]])
-      }
-    } else if (nozzles === PARTIAL_COLUMN) {
-      if (wellName in prevSelectedTipsByIndex) {
-        const indexToUnselect = prevSelectedTipsByIndex[wellName]
-        handleUnselectWell(indexToUnselect)
-      } else if (hasPickupsRemaining) {
-        const totalTipSelection =
-          PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles] ?? 0
-        const allWellsinColumn = getAllWellsInColumn(wellName, labwareDef)
-        const lengthOfColumn = allWellsinColumn.length
-        const allWellsInPartialColumn = allWellsinColumn.slice(
-          0,
-          lengthOfColumn - totalTipSelection
-        )
-        setSelectedTips(prevTips => [...prevTips, allWellsInPartialColumn])
-      }
-    } else if (
-      (channels === 8 && nozzles === ALL) ||
-      (channels === 96 && nozzles === COLUMN)
-    ) {
-      if (wellName in prevSelectedTipsByIndex) {
-        const indexToUnselect = prevSelectedTipsByIndex[wellName]
-        handleUnselectWell(indexToUnselect)
-      } else if (hasPickupsRemaining) {
-        const allWellsInColumn = getAllWellsInColumn(wellName, labwareDef)
-        setSelectedTips(prevTips => {
-          const newTips = [...prevTips]
-          newTips.push(allWellsInColumn)
-          return newTips
-        })
-      }
-    } else if (channels === 96 && nozzles === ROW) {
-      if (wellName in prevSelectedTipsByIndex) {
-        const indexToUnselect = prevSelectedTipsByIndex[wellName]
-        handleUnselectWell(indexToUnselect)
-      } else if (hasPickupsRemaining) {
-        const allWellsInRow = getAllWellsInRow(wellName, labwareDef)
-        setSelectedTips(prevTips => {
-          const newTips = [...prevTips]
-          newTips.push(allWellsInRow)
-          return newTips
-        })
-      }
-    } else if (channels === 96 && nozzles === ALL) {
-      const allWells = Object.keys(labwareDef.wells)
-      if (wellName in prevSelectedTipsByIndex) {
-        const indexToUnselect = prevSelectedTipsByIndex[wellName]
-        handleUnselectWell(indexToUnselect)
-      } else if (hasPickupsRemaining) {
-        setSelectedTips(prevTips => [...prevTips, allWells])
-      }
-    }
   }
 
   const handleHoverWell = (e: WellMouseEvent): void => {
@@ -327,7 +230,7 @@ export function SelectTips(
       const filteredWellsUnderRect = wellsUnderRect.filter(wellGroup =>
         wellGroup.every(
           wellName =>
-            tipAccessibileStatusByWellName[wellName].isAccessible &&
+            tipAccessibileStatusByWellName[wellName]?.isAccessible &&
             hasPickupsRemaining
         )
       )
@@ -337,10 +240,15 @@ export function SelectTips(
         const allAlreadySelected = filteredWellsUnderRect.every(group =>
           group.every(well => selectedFlat.has(well))
         )
-
+        const isPartialPickup = nozzles === PARTIAL_COLUMN
+        const isOverlappingWithPartialPickup =
+          isPartialPickup &&
+          filteredWellsUnderRect.every(group =>
+            group.some(well => selectedFlat.has(well))
+          )
         let updated: string[][]
         // Remove all wells if the entire selection is already selected
-        if (allAlreadySelected) {
+        if (allAlreadySelected || isOverlappingWithPartialPickup) {
           const keysToRemove = new Set(wellsUnderRect.map(g => g[0]))
           updated = next.filter(group => !keysToRemove.has(group[0]))
         } else {
@@ -380,12 +288,12 @@ export function SelectTips(
             (acc, [wellName, state]) => {
               const rawState = TIP_STATE_TO_TIP_TYPE[state]
               let status = rawState
-              if (!tipAccessibileStatusByWellName[wellName].isAccessible) {
+              if (!tipAccessibileStatusByWellName[wellName]?.isAccessible) {
                 status = rawState === NO ? NO : INACCESSIBLE
               }
               if (selectedTips.flat().some(tip => tip === wellName)) {
                 const isAccessible =
-                  tipAccessibileStatusByWellName[wellName].isAccessible
+                  tipAccessibileStatusByWellName[wellName]?.isAccessible
                 if (!isAccessible) {
                   status = SELECTED_ERROR
                 } else {
@@ -414,7 +322,6 @@ export function SelectTips(
           x={slotPosition[0]}
           y={slotPosition[1]}
           showHighlightedWells={false}
-          handleClickWell={handleClickWell}
           onMouseEnterWell={handleHoverWell}
           onMouseLeaveWell={handleLeaveWell}
           selectedTipsByIndex={selectedWellsByIndex}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
@@ -2,15 +2,13 @@ import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 
 import { ALL, COLUMN, ROW } from '@opentrons/shared-data'
-import {
-  getIsSafePickupWithinTiprack,
-  getIsSafePipetteMovement,
-} from '@opentrons/step-generation'
+import { getIsSafePickupWithinTiprack } from '@opentrons/step-generation'
 
 import { OFFDECK } from '/protocol-designer/constants'
 import { getInvariantContext } from '/protocol-designer/step-forms/selectors'
 import { getRobotStateAtActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 
+import { getAllWellsSafetyStatus } from '../../NozzleAndWellSelectionModal/getAllWellsSafetyStatus'
 import { getEntireWellSelection } from '../../NozzleAndWellSelectionModal/utils'
 import {
   INACCESSIBLE_COLLISION,
@@ -74,12 +72,13 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
   const robotState = useSelector(getRobotStateAtActiveItem)
   const invariantContext = useSelector(getInvariantContext)
   const { labwareEntities } = invariantContext
-
   return useMemo(
     () => {
       if (robotState == null) {
         return {}
       }
+        let groupEntries: {}
+
       return Object.entries(robotState.labware).reduce<
         Record<string, Record<string, AccessibilityStatus>>
       >((acc, [id, { stack }]) => {
@@ -101,9 +100,37 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
           def.ordering,
           pipetteChannels
         )
+        const allWellsSafetyStatus = getAllWellsSafetyStatus({
+          allWells: def.ordering,
+          robotState,
+          invariantContext,
+          pipetteId,
+          labwareId: id,
+          primaryNozzle,
+          nozzleConfiguration: nozzles,
+        })
         return {
           ...acc,
           [id]: wellNamesToCheck.reduce((acc, wellName) => {
+            if (groupEntries !== undefined && wellName in groupEntries) {
+              return { ...acc, ...groupEntries }
+            }
+            const wellGroup = getEntireWellSelection(
+              wellName,
+              def.ordering,
+              nozzles,
+              primaryNozzle,
+              pipetteChannels
+            )
+
+            if (groupEntries) {
+              const hasOverlap = wellGroup.some(key => {
+                return key in groupEntries
+              })
+              if (hasOverlap) {
+                return { ...acc, ...groupEntries }
+              }
+            }
             const { isSafe, isComplete } = getIsSafePickupWithinTiprack({
               tipState,
               primaryNozzle,
@@ -113,15 +140,8 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
               tiprackDef: def,
               tipsToIgnore: selectedTips.flat(),
             })
-            const isCollision = !getIsSafePipetteMovement({
-              robotState,
-              invariantContext,
-              pipetteId,
-              labwareId: id,
-              wellTargetName: wellName,
-              primaryNozzle,
-              nozzleConfiguration: nozzles,
-            })
+
+            const isCollision = allWellsSafetyStatus[wellName] === 1
             const isAccessible = isSafe && isComplete && !isCollision
             let inaccessibleReason: InaccessibleReason | null = null
             if (isCollision) {
@@ -131,14 +151,7 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
             } else if (!isComplete) {
               inaccessibleReason = INACCESSIBLE_INCOMPLETE
             }
-            const wellGroup = getEntireWellSelection(
-              wellName,
-              def.ordering,
-              nozzles,
-              primaryNozzle,
-              pipetteChannels
-            )
-            const groupEntries = Object.fromEntries(
+            groupEntries = Object.fromEntries(
               wellGroup.map(well => [
                 well,
                 {


### PR DESCRIPTION
# Overview

Tipracks had tips wrongfully marked as inaccessible because `useMemoizedTipAccessibilityByTiprackIdByWellName` was interating through every tip. This is not needed since it only matters if the primary nozzle can access it. 

Now if the well already has an entry or is part of a group entry it will skip it. This created some issues in other spots because the well did not have an accessibility entry. 

NOTE: just look at commit 806b70138827e5e6586ca51da2d04972c5b05135 the other commits are from the other branch

## Test Plan and Hands on Testing
- smoke tested 2, 3, and 5 manual tip selection - overall it worked but there were some times where tips were still marked as inaccessible but probably shouldn't be
[Blocking_Buffer_Test (1).py](https://github.com/user-attachments/files/27286211/Blocking_Buffer_Test.1.py)

https://github.com/user-attachments/assets/814c0f72-67a0-4249-a19b-072ade162aef



## Changelog
- skip redundant wells to check for accessibility
- also removed the 
- removed handleClick from SelectTips because it now uses handleSelectionDone since we switched to using a selection rectangle
- 
## Review requests

- more smoke test / maybe a different approach should be considered

## Risk assessment

- high still a little buggy

partially addresses RQA-5348