### PR TITLE
feat(protocol-designer): hide items that are related to OT-2

### DIFF
--- a/protocol-designer/src/pages/Onboarding/SelectBasics.tsx
+++ b/protocol-designer/src/pages/Onboarding/SelectBasics.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useSelector } from 'react-redux'
 
 import {
   ALIGN_CENTER,
@@ -26,6 +27,8 @@ import {
 } from '@opentrons/shared-data'
 import { uuid } from '@opentrons/step-generation'
 
+import { getEnableFork } from '/protocol-designer/feature-flags/selectors'
+
 import { HandleEnter, LINK_BUTTON_STYLE } from '../../components/atoms'
 import { BasicsButtons } from '../../components/molecules'
 import { PipetteInfoItem, SelectPipetteModal } from '../../components/organisms'
@@ -48,6 +51,8 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
   const [pipetteType, setPipetteType] = useState<PipetteType | null>(null)
   const ref = useRef<HTMLDivElement | null>(null)
 
+  const enableFork = useSelector(getEnableFork)
+
   const fields = watch('fields')
   const pipettesByMount = watch('pipettesByMount')
   const fixtures = watch('fixtures')
@@ -56,7 +61,11 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
   const hasThermocycer = watch('hasThermocycler')
   const hasWasteChute = watch('hasWasteChute')
 
-  const robotType = fields?.robotType
+  const formRobotType = fields?.robotType
+  let robotType = formRobotType
+  if (enableFork) {
+    robotType = FLEX_ROBOT_TYPE
+  }
   const has96Channel =
     pipettesByMount.left.pipetteName != null &&
     FLEX_96_CHANNEL_PIPETTES.includes(pipettesByMount.left.pipetteName)
@@ -144,6 +153,27 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
       cutoutFixtureId: 'fixedTrashSlot',
     },
   }
+
+  const handleSelectFlexRobot = (): void => {
+    setValue('fields.robotType', FLEX_ROBOT_TYPE)
+    resetPipettes()
+    setValue('hasGripper', null)
+    setValue('hasThermocycler', null)
+    setValue('hasWasteChute', null)
+    setValue('modules', {})
+    setValue('fixtures', flexTrashFixture)
+  }
+
+  useEffect(
+    () => {
+      if (enableFork && formRobotType !== FLEX_ROBOT_TYPE) {
+        handleSelectFlexRobot()
+      }
+    },
+    // TODO: Remove this effect with OT_PD_ENABLE_FORK.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [enableFork, formRobotType]
+  )
 
   const handlSelectWasteChute = (value: boolean): void => {
     if (value) {
@@ -257,36 +287,33 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
             proceed(1)
           }}
         >
-          <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing12}>
-            <StyledText desktopStyle="headingSmallBold">
-              {t('robot_type')}
-            </StyledText>
-            <Flex gridGap={SPACING.spacing4} flexWrap={WRAP}>
-              <RadioButton
-                onChange={() => {
-                  setValue('fields.robotType', FLEX_ROBOT_TYPE)
-                  resetPipettes()
-                  setValue('modules', {})
-                  setValue('fixtures', flexTrashFixture)
-                }}
-                buttonLabel={t('shared:opentrons_flex')}
-                buttonValue={FLEX_ROBOT_TYPE}
-                isSelected={robotType === FLEX_ROBOT_TYPE}
-              />
-              <RadioButton
-                onChange={() => {
-                  setValue('fields.robotType', OT2_ROBOT_TYPE)
-                  resetPipettes()
-                  setValue('hasGripper', false)
-                  setValue('modules', {})
-                  setValue('fixtures', ot2TrashFixture)
-                }}
-                buttonLabel={t('shared:ot2')}
-                buttonValue={OT2_ROBOT_TYPE}
-                isSelected={robotType === OT2_ROBOT_TYPE}
-              />
+          {!enableFork && (
+            <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing12}>
+              <StyledText desktopStyle="headingSmallBold">
+                {t('robot_type')}
+              </StyledText>
+              <Flex gridGap={SPACING.spacing4} flexWrap={WRAP}>
+                <RadioButton
+                  onChange={handleSelectFlexRobot}
+                  buttonLabel={t('shared:opentrons_flex')}
+                  buttonValue={FLEX_ROBOT_TYPE}
+                  isSelected={robotType === FLEX_ROBOT_TYPE}
+                />
+                <RadioButton
+                  onChange={() => {
+                    setValue('fields.robotType', OT2_ROBOT_TYPE)
+                    resetPipettes()
+                    setValue('hasGripper', false)
+                    setValue('modules', {})
+                    setValue('fixtures', ot2TrashFixture)
+                  }}
+                  buttonLabel={t('shared:ot2')}
+                  buttonValue={OT2_ROBOT_TYPE}
+                  isSelected={robotType === OT2_ROBOT_TYPE}
+                />
+              </Flex>
             </Flex>
-          </Flex>
+          )}
           {robotType != null ? (
             <>
               <Flex

--- a/protocol-designer/src/pages/Onboarding/__tests__/SelectBasics.test.tsx
+++ b/protocol-designer/src/pages/Onboarding/__tests__/SelectBasics.test.tsx
@@ -17,6 +17,7 @@ import { getTiprackOptions } from '../utils'
 import type { ComponentProps } from 'react'
 import type { NavigateFunction } from 'react-router-dom'
 import type { WizardFormState } from '/protocol-designer/components/organisms'
+import type * as FeatureFlagSelectors from '/protocol-designer/feature-flags/selectors'
 import type { BaseState } from '/protocol-designer/types'
 import type { WizardTileProps } from '../types'
 
@@ -24,9 +25,7 @@ vi.mock('/protocol-designer/labware-defs/selectors')
 vi.mock('/protocol-designer/components/organisms')
 vi.mock('/protocol-designer/labware-defs/actions')
 vi.mock('/protocol-designer/feature-flags/selectors', async importOriginal => {
-  const actual = await importOriginal<
-    typeof import('/protocol-designer/feature-flags/selectors')
-  >()
+  const actual = await importOriginal<typeof FeatureFlagSelectors>()
 
   return {
     ...actual,

--- a/protocol-designer/src/pages/Onboarding/__tests__/SelectBasics.test.tsx
+++ b/protocol-designer/src/pages/Onboarding/__tests__/SelectBasics.test.tsx
@@ -1,10 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
 
 import { fireEvent, screen } from '@testing-library/react'
 
-import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
+import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { renderWithProviders } from '/protocol-designer/__testing-utils__'
 import { i18n } from '/protocol-designer/assets/localization'
@@ -17,11 +17,23 @@ import { getTiprackOptions } from '../utils'
 import type { ComponentProps } from 'react'
 import type { NavigateFunction } from 'react-router-dom'
 import type { WizardFormState } from '/protocol-designer/components/organisms'
+import type { BaseState } from '/protocol-designer/types'
 import type { WizardTileProps } from '../types'
 
 vi.mock('/protocol-designer/labware-defs/selectors')
 vi.mock('/protocol-designer/components/organisms')
 vi.mock('/protocol-designer/labware-defs/actions')
+vi.mock('/protocol-designer/feature-flags/selectors', async importOriginal => {
+  const actual = await importOriginal<
+    typeof import('/protocol-designer/feature-flags/selectors')
+  >()
+
+  return {
+    ...actual,
+    getEnableFork: (state: BaseState) =>
+      state.featureFlags.flags.OT_PD_ENABLE_FORK ?? false,
+  }
+})
 vi.mock('../utils')
 const mockLocation = vi.fn()
 window.HTMLElement.prototype.scrollIntoView = vi.fn()
@@ -34,9 +46,25 @@ vi.mock('react-router-dom', async importOriginal => {
   }
 })
 
-const render = (props: ComponentProps<typeof SelectBasics>) => {
+interface RenderOptions {
+  enableFork?: boolean
+}
+
+const render = (
+  props: ComponentProps<typeof SelectBasics>,
+  options: RenderOptions = {}
+) => {
+  const initialState = {
+    featureFlags: {
+      flags: {
+        OT_PD_ENABLE_FORK: options.enableFork ?? false,
+      },
+    },
+  } as Partial<BaseState> as BaseState
+
   return renderWithProviders(<SelectBasics {...props} />, {
     i18nInstance: i18n,
+    initialState,
   })[0]
 }
 
@@ -61,10 +89,21 @@ const values = {
   hasWasteChute: false,
 } as WizardFormState
 
+const makeWatchMock = (
+  formValues: WizardFormState
+): WizardTileProps['watch'] => {
+  return vi.fn((name?: keyof WizardFormState) => {
+    if (name == null) {
+      return formValues
+    }
+    return formValues[name]
+  }) as unknown as WizardTileProps['watch']
+}
+
 const mockWizardTileProps: Partial<WizardTileProps> = {
   proceed: vi.fn(),
   setValue: vi.fn(),
-  watch: vi.fn((name: keyof typeof values) => values[name]) as any,
+  watch: makeWatchMock(values),
 }
 
 describe('SelectBasics', () => {
@@ -83,6 +122,10 @@ describe('SelectBasics', () => {
       'opentrons/opentrons_flex_96_tiprack_200ul/1': '200µL Flex tipracks',
       'opentrons/opentrons_flex_96_tiprack_1000ul/1': '1000µL Flex tipracks',
     })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
   })
 
   it('renders all the text and buttons for selecting the basics', () => {
@@ -124,5 +167,39 @@ describe('SelectBasics', () => {
 
     //  confirm
     screen.getByRole('button', { name: 'Confirm' })
+  })
+
+  it('hides the robot type question and keeps Flex options when fork is enabled', () => {
+    const forkValues: WizardFormState = {
+      ...values,
+      fields: {
+        ...values.fields,
+        robotType: OT2_ROBOT_TYPE,
+      },
+    }
+    props = {
+      ...props,
+      watch: makeWatchMock(forkValues),
+    }
+
+    render(props, { enableFork: true })
+
+    expect(
+      screen.queryByText('What kind of robot do you have?')
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('label', { name: 'Opentrons OT-2' })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('label', { name: 'Opentrons Flex' })
+    ).not.toBeInTheDocument()
+    screen.getByText('Your pipettes')
+    screen.getByText(
+      'Do you want to move labware automatically with the gripper?'
+    )
+    expect(props.setValue).toHaveBeenCalledWith(
+      'fields.robotType',
+      FLEX_ROBOT_TYPE
+    )
   })
 })


### PR DESCRIPTION


# Overview
hide items that are related to OT-2 with enableFork flag

SelectOT2Modules component will be removed when we are ready for removing the ff.

design
https://www.figma.com/design/tNK1EODJD5NB8l0W64NIaT/Feature--Forking-the-OT-2?node-id=10763-3349&m=dev


https://github.com/user-attachments/assets/436643a4-3ea1-48a3-bf36-e8c7ba341b1d


close EXEC-2623


## Test Plan and Hands on Testing
- turn on enable fork
- select `Create a Flex protocol`
and the rest of onboarding flow shows Flex steps

## Changelog
- add `enableFork` to SelectBasics
- update tests with `enableFork`

## Review requests

## Risk assessment
low