### PR TITLE
refactor(robot-server,auth-server,system-server): Customize response bodies for authorization errors

### DIFF
--- a/auth-server/auth_server/app.py
+++ b/auth-server/auth_server/app.py
@@ -10,6 +10,8 @@ from fastapi.responses import HTMLResponse
 
 from server_utils import systemd_utils
 from server_utils.auth.resource_server.fastapi import (
+    AuthorizationError,
+    handle_authorization_error,
     install_authorization_checker,
 )
 
@@ -85,6 +87,10 @@ app = FastAPI(
     redoc_url=None,
     lifespan=_lifespan,
 )
+
+
+app.exception_handler(AuthorizationError)(handle_authorization_error)
+
 
 app.include_router(oauth2_router)
 app.include_router(settings_router)

--- a/auth-server/auth_server/app.py
+++ b/auth-server/auth_server/app.py
@@ -9,7 +9,7 @@ from fastapi.openapi.docs import get_redoc_html
 from fastapi.responses import HTMLResponse
 
 from server_utils import systemd_utils
-from server_utils.auth.resource_server.fastapi_dependencies import (
+from server_utils.auth.resource_server.fastapi import (
     install_authorization_checker,
 )
 

--- a/auth-server/auth_server/settings/router.py
+++ b/auth-server/auth_server/settings/router.py
@@ -3,7 +3,7 @@ from typing import Annotated
 
 import fastapi
 
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.models.json_api import (
     RequestModel,

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 import fastapi
 
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.models.json_api import (
     PydanticResponse,

--- a/robot-server/robot_server/access_control/settings/router.py
+++ b/robot-server/robot_server/access_control/settings/router.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 import fastapi
 
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/app_setup.py
+++ b/robot-server/robot_server/app_setup.py
@@ -10,7 +10,7 @@ from fastapi.openapi.docs import get_redoc_html
 from fastapi.responses import HTMLResponse
 
 from opentrons import __version__
-from server_utils.auth.resource_server.fastapi_dependencies import (
+from server_utils.auth.resource_server.fastapi import (
     build_authorization_checker,
     install_authorization_checker,
 )

--- a/robot-server/robot_server/commands/router.py
+++ b/robot-server/robot_server/commands/router.py
@@ -8,7 +8,7 @@ from opentrons.protocol_engine import CommandIntent
 from opentrons.protocol_engine.errors import CommandDoesNotExistError
 from opentrons.protocol_runner import RunOrchestrator
 from opentrons_shared_data.errors import ErrorCodes
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -12,7 +12,7 @@ from fastapi.responses import FileResponse, StreamingResponse
 from opentrons import config
 from opentrons.protocol_reader import FileHasher, FileReaderWriter
 from opentrons_shared_data.data_files import DataFileInfo, DataFileSource, MimeType
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/deck_configuration/router.py
+++ b/robot-server/robot_server/deck_configuration/router.py
@@ -7,7 +7,7 @@ import fastapi
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
 
 from opentrons_shared_data.deck.types import DeckDefinitionV5
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/error_recovery/settings/router.py
+++ b/robot-server/robot_server/error_recovery/settings/router.py
@@ -4,7 +4,7 @@ from typing import Annotated
 
 import fastapi
 
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/errors/exception_handlers.py
+++ b/robot-server/robot_server/errors/exception_handlers.py
@@ -13,6 +13,10 @@ from opentrons_shared_data.errors import EnumeratedError, ErrorCodes, PythonExce
 from opentrons_shared_data.errors.exceptions import (
     FirmwareUpdateRequiredError as HWFirmwareUpdateRequired,
 )
+from server_utils.auth.resource_server.fastapi import (
+    AuthorizationError,
+    handle_authorization_error,
+)
 
 from .error_responses import (
     ApiError,
@@ -181,6 +185,13 @@ async def handle_firmware_upgrade_required_error(
     )
 
 
+# Normalize to async to appease FastAPI's `exception_handlers` arg.
+async def _handle_authorization_error_async(
+    request: Request, error: AuthorizationError
+) -> Response:
+    return handle_authorization_error(request, error)
+
+
 exception_handlers: Dict[
     Union[int, Type[Exception]],
     Callable[[Request, Any], Coroutine[Any, Any, Response]],
@@ -189,5 +200,6 @@ exception_handlers: Dict[
     StarletteHTTPException: handle_framework_error,
     RequestValidationError: handle_validation_error,
     HWFirmwareUpdateRequired: handle_firmware_upgrade_required_error,
+    AuthorizationError: _handle_authorization_error_async,
     Exception: handle_unexpected_error,
 }

--- a/robot-server/robot_server/errors/exception_handlers.py
+++ b/robot-server/robot_server/errors/exception_handlers.py
@@ -42,18 +42,6 @@ from robot_server.versioning import (
 log = getLogger(__name__)
 
 
-def _code_or_default(exc: BaseException) -> str:
-    if isinstance(exc, EnumeratedError):
-        # For a reason I cannot fathom, mypy thinks this is an Any.
-        # reveal_type(exc) # -> opentrons_shared_data.errors.exceptions.EnumeratedError
-        # reveal_type(exc.code) # -> opentrons_shared_data.errors.codes.ErrorCodes
-        # reveal_type(exc.code.value) # Any (????????????)
-        # This doesn't happen anywhere else or indeed in the else side of this clause.
-        return exc.code.value.code  # type: ignore [no-any-return]
-    else:
-        return ErrorCodes.GENERAL_ERROR.value.code
-
-
 def _route_is_legacy(request: Request) -> bool:
     """Check if router handling the request is a legacy v1 endpoint."""
     router = request.scope.get("router")

--- a/robot-server/robot_server/labware_offsets/router.py
+++ b/robot-server/robot_server/labware_offsets/router.py
@@ -7,7 +7,7 @@ from typing import Annotated, Literal
 import fastapi
 from pydantic.json_schema import SkipJsonSchema
 
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/maintenance_runs/router/base_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/base_router.py
@@ -14,7 +14,7 @@ from typing_extensions import Literal
 
 from opentrons.protocol_engine.resources.camera_provider import CameraProvider
 from opentrons.protocol_engine.types import EngineStatus
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/maintenance_runs/router/commands_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/commands_router.py
@@ -13,7 +13,7 @@ from opentrons.protocol_engine import (
     commands as pe_commands,
 )
 from opentrons.protocol_engine.errors import CommandDoesNotExistError
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/maintenance_runs/router/labware_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/labware_router.py
@@ -11,7 +11,7 @@ from opentrons.protocol_engine import (
     LegacyLabwareOffsetCreate,
 )
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/protocols/router.py
+++ b/robot-server/robot_server/protocols/router.py
@@ -32,7 +32,7 @@ from opentrons.protocol_reader import (
 from opentrons.util.performance_helpers import TrackingFunctions
 from opentrons_shared_data.robot import user_facing_robot_type
 from opentrons_shared_data.robot.types import RobotType
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/robot/control/router.py
+++ b/robot-server/robot_server/robot/control/router.py
@@ -7,7 +7,7 @@ from fastapi import Depends, status
 from opentrons.config import feature_flags as ff
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons_shared_data.robot.types import RobotType, RobotTypeEnum
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -7,7 +7,7 @@ from typing import Annotated, Literal, Union
 from fastapi import Depends, status
 
 from opentrons.protocol_engine.types import DeckConfigurationType
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -24,7 +24,7 @@ from opentrons.protocol_engine.resources.camera_provider import CameraProvider
 from opentrons.protocol_engine.types import CSVRuntimeParamPaths, DeckSlotLocation
 from opentrons_shared_data.errors import ErrorCodes
 from opentrons_shared_data.robot.types import RobotTypeEnum
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/runs/router/camera_router.py
+++ b/robot-server/robot_server/runs/router/camera_router.py
@@ -18,7 +18,7 @@ from opentrons.protocol_engine.resources.camera_provider import (
 from opentrons.system import camera
 from opentrons_shared_data.errors import ErrorCodes
 from opentrons_shared_data.robot.types import RobotType
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/runs/router/commands_router.py
+++ b/robot-server/robot_server/runs/router/commands_router.py
@@ -14,7 +14,7 @@ from opentrons.protocol_engine import (
 from opentrons.protocol_engine import (
     errors as pe_errors,
 )
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/runs/router/error_recovery_policy_router.py
+++ b/robot-server/robot_server/runs/router/error_recovery_policy_router.py
@@ -5,7 +5,7 @@ from typing import Annotated
 
 from fastapi import Depends, status
 
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/runs/router/labware_router.py
+++ b/robot-server/robot_server/runs/router/labware_router.py
@@ -11,7 +11,7 @@ from opentrons.protocol_engine import (
     LegacyLabwareOffsetCreate,
 )
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/service/labware/router.py
+++ b/robot-server/robot_server/service/labware/router.py
@@ -10,7 +10,7 @@ from fastapi import Depends, status
 from typing_extensions import Literal, NoReturn
 
 from opentrons_shared_data.errors import ErrorCodes
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 

--- a/robot-server/robot_server/service/legacy/routers/camera.py
+++ b/robot-server/robot_server/service/legacy/routers/camera.py
@@ -18,7 +18,7 @@ from opentrons.system import camera
 from opentrons.system.camera import PREVIEW_IMAGE, StreamConfigurationKeys
 from opentrons_shared_data.errors import ErrorCodes
 from opentrons_shared_data.robot.types import RobotType
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.models.json_api import RequestModel
 

--- a/robot-server/robot_server/service/legacy/routers/control.py
+++ b/robot-server/robot_server/service/legacy/routers/control.py
@@ -12,7 +12,7 @@ from opentrons.hardware_control import (
 from opentrons.hardware_control.types import Axis, CriticalPoint
 from opentrons.types import Mount, Point
 from opentrons_shared_data.errors import ErrorCodes
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
 from robot_server.errors.error_responses import LegacyErrorResponse

--- a/robot-server/robot_server/service/legacy/routers/modules.py
+++ b/robot-server/robot_server/service/legacy/routers/modules.py
@@ -8,7 +8,7 @@ from opentrons.hardware_control import HardwareControlAPI, modules
 from opentrons.hardware_control.modules import AbstractModule
 from opentrons_shared_data.errors.codes import ErrorCodes
 from opentrons_shared_data.errors.exceptions import APIRemoved, ModuleNotPresent
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
 from robot_server.errors.error_responses import LegacyErrorResponse

--- a/robot-server/robot_server/service/legacy/routers/motors.py
+++ b/robot-server/robot_server/service/legacy/routers/motors.py
@@ -9,7 +9,7 @@ from opentrons.hardware_control.types import Axis
 from opentrons.protocol_engine.errors import HardwareNotSupportedError
 from opentrons.protocol_engine.resources.ot3_validation import ensure_ot3_hardware
 from opentrons_shared_data.errors import ErrorCodes
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
 from robot_server.errors.error_responses import LegacyErrorResponse

--- a/robot-server/robot_server/service/legacy/routers/networking.py
+++ b/robot-server/robot_server/service/legacy/routers/networking.py
@@ -19,7 +19,7 @@ from starlette.responses import JSONResponse
 
 from opentrons.system import nmcli, wifi
 from opentrons_shared_data.errors import ErrorCodes
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
 from robot_server.errors.error_responses import LegacyErrorResponse

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -37,7 +37,7 @@ from opentrons_shared_data.pipette import (
     types as pip_types,
 )
 from opentrons_shared_data.robot.types import RobotTypeEnum
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.app_state import (
     AppState,

--- a/robot-server/robot_server/service/pipette_offset/router.py
+++ b/robot-server/robot_server/service/pipette_offset/router.py
@@ -6,7 +6,7 @@ from starlette import status
 from opentrons import types as ot_types
 from opentrons.calibration_storage.ot2 import models, pipette_offset
 from opentrons.hardware_control import API
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
 from robot_server.errors.error_responses import ErrorBody

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -4,7 +4,7 @@ from typing import Annotated, Optional
 from fastapi import APIRouter, Depends, Query
 from starlette import status as http_status_codes
 
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.models.json_api import ResourceLink
 from server_utils.fastapi_utils.models.json_api.resource_links import (

--- a/robot-server/robot_server/service/tip_length/router.py
+++ b/robot-server/robot_server/service/tip_length/router.py
@@ -7,7 +7,7 @@ from opentrons.calibration_storage import types as cal_types
 from opentrons.calibration_storage.ot2 import models, tip_length
 from opentrons.hardware_control import API
 from opentrons_shared_data.pipette.types import LabwareUri
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
 from robot_server.errors.error_responses import ErrorBody

--- a/robot-server/robot_server/subsystems/router.py
+++ b/robot-server/robot_server/subsystems/router.py
@@ -7,7 +7,7 @@ from fastapi import Depends, Request, Response, status
 from typing_extensions import Literal
 
 from opentrons.hardware_control import HardwareControlAPI, ThreadManagedHardware
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api import (

--- a/robot-server/robot_server/system/router.py
+++ b/robot-server/robot_server/system/router.py
@@ -9,7 +9,7 @@ from datetime import datetime
 
 from fastapi import Depends
 
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
 from server_utils.fastapi_utils.models.json_api.resource_links import (

--- a/robot-server/tests/conftest.py
+++ b/robot-server/tests/conftest.py
@@ -39,7 +39,7 @@ from server_utils.auth.resource_server.authorization_checker import (
     AlwaysAllowedAuthorizationChecker,
     AuthorizationChecker,
 )
-from server_utils.auth.resource_server.fastapi_dependencies import (
+from server_utils.auth.resource_server.fastapi import (
     get_authorization_checker,
 )
 

--- a/robot-server/tests/errors/test_exception_handlers.py
+++ b/robot-server/tests/errors/test_exception_handlers.py
@@ -8,6 +8,12 @@ from fastapi import FastAPI, Header, status
 from fastapi.testclient import TestClient
 from pydantic import BaseModel
 
+from server_utils.auth.resource_server.authorization_checker import (
+    NotAnActiveTokenResult,
+)
+from server_utils.auth.resource_server.fastapi import AuthorizationError
+from server_utils.auth.scopes import Scope
+
 from robot_server.constants import V1_TAG
 from robot_server.errors.error_responses import ApiError
 from robot_server.errors.exception_handlers import exception_handlers
@@ -245,4 +251,32 @@ def test_handles_legacy_validation_error(app: FastAPI, client: TestClient) -> No
             "string as an integer; body.array_field.0: Input should be a valid "
             "boolean, unable to interpret input"
         ),
+    }
+
+
+def test_handles_authorization_error(app: FastAPI, client: TestClient) -> None:
+    """It should properly format authorization errors.
+
+    We won't test every kind of authorization error here, since that's the
+    responsibility of server-utils. Just enough to make sure that the exceptions
+    don't become HTTP 500 errors.
+    """
+
+    @app.post("/trigger-auth-error")
+    def trigger_auth_error() -> None:
+        raise AuthorizationError(
+            authorization_error=NotAnActiveTokenResult(),
+            required_scopes={Scope.ROBOT_CONTROL_WRITE},
+        )
+
+    response = client.post(
+        "/trigger-auth-error",
+    )
+
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    assert response.headers["WWW-Authenticate"] == 'Bearer error="invalid_token"'
+    assert response.json() == {
+        "debugMessage": "The access token provided by the request is bogus or expired.",
+        "providedScopes": [],
+        "requiredScopes": [Scope.ROBOT_CONTROL_WRITE.api_name],
     }

--- a/server-utils/server_utils/auth/resource_server/authorization_checker.py
+++ b/server-utils/server_utils/auth/resource_server/authorization_checker.py
@@ -1,4 +1,7 @@
-"""Logic to check whether an HTTP client is authorized to do something."""
+"""Logic to check whether an HTTP client is authorized to do something.
+
+This module should be framework-agnostic, not tied to FastAPI or whatever.
+"""
 
 from __future__ import annotations
 

--- a/server-utils/server_utils/auth/resource_server/error_responses.py
+++ b/server-utils/server_utils/auth/resource_server/error_responses.py
@@ -1,4 +1,7 @@
-"""HTTP responses for authorization failures."""
+"""HTTP responses for authorization failures.
+
+This module should be framework-agnostic, not tied to FastAPI or whatever.
+"""
 
 from typing import Annotated
 
@@ -16,8 +19,8 @@ from server_utils.auth.scopes import Scope
 # todo(mm, 2026-02-10): Follow the server's existing error response conventions,
 # such as returning an error code.
 #
-# Note: The shape of this error response is just an Opentrons API design decision.
-# The OAuth 2 specs don't care.
+# Note: The shape of this response body is just an Opentrons API design decision.
+# The specs only care about response headers and status codes.
 class AuthorizationErrorResponse(BaseModel):
     """Returned when the client lacks authorization to access a protected resource."""
 

--- a/server-utils/server_utils/auth/resource_server/error_responses.py
+++ b/server-utils/server_utils/auth/resource_server/error_responses.py
@@ -31,13 +31,14 @@ class AuthorizationErrorResponse(BaseModel):
         ),
     ]
     requiredScopes: Annotated[
-        list[str], Field(description="The authorization scopes carried by the request.")
-    ]
-    providedScopes: Annotated[
         list[str],
         Field(
             description="The authorization scopes required to access the requested resource."
         ),
+    ]
+    providedScopes: Annotated[
+        list[str],
+        Field(description="The authorization scopes carried by the request."),
     ]
 
 

--- a/server-utils/server_utils/auth/resource_server/fastapi.py
+++ b/server-utils/server_utils/auth/resource_server/fastapi.py
@@ -10,9 +10,11 @@ from typing import (
     AsyncGenerator,
     Awaitable,
     Callable,
+    Final,
 )
 
 import fastapi
+import fastapi.responses
 import fastapi.security
 
 from .auth_server import TOKEN_ENDPOINT_PATH, LocalHTTPClient
@@ -21,6 +23,9 @@ from .authorization_checker import (
     AuthorizationChecker,
     AuthorizedResult,
     AuthServerAuthorizationChecker,
+    InsufficientScopeResult,
+    MissingTokenResult,
+    NotAnActiveTokenResult,
 )
 from .error_responses import build_response_for_error
 from server_utils.auth.scopes import Scope
@@ -97,25 +102,7 @@ def require_scopes(*required_scopes: Scope) -> Callable[..., Awaitable[None]]:
             # The request is authorized, yay.
             pass
         else:
-            # The request is not authorized.
-            error_status_code, error_headers, error_body = build_response_for_error(
-                authorization_result, required_scopes_set
-            )
-            # todo(mm, 2026-02-11): This currently stringifies the response body and
-            # stuffs it inside the "detail" string field. We should instead return the
-            # response body *as the response body.* To do that, need to raise some kind
-            # of structured exception, and translate it to a response in a global
-            # FastAPI exception handler.
-            stringified_error_body = (
-                f"{error_body.debugMessage}"
-                f" Required scopes: {error_body.requiredScopes}."
-                f" Provided scopes: {error_body.providedScopes}."
-            )
-            raise fastapi.HTTPException(
-                status_code=error_status_code,
-                headers=error_headers,
-                detail=stringified_error_body,
-            )
+            raise AuthorizationError(authorization_result, required_scopes_set)
 
     return dependency
 
@@ -171,3 +158,39 @@ def get_authorization_checker(
         "Forgot to initialize authorization checker as part of server startup?"
     )
     return authorization_checker
+
+
+class AuthorizationError(Exception):
+    """Raised to signal that an HTTP authorization failure should be returned to the client.
+
+    Endpoints should not deal with this directly. Instead, they should use the
+    higher-level `require_scopes()` function.
+    """
+
+    def __init__(
+        self,
+        authorization_error: InsufficientScopeResult
+        | MissingTokenResult
+        | NotAnActiveTokenResult,
+        required_scopes: set[Scope],
+    ) -> None:
+        self.authorization_error: Final = authorization_error
+        self.required_scopes: Final = required_scopes
+
+
+def handle_authorization_error(
+    request: fastapi.Request, exc: AuthorizationError
+) -> fastapi.responses.Response:
+    """Turn `AuthorizationError` exceptions into HTTP responses.
+
+    This should be installed as a global FastAPI exception handler.
+    """
+    status_code, headers, body = build_response_for_error(
+        exc.authorization_error, exc.required_scopes
+    )
+    return fastapi.responses.Response(
+        status_code=status_code,
+        headers=headers,
+        content=body.model_dump_json(by_alias=True),
+        media_type="application/json",
+    )

--- a/server-utils/server_utils/auth/resource_server/fastapi.py
+++ b/server-utils/server_utils/auth/resource_server/fastapi.py
@@ -1,4 +1,4 @@
-"""FastAPI dependencies to enforce authorization."""
+"""FastAPI-specific helpers for enforcing authorization."""
 
 # NOTE: Don't do `from __future__ import annotations` in this file.
 # See comments in `require_scopes()`.

--- a/system-server/system_server/app_setup.py
+++ b/system-server/system_server/app_setup.py
@@ -9,7 +9,9 @@ from fastapi.openapi.docs import get_redoc_html
 from fastapi.responses import HTMLResponse
 
 from server_utils.auth.resource_server.fastapi import (
+    AuthorizationError,
     build_authorization_checker,
+    handle_authorization_error,
     install_authorization_checker,
 )
 from server_utils.fastapi_utils.server_timing_middleware import server_timing_middleware
@@ -60,6 +62,8 @@ app.add_middleware(
 )
 
 app.middleware("http")(server_timing_middleware())
+
+app.exception_handler(AuthorizationError)(handle_authorization_error)
 
 # main router
 app.include_router(router=router)

--- a/system-server/system_server/app_setup.py
+++ b/system-server/system_server/app_setup.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_redoc_html
 from fastapi.responses import HTMLResponse
 
-from server_utils.auth.resource_server.fastapi_dependencies import (
+from server_utils.auth.resource_server.fastapi import (
     build_authorization_checker,
     install_authorization_checker,
 )

--- a/system-server/system_server/system/oem_mode/router.py
+++ b/system-server/system_server/system/oem_mode/router.py
@@ -17,7 +17,7 @@ from fastapi import (
     status,
 )
 
-from server_utils.auth.resource_server.fastapi_dependencies import require_scopes
+from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
 from .models import EnableOEMMode

--- a/update-server/otupdate/common/auth.py
+++ b/update-server/otupdate/common/auth.py
@@ -67,7 +67,7 @@ def require_scopes(*required_scopes: Scope) -> Callable[[Handler], Handler]:
                 return web.json_response(
                     status=status_code,
                     headers=headers,
-                    text=body.model_dump_json(),
+                    text=body.model_dump_json(by_alias=True),
                 )
 
         return wrapped

--- a/update-server/otupdate/openembedded/__main__.py
+++ b/update-server/otupdate/openembedded/__main__.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from typing import NoReturn
 
-from server_utils.auth.resource_server.fastapi_dependencies import (
+from server_utils.auth.resource_server.fastapi import (
     build_authorization_checker,
 )
 


### PR DESCRIPTION
## Overview

This allows us to customize the response body that a server returns when it rejects an unauthorized request. This will give us flexibility to return information in more readable and structured ways.

(Note that this separate from the response *headers,* which are already spec-compliant. The specs generally just care about headers and status codes, and leave the response bodies up to us.)

The new response bodies look like this:

```json
{
    "debugMessage": "The request is missing an access token.",
    "requiredScopes": [
        "run_data.write"
    ],
    "providedScopes": []
}
```

The old ones basically stuffed everything inside a `detail` string.

In the future, we'll probably want to add an Opentrons error code to this. And maybe nest everything inside a `data` property, for consistency with our existing APIs.

## Test Plan and Hands on Testing

All servers return the new response body when rejecting unauthorized requests:

* [x] system-server
* [x] auth-server
* [x] robot-server

(robot-server didn't need any changes here because it's on AIOHTTP instead of FastAPI.)

## Changelog

The actual change, described above, is in commit e8edec2c4029a20359e7161c412c2134b785cebf.

Other commits are various small refactors. See their messages for details.

## Review requests

None in particular.

## Risk assessment

Low.
