### PR TITLE
feat(app, components, protocol-visualization): step group errors

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedGroup.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedGroup.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import { COLORS, StepGroup } from '@opentrons/components'
+import { COLORS, Icon, StepGroup } from '@opentrons/components'
 
 import styles from './annotatedsteps.module.css'
 import { IndividualCommand } from './IndividualCommand'
@@ -25,6 +25,8 @@ interface AnnotatedGroupProps {
   setSelectedCommand?: Dispatch<SetStateAction<string | null>>
   handlePause?: () => void
   headerLeading?: ReactNode | null
+  // rendered after sub-commands when analysis failed inside this annotation group
+  trailingErrorsFooter?: ReactNode | null
 }
 export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
   const {
@@ -39,13 +41,19 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
     listElement,
     annotationDescription,
     headerLeading,
+    trailingErrorsFooter,
   } = props
-  const [isExpanded, setIsExpanded] = useState(() =>
-    subCommands.some(command => command.isHighlighted)
+  const hasTrailingErrors = trailingErrorsFooter != null
+
+  const [isExpanded, setIsExpanded] = useState(
+    () =>
+      subCommands.some(command => command.isHighlighted) || hasTrailingErrors
   )
   useEffect(() => {
-    setIsExpanded(subCommands.some(command => command.isHighlighted))
-  }, [subCommands])
+    setIsExpanded(
+      subCommands.some(command => command.isHighlighted) || hasTrailingErrors
+    )
+  }, [subCommands, hasTrailingErrors])
 
   const handleClick = (): void => {
     setIsExpanded(!isExpanded)
@@ -64,6 +72,15 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
         handleClick={handleClick}
         isActive={isAnyStepHighlighted}
         subtitle={annotationDescription}
+        headerPrefixIcon={
+          hasTrailingErrors ? (
+            <Icon
+              name="ot-alert"
+              size="1rem"
+              color={isAnyStepHighlighted ? COLORS.purple50 : COLORS.red60}
+            />
+          ) : undefined
+        }
         headerLeading={headerLeading}
         {...(isAnyStepHighlighted ? { titleColor: COLORS.purple50 } : {})}
       >
@@ -83,6 +100,7 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
                 setSelectedCommand={setSelectedCommand}
               />
             ))}
+            {trailingErrorsFooter}
           </div>
         ) : null}
       </StepGroup>

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedGroup.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedGroup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useLayoutEffect, useState } from 'react'
 
 import { COLORS, Icon, StepGroup } from '@opentrons/components'
 
@@ -45,11 +45,9 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
   } = props
   const hasTrailingErrors = trailingErrorsFooter != null
 
-  const [isExpanded, setIsExpanded] = useState(
-    () =>
-      subCommands.some(command => command.isHighlighted) || hasTrailingErrors
-  )
-  useEffect(() => {
+  // Inactive groups start collapsed; open before paint if this group is active or has errors.
+  const [isExpanded, setIsExpanded] = useState(false)
+  useLayoutEffect(() => {
     setIsExpanded(
       subCommands.some(command => command.isHighlighted) || hasTrailingErrors
     )
@@ -79,7 +77,7 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
               size="1rem"
               color={isAnyStepHighlighted ? COLORS.purple50 : COLORS.red60}
             />
-          ) : undefined
+          ) : null
         }
         headerLeading={headerLeading}
         {...(isAnyStepHighlighted ? { titleColor: COLORS.purple50 } : {})}

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedStepsRowItem.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedStepsRowItem.tsx
@@ -5,9 +5,7 @@ import { COLORS, Icon } from '@opentrons/components'
 import { AnnotatedGroup } from './AnnotatedGroup'
 import styles from './annotatedsteps.module.css'
 import { IndividualCommand } from './IndividualCommand'
-import {
-  ProtocolAnalysisErrorsContent,
-} from './ProtocolAnalysisErrorsContent'
+import { ProtocolAnalysisErrorsContent } from './ProtocolAnalysisErrorsContent'
 import { ProtocolAnalysisPastStepsMessage } from './ProtocolAnalysisPastStepsMessage'
 
 import type { Dispatch, SetStateAction } from 'react'

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedStepsRowItem.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedStepsRowItem.tsx
@@ -13,12 +13,12 @@ import {
 import type { Dispatch, SetStateAction } from 'react'
 import type { RowComponentProps } from 'react-window'
 import type {
+  AnalysisError,
   CompletedProtocolAnalysis,
   LabwareDefinition,
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
 import type { LeafNode } from '/app/redux/protocol-storage'
-import type { AnalysisError } from '@opentrons/shared-data'
 import type { ItemData } from './index'
 
 interface GroupAnnotatedStepRowProps {
@@ -34,10 +34,10 @@ interface GroupAnnotatedStepRowProps {
   milliSecondsPerFrame: number
   isGlobalPlaying: boolean
   tI18n: (key: string) => string
+  onShowErrorDetails: () => void
   setSelectedCommand?: Dispatch<SetStateAction<string | null>>
   handlePause?: () => void
   trailingErrors?: AnalysisError[]
-  onShowErrorDetails: () => void
 }
 
 function GroupAnnotatedStepRow(props: GroupAnnotatedStepRowProps): JSX.Element {

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedStepsRowItem.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedStepsRowItem.tsx
@@ -1,10 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { COLORS, Icon, StyledText } from '@opentrons/components'
+import { COLORS, Icon } from '@opentrons/components'
 
 import { AnnotatedGroup } from './AnnotatedGroup'
 import styles from './annotatedsteps.module.css'
 import { IndividualCommand } from './IndividualCommand'
+import {
+  ProtocolAnalysisErrorsContent,
+  ProtocolAnalysisPastStepsMessage,
+} from './ProtocolAnalysisErrorsContent'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { RowComponentProps } from 'react-window'
@@ -14,6 +18,7 @@ import type {
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
 import type { LeafNode } from '/app/redux/protocol-storage'
+import type { AnalysisError } from '@opentrons/shared-data'
 import type { ItemData } from './index'
 
 interface GroupAnnotatedStepRowProps {
@@ -31,6 +36,8 @@ interface GroupAnnotatedStepRowProps {
   tI18n: (key: string) => string
   setSelectedCommand?: Dispatch<SetStateAction<string | null>>
   handlePause?: () => void
+  trailingErrors?: AnalysisError[]
+  onShowErrorDetails: () => void
 }
 
 function GroupAnnotatedStepRow(props: GroupAnnotatedStepRowProps): JSX.Element {
@@ -41,6 +48,8 @@ function GroupAnnotatedStepRow(props: GroupAnnotatedStepRowProps): JSX.Element {
     setSelectedCommand,
     handlePause,
     tI18n,
+    trailingErrors,
+    onShowErrorDetails,
     ...annotatedGroupProps
   } = props
 
@@ -117,6 +126,17 @@ function GroupAnnotatedStepRow(props: GroupAnnotatedStepRowProps): JSX.Element {
       subCommands={subCommands}
       setSelectedCommand={setSelectedCommand}
       handlePause={handlePause}
+      trailingErrorsFooter={
+        trailingErrors != null && trailingErrors.length > 0 ? (
+          <ProtocolAnalysisErrorsContent
+            errors={trailingErrors}
+            onShowErrorDetails={onShowErrorDetails}
+            t={tI18n}
+            inGroup
+            showPastStepsMessage={false}
+          />
+        ) : null
+      }
       headerLeading={
         showPlayControl ? (
           <button
@@ -161,6 +181,8 @@ export function AnnotatedStepsRowItem(
             milliSecondsPerFrame={data.milliSecondsPerFrame}
             isGlobalPlaying={data.isGlobalPlaying}
             tI18n={data.t}
+            trailingErrors={row.trailingErrors}
+            onShowErrorDetails={data.onShowErrorDetails}
           />
         ) : row.type === 'command' ? (
           <IndividualCommand
@@ -174,36 +196,14 @@ export function AnnotatedStepsRowItem(
             setSelectedCommand={data.setSelectedCommand}
             commandNumber={row.commandNumber}
           />
+        ) : row.type === 'errors_past_steps_message' ? (
+          <ProtocolAnalysisPastStepsMessage t={data.t} />
         ) : (
-          <div className={styles.annotated_steps_error_wrapper}>
-            {row.errors.map(error => (
-              <div
-                className={styles.annotated_steps_error_container}
-                key={error.id}
-                onClick={() => {
-                  data.onShowErrorDetails()
-                }}
-              >
-                <div className={styles.annotated_steps_header}>
-                  <Icon name="ot-alert" size="1rem" color={COLORS.red60} />
-                  <StyledText
-                    desktopStyle="captionSemiBold"
-                    color={COLORS.red60}
-                  >
-                    {data.t('step_error')}
-                  </StyledText>
-                </div>
-                <StyledText desktopStyle="bodyDefaultRegular">
-                  {error.detail}
-                </StyledText>
-              </div>
-            ))}
-            <div className={styles.annotated_steps_final_command}>
-              <StyledText desktopStyle="bodyDefaultRegular">
-                {data.t('unable_to_show_steps_past_errors')}
-              </StyledText>
-            </div>
-          </div>
+          <ProtocolAnalysisErrorsContent
+            errors={row.errors}
+            onShowErrorDetails={data.onShowErrorDetails}
+            t={data.t}
+          />
         )}
       </div>
     </div>

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedStepsRowItem.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedStepsRowItem.tsx
@@ -7,8 +7,8 @@ import styles from './annotatedsteps.module.css'
 import { IndividualCommand } from './IndividualCommand'
 import {
   ProtocolAnalysisErrorsContent,
-  ProtocolAnalysisPastStepsMessage,
 } from './ProtocolAnalysisErrorsContent'
+import { ProtocolAnalysisPastStepsMessage } from './ProtocolAnalysisPastStepsMessage'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { RowComponentProps } from 'react-window'

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/IndividualCommand.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/IndividualCommand.tsx
@@ -52,8 +52,8 @@ export function IndividualCommand({
       const groupExpandedEl =
         fromGroup === true
           ? commandEl.closest<HTMLElement>(
-            `.${styles.annotated_group_expanded}`
-          )
+              `.${styles.annotated_group_expanded}`
+            )
           : null
 
       const container: HTMLElement | null =

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/IndividualCommand.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/IndividualCommand.tsx
@@ -42,41 +42,50 @@ export function IndividualCommand({
   const iconColor = isHighlighted ? COLORS.purple50 : COLORS.grey50
 
   useEffect(() => {
-    if (isHighlighted && commandRef.current && command.id === scrollTargetId) {
-      requestAnimationFrame(() => {
-        const container =
-          listElement ?? commandRef.current?.closest('[role="list"]')
-        if (container == null) {
-          commandRef.current?.scrollIntoView({
-            behavior: 'smooth',
-            block: 'nearest',
-            inline: 'nearest',
-          })
-          return
-        }
-        const containerRect = container.getBoundingClientRect()
-        const commandRect = commandRef.current?.getBoundingClientRect()
-        if (commandRect == null) return
-        const isBelow = commandRect.bottom >= containerRect.bottom - 8
-        const isAbove = commandRect.top <= containerRect.top + 1
-        if (!isBelow && !isAbove) return
-        if (container instanceof HTMLElement) {
-          const nextTop =
-            container.scrollTop + (commandRect.top - containerRect.top)
-          container.scrollTo({
-            behavior: 'smooth',
-            top: Math.max(0, nextTop),
-          })
-          return
-        }
-        commandRef.current?.scrollIntoView({
+    if (!isHighlighted || commandRef.current == null) return
+    if (command.id !== scrollTargetId) return
+
+    requestAnimationFrame(() => {
+      const commandEl = commandRef.current
+      if (commandEl == null) return
+
+      const groupExpandedEl =
+        fromGroup === true
+          ? commandEl.closest<HTMLElement>(
+              `.${styles.annotated_group_expanded}`
+            )
+          : null
+
+      const container: HTMLElement | undefined =
+        groupExpandedEl instanceof HTMLElement
+          ? groupExpandedEl
+          : listElement ??
+            commandEl.closest<HTMLElement>('[role="list"]') ??
+            undefined
+
+      if (container == null) {
+        commandEl.scrollIntoView({
           behavior: 'smooth',
-          block: isBelow ? 'start' : 'nearest',
+          block: 'nearest',
           inline: 'nearest',
         })
+        return
+      }
+
+      const containerRect = container.getBoundingClientRect()
+      const commandRect = commandEl.getBoundingClientRect()
+      const isBelow = commandRect.bottom >= containerRect.bottom - 8
+      const isAbove = commandRect.top <= containerRect.top + 1
+      if (!isBelow && !isAbove) return
+
+      const nextTop =
+        container.scrollTop + (commandRect.top - containerRect.top)
+      container.scrollTo({
+        behavior: 'smooth',
+        top: Math.max(0, nextTop),
       })
-    }
-  }, [isHighlighted, scrollTargetId, command, listElement])
+    })
+  }, [isHighlighted, scrollTargetId, command.id, listElement, fromGroup])
 
   const commandWrapStyle = clsx(styles.individual_command_wrap, {
     [styles.individual_command_wrap_from_group]: fromGroup && !isHighlighted,

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/IndividualCommand.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/IndividualCommand.tsx
@@ -59,9 +59,9 @@ export function IndividualCommand({
       const container: HTMLElement | undefined =
         groupExpandedEl instanceof HTMLElement
           ? groupExpandedEl
-          : listElement ??
+          : (listElement ??
             commandEl.closest<HTMLElement>('[role="list"]') ??
-            undefined
+            undefined)
 
       if (container == null) {
         commandEl.scrollIntoView({

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/IndividualCommand.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/IndividualCommand.tsx
@@ -52,16 +52,16 @@ export function IndividualCommand({
       const groupExpandedEl =
         fromGroup === true
           ? commandEl.closest<HTMLElement>(
-              `.${styles.annotated_group_expanded}`
-            )
+            `.${styles.annotated_group_expanded}`
+          )
           : null
 
-      const container: HTMLElement | undefined =
+      const container: HTMLElement | null =
         groupExpandedEl instanceof HTMLElement
           ? groupExpandedEl
           : (listElement ??
             commandEl.closest<HTMLElement>('[role="list"]') ??
-            undefined)
+            null)
 
       if (container == null) {
         commandEl.scrollIntoView({

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/ProtocolAnalysisErrorsContent.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/ProtocolAnalysisErrorsContent.tsx
@@ -60,4 +60,3 @@ export function ProtocolAnalysisErrorsContent(
     </div>
   )
 }
-

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/ProtocolAnalysisErrorsContent.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/ProtocolAnalysisErrorsContent.tsx
@@ -1,0 +1,80 @@
+import { COLORS, Icon, StyledText } from '@opentrons/components'
+
+import styles from './annotatedsteps.module.css'
+
+import type { AnalysisError } from '@opentrons/shared-data'
+
+interface ProtocolAnalysisErrorsContentProps {
+  errors: AnalysisError[]
+  onShowErrorDetails: () => void
+  t: (key: string) => string
+  // align padding with grouped step rows inside an expanded annotation.
+  inGroup?: boolean
+  // when false, only error cards render (past-steps line is shown as its own list row)
+  showPastStepsMessage?: boolean
+}
+
+export function ProtocolAnalysisErrorsContent(
+  props: ProtocolAnalysisErrorsContentProps
+): JSX.Element {
+  const {
+    errors,
+    onShowErrorDetails,
+    t,
+    inGroup = false,
+    showPastStepsMessage = true,
+  } = props
+
+  return (
+    <div
+      className={
+        inGroup
+          ? styles.annotated_steps_error_wrapper_in_group
+          : styles.annotated_steps_error_wrapper
+      }
+    >
+      {errors.map(error => (
+        <div
+          className={styles.annotated_steps_error_container}
+          key={error.id}
+          onClick={() => {
+            onShowErrorDetails()
+          }}
+        >
+          <div className={styles.annotated_steps_header}>
+            <Icon name="ot-alert" size="1rem" color={COLORS.red60} />
+            <StyledText desktopStyle="captionSemiBold" color={COLORS.red60}>
+              {t('step_error')}
+            </StyledText>
+          </div>
+          <StyledText desktopStyle="bodyDefaultRegular">
+            {error.detail}
+          </StyledText>
+        </div>
+      ))}
+      {showPastStepsMessage ? (
+        <div className={styles.annotated_steps_error_footer_message}>
+          <StyledText desktopStyle="bodyDefaultRegular">
+            {t('unable_to_show_steps_past_errors')}
+          </StyledText>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export function ProtocolAnalysisPastStepsMessage(props: {
+  t: (key: string) => string
+}): JSX.Element {
+  const { t } = props
+
+  return (
+    <div className={styles.annotated_steps_past_steps_row}>
+      <div className={styles.annotated_steps_error_footer_message}>
+        <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+          {t('unable_to_show_steps_past_errors')}
+        </StyledText>
+      </div>
+    </div>
+  )
+}

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/ProtocolAnalysisErrorsContent.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/ProtocolAnalysisErrorsContent.tsx
@@ -37,9 +37,7 @@ export function ProtocolAnalysisErrorsContent(
         <div
           className={styles.annotated_steps_error_container}
           key={error.id}
-          onClick={() => {
-            onShowErrorDetails()
-          }}
+          onClick={onShowErrorDetails}
         >
           <div className={styles.annotated_steps_header}>
             <Icon name="ot-alert" size="1rem" color={COLORS.red60} />
@@ -63,18 +61,3 @@ export function ProtocolAnalysisErrorsContent(
   )
 }
 
-export function ProtocolAnalysisPastStepsMessage(props: {
-  t: (key: string) => string
-}): JSX.Element {
-  const { t } = props
-
-  return (
-    <div className={styles.annotated_steps_past_steps_row}>
-      <div className={styles.annotated_steps_error_footer_message}>
-        <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
-          {t('unable_to_show_steps_past_errors')}
-        </StyledText>
-      </div>
-    </div>
-  )
-}

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/ProtocolAnalysisPastStepsMessage.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/ProtocolAnalysisPastStepsMessage.tsx
@@ -3,17 +3,17 @@ import { COLORS, StyledText } from '@opentrons/components'
 import styles from './annotatedsteps.module.css'
 
 export function ProtocolAnalysisPastStepsMessage(props: {
-    t: (key: string) => string
+  t: (key: string) => string
 }): JSX.Element {
-    const { t } = props
+  const { t } = props
 
-    return (
-        <div className={styles.annotated_steps_past_steps_row}>
-            <div className={styles.annotated_steps_error_footer_message}>
-                <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
-                    {t('unable_to_show_steps_past_errors')}
-                </StyledText>
-            </div>
-        </div>
-    )
+  return (
+    <div className={styles.annotated_steps_past_steps_row}>
+      <div className={styles.annotated_steps_error_footer_message}>
+        <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+          {t('unable_to_show_steps_past_errors')}
+        </StyledText>
+      </div>
+    </div>
+  )
 }

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/ProtocolAnalysisPastStepsMessage.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/ProtocolAnalysisPastStepsMessage.tsx
@@ -1,0 +1,19 @@
+import { COLORS, StyledText } from '@opentrons/components'
+
+import styles from './annotatedsteps.module.css'
+
+export function ProtocolAnalysisPastStepsMessage(props: {
+    t: (key: string) => string
+}): JSX.Element {
+    const { t } = props
+
+    return (
+        <div className={styles.annotated_steps_past_steps_row}>
+            <div className={styles.annotated_steps_error_footer_message}>
+                <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+                    {t('unable_to_show_steps_past_errors')}
+                </StyledText>
+            </div>
+        </div>
+    )
+}

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
@@ -146,8 +146,8 @@
 
 .annotated_steps_error_wrapper_in_group {
   display: flex;
-  flex-direction: column;
   width: 100%;
+  flex-direction: column;
   padding: 0 var(--spacing-4);
   gap: var(--spacing-4);
 }

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
@@ -144,6 +144,15 @@
   gap: var(--spacing-4);
 }
 
+/* Matches .individual_command_container_group horizontal inset inside .annotated_group_expanded */
+.annotated_steps_error_wrapper_in_group {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 0 var(--spacing-4);
+  gap: var(--spacing-4);
+}
+
 .annotated_steps_error_container {
   display: flex;
   flex-direction: column;
@@ -166,13 +175,16 @@
   gap: var(--spacing-4);
 }
 
-.annotated_steps_final_command {
+.annotated_steps_error_footer_message {
   display: flex;
   width: 100%;
-  padding: var(--spacing-8);
-  border-radius: var(--border-radius-4);
-  background-color: var(--grey-20);
-  transition:
-    background-color 500ms ease-out,
-    border-color 500ms ease-out;
+  flex-direction: column;
+  align-items: center;
+  padding-top: var(--spacing-4);
+  text-align: center;
+}
+
+/* Matches horizontal inset of .annotated_steps_error_wrapper for standalone error rows */
+.annotated_steps_past_steps_row {
+  padding: var(--spacing-8) var(--spacing-12);
 }

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
@@ -144,7 +144,6 @@
   gap: var(--spacing-4);
 }
 
-/* Matches .individual_command_container_group horizontal inset inside .annotated_group_expanded */
 .annotated_steps_error_wrapper_in_group {
   display: flex;
   flex-direction: column;
@@ -184,7 +183,6 @@
   text-align: center;
 }
 
-/* Matches horizontal inset of .annotated_steps_error_wrapper for standalone error rows */
 .annotated_steps_past_steps_row {
   padding: var(--spacing-8) var(--spacing-12);
 }

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -7,7 +7,11 @@ import { getLabwareDefinitionsFromCommands } from '@opentrons/components'
 import { ProtocolAnalysisErrorModal } from '../../Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals'
 import styles from './annotatedsteps.module.css'
 import { AnnotatedStepsRowItem } from './AnnotatedStepsRowItem'
-import { getIsVisibleProtocolStep } from './utils'
+import {
+  getGroupedNodeIndexContainingCommandId,
+  getIsVisibleProtocolStep,
+  getLastVisibleAnalysisCommandId,
+} from './utils'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type {
@@ -38,6 +42,7 @@ interface GroupRow {
   annotationType: string
   commandStartNumber: number
   annotationDescription: string
+  trailingErrors?: AnalysisError[]
 }
 
 interface CommandRow {
@@ -53,7 +58,15 @@ interface ErrorRow {
   errors: AnalysisError[]
 }
 
-type AnnotatedStepsRow = GroupRow | CommandRow | ErrorRow
+interface ErrorPastStepsMessageRow {
+  type: 'errors_past_steps_message'
+}
+
+type AnnotatedStepsRow =
+  | GroupRow
+  | CommandRow
+  | ErrorRow
+  | ErrorPastStepsMessageRow
 
 export interface ItemData {
   rows: AnnotatedStepsRow[]
@@ -85,6 +98,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     milliSecondsPerFrame = DEFAULT_STEP_GROUP_SECONDS,
     isGlobalPlaying = false,
   } = props
+
   const { t } = useTranslation('protocol_visualization')
   const [showErrorDetailsModal, setShowErrorDetailsModal] =
     useState<boolean>(false)
@@ -133,6 +147,11 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     currentCommandIndex != null
       ? (filteredCommands[currentCommandIndex]?.id ?? null)
       : null
+  const lastVisibleAnalysisCommandId = useMemo(
+    () => getLastVisibleAnalysisCommandId(analysis.commands),
+    [analysis.commands]
+  )
+
   const groupedCommandsHighlightedInfo = useMemo(
     () =>
       filteredGroupedCommands?.map(node => {
@@ -157,6 +176,25 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
       }),
     [filteredGroupedCommands, currentCommandId]
   )
+
+  const groupedRowIndexForTrailingErrors = useMemo(() => {
+    if (
+      analysis.errors.length === 0 ||
+      groupedCommandsHighlightedInfo == null ||
+      groupedCommandsHighlightedInfo.length === 0 ||
+      lastVisibleAnalysisCommandId == null
+    ) {
+      return null
+    }
+    return getGroupedNodeIndexContainingCommandId(
+      groupedCommandsHighlightedInfo,
+      lastVisibleAnalysisCommandId
+    )
+  }, [
+    analysis.errors,
+    groupedCommandsHighlightedInfo,
+    lastVisibleAnalysisCommandId,
+  ])
 
   useEffect(() => {
     if (currentCommandId == null) return
@@ -205,6 +243,10 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
             annotationType: group.annotation?.name ?? '',
             commandStartNumber: subCommandStartNumber,
             annotationDescription: group.annotation?.description ?? '',
+            ...(groupedRowIndexForTrailingErrors === index &&
+            analysis.errors.length > 0
+              ? { trailingErrors: analysis.errors }
+              : {}),
           })
           group.subCommands.forEach(subCommand => {
             nextRowIndexByCommandId.set(subCommand.command.id, rowIndex)
@@ -239,10 +281,20 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
       })
     }
 
-    if (analysis.errors.length > 0) {
+    if (
+      analysis.errors.length > 0 &&
+      groupedRowIndexForTrailingErrors == null
+    ) {
       nextRows.push({
         type: 'errors',
         errors: analysis.errors,
+      })
+    } else if (
+      analysis.errors.length > 0 &&
+      groupedRowIndexForTrailingErrors != null
+    ) {
+      nextRows.push({
+        type: 'errors_past_steps_message',
       })
     }
 
@@ -255,6 +307,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     filteredCommands,
     currentCommandIndex,
     analysis.errors,
+    groupedRowIndexForTrailingErrors,
   ])
 
   const [listRef, listRefCallback] = useListCallbackRef()

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/utils.ts
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/utils.ts
@@ -3,3 +3,36 @@ import type { RunTimeCommand } from '@opentrons/shared-data'
 export const getIsVisibleProtocolStep = (command: RunTimeCommand): boolean => {
   return !command.commandType.includes('load') && command.commandType !== 'home'
 }
+
+export function getLastVisibleAnalysisCommandId(
+  commands: RunTimeCommand[]
+): string | null {
+  for (let i = commands.length - 1; i >= 0; i--) {
+    const command = commands[i]
+    if (getIsVisibleProtocolStep(command)) {
+      return command.id
+    }
+  }
+  return null
+}
+
+export function getGroupedNodeIndexContainingCommandId(
+  groupedNodes: ReadonlyArray<
+    | {
+        annotationId: string
+        subCommands: ReadonlyArray<{ command: { id: string } }>
+      }
+    | { command: { id: string } }
+  >,
+  commandId: string
+): number | null {
+  for (let i = 0; i < groupedNodes.length; i++) {
+    const node = groupedNodes[i]
+    if ('annotationId' in node && 'subCommands' in node) {
+      if (node.subCommands.some(sc => sc.command.id === commandId)) {
+        return i
+      }
+    }
+  }
+  return null
+}

--- a/components/src/molecules/StepGroup/__tests__/StepGroup.test.tsx
+++ b/components/src/molecules/StepGroup/__tests__/StepGroup.test.tsx
@@ -90,4 +90,15 @@ describe('StepGroup', () => {
 
     expect(props.handleClick).not.toHaveBeenCalled()
   })
+
+  it('does not trigger handleClick when clicking headerPrefixIcon (stopPropagation)', () => {
+    render({
+      ...props,
+      headerPrefixIcon: <button type="button">prefix action</button>,
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'prefix action' }))
+
+    expect(props.handleClick).not.toHaveBeenCalled()
+  })
 })

--- a/components/src/molecules/StepGroup/index.tsx
+++ b/components/src/molecules/StepGroup/index.tsx
@@ -12,6 +12,11 @@ interface StepGroupProps {
   handleClick: () => void
   children: ReactNode
   subtitle?: string
+  /**
+   * Leftmost column before headerLeading / title (e.g. status icon).
+   * Clicks do not toggle expand/collapse. 8px gap before the title block.
+   */
+  headerPrefixIcon?: ReactNode
   /** Rendered 4px left of the title; clicks do not toggle expand/collapse */
   headerLeading?: ReactNode
   /** Rendered before the expand chevron; clicks do not toggle expand/collapse */
@@ -28,6 +33,7 @@ export function StepGroup(props: StepGroupProps): JSX.Element {
     isActive,
     handleClick,
     children,
+    headerPrefixIcon,
     headerLeading,
     headerTrailing,
     titleColor,
@@ -36,6 +42,57 @@ export function StepGroup(props: StepGroupProps): JSX.Element {
   const handleChildrenClick: MouseEventHandler<HTMLDivElement> = event => {
     event.stopPropagation()
   }
+
+  const titleBlockClassName =
+    headerLeading != null
+      ? styles.step_group_title_block_grid
+      : styles.step_group_title_block_stacked
+
+  const titleArea = (
+    <div className={titleBlockClassName}>
+      {headerLeading != null ? (
+        <>
+          <div
+            className={styles.step_group_leading}
+            onClick={event => {
+              event.stopPropagation()
+            }}
+          >
+            {headerLeading}
+          </div>
+          <div className={styles.step_group_title_line}>
+            <StyledText
+              desktopStyle="bodyDefaultSemiBold"
+              color={titleColor}
+            >
+              {title}
+            </StyledText>
+          </div>
+          {subtitle != null ? (
+            <div className={styles.step_group_subtitle_line}>
+              <StyledText
+                desktopStyle="captionRegular"
+                color={COLORS.grey60}
+              >
+                {subtitle}
+              </StyledText>
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <div className={styles.step_group_title_content}>
+          <StyledText desktopStyle="bodyDefaultRegular" color={titleColor}>
+            {title}
+          </StyledText>
+          {subtitle != null ? (
+            <StyledText desktopStyle="captionRegular" color={COLORS.grey60}>
+              {subtitle}
+            </StyledText>
+          ) : null}
+        </div>
+      )}
+    </div>
+  )
 
   return (
     <div
@@ -46,55 +103,21 @@ export function StepGroup(props: StepGroupProps): JSX.Element {
       }}
     >
       <div className={styles.step_group_header} onClick={handleClick}>
-        <div
-          className={
-            headerLeading != null
-              ? styles.step_group_title_block_grid
-              : styles.step_group_title_block_stacked
-          }
-        >
-          {headerLeading != null ? (
-            <>
-              <div
-                className={styles.step_group_leading}
-                onClick={event => {
-                  event.stopPropagation()
-                }}
-              >
-                {headerLeading}
-              </div>
-              <div className={styles.step_group_title_line}>
-                <StyledText
-                  desktopStyle="bodyDefaultSemiBold"
-                  color={titleColor}
-                >
-                  {title}
-                </StyledText>
-              </div>
-              {subtitle != null ? (
-                <div className={styles.step_group_subtitle_line}>
-                  <StyledText
-                    desktopStyle="captionRegular"
-                    color={COLORS.grey60}
-                  >
-                    {subtitle}
-                  </StyledText>
-                </div>
-              ) : null}
-            </>
-          ) : (
-            <div className={styles.step_group_title_content}>
-              <StyledText desktopStyle="bodyDefaultRegular" color={titleColor}>
-                {title}
-              </StyledText>
-              {subtitle != null ? (
-                <StyledText desktopStyle="captionRegular" color={COLORS.grey60}>
-                  {subtitle}
-                </StyledText>
-              ) : null}
+        {headerPrefixIcon != null ? (
+          <div className={styles.step_group_header_left}>
+            <div
+              className={styles.step_group_prefix}
+              onClick={event => {
+                event.stopPropagation()
+              }}
+            >
+              {headerPrefixIcon}
             </div>
-          )}
-        </div>
+            {titleArea}
+          </div>
+        ) : (
+          titleArea
+        )}
         <div className={styles.step_group_header_right}>
           {headerTrailing != null ? (
             <div

--- a/components/src/molecules/StepGroup/index.tsx
+++ b/components/src/molecules/StepGroup/index.tsx
@@ -12,11 +12,8 @@ interface StepGroupProps {
   handleClick: () => void
   children: ReactNode
   subtitle?: string
-  /**
-   * Leftmost column before headerLeading / title (e.g. status icon).
-   * Clicks do not toggle expand/collapse. 8px gap before the title block.
-   */
-  headerPrefixIcon?: ReactNode
+  // currently used as an error icon to display if the group has an error
+  headerPrefixIcon?: ReactNode | null
   /** Rendered 4px left of the title; clicks do not toggle expand/collapse */
   headerLeading?: ReactNode
   /** Rendered before the expand chevron; clicks do not toggle expand/collapse */
@@ -61,19 +58,13 @@ export function StepGroup(props: StepGroupProps): JSX.Element {
             {headerLeading}
           </div>
           <div className={styles.step_group_title_line}>
-            <StyledText
-              desktopStyle="bodyDefaultSemiBold"
-              color={titleColor}
-            >
+            <StyledText desktopStyle="bodyDefaultSemiBold" color={titleColor}>
               {title}
             </StyledText>
           </div>
           {subtitle != null ? (
             <div className={styles.step_group_subtitle_line}>
-              <StyledText
-                desktopStyle="captionRegular"
-                color={COLORS.grey60}
-              >
+              <StyledText desktopStyle="captionRegular" color={COLORS.grey60}>
                 {subtitle}
               </StyledText>
             </div>

--- a/components/src/molecules/StepGroup/stepgroup.module.css
+++ b/components/src/molecules/StepGroup/stepgroup.module.css
@@ -9,7 +9,6 @@
   gap: var(--spacing-4);
 }
 
-/* Prefix icon column + title block; 8px between prefix and title/play area */
 .step_group_header_left {
   display: flex;
   min-width: 0;

--- a/components/src/molecules/StepGroup/stepgroup.module.css
+++ b/components/src/molecules/StepGroup/stepgroup.module.css
@@ -9,6 +9,27 @@
   gap: var(--spacing-4);
 }
 
+/* Prefix icon column + title block; 8px between prefix and title/play area */
+.step_group_header_left {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+  gap: var(--spacing-8);
+}
+
+.step_group_prefix {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.step_group_header_left > :last-child {
+  min-width: 0;
+  flex: 1;
+}
+
 /* Title + subtitle only (no leading control) */
 .step_group_title_block_stacked {
   display: flex;

--- a/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedGroup.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedGroup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useLayoutEffect, useState } from 'react'
 
 import { COLORS, Icon, StepGroup } from '@opentrons/components'
 
@@ -45,11 +45,9 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
   } = props
   const hasTrailingErrors = trailingErrorsFooter != null
 
-  const [isExpanded, setIsExpanded] = useState(
-    () =>
-      subCommands.some(command => command.isHighlighted) || hasTrailingErrors
-  )
-  useEffect(() => {
+  // Inactive groups start collapsed; open before paint if this group is active or has errors.
+  const [isExpanded, setIsExpanded] = useState(false)
+  useLayoutEffect(() => {
     setIsExpanded(
       subCommands.some(command => command.isHighlighted) || hasTrailingErrors
     )
@@ -79,7 +77,7 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
               size="1rem"
               color={isAnyStepHighlighted ? COLORS.purple50 : COLORS.red60}
             />
-          ) : undefined
+          ) : null
         }
         headerLeading={headerLeading}
         {...(isAnyStepHighlighted ? { titleColor: COLORS.purple50 } : {})}

--- a/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedGroup.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedGroup.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-import { COLORS, StepGroup } from '@opentrons/components'
+import { COLORS, Icon, StepGroup } from '@opentrons/components'
 
 import styles from './annotatedsteps.module.css'
 import { IndividualCommand } from './IndividualCommand'
@@ -25,6 +25,8 @@ interface AnnotatedGroupProps {
   setSelectedCommand?: Dispatch<SetStateAction<string | null>> // remove redux dependency
   handlePause?: () => void
   headerLeading?: ReactNode | null
+  // rendered after sub-commands when analysis failed inside this annotation group
+  trailingErrorsFooter?: ReactNode | null
 }
 export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
   const {
@@ -39,13 +41,19 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
     listElement,
     annotationDescription,
     headerLeading,
+    trailingErrorsFooter,
   } = props
-  const [isExpanded, setIsExpanded] = useState(() =>
-    subCommands.some(command => command.isHighlighted)
+  const hasTrailingErrors = trailingErrorsFooter != null
+
+  const [isExpanded, setIsExpanded] = useState(
+    () =>
+      subCommands.some(command => command.isHighlighted) || hasTrailingErrors
   )
   useEffect(() => {
-    setIsExpanded(subCommands.some(command => command.isHighlighted))
-  }, [subCommands])
+    setIsExpanded(
+      subCommands.some(command => command.isHighlighted) || hasTrailingErrors
+    )
+  }, [subCommands, hasTrailingErrors])
 
   const handleClick = (): void => {
     setIsExpanded(!isExpanded)
@@ -64,6 +72,15 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
         handleClick={handleClick}
         isActive={isAnyStepHighlighted}
         subtitle={annotationDescription}
+        headerPrefixIcon={
+          hasTrailingErrors ? (
+            <Icon
+              name="ot-alert"
+              size="1rem"
+              color={isAnyStepHighlighted ? COLORS.purple50 : COLORS.red60}
+            />
+          ) : undefined
+        }
         headerLeading={headerLeading}
         {...(isAnyStepHighlighted ? { titleColor: COLORS.purple50 } : {})}
       >
@@ -83,6 +100,7 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
                 setSelectedCommand={setSelectedCommand}
               />
             ))}
+            {trailingErrorsFooter}
           </div>
         ) : null}
       </StepGroup>

--- a/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedStepsRowItem.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedStepsRowItem.tsx
@@ -6,9 +6,9 @@ import { AnnotatedGroup } from './AnnotatedGroup'
 import styles from './annotatedsteps.module.css'
 import { IndividualCommand } from './IndividualCommand'
 import {
-  ProtocolAnalysisErrorsContent,
-  ProtocolAnalysisPastStepsMessage,
+  ProtocolAnalysisErrorsContent
 } from './ProtocolAnalysisErrorsContent'
+import { ProtocolAnalysisPastStepsMessage } from './ProtocolAnalysisPastStepsMessage'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { RowComponentProps } from 'react-window'

--- a/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedStepsRowItem.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedStepsRowItem.tsx
@@ -5,9 +5,7 @@ import { COLORS, Icon } from '@opentrons/components'
 import { AnnotatedGroup } from './AnnotatedGroup'
 import styles from './annotatedsteps.module.css'
 import { IndividualCommand } from './IndividualCommand'
-import {
-  ProtocolAnalysisErrorsContent
-} from './ProtocolAnalysisErrorsContent'
+import { ProtocolAnalysisErrorsContent } from './ProtocolAnalysisErrorsContent'
 import { ProtocolAnalysisPastStepsMessage } from './ProtocolAnalysisPastStepsMessage'
 
 import type { Dispatch, SetStateAction } from 'react'

--- a/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedStepsRowItem.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedStepsRowItem.tsx
@@ -13,12 +13,12 @@ import {
 import type { Dispatch, SetStateAction } from 'react'
 import type { RowComponentProps } from 'react-window'
 import type {
+  AnalysisError,
   CompletedProtocolAnalysis,
   LabwareDefinition,
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
 import type { LeafNode } from '../../types'
-import type { AnalysisError } from '@opentrons/shared-data'
 import type { ItemData } from './index'
 
 interface GroupAnnotatedStepRowProps {
@@ -34,10 +34,10 @@ interface GroupAnnotatedStepRowProps {
   milliSecondsPerFrame: number
   isGlobalPlaying: boolean
   tI18n: (key: string) => string
+  onShowErrorDetails: () => void
   setSelectedCommand?: Dispatch<SetStateAction<string | null>>
   handlePause?: () => void
   trailingErrors?: AnalysisError[]
-  onShowErrorDetails: () => void
 }
 
 function GroupAnnotatedStepRow(props: GroupAnnotatedStepRowProps): JSX.Element {

--- a/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedStepsRowItem.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedStepsRowItem.tsx
@@ -1,10 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
-import { COLORS, Icon, StyledText } from '@opentrons/components'
+import { COLORS, Icon } from '@opentrons/components'
 
 import { AnnotatedGroup } from './AnnotatedGroup'
 import styles from './annotatedsteps.module.css'
 import { IndividualCommand } from './IndividualCommand'
+import {
+  ProtocolAnalysisErrorsContent,
+  ProtocolAnalysisPastStepsMessage,
+} from './ProtocolAnalysisErrorsContent'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { RowComponentProps } from 'react-window'
@@ -14,6 +18,7 @@ import type {
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
 import type { LeafNode } from '../../types'
+import type { AnalysisError } from '@opentrons/shared-data'
 import type { ItemData } from './index'
 
 interface GroupAnnotatedStepRowProps {
@@ -31,6 +36,8 @@ interface GroupAnnotatedStepRowProps {
   tI18n: (key: string) => string
   setSelectedCommand?: Dispatch<SetStateAction<string | null>>
   handlePause?: () => void
+  trailingErrors?: AnalysisError[]
+  onShowErrorDetails: () => void
 }
 
 function GroupAnnotatedStepRow(props: GroupAnnotatedStepRowProps): JSX.Element {
@@ -41,6 +48,8 @@ function GroupAnnotatedStepRow(props: GroupAnnotatedStepRowProps): JSX.Element {
     setSelectedCommand,
     handlePause,
     tI18n,
+    trailingErrors,
+    onShowErrorDetails,
     ...annotatedGroupProps
   } = props
 
@@ -117,6 +126,17 @@ function GroupAnnotatedStepRow(props: GroupAnnotatedStepRowProps): JSX.Element {
       subCommands={subCommands}
       setSelectedCommand={setSelectedCommand}
       handlePause={handlePause}
+      trailingErrorsFooter={
+        trailingErrors != null && trailingErrors.length > 0 ? (
+          <ProtocolAnalysisErrorsContent
+            errors={trailingErrors}
+            onShowErrorDetails={onShowErrorDetails}
+            t={tI18n}
+            inGroup
+            showPastStepsMessage={false}
+          />
+        ) : null
+      }
       headerLeading={
         showPlayControl ? (
           <button
@@ -160,6 +180,8 @@ export function AnnotatedStepsRowItem(
             milliSecondsPerFrame={data.milliSecondsPerFrame}
             isGlobalPlaying={data.isGlobalPlaying}
             tI18n={data.t}
+            trailingErrors={row.trailingErrors}
+            onShowErrorDetails={data.onShowErrorDetails}
           />
         ) : row.type === 'command' ? (
           <IndividualCommand
@@ -173,36 +195,14 @@ export function AnnotatedStepsRowItem(
             setSelectedCommand={data.setSelectedCommand}
             commandNumber={row.commandNumber}
           />
+        ) : row.type === 'errors_past_steps_message' ? (
+          <ProtocolAnalysisPastStepsMessage t={data.t} />
         ) : (
-          <div className={styles.annotated_steps_error_wrapper}>
-            {row.errors.map(error => (
-              <div
-                className={styles.annotated_steps_error_container}
-                key={error.id}
-                onClick={() => {
-                  data.onShowErrorDetails()
-                }}
-              >
-                <div className={styles.annotated_steps_header}>
-                  <Icon name="ot-alert" size="1rem" color={COLORS.red60} />
-                  <StyledText
-                    desktopStyle="captionSemiBold"
-                    color={COLORS.red60}
-                  >
-                    {data.t('step_error')}
-                  </StyledText>
-                </div>
-                <StyledText desktopStyle="bodyDefaultRegular">
-                  {error.detail}
-                </StyledText>
-              </div>
-            ))}
-            <div className={styles.annotated_steps_final_command}>
-              <StyledText desktopStyle="bodyDefaultRegular">
-                {data.t('unable_to_show_steps_past_errors')}
-              </StyledText>
-            </div>
-          </div>
+          <ProtocolAnalysisErrorsContent
+            errors={row.errors}
+            onShowErrorDetails={data.onShowErrorDetails}
+            t={data.t}
+          />
         )}
       </div>
     </div>

--- a/protocol-visualization/src/organisms/AnnotatedSteps/IndividualCommand.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/IndividualCommand.tsx
@@ -51,8 +51,8 @@ export function IndividualCommand({
       const groupExpandedEl =
         fromGroup === true
           ? commandEl.closest<HTMLElement>(
-            `.${styles.annotated_group_expanded}`
-          )
+              `.${styles.annotated_group_expanded}`
+            )
           : null
 
       const container: HTMLElement | null =

--- a/protocol-visualization/src/organisms/AnnotatedSteps/IndividualCommand.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/IndividualCommand.tsx
@@ -58,9 +58,9 @@ export function IndividualCommand({
       const container: HTMLElement | undefined =
         groupExpandedEl instanceof HTMLElement
           ? groupExpandedEl
-          : listElement ??
+          : (listElement ??
             commandEl.closest<HTMLElement>('[role="list"]') ??
-            undefined
+            undefined)
 
       if (container == null) {
         commandEl.scrollIntoView({

--- a/protocol-visualization/src/organisms/AnnotatedSteps/IndividualCommand.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/IndividualCommand.tsx
@@ -51,16 +51,16 @@ export function IndividualCommand({
       const groupExpandedEl =
         fromGroup === true
           ? commandEl.closest<HTMLElement>(
-              `.${styles.annotated_group_expanded}`
-            )
+            `.${styles.annotated_group_expanded}`
+          )
           : null
 
-      const container: HTMLElement | undefined =
+      const container: HTMLElement | null =
         groupExpandedEl instanceof HTMLElement
           ? groupExpandedEl
           : (listElement ??
             commandEl.closest<HTMLElement>('[role="list"]') ??
-            undefined)
+            null)
 
       if (container == null) {
         commandEl.scrollIntoView({

--- a/protocol-visualization/src/organisms/AnnotatedSteps/IndividualCommand.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/IndividualCommand.tsx
@@ -41,41 +41,50 @@ export function IndividualCommand({
   const iconColor = isHighlighted ? COLORS.purple50 : COLORS.grey50
 
   useEffect(() => {
-    if (isHighlighted && commandRef.current && command.id === scrollTargetId) {
-      requestAnimationFrame(() => {
-        const container =
-          listElement ?? commandRef.current?.closest('[role="list"]')
-        if (container == null) {
-          commandRef.current?.scrollIntoView({
-            behavior: 'smooth',
-            block: 'nearest',
-            inline: 'nearest',
-          })
-          return
-        }
-        const containerRect = container.getBoundingClientRect()
-        const commandRect = commandRef.current?.getBoundingClientRect()
-        if (commandRect == null) return
-        const isBelow = commandRect.bottom >= containerRect.bottom - 8
-        const isAbove = commandRect.top <= containerRect.top + 1
-        if (!isBelow && !isAbove) return
-        if (container instanceof HTMLElement) {
-          const nextTop =
-            container.scrollTop + (commandRect.top - containerRect.top)
-          container.scrollTo({
-            behavior: 'smooth',
-            top: Math.max(0, nextTop),
-          })
-          return
-        }
-        commandRef.current?.scrollIntoView({
+    if (!isHighlighted || commandRef.current == null) return
+    if (command.id !== scrollTargetId) return
+
+    requestAnimationFrame(() => {
+      const commandEl = commandRef.current
+      if (commandEl == null) return
+
+      const groupExpandedEl =
+        fromGroup === true
+          ? commandEl.closest<HTMLElement>(
+              `.${styles.annotated_group_expanded}`
+            )
+          : null
+
+      const container: HTMLElement | undefined =
+        groupExpandedEl instanceof HTMLElement
+          ? groupExpandedEl
+          : listElement ??
+            commandEl.closest<HTMLElement>('[role="list"]') ??
+            undefined
+
+      if (container == null) {
+        commandEl.scrollIntoView({
           behavior: 'smooth',
-          block: isBelow ? 'start' : 'nearest',
+          block: 'nearest',
           inline: 'nearest',
         })
+        return
+      }
+
+      const containerRect = container.getBoundingClientRect()
+      const commandRect = commandEl.getBoundingClientRect()
+      const isBelow = commandRect.bottom >= containerRect.bottom - 8
+      const isAbove = commandRect.top <= containerRect.top + 1
+      if (!isBelow && !isAbove) return
+
+      const nextTop =
+        container.scrollTop + (commandRect.top - containerRect.top)
+      container.scrollTo({
+        behavior: 'smooth',
+        top: Math.max(0, nextTop),
       })
-    }
-  }, [isHighlighted, scrollTargetId, command, listElement])
+    })
+  }, [isHighlighted, scrollTargetId, command.id, listElement, fromGroup])
 
   const commandWrapStyle = clsx(styles.individual_command_wrap, {
     [styles.individual_command_wrap_from_group]: fromGroup && !isHighlighted,

--- a/protocol-visualization/src/organisms/AnnotatedSteps/ProtocolAnalysisErrorsContent.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/ProtocolAnalysisErrorsContent.tsx
@@ -1,0 +1,80 @@
+import { COLORS, Icon, StyledText } from '@opentrons/components'
+
+import styles from './annotatedsteps.module.css'
+
+import type { AnalysisError } from '@opentrons/shared-data'
+
+interface ProtocolAnalysisErrorsContentProps {
+  errors: AnalysisError[]
+  onShowErrorDetails: () => void
+  t: (key: string) => string
+  // align padding with grouped step rows inside an expanded annotation.
+  inGroup?: boolean
+  // when false, only error cards render (past-steps line is shown as its own list row)
+  showPastStepsMessage?: boolean
+}
+
+export function ProtocolAnalysisErrorsContent(
+  props: ProtocolAnalysisErrorsContentProps
+): JSX.Element {
+  const {
+    errors,
+    onShowErrorDetails,
+    t,
+    inGroup = false,
+    showPastStepsMessage = true,
+  } = props
+
+  return (
+    <div
+      className={
+        inGroup
+          ? styles.annotated_steps_error_wrapper_in_group
+          : styles.annotated_steps_error_wrapper
+      }
+    >
+      {errors.map(error => (
+        <div
+          className={styles.annotated_steps_error_container}
+          key={error.id}
+          onClick={() => {
+            onShowErrorDetails()
+          }}
+        >
+          <div className={styles.annotated_steps_header}>
+            <Icon name="ot-alert" size="1rem" color={COLORS.red60} />
+            <StyledText desktopStyle="captionSemiBold" color={COLORS.red60}>
+              {t('step_error')}
+            </StyledText>
+          </div>
+          <StyledText desktopStyle="bodyDefaultRegular">
+            {error.detail}
+          </StyledText>
+        </div>
+      ))}
+      {showPastStepsMessage ? (
+        <div className={styles.annotated_steps_error_footer_message}>
+          <StyledText desktopStyle="bodyDefaultRegular">
+            {t('unable_to_show_steps_past_errors')}
+          </StyledText>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export function ProtocolAnalysisPastStepsMessage(props: {
+  t: (key: string) => string
+}): JSX.Element {
+  const { t } = props
+
+  return (
+    <div className={styles.annotated_steps_past_steps_row}>
+      <div className={styles.annotated_steps_error_footer_message}>
+        <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+          {t('unable_to_show_steps_past_errors')}
+        </StyledText>
+      </div>
+    </div>
+  )
+}

--- a/protocol-visualization/src/organisms/AnnotatedSteps/ProtocolAnalysisErrorsContent.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/ProtocolAnalysisErrorsContent.tsx
@@ -37,9 +37,7 @@ export function ProtocolAnalysisErrorsContent(
         <div
           className={styles.annotated_steps_error_container}
           key={error.id}
-          onClick={() => {
-            onShowErrorDetails()
-          }}
+          onClick={onShowErrorDetails}
         >
           <div className={styles.annotated_steps_header}>
             <Icon name="ot-alert" size="1rem" color={COLORS.red60} />
@@ -59,22 +57,6 @@ export function ProtocolAnalysisErrorsContent(
           </StyledText>
         </div>
       ) : null}
-    </div>
-  )
-}
-
-export function ProtocolAnalysisPastStepsMessage(props: {
-  t: (key: string) => string
-}): JSX.Element {
-  const { t } = props
-
-  return (
-    <div className={styles.annotated_steps_past_steps_row}>
-      <div className={styles.annotated_steps_error_footer_message}>
-        <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
-          {t('unable_to_show_steps_past_errors')}
-        </StyledText>
-      </div>
     </div>
   )
 }

--- a/protocol-visualization/src/organisms/AnnotatedSteps/ProtocolAnalysisPastStepsMessage.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/ProtocolAnalysisPastStepsMessage.tsx
@@ -3,17 +3,17 @@ import { COLORS, StyledText } from '@opentrons/components'
 import styles from './annotatedsteps.module.css'
 
 export function ProtocolAnalysisPastStepsMessage(props: {
-    t: (key: string) => string
+  t: (key: string) => string
 }): JSX.Element {
-    const { t } = props
+  const { t } = props
 
-    return (
-        <div className={styles.annotated_steps_past_steps_row}>
-            <div className={styles.annotated_steps_error_footer_message}>
-                <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
-                    {t('unable_to_show_steps_past_errors')}
-                </StyledText>
-            </div>
-        </div>
-    )
+  return (
+    <div className={styles.annotated_steps_past_steps_row}>
+      <div className={styles.annotated_steps_error_footer_message}>
+        <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+          {t('unable_to_show_steps_past_errors')}
+        </StyledText>
+      </div>
+    </div>
+  )
 }

--- a/protocol-visualization/src/organisms/AnnotatedSteps/ProtocolAnalysisPastStepsMessage.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/ProtocolAnalysisPastStepsMessage.tsx
@@ -1,0 +1,19 @@
+import { COLORS, StyledText } from '@opentrons/components'
+
+import styles from './annotatedsteps.module.css'
+
+export function ProtocolAnalysisPastStepsMessage(props: {
+    t: (key: string) => string
+}): JSX.Element {
+    const { t } = props
+
+    return (
+        <div className={styles.annotated_steps_past_steps_row}>
+            <div className={styles.annotated_steps_error_footer_message}>
+                <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+                    {t('unable_to_show_steps_past_errors')}
+                </StyledText>
+            </div>
+        </div>
+    )
+}

--- a/protocol-visualization/src/organisms/AnnotatedSteps/annotatedsteps.module.css
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/annotatedsteps.module.css
@@ -146,8 +146,8 @@
 
 .annotated_steps_error_wrapper_in_group {
   display: flex;
-  flex-direction: column;
   width: 100%;
+  flex-direction: column;
   padding: 0 var(--spacing-4);
   gap: var(--spacing-4);
 }

--- a/protocol-visualization/src/organisms/AnnotatedSteps/annotatedsteps.module.css
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/annotatedsteps.module.css
@@ -144,6 +144,15 @@
   gap: var(--spacing-4);
 }
 
+/* Matches .individual_command_container_group horizontal inset inside .annotated_group_expanded */
+.annotated_steps_error_wrapper_in_group {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 0 var(--spacing-4);
+  gap: var(--spacing-4);
+}
+
 .annotated_steps_error_container {
   display: flex;
   flex-direction: column;
@@ -166,13 +175,16 @@
   gap: var(--spacing-4);
 }
 
-.annotated_steps_final_command {
+.annotated_steps_error_footer_message {
   display: flex;
   width: 100%;
-  padding: var(--spacing-8);
-  border-radius: var(--border-radius-4);
-  background-color: var(--grey-20);
-  transition:
-    background-color 500ms ease-out,
-    border-color 500ms ease-out;
+  flex-direction: column;
+  align-items: center;
+  padding-top: var(--spacing-4);
+  text-align: center;
+}
+
+/* Matches horizontal inset of .annotated_steps_error_wrapper for standalone error rows */
+.annotated_steps_past_steps_row {
+  padding: var(--spacing-8) var(--spacing-12);
 }

--- a/protocol-visualization/src/organisms/AnnotatedSteps/annotatedsteps.module.css
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/annotatedsteps.module.css
@@ -144,7 +144,6 @@
   gap: var(--spacing-4);
 }
 
-/* Matches .individual_command_container_group horizontal inset inside .annotated_group_expanded */
 .annotated_steps_error_wrapper_in_group {
   display: flex;
   flex-direction: column;
@@ -184,7 +183,6 @@
   text-align: center;
 }
 
-/* Matches horizontal inset of .annotated_steps_error_wrapper for standalone error rows */
 .annotated_steps_past_steps_row {
   padding: var(--spacing-8) var(--spacing-12);
 }

--- a/protocol-visualization/src/organisms/AnnotatedSteps/index.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/index.tsx
@@ -7,7 +7,11 @@ import { getLabwareDefinitionsFromCommands } from '@opentrons/components'
 import styles from './annotatedsteps.module.css'
 import { AnnotatedStepsRowItem } from './AnnotatedStepsRowItem'
 import { ProtocolAnalysisErrorModal } from './ProtocolAnalysisErrorModal'
-import { getIsVisibleProtocolStep } from './utils'
+import {
+  getGroupedNodeIndexContainingCommandId,
+  getIsVisibleProtocolStep,
+  getLastVisibleAnalysisCommandId,
+} from './utils'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type {
@@ -38,6 +42,7 @@ interface GroupRow {
   annotationType: string
   commandStartNumber: number
   annotationDescription: string
+  trailingErrors?: AnalysisError[]
 }
 
 interface CommandRow {
@@ -53,7 +58,15 @@ interface ErrorRow {
   errors: AnalysisError[]
 }
 
-type AnnotatedStepsRow = GroupRow | CommandRow | ErrorRow
+interface ErrorPastStepsMessageRow {
+  type: 'errors_past_steps_message'
+}
+
+type AnnotatedStepsRow =
+  | GroupRow
+  | CommandRow
+  | ErrorRow
+  | ErrorPastStepsMessageRow
 
 export interface ItemData {
   rows: AnnotatedStepsRow[]
@@ -100,11 +113,19 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [isValidRobotSideAnalysis]
   )
-  const commandIndexById = useMemo(
+  const filteredCommands = useMemo(
     () =>
-      new Map(analysis.commands.map((command, index) => [command.id, index])),
+      analysis.commands.filter(
+        command =>
+          !command.commandType.includes('load') &&
+          command.commandType !== 'home'
+      ),
     [analysis.commands]
   )
+  const currentCommandId =
+    currentCommandIndex != null
+      ? (filteredCommands[currentCommandIndex]?.id ?? null)
+      : null
   const filteredGroupedCommands = useMemo(() => {
     if (groupedCommands == null) {
       return null
@@ -130,8 +151,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
         if ('annotationId' in node) {
           const updatedSubCommands = node.subCommands.map(subNode => ({
             ...subNode,
-            isHighlighted:
-              currentCommandIndex === commandIndexById.get(subNode.command.id),
+            isHighlighted: currentCommandId === subNode.command.id,
           }))
 
           return {
@@ -144,50 +164,58 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
         }
         return {
           ...node,
-          isHighlighted:
-            currentCommandIndex === commandIndexById.get(node.command.id),
+          isHighlighted: currentCommandId === node.command.id,
         }
       }),
-    [filteredGroupedCommands, currentCommandIndex, commandIndexById]
+    [filteredGroupedCommands, currentCommandId]
   )
-  const filteredCommands = useMemo(
-    () =>
-      analysis.commands.filter(
-        command =>
-          !command.commandType.includes('load') &&
-          command.commandType !== 'home'
-      ),
+
+  const lastVisibleAnalysisCommandId = useMemo(
+    () => getLastVisibleAnalysisCommandId(analysis.commands),
     [analysis.commands]
   )
 
+  const groupedRowIndexForTrailingErrors = useMemo(() => {
+    if (
+      analysis.errors.length === 0 ||
+      groupedCommandsHighlightedInfo == null ||
+      groupedCommandsHighlightedInfo.length === 0 ||
+      lastVisibleAnalysisCommandId == null
+    ) {
+      return null
+    }
+    return getGroupedNodeIndexContainingCommandId(
+      groupedCommandsHighlightedInfo,
+      lastVisibleAnalysisCommandId
+    )
+  }, [
+    analysis.errors,
+    groupedCommandsHighlightedInfo,
+    lastVisibleAnalysisCommandId,
+  ])
+
   useEffect(() => {
-    if (currentCommandIndex == null) return
-    if (filteredGroupedCommands != null) {
+    if (currentCommandId == null) return
+    if (filteredGroupedCommands != null && filteredGroupedCommands.length > 0) {
       const flatCommands = filteredGroupedCommands.flatMap(node =>
         'subCommands' in node ? node.subCommands : [node]
       )
 
       const targetNode = flatCommands.find(
-        node => commandIndexById.get(node.command.id) === currentCommandIndex
+        node => node.command.id === currentCommandId
       )
+      const targetCommandId = targetNode?.command.id ?? null
 
-      if (targetNode?.command.id && scrollTargetId !== targetNode.command.id) {
-        setScrollTargetId(targetNode.command.id)
+      if (targetCommandId != null && scrollTargetId !== targetCommandId) {
+        setScrollTargetId(targetCommandId)
       }
       return
     }
 
-    const targetCommand = filteredCommands[currentCommandIndex]
-    if (targetCommand?.id && scrollTargetId !== targetCommand.id) {
-      setScrollTargetId(targetCommand.id)
+    if (scrollTargetId !== currentCommandId) {
+      setScrollTargetId(currentCommandId)
     }
-  }, [
-    filteredGroupedCommands,
-    currentCommandIndex,
-    scrollTargetId,
-    commandIndexById,
-    filteredCommands,
-  ])
+  }, [filteredGroupedCommands, currentCommandId, scrollTargetId])
 
   const { rows, rowIndexByCommandId } = useMemo(() => {
     const nextRows: AnnotatedStepsRow[] = []
@@ -213,6 +241,10 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
             annotationType: group.annotation?.name ?? '',
             commandStartNumber: subCommandStartNumber,
             annotationDescription: group.annotation?.description ?? '',
+            ...(groupedRowIndexForTrailingErrors === index &&
+            analysis.errors.length > 0
+              ? { trailingErrors: analysis.errors }
+              : {}),
           })
           group.subCommands.forEach(subCommand => {
             nextRowIndexByCommandId.set(subCommand.command.id, rowIndex)
@@ -247,10 +279,20 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
       })
     }
 
-    if (analysis.errors.length > 0) {
+    if (
+      analysis.errors.length > 0 &&
+      groupedRowIndexForTrailingErrors == null
+    ) {
       nextRows.push({
         type: 'errors',
         errors: analysis.errors,
+      })
+    } else if (
+      analysis.errors.length > 0 &&
+      groupedRowIndexForTrailingErrors != null
+    ) {
+      nextRows.push({
+        type: 'errors_past_steps_message',
       })
     }
 
@@ -263,6 +305,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     filteredCommands,
     currentCommandIndex,
     analysis.errors,
+    groupedRowIndexForTrailingErrors,
   ])
 
   const [listRef, listRefCallback] = useListCallbackRef()

--- a/protocol-visualization/src/organisms/AnnotatedSteps/utils.ts
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/utils.ts
@@ -3,3 +3,36 @@ import type { RunTimeCommand } from '@opentrons/shared-data'
 export const getIsVisibleProtocolStep = (command: RunTimeCommand): boolean => {
   return !command.commandType.includes('load') && command.commandType !== 'home'
 }
+
+export function getLastVisibleAnalysisCommandId(
+  commands: RunTimeCommand[]
+): string | null {
+  for (let i = commands.length - 1; i >= 0; i--) {
+    const command = commands[i]
+    if (getIsVisibleProtocolStep(command)) {
+      return command.id
+    }
+  }
+  return null
+}
+
+export function getGroupedNodeIndexContainingCommandId(
+  groupedNodes: ReadonlyArray<
+    | {
+        annotationId: string
+        subCommands: ReadonlyArray<{ command: { id: string } }>
+      }
+    | { command: { id: string } }
+  >,
+  commandId: string
+): number | null {
+  for (let i = 0; i < groupedNodes.length; i++) {
+    const node = groupedNodes[i]
+    if ('annotationId' in node && 'subCommands' in node) {
+      if (node.subCommands.some(sc => sc.command.id === commandId)) {
+        return i
+      }
+    }
+  }
+  return null
+}


### PR DESCRIPTION
closes AUTH-2873

# Overview
<img width="244" height="594" alt="Screenshot 2026-05-06 at 17 44 00" src="https://github.com/user-attachments/assets/72d018ef-e96e-4d7e-9e3f-5295041ed157" />

<img width="246" height="732" alt="Screenshot 2026-05-06 at 17 44 45" src="https://github.com/user-attachments/assets/72091a96-5e87-44ab-8cfb-53d2ca65a23c" />

This PR adds the error information to a step group if an error occurs after a command that is in a group.

Also, this PR fixes auto scrolling within a group

NOTE: again there are 2 sources of truth so there is duplicate code between `app` and `protocol-visualization`.

## Test Plan and Hands on Testing

Test with this fixture protocol that has an error: [simpleFlexV8_error.json](https://github.com/user-attachments/files/27461256/simpleFlexV8_error.json)

see that the error is rendered at the bottom of the group

## Changelog

- add error logic to AnnotatedGroup and AnnotatedStep in both `app` and `protocol-visualziation` directories
- extend a prop in `stepGroup`
- add test coverage

## Risk assessment

affects both `app` and `protocol-visualization` but mainly important for the `app`. This is the last thing needed for step grouping UI to be feature complete for RS 9.1.0. affects PV, so like medium priority
