### PR TITLE
feat(app): faster protocol visualization playback speed options

### DIFF
--- a/app/src/assets/localization/en/protocol_visualization.json
+++ b/app/src/assets/localization/en/protocol_visualization.json
@@ -34,7 +34,7 @@
   "reference_wavelength": "Reference wavelength",
   "remaining_tips": "{{remaining}} tips",
   "right_mount": "RIGHT MOUNT",
-  "seconds_per_step": "{{seconds}}s per step",
+  "seconds_per_step": "{{seconds}} s per step",
   "slot": "Slot",
   "slot_empty": "Slot empty",
   "source_tips": "Source tips",

--- a/app/src/organisms/Desktop/ProtocolVisualization/Controls/PerStepOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/Controls/PerStepOverflowMenu.tsx
@@ -9,7 +9,7 @@ interface PerStepOverflowMenuProps {
   setMilliSecondsPerFrame: (secondsPerFrame: number) => void
 }
 
-const PER_STEP_OPTIONS = [2, 3, 4]
+const PER_STEP_OPTIONS = [0.25, 0.5, 1, 2, 3]
 
 export function PerStepOverflowMenu(
   props: PerStepOverflowMenuProps
@@ -30,27 +30,16 @@ export function PerStepOverflowMenu(
   return (
     <div ref={perStepOverflowWrapperRef} className={styles.container}>
       <MenuList>
-        <MenuItem
-          onClick={() => {
-            handleClick(PER_STEP_OPTIONS[0])
-          }}
-        >
-          {t('seconds_per_step', { seconds: PER_STEP_OPTIONS[0] })}
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            handleClick(PER_STEP_OPTIONS[1])
-          }}
-        >
-          {t('seconds_per_step', { seconds: PER_STEP_OPTIONS[1] })}
-        </MenuItem>
-        <MenuItem
-          onClick={() => {
-            handleClick(PER_STEP_OPTIONS[2])
-          }}
-        >
-          {t('seconds_per_step', { seconds: PER_STEP_OPTIONS[2] })}
-        </MenuItem>
+        {PER_STEP_OPTIONS.map(seconds => (
+          <MenuItem
+            key={seconds}
+            onClick={() => {
+              handleClick(seconds)
+            }}
+          >
+            {t('seconds_per_step', { seconds })}
+          </MenuItem>
+        ))}
       </MenuList>
     </div>
   )

--- a/app/src/organisms/Desktop/ProtocolVisualization/Controls/__tests__/Controls.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/Controls/__tests__/Controls.test.tsx
@@ -39,7 +39,7 @@ describe('Controls', () => {
       isPlaying: false,
       commands: [],
       groupedCommands: null,
-      milliSecondsPerFrame: 2000,
+      milliSecondsPerFrame: 1000,
       setMilliSecondsPerFrame: vi.fn(),
     }
     vi.mocked(NewIconButton).mockReturnValue(<div>mock NewIconButton</div>)
@@ -56,7 +56,7 @@ describe('Controls', () => {
     render(props)
     screen.getByText('Test Protocol')
     screen.getByText('No errors')
-    screen.getByText('2s per step')
+    screen.getByText('1 s per step')
   })
 
   it('should render error chip', () => {

--- a/app/src/organisms/Desktop/ProtocolVisualization/Controls/__tests__/PerStepOverflowMenu.test.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/Controls/__tests__/PerStepOverflowMenu.test.tsx
@@ -26,17 +26,19 @@ describe('PerStepOverflowMenu', () => {
       setMilliSecondsPerFrame: mockSetMilliSecondsPerFrame,
     }
   })
-  it('renders the overflow menu with 3 buttons', () => {
+  it('renders the overflow menu with 5 buttons', () => {
     render(props)
-    screen.getByText('2s per step')
-    screen.getByText('3s per step')
-    screen.getByText('4s per step')
+    screen.getByText('0.25 s per step')
+    screen.getByText('0.5 s per step')
+    screen.getByText('1 s per step')
+    screen.getByText('2 s per step')
+    screen.getByText('3 s per step')
   })
 
-  it('calls the setSelectedPerdStep function when clicking the 2 seconds per step button', () => {
+  it('calls the setSelectedPerdStep function when clicking the 1 second per step button', () => {
     render(props)
-    fireEvent.click(screen.getByText('2s per step'))
-    expect(mockSetMilliSecondsPerFrame).toHaveBeenCalledWith(2000)
+    fireEvent.click(screen.getByText('1 s per step'))
+    expect(mockSetMilliSecondsPerFrame).toHaveBeenCalledWith(1000)
     expect(mockSetShowPerStepOverflowMenu).toHaveBeenCalledWith(false)
   })
 })

--- a/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/VisualizerContainer/index.tsx
@@ -33,7 +33,7 @@ import type { MouseEvent } from 'react'
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 import type { GroupedCommands } from '/app/redux/protocol-storage'
 
-const INITIAL_MILLISECONDS_PER_FRAME = 2000
+const INITIAL_MILLISECONDS_PER_FRAME = 1000
 const INITIAL_WIDTH_PX = 230
 const MIN_CENTER_WIDTH_PX = 148
 const MIN_LEFT_COLUMN_WIDTH_PX = 148


### PR DESCRIPTION
# Overview

We shipped protocol viz with a playback feature that allows 2, 3, or 4 seconds between steps. People have requested that it go faster! So this PR does just that. Nyoom.

Closes AUTH-2900.


https://github.com/user-attachments/assets/a3d688bc-5153-46e0-bb0f-ec89633ae01c



## Test Plan and Hands on Testing

- `make -C app dev`, open viz, and watch the steps go by
- automated tests

## Changelog

- change per-step duration options to 0.25/0.5/1/2/3 s
- set 1 s as the default
- update the label format to "{{seconds}} s per step" to conform to [UX style guide](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/980746400/Opentrons+UX+Style+Guide#Units-of-measure) (always put space between quantity and unit).

## Review requests

This doesn't do anything in the `/protocol-visualization/` project. I think we should do that in a follow-up PR, yes?

## Risk assessment

low