### PR TITLE
fix(protocol-designer): correctly position single-channel pipette shadow on rectangular wells

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -137,7 +137,11 @@ export const getHoveredOffsetFromWell = (args: {
 
   return {
     x: wellX,
-    y: isSingleChannelPipette && wellIsRectangular ? wellY / 2 : wellY,
+    y:
+      getIsOnlyRectangularWellInColumn(wellName, labware.def) &&
+      isSingleChannelPipette
+        ? wellY / 2
+        : wellY,
   }
 }
 
@@ -424,4 +428,18 @@ export const getLabelOffsetByPlacement = (args: {
     x: labelOffsetX,
     y: labelOffsetY,
   }
+}
+
+const getIsOnlyRectangularWellInColumn = (
+  wellName: string,
+  def: LabwareDefinition
+): boolean => {
+  const columns = def.ordering
+  const wellColumn = columns.find(column => column.includes(wellName))
+  if (wellColumn == null) {
+    return false
+  }
+  const isWellRectangular = def.wells[wellName].shape === 'rectangular'
+  const isOnlyWellInColumn = wellColumn.length === 1
+  return isWellRectangular && isOnlyWellInColumn
 }


### PR DESCRIPTION
# Overview

This PR fixes the logic by which the pipette shadow is centered on wells in the well selection component of PD. The bug was introduced when building logic to center single-channel pipette shadows vertically for rectangular wells (i.e., in 12-channel reservoirs). However, the logic needs to also check whether the rectangular well comprises the entire column.

RQA-5349

## Test Plan and Hands on Testing

- import the protocol attached to the linked ticket
- open the existing step form and navigate through well selection
- move the pipette's target and verify that the shadow is positioned correctly

## Changelog

- fix logic for determining pipette shadow well offset with respect to single channel pipettes and rectangular wells

## Review requests

see test plan

## Risk assessment

low