### PR TITLE
fix(app): fix spacing size between text and instruments card

### DIFF
--- a/app/src/organisms/Desktop/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Desktop/Devices/InstrumentsAndModules.tsx
@@ -129,11 +129,9 @@ export function InstrumentsAndModules({
       alignItems={ALIGN_FLEX_START}
       flexDirection={DIRECTION_COLUMN}
       width="100%"
+      gap={SPACING.spacing16}
     >
-      <StyledText
-        desktopStyle="bodyLargeSemiBold"
-        marginBottom={SPACING.spacing16}
-      >
+      <StyledText desktopStyle="bodyLargeSemiBold">
         {t('instruments_and_modules')}
       </StyledText>
       <Flex


### PR DESCRIPTION


# Overview
fix spacing size between text and instruments card

close RQA-5374

## Test Plan and Hands on Testing
- run the app
- go to the device landing page
- click a device

## Changelog
- fix the spacing size between text and instrument cards

## Review requests



## Risk assessment
low
