### PR TITLE
fix(app): when dev tools are turned off turn off all feature flags

### DIFF
--- a/app/src/organisms/Desktop/AdvancedSettings/EnableDevTools.tsx
+++ b/app/src/organisms/Desktop/AdvancedSettings/EnableDevTools.tsx
@@ -13,9 +13,9 @@ import {
 
 import { ToggleButton } from '/app/atoms/buttons'
 import {
+  clearDevInternalFlags,
   getDevtoolsEnabled,
   toggleDevtools,
-  updateConfigValue,
 } from '/app/redux/config'
 
 import type { Dispatch } from '/app/redux/types'
@@ -26,7 +26,7 @@ export function EnableDevTools(): JSX.Element {
   const dispatch = useDispatch<Dispatch>()
   const toggleDevTools = (): void => {
     if (devToolsOn) {
-      dispatch(updateConfigValue('devInternal', {}))
+      dispatch(clearDevInternalFlags())
     }
     dispatch(toggleDevtools())
   }

--- a/app/src/organisms/Desktop/AdvancedSettings/EnableDevTools.tsx
+++ b/app/src/organisms/Desktop/AdvancedSettings/EnableDevTools.tsx
@@ -12,7 +12,11 @@ import {
 } from '@opentrons/components'
 
 import { ToggleButton } from '/app/atoms/buttons'
-import { getDevtoolsEnabled, toggleDevtools } from '/app/redux/config'
+import {
+  getDevtoolsEnabled,
+  toggleDevtools,
+  updateConfigValue,
+} from '/app/redux/config'
 
 import type { Dispatch } from '/app/redux/types'
 
@@ -20,7 +24,12 @@ export function EnableDevTools(): JSX.Element {
   const { t } = useTranslation('app_settings')
   const devToolsOn = useSelector(getDevtoolsEnabled)
   const dispatch = useDispatch<Dispatch>()
-  const toggleDevTools = (): unknown => dispatch(toggleDevtools())
+  const toggleDevTools = (): void => {
+    if (devToolsOn) {
+      dispatch(updateConfigValue('devInternal', {}))
+    }
+    dispatch(toggleDevtools())
+  }
 
   return (
     <Flex alignItems={ALIGN_CENTER} justifyContent={JUSTIFY_SPACE_BETWEEN}>

--- a/app/src/organisms/Desktop/AdvancedSettings/__tests__/EnableDevTools.test.tsx
+++ b/app/src/organisms/Desktop/AdvancedSettings/__tests__/EnableDevTools.test.tsx
@@ -3,7 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
-import { getDevtoolsEnabled, toggleDevtools } from '/app/redux/config'
+import {
+  clearDevInternalFlags,
+  getDevtoolsEnabled,
+  toggleDevtools,
+} from '/app/redux/config'
 
 import { EnableDevTools } from '../EnableDevTools'
 
@@ -17,6 +21,7 @@ const render = () => {
 
 describe('EnableDevTools', () => {
   beforeEach(() => {
+    vi.clearAllMocks()
     vi.mocked(getDevtoolsEnabled).mockReturnValue(true)
   })
 
@@ -29,12 +34,24 @@ describe('EnableDevTools', () => {
     screen.getByRole('switch', { name: 'enable_dev_tools' })
   })
 
-  it('should call mock toggleConfigValue when clicking the toggle button', () => {
+  it('should call toggleDevtools and clearDevInternalFlags when clicking the toggle button while dev tools are on', () => {
     render()
     const toggleButton = screen.getByRole('switch', {
       name: 'enable_dev_tools',
     })
     fireEvent.click(toggleButton)
+    expect(vi.mocked(clearDevInternalFlags)).toHaveBeenCalled()
+    expect(vi.mocked(toggleDevtools)).toHaveBeenCalled()
+  })
+
+  it('should call toggleDevtools but not clearDevInternalFlags when clicking the toggle button while dev tools are off', () => {
+    vi.mocked(getDevtoolsEnabled).mockReturnValue(false)
+    render()
+    const toggleButton = screen.getByRole('switch', {
+      name: 'enable_dev_tools',
+    })
+    fireEvent.click(toggleButton)
+    expect(vi.mocked(clearDevInternalFlags)).not.toHaveBeenCalled()
     expect(vi.mocked(toggleDevtools)).toHaveBeenCalled()
   })
 })

--- a/app/src/redux/config/actions.ts
+++ b/app/src/redux/config/actions.ts
@@ -79,6 +79,10 @@ export function toggleDevInternalFlag(
   return toggleConfigValue(`devInternal.${flag}`)
 }
 
+export function clearDevInternalFlags(): Types.UpdateConfigValueAction {
+  return updateConfigValue('devInternal', {})
+}
+
 // TODO(mc, 2020-02-05): move to `discovery` module
 export function addManualIp(ip: string): Types.AddUniqueConfigValueAction {
   return addUniqueConfigValue('discovery.candidates', ip)


### PR DESCRIPTION
# Overview

Currently when `Dev Tools` are turned off in the app, any `Feature Flags` that were turned on remain on. This PR updates functionality so that turning off `Dev Tools` turns all `Feature Flags` off.

Note that with the new behavior introduced in this PR, if a user turns off `Dev Tools` and then turns them back on, they will have to go in an re-turn on any `Feature Flags`. The `Dev Tools = true` `Feature Flag` state is not saved.

## Test Plan and Hands on Testing

Reviewed Feature Flag features when `Dev Tools` were `on`, and then confirmed that those features were no long accessible after switching `Dev Tools` to `off`. Specifically looked at `Feature Flags` "Protocol Stats", "Enable App Labware Creator", "Enable React Query Devtools", and, "Adds a robot search bar on select pages".

## Changelog

List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.

## Review requests

Reviewer should verify that turning off `Dev Tools` turns off `Feature Flags.

NOTE: To turn `Dev Tools` off in the dev version of the app you'll need to delete `--devtools` from `Opentrons/app-shell/Makefile` (lines 71 and 79). Otherwise the dev build of the app prevents the user from turning `Dev Tools` off. 

## Risk assessment

Low risk
