### PR TITLE
chore(js): Bump handlebars v4.7.8->v4.7.9

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7700,8 +7700,8 @@ packages:
   gud@1.0.0:
     resolution: {integrity: sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -18171,7 +18171,7 @@ snapshots:
     dependencies:
       conventional-commits-filter: 2.0.7
       dateformat: 3.0.3
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       json-stringify-safe: 5.0.1
       lodash: 4.18.1
       meow: 8.1.2
@@ -20514,7 +20514,7 @@ snapshots:
 
   gud@1.0.0: {}
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2


### PR DESCRIPTION
## Overview

When we create releases, we create release notes automatically from Git commit messages. `handlebars` is involved in that process. This updates it from v4.7.8 to v4.7.9 to resolve several security problems: https://github.com/handlebars-lang/handlebars.js/releases/tag/v4.7.9

## Test Plan and Hands on Testing

The way to test this would be to run `create-release.js` manually (as a dry run) to see that it still generates the changelogs correctly. Unfortunately, I had trouble with that, for reasons that seem unrelated to this PR:

```
Release failed: TypeError: Invalid Version: acuum-module-qc-26.03.18
    at new SemVer (/Users/maxmarrone/Code/Opentrons/opentrons/node_modules/.pnpm/semver@7.7.3/node_modules/semver/classes/semver.js:40:13)
    at compare (/Users/maxmarrone/Code/Opentrons/opentrons/node_modules/.pnpm/semver@7.7.3/node_modules/semver/functions/compare.js:5:3)
    at Array.sort (<anonymous>)
    at versionDetailsFromGit (/Users/maxmarrone/Code/Opentrons/opentrons/scripts/deploy/create-release.js:127:6)
    at async main (/Users/maxmarrone/Code/Opentrons/opentrons/scripts/deploy/create-release.js:222:5)
```

It looks like something is misinterpreting the tag `vacuum-module-qc-26.03.18` as semver because it begins with `v`.

## Changelog

For some reason, `pnpm update -w handlebars` didn't work for me. It changed a bunch of other stuff in the lockfile and didn't actually change handlebars. https://github.com/pnpm/pnpm/issues/5552 may be relevant. I had to do `pnpm add -wD handlebars && pnpm remove -wD handlebars`.

## Review requests

Am I doing pnpm wrong? Is there some reason `pnpm update -w handlebars` didn't work?

## Risk assessment

From the handlebars release notes, I think this should be low risk. The changes are pretty contained.