### PR TITLE
feat(protocol-designer): update copy for no accessible tips error

### DIFF
--- a/protocol-designer/src/assets/localization/en/alert.json
+++ b/protocol-designer/src/assets/localization/en/alert.json
@@ -256,9 +256,9 @@
         "title": "Not enough tips arranged correctly to complete action"
       },
       "INSUFFICIENT_TIPS": {
-        "body": "Add another tip rack to your deck or change your tip management during transfer and mix steps.",
+        "body": "Add or move a tip rack on your deck to avoid collisions, or change your tip pickup settings for this action.",
         "link": "Edit starting deck",
-        "title": "Not enough tips to complete action"
+        "title": "Not enough accessible tips"
       },
       "LABWARE_DISCARDED_IN_TRASH": {
         "body": "This step uses labware that has previously been discarded into a trash.",

--- a/protocol-designer/src/assets/localization/en/tip_selection.json
+++ b/protocol-designer/src/assets/localization/en/tip_selection.json
@@ -18,8 +18,8 @@
   },
   "no_tiprack_selected": "Select a tiprack to continue",
   "no_valid_tips_available": {
-    "title": "Not enough tips to complete action",
-    "body": "Add another tip rack to your deck or change your tip management during transfer and mix steps."
+    "title": "Not enough accessible tips",
+    "body": "Add or move a tip rack on your deck to avoid collisions, or change your tip pickup settings for this action."
   },
   "not_enough_tips_selected": "Not enough tips selected ({{count}} pickups remaining)",
   "pickups_remaining": "{{count}} pickups remaining",

--- a/protocol-designer/src/components/organisms/Alerts/__tests__/TimelineAlerts.test.tsx
+++ b/protocol-designer/src/components/organisms/Alerts/__tests__/TimelineAlerts.test.tsx
@@ -30,9 +30,9 @@ describe('TimelineAlerts', () => {
 
   it('renders the insufficient tips timeline error and clicking on the button turns it into the starting deck state terminal id ', () => {
     render()
-    screen.getByText('Not enough tips to complete action')
+    screen.getByText('Not enough accessible tips')
     screen.getByText(
-      'Add another tip rack to your deck or change your tip management during transfer and mix steps.'
+      'Add or move a tip rack on your deck to avoid collisions, or change your tip pickup settings for this action.'
     )
     fireEvent.click(screen.getByText('Edit starting deck'))
     expect(vi.mocked(selectTerminalItem)).toHaveBeenCalled()


### PR DESCRIPTION
# Overview

Modify the copy for both the form and timiline errors designating that there are no accessible tips for a liquid handling step (mix/moveLiquid).

Closes RQA-5380

## Test Plan and Hands on Testing

- Upload the protocol attached to this ticket
- Open the step and continue to the final page for tip settings. Verify that the copy matches in the inline form error.
<img width="334" height="114" alt="Screenshot 2026-05-12 at 12 44 40 PM" src="https://github.com/user-attachments/assets/975bb44f-7a45-4bb9-87ab-a67d10bd831a" />

## Changelog

- update alert copy for inaccessible tips
- update test

## Review requests

see test plan

## Risk assessment

⬇️ 