### PR TITLE
feat(app, components): handle vacuum module in desktop protocol run setup

### DIFF
--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupModuleAndDeck/SetupModulesList.tsx
@@ -36,6 +36,7 @@ import {
   MAGNETIC_BLOCK_TYPE,
   MAGNETIC_BLOCK_V1,
   OT2_ROBOT_TYPE,
+  VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import { TertiaryButton } from '/app/atoms/buttons'
@@ -334,6 +335,7 @@ export function ModulesListItem({
     attachedModuleMatch != null &&
     attachedModuleMatch.moduleType !== ABSORBANCE_READER_TYPE &&
     attachedModuleMatch.moduleType !== FLEX_STACKER_MODULE_TYPE &&
+    attachedModuleMatch.moduleType !== VACUUM_MODULE_TYPE &&
     attachedModuleMatch.moduleOffset?.last_modified == null
 
   if (needsCalibration) {

--- a/app/src/redux/modules/__fixtures__/index.ts
+++ b/app/src/redux/modules/__fixtures__/index.ts
@@ -429,6 +429,32 @@ export const mockFlexStackerMissingShuttle: Types.FlexStackerModule = {
   },
 }
 
+export const mockVacuumModule: Types.VacuumModule = {
+  id: 'heatershaker_id',
+  moduleModel: 'vacuumModuleV1',
+  moduleType: 'vacuumModuleType',
+  serialNumber: 'vac123',
+  hardwareRevision: 'vacuum_v1.0',
+  firmwareVersion: 'v1.0.0',
+  hasAvailableUpdate: true,
+  data: {
+    currentPressure: null,
+    targetPressure: null,
+    currentPower: null,
+    targetPower: null,
+    ventStatus: 'closed',
+    modeType: 'pressure',
+    status: 'idle',
+  },
+  usbPort: {
+    path: '/dev/ot_module_flexstacker0',
+    port: 1,
+    hub: true,
+    hubPort: 1,
+    portGroup: 'unknown',
+  },
+}
+
 export const mockMagneticBlock = {
   id: 'magneticBlock_id',
   moduleModel: 'magneticBlockV1',

--- a/app/src/resources/runs/__tests__/useModuleCalibrationStatus.test.tsx
+++ b/app/src/resources/runs/__tests__/useModuleCalibrationStatus.test.tsx
@@ -6,7 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
 
 import { useIsFlex } from '/app/redux-resources/robots'
-import { mockMagneticModuleGen2 } from '/app/redux/modules/__fixtures__'
+import {
+  mockMagneticModuleGen2,
+  mockVacuumModule,
+} from '/app/redux/modules/__fixtures__'
 
 import { useModuleCalibrationStatus } from '../useModuleCalibrationStatus'
 import { useModuleRenderInfoForProtocolById } from '../useModuleRenderInfoForProtocolById'
@@ -47,6 +50,16 @@ const MAGNETIC_MODULE_INFO = {
   protocolLoadOrder: 0,
   slotName: '1',
 }
+
+const VACUUM_MODULE_INFO = {
+  moduleId: 'vacuumModuleId',
+  x: 0,
+  y: 0,
+  z: 0,
+  moduleDef: {
+    moduleType: 'vacuumModuleType',
+  },
+} as any
 
 const mockOffsetData = {
   offset: {
@@ -149,5 +162,27 @@ describe('useModuleCalibrationStatus hook', () => {
       complete: false,
       reason: 'calibrate_module_failure_reason',
     })
+  })
+
+  it('should return calibration complete if vacuum module is connected', () => {
+    when(vi.mocked(useIsFlex)).calledWith('otie').thenReturn(true)
+    when(vi.mocked(useModuleRenderInfoForProtocolById))
+      .calledWith('1')
+      .thenReturn({
+        vacuumModuleId: {
+          attachedModuleMatch: {
+            ...mockVacuumModule,
+          },
+          conflictedFixture: null,
+          ...VACUUM_MODULE_INFO,
+        },
+      })
+
+    const { result } = renderHook(
+      () => useModuleCalibrationStatus('otie', '1'),
+      { wrapper }
+    )
+
+    expect(result.current).toEqual({ complete: true })
   })
 })

--- a/app/src/resources/runs/useModuleCalibrationStatus.ts
+++ b/app/src/resources/runs/useModuleCalibrationStatus.ts
@@ -4,6 +4,7 @@ import {
   ABSORBANCE_READER_TYPE,
   FLEX_STACKER_MODULE_TYPE,
   MAGNETIC_BLOCK_TYPE,
+  VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import { useIsFlex } from '/app/redux-resources/robots'
@@ -22,7 +23,8 @@ export function useModuleCalibrationStatus(
     useModuleRenderInfoForProtocolById(runId),
     moduleRenderInfo =>
       moduleRenderInfo.moduleDef.moduleType === MAGNETIC_BLOCK_TYPE ||
-      moduleRenderInfo.moduleDef.moduleType === ABSORBANCE_READER_TYPE
+      moduleRenderInfo.moduleDef.moduleType === ABSORBANCE_READER_TYPE ||
+      moduleRenderInfo.moduleDef.moduleType === VACUUM_MODULE_TYPE
   )
 
   // only check module calibration for Flex

--- a/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
+++ b/components/src/hardware-sim/BaseDeck/BaseDeck.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react'
-import partition from 'lodash/partition'
 
 import {
+  ABSORBANCE_READER_TYPE,
   FLEX_STACKER_MODULE_TYPE,
   getDeckDefFromRobotType,
   getModuleDef,
@@ -19,6 +19,7 @@ import {
   STAGING_AREA_RIGHT_SLOT_FIXTURE,
   STAGING_AREA_SLOT_WITH_MAGNETIC_BLOCK_V1_FIXTURE,
   TRASH_BIN_ADAPTER_FIXTURE,
+  VACUUM_MODULE_TYPE,
   WASTE_CHUTE_CUTOUT,
   WASTE_CHUTE_FLEX_STACKER_FIXTURES,
   WASTE_CHUTE_ONLY_FIXTURES,
@@ -29,6 +30,7 @@ import {
   AlignToModuleChildSlot,
   CenterLabwareInModuleChildSlot,
   CenterLabwareInSlot,
+  CURSOR_POINTER,
   FixedTrashText,
 } from '../..'
 import { COLORS } from '../../helix-design-system'
@@ -193,17 +195,36 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
       fixture.cutoutId === WASTE_CHUTE_CUTOUT
   )
 
-  const [singleLocationModules, stackerModules] = partition(
-    modulesOnDeck,
-    module => getModuleType(module.moduleModel) !== FLEX_STACKER_MODULE_TYPE
-  )
+  const { singleLocationModules, stackerModules, vacuumModules } =
+    modulesOnDeck.reduce<{
+      singleLocationModules: ModuleOnDeck[]
+      stackerModules: ModuleOnDeck[]
+      vacuumModules: ModuleOnDeck[]
+    }>(
+      (acc, module) => {
+        const moduleType = getModuleType(module.moduleModel)
+        if (moduleType === FLEX_STACKER_MODULE_TYPE) {
+          acc.stackerModules.push(module)
+        } else if (moduleType === VACUUM_MODULE_TYPE) {
+          acc.vacuumModules.push(module)
+        } else {
+          acc.singleLocationModules.push(module)
+        }
+        return acc
+      },
+      {
+        singleLocationModules: [],
+        stackerModules: [],
+        vacuumModules: [],
+      }
+    )
 
   return (
     <RobotCoordinateSpace
       viewBox={`${deckDef.cornerOffsetFromOrigin[0]} ${
         deckDef.cornerOffsetFromOrigin[1]
       } ${
-        stackerModules.length > 0
+        [...stackerModules, ...vacuumModules].length > 0
           ? deckDef.dimensions[0] + STACKER_DECK_VIEW_BOX_EXPANSION
           : deckDef.dimensions[0]
       } ${deckDef.dimensions[1]}`}
@@ -227,11 +248,14 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
               show4thColumn={
                 stagingAreaFixtures.length > 0 ||
                 wasteChuteStagingAreaFixtures.length > 0 ||
-                modulesOnDeck.findIndex(
-                  module =>
-                    module.moduleModel === 'absorbanceReaderV1' ||
-                    module.moduleModel === 'flexStackerModuleV1'
-                ) >= 0
+                modulesOnDeck.some(module => {
+                  const moduleType = getModuleType(module.moduleModel)
+                  return (
+                    moduleType === ABSORBANCE_READER_TYPE ||
+                    moduleType === FLEX_STACKER_MODULE_TYPE ||
+                    moduleType === VACUUM_MODULE_TYPE
+                  )
+                })
               }
             />
           ) : null}
@@ -316,7 +340,11 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
             highlightLabware,
             highlightShadowLabware,
           }) => {
-            const stackerSlotName = getStackerLocationFromSlot(
+            // enforce that module is a stacker
+            if (getModuleType(moduleModel) !== FLEX_STACKER_MODULE_TYPE) {
+              return null
+            }
+            const stackerSlotName = getStagingColumnSlotName(
               moduleLocation.slotName
             )
             const slotPosition = getPositionFromSlotId(stackerSlotName, deckDef)
@@ -384,6 +412,93 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
                             ) === 'left' &&
                             moduleModel === HEATERSHAKER_MODULE_V1
                           }
+                          highlight={highlightLabware}
+                          highlightShadow={highlightShadowLabware}
+                        />
+                      </g>
+                    </CenterLabwareInModuleChildSlot>
+                  ) : null}
+                  {moduleChildren}
+                </Module>
+              </Fragment>
+            ) : null
+          }
+        )}
+        {vacuumModules.map(
+          ({
+            moduleModel,
+            moduleLocation,
+            nestedLabwareDefsBottomToTop,
+            nestedLabwareWellFill,
+            innerProps,
+            moduleChildren,
+            onLabwareClick,
+            highlightLabware,
+            highlightShadowLabware,
+          }) => {
+            // enforce that module is a vacuum
+            if (getModuleType(moduleModel) !== VACUUM_MODULE_TYPE) {
+              return null
+            }
+            const slotPosition = getPositionFromSlotId(
+              moduleLocation.slotName,
+              deckDef
+            )
+            const moduleDef = getModuleDef(moduleModel)
+            return slotPosition != null ? (
+              <Fragment
+                key={`vacuum_${moduleModel}_${moduleLocation.slotName}`}
+              >
+                <StagingAreaFixture
+                  cutoutId={
+                    `cutout${moduleLocation.slotName}` as StagingAreaLocation
+                  }
+                  deckDefinition={deckDef}
+                  slotClipColor={darkFill}
+                  fixtureBaseColor={lightFill}
+                />
+                {wasteChuteStackerFixtures.map(fixture => {
+                  if (
+                    fixture.cutoutId === WASTE_CHUTE_CUTOUT &&
+                    moduleLocation.slotName === 'D3'
+                  ) {
+                    return (
+                      <WasteChuteFixture
+                        key={fixture.cutoutId}
+                        cutoutId={fixture.cutoutId}
+                        deckDefinition={deckDef}
+                        fixtureBaseColor={lightFill}
+                        wasteChuteColor={mediumFill}
+                      />
+                    )
+                  }
+                })}
+                <Module
+                  key={`${moduleModel} ${moduleLocation.slotName}`}
+                  def={moduleDef}
+                  x={slotPosition[0]}
+                  y={slotPosition[1]}
+                  orientation={inferModuleOrientationFromXCoordinate(
+                    slotPosition[0]
+                  )}
+                  innerProps={innerProps}
+                  targetDeckId={deckDef.otId}
+                  targetSlotId={moduleLocation.slotName}
+                  childrenPositioningMode="passThrough"
+                >
+                  {nestedLabwareDefsBottomToTop.length > 0 ? (
+                    <CenterLabwareInModuleChildSlot
+                      deckId={deckDef.otId}
+                      slotId={moduleLocation.slotName}
+                      moduleDefinition={moduleDef}
+                      labwareDefinition={nestedLabwareDefsBottomToTop[0]}
+                    >
+                      <g cursor={onLabwareClick != null ? CURSOR_POINTER : ''}>
+                        <LabwareRender
+                          definition={nestedLabwareDefsBottomToTop[0]}
+                          positioningMode="passThrough"
+                          onLabwareClick={onLabwareClick}
+                          wellFill={nestedLabwareWellFill}
                           highlight={highlightLabware}
                           highlightShadow={highlightShadowLabware}
                         />
@@ -517,8 +632,9 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
           ({ moduleModel, moduleLocation, stacked = false }) => {
             const moduleDef = getModuleDef(moduleModel)
             const parentSlotName =
-              moduleDef.moduleType === FLEX_STACKER_MODULE_TYPE
-                ? getStackerLocationFromSlot(moduleLocation.slotName)
+              moduleDef.moduleType === FLEX_STACKER_MODULE_TYPE ||
+              moduleDef.moduleType === VACUUM_MODULE_TYPE
+                ? getStagingColumnSlotName(moduleLocation.slotName)
                 : moduleLocation.slotName
             const parentSlotPosition = getPositionFromSlotId(
               parentSlotName,
@@ -582,6 +698,7 @@ export function BaseDeck(props: BaseDeckProps): JSX.Element {
   )
 }
 
-function getStackerLocationFromSlot(slotName: string): string {
+/** Slot used as the deck SVG anchor for modules that span the right slot + column 4. */
+function getStagingColumnSlotName(slotName: string): string {
   return `${slotName.charAt(0)}4`
 }


### PR DESCRIPTION
# Overview

This PR addresses vacuum module in protocol run setup, specifically in the `SetupModuleAndDeck` component. It ensures setup logic is correct (not requiring calibration), and extends our shared `BaseDeck` to handle vacuum modules. We get the ODD functionality for free from the updates to the shared hook `app/src/resources/runs/useModuleCalibrationStatus`

Closes EXEC-2260

**_[Note 1]_**: that correct rendering in `BaseDeck` is dependent upon the shared module definition being fleshed out. That is not scoped in this PR.

## Test Plan and Hands on Testing

- start setup for a vacuum module protocol ([example](https://github.com/user-attachments/files/27375285/minimal_vacuum_test.py)) on a real or dev flex
- in protocol run screen on the desktop app, find and expand Deck Hardware section

#### List View
verify that the module list item renders correctly according to the 3 possible states:
1. connected and configured  
<img width="824" height="325" alt="Screenshot 2026-05-04 at 4 29 30 PM" src="https://github.com/user-attachments/assets/831bedfe-0b40-428d-8d89-1dff07942dbb" />
2. connected, but not configured  
<img width="835" height="346" alt="Screenshot 2026-05-04 at 4 32 27 PM" src="https://github.com/user-attachments/assets/8d167870-3734-4fd2-b483-89f047c3b443" />
3. not connected  
<img width="823" height="342" alt="Screenshot 2026-05-04 at 4 31 49 PM" src="https://github.com/user-attachments/assets/c0a7ddec-3b5a-4ee2-8e24-e059d4d714e0" />

#### Map View
verify that column label 4 renders, since the vacuum module extends into the 4th column (see Note 1 above regarding rendering)

## Changelog

- extend modules that do not require calibration to vacuum
- refactor logic in `BaseDeck` for partitioning attached modules into single-slot modules, flex stacker modules, and vacuum modules
- render vacuum modules in `BaseDeck`

## Review requests

see test plan

## Risk assessment

low