### PR TITLE
feat(app): Show the user's full name instead of their username

### DIFF
--- a/api-client/src/auth/index.ts
+++ b/api-client/src/auth/index.ts
@@ -1,2 +1,3 @@
 export * from './oauth2'
 export * from './settings'
+export * from './users'

--- a/api-client/src/auth/users/getSelf.ts
+++ b/api-client/src/auth/users/getSelf.ts
@@ -1,0 +1,9 @@
+import { GET, request } from '../../request'
+
+import type { ResponsePromise } from '../../request'
+import type { HostConfig } from '../../types'
+import type { AuthUserResponse } from './types'
+
+export function getSelf(config: HostConfig): ResponsePromise<AuthUserResponse> {
+  return request<AuthUserResponse>(GET, `/auth/users/self`, null, config)
+}

--- a/api-client/src/auth/users/index.ts
+++ b/api-client/src/auth/users/index.ts
@@ -1,0 +1,2 @@
+export * from './getSelf'
+export * from './types'

--- a/api-client/src/auth/users/types.ts
+++ b/api-client/src/auth/users/types.ts
@@ -1,0 +1,14 @@
+export type AuthUserAccountType = 'admin' | 'user' | 'auditor' | 'service'
+
+export interface AuthUser {
+  userName: string
+  fullName: string
+  accountType: AuthUserAccountType
+  scopes: string[]
+  locked: boolean
+  resetPassword: boolean
+}
+
+export interface AuthUserResponse {
+  data: AuthUser
+}

--- a/app/src/organisms/ODD/Navigation/__tests__/Navigation.test.tsx
+++ b/app/src/organisms/ODD/Navigation/__tests__/Navigation.test.tsx
@@ -37,7 +37,9 @@ describe('Navigation', () => {
   beforeEach(() => {
     props = {}
     vi.mocked(getLocalRobot).mockReturnValue(mockConnectedRobot)
-    vi.mocked(useAccountIconInitial).mockReturnValue(null)
+    vi.mocked(useAccountIconInitial).mockReturnValue({
+      showIcon: false,
+    })
     vi.mocked(NavigationMenu).mockReturnValue(<div>mock NavigationMenu</div>)
     vi.mocked(useNetworkConnection).mockReturnValue({
       isEthernetConnected: false,
@@ -98,14 +100,19 @@ describe('Navigation', () => {
   describe('account icon', () => {
     const linkName = 'Account'
     it('should not render the account control when logged out', () => {
-      vi.mocked(useAccountIconInitial).mockReturnValue(null)
+      vi.mocked(useAccountIconInitial).mockReturnValue({
+        showIcon: false,
+      })
       render(props)
       expect(
         screen.queryByRole('link', { name: linkName })
       ).not.toBeInTheDocument()
     })
     it('should render the account initial and link to the account page when logged in', () => {
-      vi.mocked(useAccountIconInitial).mockReturnValue('T')
+      vi.mocked(useAccountIconInitial).mockReturnValue({
+        showIcon: true,
+        iconContents: 'T',
+      })
       render(props)
       const accountLink = screen.getByRole('link', { name: linkName })
       expect(accountLink).toHaveAttribute('href', '/account')

--- a/app/src/organisms/ODD/Navigation/hooks/useAccountIconInitial.ts
+++ b/app/src/organisms/ODD/Navigation/hooks/useAccountIconInitial.ts
@@ -4,18 +4,31 @@ import { getLocalRobotAuthState } from '/app/redux/robot-auth'
 
 import type { State } from '/app/redux/types'
 
+export type UseAccountIconInitialResult =
+  | {
+      showIcon: true
+      iconContents: string
+    }
+  | {
+      showIcon: false
+      iconContents?: null | undefined
+    }
+
 /**
- * Returns the initial to show in the account icon.
- *
- * If the user isn't currently logged in, returns `null`.
+ * Returns what to show in the account icon, if anything.
+ * (The first initial of the user's name.)
  */
-export function useAccountIconInitial(): string | null {
+export function useAccountIconInitial(): UseAccountIconInitialResult {
   // todo(mm, 2026-04-29): This should be based on the legal name, not the username.
   // To do that, a user needs to be able to fetch `GET /auth/users/{username}` for
   // their own username, but that's currently an admin-only endpoint.`
   const currentUsername = useSelector(
     (state: State) => getLocalRobotAuthState(state)?.username ?? null
   )
-  const firstChar = currentUsername?.[0]
-  return firstChar != null ? firstChar.toLocaleUpperCase() : null
+  if (currentUsername == null) {
+    return { showIcon: false }
+  } else {
+    const firstChar = currentUsername[0] ?? ''
+    return { showIcon: true, iconContents: firstChar.toLocaleUpperCase() }
+  }
 }

--- a/app/src/organisms/ODD/Navigation/hooks/useAccountIconInitial.ts
+++ b/app/src/organisms/ODD/Navigation/hooks/useAccountIconInitial.ts
@@ -11,7 +11,6 @@ export type UseAccountIconInitialResult =
     }
   | {
       showIcon: false
-      iconContents?: null | undefined
     }
 
 /**

--- a/app/src/organisms/ODD/Navigation/hooks/useAccountIconInitial.ts
+++ b/app/src/organisms/ODD/Navigation/hooks/useAccountIconInitial.ts
@@ -1,8 +1,8 @@
 import { useSelector } from 'react-redux'
 
-import { getLocalRobotAuthState } from '/app/redux/robot-auth'
+import { useSelfQuery } from '@opentrons/react-api-client'
 
-import type { State } from '/app/redux/types'
+import { getIsLoggedInToLocalRobot } from '/app/redux/robot-auth'
 
 export type UseAccountIconInitialResult =
   | {
@@ -19,16 +19,27 @@ export type UseAccountIconInitialResult =
  * (The first initial of the user's name.)
  */
 export function useAccountIconInitial(): UseAccountIconInitialResult {
-  // todo(mm, 2026-04-29): This should be based on the legal name, not the username.
-  // To do that, a user needs to be able to fetch `GET /auth/users/{username}` for
-  // their own username, but that's currently an admin-only endpoint.`
-  const currentUsername = useSelector(
-    (state: State) => getLocalRobotAuthState(state)?.username ?? null
-  )
-  if (currentUsername == null) {
-    return { showIcon: false }
+  const isLoggedIn = useSelector(getIsLoggedInToLocalRobot)
+  const query = useSelfQuery({
+    enabled: isLoggedIn,
+  })
+
+  if (!isLoggedIn) {
+    return {
+      showIcon: false,
+    }
+  } else if (query.isLoading || query.isError || query.isIdle) {
+    return {
+      showIcon: true,
+      iconContents: '',
+    }
   } else {
-    const firstChar = currentUsername[0] ?? ''
-    return { showIcon: true, iconContents: firstChar.toLocaleUpperCase() }
+    const response = query.data
+    const fullName = response.data.fullName
+    const maybeFirstChar = fullName.at(0) ?? ''
+    return {
+      showIcon: true,
+      iconContents: maybeFirstChar.toLocaleUpperCase(),
+    }
   }
 }

--- a/app/src/organisms/ODD/Navigation/index.tsx
+++ b/app/src/organisms/ODD/Navigation/index.tsx
@@ -38,7 +38,7 @@ export function Navigation(props: NavigationProps): JSX.Element {
   const { t } = useTranslation('top_navigation')
 
   const location = useLocation()
-  const accountIconInitial = useAccountIconInitial()
+  const accountIcon = useAccountIconInitial()
   const localRobot = useSelector(getLocalRobot)
   const robotName = localRobot?.name != null ? localRobot.name : 'no name'
 
@@ -130,13 +130,13 @@ export function Navigation(props: NavigationProps): JSX.Element {
             ))}
           </div>
         </div>
-        {accountIconInitial != null && (
+        {accountIcon.showIcon && (
           <NavLink
             to="/account"
             className={clsx(styles.account_icon, styles.cursor_default)}
             aria-label={t('account')}
           >
-            {accountIconInitial}
+            {accountIcon.iconContents}
           </NavLink>
         )}
         <button

--- a/app/src/pages/ODD/Account/__tests__/Account.test.tsx
+++ b/app/src/pages/ODD/Account/__tests__/Account.test.tsx
@@ -47,7 +47,7 @@ describe('Account', () => {
     vi.mocked(useAccountInfo).mockReturnValue({
       isLoggedIn: true,
       username: 'george_clooney',
-      legalName: 'George Clooney',
+      fullName: 'George Clooney',
     })
 
     renderAccount()
@@ -64,7 +64,7 @@ describe('Account', () => {
     vi.mocked(useAccountInfo).mockReturnValue({
       isLoggedIn: false,
       username: null,
-      legalName: null,
+      fullName: null,
     })
 
     renderAccount()
@@ -82,7 +82,7 @@ describe('Account', () => {
     vi.mocked(useAccountInfo).mockReturnValue({
       isLoggedIn: true,
       username: 'username',
-      legalName: 'Full Name',
+      fullName: 'Full Name',
     })
 
     renderAccount()
@@ -95,7 +95,7 @@ describe('Account', () => {
     vi.mocked(useAccountInfo).mockReturnValue({
       isLoggedIn: true,
       username: 'george_clooney',
-      legalName: 'George Clooney',
+      fullName: 'George Clooney',
     })
 
     renderAccount()

--- a/app/src/pages/ODD/Account/__tests__/hooks.test.tsx
+++ b/app/src/pages/ODD/Account/__tests__/hooks.test.tsx
@@ -49,11 +49,11 @@ describe('useAccountInfo', () => {
     expect(result.current).toStrictEqual({
       isLoggedIn: false,
       username: null,
-      legalName: null,
+      fullName: null,
     })
   })
 
-  it('returns username and legalName when logged in', () => {
+  it('returns username and fullName when logged in', () => {
     vi.mocked(getLocalRobotAuthState).mockReturnValue({
       username: 'test-user',
       accessToken: 'token',
@@ -69,7 +69,7 @@ describe('useAccountInfo', () => {
       // todo(mm, 2026-05-01): This is a placeholder. Get the actual legal name once
       // https://opentrons.atlassian.net/browse/EXEC-2610 is resolved and react-api-client
       // can send requests with auth tokens.
-      legalName: 'test-user',
+      fullName: 'test-user',
     })
   })
 })

--- a/app/src/pages/ODD/Account/__tests__/hooks.test.tsx
+++ b/app/src/pages/ODD/Account/__tests__/hooks.test.tsx
@@ -3,6 +3,8 @@ import { renderHook } from '@testing-library/react'
 import { legacy_createStore } from 'redux'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useSelfQuery } from '@opentrons/react-api-client'
+
 import { getLocalRobot } from '/app/redux/discovery'
 import { getLocalRobotAuthState, logOutOrTimeOut } from '/app/redux/robot-auth'
 
@@ -28,6 +30,10 @@ vi.mock('/app/redux/robot-auth', async importOriginal => {
   }
 })
 
+vi.mock('@opentrons/react-api-client', () => ({
+  useSelfQuery: vi.fn(),
+}))
+
 const store: Store<State> = legacy_createStore(state => state, {} as State)
 
 describe('useAccountInfo', () => {
@@ -35,13 +41,18 @@ describe('useAccountInfo', () => {
 
   beforeEach(() => {
     wrapper = ({ children }) => <Provider store={store}>{children}</Provider>
+    vi.mocked(useSelfQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+    } as any)
   })
 
   afterEach(() => {
     vi.resetAllMocks()
   })
 
-  it('returns logged-out fields when there is no local robot auth state', () => {
+  it('returns logged-out values for all fields when there is no local robot auth state', () => {
     vi.mocked(getLocalRobotAuthState).mockReturnValue(null)
 
     const { result } = renderHook(() => useAccountInfo(), { wrapper })
@@ -60,17 +71,64 @@ describe('useAccountInfo', () => {
       refreshToken: null,
       expiresAt: null,
     })
+    vi.mocked(useSelfQuery).mockReturnValue({
+      data: {
+        data: {
+          userName: 'test-user',
+          fullName: 'Test User Name',
+          accountType: 'user',
+          scopes: [],
+          locked: false,
+          resetPassword: false,
+        },
+      },
+      isLoading: false,
+      isError: false,
+    } as any)
 
     const { result } = renderHook(() => useAccountInfo(), { wrapper })
 
     expect(result.current).toStrictEqual({
       isLoggedIn: true,
       username: 'test-user',
-      // todo(mm, 2026-05-01): This is a placeholder. Get the actual legal name once
-      // https://opentrons.atlassian.net/browse/EXEC-2610 is resolved and react-api-client
-      // can send requests with auth tokens.
-      fullName: 'test-user',
+      fullName: 'Test User Name',
     })
+  })
+
+  it('returns null fullName while profile is loading', () => {
+    vi.mocked(getLocalRobotAuthState).mockReturnValue({
+      username: 'test-user',
+      accessToken: 'token',
+      refreshToken: null,
+      expiresAt: null,
+    })
+    vi.mocked(useSelfQuery).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    } as any)
+
+    const { result } = renderHook(() => useAccountInfo(), { wrapper })
+
+    expect(result.current.fullName).toBeNull()
+  })
+
+  it('returns null fullName when profile request errors', () => {
+    vi.mocked(getLocalRobotAuthState).mockReturnValue({
+      username: 'test-user',
+      accessToken: 'token',
+      refreshToken: null,
+      expiresAt: null,
+    })
+    vi.mocked(useSelfQuery).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as any)
+
+    const { result } = renderHook(() => useAccountInfo(), { wrapper })
+
+    expect(result.current.fullName).toBeNull()
   })
 })
 

--- a/app/src/pages/ODD/Account/hooks.ts
+++ b/app/src/pages/ODD/Account/hooks.ts
@@ -11,7 +11,7 @@ interface UseAccountInfoResult {
   /** null if not logged in. */
   username: string | null
   /** null if not logged in or the info is still loading. */
-  legalName: string | null
+  fullName: string | null
 }
 
 /** Returns information about the currently logged-in account. */
@@ -24,8 +24,8 @@ export function useAccountInfo(): UseAccountInfoResult {
   // can send requests with auth tokens.
   const legalName = username
   return useMemo(
-    () => ({ isLoggedIn, username, legalName }),
-    [isLoggedIn, username, legalName]
+    () => ({ isLoggedIn, username, fullName }),
+    [isLoggedIn, username, fullName]
   )
 }
 

--- a/app/src/pages/ODD/Account/hooks.ts
+++ b/app/src/pages/ODD/Account/hooks.ts
@@ -1,6 +1,8 @@
 import { useCallback, useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
+import { useSelfQuery } from '@opentrons/react-api-client'
+
 import { getLocalRobot } from '/app/redux/discovery'
 import { getLocalRobotAuthState, logOutOrTimeOut } from '/app/redux/robot-auth'
 
@@ -10,19 +12,18 @@ interface UseAccountInfoResult {
   isLoggedIn: boolean
   /** null if not logged in. */
   username: string | null
-  /** null if not logged in or the info is still loading. */
+  /** null if not logged in, data is still loading, or there was a load error. */
   fullName: string | null
 }
 
 /** Returns information about the currently logged-in account. */
 export function useAccountInfo(): UseAccountInfoResult {
   const authState = useSelector(getLocalRobotAuthState)
-  const isLoggedIn = authState != null
   const username = authState?.username ?? null
-  // todo(mm, 2026-05-01): This is a placeholder. Get the actual legal name once
-  // https://opentrons.atlassian.net/browse/EXEC-2610 is resolved and react-api-client
-  // can send requests with auth tokens.
-  const legalName = username
+  const isLoggedIn = username != null
+  const query = useSelfQuery()
+  const fullName = query.data?.data.fullName ?? null
+
   return useMemo(
     () => ({ isLoggedIn, username, fullName }),
     [isLoggedIn, username, fullName]

--- a/app/src/pages/ODD/Account/index.tsx
+++ b/app/src/pages/ODD/Account/index.tsx
@@ -17,7 +17,7 @@ import { useAccountInfo, useLogOut } from './hooks'
 export function Account(): JSX.Element {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const { isLoggedIn, username, legalName } = useAccountInfo()
+  const { isLoggedIn, username, fullName } = useAccountInfo()
   const logOut = useLogOut()
 
   useEffect(() => {
@@ -63,7 +63,7 @@ export function Account(): JSX.Element {
             }
             content={
               <StyledText oddStyle="bodyTextRegular" color={COLORS.grey60}>
-                {legalName}
+                {fullName}
               </StyledText>
             }
           />

--- a/react-api-client/src/auth/index.ts
+++ b/react-api-client/src/auth/index.ts
@@ -1,2 +1,3 @@
 export * from './oauth2'
 export * from './settings'
+export * from './users'

--- a/react-api-client/src/auth/users/index.ts
+++ b/react-api-client/src/auth/users/index.ts
@@ -1,0 +1,1 @@
+export * from './useSelfQuery'

--- a/react-api-client/src/auth/users/useSelfQuery.ts
+++ b/react-api-client/src/auth/users/useSelfQuery.ts
@@ -1,0 +1,25 @@
+import { useQuery } from 'react-query'
+
+import { getSelf } from '@opentrons/api-client'
+
+import { useHost } from '../../api'
+
+import type { AxiosError } from 'axios'
+import type { UseQueryOptions, UseQueryResult } from 'react-query'
+import type { AuthUserResponse, HostConfig } from '@opentrons/api-client'
+
+export function useSelfQuery(
+  options?: UseQueryOptions<AuthUserResponse, AxiosError>,
+  hostOverride?: HostConfig | null
+): UseQueryResult<AuthUserResponse, AxiosError> {
+  const contextHost = useHost()
+  const host =
+    hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
+  const query = useQuery<AuthUserResponse, AxiosError>(
+    [host, 'auth', 'users', 'self'],
+    () => getSelf(host!).then(response => response.data),
+    { enabled: host != null, ...options }
+  )
+
+  return query
+}


### PR DESCRIPTION
## Overview

This closes EXEC-2611 and fixes some straggling items in EXEC-2602.

## Changelog

* The account icon now shows the first letter of the user's full name, as opposed to the first letter of their username.
* The account page now shows the user's full name. Formerly, we were showing their username, as a placeholder.
* `legalName` is internally renamed to `fullName`, for consistency with the HTTP API.
* Minor refactors for clarity.

## Test Plan and Hands on Testing

<img width="1024" height="600" alt="Screenshot 2026-05-12 at 5 11 55 PM" src="https://github.com/user-attachments/assets/0d812262-7c65-4cc0-bd1f-95b883750116" />
<img width="1024" height="600" alt="Screenshot 2026-05-12 at 5 11 49 PM" src="https://github.com/user-attachments/assets/aa6fdbc3-4a8f-41eb-b8d9-52a335a22d52" />

## Review requests

None in particular.

## Risk assessment

Low. Failures here should, at worst, just cause some things to show up blank. They won't block any action.