### PR TITLE
feat(api, robot-server): remove allowStepGrouping feature flag

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -244,17 +244,6 @@ settings = [
         robot_type=[RobotTypeEnum.FLEX],
         internal_only=True,
     ),
-    SettingDefinition(
-        _id="allowStepGrouping",
-        title="Allow creation of step groups via command annotations.",
-        description=(
-            "Do not enable."
-            " This is an Opentrons internal setting to allow using in-development"
-            " command annotations and step groups."
-        ),
-        robot_type=[RobotTypeEnum.FLEX],
-        internal_only=True,
-    ),
 ]
 
 
@@ -798,6 +787,14 @@ def _migrate39to40(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate40to41(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 41 of the feature flags file.
+
+    - Removes the allowStepGrouping config element.
+    """
+    return {k: v for k, v in previous.items() if "allowStepGrouping" != k}
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -839,6 +836,7 @@ _MIGRATIONS = [
     _migrate37to38,
     _migrate38to39,
     _migrate39to40,
+    _migrate40to41,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -97,10 +97,3 @@ def hardware_subprocess_enabled() -> bool:
     return advs.get_setting_with_env_overload(
         "enableHardwareSubprocess", RobotTypeEnum.FLEX
     )
-
-
-def allow_step_grouping() -> bool:
-    return advs.get_setting_with_env_overload(
-        "allowStepGrouping",
-        RobotTypeEnum.FLEX,
-    )

--- a/api/src/opentrons/protocol_api/_command_annotations.py
+++ b/api/src/opentrons/protocol_api/_command_annotations.py
@@ -3,7 +3,12 @@ from opentrons.protocols.api_support.types import APIVersion
 
 
 class GroupedSteps:
-    """Represents a created grouping of steps."""
+    """Represents a created grouping of steps.
+
+    *Available for use from API version 2.29 onwards*
+
+    Note: Any new methods added should have API version gating
+    """
 
     def __init__(
         self, annotation_id: str, protocol_core: ProtocolCore, api_version: APIVersion
@@ -13,7 +18,6 @@ class GroupedSteps:
         self._api_version = api_version
         self._annotation_closed = False
 
-    # TODO(jbl, 2026-02-12) when feature flag is removed add a version check decorator
     def end_group(self) -> None:
         if not self._annotation_closed:
             self._protocol_core.end_step_grouping(annotation_id=self._annotation_id)

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -24,7 +24,6 @@ from opentrons_shared_data.liquid_classes.liquid_class_definition import (
 from opentrons_shared_data.liquid_classes.types import TransferPropertiesDict
 from opentrons_shared_data.pipette.types import PipetteNameType
 
-from ..config import feature_flags
 from . import validation
 from ._command_annotations import GroupedSteps
 from ._liquid import Liquid, LiquidClass
@@ -1923,6 +1922,7 @@ class ProtocolContext(CommandPublisher):
             )
         return None
 
+    @requires_version(2, 29)
     @contextmanager
     def group_steps(
         self, name: str, description: Optional[str] = None
@@ -1937,14 +1937,13 @@ class ProtocolContext(CommandPublisher):
             name: A name for the group of steps.
             description: An optional description for the step group.
         """
-        if not feature_flags.allow_step_grouping():
-            raise NotImplementedError("This method is not yet implemented.")
         annotation_id = self._core.start_step_grouping(name, description)
         try:
             yield
         finally:
             self._core.end_step_grouping(annotation_id)
 
+    @requires_version(2, 29)
     def create_and_start_step_group(
         self, name: str, description: Optional[str] = None
     ) -> GroupedSteps:
@@ -1958,8 +1957,6 @@ class ProtocolContext(CommandPublisher):
             name: A name for the group of steps.
             description: An optional description for the step group.
         """
-        if not feature_flags.allow_step_grouping():
-            raise NotImplementedError("This method is not yet implemented.")
         annotation_id = self._core.start_step_grouping(name, description)
         return GroupedSteps(
             annotation_id=annotation_id,

--- a/api/src/opentrons/protocols/api_support/definitions.py
+++ b/api/src/opentrons/protocols/api_support/definitions.py
@@ -1,6 +1,6 @@
 from .types import APIVersion
 
-MAX_SUPPORTED_VERSION = APIVersion(2, 28)
+MAX_SUPPORTED_VERSION = APIVersion(2, 29)
 """The maximum supported protocol API version in this release."""
 
 MIN_SUPPORTED_VERSION = APIVersion(2, 0)

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -9,7 +9,7 @@ from opentrons.config.advanced_settings import _ensure, _migrate
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 40
+    return 41
 
 
 # make sure to set a boolean value in default_file_settings only if
@@ -34,7 +34,6 @@ def default_file_settings() -> Dict[str, Any]:
         "disableFlexStackerLabwareDetection": None,
         "enableProtocolSubprocess": False,
         "enableHardwareSubprocess": False,
-        "allowStepGrouping": None,
     }
 
 
@@ -480,6 +479,13 @@ def v40_config(v39_config: Dict[str, Any]) -> Dict[str, Any]:
     return r
 
 
+@pytest.fixture
+def v41_config(v40_config: Dict[str, Any]) -> Dict[str, Any]:
+    r = {k: v for k, v in v40_config.items() if k != "allowStepGrouping"}
+    r["_version"] = 41
+    return r
+
+
 @pytest.fixture(
     params=[
         lazy_fixture("empty_settings"),
@@ -524,6 +530,7 @@ def v40_config(v39_config: Dict[str, Any]) -> Dict[str, Any]:
         lazy_fixture("v38_config"),
         lazy_fixture("v39_config"),
         lazy_fixture("v40_config"),
+        lazy_fixture("v41_config"),
     ],
 )
 def old_settings(request: SubRequest) -> Dict[str, Any]:
@@ -617,5 +624,4 @@ def test_ensures_config() -> None:
         "disableFlexStackerLabwareDetection": None,
         "enableProtocolSubprocess": None,
         "enableHardwareSubprocess": None,
-        "allowStepGrouping": None,
     }

--- a/api/tests/opentrons/protocol_api/test_protocol_context.py
+++ b/api/tests/opentrons/protocol_api/test_protocol_context.py
@@ -20,7 +20,6 @@ from tests.opentrons.protocol_api import (
     versions_between,
 )
 
-from opentrons.config import feature_flags as ff
 from opentrons.hardware_control.modules.types import (
     FlexStackerModuleModel,
     MagneticBlockModel,
@@ -2267,7 +2266,6 @@ def test_group_steps(
     mock_feature_flags: None,
 ) -> None:
     """It should create a command annotation during the lifetime of the context."""
-    decoy.when(ff.allow_step_grouping()).then_return(True)
     decoy.when(mock_core.start_step_grouping("name", "desc")).then_return(
         "my-annotation-id"
     )
@@ -2283,7 +2281,6 @@ def test_create_and_start_step_group(
     mock_feature_flags: None,
 ) -> None:
     """It should create a command annotation and return a step group object, which can close the annotation."""
-    decoy.when(ff.allow_step_grouping()).then_return(True)
     decoy.when(mock_core.start_step_grouping("name", "desc")).then_return(
         "my-annotation-id"
     )

--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
@@ -37,7 +37,7 @@ from opentrons.protocol_api._nozzle_layout import NozzleLayout
 from opentrons.protocols.advanced_control.transfers import common as tx_ctl_lib
 
 metadata = {"protocolName": "Gravimetric QC V3"}
-requirements = {"robotType": "Flex", "apiLevel": "2.28"}
+requirements = {"robotType": "Flex", "apiLevel": "2.29"}
 
 SCALE_SECONDS_TO_TRUE_STABILIZE = 60 * 3
 

--- a/robot-server/tests/integration/http_api/protocols/test_analyses_with_command_annotations.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_analyses_with_command_annotations.tavern.yaml
@@ -5,15 +5,6 @@ marks:
       - ot3_server_base_url
 
 stages:
-  - name: Set allowStepGrouping to True
-    request:
-      method: POST
-      url: '{ot3_server_base_url}/settings'
-      json:
-        id: 'allowStepGrouping'
-        value: true
-    response:
-      status_code: 200
   - name: Upload a protocol
     request:
       url: '{ot3_server_base_url}/protocols'

--- a/robot-server/tests/integration/http_api/runs/test_get_command_annotations_in_current_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_get_command_annotations_in_current_run.tavern.yaml
@@ -5,16 +5,6 @@ marks:
   - usefixtures:
       - ot3_server_base_url
 stages:
-  - name: Set allowStepGrouping to True
-    request:
-      method: POST
-      url: '{ot3_server_base_url}/settings'
-      json:
-        id: 'allowStepGrouping'
-        value: true
-    response:
-      status_code: 200
-
   - name: Upload a protocol with user command annotations
     request:
       url: '{ot3_server_base_url}/protocols'

--- a/robot-server/tests/integration/http_api/runs/test_get_command_annotations_in_historical_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_get_command_annotations_in_historical_run.tavern.yaml
@@ -5,16 +5,6 @@ marks:
   - usefixtures:
       - ot3_server_base_url
 stages:
-  - name: Set allowStepGrouping to True
-    request:
-      method: POST
-      url: '{ot3_server_base_url}/settings'
-      json:
-        id: 'allowStepGrouping'
-        value: true
-    response:
-      status_code: 200
-
   - name: Upload a protocol with user command annotations
     request:
       url: '{ot3_server_base_url}/protocols'

--- a/robot-server/tests/integration/protocols/basic_step_grouping.py
+++ b/robot-server/tests/integration/protocols/basic_step_grouping.py
@@ -4,7 +4,7 @@ metadata = {
     "protocolName": "Basic Step Grouping",
 }
 
-requirements = {"robotType": "Flex", "apiLevel": "2.28"}
+requirements = {"robotType": "Flex", "apiLevel": "2.29"}
 
 
 def run(protocol: ProtocolContext) -> None:


### PR DESCRIPTION
# Overview

Removes the `allowStepGrouping` robot feature flag so that step grouping can be used in protocols.
Also bumps the API level to v2.29

## Test Plan and Hands on Testing

Updated the existing unit and integration tests to run without the feature flag.

## Changelog

- removed `allowStepGrouping` from available feature flags
- added a migration from advanced settings version 40 to 41
- bumped the PAPI level to v2.29
- added 'required PAPI v2.29' decorators to `group_steps()` and `create_and_start_step_group()` methods
- updated unit and tavern tests 

## Review requests

- Did I miss anything?

## Risk assessment

- Medium. Enables users to start using step grouping & command annotations.