### PR TITLE
fix(app): tweak the condition to avoid opening the non ot-2 app

### DIFF
--- a/app-shell/src/ot2App.ts
+++ b/app-shell/src/ot2App.ts
@@ -22,7 +22,10 @@ export async function openOT2AppExternal(payload?: {
       ? `${PROTOCOL_NAME}://open?${params.toString()}`
       : `${PROTOCOL_NAME}://open`
 
-  if (app.getApplicationNameForProtocol(url) === '') {
+  const appName = app.getApplicationNameForProtocol(url)
+
+  // "Electron" means a stale dev-mode registration, not the actual Flex app
+  if (appName === '' || appName === 'Electron') {
     try {
       await shell.openExternal(OT2_APP_DOWNLOAD_PAGE)
     } catch (error) {


### PR DESCRIPTION


# Overview
prevent opening the electron app

the change is the same as https://github.com/Opentrons/opentrons-ot2/pull/69

close RQA-5359

## Test Plan and Hands on Testing


## Changelog


## Review requests


## Risk assessment
low
