### PR TITLE
feat(app): refresh robot CA certs when they expire

### DIFF
--- a/api-client/src/keys/index.ts
+++ b/api-client/src/keys/index.ts
@@ -6,4 +6,5 @@ export type {
   CACertPassword,
   EncryptedCACertificates,
   PlaintextCACertificates,
+  UnencryptedCert,
 } from './types'

--- a/app-shell/src/__tests__/certs.test.ts
+++ b/app-shell/src/__tests__/certs.test.ts
@@ -1,9 +1,17 @@
-import { pbkdf2, randomBytes } from 'crypto'
+import 'core-js/full/reflect'
+
+import { pbkdf2, randomBytes, webcrypto, X509Certificate } from 'crypto'
 import { promisify } from 'util'
+import * as x509 from '@peculiar/x509'
 import * as Fernet from 'fernet'
 import { describe, expect, it, vi } from 'vitest'
 
-import { decryptFromOTDetails } from '../certs'
+import {
+  decryptFromOTDetails,
+  validateCert,
+  validateCertShouldLoad,
+  validateCertShouldVerify,
+} from '../certs'
 
 vi.mock('../log', () => {
   const fakeLogger = {
@@ -11,6 +19,7 @@ vi.mock('../log', () => {
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
+    silly: vi.fn(),
   }
   return { createLogger: () => fakeLogger }
 })
@@ -158,5 +167,296 @@ describe('fernet decryption', () => {
     const decrypted = await decryptFromOTDetails(pw, saltEncoded, 10, encrypted)
     const decoded = decrypted.toString('utf-8')
     expect(decoded).toEqual('badger badger badger SNAKE')
+  })
+})
+
+describe('cert validity checking', async () => {
+  const signingAlgorithm = {
+    name: 'RSASSA-PKCS1-v1_5',
+    hash: 'SHA-256',
+    publicExponent: new Uint8Array([1, 0, 1]),
+    modulusLength: 2048,
+  }
+  const keys = await crypto.subtle.generateKey(signingAlgorithm, false, [
+    'sign',
+    'verify',
+  ])
+
+  it('should install a cert that is currently valid', async () => {
+    const peculiarCert = await x509.X509CertificateGenerator.createSelfSigned(
+      {
+        keys,
+        serialNumber: '01',
+        name: 'CN=Test',
+        notBefore: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        notAfter: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        signingAlgorithm,
+        extensions: [
+          new x509.BasicConstraintsExtension(true, 2, true),
+          new x509.ExtendedKeyUsageExtension([
+            '1.2.3.4.5.6.7',
+            '2.3.4.5.6.7.8',
+          ]),
+          new x509.KeyUsagesExtension(
+            x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign,
+            true
+          ),
+          await x509.SubjectKeyIdentifierExtension.create(keys.publicKey),
+        ],
+      },
+      webcrypto as Parameters<
+        typeof x509.X509CertificateGenerator.createSelfSigned
+      >[1]
+    )
+    const nodeCert = new X509Certificate(Buffer.from(peculiarCert.rawData))
+    expect(validateCertShouldLoad(nodeCert)).toBe(nodeCert)
+  })
+  it('should install a cert that is not yet valid', async () => {
+    const peculiarCert = await x509.X509CertificateGenerator.createSelfSigned(
+      {
+        keys,
+        serialNumber: '01',
+        name: 'CN=Test',
+        notBefore: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        notAfter: new Date(Date.now() + 48 * 60 * 60 * 1000),
+        signingAlgorithm,
+        extensions: [
+          new x509.BasicConstraintsExtension(true, 2, true),
+          new x509.ExtendedKeyUsageExtension([
+            '1.2.3.4.5.6.7',
+            '2.3.4.5.6.7.8',
+          ]),
+          new x509.KeyUsagesExtension(
+            x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign,
+            true
+          ),
+          await x509.SubjectKeyIdentifierExtension.create(keys.publicKey),
+        ],
+      },
+      webcrypto as Parameters<
+        typeof x509.X509CertificateGenerator.createSelfSigned
+      >[1]
+    )
+    const nodeCert = new X509Certificate(Buffer.from(peculiarCert.rawData))
+    expect(validateCertShouldLoad(nodeCert)).toBe(nodeCert)
+  })
+  it('should not install a cert that is no longer valid', async () => {
+    const peculiarCert = await x509.X509CertificateGenerator.createSelfSigned(
+      {
+        keys,
+        serialNumber: '01',
+        name: 'CN=Test',
+        notBefore: new Date(Date.now() - 48 * 60 * 60 * 1000),
+        notAfter: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        signingAlgorithm,
+        extensions: [
+          new x509.BasicConstraintsExtension(true, 2, true),
+          new x509.ExtendedKeyUsageExtension([
+            '1.2.3.4.5.6.7',
+            '2.3.4.5.6.7.8',
+          ]),
+          new x509.KeyUsagesExtension(
+            x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign,
+            true
+          ),
+          await x509.SubjectKeyIdentifierExtension.create(keys.publicKey),
+        ],
+      },
+      webcrypto as Parameters<
+        typeof x509.X509CertificateGenerator.createSelfSigned
+      >[1]
+    )
+    const nodeCert = new X509Certificate(Buffer.from(peculiarCert.rawData))
+    expect(validateCertShouldLoad(nodeCert)).toBeNull()
+  })
+  it('should verify with a cert that is currently valid', async () => {
+    const peculiarCert = await x509.X509CertificateGenerator.createSelfSigned(
+      {
+        keys,
+        serialNumber: '01',
+        name: 'CN=Test',
+        notBefore: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        notAfter: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        signingAlgorithm,
+        extensions: [
+          new x509.BasicConstraintsExtension(true, 2, true),
+          new x509.ExtendedKeyUsageExtension([
+            '1.2.3.4.5.6.7',
+            '2.3.4.5.6.7.8',
+          ]),
+          new x509.KeyUsagesExtension(
+            x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign,
+            true
+          ),
+          await x509.SubjectKeyIdentifierExtension.create(keys.publicKey),
+        ],
+      },
+      webcrypto as Parameters<
+        typeof x509.X509CertificateGenerator.createSelfSigned
+      >[1]
+    )
+    const nodeCert = new X509Certificate(Buffer.from(peculiarCert.rawData))
+    expect(validateCertShouldVerify(nodeCert)).toBe(nodeCert)
+  })
+  it('should not verify with a cert that is not yet valid', async () => {
+    const peculiarCert = await x509.X509CertificateGenerator.createSelfSigned(
+      {
+        keys,
+        serialNumber: '01',
+        name: 'CN=Test',
+        notBefore: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        notAfter: new Date(Date.now() + 48 * 60 * 60 * 1000),
+        signingAlgorithm,
+        extensions: [
+          new x509.BasicConstraintsExtension(true, 2, true),
+          new x509.ExtendedKeyUsageExtension([
+            '1.2.3.4.5.6.7',
+            '2.3.4.5.6.7.8',
+          ]),
+          new x509.KeyUsagesExtension(
+            x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign,
+            true
+          ),
+          await x509.SubjectKeyIdentifierExtension.create(keys.publicKey),
+        ],
+      },
+      webcrypto as Parameters<
+        typeof x509.X509CertificateGenerator.createSelfSigned
+      >[1]
+    )
+    const nodeCert = new X509Certificate(Buffer.from(peculiarCert.rawData))
+    expect(validateCertShouldVerify(nodeCert)).toBeNull()
+  })
+  it('should not verify with a cert that is no longer valid', async () => {
+    const peculiarCert = await x509.X509CertificateGenerator.createSelfSigned(
+      {
+        keys,
+        serialNumber: '01',
+        name: 'CN=Test',
+        notBefore: new Date(Date.now() - 48 * 60 * 60 * 1000),
+        notAfter: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        signingAlgorithm,
+        extensions: [
+          new x509.BasicConstraintsExtension(true, 2, true),
+          new x509.ExtendedKeyUsageExtension([
+            '1.2.3.4.5.6.7',
+            '2.3.4.5.6.7.8',
+          ]),
+          new x509.KeyUsagesExtension(
+            x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign,
+            true
+          ),
+          await x509.SubjectKeyIdentifierExtension.create(keys.publicKey),
+        ],
+      },
+      webcrypto as Parameters<
+        typeof x509.X509CertificateGenerator.createSelfSigned
+      >[1]
+    )
+    const nodeCert = new X509Certificate(Buffer.from(peculiarCert.rawData))
+    expect(validateCertShouldVerify(nodeCert)).toBeNull()
+  })
+})
+
+describe('incoming cert checking', async () => {
+  const ssProvider = webcrypto as Parameters<
+    typeof x509.X509CertificateGenerator.createSelfSigned
+  >[1]
+  const provider = webcrypto as Parameters<
+    typeof x509.X509CertificateGenerator.create
+  >[1]
+  const signingAlgorithm = {
+    name: 'RSASSA-PKCS1-v1_5',
+    hash: 'SHA-256',
+    publicExponent: new Uint8Array([1, 0, 1]),
+    modulusLength: 2048,
+  }
+  const caKeys = await crypto.subtle.generateKey(signingAlgorithm, false, [
+    'sign',
+    'verify',
+  ])
+  const peculiarCA = await x509.X509CertificateGenerator.createSelfSigned(
+    {
+      keys: caKeys,
+      serialNumber: '01',
+      name: 'CN=Test',
+      notBefore: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      notAfter: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      signingAlgorithm,
+      extensions: [
+        new x509.BasicConstraintsExtension(true, 2, true),
+
+        new x509.ExtendedKeyUsageExtension(['1.2.3.4.5.6.7', '2.3.4.5.6.7.8']),
+        new x509.KeyUsagesExtension(
+          x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign,
+          true
+        ),
+        await x509.SubjectKeyIdentifierExtension.create(caKeys.publicKey),
+      ],
+    },
+    ssProvider
+  )
+  const nodeCA = new X509Certificate(Buffer.from(peculiarCA.rawData))
+  const eeKeys = await crypto.subtle.generateKey(signingAlgorithm, false, [
+    'sign',
+    'verify',
+  ])
+  const peculiarEE = await x509.X509CertificateGenerator.create(
+    {
+      signingKey: caKeys.privateKey,
+      publicKey: eeKeys.publicKey,
+      issuer: peculiarCA.subject,
+      notBefore: new Date(Date.now() - 60 * 60 * 1000),
+      notAfter: new Date(Date.now() + 60 * 60 * 1000),
+      extensions: [
+        new x509.BasicConstraintsExtension(false, undefined, true),
+        new x509.KeyUsagesExtension(
+          x509.KeyUsageFlags.digitalSignature |
+            x509.KeyUsageFlags.keyEncipherment |
+            x509.KeyUsageFlags.cRLSign,
+          true
+        ),
+        new x509.ExtendedKeyUsageExtension([
+          '1.3.6.1.5.5.7.3.1',
+          '1.3.6.1.5.5.7.3.2',
+        ]),
+        await x509.SubjectKeyIdentifierExtension.create(eeKeys.publicKey),
+        await x509.AuthorityKeyIdentifierExtension.create(caKeys.publicKey),
+      ],
+    },
+    provider
+  )
+  const nodeEE = new X509Certificate(Buffer.from(peculiarEE.rawData))
+  const otherCAKey = await crypto.subtle.generateKey(signingAlgorithm, false, [
+    'sign',
+    'verify',
+  ])
+  const otherPeculiarCA = await x509.X509CertificateGenerator.createSelfSigned(
+    {
+      keys: otherCAKey,
+      serialNumber: '01',
+      name: 'CN=Test',
+      notBefore: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      notAfter: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      signingAlgorithm,
+      extensions: [
+        new x509.BasicConstraintsExtension(true, 2, true),
+
+        new x509.ExtendedKeyUsageExtension(['1.2.3.4.5.6.7', '2.3.4.5.6.7.8']),
+        new x509.KeyUsagesExtension(
+          x509.KeyUsageFlags.keyCertSign | x509.KeyUsageFlags.cRLSign,
+          true
+        ),
+        await x509.SubjectKeyIdentifierExtension.create(otherCAKey.publicKey),
+      ],
+    },
+    ssProvider
+  )
+  const otherNodeCA = new X509Certificate(Buffer.from(otherPeculiarCA.rawData))
+  it('should verify an EE certificate created by at least one CA', async () => {
+    expect(validateCert(nodeEE, [nodeCA, otherNodeCA])).toBe(true)
+  })
+  it('should reject an EE certificate not created by any CA', async () => {
+    expect(validateCert(nodeEE, [otherNodeCA])).toBe(false)
   })
 })

--- a/app-shell/src/certs.ts
+++ b/app-shell/src/certs.ts
@@ -93,6 +93,17 @@ async function tryLoadCertificate(
   }
 }
 
+export function validateCertShouldLoad(
+  certificate: X509Certificate
+): X509Certificate | null {
+  const now = Date.now()
+  if (certificate.validToDate.valueOf() < now) {
+    log.info(`Certificate ${certificate.fingerprint256} invalid (expired)`)
+    return null
+  }
+  return certificate
+}
+
 async function loadCertificatesFromDisk(): Promise<void> {
   const certDir = await getCertDir()
   log.info(`Reading robot certificates from ${certDir}`)
@@ -100,6 +111,7 @@ async function loadCertificatesFromDisk(): Promise<void> {
     withFileTypes: true,
     encoding: 'utf8',
   })
+
   for (const possibleCert of certs) {
     if (!possibleCert.isFile()) {
       continue
@@ -107,11 +119,19 @@ async function loadCertificatesFromDisk(): Promise<void> {
     if (!possibleCert.name.endsWith('.cer')) {
       continue
     }
-    const loaded = await tryLoadCertificate(join(certDir, possibleCert.name))
+    const certPath = join(certDir, possibleCert.name)
+    const loaded = await tryLoadCertificate(certPath)
     if (loaded == null) {
+      log.info(`Removing invalid certificate (can't be loaded) at ${certPath}`)
+      await rm(certPath)
       continue
     }
-    addCertificateToMap(loaded)
+    const validated = validateCertShouldLoad(loaded)
+    if (validated == null) {
+      await rm(certPath)
+      continue
+    }
+    addCertificateToMap(validated)
   }
 }
 
@@ -278,6 +298,55 @@ async function plaintextCertInstallListener(
   return true
 }
 
+export function validateCertShouldVerify(
+  certificate: X509Certificate
+): X509Certificate | null {
+  const now = Date.now()
+  if (certificate.validToDate.valueOf() < now) {
+    log.silly(
+      `Certificate ${certificate.fingerprint256} invalid for verification (expired)`
+    )
+    return null
+  }
+  if (certificate.validFromDate.valueOf() > now) {
+    log.silly(
+      `Certificate ${certificate.fingerprint256} invalid for verification (not yet valid)`
+    )
+    return null
+  }
+  return certificate
+}
+
+export function validateCert(
+  incomingCert: X509Certificate,
+  certsToVerifyAgainst: { values: () => IterableIterator<X509Certificate> }
+): boolean {
+  const now = Date.now()
+  const validatedIncoming = validateCertShouldVerify(incomingCert)
+  if (validatedIncoming == null) {
+    log.warning('Invalid certificate from request, denying')
+    return false
+  }
+  for (const knownCert of certsToVerifyAgainst.values()) {
+    if (knownCert.validFromDate.valueOf() > now) {
+      log.silly(`Ignoring cert ${knownCert.fingerprint256}, not yet valid`)
+      continue
+    }
+    const validated = validateCertShouldVerify(knownCert)
+    if (validated == null) {
+      continue
+    }
+    if (incomingCert.checkIssued(knownCert)) {
+      if (incomingCert.verify(knownCert.publicKey)) {
+        log.silly('good sign match for cert, allowing')
+        return true
+      }
+    }
+  }
+  log.info('no sign match for cert, denying')
+  return false
+}
+
 export async function registerCertIPC(): Promise<void> {
   ipcMain.handle('robot-cert:install-encrypted', encryptedCertInstallListener)
   ipcMain.handle('robot-cert:install-plaintext', plaintextCertInstallListener)
@@ -286,17 +355,10 @@ export async function registerCertIPC(): Promise<void> {
     (event, _webContents, _url, _error, certificate, allowRequest) => {
       const incomingAsBuffer = Buffer.from(certificate.data)
       const incomingAsNodeJSCert = new X509Certificate(incomingAsBuffer)
-      for (const knownCert of knownCertificates.values()) {
-        if (incomingAsNodeJSCert.checkIssued(knownCert)) {
-          if (incomingAsNodeJSCert.verify(knownCert.publicKey)) {
-            log.silly('good sign match for cert, allowing')
-            event.preventDefault()
-            allowRequest(true)
-            return
-          }
-        }
+      if (validateCert(incomingAsNodeJSCert, knownCertificates)) {
+        allowRequest(true)
+        event.preventDefault()
       }
-      log.info('no sign match for cert, denying')
     }
   )
   await loadCertificatesFromDisk()

--- a/app-shell/src/certs.ts
+++ b/app-shell/src/certs.ts
@@ -258,13 +258,29 @@ async function encryptedCertInstallListener(
     data.certificateData
   )
   const certificate = new X509Certificate(certDER)
-  log.silly(`got cert, ca: ${certificate.ca} signer: ${certificate.issuer}`)
+  log.silly(
+    `got encrypted cert, ca: ${certificate.ca} signer: ${certificate.issuer} notAfter: ${certificate.validToDate}`
+  )
+  await saveCertificateToDisk(certificate)
+  return true
+}
+
+async function plaintextCertInstallListener(
+  _event: IpcMainInvokeEvent,
+  data: { certificateData: string }
+): Promise<boolean> {
+  const certDER = Buffer.from(data.certificateData, 'base64url')
+  const certificate = new X509Certificate(certDER)
+  log.silly(
+    `got plaintext cert, ca: ${certificate.ca} signer: ${certificate.issuer} notAfter: ${certificate.validToDate}`
+  )
   await saveCertificateToDisk(certificate)
   return true
 }
 
 export async function registerCertIPC(): Promise<void> {
   ipcMain.handle('robot-cert:install-encrypted', encryptedCertInstallListener)
+  ipcMain.handle('robot-cert:install-plaintext', plaintextCertInstallListener)
   app.on(
     'certificate-error',
     (event, _webContents, _url, _error, certificate, allowRequest) => {

--- a/app-shell/src/certs.ts
+++ b/app-shell/src/certs.ts
@@ -242,7 +242,7 @@ async function doDecrypt(
   return Buffer.from(decryptedData)
 }
 
-async function certInstallListener(
+async function encryptedCertInstallListener(
   _event: IpcMainInvokeEvent,
   data: {
     certificateData: string
@@ -264,7 +264,7 @@ async function certInstallListener(
 }
 
 export async function registerCertIPC(): Promise<void> {
-  ipcMain.handle('robot-cert:install', certInstallListener)
+  ipcMain.handle('robot-cert:install-encrypted', encryptedCertInstallListener)
   app.on(
     'certificate-error',
     (event, _webContents, _url, _error, certificate, allowRequest) => {

--- a/app/src/organisms/Desktop/RobotCertImport/RobotCertRotator.tsx
+++ b/app/src/organisms/Desktop/RobotCertImport/RobotCertRotator.tsx
@@ -1,0 +1,16 @@
+import { Fragment } from 'react'
+
+import { useRotateRobotCerts } from './useRotateRobotCerts'
+
+import type { ReactNode } from 'react'
+
+export interface RobotCertRotatorProps {
+  children: ReactNode
+}
+
+export function RobotCertRotator({
+  children,
+}: RobotCertRotatorProps): JSX.Element {
+  useRotateRobotCerts()
+  return <Fragment>{children}</Fragment>
+}

--- a/app/src/organisms/Desktop/RobotCertImport/__tests__/useHandleRobotCertImport.test.tsx
+++ b/app/src/organisms/Desktop/RobotCertImport/__tests__/useHandleRobotCertImport.test.tsx
@@ -11,7 +11,7 @@ import {
 import { useHost } from '@opentrons/react-api-client'
 
 import { i18n } from '/app/i18n'
-import { tryInstallRobotCertificate } from '/app/redux/shell/remote'
+import { tryInstallEncryptedRobotCertificate } from '/app/redux/shell/remote'
 
 import { useHandleRobotCertImport } from '../useHandleRobotCertImport'
 
@@ -20,7 +20,7 @@ import type { HostConfig } from '@opentrons/api-client'
 
 vi.mock('@opentrons/api-client')
 vi.mock('/app/redux/shell/remote', () => ({
-  tryInstallRobotCertificate: vi.fn(),
+  tryInstallEncryptedRobotCertificate: vi.fn(),
 }))
 vi.mock('@opentrons/react-api-client')
 
@@ -66,7 +66,7 @@ describe('useHandleRobotCertImport', async () => {
         headers: {},
         config: {},
       })
-    when(vi.mocked(tryInstallRobotCertificate))
+    when(vi.mocked(tryInstallEncryptedRobotCertificate))
       .calledWith({
         password: 'password',
         certificateData: 'asdfasdf',
@@ -131,7 +131,7 @@ describe('useHandleRobotCertImport', async () => {
         headers: {},
         config: {},
       })
-    when(vi.mocked(tryInstallRobotCertificate))
+    when(vi.mocked(tryInstallEncryptedRobotCertificate))
       .calledWith({
         password: 'password',
         certificateData: 'asdfasdf',
@@ -139,7 +139,7 @@ describe('useHandleRobotCertImport', async () => {
         iterations: 10,
       })
       .thenReject(new Error('wrong password'))
-    when(vi.mocked(tryInstallRobotCertificate))
+    when(vi.mocked(tryInstallEncryptedRobotCertificate))
       .calledWith({
         password: 'password',
         certificateData: 'oooooooo',
@@ -223,7 +223,7 @@ describe('useHandleRobotCertImport', async () => {
         headers: {},
         config: {},
       })
-    when(vi.mocked(tryInstallRobotCertificate))
+    when(vi.mocked(tryInstallEncryptedRobotCertificate))
       .calledWith({
         password: 'password',
         certificateData: 'asdfasdf',
@@ -276,7 +276,7 @@ describe('useHandleRobotCertImport', async () => {
         headers: {},
         config: {},
       })
-    when(vi.mocked(tryInstallRobotCertificate))
+    when(vi.mocked(tryInstallEncryptedRobotCertificate))
       .calledWith({
         password: 'password',
         certificateData: 'asdfasdf',
@@ -284,7 +284,7 @@ describe('useHandleRobotCertImport', async () => {
         iterations: 10,
       })
       .thenReject(new Error('bad password sucka'))
-    when(vi.mocked(tryInstallRobotCertificate))
+    when(vi.mocked(tryInstallEncryptedRobotCertificate))
       .calledWith({
         password: 'password',
         certificateData: 'iuiuiuiu',
@@ -337,7 +337,7 @@ describe('useHandleRobotCertImport', async () => {
         headers: {},
         config: {},
       })
-    when(vi.mocked(tryInstallRobotCertificate))
+    when(vi.mocked(tryInstallEncryptedRobotCertificate))
       .calledWith({
         password: 'password',
         certificateData: 'asdfasdf',

--- a/app/src/organisms/Desktop/RobotCertImport/__tests__/useHandleRobotCertImport.test.tsx
+++ b/app/src/organisms/Desktop/RobotCertImport/__tests__/useHandleRobotCertImport.test.tsx
@@ -11,7 +11,10 @@ import {
 import { useHost } from '@opentrons/react-api-client'
 
 import { i18n } from '/app/i18n'
-import { tryInstallEncryptedRobotCertificate } from '/app/redux/shell/remote'
+import {
+  tryInstallEncryptedRobotCertificate,
+  tryInstallPlaintextRobotCertificate,
+} from '/app/redux/shell/remote'
 
 import { useHandleRobotCertImport } from '../useHandleRobotCertImport'
 
@@ -21,6 +24,7 @@ import type { HostConfig } from '@opentrons/api-client'
 vi.mock('@opentrons/api-client')
 vi.mock('/app/redux/shell/remote', () => ({
   tryInstallEncryptedRobotCertificate: vi.fn(),
+  tryInstallPlaintextRobotCertificate: vi.fn(),
 }))
 vi.mock('@opentrons/react-api-client')
 
@@ -80,6 +84,9 @@ describe('useHandleRobotCertImport', async () => {
         data: {
           data: {
             current: {
+              cert_data: 'ffffffff',
+            },
+            next: {
               cert_data: 'asdfasdf',
             },
           },
@@ -89,6 +96,9 @@ describe('useHandleRobotCertImport', async () => {
         headers: {},
         config: {},
       })
+    when(vi.mocked(tryInstallPlaintextRobotCertificate))
+      .calledWith({ certificateData: 'asdfasdf' })
+      .thenResolve(true)
     const onSuccessfulImport = vi.fn()
     const { result } = renderHook(
       () => useHandleRobotCertImport({ onSuccessfulImport }),
@@ -153,6 +163,9 @@ describe('useHandleRobotCertImport', async () => {
         data: {
           data: {
             current: {
+              cert_data: 'ffffffff',
+            },
+            next: {
               cert_data: 'asdfasdf',
             },
           },
@@ -162,6 +175,9 @@ describe('useHandleRobotCertImport', async () => {
         headers: {},
         config: {},
       })
+    when(vi.mocked(tryInstallPlaintextRobotCertificate))
+      .calledWith({ certificateData: 'asdfasdf' })
+      .thenResolve(true)
     const onSuccessfulImport = vi.fn()
     const { result } = renderHook(
       () => useHandleRobotCertImport({ onSuccessfulImport }),
@@ -365,4 +381,65 @@ describe('useHandleRobotCertImport', async () => {
     expect(onSuccessfulImport).not.toHaveBeenCalled()
     expect(result.current.passwordError).toEqual('Bad SSL connection')
   })
+  it('should not install next certificate if it does not exist', async () =>
+    async () => {
+      when(vi.mocked(getEncryptedCACertificates))
+        .calledWith(HOST_CONFIG)
+        .thenResolve({
+          data: {
+            data: {
+              current: {
+                current: {
+                  cert_data: 'asdfasdf',
+                  key_salt: 'fdsafdsa',
+                  kdf_iterations: 10,
+                  key_expires_at: new Date().toISOString(),
+                },
+              },
+            },
+          },
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {},
+        })
+      when(vi.mocked(tryInstallEncryptedRobotCertificate))
+        .calledWith({
+          password: 'password',
+          certificateData: 'asdfasdf',
+          salt: 'fdsafdsa',
+          iterations: 10,
+        })
+        .thenResolve(true)
+      when(vi.mocked(getPlaintextCACertificates))
+        .calledWith(HOST_CONFIG)
+        .thenResolve({
+          data: {
+            data: {
+              current: {
+                cert_data: 'ffffffff',
+              },
+            },
+          },
+          status: 200,
+          statusText: 'OK',
+          headers: {},
+          config: {},
+        })
+      const onSuccessfulImport = vi.fn()
+      const { result } = renderHook(
+        () => useHandleRobotCertImport({ onSuccessfulImport }),
+        {
+          wrapper,
+        }
+      )
+      act(() => {
+        result.current.setPasswordValue('password')
+      })
+      act(() => {
+        result.current.tryImport()
+      })
+      await waitFor(() => expect(onSuccessfulImport).toHaveBeenCalled())
+      expect(tryInstallPlaintextRobotCertificate).not.toHaveBeenCalled()
+    })
 })

--- a/app/src/organisms/Desktop/RobotCertImport/__tests__/useRotateRobotCerts.test.tsx
+++ b/app/src/organisms/Desktop/RobotCertImport/__tests__/useRotateRobotCerts.test.tsx
@@ -1,0 +1,123 @@
+import { QueryClient, QueryClientProvider } from 'react-query'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { when } from 'vitest-when'
+
+import { getPlaintextCACertificates } from '@opentrons/api-client'
+import { useHost } from '@opentrons/react-api-client'
+
+import { tryInstallPlaintextRobotCertificate } from '/app/redux/shell/remote'
+
+import { useRotateRobotCerts } from '../useRotateRobotCerts'
+
+import type { FunctionComponent, ReactNode } from 'react'
+import type { HostConfig } from '@opentrons/api-client'
+
+vi.mock('@opentrons/api-client')
+vi.mock('/app/redux/shell/remote', () => ({
+  tryInstallPlaintextRobotCertificate: vi.fn(),
+}))
+vi.mock('@opentrons/react-api-client')
+
+const HOST_CONFIG: HostConfig = { hostname: 'localhost' }
+
+describe('useHandleRobotCertImport', async () => {
+  let wrapper: FunctionComponent<{ children: ReactNode }>
+  beforeEach(() => {
+    when(vi.mocked(useHost)).calledWith().thenReturn(HOST_CONFIG)
+    const queryClient = new QueryClient()
+    const clientProvider: FunctionComponent<{
+      children: ReactNode
+    }> = ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+    wrapper = clientProvider
+  })
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+  it('should fetch ok when the query succeeds', async () => {
+    when(vi.mocked(getPlaintextCACertificates))
+      .calledWith(HOST_CONFIG)
+      .thenResolve({
+        data: {
+          data: {
+            current: {
+              cert_data: 'ffffffff',
+            },
+            next: {
+              cert_data: 'asdfasdf',
+            },
+          },
+        },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      })
+    when(vi.mocked(tryInstallPlaintextRobotCertificate))
+      .calledWith({ certificateData: 'asdfasdf' })
+      .thenResolve(true)
+    const { result } = renderHook(() => useRotateRobotCerts(), { wrapper })
+    await waitFor(() => expect(result.current.status === 'success'))
+    expect(vi.mocked(tryInstallPlaintextRobotCertificate)).toHaveBeenCalled()
+  })
+  it('should not error when install fails ', async () => {
+    when(vi.mocked(getPlaintextCACertificates))
+      .calledWith(HOST_CONFIG)
+      .thenResolve({
+        data: {
+          data: {
+            current: {
+              cert_data: 'ffffffff',
+            },
+            next: {
+              cert_data: 'asdfasdf',
+            },
+          },
+        },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      })
+    when(vi.mocked(tryInstallPlaintextRobotCertificate))
+      .calledWith({ certificateData: 'asdfasdf' })
+      .thenReject(new Error('oh no'))
+    const { result } = renderHook(() => useRotateRobotCerts(), { wrapper })
+    await waitFor(() => expect(result.current.status === 'success'))
+    expect(vi.mocked(tryInstallPlaintextRobotCertificate)).toHaveBeenCalled()
+  })
+  it('should end early and not error if there is no next cert', async () => {
+    when(vi.mocked(getPlaintextCACertificates))
+      .calledWith(HOST_CONFIG)
+      .thenResolve({
+        data: {
+          data: {
+            current: {
+              cert_data: 'ffffffff',
+            },
+          },
+        },
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {},
+      })
+    const { result } = renderHook(() => useRotateRobotCerts(), { wrapper })
+    await waitFor(() => expect(result.current.status === 'success'))
+    expect(
+      vi.mocked(tryInstallPlaintextRobotCertificate)
+    ).not.toHaveBeenCalled()
+  })
+  it('should end early and not error if the fetch fails', async () => {
+    when(vi.mocked(getPlaintextCACertificates))
+      .calledWith(HOST_CONFIG)
+      .thenReject(new Error('oh no'))
+    const { result } = renderHook(() => useRotateRobotCerts(), { wrapper })
+    await waitFor(() => expect(result.current.status === 'success'))
+    expect(
+      vi.mocked(tryInstallPlaintextRobotCertificate)
+    ).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/organisms/Desktop/RobotCertImport/__tests__/useRotateRobotCerts.test.tsx
+++ b/app/src/organisms/Desktop/RobotCertImport/__tests__/useRotateRobotCerts.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from 'react-query'
-import { act, renderHook, waitFor } from '@testing-library/react'
+import { renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
 

--- a/app/src/organisms/Desktop/RobotCertImport/useHandleRobotCertImport.ts
+++ b/app/src/organisms/Desktop/RobotCertImport/useHandleRobotCertImport.ts
@@ -8,7 +8,10 @@ import {
 } from '@opentrons/api-client'
 import { useHost } from '@opentrons/react-api-client'
 
-import { tryInstallEncryptedRobotCertificate } from '/app/redux/shell/remote'
+import {
+  tryInstallEncryptedRobotCertificate,
+  tryInstallPlaintextRobotCertificate,
+} from '/app/redux/shell/remote'
 
 export interface UseHandleRobotCertImportProps {
   onSuccessfulImport: () => unknown
@@ -71,13 +74,17 @@ export function useHandleRobotCertImport(
       }
 
       const plaintext = await getPlaintextCACertificates(host!)
-      if (plaintext.status === 200) {
-        return true
-      } else {
+      if (plaintext.status !== 200) {
         throw new Error(
           `Could not fetch CA certificates: ${plaintext.status} ${plaintext.statusText}`
         )
       }
+      if (plaintext.data.data.next != null) {
+        await tryInstallPlaintextRobotCertificate({
+          certificateData: plaintext.data.data.next.cert_data,
+        })
+      }
+      return true
     },
     mutationKey: [host!, 'encrypted_ca_certs'],
     onError: (err: any) => {

--- a/app/src/organisms/Desktop/RobotCertImport/useHandleRobotCertImport.ts
+++ b/app/src/organisms/Desktop/RobotCertImport/useHandleRobotCertImport.ts
@@ -8,7 +8,7 @@ import {
 } from '@opentrons/api-client'
 import { useHost } from '@opentrons/react-api-client'
 
-import { tryInstallRobotCertificate } from '/app/redux/shell/remote'
+import { tryInstallEncryptedRobotCertificate } from '/app/redux/shell/remote'
 
 export interface UseHandleRobotCertImportProps {
   onSuccessfulImport: () => unknown
@@ -32,13 +32,14 @@ export function useHandleRobotCertImport(
   }, [passwordValue])
   const host = useHost()
 
-  const tryInstallWith: typeof tryInstallRobotCertificate = async props => {
-    try {
-      return await tryInstallRobotCertificate(props)
-    } catch (err: any) {
-      return false
+  const tryInstallWith: typeof tryInstallEncryptedRobotCertificate =
+    async props => {
+      try {
+        return await tryInstallEncryptedRobotCertificate(props)
+      } catch (err: any) {
+        return false
+      }
     }
-  }
 
   const { status, mutate } = useMutation<boolean>({
     mutationFn: async () => {

--- a/app/src/organisms/Desktop/RobotCertImport/useRotateRobotCerts.ts
+++ b/app/src/organisms/Desktop/RobotCertImport/useRotateRobotCerts.ts
@@ -25,19 +25,19 @@ async function getNextCACert(
   }
 }
 
-export function useRotateRobotCerts(): UseQueryResult<void> {
+export function useRotateRobotCerts(): UseQueryResult<boolean> {
   const host = useHost()
-  return useQuery<void>({
+  return useQuery<boolean>({
     queryFn: async () => {
       if (host == null) {
-        return
+        return false
       }
       const maybeCert = await getNextCACert(host)
       if (maybeCert == null) {
-        return
+        return false
       }
 
-      await tryInstallPlaintextRobotCertificate({
+      return await tryInstallPlaintextRobotCertificate({
         certificateData: maybeCert.cert_data,
       })
     },

--- a/app/src/organisms/Desktop/RobotCertImport/useRotateRobotCerts.ts
+++ b/app/src/organisms/Desktop/RobotCertImport/useRotateRobotCerts.ts
@@ -1,0 +1,49 @@
+import { useQuery } from 'react-query'
+
+import { getPlaintextCACertificates } from '@opentrons/api-client'
+import { useHost } from '@opentrons/react-api-client'
+
+import { tryInstallPlaintextRobotCertificate } from '/app/redux/shell/remote'
+
+import type { UseQueryResult } from 'react-query'
+import type { UnencryptedCert } from '@opentrons/api-client'
+
+async function getNextCACert(
+  host: ReturnType<typeof useHost>
+): Promise<UnencryptedCert | null> {
+  if (host == null) {
+    return null
+  }
+  try {
+    const queryResult = await getPlaintextCACertificates(host)
+    return queryResult?.data?.data?.next ?? null
+  } catch (err: any) {
+    // this could be anything but most likely is an SSL error;
+    // if this fails it's fine, it just means we won't rotate the
+    // certs and react-query will retry eventually
+    return null
+  }
+}
+
+export function useRotateRobotCerts(): UseQueryResult<void> {
+  const host = useHost()
+  return useQuery<void>({
+    queryFn: async () => {
+      if (host == null) {
+        return
+      }
+      const maybeCert = await getNextCACert(host)
+      if (maybeCert == null) {
+        return
+      }
+
+      await tryInstallPlaintextRobotCertificate({
+        certificateData: maybeCert.cert_data,
+      })
+    },
+    queryKey: [host, 'rotate-robot-certs'],
+    refetchInterval: 24 * 60 * 60 * 1000,
+    staleTime: 24 * 60 * 60 * 1000,
+    enabled: host != null,
+  })
+}

--- a/app/src/pages/Desktop/Devices/CalibrationDashboard/index.tsx
+++ b/app/src/pages/Desktop/Devices/CalibrationDashboard/index.tsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 import { ApiHostProvider } from '@opentrons/react-api-client'
 
 import { CalibrationTaskList } from '/app/organisms/Desktop/CalibrationTaskList'
+import { RobotCertRotator } from '/app/organisms/Desktop/RobotCertImport/RobotCertRotator'
 import { useRobot } from '/app/redux-resources/robots'
 import { OPENTRONS_USB } from '/app/redux/discovery'
 import { appShellUSBRequestor } from '/app/redux/shell/remote'
@@ -33,16 +34,19 @@ export function CalibrationDashboard(): JSX.Element {
       hostname={robot?.ip ?? null}
       requestor={robot?.ip === OPENTRONS_USB ? appShellUSBRequestor : undefined}
     >
-      <CalibrationTaskList
-        robotName={robotName}
-        deckCalLauncher={dashboardDeckCalLauncher}
-        tipLengthCalLauncher={dashboardTipLengthCalLauncher}
-        pipOffsetCalLauncher={dashboardOffsetCalLauncher}
-        exitBeforeDeckConfigCompletion={exitBeforeDeckConfigCompletion}
-      />
-      {DashboardDeckCalWizard}
-      {DashboardOffsetCalWizard}
-      {DashboardTipLengthCalWizard}
+      <RobotCertRotator>
+        <CalibrationTaskList
+          robotName={robotName}
+          deckCalLauncher={dashboardDeckCalLauncher}
+          tipLengthCalLauncher={dashboardTipLengthCalLauncher}
+          pipOffsetCalLauncher={dashboardOffsetCalLauncher}
+          exitBeforeDeckConfigCompletion={exitBeforeDeckConfigCompletion}
+        />
+
+        {DashboardDeckCalWizard}
+        {DashboardOffsetCalWizard}
+        {DashboardTipLengthCalWizard}
+      </RobotCertRotator>
     </ApiHostProvider>
   )
 }

--- a/app/src/pages/Desktop/Devices/DeviceDetails/index.tsx
+++ b/app/src/pages/Desktop/Devices/DeviceDetails/index.tsx
@@ -4,6 +4,7 @@ import { Navigate, useParams } from 'react-router-dom'
 import { ApiHostProvider } from '@opentrons/react-api-client'
 
 import { useSyncRobotClock } from '/app/organisms/Desktop/Devices/hooks'
+import { RobotCertRotator } from '/app/organisms/Desktop/RobotCertImport/RobotCertRotator'
 import { useRobot } from '/app/redux-resources/robots'
 import { getScanning, OPENTRONS_USB } from '/app/redux/discovery'
 import { appShellUSBRequestor } from '/app/redux/shell/remote'
@@ -29,7 +30,9 @@ export function DeviceDetails(): JSX.Element | null {
       hostname={robot.ip ?? null}
       requestor={robot?.ip === OPENTRONS_USB ? appShellUSBRequestor : undefined}
     >
-      <DeviceDetailsComponent robotName={robotName} />
+      <RobotCertRotator>
+        <DeviceDetailsComponent robotName={robotName} />
+      </RobotCertRotator>
     </ApiHostProvider>
   ) : (
     <Navigate to="/devices" />

--- a/app/src/pages/Desktop/Devices/DevicesLanding/index.tsx
+++ b/app/src/pages/Desktop/Devices/DevicesLanding/index.tsx
@@ -27,6 +27,7 @@ import { Divider } from '/app/atoms/structure'
 import { CollapsibleSection } from '/app/molecules/CollapsibleSection'
 import { DevicesEmptyState } from '/app/organisms/Desktop/Devices/DevicesEmptyState'
 import { RobotCard } from '/app/organisms/Desktop/Devices/RobotCard'
+import { RobotCertRotator } from '/app/organisms/Desktop/RobotCertImport/RobotCertRotator'
 import { useFeatureFlag } from '/app/redux/config'
 import {
   getConnectableRobots,
@@ -154,7 +155,9 @@ export function DevicesLanding(): JSX.Element {
                   robot?.ip === OPENTRONS_USB ? appShellUSBRequestor : undefined
                 }
               >
-                <RobotCard robot={robot} />
+                <RobotCertRotator>
+                  <RobotCard robot={robot} />
+                </RobotCertRotator>
               </ApiHostProvider>
             ))}
             {filteredUnhealthy.map(robot => (

--- a/app/src/pages/Desktop/Devices/ProtocolRunDetails/index.tsx
+++ b/app/src/pages/Desktop/Devices/ProtocolRunDetails/index.tsx
@@ -28,6 +28,7 @@ import { ProtocolRunModuleControls } from '/app/organisms/Desktop/Devices/Protoc
 import { ProtocolRunRuntimeParameters } from '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunRunTimeParameters'
 import { ProtocolRunSetup } from '/app/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup'
 import { RunPreview } from '/app/organisms/Desktop/Devices/RunPreview'
+import { RobotCertRotator } from '/app/organisms/Desktop/RobotCertImport/RobotCertRotator'
 import { useCurrentRunStatus } from '/app/organisms/RunTimeControl'
 import { useRobot, useRobotType } from '/app/redux-resources/robots'
 import { OPENTRONS_USB } from '/app/redux/discovery'
@@ -66,24 +67,26 @@ export function ProtocolRunDetails(): JSX.Element | null {
       requestor={robot?.ip === OPENTRONS_USB ? appShellUSBRequestor : undefined}
       robotName={robot.name}
     >
-      <Box
-        minWidth="32rem"
-        height="100%"
-        overflow={OVERFLOW_SCROLL}
-        padding={SPACING.spacing16}
-      >
-        <Flex
-          flexDirection={DIRECTION_COLUMN}
-          marginBottom={SPACING.spacing16}
-          width="100%"
+      <RobotCertRotator>
+        <Box
+          minWidth="32rem"
+          height="100%"
+          overflow={OVERFLOW_SCROLL}
+          padding={SPACING.spacing16}
         >
-          <PageContents
-            runId={runId}
-            robotName={robotName}
-            protocolRunDetailsTab={protocolRunDetailsTab}
-          />
-        </Flex>
-      </Box>
+          <Flex
+            flexDirection={DIRECTION_COLUMN}
+            marginBottom={SPACING.spacing16}
+            width="100%"
+          >
+            <PageContents
+              runId={runId}
+              robotName={robotName}
+              protocolRunDetailsTab={protocolRunDetailsTab}
+            />
+          </Flex>
+        </Box>
+      </RobotCertRotator>
     </ApiHostProvider>
   ) : null
 }

--- a/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
@@ -23,6 +23,7 @@ import { RobotSettingsAdvanced } from '/app/organisms/Desktop/Devices/RobotSetti
 import { RobotSettingsCamera } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsCamera'
 import { RobotSettingsFeatureFlags } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsFeatureFlags'
 import { RobotSettingsNetworking } from '/app/organisms/Desktop/Devices/RobotSettings/RobotSettingsNetworking'
+import { RobotCertRotator } from '/app/organisms/Desktop/RobotCertImport/RobotCertRotator'
 import { RobotSettingsCalibration } from '/app/organisms/Desktop/RobotSettingsCalibration'
 import { useIsRobotBusy, useRobot } from '/app/redux-resources/robots'
 import { getDevtoolsEnabled } from '/app/redux/config'
@@ -50,7 +51,9 @@ export function RobotSettings(): JSX.Element {
       port={robot?.port ?? null}
       requestor={robot?.ip === OPENTRONS_USB ? appShellUSBRequestor : undefined}
     >
-      <RobotSettingsComponent robot={robot} />
+      <RobotCertRotator>
+        <RobotSettingsComponent robot={robot} />
+      </RobotCertRotator>
     </ApiHostProvider>
   )
 }

--- a/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
@@ -48,7 +48,6 @@ export function RobotSettings(): JSX.Element {
   return (
     <ApiHostProvider
       hostname={robot?.ip ?? null}
-      port={robot?.port ?? null}
       requestor={robot?.ip === OPENTRONS_USB ? appShellUSBRequestor : undefined}
     >
       <RobotCertRotator>

--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -149,11 +149,11 @@ remote.ipcRenderer.on(
   }
 )
 
-export async function tryInstallRobotCertificate(props: {
+export async function tryInstallEncryptedRobotCertificate(props: {
   certificateData: string
   password: string
   salt: string
   iterations: number
 }): Promise<boolean> {
-  return await remote.ipcRenderer.invoke('robot-cert:install', props)
+  return await remote.ipcRenderer.invoke('robot-cert:install-encrypted', props)
 }

--- a/app/src/redux/shell/remote.ts
+++ b/app/src/redux/shell/remote.ts
@@ -157,3 +157,9 @@ export async function tryInstallEncryptedRobotCertificate(props: {
 }): Promise<boolean> {
   return await remote.ipcRenderer.invoke('robot-cert:install-encrypted', props)
 }
+
+export async function tryInstallPlaintextRobotCertificate(props: {
+  certificateData: string
+}): Promise<boolean> {
+  return await remote.ipcRenderer.invoke('robot-cert:install-plaintext', props)
+}

--- a/key-server/Makefile
+++ b/key-server/Makefile
@@ -106,7 +106,6 @@ dev:
 # front of all the servers. don't run it unless you're going to run mitmproxy
 .PHONY: dev-mitmproxy
 dev-mitmproxy:
-	$(if $(OT_KEY_SERVER_preserve_certs),,rm -rf .key-server-storage)
 	OT_KEY_SERVER_dot_env_path=dev-mitmproxy.env $(python) -m key_server --port $(dev_port) --reload --log-level=debug
 
 # Note: No `push` target, since this project only runs on Flex (OT-3), not OT-2.

--- a/key-server/dev-mitmproxy.env
+++ b/key-server/dev-mitmproxy.env
@@ -2,3 +2,4 @@ OT_KEY_SERVER_tls_server_integration=dev-mitmproxy
 OT_KEY_SERVER_base_directory=.key-server-storage
 OT_KEY_SERVER_tls_directory=.key-server-storage/tls
 OT_KEY_SERVER_mitmproxy_touch_path=../scripts/dev_proxy.py
+OT_KEY_SERVER_image_mount_point=.key-server-storage/secure

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@eslint-react/eslint-plugin": "1.52.2",
     "@ianvs/prettier-plugin-sort-imports": "4.7.0",
     "@octokit/rest": "^19.0.5",
+    "@peculiar/x509": "^2.0.0",
     "@sentry/vite-plugin": "4.3.0",
     "@storybook/addon-docs": "9.1.20",
     "@storybook/addon-links": "9.1.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@octokit/rest':
         specifier: ^19.0.5
         version: 19.0.13(encoding@0.1.13)
+      '@peculiar/x509':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@sentry/vite-plugin':
         specifier: 4.3.0
         version: 4.3.0(encoding@0.1.13)
@@ -3413,6 +3416,40 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
+  '@peculiar/asn1-cms@2.6.1':
+    resolution: {integrity: sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==}
+
+  '@peculiar/asn1-csr@2.6.1':
+    resolution: {integrity: sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==}
+
+  '@peculiar/asn1-ecc@2.6.1':
+    resolution: {integrity: sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==}
+
+  '@peculiar/asn1-pfx@2.6.1':
+    resolution: {integrity: sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==}
+
+  '@peculiar/asn1-pkcs8@2.6.1':
+    resolution: {integrity: sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==}
+
+  '@peculiar/asn1-pkcs9@2.6.1':
+    resolution: {integrity: sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==}
+
+  '@peculiar/asn1-rsa@2.6.1':
+    resolution: {integrity: sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==}
+
+  '@peculiar/asn1-schema@2.6.0':
+    resolution: {integrity: sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==}
+
+  '@peculiar/asn1-x509-attr@2.6.1':
+    resolution: {integrity: sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==}
+
+  '@peculiar/asn1-x509@2.6.1':
+    resolution: {integrity: sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==}
+
+  '@peculiar/x509@2.0.0':
+    resolution: {integrity: sha512-r10lkuy6BNfRmyYdRAfgu6dq0HOmyIV2OLhXWE3gDEPBdX1b8miztJVyX/UxWhLwemNyDP3CLZHpDxDwSY0xaA==}
+    engines: {node: '>=20.0.0'}
+
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
@@ -5213,6 +5250,10 @@ packages:
 
   asn1.js@4.10.1:
     resolution: {integrity: sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==}
+
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
 
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
@@ -9993,6 +10034,13 @@ packages:
     resolution: {integrity: sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==}
     engines: {node: '>=8'}
 
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.1.5:
+    resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
+    engines: {node: '>=16.0.0'}
+
   q@1.5.1:
     resolution: {integrity: sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==}
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
@@ -11488,6 +11536,10 @@ packages:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tsyringe@4.10.0:
+    resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
+    engines: {node: '>= 6.0.0'}
 
   tty-browserify@0.0.1:
     resolution: {integrity: sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==}
@@ -14840,6 +14892,95 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.3.0(@opentelemetry/api@1.9.0)
 
+  '@peculiar/asn1-cms@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      '@peculiar/asn1-x509-attr': 2.6.1
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-csr@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-ecc@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pfx@2.6.1':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.1
+      '@peculiar/asn1-pkcs8': 2.6.1
+      '@peculiar/asn1-rsa': 2.6.1
+      '@peculiar/asn1-schema': 2.6.0
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs8@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-pkcs9@2.6.1':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.1
+      '@peculiar/asn1-pfx': 2.6.1
+      '@peculiar/asn1-pkcs8': 2.6.1
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      '@peculiar/asn1-x509-attr': 2.6.1
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-rsa@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-schema@2.6.0':
+    dependencies:
+      asn1js: 3.0.10
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509-attr@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      asn1js: 3.0.10
+      tslib: 2.8.1
+
+  '@peculiar/asn1-x509@2.6.1':
+    dependencies:
+      '@peculiar/asn1-schema': 2.6.0
+      asn1js: 3.0.10
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+
+  '@peculiar/x509@2.0.0':
+    dependencies:
+      '@peculiar/asn1-cms': 2.6.1
+      '@peculiar/asn1-csr': 2.6.1
+      '@peculiar/asn1-ecc': 2.6.1
+      '@peculiar/asn1-pkcs9': 2.6.1
+      '@peculiar/asn1-rsa': 2.6.1
+      '@peculiar/asn1-schema': 2.6.0
+      '@peculiar/asn1-x509': 2.6.1
+      pvtsutils: 1.3.6
+      tslib: 2.8.1
+      tsyringe: 4.10.0
+
   '@pinojs/redact@0.4.0':
     optional: true
 
@@ -17130,6 +17271,12 @@ snapshots:
       bn.js: 4.12.2
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
+
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.1.5
+      tslib: 2.8.1
 
   assert-plus@1.0.0:
     optional: true
@@ -23080,6 +23227,12 @@ snapshots:
     dependencies:
       escape-goat: 2.1.1
 
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.1.5: {}
+
   q@1.5.1: {}
 
   qap@3.3.1: {}
@@ -24866,6 +25019,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
     optional: true
+
+  tsyringe@4.10.0:
+    dependencies:
+      tslib: 1.14.1
 
   tty-browserify@0.0.1: {}
 


### PR DESCRIPTION
CA certs expire. We know this, and the key server has a system where it will build the _next_ CA it's going to use 3 months or so ahead of time, and then switch to it when the current cert expires. The app needs to account for this if it's going to store CAs over the long term.

We need to fetch the next CA whenever it's available. This will be on long enough timescales that we don't need to poll it rapidly, but on shore enough timescales - given that someone might pop open their app for a bit and then close it for the next couple months - that we do need to poll, and do it in the background wherever we talk to robots.

So this PR adds a React component that does essentially nothing except host a hook that polls every 24 hours for a robot's plaintext certificates. We can do that because the next CA is only relevant if we've already authenticated to the robot, and there's a whole different flow for first-time CA import (and we edit that flow to grab the next CA too).

The other side is that we need to remove CA certs that have expired. We also have to care whether or not the CA certs have expired when we check TLS certs. We deny them on load.

## Testing
Best tested on the dev backend, though you could do it on a robot too - it shouldn't matter.

What you need to do is generate some CA keys that are very close to expiring. You can do this by 
- run a python shell, in uv with `uv run python` inside `key-server` on dev or by running `python3` in the `/opt/opentrons-key-server` directory on a robot
- `from opentrons_key_server.tls import cryptography_utils` and `import datetime`
- figure out the key path and ca path; on dev this is `key_path=.opentrons-key-server/secure/ca_keys` and `cert_path=.key-server-storage/tls`, and on a robot with the key server running `key_path` should be `/var/lib/opentrons-key-server/ot-secure-volume/ca_keys` and `cert_path` should be `/var/lib/opentrons-key-server/tls`
- run `cryptography_utils.create_ca(key_dir, cert_dir, datetime.datetime.now() - datetime.timedelta(hours=1), datetime.timedelta(hours=2))`
- restart the key server
Now, this CA should expire soon, and you should download a next ca and use it. You may need to bump this up to 2 days instead of hours for both timedeltas.

Closes EXEC-2554

