### PR TITLE
fix(api): use model_fields in non-deprecated way

### DIFF
--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -154,7 +154,10 @@ class OT3MotionSettings(BaseModel):
     def by_gantry_load(
         self, gantry_load: GantryLoad
     ) -> Dict[str, Dict[OT3AxisKind, float]]:
-        return {name: getattr(self, name)[gantry_load] for name in OT3MotionSettings.model_fields}
+        return {
+            name: getattr(self, name)[gantry_load]
+            for name in OT3MotionSettings.model_fields
+        }
 
     @field_validator(
         "default_max_speed",
@@ -177,7 +180,10 @@ class OT3CurrentSettings(BaseModel):
     def by_gantry_load(
         self, gantry_load: GantryLoad
     ) -> Dict[str, Dict[OT3AxisKind, float]]:
-        return {name: getattr(self, name)[gantry_load] for name in OT3CurrentSettings.model_fields}
+        return {
+            name: getattr(self, name)[gantry_load]
+            for name in OT3CurrentSettings.model_fields
+        }
 
     @field_validator("hold_current", "run_current", mode="before")
     @classmethod

--- a/api/src/opentrons/config/types.py
+++ b/api/src/opentrons/config/types.py
@@ -154,7 +154,7 @@ class OT3MotionSettings(BaseModel):
     def by_gantry_load(
         self, gantry_load: GantryLoad
     ) -> Dict[str, Dict[OT3AxisKind, float]]:
-        return {name: getattr(self, name)[gantry_load] for name in self.model_fields}
+        return {name: getattr(self, name)[gantry_load] for name in OT3MotionSettings.model_fields}
 
     @field_validator(
         "default_max_speed",
@@ -177,7 +177,7 @@ class OT3CurrentSettings(BaseModel):
     def by_gantry_load(
         self, gantry_load: GantryLoad
     ) -> Dict[str, Dict[OT3AxisKind, float]]:
-        return {name: getattr(self, name)[gantry_load] for name in self.model_fields}
+        return {name: getattr(self, name)[gantry_load] for name in OT3CurrentSettings.model_fields}
 
     @field_validator("hold_current", "run_current", mode="before")
     @classmethod


### PR DESCRIPTION
# Overview

In #21280, we introduced some methods to `OT3MotionSettings` and `OT3CurrentSettings` to assist in serialization for the pipette dict and OT3 config. Part of this used the pydantic model attribute `model_fields`. However, accessing them from the instance was deprecated and was causing warnings like this when running the unit tests:

```
PydanticDeprecatedSince211: Accessing the 'model_fields' attribute on the instance is deprecated. Instead, you should access this attribute from the model class. Deprecated in Pydantic V2.11 to be removed in V3.0.
    return {name: getattr(self, name)[gantry_load] for name in self.model_fields}
```

With the two places we were using this, we went from 7 to 132 warnings in our unit tests.

The fix for this was to access the class instance instead. Doing this returned our warnings back to the 7 we previously had.

## Test Plan and Hands on Testing

Small refactor, tests should catch errors and tested on robot for regression.

## Changelog

- Change `model_field` accesses from instance to class level

## Review requests

## Risk assessment

Low.
