### PR TITLE
feat(server-utils,auth-server): Allow users to get their own info

### DIFF
--- a/auth-server/auth_server/users/models.py
+++ b/auth-server/auth_server/users/models.py
@@ -29,12 +29,13 @@ ACCOUNT_TYPE_TO_SCOPES: dict[AccountType, set[Scope]] = {
         # todo(mm, 2026-03-17): Updates should be togglable to admin-only by an auth setting.
         Scope.UPDATES_WRITE,
         # todo(mm, 2026-03-17): Protocol uploads should be togglable to admin-only by an auth setting.
+        Scope.USERS_READ_SELF,
         Scope.PROTOCOLS_WRITE,
     },
     # Auditors should have read-only access to everything. Our read-only endpoints are
     # mostly accessible without authentication, but there are some exceptions. This
     # just needs to have the scopes to cover those exceptions.
-    AccountType.AUDITOR: {Scope.USERS_READ},
+    AccountType.AUDITOR: {Scope.USERS_READ_OTHERS},
 }
 
 

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -2,11 +2,11 @@ from typing import Annotated
 
 import fastapi
 
-from server_utils.auth.resource_server.authorization_checker import AuthorizedResult
+from server_utils.auth.resource_server.authorization_checker import (
+    AuthorizationNotRequiredResult,
+)
 from server_utils.auth.resource_server.fastapi import (
-    AuthorizationError,
-    RequestAuthorization,
-    get_authorization,
+    RequireScopesResult,
     require_scopes,
 )
 from server_utils.auth.scopes import Scope
@@ -81,35 +81,15 @@ async def post_users(
         fastapi.status.HTTP_200_OK: {"model": SimpleBody[UserResponse]},
         fastapi.status.HTTP_404_NOT_FOUND: {"userNotFound": None},
     },
+    dependencies=[fastapi.Depends(require_scopes(Scope.USERS_READ_OTHERS))],
 )
 async def get_user(
     userName: str,
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)
     ],
-    request_authorization: Annotated[
-        RequestAuthorization,
-        fastapi.Depends(
-            get_authorization(
-                # OpenAPI doesn't have a machine-readable way to describe how
-                # these scopes work conditionally, so we'll just list them all.
-                scopes_for_openapi={Scope.USERS_READ_SELF, Scope.USERS_READ_OTHERS}
-            )
-        ),
-    ],
 ) -> PydanticResponse[SimpleBody[UserResponse]]:
     """Get a user by its unique identifier."""
-    token, authorization_checker = request_authorization
-    authorized_as_username = await authorization_checker.get_username(token)
-    required_scopes = (
-        {Scope.USERS_READ_SELF}
-        if userName == authorized_as_username
-        else {Scope.USERS_READ_OTHERS}
-    )
-    authorization_result = await authorization_checker.check(token, required_scopes)
-    if not isinstance(authorization_result, AuthorizedResult):
-        raise AuthorizationError(authorization_result, required_scopes)
-
     try:
         user = user_data_manager.get_user(userName)
     except UserNotFoundError:
@@ -202,4 +182,40 @@ async def update_user(
     return await PydanticResponse.create(
         status_code=fastapi.status.HTTP_200_OK,
         content=SimpleBody(data=updated_user),
+    )
+
+
+@PydanticResponse.wrap_route(
+    router.get,
+    path="/auth/users/self",
+    summary="Get the currently logged-in user",
+    description=(
+        'The "currently logged-in user" is determined from the OAuth 2 authorization'
+        " token that you attach to your request to this endpoint."
+        " See the `/auth/oauth2` endpoints."
+    ),
+    responses={fastapi.status.HTTP_401_UNAUTHORIZED: {}},
+)
+async def get_self(  # noqa: D103
+    authorization_details: Annotated[
+        RequireScopesResult, fastapi.Depends(require_scopes(Scope.USERS_READ_SELF))
+    ],
+    user_data_manager: Annotated[
+        UserDataManager, fastapi.Depends(get_user_data_manager)
+    ],
+) -> PydanticResponse[SimpleBody[UserResponse]]:
+    if isinstance(authorization_details, AuthorizationNotRequiredResult):
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_401_UNAUTHORIZED,
+            detail="This endpoint needs an access token to determine the current user.",
+        )
+
+    # Note: No try/except for UserNotFoundError. If the user passed `require_scopes()`,
+    # but we can't find them here, then that's some kind of server bug and we want to
+    # let it propagate with HTTP error code 500.
+    user = user_data_manager.get_user(authorization_details.username)
+
+    return await PydanticResponse.create(
+        status_code=fastapi.status.HTTP_200_OK,
+        content=SimpleBody(data=user),
     )

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -79,7 +79,7 @@ async def post_users(
         fastapi.status.HTTP_200_OK: {"model": SimpleBody[UserResponse]},
         fastapi.status.HTTP_404_NOT_FOUND: {"userNotFound": None},
     },
-    dependencies=[fastapi.Depends(require_scopes(Scope.USERS_READ))],
+    dependencies=[fastapi.Depends(require_scopes(Scope.USERS_READ_OTHERS))],
 )
 async def get_user(
     request: fastapi.Request,

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -2,7 +2,13 @@ from typing import Annotated
 
 import fastapi
 
-from server_utils.auth.resource_server.fastapi import require_scopes
+from server_utils.auth.resource_server.authorization_checker import AuthorizedResult
+from server_utils.auth.resource_server.fastapi import (
+    AuthorizationError,
+    RequestAuthorization,
+    get_authorization,
+    require_scopes,
+)
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.models.json_api import (
     PydanticResponse,
@@ -79,7 +85,6 @@ async def post_users(
         fastapi.status.HTTP_200_OK: {"model": SimpleBody[UserResponse]},
         fastapi.status.HTTP_404_NOT_FOUND: {"userNotFound": None},
     },
-    dependencies=[fastapi.Depends(require_scopes(Scope.USERS_READ_OTHERS))],
 )
 async def get_user(
     request: fastapi.Request,
@@ -88,8 +93,29 @@ async def get_user(
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)
     ],
+    request_authorization: Annotated[
+        RequestAuthorization,
+        fastapi.Depends(
+            get_authorization(
+                # OpenAPI doesn't have a machine-readable way to describe how
+                # these scopes work conditionally, so we'll just list them all.
+                scopes_for_openapi={Scope.USERS_READ_SELF, Scope.USERS_READ_OTHERS}
+            )
+        ),
+    ],
 ) -> PydanticResponse[SimpleBody[UserResponse]]:
     """Get a user by its unique identifier."""
+    token, authorization_checker = request_authorization
+    authorized_as_username = await authorization_checker.get_username(token)
+    required_scopes = (
+        {Scope.USERS_READ_SELF}
+        if userName == authorized_as_username
+        else {Scope.USERS_READ_OTHERS}
+    )
+    authorization_result = await authorization_checker.check(token, required_scopes)
+    if not isinstance(authorization_result, AuthorizedResult):
+        raise AuthorizationError(authorization_result, required_scopes)
+
     try:
         user = user_data_manager.get_user(userName)
     except UserNotFoundError:

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -78,9 +78,9 @@ async def post_users(
 
 @PydanticResponse.wrap_route(
     router.get,
-    path="/auth/users/{userName}",
-    summary="Get a user information",
-    description="Get a specific user by its unique identifier.",
+    path="/auth/users/byUsername/{userName}",
+    summary="Get a user",
+    description="Get a specific user, identified by their unique username.",
     responses={
         fastapi.status.HTTP_200_OK: {"model": SimpleBody[UserResponse]},
         fastapi.status.HTTP_404_NOT_FOUND: {"userNotFound": None},
@@ -131,9 +131,9 @@ async def get_user(
 
 @PydanticResponse.wrap_route(
     router.delete,
-    path="/auth/users/{userName}",
+    path="/auth/users/byUsername/{userName}",
     summary="Delete a user",
-    description="Delete a specific user by its unique identifier.",
+    description="Delete a specific user, identified by their unique username.",
     responses={
         fastapi.status.HTTP_204_NO_CONTENT: {"description": "User deleted"},
     },
@@ -163,9 +163,9 @@ async def delete_user(
 
 @PydanticResponse.wrap_route(
     router.patch,
-    path="/auth/users/{userName}",
+    path="/auth/users/byUsername/{userName}",
     summary="Update a user",
-    description="Update a specific user by its unique identifier.",
+    description="Update a specific user, identified by their unique username.",
     responses={
         fastapi.status.HTTP_200_OK: {"model": SimpleBody[UserResponse]},
     },

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -17,8 +17,6 @@ from server_utils.fastapi_utils.models.json_api import (
     SimpleEmptyBody,
 )
 
-from auth_server.oauth2.backend import Backend
-from auth_server.oauth2.fastapi_dependencies import get_oauth2_backend
 from auth_server.users.dependencies import get_user_data_manager
 from auth_server.users.models import UpdateUser, UserCreate, UserResponse
 from auth_server.users.user_data_manager import (
@@ -42,9 +40,7 @@ router = fastapi.APIRouter()
     dependencies=[fastapi.Depends(require_scopes(Scope.USERS_WRITE))],
 )
 async def post_users(
-    request: fastapi.Request,
     request_body: RequestModel[UserCreate],
-    oauth2_backend: Annotated[Backend, fastapi.Depends(get_oauth2_backend)],
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)
     ],
@@ -87,9 +83,7 @@ async def post_users(
     },
 )
 async def get_user(
-    request: fastapi.Request,
     userName: str,
-    oauth2_backend: Annotated[Backend, fastapi.Depends(get_oauth2_backend)],
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)
     ],
@@ -140,9 +134,7 @@ async def get_user(
     dependencies=[fastapi.Depends(require_scopes(Scope.USERS_WRITE))],
 )
 async def delete_user(
-    request: fastapi.Request,
     userName: str,
-    oauth2_backend: Annotated[Backend, fastapi.Depends(get_oauth2_backend)],
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)
     ],
@@ -172,10 +164,8 @@ async def delete_user(
     dependencies=[fastapi.Depends(require_scopes(Scope.USERS_WRITE))],
 )
 async def update_user(
-    request: fastapi.Request,
     request_body: RequestModel[UpdateUser],
     userName: str,
-    oauth2_backend: Annotated[Backend, fastapi.Depends(get_oauth2_backend)],
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)
     ],

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -190,8 +190,8 @@ async def update_user(
     path="/auth/users/self",
     summary="Get the currently logged-in user",
     description=(
-        'The "currently logged-in user" is determined from the OAuth 2 authorization'
-        " token that you attach to your request to this endpoint."
+        'The "currently logged-in user" is determined from the OAuth 2 access token'
+        " that you attach to your request to this endpoint."
         " See the `/auth/oauth2` endpoints."
     ),
     responses={fastapi.status.HTTP_401_UNAUTHORIZED: {}},

--- a/auth-server/tests/integration/test_failed_login_lockout.tavern.yaml
+++ b/auth-server/tests/integration/test_failed_login_lockout.tavern.yaml
@@ -120,7 +120,7 @@ stages:
   - name: Use admin credentials to see the lockout
     request:
       method: GET
-      url: '{run_server.base_url}/auth/users/test_user'
+      url: '{run_server.base_url}/auth/users/byUsername/test_user'
       headers:
         Authorization: '{admin_access_token}'
     response:
@@ -134,7 +134,7 @@ stages:
   - name: Use admin credentials to clear the lockout
     request:
       method: PATCH
-      url: '{run_server.base_url}/auth/users/test_user'
+      url: '{run_server.base_url}/auth/users/byUsername/test_user'
       headers:
         Authorization: '{admin_access_token}'
       json:

--- a/auth-server/tests/integration/test_protected_resource_access.tavern.yaml
+++ b/auth-server/tests/integration/test_protected_resource_access.tavern.yaml
@@ -52,7 +52,7 @@ stages:
         grant_type: password
         username: test_admin
         password: test_admin_password
-        scope: users.read # Omit users.write.
+        scope: users.read.others # Omit users.write.
     response:
       status_code: 200
       json:
@@ -60,7 +60,7 @@ stages:
         refresh_token: !anystr
         expires_in: !anyint
         token_type: Bearer
-        scope: users.read
+        scope: users.read.others
       save:
         json:
           access_token: access_token

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -179,7 +179,7 @@ stages:
       status_code: 404
 
 ---
-test_name: Permissions for a user to read their own info, vs. the info of other users
+test_name: Letting users read their own info
 
 marks:
   - usefixtures:
@@ -218,6 +218,9 @@ stages:
         Authorization: '{admin_access_token}'
     response:
       status_code: 201
+      save:
+        json:
+          regular_user_1_data: data
 
   - name: Create regular user 2
     request:
@@ -233,6 +236,9 @@ stages:
         Authorization: '{admin_access_token}'
     response:
       status_code: 201
+      save:
+        json:
+          regular_user_2_data: data
 
   - name: Log in as regular user 1 and get an access token
     request:
@@ -253,36 +259,50 @@ stages:
         json:
           regular_user_1_access_token: access_token
 
+  - name: Log in as regular user 2 and get an access token
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: regular_user_2
+        password: securepassword123
+    response:
+      status_code: 200
+      json:
+        access_token: !anystr
+      strict:
+        - json:off
+      save:
+        json:
+          regular_user_2_access_token: access_token
+
   - name: Unauthorized requests should be rejected
     request:
       method: GET
-      url: '{run_server.base_url}/auth/users/byUsername/regular_user_1'
+      url: '{run_server.base_url}/auth/users/self'
     response:
       status_code: 401
 
-  - name: A regular user should be allowed to fetch their own info
+  - name: Regular user 1 should be able to get their own info
     request:
       method: GET
-      url: '{run_server.base_url}/auth/users/byUsername/regular_user_1'
+      url: '{run_server.base_url}/auth/users/self'
       headers:
         authorization: 'Bearer {regular_user_1_access_token}'
     response:
       status_code: 200
+      json:
+        data: !force_original_structure '{regular_user_1_data}'
 
-  - name: A regular user should not be allowed to fetch other users' info
+  - name: Regular user 2 should be able to get their own info
     request:
       method: GET
-      url: '{run_server.base_url}/auth/users/byUsername/regular_user_2'
+      url: '{run_server.base_url}/auth/users/self'
       headers:
-        authorization: 'Bearer {regular_user_1_access_token}'
-    response:
-      status_code: 403
-
-  - name: An admin should be allowed to fetch other users' info
-    request:
-      method: GET
-      url: '{run_server.base_url}/auth/users/byUsername/regular_user_2'
-      headers:
-        Authorization: '{admin_access_token}'
+        authorization: 'Bearer {regular_user_2_access_token}'
     response:
       status_code: 200
+      json:
+        data: !force_original_structure '{regular_user_2_data}'

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -105,7 +105,7 @@ stages:
           userName: test_new_user_updated
           locked: false
           scopes: !force_original_structure '{admin_scopes_list}'
-          resetPassword: false  
+          resetPassword: false
 
   - name: Update the reset password flag
     request:
@@ -177,3 +177,112 @@ stages:
         Authorization: '{admin_access_token}'
     response:
       status_code: 404
+
+---
+test_name: Permissions for a user to read their own info, vs. the info of other users
+
+marks:
+  - usefixtures:
+      - run_server
+      - admin_access_token
+
+stages:
+  - name: Enable access control mode
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings/accessControlEnabled'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          accessControlEnabled: true
+    response:
+      status_code: 200
+      json:
+        data:
+          accessControlEnabled: true
+      strict:
+        - json:off
+
+  - name: Create regular user 1
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/users'
+      json:
+        data:
+          userName: regular_user_1
+          password: securepassword123
+          fullName: Regular User 1
+          accountType: user
+      headers:
+        Authorization: '{admin_access_token}'
+    response:
+      status_code: 201
+
+  - name: Create regular user 2
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/users'
+      json:
+        data:
+          userName: regular_user_2
+          password: securepassword123
+          fullName: Regular User 2
+          accountType: user
+      headers:
+        Authorization: '{admin_access_token}'
+    response:
+      status_code: 201
+
+  - name: Log in as regular user 1 and get an access token
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: regular_user_1
+        password: securepassword123
+    response:
+      status_code: 200
+      json:
+        access_token: !anystr
+      strict:
+        - json:off
+      save:
+        json:
+          regular_user_1_access_token: access_token
+
+  - name: Unauthorized requests should be rejected
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/regular_user_1'
+    response:
+      status_code: 401
+
+  - name: A regular user should be allowed to fetch their own info
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/regular_user_1'
+      headers:
+        authorization: 'Bearer {regular_user_1_access_token}'
+    response:
+      status_code: 200
+
+  - name: A regular user should not be allowed to fetch other users' info
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/regular_user_2'
+      headers:
+        authorization: 'Bearer {regular_user_1_access_token}'
+    response:
+      status_code: 403
+
+  - name: An admin should be allowed to fetch other users' info
+    request:
+      method: GET
+      url: '{run_server.base_url}/auth/users/regular_user_2'
+      headers:
+        Authorization: '{admin_access_token}'
+    response:
+      status_code: 200

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -51,7 +51,7 @@ stages:
   - name: Get a user information
     request:
       method: GET
-      url: '{run_server.base_url}/auth/users/test_new_user'
+      url: '{run_server.base_url}/auth/users/byUsername/test_new_user'
       headers:
         Authorization: '{admin_access_token}'
     response:
@@ -68,7 +68,7 @@ stages:
   - name: Update the user
     request:
       method: PATCH
-      url: '{run_server.base_url}/auth/users/test_new_user'
+      url: '{run_server.base_url}/auth/users/byUsername/test_new_user'
       json:
         data:
           fullName: Test New User Updated
@@ -89,7 +89,7 @@ stages:
   - name: Update the username and password
     request:
       method: PATCH
-      url: '{run_server.base_url}/auth/users/test_new_user'
+      url: '{run_server.base_url}/auth/users/byUsername/test_new_user'
       json:
         data:
           userName: test_new_user_updated
@@ -110,7 +110,7 @@ stages:
   - name: Update the reset password flag
     request:
       method: PATCH
-      url: '{run_server.base_url}/auth/users/test_new_user_updated'
+      url: '{run_server.base_url}/auth/users/byUsername/test_new_user_updated'
       json:
         data:
           resetPassword: true
@@ -130,7 +130,7 @@ stages:
   - name: Get the user information
     request:
       method: GET
-      url: '{run_server.base_url}/auth/users/test_new_user_updated'
+      url: '{run_server.base_url}/auth/users/byUsername/test_new_user_updated'
       headers:
         Authorization: '{admin_access_token}'
     response:
@@ -163,7 +163,7 @@ stages:
   - name: Delete the user
     request:
       method: DELETE
-      url: '{run_server.base_url}/auth/users/test_new_user_updated'
+      url: '{run_server.base_url}/auth/users/byUsername/test_new_user_updated'
       headers:
         Authorization: '{admin_access_token}'
     response:
@@ -172,7 +172,7 @@ stages:
   - name: Try to get the deleted user
     request:
       method: GET
-      url: '{run_server.base_url}/auth/users/test_new_user_updated'
+      url: '{run_server.base_url}/auth/users/byUsername/test_new_user_updated'
       headers:
         Authorization: '{admin_access_token}'
     response:
@@ -256,14 +256,14 @@ stages:
   - name: Unauthorized requests should be rejected
     request:
       method: GET
-      url: '{run_server.base_url}/auth/users/regular_user_1'
+      url: '{run_server.base_url}/auth/users/byUsername/regular_user_1'
     response:
       status_code: 401
 
   - name: A regular user should be allowed to fetch their own info
     request:
       method: GET
-      url: '{run_server.base_url}/auth/users/regular_user_1'
+      url: '{run_server.base_url}/auth/users/byUsername/regular_user_1'
       headers:
         authorization: 'Bearer {regular_user_1_access_token}'
     response:
@@ -272,7 +272,7 @@ stages:
   - name: A regular user should not be allowed to fetch other users' info
     request:
       method: GET
-      url: '{run_server.base_url}/auth/users/regular_user_2'
+      url: '{run_server.base_url}/auth/users/byUsername/regular_user_2'
       headers:
         authorization: 'Bearer {regular_user_1_access_token}'
     response:
@@ -281,7 +281,7 @@ stages:
   - name: An admin should be allowed to fetch other users' info
     request:
       method: GET
-      url: '{run_server.base_url}/auth/users/regular_user_2'
+      url: '{run_server.base_url}/auth/users/byUsername/regular_user_2'
       headers:
         Authorization: '{admin_access_token}'
     response:

--- a/server-utils/server_utils/auth/resource_server/auth_server.py
+++ b/server-utils/server_utils/auth/resource_server/auth_server.py
@@ -131,6 +131,7 @@ class TokenIntrospectionResponse(_StrictBaseModel):
 
     active: bool
     scope: str = ""
+    username: str | None = None
 
 
 class TokenIntrospectionRequestFormData(typing.TypedDict):

--- a/server-utils/server_utils/auth/resource_server/authorization_checker.py
+++ b/server-utils/server_utils/auth/resource_server/authorization_checker.py
@@ -29,20 +29,6 @@ class AuthorizationChecker(ABC):
         """
         pass
 
-    @abstractmethod
-    async def get_username(self, token: str | None) -> str | None:
-        """Return the user who issued a request, if known.
-
-        This is intended for the rare cases where an endpoint needs to apply different
-        access control depending on who issued the request. Most endpoints should not
-        do this--they should pass a hard-coded list of scopes to `check()` instead.
-
-        Params:
-            token: The OAuth 2 access token carried by the request,
-                or `None` if it didn't carry such a token.
-        """
-        pass
-
 
 class AlwaysAllowedAuthorizationChecker(AuthorizationChecker):
     """An `AuthorizationChecker` that always allows access."""
@@ -50,12 +36,7 @@ class AlwaysAllowedAuthorizationChecker(AuthorizationChecker):
     @override
     async def check(self, token: str | None, required_scopes: set[Scope]) -> Result:
         """See base class for documentation."""
-        return AuthorizedResult()
-
-    @override
-    async def get_username(self, token: str | None) -> str | None:
-        """See base class for documentation."""
-        return None
+        return AuthorizationNotRequiredResult()
 
 
 class AuthServerAuthorizationChecker(AuthorizationChecker):
@@ -76,36 +57,43 @@ class AuthServerAuthorizationChecker(AuthorizationChecker):
             if access_control_enabled:
                 return MissingTokenResult()
             else:
-                return AuthorizedResult()
+                return AuthorizationNotRequiredResult()
 
         else:
             token_info = await self._client.introspect_token(token)
-            provided_scopes = parse_scopes(token_info.scope)
 
+            provided_scopes = parse_scopes(token_info.scope)
             missing_scopes = required_scopes - provided_scopes
 
             if not token_info.active:
                 return NotAnActiveTokenResult()
             elif missing_scopes:
                 return InsufficientScopeResult(provided_scopes)
+            elif token_info.username is None:
+                # This should never happen in practice. Although token_info.username is
+                # optional according to the OAuth 2 specs, our implementation in
+                # auth-server should always return it.
+                raise RuntimeError(
+                    "Username not present in token introspection response."
+                    " This is a bug in auth-server."
+                )
             else:
-                return AuthorizedResult()
+                return AuthorizedResult(username=token_info.username)
 
-    @override
-    async def get_username(self, token: str | None) -> str | None:
-        """See base class for documentation."""
-        if token is None:
-            return None
-        else:
-            token_info = await self._client.introspect_token(token)
-            return token_info.username
+
+@dataclass
+class AuthorizationNotRequiredResult:
+    """Authorization was neither provided nor required--access control mode is disabled."""
+
+    pass
 
 
 @dataclass
 class AuthorizedResult:
-    """The request is authorized, or no authorization is required."""
+    """The request is authorized with a valid access token."""
 
-    pass
+    username: str
+    """The user who issued the request."""
 
 
 @dataclass
@@ -131,7 +119,8 @@ class NotAnActiveTokenResult:
 
 
 Result: TypeAlias = (
-    AuthorizedResult
+    AuthorizationNotRequiredResult
+    | AuthorizedResult
     | InsufficientScopeResult
     | MissingTokenResult
     | NotAnActiveTokenResult

--- a/server-utils/server_utils/auth/resource_server/authorization_checker.py
+++ b/server-utils/server_utils/auth/resource_server/authorization_checker.py
@@ -1,4 +1,4 @@
-"""Logic to check whether an HTTP client is authorized to do something.
+"""Interfaces that endpoints can use to check whether an HTTP client is authorized to do something.
 
 This module should be framework-agnostic, not tied to FastAPI or whatever.
 """
@@ -29,13 +29,33 @@ class AuthorizationChecker(ABC):
         """
         pass
 
+    @abstractmethod
+    async def get_username(self, token: str | None) -> str | None:
+        """Return the user who issued a request, if known.
+
+        This is intended for the rare cases where an endpoint needs to apply different
+        access control depending on who issued the request. Most endpoints should not
+        do this--they should pass a hard-coded list of scopes to `check()` instead.
+
+        Params:
+            token: The OAuth 2 access token carried by the request,
+                or `None` if it didn't carry such a token.
+        """
+        pass
+
 
 class AlwaysAllowedAuthorizationChecker(AuthorizationChecker):
     """An `AuthorizationChecker` that always allows access."""
 
     @override
     async def check(self, token: str | None, required_scopes: set[Scope]) -> Result:
+        """See base class for documentation."""
         return AuthorizedResult()
+
+    @override
+    async def get_username(self, token: str | None) -> str | None:
+        """See base class for documentation."""
+        return None
 
 
 class AuthServerAuthorizationChecker(AuthorizationChecker):
@@ -46,6 +66,7 @@ class AuthServerAuthorizationChecker(AuthorizationChecker):
 
     @override
     async def check(self, token: str | None, required_scopes: set[Scope]) -> Result:
+        """See base class for documentation."""
         if token is None:
             # The client is trying to access a protected resource without providing a token.
             # We allow this if and only if access control is disabled.
@@ -69,6 +90,15 @@ class AuthServerAuthorizationChecker(AuthorizationChecker):
                 return InsufficientScopeResult(provided_scopes)
             else:
                 return AuthorizedResult()
+
+    @override
+    async def get_username(self, token: str | None) -> str | None:
+        """See base class for documentation."""
+        if token is None:
+            return None
+        else:
+            token_info = await self._client.introspect_token(token)
+            return token_info.username
 
 
 @dataclass

--- a/server-utils/server_utils/auth/resource_server/fastapi.py
+++ b/server-utils/server_utils/auth/resource_server/fastapi.py
@@ -1,7 +1,7 @@
 """FastAPI-specific helpers for enforcing authorization."""
 
 # NOTE: Don't do `from __future__ import annotations` in this file.
-# See comments in `get_authorization()`.
+# See comments in `require_scopes()`.
 
 import logging
 from contextlib import asynccontextmanager
@@ -11,7 +11,7 @@ from typing import (
     Awaitable,
     Callable,
     Final,
-    NamedTuple,
+    TypeAlias,
 )
 
 import fastapi
@@ -22,6 +22,7 @@ from .auth_server import TOKEN_ENDPOINT_PATH, LocalHTTPClient
 from .authorization_checker import (
     AlwaysAllowedAuthorizationChecker,
     AuthorizationChecker,
+    AuthorizationNotRequiredResult,
     AuthorizedResult,
     AuthServerAuthorizationChecker,
     InsufficientScopeResult,
@@ -53,24 +54,44 @@ _authorization_checker_accessor = AppStateAccessor[AuthorizationChecker](
 )
 
 
-def require_scopes(*required_scopes: Scope) -> Callable[..., Awaitable[None]]:
-    """The main, high-level way for a FastAPI endpoint to enforce access control.
+RequireScopesResult: TypeAlias = AuthorizationNotRequiredResult | AuthorizedResult
 
-    Use this as a FastAPI dependency, like so:
+
+def require_scopes(
+    *required_scopes: Scope,
+) -> Callable[..., Awaitable[RequireScopesResult]]:
+    """A FastAPI dependency to enforce access control.
+
+    Use like so:
 
     ```
     @router.post(
         "/foo",
         # The client must have READ_FOO and WRITE_FOO permissions.
-        dependencies=[require_scopes(Scope.READ_FOO, Scope.WRITE_FOO)],
+        dependencies=[Depends(require_scopes(Scope.READ_FOO, Scope.WRITE_FOO))],
     )
     def get_foo(...) -> None:
         ...
     ```
 
-    If access control is enabled on this robot, and the client lacks authorization,
-    this rejects the request with an appropriate HTTP error response.
-    The endpoint function will not run.
+    Or, for more advanced cases where you need more authorization details:
+
+    ```
+    @router.post("/foo")
+    def get_foo(
+        # The client must have READ_FOO and WRITE_FOO permissions.
+        authorization_details: Annotated[
+            RequireScopesResult,
+            Depends(require_scopes(Scope.READ_FOO, Scope.WRITE_FOO))
+        ]
+    ) -> None:
+        # Here you can check authorization_details.
+        ...
+    ```
+
+    In either case, this dependency checks to see if the request is authorized for
+    all of the `required_scopes`. If so, it lets your endpoint function run.
+    Otherwise, it rejects the request with an appropriate HTTP error.
 
     This also automatically adds documentation to the OpenAPI document to say
     that the endpoint requires these scopes.
@@ -78,48 +99,6 @@ def require_scopes(*required_scopes: Scope) -> Callable[..., Awaitable[None]]:
     required_scopes_set = set(required_scopes)
 
     async def dependency(
-        request_authorization: Annotated[
-            RequestAuthorization,
-            fastapi.Depends(get_authorization(scopes_for_openapi=required_scopes_set)),
-        ],
-    ) -> None:
-        unvalidated_token, authorization_checker = request_authorization
-        authorization_result = await authorization_checker.check(
-            token=unvalidated_token, required_scopes=required_scopes_set
-        )
-        if isinstance(authorization_result, AuthorizedResult):
-            pass  # The request is authorized, yay.
-        else:
-            raise AuthorizationError(authorization_result, required_scopes_set)
-
-    return dependency
-
-
-class RequestAuthorization(NamedTuple):  # noqa: D101
-    unvalidated_token: str | None
-    """The OAuth 2 access token carried by the request, if any.
-
-    The token has not been validated at this point! It may be forged, expired, etc.
-    Pass it to `authorization_checker` to check.
-    """
-
-    authorization_checker: AuthorizationChecker
-
-
-def get_authorization(
-    *, scopes_for_openapi: set[Scope]
-) -> Callable[..., RequestAuthorization]:
-    """Return lower-level information about how a request was authorized.
-
-    This is for endpoints that need custom authorization logic. Most endpoints do not
-    need this and should use `require_scopes()`, which is higher-level, instead.
-
-    Params:
-        scopes_for_openapi: In the OpenAPI document, the endpoint will be documented
-            as requiring these scopes. This has no effect other than documentation.
-    """
-
-    def dependency(
         # This retrieves the request's bearer token, by depending on `_oauth_2_scheme`;
         # and it adds OpenAPI docs to list which scopes the endpoint requires,
         # by supplying the `scopes` argument.
@@ -133,14 +112,24 @@ def get_authorization(
             str | None,
             fastapi.Security(
                 _oauth_2_scheme,
-                scopes=sorted(scope.api_name for scope in scopes_for_openapi),
+                scopes=sorted(scope.api_name for scope in required_scopes_set),
             ),
         ],
         authorization_checker: Annotated[
             AuthorizationChecker, fastapi.Depends(get_authorization_checker)
         ],
-    ) -> RequestAuthorization:
-        return RequestAuthorization(bearer_token, authorization_checker)
+    ) -> RequireScopesResult:
+        authorization_result = await authorization_checker.check(
+            token=bearer_token, required_scopes=required_scopes_set
+        )
+        if isinstance(
+            authorization_result, (AuthorizationNotRequiredResult, AuthorizedResult)
+        ):
+            # The request is authorized, yay.
+            return authorization_result
+        else:
+            # The request is not authorized.
+            raise AuthorizationError(authorization_result, required_scopes_set)
 
     return dependency
 
@@ -201,10 +190,8 @@ def get_authorization_checker(
 class AuthorizationError(Exception):
     """Raised to signal that an HTTP authorization failure should be returned to the client.
 
-    Most endpoints should not deal with this directly. This is automatically raised by
-    `require_scopes()` and caught by `handle_authorization_error()`. An endpoint should
-    only raise this manually if it's implementing custom authorization logic--see
-    `get_authorization()`.
+    Endpoints should not deal with this directly. Instead, they should use the
+    higher-level `require_scopes()` function.
     """
 
     def __init__(

--- a/server-utils/server_utils/auth/resource_server/fastapi.py
+++ b/server-utils/server_utils/auth/resource_server/fastapi.py
@@ -1,7 +1,7 @@
 """FastAPI-specific helpers for enforcing authorization."""
 
 # NOTE: Don't do `from __future__ import annotations` in this file.
-# See comments in `require_scopes()`.
+# See comments in `get_authorization()`.
 
 import logging
 from contextlib import asynccontextmanager
@@ -11,6 +11,7 @@ from typing import (
     Awaitable,
     Callable,
     Final,
+    NamedTuple,
 )
 
 import fastapi
@@ -53,9 +54,9 @@ _authorization_checker_accessor = AppStateAccessor[AuthorizationChecker](
 
 
 def require_scopes(*required_scopes: Scope) -> Callable[..., Awaitable[None]]:
-    """A FastAPI dependency to make sure the client is authorized with the given scopes.
+    """The main, high-level way for a FastAPI endpoint to enforce access control.
 
-    Usage example:
+    Use this as a FastAPI dependency, like so:
 
     ```
     @router.post(
@@ -67,14 +68,58 @@ def require_scopes(*required_scopes: Scope) -> Callable[..., Awaitable[None]]:
         ...
     ```
 
-    If the client lacks authorization, this will return an HTTP error response,
-    and the endpoint function will not run.
+    If access control is enabled on this robot, and the client lacks authorization,
+    this rejects the request with an appropriate HTTP error response.
+    The endpoint function will not run.
 
-    This also documents the list of required scopes in the OpenAPI spec.
+    This also automatically adds documentation to the OpenAPI document to say
+    that the endpoint requires these scopes.
     """
     required_scopes_set = set(required_scopes)
 
     async def dependency(
+        request_authorization: Annotated[
+            RequestAuthorization,
+            fastapi.Depends(get_authorization(scopes_for_openapi=required_scopes_set)),
+        ],
+    ) -> None:
+        unvalidated_token, authorization_checker = request_authorization
+        authorization_result = await authorization_checker.check(
+            token=unvalidated_token, required_scopes=required_scopes_set
+        )
+        if isinstance(authorization_result, AuthorizedResult):
+            pass  # The request is authorized, yay.
+        else:
+            raise AuthorizationError(authorization_result, required_scopes_set)
+
+    return dependency
+
+
+class RequestAuthorization(NamedTuple):  # noqa: D101
+    unvalidated_token: str | None
+    """The OAuth 2 access token carried by the request, if any.
+
+    The token has not been validated at this point! It may be forged, expired, etc.
+    Pass it to `authorization_checker` to check.
+    """
+
+    authorization_checker: AuthorizationChecker
+
+
+def get_authorization(
+    *, scopes_for_openapi: set[Scope]
+) -> Callable[..., RequestAuthorization]:
+    """Return lower-level information about how a request was authorized.
+
+    This is for endpoints that need custom authorization logic. Most endpoints do not
+    need this and should use `require_scopes()`, which is higher-level, instead.
+
+    Params:
+        scopes_for_openapi: In the OpenAPI document, the endpoint will be documented
+            as requiring these scopes. This has no effect other than documentation.
+    """
+
+    def dependency(
         # This retrieves the request's bearer token, by depending on `_oauth_2_scheme`;
         # and it adds OpenAPI docs to list which scopes the endpoint requires,
         # by supplying the `scopes` argument.
@@ -88,21 +133,14 @@ def require_scopes(*required_scopes: Scope) -> Callable[..., Awaitable[None]]:
             str | None,
             fastapi.Security(
                 _oauth_2_scheme,
-                scopes=sorted(scope.api_name for scope in required_scopes_set),
+                scopes=sorted(scope.api_name for scope in scopes_for_openapi),
             ),
         ],
         authorization_checker: Annotated[
             AuthorizationChecker, fastapi.Depends(get_authorization_checker)
         ],
-    ) -> None:
-        authorization_result = await authorization_checker.check(
-            token=bearer_token, required_scopes=required_scopes_set
-        )
-        if isinstance(authorization_result, AuthorizedResult):
-            # The request is authorized, yay.
-            pass
-        else:
-            raise AuthorizationError(authorization_result, required_scopes_set)
+    ) -> RequestAuthorization:
+        return RequestAuthorization(bearer_token, authorization_checker)
 
     return dependency
 

--- a/server-utils/server_utils/auth/resource_server/fastapi.py
+++ b/server-utils/server_utils/auth/resource_server/fastapi.py
@@ -201,8 +201,10 @@ def get_authorization_checker(
 class AuthorizationError(Exception):
     """Raised to signal that an HTTP authorization failure should be returned to the client.
 
-    Endpoints should not deal with this directly. Instead, they should use the
-    higher-level `require_scopes()` function.
+    Most endpoints should not deal with this directly. This is automatically raised by
+    `require_scopes()` and caught by `handle_authorization_error()`. An endpoint should
+    only raise this manually if it's implementing custom authorization logic--see
+    `get_authorization()`.
     """
 
     def __init__(

--- a/server-utils/server_utils/auth/scopes.py
+++ b/server-utils/server_utils/auth/scopes.py
@@ -69,9 +69,14 @@ class Scope(enum.Enum):
         "Update the robot's software.",
     )
 
-    USERS_READ = (
-        "users.read",
-        "Read users.",
+    USERS_READ_OTHERS = (
+        "users.read.others",
+        "List all users and read their details.",
+    )
+
+    USERS_READ_SELF = (
+        "users.read.self",
+        "Read the details of the currently authenticated user.",
     )
 
     USERS_WRITE = (

--- a/server-utils/tests/auth/resource_server/test_auth_server.py
+++ b/server-utils/tests/auth/resource_server/test_auth_server.py
@@ -148,10 +148,16 @@ async def test_token_introspection(
 
     app_mock.introspect_requests.clear()
 
-    app_mock.introspect_response = {"active": True, "scope": "mama_mia papa_pia"}
+    app_mock.introspect_response = {
+        "active": True,
+        "scope": "mama_mia papa_pia",
+        "username": "test_username",
+    }
     introspect_response = await client.introspect_token("test-token")
     assert introspect_response == TokenIntrospectionResponse(
-        active=True, scope="mama_mia papa_pia"
+        active=True,
+        scope="mama_mia papa_pia",
+        username="test_username",
     )
     assert app_mock.introspect_requests == [
         {"token": "test-token", "client_id": CLIENT_ID}

--- a/server-utils/tests/auth/resource_server/test_authorization_checker.py
+++ b/server-utils/tests/auth/resource_server/test_authorization_checker.py
@@ -9,6 +9,7 @@ from server_utils.auth.resource_server.auth_server import (
 )
 from server_utils.auth.resource_server.authorization_checker import (
     AlwaysAllowedAuthorizationChecker,
+    AuthorizationNotRequiredResult,
     AuthorizedResult,
     AuthServerAuthorizationChecker,
     InsufficientScopeResult,
@@ -23,19 +24,14 @@ class TestAlwaysAllowedAuthorizationChecker:
         subject = AlwaysAllowedAuthorizationChecker()
         assert (
             await subject.check(token=None, required_scopes={Scope.USERS_WRITE})
-            == AuthorizedResult()
+            == AuthorizationNotRequiredResult()
         )
         assert (
             await subject.check(
                 token="token-abc123", required_scopes={Scope.USERS_WRITE}
             )
-            == AuthorizedResult()
+            == AuthorizationNotRequiredResult()
         )
-
-    async def test_get_username(self) -> None:
-        subject = AlwaysAllowedAuthorizationChecker()
-        assert await subject.get_username(None) is None
-        assert await subject.get_username("test-username") is None
 
 
 class TestAuthServerAuthorizationChecker:
@@ -67,7 +63,7 @@ class TestAuthServerAuthorizationChecker:
         )
         assert (
             await subject.check(token=None, required_scopes={Scope.USERS_WRITE})
-            == AuthorizedResult()
+            == AuthorizationNotRequiredResult()
         )
 
     async def test_check_given_a_token(self, mock_client: Client, decoy: Decoy) -> None:
@@ -79,14 +75,12 @@ class TestAuthServerAuthorizationChecker:
             TokenIntrospectionResponse(
                 active=True,
                 scope=serialize_scopes({Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}),
+                username="test-username",
             )
         )
-        assert (
-            await subject.check(
-                "test-token-abc123", {Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}
-            )
-            == AuthorizedResult()
-        )
+        assert await subject.check(
+            "test-token-abc123", {Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}
+        ) == AuthorizedResult(username="test-username")
 
         # Inactive -> do not authorize
         decoy.when(await mock_client.introspect_token("test-token-abc123")).then_return(
@@ -111,22 +105,3 @@ class TestAuthServerAuthorizationChecker:
         assert await subject.check(
             "test-token-abc123", {Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}
         ) == InsufficientScopeResult(provided_scopes={Scope.ROBOT_CONTROL_WRITE})
-
-    async def test_get_username_given_no_token(self, mock_client: Client) -> None:
-        """It should return "no username" if not given a token."""
-        subject = AuthServerAuthorizationChecker(mock_client)
-        assert await subject.get_username(token=None) is None
-
-    async def test_get_username_given_a_token(
-        self, mock_client: Client, decoy: Decoy
-    ) -> None:
-        """It should pass the token to the client and return the username it gets back."""
-        subject = AuthServerAuthorizationChecker(mock_client)
-        decoy.when(await mock_client.introspect_token("test-token-abc123")).then_return(
-            TokenIntrospectionResponse(active=False, username=None)
-        )
-        assert await subject.get_username(token="test-token-abc123") is None
-        decoy.when(await mock_client.introspect_token("test-token-abc123")).then_return(
-            TokenIntrospectionResponse(active=False, username="test-username")
-        )
-        assert await subject.get_username(token="test-token-abc123") == "test-username"

--- a/server-utils/tests/auth/resource_server/test_authorization_checker.py
+++ b/server-utils/tests/auth/resource_server/test_authorization_checker.py
@@ -32,6 +32,11 @@ class TestAlwaysAllowedAuthorizationChecker:
             == AuthorizedResult()
         )
 
+    async def test_get_username(self) -> None:
+        subject = AlwaysAllowedAuthorizationChecker()
+        assert await subject.get_username(None) is None
+        assert await subject.get_username("test-username") is None
+
 
 class TestAuthServerAuthorizationChecker:
     @pytest.fixture
@@ -106,3 +111,22 @@ class TestAuthServerAuthorizationChecker:
         assert await subject.check(
             "test-token-abc123", {Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}
         ) == InsufficientScopeResult(provided_scopes={Scope.ROBOT_CONTROL_WRITE})
+
+    async def test_get_username_given_no_token(self, mock_client: Client) -> None:
+        """It should return "no username" if not given a token."""
+        subject = AuthServerAuthorizationChecker(mock_client)
+        assert await subject.get_username(token=None) is None
+
+    async def test_get_username_given_a_token(
+        self, mock_client: Client, decoy: Decoy
+    ) -> None:
+        """It should pass the token to the client and return the username it gets back."""
+        subject = AuthServerAuthorizationChecker(mock_client)
+        decoy.when(await mock_client.introspect_token("test-token-abc123")).then_return(
+            TokenIntrospectionResponse(active=False, username=None)
+        )
+        assert await subject.get_username(token="test-token-abc123") is None
+        decoy.when(await mock_client.introspect_token("test-token-abc123")).then_return(
+            TokenIntrospectionResponse(active=False, username="test-username")
+        )
+        assert await subject.get_username(token="test-token-abc123") == "test-username"

--- a/server-utils/tests/auth/resource_server/test_authorization_checker.py
+++ b/server-utils/tests/auth/resource_server/test_authorization_checker.py
@@ -18,88 +18,91 @@ from server_utils.auth.resource_server.authorization_checker import (
 from server_utils.auth.scopes import Scope, serialize_scopes
 
 
-@pytest.fixture
-def mock_client(decoy: Decoy) -> Client:
-    """Return a mock in the shape of a client."""
-    return decoy.mock(cls=Client)
-
-
-async def test_always_allowed_checker() -> None:
-    subject = AlwaysAllowedAuthorizationChecker()
-
-    assert (
-        await subject.check(token=None, required_scopes={Scope.USERS_WRITE})
-        == AuthorizedResult()
-    )
-    assert (
-        await subject.check(token="token-abc123", required_scopes={Scope.USERS_WRITE})
-        == AuthorizedResult()
-    )
-
-
-async def test_auth_server_checker_given_no_token(
-    mock_client: Client, decoy: Decoy
-) -> None:
-    """When there is no token, it should authorize the request if and only if access control is disabled."""
-    subject = AuthServerAuthorizationChecker(mock_client)
-
-    decoy.when(await mock_client.get_auth_settings()).then_return(
-        AuthSettingsResponse(data=AuthSettingsResponseData(accessControlEnabled=True))
-    )
-    assert (
-        await subject.check(token=None, required_scopes={Scope.USERS_WRITE})
-        == MissingTokenResult()
-    )
-
-    decoy.when(await mock_client.get_auth_settings()).then_return(
-        AuthSettingsResponse(data=AuthSettingsResponseData(accessControlEnabled=False))
-    )
-    assert (
-        await subject.check(token=None, required_scopes={Scope.USERS_WRITE})
-        == AuthorizedResult()
-    )
-
-
-async def test_auth_server_checker_given_a_token(
-    mock_client: Client, decoy: Decoy
-) -> None:
-    """When there is a token, it should validate it by querying auth-server."""
-    subject = AuthServerAuthorizationChecker(mock_client)
-
-    # Active, and meeting all scopes -> authorize
-    decoy.when(await mock_client.introspect_token("test-token-abc123")).then_return(
-        TokenIntrospectionResponse(
-            active=True,
-            scope=serialize_scopes({Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}),
+class TestAlwaysAllowedAuthorizationChecker:
+    async def test_check(self) -> None:
+        subject = AlwaysAllowedAuthorizationChecker()
+        assert (
+            await subject.check(token=None, required_scopes={Scope.USERS_WRITE})
+            == AuthorizedResult()
         )
-    )
-    assert (
-        await subject.check(
+        assert (
+            await subject.check(
+                token="token-abc123", required_scopes={Scope.USERS_WRITE}
+            )
+            == AuthorizedResult()
+        )
+
+
+class TestAuthServerAuthorizationChecker:
+    @pytest.fixture
+    def mock_client(self, decoy: Decoy) -> Client:
+        """Return a mock in the shape of a client."""
+        return decoy.mock(cls=Client)
+
+    async def test_check_given_no_token(
+        self, mock_client: Client, decoy: Decoy
+    ) -> None:
+        """When there is no token, it should authorize the request if and only if access control is disabled."""
+        subject = AuthServerAuthorizationChecker(mock_client)
+
+        decoy.when(await mock_client.get_auth_settings()).then_return(
+            AuthSettingsResponse(
+                data=AuthSettingsResponseData(accessControlEnabled=True)
+            )
+        )
+        assert (
+            await subject.check(token=None, required_scopes={Scope.USERS_WRITE})
+            == MissingTokenResult()
+        )
+
+        decoy.when(await mock_client.get_auth_settings()).then_return(
+            AuthSettingsResponse(
+                data=AuthSettingsResponseData(accessControlEnabled=False)
+            )
+        )
+        assert (
+            await subject.check(token=None, required_scopes={Scope.USERS_WRITE})
+            == AuthorizedResult()
+        )
+
+    async def test_check_given_a_token(self, mock_client: Client, decoy: Decoy) -> None:
+        """When there is a token, it should validate it by querying auth-server."""
+        subject = AuthServerAuthorizationChecker(mock_client)
+
+        # Active, and meeting all scopes -> authorize
+        decoy.when(await mock_client.introspect_token("test-token-abc123")).then_return(
+            TokenIntrospectionResponse(
+                active=True,
+                scope=serialize_scopes({Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}),
+            )
+        )
+        assert (
+            await subject.check(
+                "test-token-abc123", {Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}
+            )
+            == AuthorizedResult()
+        )
+
+        # Inactive -> do not authorize
+        decoy.when(await mock_client.introspect_token("test-token-abc123")).then_return(
+            TokenIntrospectionResponse(
+                active=False,
+                scope=serialize_scopes({Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}),
+            )
+        )
+        assert (
+            await subject.check(
+                "test-token-abc123", {Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}
+            )
+            == NotAnActiveTokenResult()
+        )
+
+        # Not meeting all scopes -> do not authorize
+        decoy.when(await mock_client.introspect_token("test-token-abc123")).then_return(
+            TokenIntrospectionResponse(
+                active=True, scope=serialize_scopes({Scope.ROBOT_CONTROL_WRITE})
+            )
+        )
+        assert await subject.check(
             "test-token-abc123", {Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}
-        )
-        == AuthorizedResult()
-    )
-
-    # Inactive -> do not authorize
-    decoy.when(await mock_client.introspect_token("test-token-abc123")).then_return(
-        TokenIntrospectionResponse(
-            active=False,
-            scope=serialize_scopes({Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}),
-        )
-    )
-    assert (
-        await subject.check(
-            "test-token-abc123", {Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}
-        )
-        == NotAnActiveTokenResult()
-    )
-
-    # Not meeting all scopes -> do not authorize
-    decoy.when(await mock_client.introspect_token("test-token-abc123")).then_return(
-        TokenIntrospectionResponse(
-            active=True, scope=serialize_scopes({Scope.ROBOT_CONTROL_WRITE})
-        )
-    )
-    assert await subject.check(
-        "test-token-abc123", {Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}
-    ) == InsufficientScopeResult(provided_scopes={Scope.ROBOT_CONTROL_WRITE})
+        ) == InsufficientScopeResult(provided_scopes={Scope.ROBOT_CONTROL_WRITE})

--- a/update-server/otupdate/common/auth.py
+++ b/update-server/otupdate/common/auth.py
@@ -8,6 +8,7 @@ from aiohttp import web
 
 from server_utils.auth.resource_server.authorization_checker import (
     AuthorizationChecker,
+    AuthorizationNotRequiredResult,
     AuthorizedResult,
 )
 from server_utils.auth.resource_server.error_responses import build_response_for_error
@@ -56,7 +57,7 @@ def require_scopes(*required_scopes: Scope) -> Callable[[Handler], Handler]:
             result = await authorization_checker.check(
                 token=token, required_scopes=required_scopes_set
             )
-            if isinstance(result, AuthorizedResult):
+            if isinstance(result, (AuthorizationNotRequiredResult, AuthorizedResult)):
                 # The request is authorized.
                 return await handler(request)
             else:

--- a/update-server/tests/common/test_auth.py
+++ b/update-server/tests/common/test_auth.py
@@ -41,7 +41,7 @@ async def test_bearer_token_extraction_passed_to_checker(
     client, mock_checker = auth_test_cli
     decoy.when(
         await mock_checker.check(matchers.Anything(), matchers.Anything())
-    ).then_return(AuthorizedResult())
+    ).then_return(AuthorizedResult(username="test-username"))
 
     # An arbitrary endpoint that requires authorization.
     await client.post(
@@ -59,7 +59,7 @@ async def test_authorized_result(
     """When the AuthorizationChecker returns an AuthorizedResult, the request handler should run as normal."""
     client, mock_checker = auth_test_cli
     decoy.when(await mock_checker.check(None, matchers.Anything())).then_return(
-        AuthorizedResult()
+        AuthorizedResult(username="test-username")
     )
 
     # An arbitrary endpoint that requires authorization.


### PR DESCRIPTION
## Overview

This closes EXEC-2610.

## Test Plan and Hands on Testing

* [x] Added Tavern integration tests.

## Changelog

* Split the `users.read` scope into `users.read.others` and `users.read.self`. Regular users get `users.read.self`, and admins get `users.read.others`.
* ~~In `GET /users/{username}`, require `users.read.self` or `users.read.others` depending on whether a user is requesting info about themself.~~
* Add a new `GET /users/self` endpoint, requiring `users.read.self`.
* Rename the existing endpoints from `/users/{username}` to `/users/byUsername/{username}`. These require `users.read.others`.
* Update the auth utilities in `server_utils` to support this use case. This basically means letting endpoints access some lower-level auth information, so they can implement custom authorization logic themselves, instead of wrapping it all up in a FastAPI dependency.

## Review requests

Does this new `server_utils` API make sense? 

## Risk assessment

Low. We're covered by tests.
