### PR TITLE
fix(protocol-designer, shared-data, step-generation): update vacuum profile types and command params

### DIFF
--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/vacuumFormToArgs.test.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/test/vacuumFormToArgs.test.ts
@@ -235,12 +235,13 @@ describe('vacuumFormToArgs', () => {
       name: annotation.stepName,
       description: annotation.stepDetails,
       profile: [
-        { holdSeconds: 45, pressureMbar: 12.5 },
+        { enablePump: true, holdSeconds: 45, gaugePressureMbar: 12.5 },
         {
           repetitions: 3,
-          steps: [{ holdSeconds: 90, powerPercent: 88 }],
+          steps: [{ enablePump: true, holdSeconds: 90, percentPower: 88 }],
         },
       ],
+      ventAfter: false,
     }
     expect(vacuumFormToArgs(formData)).toEqual(expected)
   })

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/vacuumFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/vacuumFormToArgs.ts
@@ -93,13 +93,16 @@ const vacuumProfileStepToAtomic = (
   if (pumpData.mode === VACUUM_MODE_PRESSURE) {
     const mbar = pumpData.pressureMbar
     return {
+      enablePump: true,
       holdSeconds: durationSeconds,
-      pressureMbar: mbar != null && mbar !== '' ? Number.parseFloat(mbar) : 0,
+      gaugePressureMbar:
+        mbar != null && mbar !== '' ? Number.parseFloat(mbar) : 0,
     }
   }
   return {
+    enablePump: true,
     holdSeconds: durationSeconds,
-    powerPercent: pumpData.powerPercent,
+    percentPower: pumpData.powerPercent,
   }
 }
 
@@ -205,6 +208,7 @@ export const vacuumFormToArgs = (
       return {
         commandCreatorFnName: 'vacuumStartRunProfile',
         profile: profileElements.map(vacuumProfileItemToPeProfileElement),
+        ventAfter: endingHoldVentCheckbox,
         ...baseValues,
       }
     }

--- a/shared-data/command/types/module.ts
+++ b/shared-data/command/types/module.ts
@@ -374,14 +374,20 @@ export interface TCProfileParams {
 // Vacuum Profile params (not finalized) (nd, 2026-04-23)
 export interface AtomicVacuumProfileStepBase {
   holdSeconds: number
+  enablePump: boolean
+  holdTimeSeconds?: number
+  holdTimeMinutes?: number
+  rampRate?: number
+  timeoutSeconds?: number
+  ventAfter?: boolean
 }
 
 export interface AtomicVacuumProfileStepPressure extends AtomicVacuumProfileStepBase {
-  pressureMbar: number
+  gaugePressureMbar: number
 }
 
 export interface AtomicVacuumProfileStepPower extends AtomicVacuumProfileStepBase {
-  powerPercent: number
+  percentPower: number
 }
 
 export type AtomicVacuumProfileStep =
@@ -391,14 +397,14 @@ export type AtomicVacuumProfileStep =
 export interface VacuumProfileCycle {
   steps: AtomicVacuumProfileStep[]
   repetitions: number
+  ventAfter?: boolean
 }
 
 export type VacuumProfile = Array<VacuumProfileCycle | AtomicVacuumProfileStep>
 export interface VacuumRunProfileParams {
   moduleId: string
   profile: VacuumProfile
-  taskId?: string | null
-  ventAfter?: boolean
+  taskId?: string
 }
 
 export interface ModuleOnlyParams {

--- a/shared-data/module/definitions/3/vacuumModuleV1.json
+++ b/shared-data/module/definitions/3/vacuumModuleV1.json
@@ -3,56 +3,56 @@
   "moduleType": "vacuumModuleType",
   "model": "vacuumModuleV1",
   "labwareOffset": {
-    "x": 999999,
-    "y": 999999,
-    "z": 999999
+    "x": 10,
+    "y": 0,
+    "z": 0
   },
   "features": {},
   "dimensions": {
-    "bareOverallHeight": 999999,
-    "overLabwareHeight": 999999,
-    "xDimension": 999999,
-    "yDimension": 999999,
-    "footprintXDimension": 128,
-    "footprintYDimension": 86,
+    "bareOverallHeight": 95,
+    "overLabwareHeight": 12,
+    "xDimension": 450,
+    "yDimension": 107,
+    "footprintXDimension": 450,
+    "footprintYDimension": 107,
     "labwareInterfaceXDimension": 128,
     "labwareInterfaceYDimension": 86
   },
   "extents": {
     "total": {
       "backLeftBottom": {
-        "x": 999999,
-        "y": 999999,
-        "z": 999999
+        "x": -18,
+        "y": 1.8,
+        "z": 0
       },
       "frontRightTop": {
-        "x": 999999,
-        "y": 999999,
-        "z": 999999
+        "x": 274,
+        "y": -105.2,
+        "z": 95
       }
     }
   },
   "cornerOffsetFromSlot": {
-    "x": 999999,
-    "y": 999999,
-    "z": 999999
+    "x": -18,
+    "y": -1.8,
+    "z": 0
   },
   "calibrationPoint": {
-    "x": 999999,
-    "y": 999999,
-    "z": 999999
+    "x": 64,
+    "y": 43,
+    "z": 55
   },
   "gripperOffsets": {
     "default": {
       "pickUpOffset": {
-        "x": 999999,
-        "y": 999999,
-        "z": 999999
+        "x": 0,
+        "y": 0,
+        "z": 0
       },
       "dropOffset": {
-        "x": 999999,
-        "y": 999999,
-        "z": 999999
+        "x": 0,
+        "y": 0,
+        "z": 1
       }
     }
   },

--- a/shared-data/module/definitions/3/vacuumModuleV1.json
+++ b/shared-data/module/definitions/3/vacuumModuleV1.json
@@ -3,44 +3,44 @@
   "moduleType": "vacuumModuleType",
   "model": "vacuumModuleV1",
   "labwareOffset": {
-    "x": 10,
+    "x": 0,
     "y": 0,
     "z": 0
   },
   "features": {},
   "dimensions": {
-    "bareOverallHeight": 95,
-    "overLabwareHeight": 12,
-    "xDimension": 450,
-    "yDimension": 107,
-    "footprintXDimension": 450,
-    "footprintYDimension": 107,
+    "bareOverallHeight": 40,
+    "overLabwareHeight": 0,
+    "xDimension": 143,
+    "yDimension": 101.5,
+    "footprintXDimension": 143,
+    "footprintYDimension": 101.5,
     "labwareInterfaceXDimension": 128,
     "labwareInterfaceYDimension": 86
   },
   "extents": {
     "total": {
       "backLeftBottom": {
-        "x": -18,
-        "y": 1.8,
+        "x": 0,
+        "y": 0,
         "z": 0
       },
       "frontRightTop": {
-        "x": 274,
-        "y": -105.2,
-        "z": 95
+        "x": 143,
+        "y": 101.5,
+        "z": 37
       }
     }
   },
   "cornerOffsetFromSlot": {
-    "x": -18,
-    "y": -1.8,
+    "x": 0,
+    "y": 0,
     "z": 0
   },
   "calibrationPoint": {
-    "x": 64,
-    "y": 43,
-    "z": 55
+    "x": 0,
+    "y": 0,
+    "z": 0
   },
   "gripperOffsets": {
     "default": {
@@ -50,9 +50,9 @@
         "z": 0
       },
       "dropOffset": {
-        "x": 0,
+        "x": 1,
         "y": 0,
-        "z": 1
+        "z": 0
       }
     }
   },
@@ -60,10 +60,7 @@
   "quirks": [],
   "slotTransforms": {},
   "orientation": {
-    "A3": "right",
-    "A4": "right",
-    "D3": "right",
-    "D4": "right"
+    "A3": "right"
   },
   "compatibleWith": [],
   "incompatibleWithDecks": ["ot2_standard", "ot2_short_trash"]

--- a/step-generation/src/commandCreators/atomic/__tests__/vacuumStartRunProfile.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/vacuumStartRunProfile.test.ts
@@ -126,13 +126,14 @@ mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
       python: `
 mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
     profile=[
+        {"power_percent": 30, "hold_time_seconds": 5},
         {
             "power_percent": 30,
             "hold_time_seconds": 5,
             "vent_after": False,
         }
     ],
-    repetitions=2
+    repetitions=1
 )`.trim(),
     })
   })

--- a/step-generation/src/commandCreators/atomic/__tests__/vacuumStartRunProfile.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/vacuumStartRunProfile.test.ts
@@ -87,7 +87,11 @@ describe('vacuumStartRunProfile', () => {
       python: `
 mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
     profile=[
-        {"gauge_pressure": 55, "hold_time_seconds": 12}
+        {
+            "gauge_pressure": 55,
+            "hold_time_seconds": 12,
+            "vent_after": True,
+        }
     ],
     repetitions=1
 )`.trim(),
@@ -122,7 +126,11 @@ mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
       python: `
 mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
     profile=[
-        {"power_percent": 30, "hold_time_seconds": 5}
+        {
+            "power_percent": 30,
+            "hold_time_seconds": 5,
+            "vent_after": False,
+        }
     ],
     repetitions=2
 )`.trim(),

--- a/step-generation/src/commandCreators/atomic/__tests__/vacuumStartRunProfile.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/vacuumStartRunProfile.test.ts
@@ -16,8 +16,11 @@ import {
 } from '../../../fixtures'
 import { vacuumStartRunProfile } from '../vacuumStartRunProfile'
 
-import type { VacuumModuleStartRunProfileCreateCommand } from '@opentrons/shared-data'
-import type { InvariantContext, RobotState } from '../../../types'
+import type {
+  InvariantContext,
+  RobotState,
+  VacuumStartRunProfileArgs,
+} from '../../../types'
 
 const vacuumModuleId = 'vacuumModuleId'
 
@@ -56,12 +59,19 @@ describe('vacuumStartRunProfile', () => {
   }
 
   it('generates JSON and python for a single atomic profile step with ventAfter', () => {
-    const params: VacuumModuleStartRunProfileCreateCommand['params'] = {
+    const args: VacuumStartRunProfileArgs = {
       moduleId: vacuumModuleId,
-      profile: [{ holdSeconds: 12, pressureMbar: 55 }],
+      commandCreatorFnName: 'vacuumStartRunProfile',
       ventAfter: true,
+      profile: [
+        {
+          enablePump: true,
+          holdSeconds: 12,
+          gaugePressureMbar: 55,
+        },
+      ],
     }
-    const result = vacuumStartRunProfile(params, invariantContext, robotState)
+    const result = vacuumStartRunProfile(args, invariantContext, robotState)
     expect(getSuccessResult(result)).toEqual({
       commands: [
         {
@@ -69,8 +79,7 @@ describe('vacuumStartRunProfile', () => {
           key: expect.any(String),
           params: {
             moduleId: vacuumModuleId,
-            profile: params.profile,
-            ventAfter: true,
+            profile: [{ ...args.profile[0], ventAfter: true }],
             taskId: 'mock_vacuum_module_task_1',
           },
         },
@@ -80,24 +89,24 @@ mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
     profile=[
         {"gauge_pressure": 55, "hold_time_seconds": 12}
     ],
-    repetitions=1,
-    vent_after=True
+    repetitions=1
 )`.trim(),
     })
   })
 
   it('generates JSON and python for a sole cycle with repetitions (power steps)', () => {
-    const params: VacuumModuleStartRunProfileCreateCommand['params'] = {
+    const args: VacuumStartRunProfileArgs = {
+      commandCreatorFnName: 'vacuumStartRunProfile',
       moduleId: vacuumModuleId,
       profile: [
         {
           repetitions: 2,
-          steps: [{ holdSeconds: 5, powerPercent: 30 }],
+          steps: [{ enablePump: true, holdSeconds: 5, percentPower: 30 }],
         },
       ],
       ventAfter: false,
     }
-    const result = vacuumStartRunProfile(params, invariantContext, robotState)
+    const result = vacuumStartRunProfile(args, invariantContext, robotState)
     expect(getSuccessResult(result)).toEqual({
       commands: [
         {
@@ -105,8 +114,7 @@ mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
           key: expect.any(String),
           params: {
             moduleId: vacuumModuleId,
-            profile: params.profile,
-            ventAfter: false,
+            profile: [{ ...args.profile[0], ventAfter: false }],
             taskId: 'mock_vacuum_module_task_1',
           },
         },
@@ -128,8 +136,16 @@ mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
     }
     const result = vacuumStartRunProfile(
       {
+        commandCreatorFnName: 'vacuumStartRunProfile',
         moduleId: vacuumModuleId,
-        profile: [{ holdSeconds: 1, pressureMbar: 1 }],
+        ventAfter: false,
+        profile: [
+          {
+            enablePump: true,
+            holdSeconds: 1,
+            gaugePressureMbar: 1,
+          },
+        ],
       },
       invariantContext,
       robotNoVacuum
@@ -157,8 +173,16 @@ mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
     })
     const result = vacuumStartRunProfile(
       {
+        commandCreatorFnName: 'vacuumStartRunProfile',
         moduleId: vacuumModuleId,
-        profile: [{ holdSeconds: 1, pressureMbar: 1 }],
+        ventAfter: false,
+        profile: [
+          {
+            enablePump: true,
+            holdSeconds: 1,
+            gaugePressureMbar: 1,
+          },
+        ],
       },
       invariantContext,
       busyRobot

--- a/step-generation/src/commandCreators/atomic/vacuumCloseVent.ts
+++ b/step-generation/src/commandCreators/atomic/vacuumCloseVent.ts
@@ -27,7 +27,7 @@ export const vacuumCloseVent: CommandCreator<VacuumCloseVentArgs> = (
     }
   }
 
-  const dummyPython = `${module.pythonName}.close_vent()`
+  const python = `${module.pythonName}.close_vent()`
   return {
     commands: [
       {
@@ -38,6 +38,6 @@ export const vacuumCloseVent: CommandCreator<VacuumCloseVentArgs> = (
         },
       },
     ],
-    python: dummyPython,
+    python,
   }
 }

--- a/step-generation/src/commandCreators/atomic/vacuumOpenVent.ts
+++ b/step-generation/src/commandCreators/atomic/vacuumOpenVent.ts
@@ -25,7 +25,7 @@ export const vacuumOpenVent: CommandCreator<
       errors: [errorCreators.liveTaskError()],
     }
   }
-  const dummyPython = `${module.pythonName}.open_vent()`
+  const python = `${module.pythonName}.open_vent()`
   return {
     commands: [
       {
@@ -36,6 +36,6 @@ export const vacuumOpenVent: CommandCreator<
         },
       },
     ],
-    python: dummyPython,
+    python,
   }
 }

--- a/step-generation/src/commandCreators/atomic/vacuumStartRunProfile.ts
+++ b/step-generation/src/commandCreators/atomic/vacuumStartRunProfile.ts
@@ -31,7 +31,7 @@ export const vacuumStartRunProfile: CommandCreator<
 
   // 1-indexed profile task ID
   const taskId = `${vacuumPythonName}_task_${vacuumState.numPumpActivitiesStarted + 1}`
-  const profileArgs = getVacuumProfileStepString(profile)
+  const profileArgs = getVacuumProfileStepString(profile, ventAfter)
 
   // explicitly attach the ventAfter param to the final step of the profile in accordance with PE command shape
   // there is no direct ventAfter param at the startRunProfile command params top level

--- a/step-generation/src/commandCreators/atomic/vacuumStartRunProfile.ts
+++ b/step-generation/src/commandCreators/atomic/vacuumStartRunProfile.ts
@@ -1,19 +1,14 @@
 import * as errorCreators from '../../errorCreators'
 import { vacuumModuleStateGetter } from '../../robotStateSelectors'
-import {
-  formatPyValue,
-  getModuleHasLiveTask,
-  indentPyLines,
-  uuid,
-} from '../../utils'
+import { getModuleHasLiveTask, indentPyLines, uuid } from '../../utils'
 import { getVacuumProfileStepString } from '../../utils/vacuumPythonArgs/getVacuumProfileStepString'
 
 import type { VacuumModuleStartRunProfileCreateCommand } from '@opentrons/shared-data'
-import type { CommandCreator } from '../../types'
+import type { CommandCreator, VacuumStartRunProfileArgs } from '../../types'
 
 // TODO: (nd, 2026-04-20) command creator implementation
 export const vacuumStartRunProfile: CommandCreator<
-  VacuumModuleStartRunProfileCreateCommand['params']
+  VacuumStartRunProfileArgs
 > = (args, invariantContext, prevRobotState) => {
   const { moduleId, profile, ventAfter } = args
 
@@ -37,15 +32,18 @@ export const vacuumStartRunProfile: CommandCreator<
   // 1-indexed profile task ID
   const taskId = `${vacuumPythonName}_task_${vacuumState.numPumpActivitiesStarted + 1}`
   const profileArgs = getVacuumProfileStepString(profile)
-  const ventAfterArg = ventAfter
-    ? `vent_after=${formatPyValue(ventAfter)}`
-    : null
-  const allArgs = [
-    ...profileArgs,
-    ...(ventAfterArg != null ? [ventAfterArg] : []),
-  ]
 
-  const dummyPython = `${taskId} = ${vacuumPythonName}.start_execute_profile(\n${indentPyLines(allArgs.join(',\n'))}\n)`
+  // explicitly attach the ventAfter param to the final step of the profile in accordance with PE command shape
+  // there is no direct ventAfter param at the startRunProfile command params top level
+  const profileWithVentOnFinal: VacuumModuleStartRunProfileCreateCommand['params']['profile'] =
+    profile.map((step, index) => {
+      if (index === profile.length - 1) {
+        return { ...step, ventAfter }
+      }
+      return step
+    })
+
+  const dummyPython = `${taskId} = ${vacuumPythonName}.start_execute_profile(\n${indentPyLines(profileArgs.join(',\n'))}\n)`
 
   return {
     commands: [
@@ -54,8 +52,7 @@ export const vacuumStartRunProfile: CommandCreator<
         key: uuid(),
         params: {
           moduleId,
-          profile,
-          ventAfter,
+          profile: profileWithVentOnFinal,
           taskId,
         },
       },

--- a/step-generation/src/commandCreators/atomic/vacuumStartRunProfile.ts
+++ b/step-generation/src/commandCreators/atomic/vacuumStartRunProfile.ts
@@ -43,7 +43,7 @@ export const vacuumStartRunProfile: CommandCreator<
       return step
     })
 
-  const dummyPython = `${taskId} = ${vacuumPythonName}.start_execute_profile(\n${indentPyLines(profileArgs.join(',\n'))}\n)`
+  const python = `${taskId} = ${vacuumPythonName}.start_execute_profile(\n${indentPyLines(profileArgs.join(',\n'))}\n)`
 
   return {
     commands: [
@@ -57,7 +57,6 @@ export const vacuumStartRunProfile: CommandCreator<
         },
       },
     ],
-    // TODO: (nd, 2026-04-23) implement Python
-    python: dummyPython,
+    python,
   }
 }

--- a/step-generation/src/commandCreators/atomic/vacuumStopPump.ts
+++ b/step-generation/src/commandCreators/atomic/vacuumStopPump.ts
@@ -17,7 +17,7 @@ export const vacuumStopPump: CommandCreator<
     }
   }
 
-  const dummyPython = `${module.pythonName}.stop_vacuum()`
+  const python = `${module.pythonName}.stop_vacuum()`
   return {
     commands: [
       {
@@ -28,6 +28,6 @@ export const vacuumStopPump: CommandCreator<
         },
       },
     ],
-    python: dummyPython,
+    python,
   }
 }

--- a/step-generation/src/getNextRobotStateAndWarnings/__tests__/vacuumUpdates.test.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/__tests__/vacuumUpdates.test.ts
@@ -632,7 +632,7 @@ describe('forVacuumStopPump', () => {
 })
 
 const sampleVacuumProfile: VacuumModuleStartRunProfileCreateCommand['params']['profile'] =
-  [{ holdSeconds: 2, pressureMbar: 150 }]
+  [{ enablePump: true, holdSeconds: 2, gaugePressureMbar: 150 }]
 
 describe('forVacuumStartRunProfile', () => {
   it('sets profile activity and increments numPumpActivitiesStarted when module and taskId are present', () => {
@@ -648,7 +648,6 @@ describe('forVacuumStartRunProfile', () => {
         moduleId: vacuumModuleId,
         profile: sampleVacuumProfile,
         taskId: vacuumTaskId,
-        ventAfter: false,
       },
       invariantContext,
       robot
@@ -660,7 +659,7 @@ describe('forVacuumStartRunProfile', () => {
       type: 'profile',
       profileElements: sampleVacuumProfile,
       taskId: vacuumTaskId,
-      ventAfter: false,
+      ventAfter: true,
     })
     expect(updated.numPumpActivitiesStarted).toBe(1)
     expect(updated.ventStatus).toBe(VACUUM_VENT_CLOSED)

--- a/step-generation/src/getNextRobotStateAndWarnings/vacuumUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/vacuumUpdates.ts
@@ -135,18 +135,19 @@ export const forVacuumStartRunProfile = (
   invariantContext: InvariantContext,
   robotStateAndWarnings: RobotStateAndWarnings
 ): void => {
-  const { moduleId, profile, taskId, ventAfter = true } = params
+  const { moduleId, profile, taskId } = params
   const { robotState } = robotStateAndWarnings
   const moduleState = vacuumModuleStateGetter(robotState, moduleId)
   // taskId should not be null, but this is to satisfy type checks
   if (moduleState == null || taskId == null) {
     return
   }
+  const shouldVentAfterFinalProfileStep = profile.at(-1)?.ventAfter ?? true
   moduleState.currentPumpActivity = {
     type: 'profile',
     profileElements: profile,
     taskId,
-    ventAfter,
+    ventAfter: shouldVentAfterFinalProfileStep,
   }
   moduleState.numPumpActivitiesStarted++
 }

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -884,7 +884,7 @@ export interface VacuumStartRunProfileArgs extends CommonArgs {
   moduleId: string
   commandCreatorFnName: 'vacuumStartRunProfile'
   profile: VacuumRunProfileParams['profile']
-  ventAfter?: boolean
+  ventAfter: boolean
 }
 
 export type VacuumArgs =

--- a/step-generation/src/utils/__tests__/getModuleHasLiveTask.test.ts
+++ b/step-generation/src/utils/__tests__/getModuleHasLiveTask.test.ts
@@ -34,7 +34,9 @@ describe('getModuleHasLiveTask', () => {
         ...VACUUM_MODULE_INITIAL_STATE,
         currentPumpActivity: {
           type: 'profile' as const,
-          profileElements: [{ holdSeconds: 1, pressureMbar: 50 }],
+          profileElements: [
+            { enablePump: true, holdSeconds: 1, gaugePressureMbar: 50 },
+          ],
           taskId: 'vac-task',
           ventAfter: false,
         },

--- a/step-generation/src/utils/vacuumPythonArgs/__tests__/getVacuumProfileStepString.test.ts
+++ b/step-generation/src/utils/vacuumPythonArgs/__tests__/getVacuumProfileStepString.test.ts
@@ -10,7 +10,9 @@ describe('getVacuumProfileStepString', () => {
   const indentedPowerStep = '    {"power_percent": 30, "hold_time_seconds": 5}'
 
   it('formats a single atomic pressure step with repetitions=1', () => {
-    const profile: VacuumProfile = [{ holdSeconds: 12, pressureMbar: 55 }]
+    const profile: VacuumProfile = [
+      { enablePump: true, holdSeconds: 12, gaugePressureMbar: 55 },
+    ]
     expect(getVacuumProfileStepString(profile)).toEqual([
       `profile=[\n${indentedPressureStep}\n]`,
       'repetitions=1',
@@ -18,7 +20,9 @@ describe('getVacuumProfileStepString', () => {
   })
 
   it('formats a single atomic power step with repetitions=1', () => {
-    const profile: VacuumProfile = [{ holdSeconds: 5, powerPercent: 30 }]
+    const profile: VacuumProfile = [
+      { enablePump: true, holdSeconds: 5, percentPower: 30 },
+    ]
     expect(getVacuumProfileStepString(profile)).toEqual([
       `profile=[\n${indentedPowerStep}\n]`,
       'repetitions=1',
@@ -29,7 +33,7 @@ describe('getVacuumProfileStepString', () => {
     const profile: VacuumProfile = [
       {
         repetitions: 2,
-        steps: [{ holdSeconds: 5, powerPercent: 30 }],
+        steps: [{ enablePump: true, holdSeconds: 5, percentPower: 30 }],
       },
     ]
     expect(getVacuumProfileStepString(profile)).toEqual([
@@ -40,8 +44,8 @@ describe('getVacuumProfileStepString', () => {
 
   it('flattens multiple top-level atomic steps and sets repetitions=1', () => {
     const profile: VacuumProfile = [
-      { holdSeconds: 1, pressureMbar: 10 },
-      { holdSeconds: 2, pressureMbar: 20 },
+      { enablePump: true, holdSeconds: 1, gaugePressureMbar: 10 },
+      { enablePump: true, holdSeconds: 2, gaugePressureMbar: 20 },
     ]
     expect(getVacuumProfileStepString(profile)).toEqual([
       `profile=[\n    {"gauge_pressure": 10, "hold_time_seconds": 1},\n    {"gauge_pressure": 20, "hold_time_seconds": 2}\n]`,
@@ -51,10 +55,10 @@ describe('getVacuumProfileStepString', () => {
 
   it('expands a cycle by repetitions when not sole top-level cycle', () => {
     const profile: VacuumProfile = [
-      { holdSeconds: 1, pressureMbar: 100 },
+      { enablePump: true, holdSeconds: 1, gaugePressureMbar: 100 },
       {
         repetitions: 2,
-        steps: [{ holdSeconds: 5, powerPercent: 30 }],
+        steps: [{ enablePump: true, holdSeconds: 5, percentPower: 30 }],
       },
     ]
     expect(getVacuumProfileStepString(profile)).toEqual([
@@ -68,8 +72,8 @@ describe('getVacuumProfileStepString', () => {
       {
         repetitions: 2,
         steps: [
-          { holdSeconds: 1, pressureMbar: 1 },
-          { holdSeconds: 2, powerPercent: 50 },
+          { enablePump: true, holdSeconds: 1, gaugePressureMbar: 1 },
+          { enablePump: true, holdSeconds: 2, percentPower: 50 },
         ],
       },
     ]

--- a/step-generation/src/utils/vacuumPythonArgs/__tests__/getVacuumProfileStepString.test.ts
+++ b/step-generation/src/utils/vacuumPythonArgs/__tests__/getVacuumProfileStepString.test.ts
@@ -37,7 +37,7 @@ describe('getVacuumProfileStepString', () => {
     ])
   })
 
-  it('formats sole cycle using inner steps once and cycle repetitions', () => {
+  it('flattens sole cycle into multiple atomic steps and sets repetitions to 1', () => {
     const profile: VacuumProfile = [
       {
         repetitions: 2,
@@ -46,13 +46,14 @@ describe('getVacuumProfileStepString', () => {
     ]
     expect(getVacuumProfileStepString(profile, true)).toEqual([
       `profile=[
+    {"power_percent": 30, "hold_time_seconds": 5},
     {
         "power_percent": 30,
         "hold_time_seconds": 5,
         "vent_after": True,
     }
 ]`,
-      'repetitions=2',
+      'repetitions=1',
     ])
   })
 
@@ -96,7 +97,7 @@ describe('getVacuumProfileStepString', () => {
     ])
   })
 
-  it('formats sole cycle with multiple inner steps and outer repetitions', () => {
+  it('flattens sole cycle with multiple inner steps and outer repetitions', () => {
     const profile: VacuumProfile = [
       {
         repetitions: 2,
@@ -114,13 +115,15 @@ describe('getVacuumProfileStepString', () => {
     expect(getVacuumProfileStepString(profile, true)).toEqual([
       `profile=[
     {"gauge_pressure": 1, "hold_time_seconds": 1},
+    {"power_percent": 50, "hold_time_seconds": 2},
+    {"gauge_pressure": 1, "hold_time_seconds": 1},
     {
         "power_percent": 50,
         "hold_time_seconds": 2,
         "vent_after": True,
     }
 ]`,
-      'repetitions=2',
+      'repetitions=1',
     ])
   })
 })

--- a/step-generation/src/utils/vacuumPythonArgs/__tests__/getVacuumProfileStepString.test.ts
+++ b/step-generation/src/utils/vacuumPythonArgs/__tests__/getVacuumProfileStepString.test.ts
@@ -5,16 +5,18 @@ import { getVacuumProfileStepString } from '../getVacuumProfileStepString'
 import type { VacuumProfile } from '@opentrons/shared-data'
 
 describe('getVacuumProfileStepString', () => {
-  const indentedPressureStep =
-    '    {"gauge_pressure": 55, "hold_time_seconds": 12}'
-  const indentedPowerStep = '    {"power_percent": 30, "hold_time_seconds": 5}'
-
   it('formats a single atomic pressure step with repetitions=1', () => {
     const profile: VacuumProfile = [
       { enablePump: true, holdSeconds: 12, gaugePressureMbar: 55 },
     ]
-    expect(getVacuumProfileStepString(profile)).toEqual([
-      `profile=[\n${indentedPressureStep}\n]`,
+    expect(getVacuumProfileStepString(profile, true)).toEqual([
+      `profile=[
+    {
+        "gauge_pressure": 55,
+        "hold_time_seconds": 12,
+        "vent_after": True,
+    }
+]`,
       'repetitions=1',
     ])
   })
@@ -23,8 +25,14 @@ describe('getVacuumProfileStepString', () => {
     const profile: VacuumProfile = [
       { enablePump: true, holdSeconds: 5, percentPower: 30 },
     ]
-    expect(getVacuumProfileStepString(profile)).toEqual([
-      `profile=[\n${indentedPowerStep}\n]`,
+    expect(getVacuumProfileStepString(profile, true)).toEqual([
+      `profile=[
+    {
+        "power_percent": 30,
+        "hold_time_seconds": 5,
+        "vent_after": True,
+    }
+]`,
       'repetitions=1',
     ])
   })
@@ -36,8 +44,14 @@ describe('getVacuumProfileStepString', () => {
         steps: [{ enablePump: true, holdSeconds: 5, percentPower: 30 }],
       },
     ]
-    expect(getVacuumProfileStepString(profile)).toEqual([
-      `profile=[\n${indentedPowerStep}\n]`,
+    expect(getVacuumProfileStepString(profile, true)).toEqual([
+      `profile=[
+    {
+        "power_percent": 30,
+        "hold_time_seconds": 5,
+        "vent_after": True,
+    }
+]`,
       'repetitions=2',
     ])
   })
@@ -47,8 +61,15 @@ describe('getVacuumProfileStepString', () => {
       { enablePump: true, holdSeconds: 1, gaugePressureMbar: 10 },
       { enablePump: true, holdSeconds: 2, gaugePressureMbar: 20 },
     ]
-    expect(getVacuumProfileStepString(profile)).toEqual([
-      `profile=[\n    {"gauge_pressure": 10, "hold_time_seconds": 1},\n    {"gauge_pressure": 20, "hold_time_seconds": 2}\n]`,
+    expect(getVacuumProfileStepString(profile, true)).toEqual([
+      `profile=[
+    {"gauge_pressure": 10, "hold_time_seconds": 1},
+    {
+        "gauge_pressure": 20,
+        "hold_time_seconds": 2,
+        "vent_after": True,
+    }
+]`,
       'repetitions=1',
     ])
   })
@@ -61,8 +82,16 @@ describe('getVacuumProfileStepString', () => {
         steps: [{ enablePump: true, holdSeconds: 5, percentPower: 30 }],
       },
     ]
-    expect(getVacuumProfileStepString(profile)).toEqual([
-      `profile=[\n    {"gauge_pressure": 100, "hold_time_seconds": 1},\n    {"power_percent": 30, "hold_time_seconds": 5},\n    {"power_percent": 30, "hold_time_seconds": 5}\n]`,
+    expect(getVacuumProfileStepString(profile, true)).toEqual([
+      `profile=[
+    {"gauge_pressure": 100, "hold_time_seconds": 1},
+    {"power_percent": 30, "hold_time_seconds": 5},
+    {
+        "power_percent": 30,
+        "hold_time_seconds": 5,
+        "vent_after": True,
+    }
+]`,
       'repetitions=1',
     ])
   })
@@ -73,12 +102,24 @@ describe('getVacuumProfileStepString', () => {
         repetitions: 2,
         steps: [
           { enablePump: true, holdSeconds: 1, gaugePressureMbar: 1 },
-          { enablePump: true, holdSeconds: 2, percentPower: 50 },
+          {
+            enablePump: true,
+            holdSeconds: 2,
+            percentPower: 50,
+            ventAfter: true,
+          },
         ],
       },
     ]
-    expect(getVacuumProfileStepString(profile)).toEqual([
-      `profile=[\n    {"gauge_pressure": 1, "hold_time_seconds": 1},\n    {"power_percent": 50, "hold_time_seconds": 2}\n]`,
+    expect(getVacuumProfileStepString(profile, true)).toEqual([
+      `profile=[
+    {"gauge_pressure": 1, "hold_time_seconds": 1},
+    {
+        "power_percent": 50,
+        "hold_time_seconds": 2,
+        "vent_after": True,
+    }
+]`,
       'repetitions=2',
     ])
   })

--- a/step-generation/src/utils/vacuumPythonArgs/getVacuumProfileStepString.ts
+++ b/step-generation/src/utils/vacuumPythonArgs/getVacuumProfileStepString.ts
@@ -55,38 +55,41 @@ export const getVacuumProfileStepString = (
   profile: VacuumProfile,
   ventAfter: boolean
 ): string[] => {
-  let profileArg: string
-  let repetitionsArg: string
-  // return sole cycle with repetitions if applicable
-  if (profile.length === 1 && 'repetitions' in profile[0]) {
-    const { steps, repetitions } = profile[0]
-    profileArg = `profile=[\n${indentPyLines(
-      steps
-        .map((step, i) => {
-          if (i === steps.length - 1) {
-            return _getVacuumProfileAtomicStepString(step, ventAfter)
-          }
-          return _getVacuumProfileAtomicStepString(step)
-        })
-        .join(',\n')
-    )}\n]`
-    repetitionsArg = `repetitions=${formatPyValue(repetitions)}`
-    return [profileArg, repetitionsArg]
-  } else {
-    // either a single atomic step or multiple steps
-    const atomicProfileSteps = _getAtomicVacuumProfileSteps(profile)
-    profileArg = `profile=[\n${indentPyLines(
-      atomicProfileSteps
-        .map((step, i) => {
-          if (i === atomicProfileSteps.length - 1) {
-            return _getVacuumProfileAtomicStepString(step, ventAfter)
-          }
-          return _getVacuumProfileAtomicStepString(step)
-        })
-        .join(',\n')
-    )}\n]`
-    // hard-coded to 1 repetition if we flatten all steps
-    repetitionsArg = `repetitions=${formatPyValue(1)}`
-  }
+  // In the future, we should return sole cycle with repetitions if applicable
+  // For now, the shape of the PE command and specced PAPI does not accommodate a
+  // profile-scoped vent control param, so we flatten all steps and add the vent control
+  // to the final-final step (last step of the last cycle repetition)
+  // I will leave the code here for future reference if PE/PAPI support this behavior
+
+  // let profileArg: string
+  // let repetitionsArg: string
+  // if (profile.length === 1 && 'repetitions' in profile[0]) {
+  //   const { steps, repetitions } = profile[0]
+  //   profileArg = `profile=[\n${indentPyLines(
+  //     steps
+  //       .map((step, i) => {
+  //         if (i === steps.length - 1) {
+  //           return _getVacuumProfileAtomicStepString(step, ventAfter)
+  //         }
+  //         return _getVacuumProfileAtomicStepString(step)
+  //       })
+  //       .join(',\n')
+  //   )}\n]`
+  //   repetitionsArg = `repetitions=${formatPyValue(repetitions)}`
+  //   return [profileArg, repetitionsArg]
+
+  const atomicProfileSteps = _getAtomicVacuumProfileSteps(profile)
+  const profileArg = `profile=[\n${indentPyLines(
+    atomicProfileSteps
+      .map((step, i) => {
+        if (i === atomicProfileSteps.length - 1) {
+          return _getVacuumProfileAtomicStepString(step, ventAfter)
+        }
+        return _getVacuumProfileAtomicStepString(step)
+      })
+      .join(',\n')
+  )}\n]`
+  // hard-coded to 1 repetition if we flatten all steps
+  const repetitionsArg = `repetitions=${formatPyValue(1)}`
   return [profileArg, repetitionsArg]
 }

--- a/step-generation/src/utils/vacuumPythonArgs/getVacuumProfileStepString.ts
+++ b/step-generation/src/utils/vacuumPythonArgs/getVacuumProfileStepString.ts
@@ -32,24 +32,28 @@ const _getVacuumProfileAtomicStepString = (
   step: AtomicVacuumProfileStep,
   ventAfter?: boolean
 ): string => {
+  const { holdSeconds } = step
+  const baseDict = {
+    hold_time_seconds: holdSeconds,
+    ...(ventAfter != null ? { vent_after: ventAfter } : {}),
+  }
   if ('gaugePressureMbar' in step) {
-    const { gaugePressureMbar, holdSeconds } = step
+    const { gaugePressureMbar } = step
     return formatPyDict({
       gauge_pressure: gaugePressureMbar,
-      hold_time_seconds: holdSeconds,
+      ...baseDict,
     })
   }
-  const { percentPower, holdSeconds } = step
+  const { percentPower } = step
   return formatPyDict({
     power_percent: Number(percentPower),
-    hold_time_seconds: Number(holdSeconds),
-    ...(ventAfter != null ? { vent_after: formatPyValue(ventAfter) } : {}),
+    ...baseDict,
   })
 }
 
 export const getVacuumProfileStepString = (
   profile: VacuumProfile,
-  ventAfter?: boolean
+  ventAfter: boolean
 ): string[] => {
   let profileArg: string
   let repetitionsArg: string

--- a/step-generation/src/utils/vacuumPythonArgs/getVacuumProfileStepString.ts
+++ b/step-generation/src/utils/vacuumPythonArgs/getVacuumProfileStepString.ts
@@ -29,37 +29,58 @@ const _getAtomicVacuumProfileSteps = (
 }
 
 const _getVacuumProfileAtomicStepString = (
-  step: AtomicVacuumProfileStep
+  step: AtomicVacuumProfileStep,
+  ventAfter?: boolean
 ): string => {
-  if ('pressureMbar' in step) {
-    const { pressureMbar, holdSeconds } = step
+  if ('gaugePressureMbar' in step) {
+    const { gaugePressureMbar, holdSeconds } = step
     return formatPyDict({
-      gauge_pressure: pressureMbar,
+      gauge_pressure: gaugePressureMbar,
       hold_time_seconds: holdSeconds,
     })
   }
-  const { powerPercent, holdSeconds } = step
+  const { percentPower, holdSeconds } = step
   return formatPyDict({
-    power_percent: Number(powerPercent),
+    power_percent: Number(percentPower),
     hold_time_seconds: Number(holdSeconds),
+    ...(ventAfter != null ? { vent_after: formatPyValue(ventAfter) } : {}),
   })
 }
 
 export const getVacuumProfileStepString = (
-  profile: VacuumProfile
+  profile: VacuumProfile,
+  ventAfter?: boolean
 ): string[] => {
-  // return sole cycle with repetitions if applicable
   let profileArg: string
   let repetitionsArg: string
+  // return sole cycle with repetitions if applicable
   if (profile.length === 1 && 'repetitions' in profile[0]) {
     const { steps, repetitions } = profile[0]
-    profileArg = `profile=[\n${indentPyLines(steps.map(_getVacuumProfileAtomicStepString).join(',\n'))}\n]`
+    profileArg = `profile=[\n${indentPyLines(
+      steps
+        .map((step, i) => {
+          if (i === steps.length - 1) {
+            return _getVacuumProfileAtomicStepString(step, ventAfter)
+          }
+          return _getVacuumProfileAtomicStepString(step)
+        })
+        .join(',\n')
+    )}\n]`
     repetitionsArg = `repetitions=${formatPyValue(repetitions)}`
     return [profileArg, repetitionsArg]
   } else {
     // either a single atomic step or multiple steps
     const atomicProfileSteps = _getAtomicVacuumProfileSteps(profile)
-    profileArg = `profile=[\n${indentPyLines(atomicProfileSteps.map(_getVacuumProfileAtomicStepString).join(',\n'))}\n]`
+    profileArg = `profile=[\n${indentPyLines(
+      atomicProfileSteps
+        .map((step, i) => {
+          if (i === atomicProfileSteps.length - 1) {
+            return _getVacuumProfileAtomicStepString(step, ventAfter)
+          }
+          return _getVacuumProfileAtomicStepString(step)
+        })
+        .join(',\n')
+    )}\n]`
     // hard-coded to 1 repetition if we flatten all steps
     repetitionsArg = `repetitions=${formatPyValue(1)}`
   }


### PR DESCRIPTION
# Overview

Update the vacuum module profile command creator's params with the introduction of protocol engine's vacuum module profile command.

EXEC-2371

## Test Plan and Hands on Testing

#### PD UI
- Should be no UI changes in PD

#### Step-generation
- Import and reexport a protocol with a profile step ([example](https://github.com/user-attachments/files/27529722/vac_test_cma_golden.py))
- Verify that the the last step of the profile specifies the ending vent position. There should be no profile-scoped vent control param. 


old behavior:
```typescript
    vacuum_module_1_task_2 = vacuum_module_1.start_execute_profile(
        profile=[
            {"power_percent": 44, "hold_time_seconds": 10},
            {"power_percent": 45, "hold_time_seconds": 11}
        ],
        repetitions=1,
        vent_after=True
    )
```

new behavior:
```typescript
    vacuum_module_1_task_2 = vacuum_module_1.start_execute_profile(
        profile=[
            {"power_percent": 44, "hold_time_seconds": 10,},
            {
                "power_percent": 45,
                "hold_time_seconds": 11,
                "vent_after": True
            }
        ],
        repetitions=1
    )
```

## Changelog

- move vent logic to last step of a profile, away from the profile itself, according to the expected shape of vacuum profile command params
- mirror behavior in emitted Python
- update types and tests accordingly

## Review requests

see test plan

## Risk assessment

low