### PR TITLE
feat(protocol-designer, step-generation): expose addressable area responsible for collision

### DIFF
--- a/protocol-designer/src/assets/localization/en/alert.json
+++ b/protocol-designer/src/assets/localization/en/alert.json
@@ -325,8 +325,16 @@
         "body": "Picking up labware with the gripper while tips are on an adjacent pipette can cause collisions. Drop tips from all pipettes before this step.",
         "title": "Gripper movement with tips attached"
       },
-      "POSSIBLE_PIPETTE_COLLISION": {
-        "body": "There is a possibility that the pipette will collide with the adjacent labware, modules, or trash fixtures for partial tip pick up.",
+      "POSSIBLE_PIPETTE_COLLISION_ADJACENT_ADDRESSABLE_AREA": {
+        "body": "There is a possibility that the pipette will collide with adjacent items in {{addressableAreaCausingCollisionDisplayName}}.",
+        "title": "Pipette collisions likely"
+      },
+      "POSSIBLE_PIPETTE_COLLISION_OUTSIDE_DECK_EXTENTS": {
+        "body": "There is a possibility that the pipette will move outside the deck extents.",
+        "title": "Pipette collisions likely"
+      },
+      "POSSIBLE_PIPETTE_COLLISION_THERMOCYCLER_LID": {
+        "body": "There is a possibility that the pipette will collide with the Thermocycler lid.",
         "title": "Pipette collisions likely"
       },
       "REMOVE_96_CHANNEL_TIPRACK_ADAPTER": {

--- a/protocol-designer/src/components/organisms/Alerts/ErrorContents.tsx
+++ b/protocol-designer/src/components/organisms/Alerts/ErrorContents.tsx
@@ -19,17 +19,19 @@ import type { AlertLevel } from './types'
 interface ErrorContentsProps {
   errorType: ErrorType
   level: AlertLevel
+  translationParams?: Record<string, string>
 }
 export const ErrorContents = (
   props: ErrorContentsProps
 ): JSX.Element | null => {
-  const { errorType, level } = props
+  const { errorType, level, translationParams } = props
   const { t } = useTranslation(['alert', 'shared'])
   const dispatch = useDispatch()
 
   if (level === 'timeline') {
     const bodyText = t(`timeline.error.${errorType}.body`, {
       defaultValue: '',
+      ...translationParams,
     })
     switch (errorType) {
       case 'INSUFFICIENT_TIPS':

--- a/protocol-designer/src/components/organisms/Alerts/TimelineAlerts.tsx
+++ b/protocol-designer/src/components/organisms/Alerts/TimelineAlerts.tsx
@@ -25,7 +25,13 @@ function TimelineAlertsComponent(props: StyleProps): JSX.Element | null {
   const timelineErrors = (timeline.errors || ([] as CommandCreatorError[])).map(
     (error: CommandCreatorError) => ({
       title: t(`timeline.error.${error.type}.title`, error.message),
-      description: <ErrorContents level="timeline" errorType={error.type} />,
+      description: (
+        <ErrorContents
+          level="timeline"
+          errorType={error.type}
+          translationParams={error.translationParams}
+        />
+      ),
     })
   )
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/__tests__/getAllWellsSafetyStatus.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/__tests__/getAllWellsSafetyStatus.test.ts
@@ -17,14 +17,14 @@ import {
   ROW,
   SINGLE,
 } from '@opentrons/shared-data'
-import { getIsSafePipetteMovement } from '@opentrons/step-generation'
+import { getPipetteMovementSafetyStatus } from '@opentrons/step-generation'
 
 import { getAllWellsSafetyStatus } from '../getAllWellsSafetyStatus'
 
 import type { LabwareDefinition } from '@opentrons/shared-data'
 
 vi.mock('@opentrons/step-generation', () => ({
-  getIsSafePipetteMovement: vi.fn(),
+  getPipetteMovementSafetyStatus: vi.fn(),
 }))
 
 describe('getAllWellsSafetyStatus', () => {
@@ -68,7 +68,7 @@ describe('getAllWellsSafetyStatus', () => {
 
   describe('ROW mode', () => {
     it('marks entire row safe when first well is safe', () => {
-      ;(getIsSafePipetteMovement as any).mockReturnValue(true)
+      ;(getPipetteMovementSafetyStatus as any).mockReturnValue({ isSafe: true })
 
       const result = getAllWellsSafetyStatus({
         allWells,
@@ -90,18 +90,24 @@ describe('getAllWellsSafetyStatus', () => {
       })
 
       // Should be called once per row (3 rows)
-      expect(getIsSafePipetteMovement).toHaveBeenCalledTimes(3)
-      expect(getIsSafePipetteMovement).toHaveBeenNthCalledWith(
+      expect(getPipetteMovementSafetyStatus).toHaveBeenCalledTimes(3)
+      expect(getPipetteMovementSafetyStatus).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({ wellTargetName: 'A1' })
       )
     })
 
     it('marks entire row unsafe when first well is unsafe', () => {
-      ;(getIsSafePipetteMovement as any)
-        .mockReturnValueOnce(false) // row A
-        .mockReturnValueOnce(true) // row B
-        .mockReturnValueOnce(false) // row C
+      ;(getPipetteMovementSafetyStatus as any)
+        .mockReturnValueOnce({
+          isSafe: false,
+          reason: { type: 'outsidePipetteExtents' },
+        }) // row A
+        .mockReturnValueOnce({ isSafe: true }) // row B
+        .mockReturnValueOnce({
+          isSafe: false,
+          reason: { type: 'outsidePipetteExtents' },
+        }) // row C
 
       const result = getAllWellsSafetyStatus({
         allWells,
@@ -126,9 +132,12 @@ describe('getAllWellsSafetyStatus', () => {
 
   describe('COLUMN mode', () => {
     it('marks entire column based on first well safety', () => {
-      ;(getIsSafePipetteMovement as any)
-        .mockReturnValueOnce(true) // column 1
-        .mockReturnValueOnce(false) // column 2
+      ;(getPipetteMovementSafetyStatus as any)
+        .mockReturnValueOnce({ isSafe: true }) // column 1
+        .mockReturnValueOnce({
+          isSafe: false,
+          reason: { type: 'outsidePipetteExtents' },
+        }) // column 2
 
       const result = getAllWellsSafetyStatus({
         allWells,
@@ -149,12 +158,12 @@ describe('getAllWellsSafetyStatus', () => {
         C2: 1,
       })
 
-      expect(getIsSafePipetteMovement).toHaveBeenCalledTimes(2)
-      expect(getIsSafePipetteMovement).toHaveBeenNthCalledWith(
+      expect(getPipetteMovementSafetyStatus).toHaveBeenCalledTimes(2)
+      expect(getPipetteMovementSafetyStatus).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({ wellTargetName: 'A1' })
       )
-      expect(getIsSafePipetteMovement).toHaveBeenNthCalledWith(
+      expect(getPipetteMovementSafetyStatus).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({ wellTargetName: 'A2' })
       )
@@ -163,13 +172,24 @@ describe('getAllWellsSafetyStatus', () => {
 
   describe('SINGLE nozzle mode', () => {
     it('checks each well individually', () => {
-      ;(getIsSafePipetteMovement as any)
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(false)
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(false)
-        .mockReturnValueOnce(true)
-        .mockReturnValueOnce(false)
+      ;(getPipetteMovementSafetyStatus as any)
+        .mockReturnValueOnce({ isSafe: true })
+        .mockReturnValueOnce({
+          isSafe: false,
+          reason: { type: 'outsidePipetteExtents' },
+        })
+        .mockReturnValueOnce({ isSafe: true })
+        .mockReturnValueOnce({
+          isSafe: false,
+          reason: { type: 'adjacentAdressableAreaCollision' },
+          addressableAreaCausingCollision: 'A1',
+        })
+        .mockReturnValueOnce({ isSafe: true })
+        .mockReturnValueOnce({
+          isSafe: false,
+          reason: { type: 'adjacentAdressableAreaCollision' },
+          addressableAreaCausingCollision: 'A2',
+        })
 
       const result = getAllWellsSafetyStatus({
         allWells,
@@ -190,7 +210,7 @@ describe('getAllWellsSafetyStatus', () => {
         C2: 1,
       })
 
-      expect(getIsSafePipetteMovement).toHaveBeenCalledTimes(6)
+      expect(getPipetteMovementSafetyStatus).toHaveBeenCalledTimes(6)
     })
   })
   describe('PARTIAL COLUMN mode', () => {
@@ -208,7 +228,9 @@ describe('getAllWellsSafetyStatus', () => {
     it.each(cases)(
       'handles partial column mode with $tipCount tips ($nozzle)',
       ({ nozzle, tipCount }) => {
-        ;(getIsSafePipetteMovement as any).mockReturnValue(true)
+        ;(getPipetteMovementSafetyStatus as any).mockReturnValue({
+          isSafe: true,
+        })
 
         const result = getAllWellsSafetyStatus({
           allWells: [column],

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/getAllWellsSafetyStatus.ts
@@ -6,7 +6,7 @@ import {
   ROW,
   SINGLE,
 } from '@opentrons/shared-data'
-import { getIsSafePipetteMovement } from '@opentrons/step-generation'
+import { getPipetteMovementSafetyStatus } from '@opentrons/step-generation'
 
 import { canPipetteUseLabware } from '../../../../../../utils'
 
@@ -64,8 +64,8 @@ export function getAllWellsSafetyStatus(
     for (let rowIndex = 0; rowIndex < numRows; rowIndex++) {
       const firstWell = allWells[0][rowIndex]
       const safe =
-        robotState === null ||
-        getIsSafePipetteMovement({
+        robotState == null ||
+        getPipetteMovementSafetyStatus({
           robotState,
           invariantContext,
           pipetteId,
@@ -74,7 +74,7 @@ export function getAllWellsSafetyStatus(
           primaryNozzle,
           nozzleConfiguration,
           tiprackId,
-        })
+        }).isSafe
 
       // mark all wells in this row
       allWells.forEach(column => {
@@ -90,8 +90,8 @@ export function getAllWellsSafetyStatus(
       const column = allWells[colIndex]
       const firstWell = column[0]
       const safe =
-        robotState === null ||
-        getIsSafePipetteMovement({
+        robotState == null ||
+        getPipetteMovementSafetyStatus({
           robotState,
           invariantContext,
           pipetteId,
@@ -100,7 +100,7 @@ export function getAllWellsSafetyStatus(
           primaryNozzle,
           nozzleConfiguration,
           tiprackId,
-        })
+        }).isSafe
 
       column.forEach(wellName => {
         allWellsWithStatus[wellName] = safe ? 0 : 1
@@ -109,8 +109,8 @@ export function getAllWellsSafetyStatus(
   } else if (nozzleConfiguration === ALL && channels === 96) {
     // ALL 96 Nozzles: only check the first well
     const safe =
-      robotState === null ||
-      getIsSafePipetteMovement({
+      robotState == null ||
+      getPipetteMovementSafetyStatus({
         robotState,
         invariantContext,
         pipetteId,
@@ -119,7 +119,7 @@ export function getAllWellsSafetyStatus(
         primaryNozzle,
         nozzleConfiguration,
         tiprackId,
-      })
+      }).isSafe
 
     allWells.flat().forEach(wellName => {
       allWellsWithStatus[wellName] = safe ? 0 : 1
@@ -128,8 +128,8 @@ export function getAllWellsSafetyStatus(
     // SINGLE nozzle for 8ch and 96ch: check every well individually
     allWells.flat().forEach(wellName => {
       const safe =
-        robotState === null ||
-        getIsSafePipetteMovement({
+        robotState == null ||
+        getPipetteMovementSafetyStatus({
           robotState,
           invariantContext,
           pipetteId,
@@ -138,7 +138,7 @@ export function getAllWellsSafetyStatus(
           primaryNozzle,
           nozzleConfiguration,
           tiprackId,
-        })
+        }).isSafe
 
       allWellsWithStatus[wellName] = safe ? 0 : 1
     })
@@ -150,8 +150,8 @@ export function getAllWellsSafetyStatus(
       for (let i = 0; i < column.length; i++) {
         const wellToTest = column[i]
         const safe =
-          robotState === null ||
-          getIsSafePipetteMovement({
+          robotState == null ||
+          getPipetteMovementSafetyStatus({
             robotState,
             invariantContext,
             pipetteId,
@@ -160,7 +160,7 @@ export function getAllWellsSafetyStatus(
             primaryNozzle,
             nozzleConfiguration,
             tiprackId,
-          })
+          }).isSafe
 
         const canFitBlock = i <= column.length - totalSelectionLength
         const labwareHasOneRow = labwareDef.ordering[0].length === 1
@@ -174,8 +174,8 @@ export function getAllWellsSafetyStatus(
           for (let k = i + totalSelectionLength; k < column.length; k++) {
             const remainingWell = column[k]
             const remainingSafe =
-              robotState === null ||
-              getIsSafePipetteMovement({
+              robotState == null ||
+              getPipetteMovementSafetyStatus({
                 robotState,
                 invariantContext,
                 pipetteId,
@@ -184,7 +184,7 @@ export function getAllWellsSafetyStatus(
                 primaryNozzle,
                 nozzleConfiguration,
                 tiprackId,
-              })
+              }).isSafe
 
             allWellsWithStatus[remainingWell] = remainingSafe ? 0 : 1
           }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux'
 import { ALL, COLUMN, ROW } from '@opentrons/shared-data'
 import {
   getIsSafePickupWithinTiprack,
-  getIsSafePipetteMovement,
+  getPipetteMovementSafetyStatus,
 } from '@opentrons/step-generation'
 
 import { OFFDECK } from '/protocol-designer/constants'
@@ -113,7 +113,7 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
               tiprackDef: def,
               tipsToIgnore: selectedTips.flat(),
             })
-            const isCollision = !getIsSafePipetteMovement({
+            const isCollision = getPipetteMovementSafetyStatus({
               robotState,
               invariantContext,
               pipetteId,
@@ -121,7 +121,7 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
               wellTargetName: wellName,
               primaryNozzle,
               nozzleConfiguration: nozzles,
-            })
+            }).isSafe
             const isAccessible = isSafe && isComplete && !isCollision
             let inaccessibleReason: InaccessibleReason | null = null
             if (isCollision) {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -7,7 +7,7 @@ import {
 import {
   COLUMN_4_SLOTS,
   getIsSafePickupWithinTiprack,
-  getIsSafePipetteMovement,
+  getPipetteMovementSafetyStatus,
   getSlotInLocationStack,
 } from '@opentrons/step-generation'
 
@@ -300,17 +300,16 @@ export const getValidTiprackIds = (args: {
               tipsToIgnore: addedWells,
             })
           const isSafeMoveConsideringDeck =
-            robotState != null
-              ? getIsSafePipetteMovement({
-                  robotState,
-                  invariantContext,
-                  pipetteId,
-                  labwareId: id,
-                  wellTargetName: wellName,
-                  primaryNozzle,
-                  nozzleConfiguration: nozzles,
-                })
-              : true
+            robotState == null ||
+            getPipetteMovementSafetyStatus({
+              robotState,
+              invariantContext,
+              pipetteId,
+              labwareId: id,
+              wellTargetName: wellName,
+              primaryNozzle,
+              nozzleConfiguration: nozzles,
+            }).isSafe
           if (isSafeWithinTiprack && isSafeMoveConsideringDeck && isComplete) {
             const allAffectedWells = getEntireWellSelection(
               wellName,

--- a/step-generation/src/commandCreators/atomic/aspirate.ts
+++ b/step-generation/src/commandCreators/atomic/aspirate.ts
@@ -10,8 +10,8 @@ import {
   getIsHeaterShakerEastWestMultiChannelPipette,
   getIsHeaterShakerEastWestWithLatchOpen,
   getIsHeaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette,
-  getIsSafePipetteMovement,
   getLabwareSlot,
+  getPipetteMovementSafetyStatus,
   getSlotInLocationStack,
   indentPyLines,
   modulePipetteCollision,
@@ -119,26 +119,31 @@ export const aspirate: CommandCreator<ExtendedAspirateParams> = (
 
   const isMultiChannelPipette =
     invariantContext.pipetteEntities[pipetteId]?.spec.channels !== 1
+  const pipetteMovementSafetyStatus = getPipetteMovementSafetyStatus({
+    robotState: prevRobotState,
+    invariantContext,
+    pipetteId,
+    labwareId,
+    wellLocationOffset: (wellLocation?.offset as Point) ?? {
+      x: 0,
+      y: 0,
+      z: 0,
+    },
+    wellTargetName: wellName,
+    primaryNozzle,
+    nozzleConfiguration: nozzles,
+  })
 
   if (
     isMultiChannelPipette &&
     pipetteSpec &&
-    !getIsSafePipetteMovement({
-      robotState: prevRobotState,
-      invariantContext,
-      pipetteId,
-      labwareId,
-      wellLocationOffset: (wellLocation?.offset as Point) ?? {
-        x: 0,
-        y: 0,
-        z: 0,
-      },
-      wellTargetName: wellName,
-      primaryNozzle,
-      nozzleConfiguration: nozzles,
-    })
+    !pipetteMovementSafetyStatus.isSafe
   ) {
-    errors.push(errorCreators.possiblePipetteCollision())
+    errors.push(
+      errorCreators.possiblePipetteCollision({
+        unsafePipetteMovementReason: pipetteMovementSafetyStatus.reason,
+      })
+    )
   }
 
   if (

--- a/step-generation/src/commandCreators/atomic/dispense.ts
+++ b/step-generation/src/commandCreators/atomic/dispense.ts
@@ -9,8 +9,8 @@ import {
   getIsHeaterShakerEastWestMultiChannelPipette,
   getIsHeaterShakerEastWestWithLatchOpen,
   getIsHeaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette,
-  getIsSafePipetteMovement,
   getLabwareSlot,
+  getPipetteMovementSafetyStatus,
   getSlotInLocationStack,
   indentPyLines,
   modulePipetteCollision,
@@ -120,24 +120,26 @@ export const dispense: CommandCreator<DispenseAtomicCommandParams> = (
   const isMultiChannelPipette =
     invariantContext.pipetteEntities[pipetteId]?.spec.channels !== 1
 
-  if (
-    isMultiChannelPipette &&
-    !getIsSafePipetteMovement({
-      robotState: prevRobotState,
-      invariantContext,
-      pipetteId,
-      labwareId,
-      wellLocationOffset: (wellLocation?.offset as Point) ?? {
-        x: 0,
-        y: 0,
-        z: 0,
-      },
-      wellTargetName: wellName,
-      primaryNozzle,
-      nozzleConfiguration: nozzles,
-    })
-  ) {
-    errors.push(errorCreators.possiblePipetteCollision())
+  const pipetteMovementSafetyStatus = getPipetteMovementSafetyStatus({
+    robotState: prevRobotState,
+    invariantContext,
+    pipetteId,
+    labwareId,
+    wellLocationOffset: (wellLocation?.offset as Point) ?? {
+      x: 0,
+      y: 0,
+      z: 0,
+    },
+    wellTargetName: wellName,
+    primaryNozzle,
+    nozzleConfiguration: nozzles,
+  })
+  if (isMultiChannelPipette && !pipetteMovementSafetyStatus.isSafe) {
+    errors.push(
+      errorCreators.possiblePipetteCollision({
+        unsafePipetteMovementReason: pipetteMovementSafetyStatus.reason,
+      })
+    )
   }
 
   if (

--- a/step-generation/src/commandCreators/atomic/moveToWell.ts
+++ b/step-generation/src/commandCreators/atomic/moveToWell.ts
@@ -10,8 +10,8 @@ import {
   getIsHeaterShakerEastWestMultiChannelPipette,
   getIsHeaterShakerEastWestWithLatchOpen,
   getIsHeaterShakerNorthSouthOfNonTiprackWithMultiChannelPipette,
-  getIsSafePipetteMovement,
   getLabwareSlot,
+  getPipetteMovementSafetyStatus,
   getSlotInLocationStack,
   modulePipetteCollision,
   pipetteAdjacentHeaterShakerWhileShaking,
@@ -186,25 +186,31 @@ export const moveToWell: CommandCreator<MoveToWellParams> = (
   const isMultiChannelPipette =
     invariantContext.pipetteEntities[pipetteId]?.spec.channels !== 1
   const pipetteSpecs = invariantContext.pipetteEntities[pipetteId]?.spec
+
+  const pipetteMovementSafetyStatus = getPipetteMovementSafetyStatus({
+    robotState: prevRobotState,
+    invariantContext,
+    pipetteId,
+    labwareId,
+    wellLocationOffset: (wellLocation?.offset as Point) ?? {
+      x: 0,
+      y: 0,
+      z: 0,
+    },
+    wellTargetName: wellName,
+    nozzleConfiguration,
+    primaryNozzle,
+  })
   if (
     isMultiChannelPipette &&
     pipetteSpecs &&
-    !getIsSafePipetteMovement({
-      robotState: prevRobotState,
-      invariantContext,
-      pipetteId,
-      labwareId,
-      wellLocationOffset: (wellLocation?.offset as Point) ?? {
-        x: 0,
-        y: 0,
-        z: 0,
-      },
-      wellTargetName: wellName,
-      nozzleConfiguration,
-      primaryNozzle,
-    })
+    !pipetteMovementSafetyStatus.isSafe
   ) {
-    errors.push(errorCreators.possiblePipetteCollision())
+    errors.push(
+      errorCreators.possiblePipetteCollision({
+        unsafePipetteMovementReason: pipetteMovementSafetyStatus.reason,
+      })
+    )
   }
   if (errors.length > 0) {
     return {

--- a/step-generation/src/commandCreators/atomic/pickUpTip.ts
+++ b/step-generation/src/commandCreators/atomic/pickUpTip.ts
@@ -8,7 +8,7 @@ import {
 import {
   formatPyStr,
   getIsSafePickupWithinTiprack,
-  getIsSafePipetteMovement,
+  getPipetteMovementSafetyStatus,
   getSlotInLocationStack,
   uuid,
 } from '../../utils'
@@ -45,7 +45,7 @@ export const pickUpTip: CommandCreator<PickUpTipAtomicParams> = (
   } = args
   const errors: CommandCreatorError[] = []
   const channels = invariantContext.pipetteEntities[pipetteId].spec.channels
-  const isSafePipetteMovement = getIsSafePipetteMovement({
+  const pipetteMovementSafetyStatus = getPipetteMovementSafetyStatus({
     robotState: prevRobotState,
     invariantContext,
     pipetteId,
@@ -66,8 +66,12 @@ export const pickUpTip: CommandCreator<PickUpTipAtomicParams> = (
     tiprackDef: invariantContext.labwareEntities[labwareId].def,
   })
 
-  if (!isSafePipetteMovement) {
-    errors.push(possiblePipetteCollision())
+  if (!pipetteMovementSafetyStatus.isSafe) {
+    errors.push(
+      possiblePipetteCollision({
+        unsafePipetteMovementReason: pipetteMovementSafetyStatus.reason,
+      })
+    )
   }
 
   if (!isSafeWithinTiprack.isSafe) {

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -28,7 +28,7 @@ import {
   formatChangeTipArg,
   formatPyStr,
   getIsRetractSafeForAirGap,
-  getIsSafePipetteMovement,
+  getPipetteMovementSafetyStatus,
   getSlotInLocationStack,
   getTargetTipsFromWellSets,
   getTransferPlanAndReferenceVolumes,
@@ -301,7 +301,7 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
   }
 
   if (isMultiChannelPipette && nozzles !== ALL) {
-    const isAspirateSafePipetteMovement = getIsSafePipetteMovement({
+    const aspiratePipetteMovementSafetyStatus = getPipetteMovementSafetyStatus({
       robotState: prevRobotState,
       invariantContext,
       pipetteId: pipette,
@@ -310,7 +310,15 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       primaryNozzle,
       nozzleConfiguration: nozzles,
     })
-    const isDispenseSafePipetteMovement = getIsSafePipetteMovement({
+    if (!aspiratePipetteMovementSafetyStatus.isSafe) {
+      errors.push(
+        errorCreators.possiblePipetteCollision({
+          unsafePipetteMovementReason:
+            aspiratePipetteMovementSafetyStatus.reason,
+        })
+      )
+    }
+    const dispensePipetteMovementSafetyStatus = getPipetteMovementSafetyStatus({
       robotState: prevRobotState,
       invariantContext,
       pipetteId: pipette,
@@ -319,8 +327,13 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       primaryNozzle,
       nozzleConfiguration: nozzles,
     })
-    if (!isAspirateSafePipetteMovement && !isDispenseSafePipetteMovement) {
-      errors.push(errorCreators.possiblePipetteCollision())
+    if (!dispensePipetteMovementSafetyStatus.isSafe) {
+      errors.push(
+        errorCreators.possiblePipetteCollision({
+          unsafePipetteMovementReason:
+            dispensePipetteMovementSafetyStatus.reason,
+        })
+      )
     }
   }
   const dispenseWellDepth =

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -31,7 +31,7 @@ import {
   formatChangeTipArg,
   formatPyStr,
   getIsRetractSafeForAirGap,
-  getIsSafePipetteMovement,
+  getPipetteMovementSafetyStatus,
   getSlotInLocationStack,
   getTargetTipsFromWellSets,
   getTransferPlanAndReferenceVolumes,
@@ -323,7 +323,7 @@ export const distribute: CommandCreator<DistributeArgs> = (
   }
 
   if (isMultiChannelPipette && nozzles !== ALL) {
-    const isAspirateSafePipetteMovement = getIsSafePipetteMovement({
+    const aspiratePipetteMovementSafetyStatus = getPipetteMovementSafetyStatus({
       robotState: prevRobotState,
       invariantContext,
       pipetteId: pipette,
@@ -333,7 +333,15 @@ export const distribute: CommandCreator<DistributeArgs> = (
       primaryNozzle,
       nozzleConfiguration: nozzles,
     })
-    const isDispenseSafePipetteMovement = getIsSafePipetteMovement({
+    if (!aspiratePipetteMovementSafetyStatus.isSafe) {
+      errors.push(
+        errorCreators.possiblePipetteCollision({
+          unsafePipetteMovementReason:
+            aspiratePipetteMovementSafetyStatus.reason,
+        })
+      )
+    }
+    const dispensePipetteMovementSafetyStatus = getPipetteMovementSafetyStatus({
       robotState: prevRobotState,
       invariantContext,
       pipetteId: pipette,
@@ -343,8 +351,13 @@ export const distribute: CommandCreator<DistributeArgs> = (
       primaryNozzle,
       nozzleConfiguration: nozzles,
     })
-    if (!isAspirateSafePipetteMovement && !isDispenseSafePipetteMovement) {
-      errors.push(errorCreators.possiblePipetteCollision())
+    if (!dispensePipetteMovementSafetyStatus.isSafe) {
+      errors.push(
+        errorCreators.possiblePipetteCollision({
+          unsafePipetteMovementReason:
+            dispensePipetteMovementSafetyStatus.reason,
+        })
+      )
     }
   }
 

--- a/step-generation/src/commandCreators/compound/mix.ts
+++ b/step-generation/src/commandCreators/compound/mix.ts
@@ -16,7 +16,7 @@ import {
   curryWithoutPython,
   formatPyStr,
   formatPyWellLocation,
-  getIsSafePipetteMovement,
+  getPipetteMovementSafetyStatus,
   getSlotInLocationStack,
   getTargetTipsFromWellSets,
   indentPyLines,
@@ -370,7 +370,7 @@ export const mix: CommandCreator<MixArgs> = (
   }
 
   if (isMultiChannelPipette) {
-    const isAspirateSafePipetteMovement = getIsSafePipetteMovement({
+    const aspiratePipetteMovementSafetyStatus = getPipetteMovementSafetyStatus({
       robotState: prevRobotState,
       invariantContext,
       pipetteId: pipette,
@@ -380,19 +380,34 @@ export const mix: CommandCreator<MixArgs> = (
       primaryNozzle,
       nozzleConfiguration: nozzles,
     })
-    const isDispenseSafePipetteMovement = getIsSafePipetteMovement({
-      robotState: prevRobotState,
-      invariantContext,
-      pipetteId: pipette,
-      labwareId: labware,
-      wellLocationOffset: { x: xOffset, y: yOffset },
-      wellTargetName: wells[0],
-      primaryNozzle,
-      nozzleConfiguration: nozzles,
-    })
-    if (!isAspirateSafePipetteMovement && !isDispenseSafePipetteMovement) {
+    if (!aspiratePipetteMovementSafetyStatus.isSafe) {
       return {
-        errors: [errorCreators.possiblePipetteCollision()],
+        errors: [
+          errorCreators.possiblePipetteCollision({
+            unsafePipetteMovementReason:
+              aspiratePipetteMovementSafetyStatus.reason,
+          }),
+        ],
+      }
+    }
+    const dispensePipetteMovementSafetyStatus = getPipetteMovementSafetyStatus({
+      robotState: prevRobotState,
+      invariantContext,
+      pipetteId: pipette,
+      labwareId: labware,
+      wellLocationOffset: { x: xOffset, y: yOffset },
+      wellTargetName: wells[0],
+      primaryNozzle,
+      nozzleConfiguration: nozzles,
+    })
+    if (!dispensePipetteMovementSafetyStatus.isSafe) {
+      return {
+        errors: [
+          errorCreators.possiblePipetteCollision({
+            unsafePipetteMovementReason:
+              dispensePipetteMovementSafetyStatus.reason,
+          }),
+        ],
       }
     }
   }

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -1,5 +1,5 @@
 /** Utility fns to create reusable CommandCreatorErrors */
-import type { CommandCreatorError } from './types'
+import type { CommandCreatorError, UnsafePipetteMovementReason } from './types'
 
 // NOTE: in PD UI, the `message` key here is finally handled by ErrorContents component.
 // To support step-generation as an independent library (someday), messages should also exist here
@@ -274,11 +274,34 @@ export const tallLabwareEastWestOfHeaterShaker = (
   }
 }
 
-export const possiblePipetteCollision = (): CommandCreatorError => {
-  return {
-    type: 'POSSIBLE_PIPETTE_COLLISION',
-    message:
-      'There is a possibility that the Pipette will collide with the a labware or module on the deck',
+export const possiblePipetteCollision = (args: {
+  unsafePipetteMovementReason: UnsafePipetteMovementReason
+}): CommandCreatorError => {
+  const { unsafePipetteMovementReason } = args
+
+  switch (unsafePipetteMovementReason.type) {
+    case 'thermocyclerLidCollision':
+      return {
+        type: 'POSSIBLE_PIPETTE_COLLISION_THERMOCYCLER_LID',
+        message:
+          'There is a possibility that the Pipette will collide with the Thermocycler lid',
+      }
+    case 'outsidePipetteExtents':
+      return {
+        type: 'POSSIBLE_PIPETTE_COLLISION_OUTSIDE_DECK_EXTENTS',
+        message:
+          'There is a possibility that the pipette will move outside the deck extents.',
+      }
+    case 'adjacentAdressableAreaCollision':
+      return {
+        type: 'POSSIBLE_PIPETTE_COLLISION_ADJACENT_ADDRESSABLE_AREA',
+        message: `There is a possibility that the pipette will collide with adjacent items in ${unsafePipetteMovementReason.addressableAreaCausingCollision.displayName}`,
+        translationParams: {
+          addressableAreaCausingCollisionDisplayName:
+            unsafePipetteMovementReason.addressableAreaCausingCollision
+              .displayName,
+        },
+      }
   }
 }
 

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -1,5 +1,6 @@
 import type {
   ABSORBANCE_READER_TYPE,
+  AddressableArea,
   CreateCommand,
   FLEX_STACKER_MODULE_TYPE,
   FlexStackerStoredLabwareGroup,
@@ -920,7 +921,9 @@ export type ErrorType =
   | 'PIPETTE_HAS_TIP'
   | 'PIPETTE_VOLUME_EXCEEDED'
   | 'PIPETTING_INTO_COLUMN_4'
-  | 'POSSIBLE_PIPETTE_COLLISION'
+  | 'POSSIBLE_PIPETTE_COLLISION_THERMOCYCLER_LID'
+  | 'POSSIBLE_PIPETTE_COLLISION_OUTSIDE_DECK_EXTENTS'
+  | 'POSSIBLE_PIPETTE_COLLISION_ADJACENT_ADDRESSABLE_AREA'
   | 'REMOVE_96_CHANNEL_TIPRACK_ADAPTER'
   | 'RETRACT_BELOW_ASPIRATE'
   | 'RETRACT_BELOW_DISPENSE'
@@ -940,6 +943,7 @@ export type ErrorType =
 export interface CommandCreatorError {
   message: string
   type: ErrorType
+  translationParams?: Record<string, string>
 }
 
 export type WarningType =
@@ -1016,3 +1020,19 @@ export interface WellContentsByNumber {
 }
 
 export type TipTrackingOption = typeof AUTOMATIC | typeof MANUAL
+
+export type UnsafePipetteMovementReason =
+  | {
+      type: 'thermocyclerLidCollision'
+    }
+  | {
+      type: 'outsidePipetteExtents'
+    }
+  | {
+      type: 'adjacentAdressableAreaCollision'
+      addressableAreaCausingCollision: AddressableArea
+    }
+
+export type PipetteMovementSafetyStatus =
+  | { isSafe: true }
+  | { isSafe: false; reason: UnsafePipetteMovementReason }

--- a/step-generation/src/utils/__tests__/getPipetteMovementSafetyStatus.test.ts
+++ b/step-generation/src/utils/__tests__/getPipetteMovementSafetyStatus.test.ts
@@ -14,7 +14,7 @@ import {
   TEMPERATURE_MODULE_V2,
 } from '@opentrons/shared-data'
 
-import { getIsSafePipetteMovement } from '..'
+import { getPipetteMovementSafetyStatus } from '..'
 import { CLEAN } from '../../constants'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
@@ -29,7 +29,7 @@ const mockLabware2 = 'labwareId2'
 const mockAdapter = 'adapterId'
 const mockWellName = 'A1'
 
-describe('getIsSafePipetteMovement', () => {
+describe('getPipetteMovementSafetyStatus', () => {
   let mockInvariantProperties: InvariantContext
   let mockRobotState: RobotState
   beforeEach(() => {
@@ -98,7 +98,7 @@ describe('getIsSafePipetteMovement', () => {
   })
 
   it('returns true when the labware id is a trash bin', () => {
-    const result = getIsSafePipetteMovement({
+    const { isSafe } = getPipetteMovementSafetyStatus({
       pipetteId: mockPipId,
       robotState: {
         labware: {},
@@ -114,10 +114,10 @@ describe('getIsSafePipetteMovement', () => {
       primaryNozzle: A1_NOZZLE,
       nozzleConfiguration: ALL,
     })
-    expect(result).toEqual(true)
+    expect(isSafe).toEqual(true)
   })
   it('returns false when 96ch single tip pick up will overlap with waste chute', () => {
-    const result = getIsSafePipetteMovement({
+    const { isSafe } = getPipetteMovementSafetyStatus({
       robotState: {
         ...mockRobotState,
         pipettes: {
@@ -146,10 +146,10 @@ describe('getIsSafePipetteMovement', () => {
       primaryNozzle: A1_NOZZLE,
       nozzleConfiguration: SINGLE,
     })
-    expect(result).toEqual(false)
+    expect(isSafe).toEqual(false)
   })
   it('returns false when within pipette extents is false', () => {
-    const result = getIsSafePipetteMovement({
+    const { isSafe } = getPipetteMovementSafetyStatus({
       robotState: {
         ...mockRobotState,
         pipettes: {
@@ -168,7 +168,7 @@ describe('getIsSafePipetteMovement', () => {
       primaryNozzle: A1_NOZZLE,
       nozzleConfiguration: COLUMN,
     })
-    expect(result).toEqual(false)
+    expect(isSafe).toEqual(false)
   })
   it('returns true when there are no collisions and a module near it', () => {
     mockRobotState.modules = {
@@ -182,7 +182,7 @@ describe('getIsSafePipetteMovement', () => {
         pythonName: 'mockPythonName',
       },
     }
-    const result = getIsSafePipetteMovement({
+    const { isSafe } = getPipetteMovementSafetyStatus({
       robotState: mockRobotState,
       invariantContext: mockInvariantProperties,
       pipetteId: mockPipId,
@@ -192,7 +192,7 @@ describe('getIsSafePipetteMovement', () => {
       primaryNozzle: A1_NOZZLE,
       nozzleConfiguration: ALL,
     })
-    expect(result).toEqual(true)
+    expect(isSafe).toEqual(true)
   })
   it('returns false when there is a tip that collides', () => {
     mockRobotState.tipState.tipracks = {
@@ -202,7 +202,7 @@ describe('getIsSafePipetteMovement', () => {
       ...mockRobotState.labware,
       [mockAdapter]: { stack: [mockAdapter, 'D1'] },
     }
-    const result = getIsSafePipetteMovement({
+    const { isSafe } = getPipetteMovementSafetyStatus({
       robotState: {
         ...mockRobotState,
         pipettes: {
@@ -221,7 +221,7 @@ describe('getIsSafePipetteMovement', () => {
       primaryNozzle: A12_NOZZLE,
       nozzleConfiguration: COLUMN,
     })
-    expect(result).toEqual(false)
+    expect(isSafe).toEqual(false)
   })
   it('returns false when there is a tall module nearby in a diagonal slot with adapter and labware', () => {
     mockRobotState.modules = {
@@ -244,7 +244,7 @@ describe('getIsSafePipetteMovement', () => {
         pythonName: 'mockPythonName',
       },
     }
-    const result = getIsSafePipetteMovement({
+    const { isSafe } = getPipetteMovementSafetyStatus({
       robotState: {
         ...mockRobotState,
         pipettes: {
@@ -263,7 +263,7 @@ describe('getIsSafePipetteMovement', () => {
       primaryNozzle: A12_NOZZLE,
       nozzleConfiguration: COLUMN,
     })
-    expect(result).toEqual(false)
+    expect(isSafe).toEqual(false)
   })
   //    todo(jr, 4/23/24): add more test cases, test thermocycler collision - i'll do this in a follow up
 })

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -46,6 +46,7 @@ import type {
   LabwareEntity,
   ModuleEntities,
   PipetteEntity,
+  PipetteMovementSafetyStatus,
   Point,
   RobotState,
   TipState,
@@ -218,13 +219,13 @@ const getHighestZInSlot = (
 }
 
 //  check if the slot overlaps with the pipette position
-const getSlotHasPotentialCollidingObject = (
+const getSlotPotentialCollidingObject = (
   pipetteBounds: Point[],
   slotInfo: SlotInfo[],
   robotState: RobotState,
   invariantContext: InvariantContext,
   robotType: RobotType
-): boolean => {
+): { addressableAreaCausingCollision: AddressableArea } | null => {
   for (const slot of slotInfo) {
     const slotBounds = slot.addressableArea?.boundingBox
     const slotPosition = slot.position
@@ -258,12 +259,15 @@ const getSlotHasPotentialCollidingObject = (
         robotType
       )
 
-      if (highestZInSurroundingSlot >= pipetteBounds[0]?.z) {
-        return true
+      if (
+        highestZInSurroundingSlot >= pipetteBounds[0]?.z &&
+        slot.addressableArea != null
+      ) {
+        return { addressableAreaCausingCollision: slot.addressableArea }
       }
     }
   }
-  return false
+  return null
 }
 
 const getWillCollideWithThermocyclerLid = (
@@ -309,7 +313,7 @@ const getWellPosition = (
 }
 
 //  util to use in step-generation for if the pipette movement is safe
-export const getIsSafePipetteMovement = (args: {
+export const getPipetteMovementSafetyStatus = (args: {
   robotState: RobotState
   invariantContext: InvariantContext
   pipetteId: string
@@ -319,7 +323,7 @@ export const getIsSafePipetteMovement = (args: {
   tiprackId?: string
   primaryNozzle: PrimaryNozzleConfigurationStyle
   nozzleConfiguration: NozzleConfigurationStyle
-}): boolean => {
+}): PipetteMovementSafetyStatus => {
   const {
     robotState,
     invariantContext,
@@ -341,6 +345,11 @@ export const getIsSafePipetteMovement = (args: {
 
   const pipetteEntity = pipetteEntities[pipetteId]
 
+  // if pipette entity is not found, return safe, since the responsibility of this function is to check if the pipette movement is safe, not to check if the pipette exists
+  if (pipetteEntity == null) {
+    return { isSafe: true }
+  }
+
   const { spec: pipetteSpecs } = pipetteEntity
   const { channels } = pipetteSpecs
 
@@ -356,7 +365,7 @@ export const getIsSafePipetteMovement = (args: {
     wellTargetName == null ||
     channels === 1
   ) {
-    return true
+    return { isSafe: true }
   }
   // If tiprackId is explicitly provided, assume the pipette currently has a tip attached.
   // This is used in WellSelector.ts / getAllWellsSafetyStatus to force "tip present"
@@ -434,7 +443,7 @@ export const getIsSafePipetteMovement = (args: {
     robotType,
   })
   if (!isWithinPipetteExtents) {
-    return false
+    return { isSafe: false, reason: { type: 'outsidePipetteExtents' } }
   }
   const surroundingSlots =
     robotType === OT2_ROBOT_TYPE
@@ -448,19 +457,35 @@ export const getIsSafePipetteMovement = (args: {
       position,
     }
   })
-  return (
-    !getWillCollideWithThermocyclerLid(
+  if (
+    getWillCollideWithThermocyclerLid(
       pipetteBoundsAtWellLocation,
       moduleEntities
-    ) &&
-    !getSlotHasPotentialCollidingObject(
-      pipetteBoundsAtWellLocation,
-      slotInfos,
-      robotState,
-      invariantContext,
-      robotType
     )
+  ) {
+    return {
+      isSafe: false,
+      reason: { type: 'thermocyclerLidCollision' },
+    }
+  }
+  const slotPotentialCollidingObject = getSlotPotentialCollidingObject(
+    pipetteBoundsAtWellLocation,
+    slotInfos,
+    robotState,
+    invariantContext,
+    robotType
   )
+  if (slotPotentialCollidingObject != null) {
+    return {
+      isSafe: false,
+      reason: {
+        type: 'adjacentAdressableAreaCollision',
+        addressableAreaCausingCollision:
+          slotPotentialCollidingObject.addressableAreaCausingCollision,
+      },
+    }
+  }
+  return { isSafe: true }
 }
 
 interface TipPickupAvailability {


### PR DESCRIPTION
# Overview

Refactor pipette movement safety logic in `safePipetteMovements.ts` to `getPipetteMovementSafetyStatus` to return not only whether a pipette movement is safe but also the reason for its lack of safety if applicable. This reason is bubbled up through step generation to our error creators, where we can accurately render an adjacent slot that will possibly result in a pipette collision (produced in some partial tip pickups).

Closes RQA-5377
## Test Plan and Hands on Testing

- Import the protocol attached to the ticket
- Verify that the error message correctly displays that the pipette will move outside of the deck extents
<img width="518" height="71" alt="Screenshot 2026-05-11 at 4 59 39 PM" src="https://github.com/user-attachments/assets/d715e6e6-7aff-4cae-bf6f-7e50405822bc" />
- In starting deck state, move the 200µl tiprack from slot C3 to C2
- Verify that the timeline error disappears
- In starting deck state, move the 50µl tiprack from slot A3 to C3
- Verify that a new timeline error appears, correctly displaying that the pipette will possibly collide with the items in slot C3
<img width="576" height="74" alt="Screenshot 2026-05-11 at 4 59 24 PM" src="https://github.com/user-attachments/assets/010842db-7b54-4382-a6f7-2ea3e6a7d6cc" />

## Changelog

- extend the logic of our pipette safety checker to return the reason why a movement is potentially unsafe
- refactor all instances of this utility accordingly
- refactor error creator for pipette collisions to switch on these unsafe types
- update unit tests

## Review requests

see test plan

## Risk assessment

Low. Raw safety boolean is still readily accessible from the refactored utility. All new logic is purely additive