### PR TITLE
fix(ci): enable pnpm in tag-releases workflow so create-release runs

### DIFF
--- a/.github/workflows/tag-releases.yaml
+++ b/.github/workflows/tag-releases.yaml
@@ -25,6 +25,10 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '22.22.0'
+      # setup-node does not put pnpm on PATH; without this, setup-js fails with
+      # "pnpm: command not found" and the create-release step never runs (draft + prerelease never set).
+      - name: 'enable pnpm (corepack)'
+        run: corepack enable && corepack prepare pnpm@10.32.1 --activate
       - name: 'cache pnpm cache'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:

--- a/.github/workflows/tag-releases.yaml
+++ b/.github/workflows/tag-releases.yaml
@@ -22,25 +22,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version: '22.22.0'
-      # setup-node does not put pnpm on PATH; without this, setup-js fails with
-      # "pnpm: command not found" and the create-release step never runs (draft + prerelease never set).
-      - name: 'enable pnpm (corepack)'
-        run: corepack enable && corepack prepare pnpm@10.32.1 --activate
-      - name: 'cache pnpm cache'
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: |
-            ${{ github.workspace }}/.npm-cache/_prebuild
-            ${{ github.workspace }}/.pnpm-cache
-          key: js-${{ hashFiles('pnpm-lock.yaml') }}
-      - name: 'setup-js'
-        run: |
-          npm config set cache ${{ github.workspace }}/.npm-cache
-          pnpm config set cache ${{ github.workspace }}/.pnpm-cache
-          pnpm install
+      - uses: ./.github/actions/js/setup
 
       - name: 'create release'
         run: |


### PR DESCRIPTION
The “Create github release for tag” workflow runs pnpm install after the yarn → pnpm migration but never installed pnpm on the runner, so setup-js failed with pnpm: command not found and the create release step was skipped. That left GitHub releases for tags (including ot3@… prereleases) to be created only by other automation without the draft/changelog and correct prerelease flag from create-release.js.

Enable pnpm via Corepack using the repo’s packageManager version (pnpm@10.32.1) so pnpm install succeeds and create-release.js runs again on tag pushes.