### PR TITLE
fix(app): changed LPC confirm offset button text

### DIFF
--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -173,7 +173,7 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
   // override into all the hooks in this component that will try to use the robot API.
   const hostConfig = useMemo<HostConfig>(
     () => ({
-      hostname: '127.0.0.1',
+      hostname: '10.14.19.202',
     }),
     []
   )

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -173,7 +173,7 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
   // override into all the hooks in this component that will try to use the robot API.
   const hostConfig = useMemo<HostConfig>(
     () => ({
-      hostname: '10.14.19.202',
+      hostname: '127.0.0.1',
     }),
     []
   )

--- a/app/src/assets/localization/en/labware_position_check.json
+++ b/app/src/assets/localization/en/labware_position_check.json
@@ -34,6 +34,7 @@
   "confirm": "Confirm",
   "confirm_detached": "Confirm removal",
   "confirm_go_back_without_saving": "Are you sure you want to go back to the the labware list without saving?",
+  "confirm_offset": "Confirm offset",
   "confirm_pick_up_tip_modal_title": "Did the pipette pick up a tip successfully?",
   "confirm_pick_up_tip_modal_try_again_text": "No, try again",
   "confirm_placement": "Confirm placement",

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/__tests__/CheckLabware.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/__tests__/CheckLabware.test.tsx
@@ -183,7 +183,7 @@ describe('CheckLabware', () => {
     const primaryButton = screen.getByTestId('primary-button')
     expect(primaryButton).toHaveAttribute(
       'data-button-text',
-      'Confirm placement'
+      'Confirm offset'
     )
     expect(primaryButton).toHaveAttribute('data-click-handler', 'true')
   })
@@ -198,7 +198,7 @@ describe('CheckLabware', () => {
     const primaryButton = screen.getByTestId('primary-button')
     expect(primaryButton).toHaveAttribute(
       'data-button-text',
-      'Confirm placement'
+      'Confirm offset'
     )
     expect(primaryButton).toHaveAttribute('data-click-handler', 'true')
   })

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/__tests__/CheckLabware.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/__tests__/CheckLabware.test.tsx
@@ -181,10 +181,7 @@ describe('CheckLabware', () => {
     expect(header).toHaveTextContent('Test Content Header')
 
     const primaryButton = screen.getByTestId('primary-button')
-    expect(primaryButton).toHaveAttribute(
-      'data-button-text',
-      'Confirm offset'
-    )
+    expect(primaryButton).toHaveAttribute('data-button-text', 'Confirm offset')
     expect(primaryButton).toHaveAttribute('data-click-handler', 'true')
   })
 
@@ -196,10 +193,7 @@ describe('CheckLabware', () => {
     expect(header).toHaveTextContent('Test Content Header')
 
     const primaryButton = screen.getByTestId('primary-button')
-    expect(primaryButton).toHaveAttribute(
-      'data-button-text',
-      'Confirm offset'
-    )
+    expect(primaryButton).toHaveAttribute('data-button-text', 'Confirm offset')
     expect(primaryButton).toHaveAttribute('data-click-handler', 'true')
   })
 

--- a/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/index.tsx
+++ b/app/src/organisms/LabwarePositionCheck/steps/HandleLabware/EditOffset/CheckLabware/index.tsx
@@ -190,8 +190,8 @@ function CheckLabwareContentODD(props: CheckLabwareContentProps): JSX.Element {
         {...props}
         header={contentHeader}
         desktopHeaderBtnCopy={t('exit')}
-        desktopFooterBtnCopy={t('confirm_placement')}
-        oddHeaderBtnCopy={t('confirm_placement')}
+        desktopFooterBtnCopy={t('confirm_offset')}
+        oddHeaderBtnCopy={t('confirm_offset')}
         onClickButton={handleProceed}
         onClickBack={handleGoBack}
       >
@@ -279,8 +279,8 @@ function CheckLabwareContentDesktop(
       {...props}
       header={contentHeader}
       desktopHeaderBtnCopy={t('exit')}
-      desktopFooterBtnCopy={t('confirm_placement')}
-      oddHeaderBtnCopy={t('confirm_placement')}
+      desktopFooterBtnCopy={t('confirm_offset')}
+      oddHeaderBtnCopy={t('confirm_offset')}
       onClickButton={handleProceed}
       onClickBack={handleGoBack}
       containerStyle={DESKTOP_CONTAINER_STYLE}


### PR DESCRIPTION
Changed 'confirm placement' button in LPC jogging flow to 'confirm offset' for clarity

Fixes [EXEC-1595](https://opentrons.atlassian.net/browse/EXEC-1595)

# Overview

<img width="1136" height="712" alt="Screenshot 2026-05-06 at 3 57 11 PM" src="https://github.com/user-attachments/assets/5f51ce2d-6b51-4859-8716-7e445607e4cf" />

<img width="1136" height="908" alt="Screenshot 2026-05-07 at 10 25 54 AM" src="https://github.com/user-attachments/assets/8ac73fd2-0bda-4ca4-a8a1-566a54f6ca19" />


These buttons used to say 'confirm placement' but that was confusing for users so now it says 'confirm offset' because you're confirming the offset.

## Test Plan and Hands on Testing

Updated test in CheckLabware.test.tsx

To test, go to LPC flow, get to the step where you're jogging around the gantry, see that the button now says 'confirm offset'. 

## Review requests

Please confirm that I didn't somehow break everything. 

## Risk assessment

This adds a line to the english JSON - 'confirm_offset'. This will need to be added to the mandarin translation to prevent UI issues.

[EXEC-1595]: https://opentrons.atlassian.net/browse/EXEC-1595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ