### PR TITLE
fix(app-shell): Fix failing tests in edge

### DIFF
--- a/app-shell/src/__tests__/certs.test.ts
+++ b/app-shell/src/__tests__/certs.test.ts
@@ -51,7 +51,7 @@ describe('fernet decryption', () => {
       )
     ).rejects.toThrow(
       expect.objectContaining({
-        message: 'The operation failed for an operation-specific reason',
+        message: 'Incorrect password',
       })
     )
   })
@@ -69,7 +69,7 @@ describe('fernet decryption', () => {
       decryptFromOTDetails(pw, badSaltEncoded, 10, encrypted)
     ).rejects.toThrow(
       expect.objectContaining({
-        message: 'The operation failed for an operation-specific reason',
+        message: 'Incorrect password',
       })
     )
   })
@@ -87,7 +87,7 @@ describe('fernet decryption', () => {
       decryptFromOTDetails(pw, saltEncoded, 11, encrypted)
     ).rejects.toThrow(
       expect.objectContaining({
-        message: 'The operation failed for an operation-specific reason',
+        message: 'Incorrect password',
       })
     )
   })
@@ -106,7 +106,7 @@ describe('fernet decryption', () => {
       decryptFromOTDetails(pw, saltEncoded, 10, encrypted)
     ).rejects.toThrow(
       expect.objectContaining({
-        message: 'Encrypted certificate is too old',
+        message: 'Incorrect password',
       })
     )
   })
@@ -140,7 +140,7 @@ describe('fernet decryption', () => {
       decryptFromOTDetails(pw, saltEncoded, 10, encrypted)
     ).rejects.toThrow(
       expect.objectContaining({
-        message: 'Encrypted certificate is from the future',
+        message: 'Incorrect password',
       })
     )
   })

--- a/app-shell/src/certs.ts
+++ b/app-shell/src/certs.ts
@@ -40,6 +40,20 @@ export async function decryptFromOTDetails(
   kdfIterations: number,
   token: string
 ): Promise<Buffer> {
+  try {
+    return await doDecrypt(password, saltBase64, kdfIterations, token)
+  } catch (err: any) {
+    log.info(`Failed to decrypt: ${err?.message ?? JSON.stringify(err)} `)
+    throw new Error('Incorrect password')
+  }
+}
+
+async function doDecrypt(
+  password: string,
+  saltBase64: string,
+  kdfIterations: number,
+  token: string
+): Promise<Buffer> {
   log.info(
     `decrypting with password ${password} salt ${saltBase64} kdf iterations ${kdfIterations} token ${token}`
   )
@@ -125,7 +139,7 @@ export async function decryptFromOTDetails(
     unsigned_token
   )
   if (!verification) {
-    throw new Error('Invalid or tampered with internal data!')
+    throw new Error('Verification failed')
   }
   // where we differ from the example above - this is not an encoded UTF-8 string but an encoded
   // byte sequence


### PR DESCRIPTION
Which exception gets thrown - whether webcrypto would fail or whether it would succeed but give garbled data we'd catch in other checks - isn't stable and depends on the details of the randomly generated keys. We don't actually want to test cryptographic details here, just that the operations as a whole succeed or fail; so let's just wrap, log, and throw something consistent.
