### PR TITLE
fix(shared-data, app, protocol-visualization): ot2 tc and trash hovers

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewOverlay/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewOverlay/index.tsx
@@ -53,6 +53,8 @@ interface SlotOverlayProps {
   children?: ReactNode
 }
 
+const X_OFFSET = 30 // center the fixedTrash overlay
+
 export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
   const {
     slotId,
@@ -208,7 +210,7 @@ export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
         key="ot2_hover"
         width={width}
         height={height}
-        x={slotId === 'fixedTrash' ? x - 30 : x}
+        x={slotId === 'fixedTrash' ? x - X_OFFSET : x}
         y={y}
         flexProps={{ flex: '1' }}
         foreignObjectProps={{

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewOverlay/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewOverlay/index.tsx
@@ -199,7 +199,8 @@ export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
   } else {
     const { width, x, y, height } = getOT2HoverDimensions(
       hasTCOnSlot,
-      slotPosition
+      slotPosition,
+      true
     )
 
     return (
@@ -207,7 +208,7 @@ export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
         key="ot2_hover"
         width={width}
         height={height}
-        x={x}
+        x={slotId === 'fixedTrash' ? x - 30 : x}
         y={y}
         flexProps={{ flex: '1' }}
         foreignObjectProps={{

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/Ot2FixedTrashCommandSummary.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/Ot2FixedTrashCommandSummary.tsx
@@ -37,7 +37,6 @@ export function Ot2FixedTrashCommandSummary(
   )
   const commandSummary = useCommandTypeSummaries(commandType)
   const slotPosition = getPositionFromSlotId('fixedTrash', deckDef)
-  console.log('slotPosition', slotPosition)
   const slotBoundingBox = addressableArea?.boundingBox
 
   if (slotPosition == null || slotBoundingBox == null) {
@@ -46,7 +45,7 @@ export function Ot2FixedTrashCommandSummary(
   return (
     <>
       <RobotCoordsForeignDiv
-        x={slotPosition[0]}
+        x={slotPosition[0] - 30}
         y={slotPosition[1]}
         width={slotBoundingBox.xDimension}
         height={slotBoundingBox.yDimension}
@@ -76,7 +75,7 @@ export function Ot2FixedTrashCommandSummary(
             isZoomed: false,
           },
         ]}
-        x={slotPosition[0]}
+        x={slotPosition[0] - 30}
         y={slotPosition[1] - Y_OFFSET}
         width={slotBoundingBox.xDimension}
         height={slotBoundingBox.yDimension}

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/Ot2FixedTrashCommandSummary.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/Ot2FixedTrashCommandSummary.tsx
@@ -20,6 +20,7 @@ import {
 import type { CutoutId, RunTimeCommand } from '@opentrons/shared-data'
 
 const Y_OFFSET = 28 // allow for the deck label set to be even with the slot
+const X_OFFSET = 30 // center the fixedTrash overlay
 
 interface Ot2TrashCommandSummaryProps {
   commandType: RunTimeCommand['commandType']
@@ -45,7 +46,7 @@ export function Ot2FixedTrashCommandSummary(
   return (
     <>
       <RobotCoordsForeignDiv
-        x={slotPosition[0] - 30}
+        x={slotPosition[0] - X_OFFSET}
         y={slotPosition[1]}
         width={slotBoundingBox.xDimension}
         height={slotBoundingBox.yDimension}
@@ -75,7 +76,7 @@ export function Ot2FixedTrashCommandSummary(
             isZoomed: false,
           },
         ]}
-        x={slotPosition[0] - 30}
+        x={slotPosition[0] - X_OFFSET}
         y={slotPosition[1] - Y_OFFSET}
         width={slotBoundingBox.xDimension}
         height={slotBoundingBox.yDimension}

--- a/js-package-testing/src/App.tsx
+++ b/js-package-testing/src/App.tsx
@@ -8,6 +8,7 @@ import StackerAnalysis from './StackerAnalysis.json'
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 
 import './styles.css'
+
 import { useState } from 'react'
 
 const analysis = StackerAnalysis as unknown as ProtocolAnalysisOutput
@@ -69,7 +70,8 @@ function DeckMapPage(): JSX.Element {
       <div className="analysis_info">
         <h3>Analysis</h3>
         <p>
-          <strong>Protocol:</strong> {analysis.metadata?.protocolName ?? 'ot-2 protocol'}
+          <strong>Protocol:</strong>{' '}
+          {analysis.metadata?.protocolName ?? 'ot-2 protocol'}
         </p>
         <p>
           <strong>Robot type:</strong> {analysis.robotType}
@@ -97,24 +99,39 @@ function DeckMapPage(): JSX.Element {
 }
 
 function VisualizationPage(): JSX.Element {
-
   const [showFlex, setShowFlex] = useState<boolean>(true)
   return (
     <main className="demo_section protocol_visualization_section">
       <h2>Protocol visualization</h2>
-      <div style={{display: 'flex', gap: '1rem'}}>
-      <PrimaryButton onClick={() => {setShowFlex(true)}}>Flex</PrimaryButton>
-       <PrimaryButton onClick={() => {setShowFlex(false)}}>Ot-2</PrimaryButton>
-       </div>
+      <div style={{ display: 'flex', gap: '1rem' }}>
+        <PrimaryButton
+          onClick={() => {
+            setShowFlex(true)
+          }}
+        >
+          Flex
+        </PrimaryButton>
+        <PrimaryButton
+          onClick={() => {
+            setShowFlex(false)
+          }}
+        >
+          Ot-2
+        </PrimaryButton>
+      </div>
       <p>
-        From <code>@opentrons/protocol-visualization</code> using the {' '}
-        {showFlex ? 'StackerAnalysis' : 'Ot2Analysis'} fixture as the deck map page.
+        From <code>@opentrons/protocol-visualization</code> using the{' '}
+        {showFlex ? 'StackerAnalysis' : 'Ot2Analysis'} fixture as the deck map
+        page.
       </p>
       <div
         data-testid="protocol-visualization-container"
         className="protocol_visualization_demo"
       >
-        <ProtocolVisualization analysis={showFlex ? analysis : ot2Analysis} groupedCommands={null} />
+        <ProtocolVisualization
+          analysis={showFlex ? analysis : ot2Analysis}
+          groupedCommands={null}
+        />
       </div>
     </main>
   )

--- a/js-package-testing/src/App.tsx
+++ b/js-package-testing/src/App.tsx
@@ -1,14 +1,18 @@
-import { ProtocolDeck } from '@opentrons/components'
+import { PrimaryButton, ProtocolDeck } from '@opentrons/components'
 import { ProtocolVisualization } from '@opentrons/protocol-visualization'
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
+import Ot2Analysis from './ot2Analysis.json'
 import StackerAnalysis from './StackerAnalysis.json'
 
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 
 import './styles.css'
+import { useState } from 'react'
 
 const analysis = StackerAnalysis as unknown as ProtocolAnalysisOutput
+const ot2Analysis = Ot2Analysis as unknown as ProtocolAnalysisOutput
+
 type DemoPage = 'deck-map' | 'protocol-visualization'
 
 function getCurrentPage(): DemoPage {
@@ -65,7 +69,7 @@ function DeckMapPage(): JSX.Element {
       <div className="analysis_info">
         <h3>Analysis</h3>
         <p>
-          <strong>Protocol:</strong> {analysis.metadata.protocolName}
+          <strong>Protocol:</strong> {analysis.metadata?.protocolName ?? 'ot-2 protocol'}
         </p>
         <p>
           <strong>Robot type:</strong> {analysis.robotType}
@@ -74,7 +78,6 @@ function DeckMapPage(): JSX.Element {
           <strong>FLEX_ROBOT_TYPE:</strong> {FLEX_ROBOT_TYPE}
         </p>
       </div>
-
       <div
         data-testid="protocol-deck-container"
         className="protocol_deck_container"
@@ -94,18 +97,24 @@ function DeckMapPage(): JSX.Element {
 }
 
 function VisualizationPage(): JSX.Element {
+
+  const [showFlex, setShowFlex] = useState<boolean>(true)
   return (
     <main className="demo_section protocol_visualization_section">
       <h2>Protocol visualization</h2>
+      <div style={{display: 'flex', gap: '1rem'}}>
+      <PrimaryButton onClick={() => {setShowFlex(true)}}>Flex</PrimaryButton>
+       <PrimaryButton onClick={() => {setShowFlex(false)}}>Ot-2</PrimaryButton>
+       </div>
       <p>
-        From <code>@opentrons/protocol-visualization</code> using the same
-        StackerAnalysis fixture as the deck map page.
+        From <code>@opentrons/protocol-visualization</code> using the {' '}
+        {showFlex ? 'StackerAnalysis' : 'Ot2Analysis'} fixture as the deck map page.
       </p>
       <div
         data-testid="protocol-visualization-container"
         className="protocol_visualization_demo"
       >
-        <ProtocolVisualization analysis={analysis} groupedCommands={null} />
+        <ProtocolVisualization analysis={showFlex ? analysis : ot2Analysis} groupedCommands={null} />
       </div>
     </main>
   )

--- a/js-package-testing/src/ot2Analysis.json
+++ b/js-package-testing/src/ot2Analysis.json
@@ -8,10 +8,7 @@
   ],
   "config": {
     "protocolType": "python",
-    "apiVersion": [
-      2,
-      28
-    ]
+    "apiVersion": [2, 28]
   },
   "metadata": {
     "protocolName": "ot2TC",
@@ -83,9 +80,7 @@
           },
           {
             "kind": "onCutoutFixture",
-            "possibleCutoutFixtureIds": [
-              "singleStandardSlot"
-            ],
+            "possibleCutoutFixtureIds": ["singleStandardSlot"],
             "cutoutId": "cutout2"
           }
         ],
@@ -120,126 +115,18 @@
             "z": 0
           },
           "ordering": [
-            [
-              "A1",
-              "B1",
-              "C1",
-              "D1",
-              "E1",
-              "F1",
-              "G1",
-              "H1"
-            ],
-            [
-              "A2",
-              "B2",
-              "C2",
-              "D2",
-              "E2",
-              "F2",
-              "G2",
-              "H2"
-            ],
-            [
-              "A3",
-              "B3",
-              "C3",
-              "D3",
-              "E3",
-              "F3",
-              "G3",
-              "H3"
-            ],
-            [
-              "A4",
-              "B4",
-              "C4",
-              "D4",
-              "E4",
-              "F4",
-              "G4",
-              "H4"
-            ],
-            [
-              "A5",
-              "B5",
-              "C5",
-              "D5",
-              "E5",
-              "F5",
-              "G5",
-              "H5"
-            ],
-            [
-              "A6",
-              "B6",
-              "C6",
-              "D6",
-              "E6",
-              "F6",
-              "G6",
-              "H6"
-            ],
-            [
-              "A7",
-              "B7",
-              "C7",
-              "D7",
-              "E7",
-              "F7",
-              "G7",
-              "H7"
-            ],
-            [
-              "A8",
-              "B8",
-              "C8",
-              "D8",
-              "E8",
-              "F8",
-              "G8",
-              "H8"
-            ],
-            [
-              "A9",
-              "B9",
-              "C9",
-              "D9",
-              "E9",
-              "F9",
-              "G9",
-              "H9"
-            ],
-            [
-              "A10",
-              "B10",
-              "C10",
-              "D10",
-              "E10",
-              "F10",
-              "G10",
-              "H10"
-            ],
-            [
-              "A11",
-              "B11",
-              "C11",
-              "D11",
-              "E11",
-              "F11",
-              "G11",
-              "H11"
-            ],
-            [
-              "A12",
-              "B12",
-              "C12",
-              "D12",
-              "E12",
-              "F12",
-              "G12",
-              "H12"
-            ]
+            ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+            ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+            ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+            ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+            ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+            ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+            ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+            ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+            ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+            ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+            ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+            ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
           ],
           "dimensions": {
             "yDimension": 85.48,
@@ -1249,9 +1136,7 @@
           },
           {
             "kind": "onCutoutFixture",
-            "possibleCutoutFixtureIds": [
-              "singleStandardSlot"
-            ],
+            "possibleCutoutFixtureIds": ["singleStandardSlot"],
             "cutoutId": "cutout9"
           }
         ],
@@ -1267,9 +1152,7 @@
           },
           "brand": {
             "brand": "Axygen",
-            "brandId": [
-              "P-96-450V-C-S"
-            ]
+            "brandId": ["P-96-450V-C-S"]
           },
           "parameters": {
             "format": "96Standard",
@@ -1284,126 +1167,18 @@
             "z": 0
           },
           "ordering": [
-            [
-              "A1",
-              "B1",
-              "C1",
-              "D1",
-              "E1",
-              "F1",
-              "G1",
-              "H1"
-            ],
-            [
-              "A2",
-              "B2",
-              "C2",
-              "D2",
-              "E2",
-              "F2",
-              "G2",
-              "H2"
-            ],
-            [
-              "A3",
-              "B3",
-              "C3",
-              "D3",
-              "E3",
-              "F3",
-              "G3",
-              "H3"
-            ],
-            [
-              "A4",
-              "B4",
-              "C4",
-              "D4",
-              "E4",
-              "F4",
-              "G4",
-              "H4"
-            ],
-            [
-              "A5",
-              "B5",
-              "C5",
-              "D5",
-              "E5",
-              "F5",
-              "G5",
-              "H5"
-            ],
-            [
-              "A6",
-              "B6",
-              "C6",
-              "D6",
-              "E6",
-              "F6",
-              "G6",
-              "H6"
-            ],
-            [
-              "A7",
-              "B7",
-              "C7",
-              "D7",
-              "E7",
-              "F7",
-              "G7",
-              "H7"
-            ],
-            [
-              "A8",
-              "B8",
-              "C8",
-              "D8",
-              "E8",
-              "F8",
-              "G8",
-              "H8"
-            ],
-            [
-              "A9",
-              "B9",
-              "C9",
-              "D9",
-              "E9",
-              "F9",
-              "G9",
-              "H9"
-            ],
-            [
-              "A10",
-              "B10",
-              "C10",
-              "D10",
-              "E10",
-              "F10",
-              "G10",
-              "H10"
-            ],
-            [
-              "A11",
-              "B11",
-              "C11",
-              "D11",
-              "E11",
-              "F11",
-              "G11",
-              "H11"
-            ],
-            [
-              "A12",
-              "B12",
-              "C12",
-              "D12",
-              "E12",
-              "F12",
-              "G12",
-              "H12"
-            ]
+            ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"],
+            ["A2", "B2", "C2", "D2", "E2", "F2", "G2", "H2"],
+            ["A3", "B3", "C3", "D3", "E3", "F3", "G3", "H3"],
+            ["A4", "B4", "C4", "D4", "E4", "F4", "G4", "H4"],
+            ["A5", "B5", "C5", "D5", "E5", "F5", "G5", "H5"],
+            ["A6", "B6", "C6", "D6", "E6", "F6", "G6", "H6"],
+            ["A7", "B7", "C7", "D7", "E7", "F7", "G7", "H7"],
+            ["A8", "B8", "C8", "D8", "E8", "F8", "G8", "H8"],
+            ["A9", "B9", "C9", "D9", "E9", "F9", "G9", "H9"],
+            ["A10", "B10", "C10", "D10", "E10", "F10", "G10", "H10"],
+            ["A11", "B11", "C11", "D11", "E11", "F11", "G11", "H11"],
+            ["A12", "B12", "C12", "D12", "E12", "F12", "G12", "H12"]
           ],
           "dimensions": {
             "yDimension": 85.34,
@@ -2619,12 +2394,7 @@
                 }
               },
               "speed": 125,
-              "airGapByVolume": [
-                [
-                  0,
-                  0
-                ]
-              ],
+              "airGapByVolume": [[0, 0]],
               "touchTip": {
                 "enable": false
               },
@@ -2640,18 +2410,8 @@
                 "z": 1
               }
             },
-            "flowRateByVolume": [
-              [
-                0,
-                150
-              ]
-            ],
-            "correctionByVolume": [
-              [
-                0,
-                0
-              ]
-            ],
+            "flowRateByVolume": [[0, 150]],
+            "correctionByVolume": [[0, 0]],
             "preWet": false,
             "mix": {
               "enable": false
@@ -2685,12 +2445,7 @@
                 }
               },
               "speed": 125,
-              "airGapByVolume": [
-                [
-                  0,
-                  0
-                ]
-              ],
+              "airGapByVolume": [[0, 0]],
               "blowout": {
                 "enable": false
               },
@@ -2709,27 +2464,12 @@
                 "z": 1
               }
             },
-            "flowRateByVolume": [
-              [
-                0,
-                300
-              ]
-            ],
-            "correctionByVolume": [
-              [
-                0,
-                0
-              ]
-            ],
+            "flowRateByVolume": [[0, 300]],
+            "correctionByVolume": [[0, 0]],
             "mix": {
               "enable": false
             },
-            "pushOutByVolume": [
-              [
-                0,
-                0
-              ]
-            ],
+            "pushOutByVolume": [[0, 0]],
             "delay": {
               "enable": false
             }
@@ -2755,9 +2495,7 @@
       "status": "succeeded",
       "params": {
         "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c",
-        "labwareIds": [
-          "a0b54d20-da8c-4599-aa26-0ac784078938"
-        ]
+        "labwareIds": ["a0b54d20-da8c-4599-aa26-0ac784078938"]
       },
       "result": {
         "nextTipInfo": {
@@ -3173,12 +2911,7 @@
             }
           },
           "speed": 125,
-          "airGapByVolume": [
-            [
-              0,
-              0
-            ]
-          ],
+          "airGapByVolume": [[0, 0]],
           "touchTip": {
             "enable": false
           },
@@ -3194,18 +2927,8 @@
             "z": 1
           }
         },
-        "flowRateByVolume": [
-          [
-            0,
-            150
-          ]
-        ],
-        "correctionByVolume": [
-          [
-            0,
-            0
-          ]
-        ],
+        "flowRateByVolume": [[0, 150]],
+        "correctionByVolume": [[0, 0]],
         "preWet": false,
         "mix": {
           "enable": false
@@ -3239,12 +2962,7 @@
             }
           },
           "speed": 125,
-          "airGapByVolume": [
-            [
-              0,
-              0
-            ]
-          ],
+          "airGapByVolume": [[0, 0]],
           "blowout": {
             "enable": false
           },
@@ -3263,27 +2981,12 @@
             "z": 1
           }
         },
-        "flowRateByVolume": [
-          [
-            0,
-            300
-          ]
-        ],
-        "correctionByVolume": [
-          [
-            0,
-            0
-          ]
-        ],
+        "flowRateByVolume": [[0, 300]],
+        "correctionByVolume": [[0, 0]],
         "mix": {
           "enable": false
         },
-        "pushOutByVolume": [
-          [
-            0,
-            0
-          ]
-        ],
+        "pushOutByVolume": [[0, 0]],
         "delay": {
           "enable": false
         }

--- a/js-package-testing/src/ot2Analysis.json
+++ b/js-package-testing/src/ot2Analysis.json
@@ -1,0 +1,1313 @@
+{
+  "createdAt": "2026-05-11T13:33:42.844190Z",
+  "files": [
+    {
+      "name": "ot2TC.py",
+      "role": "main"
+    }
+  ],
+  "config": {
+    "protocolType": "python",
+    "apiVersion": [
+      2,
+      28
+    ]
+  },
+  "metadata": {
+    "protocolName": "ot2TC",
+    "created": "2026-05-11T13:33:07.098Z",
+    "internalAppBuildDate": "Tue, 05 May 2026 15:37:27 GMT",
+    "lastModified": "2026-05-11T13:33:25.498Z",
+    "protocolDesigner": "8.10.1",
+    "source": "Protocol Designer"
+  },
+  "result": "ok",
+  "robotType": "OT-2 Standard",
+  "runTimeParameters": [],
+  "commands": [
+    {
+      "id": "3b9b42be-95fa-4451-b6fb-ecce5c71afe9",
+      "createdAt": "2026-05-11T13:33:42.813007Z",
+      "commandType": "home",
+      "key": "50c7ae73a4e3f7129874f39dfb514803",
+      "status": "succeeded",
+      "params": {},
+      "result": {},
+      "startedAt": "2026-05-11T13:33:42.813097Z",
+      "completedAt": "2026-05-11T13:33:42.813135Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "46179761-bd0c-4e63-9b32-698d5ad9ee23",
+      "createdAt": "2026-05-11T13:33:42.813415Z",
+      "commandType": "loadModule",
+      "key": "8511b05ba5565bf0e6dcccd800e2ee23",
+      "status": "succeeded",
+      "params": {
+        "model": "thermocyclerModuleV1",
+        "location": {
+          "slotName": "7"
+        }
+      },
+      "result": {
+        "moduleId": "cb021a02-ce23-47e9-87ad-496fe96af521",
+        "model": "thermocyclerModuleV1",
+        "serialNumber": "fake-serial-number-56e9dd7f-3189-4368-b7c3-90c138d4271d"
+      },
+      "startedAt": "2026-05-11T13:33:42.813476Z",
+      "completedAt": "2026-05-11T13:33:42.813803Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "2a8926e8-80a2-41e2-8687-50b80057fac4",
+      "createdAt": "2026-05-11T13:33:42.814304Z",
+      "commandType": "loadLabware",
+      "key": "b9563ff54d4bfe61c469a7da06e79f42",
+      "status": "succeeded",
+      "params": {
+        "location": {
+          "slotName": "2"
+        },
+        "loadName": "opentrons_96_tiprack_300ul",
+        "namespace": "opentrons",
+        "version": 1
+      },
+      "result": {
+        "labwareId": "d0df6426-a4eb-45e1-84df-db08b491ef50",
+        "locationSequence": [
+          {
+            "kind": "onAddressableArea",
+            "addressableAreaName": "2"
+          },
+          {
+            "kind": "onCutoutFixture",
+            "possibleCutoutFixtureIds": [
+              "singleStandardSlot"
+            ],
+            "cutoutId": "cutout2"
+          }
+        ],
+        "definition": {
+          "schemaVersion": 2,
+          "version": 1,
+          "namespace": "opentrons",
+          "metadata": {
+            "displayName": "Opentrons OT-2 96 Tip Rack 300 µL",
+            "displayCategory": "tipRack",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "brand": {
+            "brand": "Opentrons",
+            "brandId": [],
+            "links": [
+              "https://shop.opentrons.com/collections/opentrons-tips/products/opentrons-300ul-tips"
+            ]
+          },
+          "parameters": {
+            "format": "96Standard",
+            "isTiprack": true,
+            "tipLength": 59.3,
+            "tipOverlap": 7.47,
+            "loadName": "opentrons_96_tiprack_300ul",
+            "isMagneticModuleCompatible": false
+          },
+          "cornerOffsetFromSlot": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ]
+          ],
+          "dimensions": {
+            "yDimension": 85.48,
+            "zDimension": 64.49,
+            "xDimension": 127.76
+          },
+          "wells": {
+            "A1": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "z": 5.39,
+              "y": 74.24
+            },
+            "B1": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "z": 5.39,
+              "y": 65.24
+            },
+            "C1": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "z": 5.39,
+              "y": 56.24
+            },
+            "D1": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "z": 5.39,
+              "y": 47.24
+            },
+            "E1": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "z": 5.39,
+              "y": 38.24
+            },
+            "F1": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "z": 5.39,
+              "y": 29.24
+            },
+            "G1": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "z": 5.39,
+              "y": 20.24
+            },
+            "H1": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 14.38,
+              "z": 5.39,
+              "y": 11.24
+            },
+            "A2": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "z": 5.39,
+              "y": 74.24
+            },
+            "B2": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "z": 5.39,
+              "y": 65.24
+            },
+            "C2": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "z": 5.39,
+              "y": 56.24
+            },
+            "D2": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "z": 5.39,
+              "y": 47.24
+            },
+            "E2": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "z": 5.39,
+              "y": 38.24
+            },
+            "F2": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "z": 5.39,
+              "y": 29.24
+            },
+            "G2": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "z": 5.39,
+              "y": 20.24
+            },
+            "H2": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 23.38,
+              "z": 5.39,
+              "y": 11.24
+            },
+            "A3": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "z": 5.39,
+              "y": 74.24
+            },
+            "B3": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "z": 5.39,
+              "y": 65.24
+            },
+            "C3": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "z": 5.39,
+              "y": 56.24
+            },
+            "D3": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "z": 5.39,
+              "y": 47.24
+            },
+            "E3": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "z": 5.39,
+              "y": 38.24
+            },
+            "F3": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "z": 5.39,
+              "y": 29.24
+            },
+            "G3": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "z": 5.39,
+              "y": 20.24
+            },
+            "H3": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 32.38,
+              "z": 5.39,
+              "y": 11.24
+            },
+            "A4": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "z": 5.39,
+              "y": 74.24
+            },
+            "B4": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "z": 5.39,
+              "y": 65.24
+            },
+            "C4": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "z": 5.39,
+              "y": 56.24
+            },
+            "D4": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "z": 5.39,
+              "y": 47.24
+            },
+            "E4": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "z": 5.39,
+              "y": 38.24
+            },
+            "F4": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "z": 5.39,
+              "y": 29.24
+            },
+            "G4": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "z": 5.39,
+              "y": 20.24
+            },
+            "H4": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 41.38,
+              "z": 5.39,
+              "y": 11.24
+            },
+            "A5": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "z": 5.39,
+              "y": 74.24
+            },
+            "B5": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "z": 5.39,
+              "y": 65.24
+            },
+            "C5": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "z": 5.39,
+              "y": 56.24
+            },
+            "D5": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "z": 5.39,
+              "y": 47.24
+            },
+            "E5": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "z": 5.39,
+              "y": 38.24
+            },
+            "F5": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "z": 5.39,
+              "y": 29.24
+            },
+            "G5": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "z": 5.39,
+              "y": 20.24
+            },
+            "H5": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 50.38,
+              "z": 5.39,
+              "y": 11.24
+            },
+            "A6": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "z": 5.39,
+              "y": 74.24
+            },
+            "B6": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "z": 5.39,
+              "y": 65.24
+            },
+            "C6": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "z": 5.39,
+              "y": 56.24
+            },
+            "D6": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "z": 5.39,
+              "y": 47.24
+            },
+            "E6": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "z": 5.39,
+              "y": 38.24
+            },
+            "F6": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "z": 5.39,
+              "y": 29.24
+            },
+            "G6": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "z": 5.39,
+              "y": 20.24
+            },
+            "H6": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 59.38,
+              "z": 5.39,
+              "y": 11.24
+            },
+            "A7": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "z": 5.39,
+              "y": 74.24
+            },
+            "B7": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "z": 5.39,
+              "y": 65.24
+            },
+            "C7": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "z": 5.39,
+              "y": 56.24
+            },
+            "D7": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "z": 5.39,
+              "y": 47.24
+            },
+            "E7": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "z": 5.39,
+              "y": 38.24
+            },
+            "F7": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "z": 5.39,
+              "y": 29.24
+            },
+            "G7": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "z": 5.39,
+              "y": 20.24
+            },
+            "H7": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 68.38,
+              "z": 5.39,
+              "y": 11.24
+            },
+            "A8": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "z": 5.39,
+              "y": 74.24
+            },
+            "B8": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "z": 5.39,
+              "y": 65.24
+            },
+            "C8": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "z": 5.39,
+              "y": 56.24
+            },
+            "D8": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "z": 5.39,
+              "y": 47.24
+            },
+            "E8": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "z": 5.39,
+              "y": 38.24
+            },
+            "F8": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "z": 5.39,
+              "y": 29.24
+            },
+            "G8": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "z": 5.39,
+              "y": 20.24
+            },
+            "H8": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 77.38,
+              "z": 5.39,
+              "y": 11.24
+            },
+            "A9": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "z": 5.39,
+              "y": 74.24
+            },
+            "B9": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "z": 5.39,
+              "y": 65.24
+            },
+            "C9": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "z": 5.39,
+              "y": 56.24
+            },
+            "D9": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "z": 5.39,
+              "y": 47.24
+            },
+            "E9": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "z": 5.39,
+              "y": 38.24
+            },
+            "F9": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "z": 5.39,
+              "y": 29.24
+            },
+            "G9": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "z": 5.39,
+              "y": 20.24
+            },
+            "H9": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 86.38,
+              "z": 5.39,
+              "y": 11.24
+            },
+            "A10": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "z": 5.39,
+              "y": 74.24
+            },
+            "B10": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "z": 5.39,
+              "y": 65.24
+            },
+            "C10": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "z": 5.39,
+              "y": 56.24
+            },
+            "D10": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "z": 5.39,
+              "y": 47.24
+            },
+            "E10": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "z": 5.39,
+              "y": 38.24
+            },
+            "F10": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "z": 5.39,
+              "y": 29.24
+            },
+            "G10": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "z": 5.39,
+              "y": 20.24
+            },
+            "H10": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 95.38,
+              "z": 5.39,
+              "y": 11.24
+            },
+            "A11": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "z": 5.39,
+              "y": 74.24
+            },
+            "B11": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "z": 5.39,
+              "y": 65.24
+            },
+            "C11": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "z": 5.39,
+              "y": 56.24
+            },
+            "D11": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "z": 5.39,
+              "y": 47.24
+            },
+            "E11": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "z": 5.39,
+              "y": 38.24
+            },
+            "F11": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "z": 5.39,
+              "y": 29.24
+            },
+            "G11": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "z": 5.39,
+              "y": 20.24
+            },
+            "H11": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 104.38,
+              "z": 5.39,
+              "y": 11.24
+            },
+            "A12": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "z": 5.39,
+              "y": 74.24
+            },
+            "B12": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "z": 5.39,
+              "y": 65.24
+            },
+            "C12": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "z": 5.39,
+              "y": 56.24
+            },
+            "D12": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "z": 5.39,
+              "y": 47.24
+            },
+            "E12": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "z": 5.39,
+              "y": 38.24
+            },
+            "F12": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "z": 5.39,
+              "y": 29.24
+            },
+            "G12": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "z": 5.39,
+              "y": 20.24
+            },
+            "H12": {
+              "shape": "circular",
+              "diameter": 5.23,
+              "depth": 59.3,
+              "totalLiquidVolume": 300,
+              "x": 113.38,
+              "z": 5.39,
+              "y": 11.24
+            }
+          },
+          "groups": [
+            {
+              "wells": [
+                "A1",
+                "B1",
+                "C1",
+                "D1",
+                "E1",
+                "F1",
+                "G1",
+                "H1",
+                "A2",
+                "B2",
+                "C2",
+                "D2",
+                "E2",
+                "F2",
+                "G2",
+                "H2",
+                "A3",
+                "B3",
+                "C3",
+                "D3",
+                "E3",
+                "F3",
+                "G3",
+                "H3",
+                "A4",
+                "B4",
+                "C4",
+                "D4",
+                "E4",
+                "F4",
+                "G4",
+                "H4",
+                "A5",
+                "B5",
+                "C5",
+                "D5",
+                "E5",
+                "F5",
+                "G5",
+                "H5",
+                "A6",
+                "B6",
+                "C6",
+                "D6",
+                "E6",
+                "F6",
+                "G6",
+                "H6",
+                "A7",
+                "B7",
+                "C7",
+                "D7",
+                "E7",
+                "F7",
+                "G7",
+                "H7",
+                "A8",
+                "B8",
+                "C8",
+                "D8",
+                "E8",
+                "F8",
+                "G8",
+                "H8",
+                "A9",
+                "B9",
+                "C9",
+                "D9",
+                "E9",
+                "F9",
+                "G9",
+                "H9",
+                "A10",
+                "B10",
+                "C10",
+                "D10",
+                "E10",
+                "F10",
+                "G10",
+                "H10",
+                "A11",
+                "B11",
+                "C11",
+                "D11",
+                "E11",
+                "F11",
+                "G11",
+                "H11",
+                "A12",
+                "B12",
+                "C12",
+                "D12",
+                "E12",
+                "F12",
+                "G12",
+                "H12"
+              ],
+              "metadata": {}
+            }
+          ],
+          "stackingOffsetWithLabware": {},
+          "stackingOffsetWithModule": {},
+          "allowedRoles": [],
+          "gripperOffsets": {}
+        }
+      },
+      "startedAt": "2026-05-11T13:33:42.814354Z",
+      "completedAt": "2026-05-11T13:33:42.815695Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "97c857bb-d1f4-4343-9d54-e029dac4576f",
+      "createdAt": "2026-05-11T13:33:42.841910Z",
+      "commandType": "loadPipette",
+      "key": "2763353e564ce1df96aeccf789058132",
+      "status": "succeeded",
+      "params": {
+        "pipetteName": "p300_single",
+        "mount": "left",
+        "tipOverlapNotAfterVersion": "v3",
+        "liquidPresenceDetection": false
+      },
+      "result": {
+        "pipetteId": "707b5c1d-a608-4527-87aa-ea1df9eb0fee"
+      },
+      "startedAt": "2026-05-11T13:33:42.841994Z",
+      "completedAt": "2026-05-11T13:33:42.842915Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "57c82b67-8dac-432b-93a4-0f3ee312bcbd",
+      "createdAt": "2026-05-11T13:33:42.843292Z",
+      "commandType": "waitForResume",
+      "key": "6acecf3bb07f1e2aadc8635f489f7a97",
+      "status": "succeeded",
+      "params": {},
+      "result": {},
+      "startedAt": "2026-05-11T13:33:42.843353Z",
+      "completedAt": "2026-05-11T13:33:42.843378Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "704b7fb3-0895-452a-9b02-ed4b140aec32",
+      "createdAt": "2026-05-11T13:33:42.843551Z",
+      "commandType": "thermocycler/openLid",
+      "key": "53a00c8c35f0e1b4d3005bad2de593f6",
+      "status": "succeeded",
+      "params": {
+        "moduleId": "cb021a02-ce23-47e9-87ad-496fe96af521"
+      },
+      "result": {},
+      "startedAt": "2026-05-11T13:33:42.843600Z",
+      "completedAt": "2026-05-11T13:33:42.843625Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    }
+  ],
+  "labware": [
+    {
+      "id": "d0df6426-a4eb-45e1-84df-db08b491ef50",
+      "loadName": "opentrons_96_tiprack_300ul",
+      "definitionUri": "opentrons/opentrons_96_tiprack_300ul/1",
+      "location": {
+        "slotName": "2"
+      }
+    }
+  ],
+  "pipettes": [
+    {
+      "id": "707b5c1d-a608-4527-87aa-ea1df9eb0fee",
+      "pipetteName": "p300_single",
+      "mount": "left"
+    }
+  ],
+  "modules": [
+    {
+      "id": "cb021a02-ce23-47e9-87ad-496fe96af521",
+      "model": "thermocyclerModuleV1",
+      "location": {
+        "slotName": "7"
+      },
+      "serialNumber": "fake-serial-number-56e9dd7f-3189-4368-b7c3-90c138d4271d"
+    }
+  ],
+  "liquids": [],
+  "liquidClasses": [],
+  "errors": [],
+  "commandAnnotations": [],
+  "commandPreconditions": {
+    "isCameraUsed": false
+  },
+  "labwareOffsets": []
+}

--- a/js-package-testing/src/ot2Analysis.json
+++ b/js-package-testing/src/ot2Analysis.json
@@ -1,8 +1,8 @@
 {
-  "createdAt": "2026-05-11T13:33:42.844190Z",
+  "createdAt": "2026-05-12T13:16:44.637079Z",
   "files": [
     {
-      "name": "ot2TC.py",
+      "name": "ot2TC (1).py",
       "role": "main"
     }
   ],
@@ -17,7 +17,7 @@
     "protocolName": "ot2TC",
     "created": "2026-05-11T13:33:07.098Z",
     "internalAppBuildDate": "Tue, 05 May 2026 15:37:27 GMT",
-    "lastModified": "2026-05-11T13:33:25.498Z",
+    "lastModified": "2026-05-12T13:15:48.714Z",
     "protocolDesigner": "8.10.1",
     "source": "Protocol Designer"
   },
@@ -26,21 +26,21 @@
   "runTimeParameters": [],
   "commands": [
     {
-      "id": "3b9b42be-95fa-4451-b6fb-ecce5c71afe9",
-      "createdAt": "2026-05-11T13:33:42.813007Z",
+      "id": "06f4b7d1-12d0-4ef0-a9bf-4226c4fdeb3e",
+      "createdAt": "2026-05-12T13:16:44.625823Z",
       "commandType": "home",
       "key": "50c7ae73a4e3f7129874f39dfb514803",
       "status": "succeeded",
       "params": {},
       "result": {},
-      "startedAt": "2026-05-11T13:33:42.813097Z",
-      "completedAt": "2026-05-11T13:33:42.813135Z",
+      "startedAt": "2026-05-12T13:16:44.625910Z",
+      "completedAt": "2026-05-12T13:16:44.625946Z",
       "notes": [],
       "commandAnnotationIds": []
     },
     {
-      "id": "46179761-bd0c-4e63-9b32-698d5ad9ee23",
-      "createdAt": "2026-05-11T13:33:42.813415Z",
+      "id": "705af988-ab65-4858-835d-84cdbe05d53e",
+      "createdAt": "2026-05-12T13:16:44.626210Z",
       "commandType": "loadModule",
       "key": "8511b05ba5565bf0e6dcccd800e2ee23",
       "status": "succeeded",
@@ -51,18 +51,18 @@
         }
       },
       "result": {
-        "moduleId": "cb021a02-ce23-47e9-87ad-496fe96af521",
+        "moduleId": "2cef6ce2-1acc-4298-b28a-6a9e60f3aef0",
         "model": "thermocyclerModuleV1",
-        "serialNumber": "fake-serial-number-56e9dd7f-3189-4368-b7c3-90c138d4271d"
+        "serialNumber": "fake-serial-number-f951f55a-1754-4b24-bc95-be36ed5b47d3"
       },
-      "startedAt": "2026-05-11T13:33:42.813476Z",
-      "completedAt": "2026-05-11T13:33:42.813803Z",
+      "startedAt": "2026-05-12T13:16:44.626263Z",
+      "completedAt": "2026-05-12T13:16:44.626736Z",
       "notes": [],
       "commandAnnotationIds": []
     },
     {
-      "id": "2a8926e8-80a2-41e2-8687-50b80057fac4",
-      "createdAt": "2026-05-11T13:33:42.814304Z",
+      "id": "4fbe2492-3749-4761-a31e-27a9e6100750",
+      "createdAt": "2026-05-12T13:16:44.627273Z",
       "commandType": "loadLabware",
       "key": "b9563ff54d4bfe61c469a7da06e79f42",
       "status": "succeeded",
@@ -75,7 +75,7 @@
         "version": 1
       },
       "result": {
-        "labwareId": "d0df6426-a4eb-45e1-84df-db08b491ef50",
+        "labwareId": "a0b54d20-da8c-4599-aa26-0ac784078938",
         "locationSequence": [
           {
             "kind": "onAddressableArea",
@@ -1221,16 +1221,1328 @@
           "gripperOffsets": {}
         }
       },
-      "startedAt": "2026-05-11T13:33:42.814354Z",
-      "completedAt": "2026-05-11T13:33:42.815695Z",
+      "startedAt": "2026-05-12T13:16:44.627335Z",
+      "completedAt": "2026-05-12T13:16:44.628433Z",
       "notes": [],
       "commandAnnotationIds": []
     },
     {
-      "id": "97c857bb-d1f4-4343-9d54-e029dac4576f",
-      "createdAt": "2026-05-11T13:33:42.841910Z",
+      "id": "82c045f8-38ee-44c2-b052-348420ae66e5",
+      "createdAt": "2026-05-12T13:16:44.628871Z",
+      "commandType": "loadLabware",
+      "key": "07af6536632377008ed92723cc8c5072",
+      "status": "succeeded",
+      "params": {
+        "location": {
+          "slotName": "9"
+        },
+        "loadName": "axygen_96_wellplate_500ul",
+        "namespace": "opentrons",
+        "version": 2
+      },
+      "result": {
+        "labwareId": "a4aeeff8-14d4-4d56-b188-bf9fa7fb0dde",
+        "locationSequence": [
+          {
+            "kind": "onAddressableArea",
+            "addressableAreaName": "9"
+          },
+          {
+            "kind": "onCutoutFixture",
+            "possibleCutoutFixtureIds": [
+              "singleStandardSlot"
+            ],
+            "cutoutId": "cutout9"
+          }
+        ],
+        "definition": {
+          "schemaVersion": 2,
+          "version": 2,
+          "namespace": "opentrons",
+          "metadata": {
+            "displayName": "Axygen 96 Well Plate 500 µL",
+            "displayCategory": "wellPlate",
+            "displayVolumeUnits": "µL",
+            "tags": []
+          },
+          "brand": {
+            "brand": "Axygen",
+            "brandId": [
+              "P-96-450V-C-S"
+            ]
+          },
+          "parameters": {
+            "format": "96Standard",
+            "quirks": [],
+            "isTiprack": false,
+            "loadName": "axygen_96_wellplate_500ul",
+            "isMagneticModuleCompatible": false
+          },
+          "cornerOffsetFromSlot": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          },
+          "ordering": [
+            [
+              "A1",
+              "B1",
+              "C1",
+              "D1",
+              "E1",
+              "F1",
+              "G1",
+              "H1"
+            ],
+            [
+              "A2",
+              "B2",
+              "C2",
+              "D2",
+              "E2",
+              "F2",
+              "G2",
+              "H2"
+            ],
+            [
+              "A3",
+              "B3",
+              "C3",
+              "D3",
+              "E3",
+              "F3",
+              "G3",
+              "H3"
+            ],
+            [
+              "A4",
+              "B4",
+              "C4",
+              "D4",
+              "E4",
+              "F4",
+              "G4",
+              "H4"
+            ],
+            [
+              "A5",
+              "B5",
+              "C5",
+              "D5",
+              "E5",
+              "F5",
+              "G5",
+              "H5"
+            ],
+            [
+              "A6",
+              "B6",
+              "C6",
+              "D6",
+              "E6",
+              "F6",
+              "G6",
+              "H6"
+            ],
+            [
+              "A7",
+              "B7",
+              "C7",
+              "D7",
+              "E7",
+              "F7",
+              "G7",
+              "H7"
+            ],
+            [
+              "A8",
+              "B8",
+              "C8",
+              "D8",
+              "E8",
+              "F8",
+              "G8",
+              "H8"
+            ],
+            [
+              "A9",
+              "B9",
+              "C9",
+              "D9",
+              "E9",
+              "F9",
+              "G9",
+              "H9"
+            ],
+            [
+              "A10",
+              "B10",
+              "C10",
+              "D10",
+              "E10",
+              "F10",
+              "G10",
+              "H10"
+            ],
+            [
+              "A11",
+              "B11",
+              "C11",
+              "D11",
+              "E11",
+              "F11",
+              "G11",
+              "H11"
+            ],
+            [
+              "A12",
+              "B12",
+              "C12",
+              "D12",
+              "E12",
+              "F12",
+              "G12",
+              "H12"
+            ]
+          ],
+          "dimensions": {
+            "yDimension": 85.34,
+            "zDimension": 14.35,
+            "xDimension": 127.64
+          },
+          "wells": {
+            "A1": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 14.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 74.1
+            },
+            "B1": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 14.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 65.1
+            },
+            "C1": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 14.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 56.1
+            },
+            "D1": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 14.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 47.1
+            },
+            "E1": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 14.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 38.1
+            },
+            "F1": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 14.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 29.1
+            },
+            "G1": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 14.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 20.1
+            },
+            "H1": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 14.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 11.1
+            },
+            "A2": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 23.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 74.1
+            },
+            "B2": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 23.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 65.1
+            },
+            "C2": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 23.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 56.1
+            },
+            "D2": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 23.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 47.1
+            },
+            "E2": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 23.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 38.1
+            },
+            "F2": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 23.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 29.1
+            },
+            "G2": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 23.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 20.1
+            },
+            "H2": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 23.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 11.1
+            },
+            "A3": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 32.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 74.1
+            },
+            "B3": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 32.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 65.1
+            },
+            "C3": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 32.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 56.1
+            },
+            "D3": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 32.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 47.1
+            },
+            "E3": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 32.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 38.1
+            },
+            "F3": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 32.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 29.1
+            },
+            "G3": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 32.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 20.1
+            },
+            "H3": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 32.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 11.1
+            },
+            "A4": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 41.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 74.1
+            },
+            "B4": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 41.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 65.1
+            },
+            "C4": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 41.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 56.1
+            },
+            "D4": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 41.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 47.1
+            },
+            "E4": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 41.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 38.1
+            },
+            "F4": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 41.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 29.1
+            },
+            "G4": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 41.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 20.1
+            },
+            "H4": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 41.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 11.1
+            },
+            "A5": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 50.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 74.1
+            },
+            "B5": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 50.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 65.1
+            },
+            "C5": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 50.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 56.1
+            },
+            "D5": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 50.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 47.1
+            },
+            "E5": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 50.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 38.1
+            },
+            "F5": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 50.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 29.1
+            },
+            "G5": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 50.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 20.1
+            },
+            "H5": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 50.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 11.1
+            },
+            "A6": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 59.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 74.1
+            },
+            "B6": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 59.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 65.1
+            },
+            "C6": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 59.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 56.1
+            },
+            "D6": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 59.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 47.1
+            },
+            "E6": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 59.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 38.1
+            },
+            "F6": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 59.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 29.1
+            },
+            "G6": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 59.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 20.1
+            },
+            "H6": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 59.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 11.1
+            },
+            "A7": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 68.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 74.1
+            },
+            "B7": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 68.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 65.1
+            },
+            "C7": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 68.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 56.1
+            },
+            "D7": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 68.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 47.1
+            },
+            "E7": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 68.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 38.1
+            },
+            "F7": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 68.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 29.1
+            },
+            "G7": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 68.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 20.1
+            },
+            "H7": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 68.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 11.1
+            },
+            "A8": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 77.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 74.1
+            },
+            "B8": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 77.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 65.1
+            },
+            "C8": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 77.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 56.1
+            },
+            "D8": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 77.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 47.1
+            },
+            "E8": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 77.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 38.1
+            },
+            "F8": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 77.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 29.1
+            },
+            "G8": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 77.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 20.1
+            },
+            "H8": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 77.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 11.1
+            },
+            "A9": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 86.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 74.1
+            },
+            "B9": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 86.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 65.1
+            },
+            "C9": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 86.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 56.1
+            },
+            "D9": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 86.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 47.1
+            },
+            "E9": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 86.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 38.1
+            },
+            "F9": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 86.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 29.1
+            },
+            "G9": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 86.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 20.1
+            },
+            "H9": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 86.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 11.1
+            },
+            "A10": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 95.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 74.1
+            },
+            "B10": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 95.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 65.1
+            },
+            "C10": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 95.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 56.1
+            },
+            "D10": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 95.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 47.1
+            },
+            "E10": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 95.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 38.1
+            },
+            "F10": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 95.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 29.1
+            },
+            "G10": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 95.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 20.1
+            },
+            "H10": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 95.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 11.1
+            },
+            "A11": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 104.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 74.1
+            },
+            "B11": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 104.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 65.1
+            },
+            "C11": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 104.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 56.1
+            },
+            "D11": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 104.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 47.1
+            },
+            "E11": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 104.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 38.1
+            },
+            "F11": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 104.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 29.1
+            },
+            "G11": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 104.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 20.1
+            },
+            "H11": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 104.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 11.1
+            },
+            "A12": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 113.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 74.1
+            },
+            "B12": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 113.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 65.1
+            },
+            "C12": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 113.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 56.1
+            },
+            "D12": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 113.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 47.1
+            },
+            "E12": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 113.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 38.1
+            },
+            "F12": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 113.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 29.1
+            },
+            "G12": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 113.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 20.1
+            },
+            "H12": {
+              "shape": "circular",
+              "diameter": 8.5,
+              "depth": 12.43,
+              "totalLiquidVolume": 500,
+              "x": 113.38,
+              "z": 1.92,
+              "geometryDefinitionId": "conicalWell",
+              "y": 11.1
+            }
+          },
+          "groups": [
+            {
+              "wells": [
+                "A1",
+                "B1",
+                "C1",
+                "D1",
+                "E1",
+                "F1",
+                "G1",
+                "H1",
+                "A2",
+                "B2",
+                "C2",
+                "D2",
+                "E2",
+                "F2",
+                "G2",
+                "H2",
+                "A3",
+                "B3",
+                "C3",
+                "D3",
+                "E3",
+                "F3",
+                "G3",
+                "H3",
+                "A4",
+                "B4",
+                "C4",
+                "D4",
+                "E4",
+                "F4",
+                "G4",
+                "H4",
+                "A5",
+                "B5",
+                "C5",
+                "D5",
+                "E5",
+                "F5",
+                "G5",
+                "H5",
+                "A6",
+                "B6",
+                "C6",
+                "D6",
+                "E6",
+                "F6",
+                "G6",
+                "H6",
+                "A7",
+                "B7",
+                "C7",
+                "D7",
+                "E7",
+                "F7",
+                "G7",
+                "H7",
+                "A8",
+                "B8",
+                "C8",
+                "D8",
+                "E8",
+                "F8",
+                "G8",
+                "H8",
+                "A9",
+                "B9",
+                "C9",
+                "D9",
+                "E9",
+                "F9",
+                "G9",
+                "H9",
+                "A10",
+                "B10",
+                "C10",
+                "D10",
+                "E10",
+                "F10",
+                "G10",
+                "H10",
+                "A11",
+                "B11",
+                "C11",
+                "D11",
+                "E11",
+                "F11",
+                "G11",
+                "H11",
+                "A12",
+                "B12",
+                "C12",
+                "D12",
+                "E12",
+                "F12",
+                "G12",
+                "H12"
+              ],
+              "metadata": {
+                "wellBottomShape": "v"
+              }
+            }
+          ],
+          "stackingOffsetWithLabware": {
+            "opentrons_universal_flat_adapter": {
+              "x": 0,
+              "y": 0,
+              "z": 8.25
+            },
+            "millipore_24_ball_magnet": {
+              "x": 0,
+              "y": 0,
+              "z": 4.85
+            }
+          },
+          "stackingOffsetWithModule": {
+            "magneticBlockV1": {
+              "x": 0,
+              "y": 0,
+              "z": 1.94
+            }
+          },
+          "allowedRoles": [],
+          "gripperOffsets": {},
+          "stackLimit": 2,
+          "innerLabwareGeometry": {
+            "conicalWell": {
+              "sections": [
+                {
+                  "shape": "conical",
+                  "bottomDiameter": 8.18,
+                  "topDiameter": 8.5,
+                  "topHeight": 12.43,
+                  "bottomHeight": 3.89,
+                  "xCount": 1,
+                  "yCount": 1
+                },
+                {
+                  "shape": "conical",
+                  "bottomDiameter": 0.723,
+                  "topDiameter": 8.18,
+                  "topHeight": 3.89,
+                  "bottomHeight": 0.15,
+                  "xCount": 1,
+                  "yCount": 1
+                },
+                {
+                  "shape": "spherical",
+                  "radiusOfCurvature": 0.511,
+                  "topHeight": 0.15,
+                  "bottomHeight": 0,
+                  "xCount": 1,
+                  "yCount": 1
+                }
+              ]
+            }
+          }
+        }
+      },
+      "startedAt": "2026-05-12T13:16:44.628955Z",
+      "completedAt": "2026-05-12T13:16:44.629585Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "a88ec076-ef5a-46df-af71-6a8e9495d239",
+      "createdAt": "2026-05-12T13:16:44.629943Z",
       "commandType": "loadPipette",
-      "key": "2763353e564ce1df96aeccf789058132",
+      "key": "07ec09c7938c2a88b56846006440a5ee",
       "status": "succeeded",
       "params": {
         "pipetteName": "p300_single",
@@ -1239,71 +2551,749 @@
         "liquidPresenceDetection": false
       },
       "result": {
-        "pipetteId": "707b5c1d-a608-4527-87aa-ea1df9eb0fee"
+        "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c"
       },
-      "startedAt": "2026-05-11T13:33:42.841994Z",
-      "completedAt": "2026-05-11T13:33:42.842915Z",
+      "startedAt": "2026-05-12T13:16:44.630000Z",
+      "completedAt": "2026-05-12T13:16:44.630949Z",
       "notes": [],
       "commandAnnotationIds": []
     },
     {
-      "id": "57c82b67-8dac-432b-93a4-0f3ee312bcbd",
-      "createdAt": "2026-05-11T13:33:42.843292Z",
+      "id": "0066fff4-bc2b-4888-9a04-f1b2412374b1",
+      "createdAt": "2026-05-12T13:16:44.631226Z",
       "commandType": "waitForResume",
-      "key": "6acecf3bb07f1e2aadc8635f489f7a97",
+      "key": "d761e2b6354642c721f8d64e993601d2",
       "status": "succeeded",
       "params": {},
       "result": {},
-      "startedAt": "2026-05-11T13:33:42.843353Z",
-      "completedAt": "2026-05-11T13:33:42.843378Z",
+      "startedAt": "2026-05-12T13:16:44.631273Z",
+      "completedAt": "2026-05-12T13:16:44.631294Z",
       "notes": [],
       "commandAnnotationIds": []
     },
     {
-      "id": "704b7fb3-0895-452a-9b02-ed4b140aec32",
-      "createdAt": "2026-05-11T13:33:42.843551Z",
+      "id": "86f3a27d-3b9c-4fb5-8f40-6a4b3a7d8c13",
+      "createdAt": "2026-05-12T13:16:44.631442Z",
       "commandType": "thermocycler/openLid",
-      "key": "53a00c8c35f0e1b4d3005bad2de593f6",
+      "key": "186376efac0a118ddce7f69c348f3b9e",
       "status": "succeeded",
       "params": {
-        "moduleId": "cb021a02-ce23-47e9-87ad-496fe96af521"
+        "moduleId": "2cef6ce2-1acc-4298-b28a-6a9e60f3aef0"
       },
       "result": {},
-      "startedAt": "2026-05-11T13:33:42.843600Z",
-      "completedAt": "2026-05-11T13:33:42.843625Z",
+      "startedAt": "2026-05-12T13:16:44.631490Z",
+      "completedAt": "2026-05-12T13:16:44.631515Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "90acd0a7-166a-4855-8a1e-5498a1070482",
+      "createdAt": "2026-05-12T13:16:44.632101Z",
+      "commandType": "loadLiquidClass",
+      "key": "5df947dffea0310fd181ad7d47d57e94",
+      "status": "succeeded",
+      "params": {
+        "liquidClassRecord": {
+          "aspirate": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 125,
+              "delay": {
+                "enable": false
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 125,
+              "airGapByVolume": [
+                [
+                  0,
+                  0
+                ]
+              ],
+              "touchTip": {
+                "enable": false
+              },
+              "delay": {
+                "enable": false
+              }
+            },
+            "aspiratePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 1
+              }
+            },
+            "flowRateByVolume": [
+              [
+                0,
+                150
+              ]
+            ],
+            "correctionByVolume": [
+              [
+                0,
+                0
+              ]
+            ],
+            "preWet": false,
+            "mix": {
+              "enable": false
+            },
+            "delay": {
+              "enable": false
+            }
+          },
+          "singleDispense": {
+            "submerge": {
+              "startPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 125,
+              "delay": {
+                "enable": false
+              }
+            },
+            "retract": {
+              "endPosition": {
+                "positionReference": "well-top",
+                "offset": {
+                  "x": 0,
+                  "y": 0,
+                  "z": 2
+                }
+              },
+              "speed": 125,
+              "airGapByVolume": [
+                [
+                  0,
+                  0
+                ]
+              ],
+              "blowout": {
+                "enable": false
+              },
+              "touchTip": {
+                "enable": false
+              },
+              "delay": {
+                "enable": false
+              }
+            },
+            "dispensePosition": {
+              "positionReference": "well-bottom",
+              "offset": {
+                "x": 0,
+                "y": 0,
+                "z": 1
+              }
+            },
+            "flowRateByVolume": [
+              [
+                0,
+                300
+              ]
+            ],
+            "correctionByVolume": [
+              [
+                0,
+                0
+              ]
+            ],
+            "mix": {
+              "enable": false
+            },
+            "pushOutByVolume": [
+              [
+                0,
+                0
+              ]
+            ],
+            "delay": {
+              "enable": false
+            }
+          },
+          "tiprack": "opentrons/opentrons_96_tiprack_300ul/1",
+          "liquidClassName": "transfer_step_3",
+          "pipetteModel": "p300_single"
+        }
+      },
+      "result": {
+        "liquidClassId": "79d70002-4e58-46cc-9bd6-c4fcfe864609"
+      },
+      "startedAt": "2026-05-12T13:16:44.632148Z",
+      "completedAt": "2026-05-12T13:16:44.632339Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "3d633cf3-fbdc-4336-a2ab-6101e49a06c5",
+      "createdAt": "2026-05-12T13:16:44.632584Z",
+      "commandType": "getNextTip",
+      "key": "372f8dafecf99e16e03c0385b52c8044",
+      "status": "succeeded",
+      "params": {
+        "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c",
+        "labwareIds": [
+          "a0b54d20-da8c-4599-aa26-0ac784078938"
+        ]
+      },
+      "result": {
+        "nextTipInfo": {
+          "labwareId": "a0b54d20-da8c-4599-aa26-0ac784078938",
+          "tipStartingWell": "A1"
+        }
+      },
+      "startedAt": "2026-05-12T13:16:44.632629Z",
+      "completedAt": "2026-05-12T13:16:44.632664Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "b4f76f53-4f27-4d7b-8ca0-5081101c909e",
+      "createdAt": "2026-05-12T13:16:44.632827Z",
+      "commandType": "pickUpTip",
+      "key": "3bd634e4e19c8d3789a750a4dbaa4390",
+      "status": "succeeded",
+      "params": {
+        "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c",
+        "labwareId": "a0b54d20-da8c-4599-aa26-0ac784078938",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 0
+          }
+        }
+      },
+      "result": {
+        "position": {
+          "x": 146.88,
+          "y": 74.24,
+          "z": 64.69
+        },
+        "tipVolume": 300,
+        "tipLength": 51.83,
+        "tipDiameter": 5.23
+      },
+      "startedAt": "2026-05-12T13:16:44.632872Z",
+      "completedAt": "2026-05-12T13:16:44.633051Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "b04f02c8-e3b4-45da-8eed-d9063b9a2848",
+      "createdAt": "2026-05-12T13:16:44.633315Z",
+      "commandType": "moveToWell",
+      "key": "a136b8aa006b6b67b59f10220df675f4",
+      "status": "succeeded",
+      "params": {
+        "forceDirect": false,
+        "labwareId": "a4aeeff8-14d4-4d56-b188-bf9fa7fb0dde",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 2.0000000000000018
+          },
+          "volumeOffset": 0
+        },
+        "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c"
+      },
+      "result": {
+        "position": {
+          "x": 279.38,
+          "y": 255.1,
+          "z": 16.35
+        }
+      },
+      "startedAt": "2026-05-12T13:16:44.633357Z",
+      "completedAt": "2026-05-12T13:16:44.633494Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "1ae567b1-61ce-417f-8bfb-79a91aa8c888",
+      "createdAt": "2026-05-12T13:16:44.633625Z",
+      "commandType": "moveToWell",
+      "key": "5d1d721e204730bd8bf8d64fc8243b04",
+      "status": "succeeded",
+      "params": {
+        "forceDirect": true,
+        "speed": 125,
+        "labwareId": "a4aeeff8-14d4-4d56-b188-bf9fa7fb0dde",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": -11.43
+          },
+          "volumeOffset": 0
+        },
+        "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c"
+      },
+      "result": {
+        "position": {
+          "x": 279.38,
+          "y": 255.1,
+          "z": 2.92
+        }
+      },
+      "startedAt": "2026-05-12T13:16:44.633664Z",
+      "completedAt": "2026-05-12T13:16:44.633737Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "815e0dd7-6115-4f62-be98-97c88eda3c8d",
+      "createdAt": "2026-05-12T13:16:44.633852Z",
+      "commandType": "aspirateInPlace",
+      "key": "82c09fdc388371e6e275c0abed0eaea3",
+      "status": "succeeded",
+      "params": {
+        "flowRate": 150,
+        "volume": 10,
+        "correctionVolume": 0,
+        "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c"
+      },
+      "result": {
+        "volume": 10
+      },
+      "startedAt": "2026-05-12T13:16:44.633893Z",
+      "completedAt": "2026-05-12T13:16:44.633931Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "fa8eaafe-2a6a-4052-9b75-7955d56f6807",
+      "createdAt": "2026-05-12T13:16:44.634096Z",
+      "commandType": "moveToWell",
+      "key": "41b0c623e037c80479c73d7914abca70",
+      "status": "succeeded",
+      "params": {
+        "forceDirect": true,
+        "speed": 125,
+        "labwareId": "a4aeeff8-14d4-4d56-b188-bf9fa7fb0dde",
+        "wellName": "A1",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 2.0000000000000018
+          },
+          "volumeOffset": 0
+        },
+        "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c"
+      },
+      "result": {
+        "position": {
+          "x": 279.38,
+          "y": 255.1,
+          "z": 16.35
+        }
+      },
+      "startedAt": "2026-05-12T13:16:44.634139Z",
+      "completedAt": "2026-05-12T13:16:44.634220Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "0ade959d-37d4-4f0c-bdc4-fe1531ef5535",
+      "createdAt": "2026-05-12T13:16:44.634423Z",
+      "commandType": "moveToWell",
+      "key": "5fcbee4b850866d8d9489a704ce89ef5",
+      "status": "succeeded",
+      "params": {
+        "forceDirect": false,
+        "labwareId": "a4aeeff8-14d4-4d56-b188-bf9fa7fb0dde",
+        "wellName": "H12",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 2.0000000000000018
+          },
+          "volumeOffset": 0
+        },
+        "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c"
+      },
+      "result": {
+        "position": {
+          "x": 378.38,
+          "y": 192.1,
+          "z": 16.35
+        }
+      },
+      "startedAt": "2026-05-12T13:16:44.634463Z",
+      "completedAt": "2026-05-12T13:16:44.634537Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "565248d2-6e91-4460-b100-1651f79e35d7",
+      "createdAt": "2026-05-12T13:16:44.634652Z",
+      "commandType": "moveToWell",
+      "key": "3d735e2061fd9f45b6e1ecbef33b77ff",
+      "status": "succeeded",
+      "params": {
+        "forceDirect": true,
+        "speed": 125,
+        "labwareId": "a4aeeff8-14d4-4d56-b188-bf9fa7fb0dde",
+        "wellName": "H12",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": -11.43
+          },
+          "volumeOffset": 0
+        },
+        "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c"
+      },
+      "result": {
+        "position": {
+          "x": 378.38,
+          "y": 192.1,
+          "z": 2.92
+        }
+      },
+      "startedAt": "2026-05-12T13:16:44.634690Z",
+      "completedAt": "2026-05-12T13:16:44.634758Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "f346d241-c4ab-43d3-80a0-7bad5238b7d9",
+      "createdAt": "2026-05-12T13:16:44.634873Z",
+      "commandType": "dispenseInPlace",
+      "key": "89ac622f98ffdbce34e21bced46ac44d",
+      "status": "succeeded",
+      "params": {
+        "flowRate": 300,
+        "volume": 10,
+        "correctionVolume": 0,
+        "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c",
+        "pushOut": 0
+      },
+      "result": {
+        "volume": 10
+      },
+      "startedAt": "2026-05-12T13:16:44.634913Z",
+      "completedAt": "2026-05-12T13:16:44.635220Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "200ffea4-7c51-4694-95b0-eedd25f71ec6",
+      "createdAt": "2026-05-12T13:16:44.635397Z",
+      "commandType": "moveToWell",
+      "key": "bc54ecdc97dfb2c20606eb7a9e953435",
+      "status": "succeeded",
+      "params": {
+        "forceDirect": true,
+        "speed": 125,
+        "labwareId": "a4aeeff8-14d4-4d56-b188-bf9fa7fb0dde",
+        "wellName": "H12",
+        "wellLocation": {
+          "origin": "top",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 2.0000000000000018
+          },
+          "volumeOffset": 0
+        },
+        "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c"
+      },
+      "result": {
+        "position": {
+          "x": 378.38,
+          "y": 192.1,
+          "z": 16.35
+        }
+      },
+      "startedAt": "2026-05-12T13:16:44.635436Z",
+      "completedAt": "2026-05-12T13:16:44.635508Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "80a73523-d1ba-47c9-a174-cde5859c80fc",
+      "createdAt": "2026-05-12T13:16:44.635620Z",
+      "commandType": "configureForVolume",
+      "key": "d9d5478c49f977861f6597f88e9d8b25",
+      "status": "succeeded",
+      "params": {
+        "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c",
+        "volume": 300,
+        "tipOverlapNotAfterVersion": "v3"
+      },
+      "result": {},
+      "startedAt": "2026-05-12T13:16:44.635660Z",
+      "completedAt": "2026-05-12T13:16:44.635860Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "8d118b97-1559-47eb-8451-30acdbccd1d7",
+      "createdAt": "2026-05-12T13:16:44.636018Z",
+      "commandType": "moveToAddressableAreaForDropTip",
+      "key": "fd44a033b493191b18ff7b7dfc4e5db4",
+      "status": "succeeded",
+      "params": {
+        "forceDirect": false,
+        "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c",
+        "addressableAreaName": "fixedTrash",
+        "offset": {
+          "x": 0,
+          "y": 0,
+          "z": 0
+        },
+        "alternateDropLocation": true,
+        "ignoreTipConfiguration": true
+      },
+      "result": {
+        "position": {
+          "x": 363.89500000000004,
+          "y": 351.5,
+          "z": 82
+        }
+      },
+      "startedAt": "2026-05-12T13:16:44.636057Z",
+      "completedAt": "2026-05-12T13:16:44.636174Z",
+      "notes": [],
+      "commandAnnotationIds": []
+    },
+    {
+      "id": "5f27c820-1c6c-4aca-8084-32491c8a84ce",
+      "createdAt": "2026-05-12T13:16:44.636291Z",
+      "commandType": "dropTipInPlace",
+      "key": "4fa316a827defde08d2ead7ab3d2acfd",
+      "status": "succeeded",
+      "params": {
+        "pipetteId": "19452963-27bd-4c78-8496-220e6059e48c"
+      },
+      "result": {},
+      "startedAt": "2026-05-12T13:16:44.636330Z",
+      "completedAt": "2026-05-12T13:16:44.636351Z",
       "notes": [],
       "commandAnnotationIds": []
     }
   ],
   "labware": [
     {
-      "id": "d0df6426-a4eb-45e1-84df-db08b491ef50",
+      "id": "a0b54d20-da8c-4599-aa26-0ac784078938",
       "loadName": "opentrons_96_tiprack_300ul",
       "definitionUri": "opentrons/opentrons_96_tiprack_300ul/1",
       "location": {
         "slotName": "2"
       }
+    },
+    {
+      "id": "a4aeeff8-14d4-4d56-b188-bf9fa7fb0dde",
+      "loadName": "axygen_96_wellplate_500ul",
+      "definitionUri": "opentrons/axygen_96_wellplate_500ul/2",
+      "location": {
+        "slotName": "9"
+      }
     }
   ],
   "pipettes": [
     {
-      "id": "707b5c1d-a608-4527-87aa-ea1df9eb0fee",
+      "id": "19452963-27bd-4c78-8496-220e6059e48c",
       "pipetteName": "p300_single",
       "mount": "left"
     }
   ],
   "modules": [
     {
-      "id": "cb021a02-ce23-47e9-87ad-496fe96af521",
+      "id": "2cef6ce2-1acc-4298-b28a-6a9e60f3aef0",
       "model": "thermocyclerModuleV1",
       "location": {
         "slotName": "7"
       },
-      "serialNumber": "fake-serial-number-56e9dd7f-3189-4368-b7c3-90c138d4271d"
+      "serialNumber": "fake-serial-number-f951f55a-1754-4b24-bc95-be36ed5b47d3"
     }
   ],
   "liquids": [],
-  "liquidClasses": [],
+  "liquidClasses": [
+    {
+      "aspirate": {
+        "submerge": {
+          "startPosition": {
+            "positionReference": "well-top",
+            "offset": {
+              "x": 0,
+              "y": 0,
+              "z": 2
+            }
+          },
+          "speed": 125,
+          "delay": {
+            "enable": false
+          }
+        },
+        "retract": {
+          "endPosition": {
+            "positionReference": "well-top",
+            "offset": {
+              "x": 0,
+              "y": 0,
+              "z": 2
+            }
+          },
+          "speed": 125,
+          "airGapByVolume": [
+            [
+              0,
+              0
+            ]
+          ],
+          "touchTip": {
+            "enable": false
+          },
+          "delay": {
+            "enable": false
+          }
+        },
+        "aspiratePosition": {
+          "positionReference": "well-bottom",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 1
+          }
+        },
+        "flowRateByVolume": [
+          [
+            0,
+            150
+          ]
+        ],
+        "correctionByVolume": [
+          [
+            0,
+            0
+          ]
+        ],
+        "preWet": false,
+        "mix": {
+          "enable": false
+        },
+        "delay": {
+          "enable": false
+        }
+      },
+      "singleDispense": {
+        "submerge": {
+          "startPosition": {
+            "positionReference": "well-top",
+            "offset": {
+              "x": 0,
+              "y": 0,
+              "z": 2
+            }
+          },
+          "speed": 125,
+          "delay": {
+            "enable": false
+          }
+        },
+        "retract": {
+          "endPosition": {
+            "positionReference": "well-top",
+            "offset": {
+              "x": 0,
+              "y": 0,
+              "z": 2
+            }
+          },
+          "speed": 125,
+          "airGapByVolume": [
+            [
+              0,
+              0
+            ]
+          ],
+          "blowout": {
+            "enable": false
+          },
+          "touchTip": {
+            "enable": false
+          },
+          "delay": {
+            "enable": false
+          }
+        },
+        "dispensePosition": {
+          "positionReference": "well-bottom",
+          "offset": {
+            "x": 0,
+            "y": 0,
+            "z": 1
+          }
+        },
+        "flowRateByVolume": [
+          [
+            0,
+            300
+          ]
+        ],
+        "correctionByVolume": [
+          [
+            0,
+            0
+          ]
+        ],
+        "mix": {
+          "enable": false
+        },
+        "pushOutByVolume": [
+          [
+            0,
+            0
+          ]
+        ],
+        "delay": {
+          "enable": false
+        }
+      },
+      "tiprack": "opentrons/opentrons_96_tiprack_300ul/1",
+      "liquidClassName": "transfer_step_3",
+      "pipetteModel": "p300_single",
+      "liquidClassId": "79d70002-4e58-46cc-9bd6-c4fcfe864609"
+    }
+  ],
   "errors": [],
   "commandAnnotations": [],
   "commandPreconditions": {

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/SlotOverlay.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/SlotOverlay.tsx
@@ -83,7 +83,7 @@ export function SlotOverlay(props: SlotOverlayProps): JSX.Element | null {
           hasTCOnSlot != null,
           slotPosition
         )
-      : getOT2HoverDimensions(hasTCOnSlot != null, slotPosition)
+      : getOT2HoverDimensions(hasTCOnSlot != null, slotPosition, false)
 
   return (
     <RobotCoordsForeignObject

--- a/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/SlotHover.tsx
@@ -126,7 +126,8 @@ export function SlotHover(props: SlotHoverProps): JSX.Element | null {
   } else {
     const { width, height, x, y } = getOT2HoverDimensions(
       hasTCOnSlot != null,
-      slotPosition
+      slotPosition,
+      false
     )
 
     return (

--- a/protocol-visualization/src/organisms/DeckView/DeckViewOverlay/index.tsx
+++ b/protocol-visualization/src/organisms/DeckView/DeckViewOverlay/index.tsx
@@ -199,15 +199,15 @@ export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
   } else {
     const { width, x, y, height } = getOT2HoverDimensions(
       hasTCOnSlot,
-      slotPosition
+      slotPosition,
+      true
     )
-
     return (
       <RobotCoordsForeignObject
         key="ot2_hover"
         width={width}
         height={height}
-        x={x}
+        x={slotId === 'fixedTrash' ? x - 30 : x}
         y={y}
         flexProps={{ flex: '1' }}
         foreignObjectProps={{

--- a/protocol-visualization/src/organisms/DeckView/DeckViewOverlay/index.tsx
+++ b/protocol-visualization/src/organisms/DeckView/DeckViewOverlay/index.tsx
@@ -53,6 +53,8 @@ interface SlotOverlayProps {
   children?: ReactNode
 }
 
+const X_OFFSET = 30 // center the fixedTrash overlay
+
 export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
   const {
     slotId,
@@ -207,7 +209,7 @@ export function DeckViewOverlay(props: SlotOverlayProps): JSX.Element | null {
         key="ot2_hover"
         width={width}
         height={height}
-        x={slotId === 'fixedTrash' ? x - 30 : x}
+        x={slotId === 'fixedTrash' ? x - X_OFFSET : x}
         y={y}
         flexProps={{ flex: '1' }}
         foreignObjectProps={{

--- a/protocol-visualization/src/organisms/DeckView/Ot2FixedTrashCommandSummary.tsx
+++ b/protocol-visualization/src/organisms/DeckView/Ot2FixedTrashCommandSummary.tsx
@@ -20,7 +20,7 @@ import {
 import type { CutoutId, RunTimeCommand } from '@opentrons/shared-data'
 
 const Y_OFFSET = 28 // allow for the deck label set to be even with the slot
-
+const X_OFFSET = 30 // center the fixedTrash overlay
 interface Ot2TrashCommandSummaryProps {
   commandType: RunTimeCommand['commandType']
   cutoutId: CutoutId
@@ -45,7 +45,7 @@ export function Ot2FixedTrashCommandSummary(
   return (
     <>
       <RobotCoordsForeignDiv
-        x={slotPosition[0] - 30}
+        x={slotPosition[0] - X_OFFSET}
         y={slotPosition[1]}
         width={slotBoundingBox.xDimension}
         height={slotBoundingBox.yDimension}
@@ -75,7 +75,7 @@ export function Ot2FixedTrashCommandSummary(
             isZoomed: false,
           },
         ]}
-        x={slotPosition[0] - 30}
+        x={slotPosition[0] - X_OFFSET}
         y={slotPosition[1] - Y_OFFSET}
         width={slotBoundingBox.xDimension}
         height={slotBoundingBox.yDimension}

--- a/protocol-visualization/src/organisms/DeckView/Ot2FixedTrashCommandSummary.tsx
+++ b/protocol-visualization/src/organisms/DeckView/Ot2FixedTrashCommandSummary.tsx
@@ -37,7 +37,6 @@ export function Ot2FixedTrashCommandSummary(
   )
   const commandSummary = useCommandTypeSummaries(commandType)
   const slotPosition = getPositionFromSlotId('fixedTrash', deckDef)
-  console.log('slotPosition', slotPosition)
   const slotBoundingBox = addressableArea?.boundingBox
 
   if (slotPosition == null || slotBoundingBox == null) {
@@ -46,7 +45,7 @@ export function Ot2FixedTrashCommandSummary(
   return (
     <>
       <RobotCoordsForeignDiv
-        x={slotPosition[0]}
+        x={slotPosition[0] - 30}
         y={slotPosition[1]}
         width={slotBoundingBox.xDimension}
         height={slotBoundingBox.yDimension}
@@ -76,7 +75,7 @@ export function Ot2FixedTrashCommandSummary(
             isZoomed: false,
           },
         ]}
-        x={slotPosition[0]}
+        x={slotPosition[0] - 30}
         y={slotPosition[1] - Y_OFFSET}
         width={slotBoundingBox.xDimension}
         height={slotBoundingBox.yDimension}

--- a/shared-data/js/helpers/slotHovers.ts
+++ b/shared-data/js/helpers/slotHovers.ts
@@ -61,7 +61,9 @@ const TC_ADJUSTED_H = 178
 
 export const getOT2HoverDimensions = (
   hasTCOnSlot: boolean,
-  slotPosition: CoordinateTuple
+  slotPosition: CoordinateTuple,
+  // TODO: investigate why the TC adjusted Y is needed for PD???
+  forVisualization: boolean,
 ): HoverDimensions => {
   const y = slotPosition[1]
   const x = slotPosition[0]
@@ -70,6 +72,6 @@ export const getOT2HoverDimensions = (
     width: hasTCOnSlot ? TC_ADJUSTED_W : 128, // 128 is the standard width
     height: hasTCOnSlot ? TC_ADJUSTED_H : 85, // 85 is the standard height
     x,
-    y: hasTCOnSlot ? y - TC_ADJUSTED_Y : y,
+    y: hasTCOnSlot && !forVisualization ? y - TC_ADJUSTED_Y : y,
   }
 }

--- a/shared-data/js/helpers/slotHovers.ts
+++ b/shared-data/js/helpers/slotHovers.ts
@@ -63,7 +63,7 @@ export const getOT2HoverDimensions = (
   hasTCOnSlot: boolean,
   slotPosition: CoordinateTuple,
   // TODO: investigate why the TC adjusted Y is needed for PD???
-  forVisualization: boolean,
+  forVisualization: boolean
 ): HoverDimensions => {
   const y = slotPosition[1]
   const x = slotPosition[0]

--- a/step-generation/src/utils/constructInvariantContextFromAnalysis.ts
+++ b/step-generation/src/utils/constructInvariantContextFromAnalysis.ts
@@ -222,9 +222,19 @@ export function constructInvariantContextFromAnalysis(
         if (
           !Object.values(acc.trashBinEntities).some(
             entity => entity.location === location
-          ) &&
-          addressableAreaName.includes('movableTrash')
-        ) {
+          )
+        ) 
+        if (          addressableAreaName.includes('movableTrash'))
+        {
+          trashBinEntities = {
+            ...acc.trashBinEntities,
+            [id]: {
+              pythonName: 'trash_bin_1',
+              id,
+              location,
+            },
+          }
+        } else {
           trashBinEntities = {
             ...acc.trashBinEntities,
             [id]: {

--- a/step-generation/src/utils/constructInvariantContextFromAnalysis.ts
+++ b/step-generation/src/utils/constructInvariantContextFromAnalysis.ts
@@ -223,7 +223,7 @@ export function constructInvariantContextFromAnalysis(
           !Object.values(acc.trashBinEntities).some(
             entity => entity.location === location
           )
-        )
+        ) {
           if (addressableAreaName.includes('movableTrash')) {
             trashBinEntities = {
               ...acc.trashBinEntities,
@@ -243,6 +243,7 @@ export function constructInvariantContextFromAnalysis(
               },
             }
           }
+        }
         let wasteChuteEntities: WasteChuteEntities = acc.wasteChuteEntities
         if (addressableAreaName.includes('WasteChute')) {
           wasteChuteEntities = {

--- a/step-generation/src/utils/constructInvariantContextFromAnalysis.ts
+++ b/step-generation/src/utils/constructInvariantContextFromAnalysis.ts
@@ -223,27 +223,26 @@ export function constructInvariantContextFromAnalysis(
           !Object.values(acc.trashBinEntities).some(
             entity => entity.location === location
           )
-        ) 
-        if (          addressableAreaName.includes('movableTrash'))
-        {
-          trashBinEntities = {
-            ...acc.trashBinEntities,
-            [id]: {
-              pythonName: 'trash_bin_1',
-              id,
-              location,
-            },
+        )
+          if (addressableAreaName.includes('movableTrash')) {
+            trashBinEntities = {
+              ...acc.trashBinEntities,
+              [id]: {
+                pythonName: 'trash_bin_1',
+                id,
+                location,
+              },
+            }
+          } else {
+            trashBinEntities = {
+              ...acc.trashBinEntities,
+              [id]: {
+                pythonName: 'trash_bin_1',
+                id,
+                location,
+              },
+            }
           }
-        } else {
-          trashBinEntities = {
-            ...acc.trashBinEntities,
-            [id]: {
-              pythonName: 'trash_bin_1',
-              id,
-              location,
-            },
-          }
-        }
         let wasteChuteEntities: WasteChuteEntities = acc.wasteChuteEntities
         if (addressableAreaName.includes('WasteChute')) {
           wasteChuteEntities = {


### PR DESCRIPTION
# Overview

closes AUTH-2504 RQA-5360 RQA-5361 RQA-5365

the OT-2 trash and TC hovers should be fixed now, as well as highlighting the trash slot when the pipette is associated with it:

https://github.com/user-attachments/assets/103ff99f-2430-4323-80c9-891878ce75f4


## Test Plan and Hands on Testing

Test on `js-package-testing`, cd into `js-package-testing` and run `make dev` and it should launch the dev env. Click on the PV button and the OT-2 button and you should be able to test the protocol with a TC for and ot-2, see that:

1. the hover state for TC is right
2. the hover state for trash is right
3. when dropping tips into trash, the outline is right

review that the code matches in the app and the PV directory. you can only test it in `js-package-testing`

## Changelog

update the slot hover for the TC and trashBin in both the shared-data util and in the 2 components that are identical in the app and PV directories

add an analysis fixture so you can smoke test this in js-package-testing

fix bug in step-generation's `constructInvariantContextFromAnalysis` because it accidentally wasn't accounting for the ot-2 fixed trash

## Risk assessment

this is contained in PV's OT-2 only for protocol visualization and the app, can't even access it in the monorepo's run app, so low.