### PR TITLE
chore: Silence deprecation warnings from old FastAPI version

### DIFF
--- a/auth-server/pyproject.toml
+++ b/auth-server/pyproject.toml
@@ -137,6 +137,9 @@ addopts = ["--color=yes", "--strict-markers"]
 asyncio_mode = "auto"
 filterwarnings = [
     "error::pydantic.PydanticDeprecatedSince20",
+    # FastAPI 0.100.0 calls pydantic_core's deprecated `general_plain_validator_function`
+    # internally. Ignore until we upgrade FastAPI.
+    "ignore:`general_plain_validator_function` is deprecated:DeprecationWarning",
 ]
 
 [tool.mypy]

--- a/key-server/pyproject.toml
+++ b/key-server/pyproject.toml
@@ -131,6 +131,9 @@ addopts = ["--color=yes", "--strict-markers"]
 asyncio_mode = "auto"
 filterwarnings = [
     "error::pydantic.PydanticDeprecatedSince20",
+    # FastAPI 0.100.0 calls pydantic_core's deprecated `general_plain_validator_function`
+    # internally. Ignore until we upgrade FastAPI.
+    "ignore:`general_plain_validator_function` is deprecated:DeprecationWarning",
 ]
 
 [tool.mypy]

--- a/robot-server/pyproject.toml
+++ b/robot-server/pyproject.toml
@@ -182,6 +182,9 @@ markers = [
 filterwarnings = [
     "error::sqlalchemy.exc.RemovedIn20Warning",
     "error::pydantic.PydanticDeprecatedSince20",
+    # FastAPI 0.100.0 calls pydantic_core's deprecated `general_plain_validator_function`
+    # internally. Ignore until we upgrade FastAPI.
+    "ignore:`general_plain_validator_function` is deprecated:DeprecationWarning",
 ]
 
 [tool.mypy]

--- a/server-utils/pyproject.toml
+++ b/server-utils/pyproject.toml
@@ -119,6 +119,9 @@ addopts = ["--color=yes", "--strict-markers"]
 asyncio_mode = "auto"
 filterwarnings = [
     "error::pydantic.PydanticDeprecatedSince20",
+    # FastAPI 0.100.0 calls pydantic_core's deprecated `general_plain_validator_function`
+    # internally. Ignore until we upgrade FastAPI.
+    "ignore:`general_plain_validator_function` is deprecated:DeprecationWarning",
 ]
 
 [tool.mypy]

--- a/system-server/pyproject.toml
+++ b/system-server/pyproject.toml
@@ -144,6 +144,9 @@ asyncio_mode = "auto"
 filterwarnings = [
     "error::sqlalchemy.exc.RemovedIn20Warning",
     "error::pydantic.PydanticDeprecatedSince20",
+    # FastAPI 0.100.0 calls pydantic_core's deprecated `general_plain_validator_function`
+    # internally. Ignore until we upgrade FastAPI.
+    "ignore:`general_plain_validator_function` is deprecated:DeprecationWarning",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
## Overview

Several of our projects' unit tests were printing this warning:

```
DeprecationWarning: `general_plain_validator_function` is deprecated, use `with_info_plain_validator_function` instead.
    return general_plain_validator_function(cls._validate)
```

This comes from using an old version of FastAPI with a new version of Pydantic. There's nothing we can do about this except update FastAPI, which we don't have any near-term plans to do. So this silences the warning.

## Test Plan and Hands on Testing

* [x] These warnings are gone now.

## Review requests

None.

## Risk assessment

Low.