### PR TITLE
refactor(react-api-client) Add `secure` to ApiHostProvider

### DIFF
--- a/react-api-client/src/api/ApiHostProvider.tsx
+++ b/react-api-client/src/api/ApiHostProvider.tsx
@@ -1,35 +1,25 @@
 import * as React from 'react'
 
-import type { AxiosRequestConfig } from 'axios'
-import type { HostConfig, ResponsePromise } from '@opentrons/api-client'
+import type { HostConfig } from '@opentrons/api-client'
 
 export const ApiHostContext = React.createContext<HostConfig | null>(null)
 
-export interface ApiHostProviderProps {
-  hostname: string | null
-  port?: number | null
-  requestor?: <ResData>(config: AxiosRequestConfig) => ResponsePromise<ResData>
-  robotName?: string | null
-  token?: string
+export type ApiHostProviderProps = Omit<HostConfig, 'hostname'> & {
+  hostname: HostConfig['hostname'] | null
+} & {
   children?: React.ReactNode
 }
 
 export function ApiHostProvider(props: ApiHostProviderProps): JSX.Element {
-  const {
-    hostname,
-    port = null,
-    requestor,
-    robotName = null,
-    token,
-    children,
-  } = props
+  const { hostname, port, secure, requestor, robotName, token, children } =
+    props
 
   const hostConfig = React.useMemo<HostConfig | null>(
     () =>
       hostname !== null
-        ? { hostname, port, requestor, robotName, token }
+        ? { hostname, port, secure, requestor, robotName, token }
         : null,
-    [hostname, port, requestor, robotName, token]
+    [hostname, port, secure, requestor, robotName, token]
   )
 
   return (

--- a/react-api-client/src/api/ApiHostProvider.tsx
+++ b/react-api-client/src/api/ApiHostProvider.tsx
@@ -1,33 +1,35 @@
 import * as React from 'react'
 
-import type { HostConfig } from '@opentrons/api-client'
+import type { AxiosRequestConfig } from 'axios'
+import type { HostConfig, ResponsePromise } from '@opentrons/api-client'
 
 export const ApiHostContext = React.createContext<HostConfig | null>(null)
 
-export type ApiHostProviderProps = React.PropsWithChildren<HostConfig>
+export interface ApiHostProviderProps {
+  hostname: string | null
+  port?: number | null
+  requestor?: <ResData>(config: AxiosRequestConfig) => ResponsePromise<ResData>
+  robotName?: string | null
+  token?: string
+  children?: React.ReactNode
+}
 
 export function ApiHostProvider(props: ApiHostProviderProps): JSX.Element {
-  // We want to create a HostConfig object straight from our props, just passing them
-  // straight through. Spiritually, we are doing `{children, ...hostConfig} = props`.
-  // But for memoization reasons, we destructure all the props individually.
   const {
-    children,
     hostname,
-    port,
-    secure,
+    port = null,
     requestor,
-    robotName,
+    robotName = null,
     token,
-    ...rest
+    children,
   } = props
-  assertEmpty(rest) // Make sure we didn't forget to destructure anything.
 
   const hostConfig = React.useMemo<HostConfig | null>(
     () =>
       hostname !== null
-        ? { hostname, port, secure, requestor, robotName, token }
+        ? { hostname, port, requestor, robotName, token }
         : null,
-    [hostname, port, secure, requestor, robotName, token]
+    [hostname, port, requestor, robotName, token]
   )
 
   return (
@@ -36,6 +38,3 @@ export function ApiHostProvider(props: ApiHostProviderProps): JSX.Element {
     </ApiHostContext.Provider>
   )
 }
-
-/** Cause a type-checking error if anything other than an empty object ({}) is passed. */
-function assertEmpty(object: Record<string, never>): void {}

--- a/react-api-client/src/api/ApiHostProvider.tsx
+++ b/react-api-client/src/api/ApiHostProvider.tsx
@@ -1,35 +1,33 @@
 import * as React from 'react'
 
-import type { AxiosRequestConfig } from 'axios'
-import type { HostConfig, ResponsePromise } from '@opentrons/api-client'
+import type { HostConfig } from '@opentrons/api-client'
 
 export const ApiHostContext = React.createContext<HostConfig | null>(null)
 
-export interface ApiHostProviderProps {
-  hostname: string | null
-  port?: number | null
-  requestor?: <ResData>(config: AxiosRequestConfig) => ResponsePromise<ResData>
-  robotName?: string | null
-  token?: string
-  children?: React.ReactNode
-}
+export type ApiHostProviderProps = React.PropsWithChildren<HostConfig>
 
 export function ApiHostProvider(props: ApiHostProviderProps): JSX.Element {
+  // We want to create a HostConfig object straight from our props, just passing them
+  // straight through. Spiritually, we are doing `{children, ...hostConfig} = props`.
+  // But for memoization reasons, we destructure all the props individually.
   const {
-    hostname,
-    port = null,
-    requestor,
-    robotName = null,
-    token,
     children,
+    hostname,
+    port,
+    secure,
+    requestor,
+    robotName,
+    token,
+    ...rest
   } = props
+  assertEmpty(rest) // Make sure we didn't forget to destructure anything.
 
   const hostConfig = React.useMemo<HostConfig | null>(
     () =>
       hostname !== null
-        ? { hostname, port, requestor, robotName, token }
+        ? { hostname, port, secure, requestor, robotName, token }
         : null,
-    [hostname, port, requestor, robotName, token]
+    [hostname, port, secure, requestor, robotName, token]
   )
 
   return (
@@ -38,3 +36,6 @@ export function ApiHostProvider(props: ApiHostProviderProps): JSX.Element {
     </ApiHostContext.Provider>
   )
 }
+
+/** Cause a type-checking error if anything other than an empty object ({}) is passed. */
+function assertEmpty(object: Record<string, never>): void {}

--- a/react-api-client/src/api/ApiHostProvider.tsx
+++ b/react-api-client/src/api/ApiHostProvider.tsx
@@ -11,8 +11,17 @@ export type ApiHostProviderProps = Omit<HostConfig, 'hostname'> & {
 }
 
 export function ApiHostProvider(props: ApiHostProviderProps): JSX.Element {
-  const { hostname, port, secure, requestor, robotName, token, children } =
-    props
+  const {
+    hostname,
+    port,
+    secure,
+    requestor,
+    robotName,
+    token,
+    children,
+    ...rest
+  } = props
+  assertEmpty(rest) // Make sure we didn't forget to destructure anything.
 
   const hostConfig = React.useMemo<HostConfig | null>(
     () =>
@@ -28,3 +37,6 @@ export function ApiHostProvider(props: ApiHostProviderProps): JSX.Element {
     </ApiHostContext.Provider>
   )
 }
+
+/** Cause a type-checking error if anything other than an empty object ({}) is passed. */
+function assertEmpty(object: Record<string, never>): void {}


### PR DESCRIPTION
## Overview

The `HostConfig` type recently gained a `secure` property to switch from `http://` to `https://`. This makes sure we can set that property in its context provider, `<ApiHostProvider>`. This also refactors `<ApiHostProvider>` to make it slightly easier to keep in sync with the underlying `HostConfig` type.

## Test Plan and Hands on Testing

* [ ] Smoke test the desktop app and make sure it can still contact a robot.

## Review requests

Is there a better way to write this to enforce that `<ApiHostProvider>` stays in sync with `HostConfig`, without interfering with memoization?

We could unflatten the props and make `<ApiHostProvider>` take a `value: HostConfig` object. But then every call site needs to care about referential stability when it constructs that object.

We could `memo()` the whole component, but I'm not sure I trust that to correctly keep the `hostConfig` referentially stable if `children` changes and nothing else changes.

## Risk assessment

Low.