### PR TITLE
refactor(api): prevent z-axis motion during pipette probe attachment

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -21,8 +21,6 @@ if TYPE_CHECKING:
 # These offsets supplied from HW
 _ATTACH_POINT = Point(x=0, y=110)
 _MAX_Z_AXIS_MOTION_RANGE = 215
-# These offsets are by eye measuring
-_INSTRUMENT_ATTACH_Z_POINT = 400.0
 _LEFT_MOUNT_Z_MARGIN = 5
 # Move the right mount a bit higher than the left so the user won't forget to unscrew
 _RIGHT_MOUNT_Z_MARGIN = 20
@@ -98,11 +96,6 @@ class MoveToMaintenancePositionImplementation(
                 mount = params.mount.to_hw_mount()
                 mount_to_axis = Axis.by_mount(mount)
                 await ot3_api.prepare_for_mount_movement(mount)
-                await ot3_api.move_axes(
-                    {
-                        mount_to_axis: _INSTRUMENT_ATTACH_Z_POINT,
-                    }
-                )
                 await ot3_api.disengage_axes([mount_to_axis])
             else:
                 max_motion_range = max_height_z_tip - _MAX_Z_AXIS_MOTION_RANGE

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -69,9 +69,6 @@ async def test_calibration_move_to_location_implementation_for_attach_instrument
             critical_point=CriticalPoint.MOUNT,
         ),
         await ot3_hardware_api.prepare_for_mount_movement(hw_mount),
-        await ot3_hardware_api.move_axes(
-            position={Axis.by_mount(hw_mount): 400},
-        ),
         await ot3_hardware_api.disengage_axes(
             [Axis.by_mount(hw_mount)],
         ),


### PR DESCRIPTION
Closes [EXEC-1694](https://opentrons.atlassian.net/browse/EXEC-1694)

# Overview

When we attach a calibration probe during any of our maintenance run flows, we move to a defined maintenance position. This maintenance position contains a z-axis move that lowers the pipette. During LPC setup, when we move to the defined maintenance position, it's possible that the pipette collides with custom labware on the deck.

To fix, we update `moveToMaintenancePosition` to exclude z-axis traversal for pipette attachment cases. Updating this behavior does apply to pipette and module calibration flows too: now when attaching the probe, we'll never descend the pipette.

## Test Plan and Hands on Testing

- Smoke tested LPC setup and pipette wizard flows. The pipette correctly no longer descends when attaching a calibration probe.

## Changelog

- When attaching a calibration probe, the target pipette no longer lowers.

## Risk assessment

- low - we only use `moveToMaintenancePosition` in calibration flows, so it's relatively easy to audit intended behavior.


[EXEC-1694]: https://opentrons.atlassian.net/browse/EXEC-1694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ