### PR TITLE
refactor(app-shell): update the protocols path to reflect correct release

### DIFF
--- a/app-shell/src/protocol-storage/__tests__/file-system.test.ts
+++ b/app-shell/src/protocol-storage/__tests__/file-system.test.ts
@@ -54,8 +54,8 @@ describe('protocol storage directory utilities', () => {
       )
     })
 
-    it('uses protocols-10.0-plus as NOT_OT2_PROTOCOLS_DIRECTORY_NAME', () => {
-      expect(NOT_OT2_PROTOCOLS_DIRECTORY_NAME).toBe('protocols-10.0-plus')
+    it('uses protocols-9.1-plus as NOT_OT2_PROTOCOLS_DIRECTORY_NAME', () => {
+      expect(NOT_OT2_PROTOCOLS_DIRECTORY_NAME).toBe('protocols-9.1-plus')
     })
   })
 

--- a/app-shell/src/protocol-storage/file-system.ts
+++ b/app-shell/src/protocol-storage/file-system.ts
@@ -36,7 +36,7 @@ export const PROTOCOLS_DIRECTORY_PATH = path.join(
   PROTOCOLS_DIRECTORY_NAME
 )
 
-export const NOT_OT2_PROTOCOLS_DIRECTORY_NAME = 'protocols-10.0-plus'
+export const NOT_OT2_PROTOCOLS_DIRECTORY_NAME = 'protocols-9.1-plus'
 export const NOT_OT2_PROTOCOLS_DIRECTORY_PATH = path.join(
   app.getPath('userData'),
   NOT_OT2_PROTOCOLS_DIRECTORY_NAME


### PR DESCRIPTION
# Overview

The modern app copies protocols to a new directory on first time initialization. The protocols directory uses the version as a part of the directory naming scheme. We need to update it to reflect the correct release in which these changes will be included.

## Test Plan and Hands on Testing

- Verified the `9.1-plus` directory exists within the `Opentrons` app directory. 

## Risk assessment

- very low, this only impacts people who have already toggled the feature flag. they just get two directories with protocols for the price of one!