### PR TITLE
feat(protocol-designer): always allow entering tip selector modal

### DIFF
--- a/protocol-designer/src/assets/localization/en/tip_selection.json
+++ b/protocol-designer/src/assets/localization/en/tip_selection.json
@@ -29,6 +29,10 @@
   "select_tiprack": "Select a tip rack to pick up tips from",
   "select_tips": "Select tips",
   "select_tips_for_tracking": "Select tips for manual tip tracking",
+  "selected_tiprack_not_valid": {
+    "title": "Not enough accessible tips in selected tiprack",
+    "body": "Select another tip rack to complete this action."
+  },
   "accessible": {
     "deselect_multiple": "Deselect tips",
     "deselect_one": "Deselect tip",

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTiprack.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTiprack.tsx
@@ -19,11 +19,7 @@ import { getIsTiprackSelectable } from './utils'
 
 import type { TipSelectionBaseProps } from './types'
 
-interface SelectTiprackProps extends TipSelectionBaseProps {
-  validTiprackIds: string[]
-}
-
-export function SelectTiprack(props: SelectTiprackProps): JSX.Element {
+export function SelectTiprack(props: TipSelectionBaseProps): JSX.Element {
   const {
     selectedTiprackId,
     setSelectedTiprackId,
@@ -32,7 +28,6 @@ export function SelectTiprack(props: SelectTiprackProps): JSX.Element {
     deckDef,
     pipetteSpecs,
     nozzles,
-    validTiprackIds,
   } = props
   const { t } = useTranslation('tip_selection')
   const { labware: allLabware } = activeDeckSetup
@@ -66,7 +61,6 @@ export function SelectTiprack(props: SelectTiprackProps): JSX.Element {
           pipetteSpecs,
           nozzles,
           labwareEntities,
-          validTiprackIds,
         })
         if (selectedTiprackId === null && isTiprackSelectable) {
           setSelectedTiprackId(id)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -294,6 +294,7 @@ export function SelectTips(
       clearTimeout(leaveTimeoutRef.current)
     }
     leaveTimeoutRef.current = setTimeout(() => {
+      setWellShadow(null)
       setHoveredWells(null)
       currentHoveredWellRef.current = null
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/TipSelectionModal.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/TipSelectionModal.tsx
@@ -30,6 +30,8 @@ interface TipSelectionModalProps {
   showErrorBanner: boolean
   numPickupsRemaining: number
   showReusingTipsBanner: boolean
+  showNoAvailableTipracksBanner: boolean
+  showSelectedTiprackNotValidBanner: boolean
   errorReason: TipSelectionBannerReason | null
 }
 
@@ -46,6 +48,8 @@ export function TipSelectionModal(props: TipSelectionModalProps): JSX.Element {
     showErrorBanner,
     numPickupsRemaining,
     showReusingTipsBanner,
+    showNoAvailableTipracksBanner,
+    showSelectedTiprackNotValidBanner,
     errorReason,
   } = props
   const { t } = useTranslation('tip_selection')
@@ -73,6 +77,24 @@ export function TipSelectionModal(props: TipSelectionModalProps): JSX.Element {
           hug
         />
       ) : null}
+      {showNoAvailableTipracksBanner && currentStepIndex === 0 ? (
+        <InlineNotification
+          type="error"
+          heading={t('no_valid_tips_available.title')}
+          message={t('no_valid_tips_available.body')}
+          hug
+        />
+      ) : null}
+      {!showNoAvailableTipracksBanner &&
+      showSelectedTiprackNotValidBanner &&
+      currentStepIndex === 0 ? (
+        <InlineNotification
+          type="alert"
+          heading={t('selected_tiprack_not_valid.title')}
+          message={t('selected_tiprack_not_valid.body')}
+          hug
+        />
+      ) : null}
       {(errorReason == null || !showErrorBanner) &&
       showReusingTipsBanner &&
       currentStepIndex === 1 ? (
@@ -85,7 +107,9 @@ export function TipSelectionModal(props: TipSelectionModalProps): JSX.Element {
       {showBackButton ? (
         <SecondaryButton onClick={onBack}>{t('go_back')}</SecondaryButton>
       ) : null}
-      <PrimaryButton onClick={onContinue}>{continueText}</PrimaryButton>
+      <div className={styles.modal_footer_continue}>
+        <PrimaryButton onClick={onContinue}>{continueText}</PrimaryButton>
+      </div>
     </div>
   )
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/__tests__/utils.test.ts
@@ -7,7 +7,11 @@ import {
 } from '@opentrons/shared-data'
 import { getSlotInLocationStack } from '@opentrons/step-generation'
 
-import { getIsTiprackSelectable, getViewboxFromSelectedLabware } from '../utils'
+import {
+  getAreAnyMatchingTipracksSelectable,
+  getIsTiprackSelectable,
+  getViewboxFromSelectedLabware,
+} from '../utils'
 
 import type { PipetteV2Specs } from '@opentrons/shared-data'
 import type { RobotState } from '@opentrons/step-generation'
@@ -72,7 +76,6 @@ describe('getIsTiprackSelectable', () => {
         pipetteSpecs: { channels: 1 } as PipetteV2Specs,
         nozzles: ALL,
         labwareEntities: {},
-        validTiprackIds: [mockTiprackId],
       })
     ).toBe(true)
   })
@@ -85,7 +88,6 @@ describe('getIsTiprackSelectable', () => {
         pipetteSpecs: { channels: 1 } as PipetteV2Specs,
         nozzles: ALL,
         labwareEntities: {},
-        validTiprackIds: [mockTiprackId],
       })
     ).toBe(false)
   })
@@ -99,7 +101,6 @@ describe('getIsTiprackSelectable', () => {
         pipetteSpecs: { channels: 1 } as PipetteV2Specs,
         nozzles: ALL,
         labwareEntities: {},
-        validTiprackIds: [mockTiprackId],
       })
     ).toBe(false)
   })
@@ -113,7 +114,6 @@ describe('getIsTiprackSelectable', () => {
         pipetteSpecs: { channels: 1 } as PipetteV2Specs,
         nozzles: ALL,
         labwareEntities: {},
-        validTiprackIds: [mockTiprackId],
       })
     ).toBe(false)
   })
@@ -131,7 +131,6 @@ describe('getIsTiprackSelectable', () => {
         labwareEntities: {
           [MOCK_ADAPTER_ID]: { labwareDefURI: MOCK_ADAPTER_URI } as any,
         },
-        validTiprackIds: [mockTiprackId],
       })
     ).toBe(true)
   })
@@ -149,7 +148,6 @@ describe('getIsTiprackSelectable', () => {
         labwareEntities: {
           [MOCK_ADAPTER_ID]: { labwareDefURI: MOCK_ADAPTER_URI } as any,
         },
-        validTiprackIds: [mockTiprackId],
       })
     ).toBe(false)
   })
@@ -171,7 +169,6 @@ describe('getIsTiprackSelectable', () => {
             labwareEntities: {
               [MOCK_ADAPTER_ID]: { labwareDefURI: MOCK_ADAPTER_URI } as any,
             },
-            validTiprackIds: [mockTiprackId],
           })
         ).toBe(false)
       })
@@ -189,7 +186,6 @@ describe('getIsTiprackSelectable', () => {
             labwareEntities: {
               [MOCK_ADAPTER_ID]: { labwareDefURI: MOCK_ADAPTER_URI } as any,
             },
-            validTiprackIds: [mockTiprackId],
           })
         ).toBe(true)
       })
@@ -197,6 +193,40 @@ describe('getIsTiprackSelectable', () => {
   })
 })
 
+describe('getAreAnyMatchingTipracksSelectable', () => {
+  beforeEach(() => {
+    vi.mocked(getIsTiprack).mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns true when there are matching tipracks', () => {
+    expect(
+      getAreAnyMatchingTipracksSelectable({
+        allLabware: [labware],
+        formTiprackUri: MOCK_TIPRACK_URI,
+        pipetteSpecs: { channels: 1 } as PipetteV2Specs,
+        nozzles: ALL,
+        labwareEntities: {},
+        validTiprackIds: [mockTiprackId],
+      })
+    ).toBe(true)
+  })
+  it('returns false when there are no matching tipracks', () => {
+    expect(
+      getAreAnyMatchingTipracksSelectable({
+        allLabware: [labware],
+        formTiprackUri: MOCK_TIPRACK_URI,
+        pipetteSpecs: { channels: 1 } as PipetteV2Specs,
+        nozzles: ALL,
+        labwareEntities: {},
+        validTiprackIds: [],
+      })
+    ).toBe(false)
+  })
+})
 describe('getViewboxFromSelectedLabware', () => {
   beforeEach(() => {
     vi.mocked(getSlotInLocationStack).mockReturnValue('A1')

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
@@ -20,6 +20,10 @@ import {
 import { SelectTiprack } from './SelectTiprack'
 import { SelectTips } from './SelectTips'
 import { TipSelectionModal } from './TipSelectionModal'
+import {
+  getAreAnyMatchingTipracksSelectable,
+  getIsTiprackSelectableAndValid,
+} from './utils'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type {
@@ -82,7 +86,7 @@ export function TipSelectionWizard(
       ? robotState?.tipState.tipracks[selectedTiprackId]
       : null
   const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
-  const { pipetteEntities } = useSelector(getInvariantContext)
+  const { pipetteEntities, labwareEntities } = useSelector(getInvariantContext)
   const { spec: pipetteSpecs } = pipetteEntities[pipetteId]
   const robotType = useSelector(getRobotType)
   const { makeSnackbar } = useKitchen()
@@ -96,6 +100,26 @@ export function TipSelectionWizard(
     updateFormTipsSelected(selectedTips)
     setShowTipSelectionModal(false)
   }
+
+  const areAnyMatchingTipracksSelectable = getAreAnyMatchingTipracksSelectable({
+    allLabware: Object.values(activeDeckSetup.labware),
+    formTiprackUri,
+    pipetteSpecs,
+    nozzles,
+    labwareEntities,
+    validTiprackIds,
+  })
+
+  const isSelectedTiprackValid =
+    selectedTiprackId != null &&
+    getIsTiprackSelectableAndValid({
+      labware: activeDeckSetup.labware[selectedTiprackId],
+      formTiprackUri,
+      pipetteSpecs,
+      nozzles,
+      labwareEntities,
+      validTiprackIds,
+    })
 
   const selectedTiprackStatus =
     selectedTiprackId != null ? tipAccessibilityStatus[selectedTiprackId] : {}
@@ -168,9 +192,7 @@ export function TipSelectionWizard(
   let currentComponent: JSX.Element
   switch (currentStepIndex) {
     case 0:
-      currentComponent = (
-        <SelectTiprack {...baseProps} validTiprackIds={validTiprackIds} />
-      )
+      currentComponent = <SelectTiprack {...baseProps} />
       break
     case 1:
       currentComponent = (
@@ -208,6 +230,8 @@ export function TipSelectionWizard(
       showErrorBanner={showErrorBanner}
       numPickupsRemaining={numPickups - selectedTips.length}
       showReusingTipsBanner={isAnySelectedWellUsed}
+      showNoAvailableTipracksBanner={!areAnyMatchingTipracksSelectable}
+      showSelectedTiprackNotValidBanner={!isSelectedTiprackValid}
       errorReason={errorReason}
     >
       {currentComponent}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/tipselectionwizard.module.css
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/tipselectionwizard.module.css
@@ -24,6 +24,10 @@
   gap: var(--spacing-8);
 }
 
+.modal_footer_continue {
+  align-self: flex-end;
+}
+
 .modal_header {
   display: flex;
   flex-direction: row;

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/tipselectionwizard.module.css
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/tipselectionwizard.module.css
@@ -78,4 +78,3 @@
   display: flex;
   width: 10rem;
 }
-

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -207,14 +207,16 @@ export function getIsTiprackSelectable(args: {
   )
 }
 
-export const getIsTiprackSelectableAndValid = (args: {
+interface GetIsTiprackSelectableAndValidArgs {
   labware: LabwareOnDeck
   formTiprackUri: string
   pipetteSpecs: PipetteV2Specs
   nozzles: NozzleConfigurationStyle
   labwareEntities: LabwareEntities
   validTiprackIds: string[]
-}): boolean => {
+}
+
+export const getIsTiprackSelectableAndValid = (args: GetIsTiprackSelectableAndValidArgs): boolean => {
   const {
     labware,
     formTiprackUri,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -216,7 +216,9 @@ interface GetIsTiprackSelectableAndValidArgs {
   validTiprackIds: string[]
 }
 
-export const getIsTiprackSelectableAndValid = (args: GetIsTiprackSelectableAndValidArgs): boolean => {
+export const getIsTiprackSelectableAndValid = (
+  args: GetIsTiprackSelectableAndValidArgs
+): boolean => {
   const {
     labware,
     formTiprackUri,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -185,17 +185,10 @@ export function getIsTiprackSelectable(args: {
   pipetteSpecs: PipetteV2Specs
   nozzles: NozzleConfigurationStyle
   labwareEntities: LabwareEntities
-  validTiprackIds: string[]
 }): boolean {
   // TODO: check if tiprack is on stacker. Will bottom of stack still be slot?
-  const {
-    labware,
-    formTiprackUri,
-    pipetteSpecs,
-    nozzles,
-    labwareEntities,
-    validTiprackIds,
-  } = args
+  const { labware, formTiprackUri, pipetteSpecs, nozzles, labwareEntities } =
+    args
   const { channels } = pipetteSpecs
   const { def, labwareDefURI, stack } = labware
   const isPickupCompatibleWithPossibleAdapter =
@@ -210,9 +203,72 @@ export function getIsTiprackSelectable(args: {
     getIsTiprack(def) &&
     labwareDefURI === formTiprackUri &&
     !COLUMN_4_SLOTS.includes(slot) &&
-    isPickupCompatibleWithPossibleAdapter &&
-    validTiprackIds.includes(labware.id)
+    isPickupCompatibleWithPossibleAdapter
   )
+}
+
+export const getIsTiprackSelectableAndValid = (args: {
+  labware: LabwareOnDeck
+  formTiprackUri: string
+  pipetteSpecs: PipetteV2Specs
+  nozzles: NozzleConfigurationStyle
+  labwareEntities: LabwareEntities
+  validTiprackIds: string[]
+}): boolean => {
+  const {
+    labware,
+    formTiprackUri,
+    pipetteSpecs,
+    nozzles,
+    labwareEntities,
+    validTiprackIds,
+  } = args
+  const isSelectable = getIsTiprackSelectable({
+    labware,
+    formTiprackUri,
+    pipetteSpecs,
+    nozzles,
+    labwareEntities,
+  })
+  return isSelectable && validTiprackIds.includes(labware.id)
+}
+
+export const getAreAnyMatchingTipracksSelectable = (args: {
+  allLabware: LabwareOnDeck[]
+  formTiprackUri: string
+  pipetteSpecs: PipetteV2Specs
+  nozzles: NozzleConfigurationStyle
+  labwareEntities: LabwareEntities
+  validTiprackIds: string[]
+}): boolean => {
+  const {
+    allLabware,
+    formTiprackUri,
+    pipetteSpecs,
+    nozzles,
+    labwareEntities,
+    validTiprackIds,
+  } = args
+  const { channels } = pipetteSpecs
+  return validTiprackIds.some(id => {
+    const labware = allLabware.find(l => l.id === id)
+    if (labware == null) {
+      return false
+    }
+    const { def, labwareDefURI, stack } = labware
+    const isPickupCompatibleWithPossibleAdapter =
+      getIsPickupCompatibleWithPossibleAdapter(
+        stack,
+        labwareEntities,
+        nozzles,
+        channels
+      )
+    return (
+      getIsTiprack(def) &&
+      labwareDefURI === formTiprackUri &&
+      isPickupCompatibleWithPossibleAdapter
+    )
+  })
 }
 
 export const getAllWellsInColumn = (

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipTrackingField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipTrackingField.tsx
@@ -178,7 +178,7 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
           ))}
         </Flex>
       </Flex>
-      {formData.tip_tracking === MANUAL && hasValidTiprackForPickup ? (
+      {formData.tip_tracking === MANUAL ? (
         <Flex className={styles.manual_container}>
           <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
             {t('step_edit_form.field.tip_tracking.manual.title')}


### PR DESCRIPTION
# Overview

Since it can be unclear why tip selection may cause collisions, product has specified to allow the user to enter the tip selector modal for a visual guide to tiprack and tip accessibility. We should allow the user to enter the modal even if there are no possible tipracks + tips that are able to accommodate the mix or transfer plan. Similarly, we should allow selecting "bad" tipracks with a meaningful error or warning inline notification.

Closes RQA-5381

## Test Plan and Hands on Testing

#### No valid tips on the deck
- import a protocol that does not have enough tips on deck to accommodate a liquid handling step
- open the failing step and navigate to the final page (tip settings)
- click manual tip selection, and verify that the tip selector button appears even though there is an inline error telling you there are no available tips
<img width="336" height="677" alt="Screenshot 2026-05-12 at 2 51 56 PM" src="https://github.com/user-attachments/assets/e6a1dcad-0467-43b0-8c2e-937076681f29" />
- open the tip modal anyway, and verify the error banner in the modal appears
<img width="919" height="791" alt="Screenshot 2026-05-12 at 2 53 27 PM" src="https://github.com/user-attachments/assets/0c000f4c-caf4-4605-a4d0-4f492a529f1c" />
-verify that you can still select any tiprack that matches the form's tiprack volume, even if it does not expose valid tips, and you can continue to select tips even though none are accessible

#### Some valid tips on the deck

- in the same protocol, add a 200µl tiprack to slot C3 (valid)
- reopen the transfer form > tip selector modal
- verify that you can select the invalid tiprack in slot A2, and the warning inline notification appears. you can continue to select tips even though none are accessible
- select the tiprack in slot C3, and verify that you can proceed as normal

## Changelog

- update logic for allowing a user to enter tip selection flow
- allow users to select "bad" tipracks and continue to tip selection
- show 2 new inline notifications on tiprack selection step of modal

## Review requests

see test plan

## Risk assessment

low