### PR TITLE
feat(api): add vent_after parameter to vacuum module profile cycles

### DIFF
--- a/api/src/opentrons/hardware_control/modules/types.py
+++ b/api/src/opentrons/hardware_control/modules/types.py
@@ -49,6 +49,7 @@ class VacuumModulePressureStep(VacuumModuleStepBase):
 class VacuumModuleCycle(TypedDict):
     steps: List[VacuumModuleStep]
     repetitions: int
+    vent_after: bool | None
 
 
 VacuumModuleStep = Union[VacuumModulePowerStep, VacuumModulePressureStep]

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -455,8 +455,10 @@ class VacuumModule(mod_abc.AbstractModule):
                     for step in this_cycle["steps"]:
                         self._current_step_index += 1
                         await self._execute_cycle_step(step)
-                if this_cycle["vent_after"] is not None and this_cycle["vent_after"]:
-                    await self.set_vent_state(vent_state=VentState.OPENED)
+                if this_cycle["vent_after"] is not None:
+                    await self.set_vent_state(
+                        vent_state=VentState(this_cycle["vent_after"])
+                    )
             else:
                 await self._execute_cycle_step(step_or_cycle)
 

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -455,6 +455,8 @@ class VacuumModule(mod_abc.AbstractModule):
                     for step in this_cycle["steps"]:
                         self._current_step_index += 1
                         await self._execute_cycle_step(step)
+                if this_cycle["vent_after"] is not None and this_cycle["vent_after"]:
+                    await self.set_vent_state(vent_state=VentState.OPENED)
             else:
                 await self._execute_cycle_step(step_or_cycle)
 

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/start_run_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/start_run_profile.py
@@ -78,13 +78,18 @@ class VacuumModuleProfileCycle(BaseModel):
 
     steps: List[StartRunProfileStepParams]
     repetitions: int
+    ventAfter: bool | SkipJsonSchema[None] = None
 
     def convert_element(self) -> VacuumModuleCycle:
         """Convert a VacuumModuleCycle into a hardware controller type."""
         steps: List[VacuumModuleStep] = []
         for step in self.steps:
             steps.append(step.convert_element())
-        return VacuumModuleCycle(steps=steps, repetitions=self.repetitions)
+        return VacuumModuleCycle(
+            steps=steps,
+            repetitions=self.repetitions,
+            vent_after=self.ventAfter if self.ventAfter is not None else None,
+        )
 
 
 StartRunProfileStepParams = Union[

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/start_run_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/start_run_profile.py
@@ -88,7 +88,7 @@ class VacuumModuleProfileCycle(BaseModel):
         return VacuumModuleCycle(
             steps=steps,
             repetitions=self.repetitions,
-            vent_after=self.ventAfter if self.ventAfter is not None else None,
+            vent_after=self.ventAfter,
         )
 
 

--- a/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
@@ -60,6 +60,12 @@ def set_pump_state_spy(mock_driver: SimulatingDriver) -> mock.AsyncMock:
 
 
 @pytest.fixture
+def set_vent_state_spy(mock_driver: SimulatingDriver) -> mock.AsyncMock:
+    """Build a spy for set pump state."""
+    return mock.AsyncMock(wraps=mock_driver.set_vent_state)
+
+
+@pytest.fixture
 async def test_execute_profile_subject(
     usb_port: USBPort,
     mock_driver: SimulatingDriver,
@@ -68,6 +74,7 @@ async def test_execute_profile_subject(
     module_disconnected_callback: ModuleDisconnectedCallback,
     set_vacuum_state_spy: mock.AsyncMock,
     set_pump_state_spy: mock.AsyncMock,
+    set_vent_state_spy: mock.AsyncMock,
     decoy: Decoy,
 ) -> AsyncGenerator[modules.VacuumModule, None]:
     """Test subject with mocked driver."""
@@ -75,6 +82,7 @@ async def test_execute_profile_subject(
     poller = Poller(reader=reader, interval=SIMULATING_POLL_PERIOD)
     mock_driver.set_vacuum_state = set_vacuum_state_spy  # type: ignore[method-assign]
     mock_driver.set_pump_state = set_pump_state_spy  # type: ignore[method-assign]
+    mock_driver.set_vent_state = set_vent_state_spy  # type: ignore[method-assign]
     vacuum = modules.VacuumModule(
         port="/dev/ot_module_sim_vacuummodule0",
         usb_port=usb_port,
@@ -411,6 +419,7 @@ async def test_execute_profile(
     mock_driver: SimulatingDriver,
     set_vacuum_state_spy: mock.AsyncMock,
     set_pump_state_spy: mock.AsyncMock,
+    set_vent_state_spy: mock.AsyncMock,
 ) -> None:
     """Ensure that execute_profile calls down to the correct hardware control functions in the right quantity."""
     subject = test_execute_profile_subject
@@ -466,6 +475,7 @@ async def test_execute_profile(
                 },
             ],
             "repetitions": 9,
+            "vent_after": True,
         },
         {
             "enable_pump": False,
@@ -550,5 +560,8 @@ async def test_execute_profile(
             vent_after=False,
         )
     )
+    set_vent_state_expected_call_list = [mock.call(state=VentState.OPENED)]
+
     assert set_vacuum_state_spy.call_args_list == set_vacuum_state_expected_call_list
     assert set_pump_state_spy.call_args_list == set_pump_state_expected_call_list
+    assert set_vent_state_spy.call_args_list == set_vent_state_expected_call_list

--- a/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
@@ -1,7 +1,6 @@
 import asyncio
 from typing import AsyncGenerator, List, Optional, Union
 
-import mock
 import pytest
 from decoy import Decoy
 
@@ -48,83 +47,12 @@ def mock_driver(decoy: Decoy) -> SimulatingDriver:
 
 
 @pytest.fixture
-def set_vacuum_state_spy(mock_driver: SimulatingDriver) -> mock.AsyncMock:
-    """Build a spy for set vacuum state."""
-    return mock.AsyncMock(wraps=mock_driver.set_vacuum_state)
-
-
-@pytest.fixture
-def set_pump_state_spy(mock_driver: SimulatingDriver) -> mock.AsyncMock:
-    """Build a spy for set pump state."""
-    return mock.AsyncMock(wraps=mock_driver.set_pump_state)
-
-
-@pytest.fixture
-def set_vent_state_spy(mock_driver: SimulatingDriver) -> mock.AsyncMock:
-    """Build a spy for set pump state."""
-    return mock.AsyncMock(wraps=mock_driver.set_vent_state)
-
-
-@pytest.fixture
-async def test_execute_profile_subject(
-    usb_port: USBPort,
-    mock_driver: SimulatingDriver,
-    mock_execution_manager: ExecutionManager,
-    module_error_callback: ModuleErrorCallback,
-    module_disconnected_callback: ModuleDisconnectedCallback,
-    set_vacuum_state_spy: mock.AsyncMock,
-    set_pump_state_spy: mock.AsyncMock,
-    set_vent_state_spy: mock.AsyncMock,
-    decoy: Decoy,
-) -> AsyncGenerator[modules.VacuumModule, None]:
-    """Test subject with mocked driver."""
-    reader = VacuumModuleReader(driver=mock_driver)
-    poller = Poller(reader=reader, interval=SIMULATING_POLL_PERIOD)
-    mock_driver.set_vacuum_state = set_vacuum_state_spy  # type: ignore[method-assign]
-    mock_driver.set_pump_state = set_pump_state_spy  # type: ignore[method-assign]
-    mock_driver.set_vent_state = set_vent_state_spy  # type: ignore[method-assign]
-    vacuum = modules.VacuumModule(
-        port="/dev/ot_module_sim_vacuummodule0",
-        usb_port=usb_port,
-        driver=mock_driver,
-        reader=reader,
-        poller=poller,
-        device_info={
-            "serial": "dummySerialFS",
-            "model": "nff",
-            "version": "vacuum-fw",
-            "reset_reason": "0",
-        },
-        hw_control_loop=asyncio.get_running_loop(),
-        execution_manager=mock_execution_manager,
-        error_callback=module_error_callback,
-        disconnected_callback=module_disconnected_callback,
-    )
-    decoy.when(await mock_driver.get_device_info()).then_return(
-        {
-            "serial": "vacuum-fw",
-            "model": HardwareRevision.NFF.value,
-            "version": "dummySerialFS",
-            "reset_reason": "0",
-        }
-    )
-
-    await poller.start()
-    try:
-        yield vacuum
-    finally:
-        await vacuum.cleanup()
-
-
-@pytest.fixture
 async def subject(
     usb_port: USBPort,
     mock_driver: SimulatingDriver,
     mock_execution_manager: ExecutionManager,
     module_error_callback: ModuleErrorCallback,
     module_disconnected_callback: ModuleDisconnectedCallback,
-    set_vacuum_state_spy: mock.AsyncMock,
-    set_pump_state_spy: mock.AsyncMock,
     decoy: Decoy,
 ) -> AsyncGenerator[modules.VacuumModule, None]:
     """Test subject with mocked driver."""
@@ -415,14 +343,11 @@ async def test_update_vacuum_state(
 
 
 async def test_execute_profile(
-    test_execute_profile_subject: modules.VacuumModule,
+    subject: modules.VacuumModule,
     mock_driver: SimulatingDriver,
-    set_vacuum_state_spy: mock.AsyncMock,
-    set_pump_state_spy: mock.AsyncMock,
-    set_vent_state_spy: mock.AsyncMock,
+    decoy: Decoy,
 ) -> None:
     """Ensure that execute_profile calls down to the correct hardware control functions in the right quantity."""
-    subject = test_execute_profile_subject
     profile: List[
         Union[VacuumModuleCycle, VacuumModulePowerStep, VacuumModulePressureStep]
     ] = [
@@ -489,8 +414,8 @@ async def test_execute_profile(
     ]
     await subject.execute_profile(profile)
 
-    set_vacuum_state_expected_call_list = [
-        mock.call(
+    decoy.verify(
+        await mock_driver.set_vacuum_state(
             enable_vacuum=True,
             gauge_pressure_mbar=-300,
             duration_s=343,
@@ -498,12 +423,9 @@ async def test_execute_profile(
             rate=1.3,
             vent_after=True,
         ),
-        mock.call(
-            enable_vacuum=False
-        ),  # there should be a call to disable pressure control for every set_pump_state call
-    ]
-    set_pump_state_expected_call_list = [
-        mock.call(
+    )
+    decoy.verify(
+        await mock_driver.set_pump_state(
             start_pump=True,
             target_rpm=None,
             duty_cycle=61,
@@ -512,10 +434,15 @@ async def test_execute_profile(
             rate=1.4,
             vent_after=False,
         )
-    ]
+    )
+    decoy.verify(
+        await mock_driver.set_vacuum_state(
+            enable_vacuum=False
+        ),  # there should be a call to disable pressure control for every set_pump_state call
+    )
     for i in range(9):
-        set_pump_state_expected_call_list.append(
-            mock.call(
+        decoy.verify(
+            await mock_driver.set_pump_state(
                 start_pump=True,
                 target_rpm=None,
                 duty_cycle=99,
@@ -525,9 +452,9 @@ async def test_execute_profile(
                 vent_after=False,
             )
         )
-        set_vacuum_state_expected_call_list.append(mock.call(enable_vacuum=False))
-        set_vacuum_state_expected_call_list.append(
-            mock.call(
+        decoy.verify(await mock_driver.set_vacuum_state(enable_vacuum=False))
+        decoy.verify(
+            await mock_driver.set_vacuum_state(
                 enable_vacuum=True,
                 gauge_pressure_mbar=-99,
                 duration_s=639,
@@ -537,8 +464,8 @@ async def test_execute_profile(
             )
         )
 
-        set_pump_state_expected_call_list.append(
-            mock.call(
+        decoy.verify(
+            await mock_driver.set_pump_state(
                 start_pump=True,
                 target_rpm=None,
                 duty_cycle=11,
@@ -548,10 +475,11 @@ async def test_execute_profile(
                 vent_after=False,
             )
         )
-        set_vacuum_state_expected_call_list.append(mock.call(enable_vacuum=False))
+        decoy.verify(await mock_driver.set_vacuum_state(enable_vacuum=False))
 
-    set_vacuum_state_expected_call_list.append(
-        mock.call(
+    decoy.verify(await mock_driver.set_vent_state(state=VentState.OPENED))
+    decoy.verify(
+        await mock_driver.set_vacuum_state(
             enable_vacuum=False,
             gauge_pressure_mbar=-111,
             duration_s=720,
@@ -560,8 +488,3 @@ async def test_execute_profile(
             vent_after=False,
         )
     )
-    set_vent_state_expected_call_list = [mock.call(state=VentState.OPENED)]
-
-    assert set_vacuum_state_spy.call_args_list == set_vacuum_state_expected_call_list
-    assert set_pump_state_spy.call_args_list == set_pump_state_expected_call_list
-    assert set_vent_state_spy.call_args_list == set_vent_state_expected_call_list

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_run_profile.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_run_profile.py
@@ -134,6 +134,7 @@ async def test_start_run_profile(
                 ),
             ],
             repetitions=vm_cycle.repetitions,
+            vent_after=vm_cycle.ventAfter,
         ),
     ]
 

--- a/shared-data/command/schemas/17.json
+++ b/shared-data/command/schemas/17.json
@@ -9,9 +9,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "addressableAreaName"
-      ],
+      "required": ["addressableAreaName"],
       "title": "AddressableAreaLocation",
       "type": "object"
     },
@@ -31,11 +29,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ],
+      "required": ["x", "y", "z"],
       "title": "AddressableOffsetVector",
       "type": "object"
     },
@@ -70,9 +64,7 @@
           "$ref": "#/$defs/AirGapInPlaceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "AirGapInPlaceCreate",
       "type": "object"
     },
@@ -110,11 +102,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["flowRate", "volume", "pipetteId"],
       "title": "AirGapInPlaceParams",
       "type": "object"
     },
@@ -162,9 +150,7 @@
           "$ref": "#/$defs/AspirateParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "AspirateCreate",
       "type": "object"
     },
@@ -199,9 +185,7 @@
           "$ref": "#/$defs/AspirateInPlaceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "AspirateInPlaceCreate",
       "type": "object"
     },
@@ -239,11 +223,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["flowRate", "volume", "pipetteId"],
       "title": "AspirateInPlaceParams",
       "type": "object"
     },
@@ -295,13 +275,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
       "title": "AspirateParams",
       "type": "object"
     },
@@ -449,9 +423,7 @@
           "$ref": "#/$defs/AspirateWhileTrackingParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "AspirateWhileTrackingCreate",
       "type": "object"
     },
@@ -512,13 +484,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
       "title": "AspirateWhileTrackingParams",
       "type": "object"
     },
@@ -553,9 +519,7 @@
           "$ref": "#/$defs/BlowOutParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "BlowOutCreate",
       "type": "object"
     },
@@ -590,9 +554,7 @@
           "$ref": "#/$defs/BlowOutInPlaceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "BlowOutInPlaceCreate",
       "type": "object"
     },
@@ -611,10 +573,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "pipetteId"
-      ],
+      "required": ["flowRate", "pipetteId"],
       "title": "BlowOutInPlaceParams",
       "type": "object"
     },
@@ -647,22 +606,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "flowRate", "pipetteId"],
       "title": "BlowOutParams",
       "type": "object"
     },
     "BlowoutLocation": {
       "description": "Location for blowout during a transfer function.",
-      "enum": [
-        "source",
-        "destination",
-        "trash"
-      ],
+      "enum": ["source", "destination", "trash"],
       "title": "BlowoutLocation",
       "type": "string"
     },
@@ -701,10 +651,7 @@
           "description": "Location well or trash entity for blow out."
         }
       },
-      "required": [
-        "location",
-        "flowRate"
-      ],
+      "required": ["location", "flowRate"],
       "title": "BlowoutParams",
       "type": "object"
     },
@@ -723,9 +670,7 @@
           "title": "Params"
         }
       },
-      "required": [
-        "enable"
-      ],
+      "required": ["enable"],
       "title": "BlowoutProperties",
       "type": "object"
     },
@@ -760,9 +705,7 @@
           "$ref": "#/$defs/CSVWriteRowParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CSVWriteRowCreate",
       "type": "object"
     },
@@ -783,10 +726,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "fileId",
-        "rowData"
-      ],
+      "required": ["fileId", "rowData"],
       "title": "CSVWriteRowParams",
       "type": "object"
     },
@@ -821,9 +761,7 @@
           "$ref": "#/$defs/CalibrateGripperParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CalibrateGripperCreate",
       "type": "object"
     },
@@ -840,17 +778,12 @@
           "title": "Otherjawoffset"
         }
       },
-      "required": [
-        "jaw"
-      ],
+      "required": ["jaw"],
       "title": "CalibrateGripperParams",
       "type": "object"
     },
     "CalibrateGripperParamsJaw": {
-      "enum": [
-        "front",
-        "rear"
-      ],
+      "enum": ["front", "rear"],
       "title": "CalibrateGripperParamsJaw",
       "type": "string"
     },
@@ -885,9 +818,7 @@
           "$ref": "#/$defs/CalibrateModuleParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CalibrateModuleCreate",
       "type": "object"
     },
@@ -909,11 +840,7 @@
           "description": "The instrument mount used to calibrate the module."
         }
       },
-      "required": [
-        "moduleId",
-        "labwareId",
-        "mount"
-      ],
+      "required": ["moduleId", "labwareId", "mount"],
       "title": "CalibrateModuleParams",
       "type": "object"
     },
@@ -948,9 +875,7 @@
           "$ref": "#/$defs/CalibratePipetteParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CalibratePipetteCreate",
       "type": "object"
     },
@@ -962,9 +887,7 @@
           "description": "Instrument mount to calibrate."
         }
       },
-      "required": [
-        "mount"
-      ],
+      "required": ["mount"],
       "title": "CalibratePipetteParams",
       "type": "object"
     },
@@ -999,9 +922,7 @@
           "$ref": "#/$defs/CaptureImageParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CaptureImageCreate",
       "type": "object"
     },
@@ -1146,9 +1067,7 @@
           "$ref": "#/$defs/CloseGripperJawParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CloseGripperJawCreate",
       "type": "object"
     },
@@ -1195,9 +1114,7 @@
           "$ref": "#/$defs/CloseLabwareLatchParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CloseLabwareLatchCreate",
       "type": "object"
     },
@@ -1210,9 +1127,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "CloseLabwareLatchParams",
       "type": "object"
     },
@@ -1247,9 +1162,7 @@
           "$ref": "#/$defs/CloseVentParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CloseVentCreate",
       "type": "object"
     },
@@ -1262,9 +1175,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "CloseVentParams",
       "type": "object"
     },
@@ -1273,12 +1184,7 @@
       "properties": {
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -1289,19 +1195,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ],
+      "required": ["primaryNozzle"],
       "title": "ColumnNozzleLayoutConfiguration",
       "type": "object"
     },
     "CommandIntent": {
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": [
-        "protocol",
-        "setup",
-        "fixit"
-      ],
+      "enum": ["protocol", "setup", "fixit"],
       "title": "CommandIntent",
       "type": "string"
     },
@@ -1336,9 +1236,7 @@
           "$ref": "#/$defs/CommentParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CommentCreate",
       "type": "object"
     },
@@ -1351,9 +1249,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "message"
-      ],
+      "required": ["message"],
       "title": "CommentParams",
       "type": "object"
     },
@@ -1388,9 +1284,7 @@
           "$ref": "#/$defs/ConfigureForVolumeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "ConfigureForVolumeCreate",
       "type": "object"
     },
@@ -1414,10 +1308,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "pipetteId",
-        "volume"
-      ],
+      "required": ["pipetteId", "volume"],
       "title": "ConfigureForVolumeParams",
       "type": "object"
     },
@@ -1452,9 +1343,7 @@
           "$ref": "#/$defs/ConfigureNozzleLayoutParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "ConfigureNozzleLayoutCreate",
       "type": "object"
     },
@@ -1487,10 +1376,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "configurationParams"
-      ],
+      "required": ["pipetteId", "configurationParams"],
       "title": "ConfigureNozzleLayoutParams",
       "type": "object"
     },
@@ -1532,11 +1418,7 @@
           "title": "Z"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ],
+      "required": ["x", "y", "z"],
       "title": "Coordinate",
       "type": "object"
     },
@@ -1571,9 +1453,7 @@
           "$ref": "#/$defs/CreateCSVParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CreateCSVCreate",
       "type": "object"
     },
@@ -1591,10 +1471,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "fileName",
-        "columns"
-      ],
+      "required": ["fileName", "columns"],
       "title": "CreateCSVParams",
       "type": "object"
     },
@@ -1629,9 +1506,7 @@
           "$ref": "#/$defs/CreateTimerParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CreateTimerCreate",
       "type": "object"
     },
@@ -1657,9 +1532,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "time"
-      ],
+      "required": ["time"],
       "title": "CreateTimerParams",
       "type": "object"
     },
@@ -1694,9 +1567,7 @@
           "$ref": "#/$defs/CustomParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CustomCreate",
       "type": "object"
     },
@@ -1738,9 +1609,7 @@
           "$ref": "#/$defs/DeactivateBlockParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DeactivateBlockCreate",
       "type": "object"
     },
@@ -1753,9 +1622,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "DeactivateBlockParams",
       "type": "object"
     },
@@ -1790,9 +1657,7 @@
           "$ref": "#/$defs/DeactivateHeaterParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DeactivateHeaterCreate",
       "type": "object"
     },
@@ -1805,9 +1670,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "DeactivateHeaterParams",
       "type": "object"
     },
@@ -1842,9 +1705,7 @@
           "$ref": "#/$defs/DeactivateLidParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DeactivateLidCreate",
       "type": "object"
     },
@@ -1857,9 +1718,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "DeactivateLidParams",
       "type": "object"
     },
@@ -1894,9 +1753,7 @@
           "$ref": "#/$defs/DeactivateShakerParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DeactivateShakerCreate",
       "type": "object"
     },
@@ -1909,9 +1766,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "DeactivateShakerParams",
       "type": "object"
     },
@@ -1946,9 +1801,7 @@
           "$ref": "#/$defs/DeactivateTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DeactivateTemperatureCreate",
       "type": "object"
     },
@@ -1961,9 +1814,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "DeactivateTemperatureParams",
       "type": "object"
     },
@@ -1983,11 +1834,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ],
+      "required": ["x", "y", "z"],
       "title": "DeckPoint",
       "type": "object"
     },
@@ -1999,9 +1846,7 @@
           "description": "A slot on the robot's deck.\n\nThe plain numbers like `\"5\"` are for the OT-2, and the coordinates like `\"C2\"` are for the Flex.\n\nWhen you provide one of these values, you can use either style. It will automatically be converted to match the robot.\n\nWhen one of these values is returned, it will always match the robot."
         }
       },
-      "required": [
-        "slotName"
-      ],
+      "required": ["slotName"],
       "title": "DeckSlotLocation",
       "type": "object"
     },
@@ -2055,9 +1900,7 @@
           "title": "Duration"
         }
       },
-      "required": [
-        "duration"
-      ],
+      "required": ["duration"],
       "title": "DelayParams",
       "type": "object"
     },
@@ -2076,9 +1919,7 @@
           "title": "Params"
         }
       },
-      "required": [
-        "enable"
-      ],
+      "required": ["enable"],
       "title": "DelayProperties",
       "type": "object"
     },
@@ -2113,9 +1954,7 @@
           "$ref": "#/$defs/DisengageParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DisengageCreate",
       "type": "object"
     },
@@ -2128,9 +1967,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "DisengageParams",
       "type": "object"
     },
@@ -2165,9 +2002,7 @@
           "$ref": "#/$defs/DispenseParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DispenseCreate",
       "type": "object"
     },
@@ -2202,9 +2037,7 @@
           "$ref": "#/$defs/DispenseInPlaceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DispenseInPlaceCreate",
       "type": "object"
     },
@@ -2247,11 +2080,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["flowRate", "volume", "pipetteId"],
       "title": "DispenseInPlaceParams",
       "type": "object"
     },
@@ -2308,13 +2137,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
       "title": "DispenseParams",
       "type": "object"
     },
@@ -2349,9 +2172,7 @@
           "$ref": "#/$defs/DispenseWhileTrackingParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DispenseWhileTrackingCreate",
       "type": "object"
     },
@@ -2417,13 +2238,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
       "title": "DispenseWhileTrackingParams",
       "type": "object"
     },
@@ -2458,9 +2273,7 @@
           "$ref": "#/$defs/DropTipParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DropTipCreate",
       "type": "object"
     },
@@ -2495,9 +2308,7 @@
           "$ref": "#/$defs/DropTipInPlaceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DropTipInPlaceCreate",
       "type": "object"
     },
@@ -2515,9 +2326,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ],
+      "required": ["pipetteId"],
       "title": "DropTipInPlaceParams",
       "type": "object"
     },
@@ -2559,11 +2368,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareId",
-        "wellName"
-      ],
+      "required": ["pipetteId", "labwareId", "wellName"],
       "title": "DropTipParams",
       "type": "object"
     },
@@ -2583,12 +2388,7 @@
     },
     "DropTipWellOrigin": {
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": [
-        "top",
-        "bottom",
-        "center",
-        "default"
-      ],
+      "enum": ["top", "bottom", "center", "default"],
       "title": "DropTipWellOrigin",
       "type": "string"
     },
@@ -2623,9 +2423,7 @@
           "$ref": "#/$defs/EmptyParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "EmptyCreate",
       "type": "object"
     },
@@ -2662,10 +2460,7 @@
           "description": "How to empty the stacker. If manualWithPause, pause the protocol until the client sends an interaction, and mark the labware pool as empty thereafter. If logical, do not pause but immediately apply the specified count."
         }
       },
-      "required": [
-        "moduleId",
-        "strategy"
-      ],
+      "required": ["moduleId", "strategy"],
       "title": "EmptyParams",
       "type": "object"
     },
@@ -2700,9 +2495,7 @@
           "$ref": "#/$defs/EngageParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "EngageCreate",
       "type": "object"
     },
@@ -2720,10 +2513,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId",
-        "height"
-      ],
+      "required": ["moduleId", "height"],
       "title": "EngageParams",
       "type": "object"
     },
@@ -2758,9 +2548,7 @@
           "$ref": "#/$defs/FillParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "FillCreate",
       "type": "object"
     },
@@ -2813,10 +2601,7 @@
           "description": "How to fill the stacker. If manualWithPause, pause the protocol until the client sends an interaction, and apply the new specified count thereafter. If logical, do not pause but immediately apply the specified count."
         }
       },
-      "required": [
-        "moduleId",
-        "strategy"
-      ],
+      "required": ["moduleId", "strategy"],
       "title": "FillParams",
       "type": "object"
     },
@@ -2851,9 +2636,7 @@
           "$ref": "#/$defs/GetNextTipParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "GetNextTipCreate",
       "type": "object"
     },
@@ -2879,10 +2662,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareIds"
-      ],
+      "required": ["pipetteId", "labwareIds"],
       "title": "GetNextTipParams",
       "type": "object"
     },
@@ -2917,9 +2697,7 @@
           "$ref": "#/$defs/GetTipPresenceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "GetTipPresenceCreate",
       "type": "object"
     },
@@ -2932,9 +2710,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ],
+      "required": ["pipetteId"],
       "title": "GetTipPresenceParams",
       "type": "object"
     },
@@ -2969,9 +2745,7 @@
           "$ref": "#/$defs/HomeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "HomeCreate",
       "type": "object"
     },
@@ -3026,9 +2800,7 @@
           "$ref": "#/$defs/IdentifyModuleParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "IdentifyModuleCreate",
       "type": "object"
     },
@@ -3063,11 +2835,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "model",
-        "moduleId",
-        "start"
-      ],
+      "required": ["model", "moduleId", "start"],
       "title": "IdentifyModuleParams",
       "type": "object"
     },
@@ -3102,9 +2870,7 @@
           "$ref": "#/$defs/InitializeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "InitializeCreate",
       "type": "object"
     },
@@ -3113,10 +2879,7 @@
       "properties": {
         "measureMode": {
           "description": "Initialize single or multi measurement mode.",
-          "enum": [
-            "single",
-            "multi"
-          ],
+          "enum": ["single", "multi"],
           "title": "Measuremode",
           "type": "string"
         },
@@ -3139,31 +2902,19 @@
           "type": "array"
         }
       },
-      "required": [
-        "moduleId",
-        "measureMode",
-        "sampleWavelengths"
-      ],
+      "required": ["moduleId", "measureMode", "sampleWavelengths"],
       "title": "InitializeParams",
       "type": "object"
     },
     "InstrumentSensorId": {
       "description": "Primary and secondary sensor ids.",
-      "enum": [
-        "primary",
-        "secondary",
-        "both"
-      ],
+      "enum": ["primary", "secondary", "both"],
       "title": "InstrumentSensorId",
       "type": "string"
     },
     "LabwareMovementStrategy": {
       "description": "Strategy to use for labware movement.",
-      "enum": [
-        "usingGripper",
-        "manualMoveWithPause",
-        "manualMoveWithoutPause"
-      ],
+      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
       "title": "LabwareMovementStrategy",
       "type": "string"
     },
@@ -3183,11 +2934,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ],
+      "required": ["x", "y", "z"],
       "title": "LabwareOffsetVector",
       "type": "object"
     },
@@ -3277,11 +3024,7 @@
           "title": "Zoffset"
         }
       },
-      "required": [
-        "zOffset",
-        "mmFromEdge",
-        "speed"
-      ],
+      "required": ["zOffset", "mmFromEdge", "speed"],
       "title": "LiquidClassTouchTipParams",
       "type": "object"
     },
@@ -3344,9 +3087,7 @@
           "$ref": "#/$defs/LiquidProbeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LiquidProbeCreate",
       "type": "object"
     },
@@ -3373,11 +3114,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "pipetteId"],
       "title": "LiquidProbeParams",
       "type": "object"
     },
@@ -3412,9 +3149,7 @@
           "$ref": "#/$defs/LoadLabwareParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LoadLabwareCreate",
       "type": "object"
     },
@@ -3477,12 +3212,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "location",
-        "loadName",
-        "namespace",
-        "version"
-      ],
+      "required": ["location", "loadName", "namespace", "version"],
       "title": "LoadLabwareParams",
       "type": "object"
     },
@@ -3517,9 +3247,7 @@
           "$ref": "#/$defs/LoadLidParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LoadLidCreate",
       "type": "object"
     },
@@ -3572,12 +3300,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "location",
-        "loadName",
-        "namespace",
-        "version"
-      ],
+      "required": ["location", "loadName", "namespace", "version"],
       "title": "LoadLidParams",
       "type": "object"
     },
@@ -3612,9 +3335,7 @@
           "$ref": "#/$defs/LoadLidStackParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LoadLidStackCreate",
       "type": "object"
     },
@@ -3685,13 +3406,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "location",
-        "loadName",
-        "namespace",
-        "version",
-        "quantity"
-      ],
+      "required": ["location", "loadName", "namespace", "version", "quantity"],
       "title": "LoadLidStackParams",
       "type": "object"
     },
@@ -3726,9 +3441,7 @@
           "$ref": "#/$defs/LoadLiquidClassParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LoadLiquidClassCreate",
       "type": "object"
     },
@@ -3745,9 +3458,7 @@
           "description": "The liquid class to store."
         }
       },
-      "required": [
-        "liquidClassRecord"
-      ],
+      "required": ["liquidClassRecord"],
       "title": "LoadLiquidClassParams",
       "type": "object"
     },
@@ -3782,9 +3493,7 @@
           "$ref": "#/$defs/LoadLiquidParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LoadLiquidCreate",
       "type": "object"
     },
@@ -3818,11 +3527,7 @@
           "type": "object"
         }
       },
-      "required": [
-        "liquidId",
-        "labwareId",
-        "volumeByWell"
-      ],
+      "required": ["liquidId", "labwareId", "volumeByWell"],
       "title": "LoadLiquidParams",
       "type": "object"
     },
@@ -3857,9 +3562,7 @@
           "$ref": "#/$defs/LoadModuleParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LoadModuleCreate",
       "type": "object"
     },
@@ -3880,10 +3583,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "model",
-        "location"
-      ],
+      "required": ["model", "location"],
       "title": "LoadModuleParams",
       "type": "object"
     },
@@ -3918,9 +3618,7 @@
           "$ref": "#/$defs/LoadPipetteParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LoadPipetteCreate",
       "type": "object"
     },
@@ -3951,19 +3649,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteName",
-        "mount"
-      ],
+      "required": ["pipetteName", "mount"],
       "title": "LoadPipetteParams",
       "type": "object"
     },
     "MaintenancePosition": {
       "description": "Maintenance position options.",
-      "enum": [
-        "attachPlate",
-        "attachInstrument"
-      ],
+      "enum": ["attachPlate", "attachInstrument"],
       "title": "MaintenancePosition",
       "type": "string"
     },
@@ -3992,10 +3684,7 @@
           "title": "Volume"
         }
       },
-      "required": [
-        "repetitions",
-        "volume"
-      ],
+      "required": ["repetitions", "volume"],
       "title": "MixParams",
       "type": "object"
     },
@@ -4014,9 +3703,7 @@
           "title": "Params"
         }
       },
-      "required": [
-        "enable"
-      ],
+      "required": ["enable"],
       "title": "MixProperties",
       "type": "object"
     },
@@ -4029,9 +3716,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "ModuleLocation",
       "type": "object"
     },
@@ -4070,11 +3755,7 @@
       "type": "string"
     },
     "MountType": {
-      "enum": [
-        "left",
-        "right",
-        "extension"
-      ],
+      "enum": ["left", "right", "extension"],
       "title": "MountType",
       "type": "string"
     },
@@ -4109,9 +3790,7 @@
           "$ref": "#/$defs/MoveAxesRelativeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveAxesRelativeCreate",
       "type": "object"
     },
@@ -4135,9 +3814,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "axis_map"
-      ],
+      "required": ["axis_map"],
       "title": "MoveAxesRelativeParams",
       "type": "object"
     },
@@ -4172,9 +3849,7 @@
           "$ref": "#/$defs/MoveAxesToParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveAxesToCreate",
       "type": "object"
     },
@@ -4209,9 +3884,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "axis_map"
-      ],
+      "required": ["axis_map"],
       "title": "MoveAxesToParams",
       "type": "object"
     },
@@ -4246,9 +3919,7 @@
           "$ref": "#/$defs/MoveLabwareParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveLabwareCreate",
       "type": "object"
     },
@@ -4305,11 +3976,7 @@
           "description": "Whether to use the gripper to perform the labware movement or to perform a manual movement with an option to pause."
         }
       },
-      "required": [
-        "labwareId",
-        "newLocation",
-        "strategy"
-      ],
+      "required": ["labwareId", "newLocation", "strategy"],
       "title": "MoveLabwareParams",
       "type": "object"
     },
@@ -4344,9 +4011,7 @@
           "$ref": "#/$defs/MoveRelativeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveRelativeCreate",
       "type": "object"
     },
@@ -4368,11 +4033,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "axis",
-        "distance"
-      ],
+      "required": ["pipetteId", "axis", "distance"],
       "title": "MoveRelativeParams",
       "type": "object"
     },
@@ -4407,9 +4068,7 @@
           "$ref": "#/$defs/MoveToAddressableAreaParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveToAddressableAreaCreate",
       "type": "object"
     },
@@ -4444,9 +4103,7 @@
           "$ref": "#/$defs/MoveToAddressableAreaForDropTipParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveToAddressableAreaForDropTipCreate",
       "type": "object"
     },
@@ -4499,10 +4156,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "pipetteId",
-        "addressableAreaName"
-      ],
+      "required": ["pipetteId", "addressableAreaName"],
       "title": "MoveToAddressableAreaForDropTipParams",
       "type": "object"
     },
@@ -4551,10 +4205,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "addressableAreaName"
-      ],
+      "required": ["pipetteId", "addressableAreaName"],
       "title": "MoveToAddressableAreaParams",
       "type": "object"
     },
@@ -4589,9 +4240,7 @@
           "$ref": "#/$defs/MoveToCoordinatesParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveToCoordinatesCreate",
       "type": "object"
     },
@@ -4624,10 +4273,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "pipetteId",
-        "coordinates"
-      ],
+      "required": ["pipetteId", "coordinates"],
       "title": "MoveToCoordinatesParams",
       "type": "object"
     },
@@ -4662,9 +4308,7 @@
           "$ref": "#/$defs/MoveToParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveToCreate",
       "type": "object"
     },
@@ -4699,9 +4343,7 @@
           "$ref": "#/$defs/MoveToMaintenancePositionParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveToMaintenancePositionCreate",
       "type": "object"
     },
@@ -4718,9 +4360,7 @@
           "description": "Gantry mount to move maintenance position."
         }
       },
-      "required": [
-        "mount"
-      ],
+      "required": ["mount"],
       "title": "MoveToMaintenancePositionParams",
       "type": "object"
     },
@@ -4741,10 +4381,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "mount",
-        "destination"
-      ],
+      "required": ["mount", "destination"],
       "title": "MoveToParams",
       "type": "object"
     },
@@ -4779,9 +4416,7 @@
           "$ref": "#/$defs/MoveToWellParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveToWellCreate",
       "type": "object"
     },
@@ -4824,21 +4459,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "pipetteId"],
       "title": "MoveToWellParams",
       "type": "object"
     },
     "MovementAxis": {
       "description": "Axis on which to issue a relative movement.",
-      "enum": [
-        "x",
-        "y",
-        "z"
-      ],
+      "enum": ["x", "y", "z"],
       "title": "MovementAxis",
       "type": "string"
     },
@@ -5027,9 +4654,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId"
-      ],
+      "required": ["labwareId"],
       "title": "OnLabwareLocation",
       "type": "object"
     },
@@ -5064,9 +4689,7 @@
           "$ref": "#/$defs/OpenGripperJawParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "OpenGripperJawCreate",
       "type": "object"
     },
@@ -5107,9 +4730,7 @@
           "$ref": "#/$defs/OpenLabwareLatchParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "OpenLabwareLatchCreate",
       "type": "object"
     },
@@ -5122,9 +4743,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "OpenLabwareLatchParams",
       "type": "object"
     },
@@ -5159,9 +4778,7 @@
           "$ref": "#/$defs/OpenVentParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "OpenVentCreate",
       "type": "object"
     },
@@ -5174,9 +4791,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "OpenVentParams",
       "type": "object"
     },
@@ -5211,9 +4826,7 @@
           "$ref": "#/$defs/PickUpTipParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "PickUpTipCreate",
       "type": "object"
     },
@@ -5240,11 +4853,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareId",
-        "wellName"
-      ],
+      "required": ["pipetteId", "labwareId", "wellName"],
       "title": "PickUpTipParams",
       "type": "object"
     },
@@ -5264,11 +4873,7 @@
     },
     "PickUpTipWellOrigin": {
       "description": "The origin of a PickUpTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": [
-        "top",
-        "bottom",
-        "center"
-      ],
+      "enum": ["top", "bottom", "center"],
       "title": "PickUpTipWellOrigin",
       "type": "string"
     },
@@ -5300,12 +4905,7 @@
     },
     "PositionReference": {
       "description": "Positional reference for liquid handling operations.",
-      "enum": [
-        "well-bottom",
-        "well-top",
-        "well-center",
-        "liquid-meniscus"
-      ],
+      "enum": ["well-bottom", "well-top", "well-center", "liquid-meniscus"],
       "title": "PositionReference",
       "type": "string"
     },
@@ -5340,9 +4940,7 @@
           "$ref": "#/$defs/PrepareToAspirateParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "PrepareToAspirateCreate",
       "type": "object"
     },
@@ -5355,9 +4953,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ],
+      "required": ["pipetteId"],
       "title": "PrepareToAspirateParams",
       "type": "object"
     },
@@ -5392,9 +4988,7 @@
           "$ref": "#/$defs/PressureDispenseParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "PressureDispenseCreate",
       "type": "object"
     },
@@ -5446,13 +5040,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
       "title": "PressureDispenseParams",
       "type": "object"
     },
@@ -5473,10 +5061,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "steps",
-        "repetitions"
-      ],
+      "required": ["steps", "repetitions"],
       "title": "ProfileCycle",
       "type": "object"
     },
@@ -5499,10 +5084,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "celsius",
-        "holdSeconds"
-      ],
+      "required": ["celsius", "holdSeconds"],
       "title": "ProfileStep",
       "type": "object"
     },
@@ -5523,12 +5105,7 @@
         },
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -5539,11 +5116,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle",
-        "frontRightNozzle",
-        "backLeftNozzle"
-      ],
+      "required": ["primaryNozzle", "frontRightNozzle", "backLeftNozzle"],
       "title": "QuadrantNozzleLayoutConfiguration",
       "type": "object"
     },
@@ -5578,9 +5151,7 @@
           "$ref": "#/$defs/ReadAbsorbanceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "ReadAbsorbanceCreate",
       "type": "object"
     },
@@ -5598,9 +5169,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "ReadAbsorbanceParams",
       "type": "object"
     },
@@ -5635,9 +5204,7 @@
           "$ref": "#/$defs/ReloadLabwareParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "ReloadLabwareCreate",
       "type": "object"
     },
@@ -5650,9 +5217,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId"
-      ],
+      "required": ["labwareId"],
       "title": "ReloadLabwareParams",
       "type": "object"
     },
@@ -5764,9 +5329,7 @@
           "$ref": "#/$defs/RetractAxisParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "RetractAxisCreate",
       "type": "object"
     },
@@ -5778,9 +5341,7 @@
           "description": "Axis to retract to its home position as quickly as safely possible. The difference between retracting an axis and homing an axis using the home command is that a home will always probe the limit switch and will work as the first motion command a robot will need to execute; On the other hand, retraction will rely on this previously determined  home position to move to it as fast as safely possible. So on the Flex, it will move (fast) the axis to the previously recorded home position and on the OT2, it will move (fast) the axis a safe distance from the previously recorded home position, and then slowly approach the limit switch."
         }
       },
-      "required": [
-        "axis"
-      ],
+      "required": ["axis"],
       "title": "RetractAxisParams",
       "type": "object"
     },
@@ -5897,9 +5458,7 @@
           "$ref": "#/$defs/RetrieveParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "RetrieveCreate",
       "type": "object"
     },
@@ -5932,9 +5491,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "RetrieveParams",
       "type": "object"
     },
@@ -5943,12 +5500,7 @@
       "properties": {
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -5959,9 +5511,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ],
+      "required": ["primaryNozzle"],
       "title": "RowNozzleLayoutConfiguration",
       "type": "object"
     },
@@ -5996,9 +5546,7 @@
           "$ref": "#/$defs/RunExtendedProfileParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "RunExtendedProfileCreate",
       "type": "object"
     },
@@ -6031,10 +5579,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "moduleId",
-        "profileElements"
-      ],
+      "required": ["moduleId", "profileElements"],
       "title": "RunExtendedProfileParams",
       "type": "object"
     },
@@ -6069,9 +5614,7 @@
           "$ref": "#/$defs/RunProfileParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "RunProfileCreate",
       "type": "object"
     },
@@ -6097,10 +5640,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "moduleId",
-        "profile"
-      ],
+      "required": ["moduleId", "profile"],
       "title": "RunProfileParams",
       "type": "object"
     },
@@ -6123,10 +5663,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "celsius",
-        "holdSeconds"
-      ],
+      "required": ["celsius", "holdSeconds"],
       "title": "RunProfileStepParams",
       "type": "object"
     },
@@ -6161,9 +5698,7 @@
           "$ref": "#/$defs/SavePositionParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SavePositionCreate",
       "type": "object"
     },
@@ -6186,9 +5721,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ],
+      "required": ["pipetteId"],
       "title": "SavePositionParams",
       "type": "object"
     },
@@ -6223,9 +5756,7 @@
           "$ref": "#/$defs/SealPipetteToTipParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SealPipetteToTipCreate",
       "type": "object"
     },
@@ -6264,11 +5795,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareId",
-        "wellName"
-      ],
+      "required": ["pipetteId", "labwareId", "wellName"],
       "title": "SealPipetteToTipParams",
       "type": "object"
     },
@@ -6303,9 +5830,7 @@
           "$ref": "#/$defs/SetAndWaitForShakeSpeedParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetAndWaitForShakeSpeedCreate",
       "type": "object"
     },
@@ -6323,10 +5848,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "rpm"
-      ],
+      "required": ["moduleId", "rpm"],
       "title": "SetAndWaitForShakeSpeedParams",
       "type": "object"
     },
@@ -6361,9 +5883,7 @@
           "$ref": "#/$defs/SetRailLightsParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetRailLightsCreate",
       "type": "object"
     },
@@ -6376,9 +5896,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "on"
-      ],
+      "required": ["on"],
       "title": "SetRailLightsParams",
       "type": "object"
     },
@@ -6413,9 +5931,7 @@
           "$ref": "#/$defs/SetShakeSpeedParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetShakeSpeedCreate",
       "type": "object"
     },
@@ -6446,10 +5962,7 @@
           "title": "Taskid"
         }
       },
-      "required": [
-        "moduleId",
-        "rpm"
-      ],
+      "required": ["moduleId", "rpm"],
       "title": "SetShakeSpeedParams",
       "type": "object"
     },
@@ -6484,9 +5997,7 @@
           "$ref": "#/$defs/SetStatusBarParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetStatusBarCreate",
       "type": "object"
     },
@@ -6498,9 +6009,7 @@
           "description": "The animation that should be executed on the status bar."
         }
       },
-      "required": [
-        "animation"
-      ],
+      "required": ["animation"],
       "title": "SetStatusBarParams",
       "type": "object"
     },
@@ -6535,9 +6044,7 @@
           "$ref": "#/$defs/SetStoredLabwareParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetStoredLabwareCreate",
       "type": "object"
     },
@@ -6609,10 +6116,7 @@
           "description": "The details of the primary labware (i.e. not the lid or adapter, if any) stored in the stacker."
         }
       },
-      "required": [
-        "moduleId",
-        "primaryLabware"
-      ],
+      "required": ["moduleId", "primaryLabware"],
       "title": "SetStoredLabwareParams",
       "type": "object"
     },
@@ -6647,9 +6151,7 @@
           "$ref": "#/$defs/SetTargetBlockTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetTargetBlockTemperatureCreate",
       "type": "object"
     },
@@ -6687,10 +6189,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ],
+      "required": ["moduleId", "celsius"],
       "title": "SetTargetBlockTemperatureParams",
       "type": "object"
     },
@@ -6725,9 +6224,7 @@
           "$ref": "#/$defs/SetTargetLidTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetTargetLidTemperatureCreate",
       "type": "object"
     },
@@ -6750,10 +6247,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ],
+      "required": ["moduleId", "celsius"],
       "title": "SetTargetLidTemperatureParams",
       "type": "object"
     },
@@ -6788,9 +6282,7 @@
           "$ref": "#/$defs/SetTipStateParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetTipStateCreate",
       "type": "object"
     },
@@ -6815,11 +6307,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "labwareId",
-        "wellNames",
-        "tipWellState"
-      ],
+      "required": ["labwareId", "wellNames", "tipWellState"],
       "title": "SetTipStateParams",
       "type": "object"
     },
@@ -6972,12 +6460,7 @@
       "properties": {
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -6988,27 +6471,19 @@
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ],
+      "required": ["primaryNozzle"],
       "title": "SingleNozzleLayoutConfiguration",
       "type": "object"
     },
     "StackerFillEmptyStrategy": {
       "description": "Strategy to use for filling or emptying a stacker.",
-      "enum": [
-        "manualWithPause",
-        "logical"
-      ],
+      "enum": ["manualWithPause", "logical"],
       "title": "StackerFillEmptyStrategy",
       "type": "string"
     },
     "StackerLabwareMovementStrategy": {
       "description": "Strategy to retrieve or store labware.",
-      "enum": [
-        "automatic",
-        "manual"
-      ],
+      "enum": ["automatic", "manual"],
       "title": "StackerLabwareMovementStrategy",
       "type": "string"
     },
@@ -7031,11 +6506,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "loadName",
-        "namespace",
-        "version"
-      ],
+      "required": ["loadName", "namespace", "version"],
       "title": "StackerStoredLabwareDetails",
       "type": "object"
     },
@@ -7057,9 +6528,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "primaryLabwareId"
-      ],
+      "required": ["primaryLabwareId"],
       "title": "StackerStoredLabwareGroup",
       "type": "object"
     },
@@ -7094,9 +6563,7 @@
           "$ref": "#/$defs/StartRunExtendedProfileParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "StartRunExtendedProfileCreate",
       "type": "object"
     },
@@ -7142,10 +6609,7 @@
           "title": "Taskid"
         }
       },
-      "required": [
-        "moduleId",
-        "profileElements"
-      ],
+      "required": ["moduleId", "profileElements"],
       "title": "StartRunExtendedProfileParams",
       "type": "object"
     },
@@ -7180,9 +6644,7 @@
           "$ref": "#/$defs/StartRunProfileParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "StartRunProfileCreate",
       "type": "object"
     },
@@ -7226,10 +6688,7 @@
           "title": "Taskid"
         }
       },
-      "required": [
-        "moduleId",
-        "profile"
-      ],
+      "required": ["moduleId", "profile"],
       "title": "StartRunProfileParams",
       "type": "object"
     },
@@ -7264,9 +6723,7 @@
           "$ref": "#/$defs/StartSetVacuumPowerParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "StartSetVacuumPowerCreate",
       "type": "object"
     },
@@ -7308,10 +6765,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "moduleId",
-        "percentPower"
-      ],
+      "required": ["moduleId", "percentPower"],
       "title": "StartSetVacuumPowerParams",
       "type": "object"
     },
@@ -7346,9 +6800,7 @@
           "$ref": "#/$defs/StartSetVacuumPressureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "StartSetVacuumPressureCreate",
       "type": "object"
     },
@@ -7390,22 +6842,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "moduleId",
-        "gaugePressure"
-      ],
+      "required": ["moduleId", "gaugePressure"],
       "title": "StartSetVacuumPressureParams",
       "type": "object"
     },
     "StatusBarAnimation": {
       "description": "Status Bar animation options.",
-      "enum": [
-        "idle",
-        "confirm",
-        "updating",
-        "disco",
-        "off"
-      ],
+      "enum": ["idle", "confirm", "updating", "disco", "off"],
       "title": "StatusBarAnimation",
       "type": "string"
     },
@@ -7440,9 +6883,7 @@
           "$ref": "#/$defs/StopVacuumParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "StopVacuumCreate",
       "type": "object"
     },
@@ -7455,9 +6896,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "StopVacuumParams",
       "type": "object"
     },
@@ -7492,9 +6931,7 @@
           "$ref": "#/$defs/StoreParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "StoreCreate",
       "type": "object"
     },
@@ -7511,10 +6948,7 @@
           "description": "If manual, indicates that labware has been moved to the hopper manually by the user, as required in error recovery."
         }
       },
-      "required": [
-        "moduleId",
-        "strategy"
-      ],
+      "required": ["moduleId", "strategy"],
       "title": "StoreParams",
       "type": "object"
     },
@@ -7545,11 +6979,7 @@
           "description": "Tip position before starting the submerge."
         }
       },
-      "required": [
-        "startPosition",
-        "speed",
-        "delay"
-      ],
+      "required": ["startPosition", "speed", "delay"],
       "title": "Submerge",
       "type": "object"
     },
@@ -7591,30 +7021,19 @@
           "description": "Position reference for tip position."
         }
       },
-      "required": [
-        "positionReference",
-        "offset"
-      ],
+      "required": ["positionReference", "offset"],
       "title": "TipPosition",
       "type": "object"
     },
     "TipPresenceStatus": {
       "description": "Tip presence status reported by a pipette.",
-      "enum": [
-        "present",
-        "absent",
-        "unknown"
-      ],
+      "enum": ["present", "absent", "unknown"],
       "title": "TipPresenceStatus",
       "type": "string"
     },
     "TipRackWellState": {
       "description": "The state of a single tip in a tip rack's well.",
-      "enum": [
-        "clean",
-        "used",
-        "empty"
-      ],
+      "enum": ["clean", "used", "empty"],
       "title": "TipRackWellState",
       "type": "string"
     },
@@ -7649,9 +7068,7 @@
           "$ref": "#/$defs/TouchTipParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "TouchTipCreate",
       "type": "object"
     },
@@ -7694,11 +7111,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "pipetteId"],
       "title": "TouchTipParams",
       "type": "object"
     },
@@ -7717,9 +7130,7 @@
           "title": "Params"
         }
       },
-      "required": [
-        "enable"
-      ],
+      "required": ["enable"],
       "title": "TouchTipProperties",
       "type": "object"
     },
@@ -7754,9 +7165,7 @@
           "$ref": "#/$defs/TryLiquidProbeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "TryLiquidProbeCreate",
       "type": "object"
     },
@@ -7783,11 +7192,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "pipetteId"],
       "title": "TryLiquidProbeParams",
       "type": "object"
     },
@@ -7822,9 +7227,7 @@
           "$ref": "#/$defs/UnsafeBlowOutInPlaceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeBlowOutInPlaceCreate",
       "type": "object"
     },
@@ -7843,10 +7246,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "pipetteId"
-      ],
+      "required": ["flowRate", "pipetteId"],
       "title": "UnsafeBlowOutInPlaceParams",
       "type": "object"
     },
@@ -7881,9 +7281,7 @@
           "$ref": "#/$defs/UnsafeDropTipInPlaceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeDropTipInPlaceCreate",
       "type": "object"
     },
@@ -7901,9 +7299,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ],
+      "required": ["pipetteId"],
       "title": "UnsafeDropTipInPlaceParams",
       "type": "object"
     },
@@ -7938,9 +7334,7 @@
           "$ref": "#/$defs/UnsafeEngageAxesParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeEngageAxesCreate",
       "type": "object"
     },
@@ -7956,9 +7350,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "axes"
-      ],
+      "required": ["axes"],
       "title": "UnsafeEngageAxesParams",
       "type": "object"
     },
@@ -7993,9 +7385,7 @@
           "$ref": "#/$defs/UnsafeFlexStackerCloseLatchParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeFlexStackerCloseLatchCreate",
       "type": "object"
     },
@@ -8008,9 +7398,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "UnsafeFlexStackerCloseLatchParams",
       "type": "object"
     },
@@ -8045,9 +7433,7 @@
           "$ref": "#/$defs/UnsafeFlexStackerManualRetrieveParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeFlexStackerManualRetrieveCreate",
       "type": "object"
     },
@@ -8080,9 +7466,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "UnsafeFlexStackerManualRetrieveParams",
       "type": "object"
     },
@@ -8117,9 +7501,7 @@
           "$ref": "#/$defs/UnsafeFlexStackerOpenLatchParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeFlexStackerOpenLatchCreate",
       "type": "object"
     },
@@ -8132,9 +7514,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "UnsafeFlexStackerOpenLatchParams",
       "type": "object"
     },
@@ -8169,9 +7549,7 @@
           "$ref": "#/$defs/UnsafeFlexStackerPrepareShuttleParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeFlexStackerPrepareShuttleCreate",
       "type": "object"
     },
@@ -8190,9 +7568,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "UnsafeFlexStackerPrepareShuttleParams",
       "type": "object"
     },
@@ -8227,9 +7603,7 @@
           "$ref": "#/$defs/UnsafePlaceLabwareParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafePlaceLabwareCreate",
       "type": "object"
     },
@@ -8260,10 +7634,7 @@
           "title": "Location"
         }
       },
-      "required": [
-        "labwareURI",
-        "location"
-      ],
+      "required": ["labwareURI", "location"],
       "title": "UnsafePlaceLabwareParams",
       "type": "object"
     },
@@ -8298,9 +7669,7 @@
           "$ref": "#/$defs/UnsafeUngripLabwareParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeUngripLabwareCreate",
       "type": "object"
     },
@@ -8341,9 +7710,7 @@
           "$ref": "#/$defs/UnsealPipetteFromTipParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsealPipetteFromTipCreate",
       "type": "object"
     },
@@ -8370,11 +7737,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareId",
-        "wellName"
-      ],
+      "required": ["pipetteId", "labwareId", "wellName"],
       "title": "UnsealPipetteFromTipParams",
       "type": "object"
     },
@@ -8409,9 +7772,7 @@
           "$ref": "#/$defs/UpdatePositionEstimatorsParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UpdatePositionEstimatorsCreate",
       "type": "object"
     },
@@ -8427,9 +7788,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "axes"
-      ],
+      "required": ["axes"],
       "title": "UpdatePositionEstimatorsParams",
       "type": "object"
     },
@@ -8460,10 +7819,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "steps",
-        "repetitions"
-      ],
+      "required": ["steps", "repetitions"],
       "title": "VacuumModuleProfileCycle",
       "type": "object"
     },
@@ -8505,9 +7861,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "enablePump"
-      ],
+      "required": ["enablePump"],
       "title": "VacuumModuleProfilePowerStep",
       "type": "object"
     },
@@ -8549,9 +7903,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "enablePump"
-      ],
+      "required": ["enablePump"],
       "title": "VacuumModuleProfilePressureStep",
       "type": "object"
     },
@@ -8571,11 +7923,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ],
+      "required": ["x", "y", "z"],
       "title": "Vec3f",
       "type": "object"
     },
@@ -8610,9 +7958,7 @@
           "$ref": "#/$defs/VerifyTipPresenceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "VerifyTipPresenceCreate",
       "type": "object"
     },
@@ -8634,10 +7980,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "expectedState"
-      ],
+      "required": ["pipetteId", "expectedState"],
       "title": "VerifyTipPresenceParams",
       "type": "object"
     },
@@ -8672,9 +8015,7 @@
           "$ref": "#/$defs/WaitForBlockTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "WaitForBlockTemperatureCreate",
       "type": "object"
     },
@@ -8687,9 +8028,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "WaitForBlockTemperatureParams",
       "type": "object"
     },
@@ -8724,9 +8063,7 @@
           "$ref": "#/$defs/WaitForDurationParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "WaitForDurationCreate",
       "type": "object"
     },
@@ -8744,9 +8081,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "seconds"
-      ],
+      "required": ["seconds"],
       "title": "WaitForDurationParams",
       "type": "object"
     },
@@ -8781,9 +8116,7 @@
           "$ref": "#/$defs/WaitForLidTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "WaitForLidTemperatureCreate",
       "type": "object"
     },
@@ -8796,9 +8129,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "WaitForLidTemperatureParams",
       "type": "object"
     },
@@ -8815,10 +8146,7 @@
         },
         "commandType": {
           "default": "waitForResume",
-          "enum": [
-            "waitForResume",
-            "pause"
-          ],
+          "enum": ["waitForResume", "pause"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -8836,9 +8164,7 @@
           "$ref": "#/$defs/WaitForResumeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "WaitForResumeCreate",
       "type": "object"
     },
@@ -8885,9 +8211,7 @@
           "$ref": "#/$defs/WaitForTasksParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "WaitForTasksCreate",
       "type": "object"
     },
@@ -8903,9 +8227,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "task_ids"
-      ],
+      "required": ["task_ids"],
       "title": "WaitForTasksParams",
       "type": "object"
     },
@@ -8953,12 +8275,7 @@
     },
     "WellOrigin": {
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    MENISCUS: the meniscus-center of the well",
-      "enum": [
-        "top",
-        "bottom",
-        "center",
-        "meniscus"
-      ],
+      "enum": ["top", "bottom", "center", "meniscus"],
       "title": "WellOrigin",
       "type": "string"
     },
@@ -8993,9 +8310,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CloseLidCreate",
       "type": "object"
     },
@@ -9008,9 +8323,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "CloseLidParams",
       "type": "object"
     },
@@ -9045,9 +8358,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "OpenLidCreate",
       "type": "object"
     },
@@ -9060,9 +8371,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "OpenLidParams",
       "type": "object"
     },
@@ -9097,9 +8406,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetTargetTemperatureCreate",
       "type": "object"
     },
@@ -9122,10 +8429,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ],
+      "required": ["moduleId", "celsius"],
       "title": "SetTargetTemperatureParams",
       "type": "object"
     },
@@ -9160,9 +8464,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "WaitForTemperatureCreate",
       "type": "object"
     },
@@ -9180,9 +8482,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "WaitForTemperatureParams",
       "type": "object"
     },
@@ -9217,9 +8517,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetTargetTemperatureCreate",
       "type": "object"
     },
@@ -9242,10 +8540,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ],
+      "required": ["moduleId", "celsius"],
       "title": "SetTargetTemperatureParams",
       "type": "object"
     },
@@ -9280,9 +8575,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "WaitForTemperatureCreate",
       "type": "object"
     },
@@ -9300,9 +8593,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "WaitForTemperatureParams",
       "type": "object"
     },
@@ -9337,9 +8628,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CloseLidCreate",
       "type": "object"
     },
@@ -9352,9 +8641,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "CloseLidParams",
       "type": "object"
     },
@@ -9389,9 +8676,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "OpenLidCreate",
       "type": "object"
     },
@@ -9404,9 +8689,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "OpenLidParams",
       "type": "object"
     }

--- a/shared-data/command/schemas/17.json
+++ b/shared-data/command/schemas/17.json
@@ -9,7 +9,9 @@
           "type": "string"
         }
       },
-      "required": ["addressableAreaName"],
+      "required": [
+        "addressableAreaName"
+      ],
       "title": "AddressableAreaLocation",
       "type": "object"
     },
@@ -29,7 +31,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"],
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
       "title": "AddressableOffsetVector",
       "type": "object"
     },
@@ -64,7 +70,9 @@
           "$ref": "#/$defs/AirGapInPlaceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "AirGapInPlaceCreate",
       "type": "object"
     },
@@ -102,7 +110,11 @@
           "type": "number"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"],
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "AirGapInPlaceParams",
       "type": "object"
     },
@@ -150,7 +162,9 @@
           "$ref": "#/$defs/AspirateParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "AspirateCreate",
       "type": "object"
     },
@@ -185,7 +199,9 @@
           "$ref": "#/$defs/AspirateInPlaceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "AspirateInPlaceCreate",
       "type": "object"
     },
@@ -223,7 +239,11 @@
           "type": "number"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"],
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "AspirateInPlaceParams",
       "type": "object"
     },
@@ -275,7 +295,13 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "AspirateParams",
       "type": "object"
     },
@@ -423,7 +449,9 @@
           "$ref": "#/$defs/AspirateWhileTrackingParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "AspirateWhileTrackingCreate",
       "type": "object"
     },
@@ -484,7 +512,13 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "AspirateWhileTrackingParams",
       "type": "object"
     },
@@ -519,7 +553,9 @@
           "$ref": "#/$defs/BlowOutParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "BlowOutCreate",
       "type": "object"
     },
@@ -554,7 +590,9 @@
           "$ref": "#/$defs/BlowOutInPlaceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "BlowOutInPlaceCreate",
       "type": "object"
     },
@@ -573,7 +611,10 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "pipetteId"],
+      "required": [
+        "flowRate",
+        "pipetteId"
+      ],
       "title": "BlowOutInPlaceParams",
       "type": "object"
     },
@@ -606,13 +647,22 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "pipetteId"
+      ],
       "title": "BlowOutParams",
       "type": "object"
     },
     "BlowoutLocation": {
       "description": "Location for blowout during a transfer function.",
-      "enum": ["source", "destination", "trash"],
+      "enum": [
+        "source",
+        "destination",
+        "trash"
+      ],
       "title": "BlowoutLocation",
       "type": "string"
     },
@@ -651,7 +701,10 @@
           "description": "Location well or trash entity for blow out."
         }
       },
-      "required": ["location", "flowRate"],
+      "required": [
+        "location",
+        "flowRate"
+      ],
       "title": "BlowoutParams",
       "type": "object"
     },
@@ -670,7 +723,9 @@
           "title": "Params"
         }
       },
-      "required": ["enable"],
+      "required": [
+        "enable"
+      ],
       "title": "BlowoutProperties",
       "type": "object"
     },
@@ -705,7 +760,9 @@
           "$ref": "#/$defs/CSVWriteRowParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CSVWriteRowCreate",
       "type": "object"
     },
@@ -726,7 +783,10 @@
           "type": "array"
         }
       },
-      "required": ["fileId", "rowData"],
+      "required": [
+        "fileId",
+        "rowData"
+      ],
       "title": "CSVWriteRowParams",
       "type": "object"
     },
@@ -761,7 +821,9 @@
           "$ref": "#/$defs/CalibrateGripperParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CalibrateGripperCreate",
       "type": "object"
     },
@@ -778,12 +840,17 @@
           "title": "Otherjawoffset"
         }
       },
-      "required": ["jaw"],
+      "required": [
+        "jaw"
+      ],
       "title": "CalibrateGripperParams",
       "type": "object"
     },
     "CalibrateGripperParamsJaw": {
-      "enum": ["front", "rear"],
+      "enum": [
+        "front",
+        "rear"
+      ],
       "title": "CalibrateGripperParamsJaw",
       "type": "string"
     },
@@ -818,7 +885,9 @@
           "$ref": "#/$defs/CalibrateModuleParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CalibrateModuleCreate",
       "type": "object"
     },
@@ -840,7 +909,11 @@
           "description": "The instrument mount used to calibrate the module."
         }
       },
-      "required": ["moduleId", "labwareId", "mount"],
+      "required": [
+        "moduleId",
+        "labwareId",
+        "mount"
+      ],
       "title": "CalibrateModuleParams",
       "type": "object"
     },
@@ -875,7 +948,9 @@
           "$ref": "#/$defs/CalibratePipetteParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CalibratePipetteCreate",
       "type": "object"
     },
@@ -887,7 +962,9 @@
           "description": "Instrument mount to calibrate."
         }
       },
-      "required": ["mount"],
+      "required": [
+        "mount"
+      ],
       "title": "CalibratePipetteParams",
       "type": "object"
     },
@@ -922,7 +999,9 @@
           "$ref": "#/$defs/CaptureImageParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CaptureImageCreate",
       "type": "object"
     },
@@ -1067,7 +1146,9 @@
           "$ref": "#/$defs/CloseGripperJawParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CloseGripperJawCreate",
       "type": "object"
     },
@@ -1114,7 +1195,9 @@
           "$ref": "#/$defs/CloseLabwareLatchParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CloseLabwareLatchCreate",
       "type": "object"
     },
@@ -1127,7 +1210,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "CloseLabwareLatchParams",
       "type": "object"
     },
@@ -1162,7 +1247,9 @@
           "$ref": "#/$defs/CloseVentParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CloseVentCreate",
       "type": "object"
     },
@@ -1175,7 +1262,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "CloseVentParams",
       "type": "object"
     },
@@ -1184,7 +1273,12 @@
       "properties": {
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -1195,13 +1289,19 @@
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"],
+      "required": [
+        "primaryNozzle"
+      ],
       "title": "ColumnNozzleLayoutConfiguration",
       "type": "object"
     },
     "CommandIntent": {
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": ["protocol", "setup", "fixit"],
+      "enum": [
+        "protocol",
+        "setup",
+        "fixit"
+      ],
       "title": "CommandIntent",
       "type": "string"
     },
@@ -1236,7 +1336,9 @@
           "$ref": "#/$defs/CommentParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CommentCreate",
       "type": "object"
     },
@@ -1249,7 +1351,9 @@
           "type": "string"
         }
       },
-      "required": ["message"],
+      "required": [
+        "message"
+      ],
       "title": "CommentParams",
       "type": "object"
     },
@@ -1284,7 +1388,9 @@
           "$ref": "#/$defs/ConfigureForVolumeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "ConfigureForVolumeCreate",
       "type": "object"
     },
@@ -1308,7 +1414,10 @@
           "type": "number"
         }
       },
-      "required": ["pipetteId", "volume"],
+      "required": [
+        "pipetteId",
+        "volume"
+      ],
       "title": "ConfigureForVolumeParams",
       "type": "object"
     },
@@ -1343,7 +1452,9 @@
           "$ref": "#/$defs/ConfigureNozzleLayoutParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "ConfigureNozzleLayoutCreate",
       "type": "object"
     },
@@ -1376,7 +1487,10 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "configurationParams"],
+      "required": [
+        "pipetteId",
+        "configurationParams"
+      ],
       "title": "ConfigureNozzleLayoutParams",
       "type": "object"
     },
@@ -1418,7 +1532,11 @@
           "title": "Z"
         }
       },
-      "required": ["x", "y", "z"],
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
       "title": "Coordinate",
       "type": "object"
     },
@@ -1453,7 +1571,9 @@
           "$ref": "#/$defs/CreateCSVParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CreateCSVCreate",
       "type": "object"
     },
@@ -1471,7 +1591,10 @@
           "type": "string"
         }
       },
-      "required": ["fileName", "columns"],
+      "required": [
+        "fileName",
+        "columns"
+      ],
       "title": "CreateCSVParams",
       "type": "object"
     },
@@ -1506,7 +1629,9 @@
           "$ref": "#/$defs/CreateTimerParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CreateTimerCreate",
       "type": "object"
     },
@@ -1532,7 +1657,9 @@
           "type": "number"
         }
       },
-      "required": ["time"],
+      "required": [
+        "time"
+      ],
       "title": "CreateTimerParams",
       "type": "object"
     },
@@ -1567,7 +1694,9 @@
           "$ref": "#/$defs/CustomParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CustomCreate",
       "type": "object"
     },
@@ -1609,7 +1738,9 @@
           "$ref": "#/$defs/DeactivateBlockParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DeactivateBlockCreate",
       "type": "object"
     },
@@ -1622,7 +1753,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "DeactivateBlockParams",
       "type": "object"
     },
@@ -1657,7 +1790,9 @@
           "$ref": "#/$defs/DeactivateHeaterParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DeactivateHeaterCreate",
       "type": "object"
     },
@@ -1670,7 +1805,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "DeactivateHeaterParams",
       "type": "object"
     },
@@ -1705,7 +1842,9 @@
           "$ref": "#/$defs/DeactivateLidParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DeactivateLidCreate",
       "type": "object"
     },
@@ -1718,7 +1857,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "DeactivateLidParams",
       "type": "object"
     },
@@ -1753,7 +1894,9 @@
           "$ref": "#/$defs/DeactivateShakerParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DeactivateShakerCreate",
       "type": "object"
     },
@@ -1766,7 +1909,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "DeactivateShakerParams",
       "type": "object"
     },
@@ -1801,7 +1946,9 @@
           "$ref": "#/$defs/DeactivateTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DeactivateTemperatureCreate",
       "type": "object"
     },
@@ -1814,7 +1961,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "DeactivateTemperatureParams",
       "type": "object"
     },
@@ -1834,7 +1983,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"],
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
       "title": "DeckPoint",
       "type": "object"
     },
@@ -1846,7 +1999,9 @@
           "description": "A slot on the robot's deck.\n\nThe plain numbers like `\"5\"` are for the OT-2, and the coordinates like `\"C2\"` are for the Flex.\n\nWhen you provide one of these values, you can use either style. It will automatically be converted to match the robot.\n\nWhen one of these values is returned, it will always match the robot."
         }
       },
-      "required": ["slotName"],
+      "required": [
+        "slotName"
+      ],
       "title": "DeckSlotLocation",
       "type": "object"
     },
@@ -1900,7 +2055,9 @@
           "title": "Duration"
         }
       },
-      "required": ["duration"],
+      "required": [
+        "duration"
+      ],
       "title": "DelayParams",
       "type": "object"
     },
@@ -1919,7 +2076,9 @@
           "title": "Params"
         }
       },
-      "required": ["enable"],
+      "required": [
+        "enable"
+      ],
       "title": "DelayProperties",
       "type": "object"
     },
@@ -1954,7 +2113,9 @@
           "$ref": "#/$defs/DisengageParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DisengageCreate",
       "type": "object"
     },
@@ -1967,7 +2128,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "DisengageParams",
       "type": "object"
     },
@@ -2002,7 +2165,9 @@
           "$ref": "#/$defs/DispenseParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DispenseCreate",
       "type": "object"
     },
@@ -2037,7 +2202,9 @@
           "$ref": "#/$defs/DispenseInPlaceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DispenseInPlaceCreate",
       "type": "object"
     },
@@ -2080,7 +2247,11 @@
           "type": "number"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"],
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "DispenseInPlaceParams",
       "type": "object"
     },
@@ -2137,7 +2308,13 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "DispenseParams",
       "type": "object"
     },
@@ -2172,7 +2349,9 @@
           "$ref": "#/$defs/DispenseWhileTrackingParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DispenseWhileTrackingCreate",
       "type": "object"
     },
@@ -2238,7 +2417,13 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "DispenseWhileTrackingParams",
       "type": "object"
     },
@@ -2273,7 +2458,9 @@
           "$ref": "#/$defs/DropTipParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DropTipCreate",
       "type": "object"
     },
@@ -2308,7 +2495,9 @@
           "$ref": "#/$defs/DropTipInPlaceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DropTipInPlaceCreate",
       "type": "object"
     },
@@ -2326,7 +2515,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"],
+      "required": [
+        "pipetteId"
+      ],
       "title": "DropTipInPlaceParams",
       "type": "object"
     },
@@ -2368,7 +2559,11 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "labwareId", "wellName"],
+      "required": [
+        "pipetteId",
+        "labwareId",
+        "wellName"
+      ],
       "title": "DropTipParams",
       "type": "object"
     },
@@ -2388,7 +2583,12 @@
     },
     "DropTipWellOrigin": {
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": ["top", "bottom", "center", "default"],
+      "enum": [
+        "top",
+        "bottom",
+        "center",
+        "default"
+      ],
       "title": "DropTipWellOrigin",
       "type": "string"
     },
@@ -2423,7 +2623,9 @@
           "$ref": "#/$defs/EmptyParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "EmptyCreate",
       "type": "object"
     },
@@ -2460,7 +2662,10 @@
           "description": "How to empty the stacker. If manualWithPause, pause the protocol until the client sends an interaction, and mark the labware pool as empty thereafter. If logical, do not pause but immediately apply the specified count."
         }
       },
-      "required": ["moduleId", "strategy"],
+      "required": [
+        "moduleId",
+        "strategy"
+      ],
       "title": "EmptyParams",
       "type": "object"
     },
@@ -2495,7 +2700,9 @@
           "$ref": "#/$defs/EngageParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "EngageCreate",
       "type": "object"
     },
@@ -2513,7 +2720,10 @@
           "type": "string"
         }
       },
-      "required": ["moduleId", "height"],
+      "required": [
+        "moduleId",
+        "height"
+      ],
       "title": "EngageParams",
       "type": "object"
     },
@@ -2548,7 +2758,9 @@
           "$ref": "#/$defs/FillParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "FillCreate",
       "type": "object"
     },
@@ -2601,7 +2813,10 @@
           "description": "How to fill the stacker. If manualWithPause, pause the protocol until the client sends an interaction, and apply the new specified count thereafter. If logical, do not pause but immediately apply the specified count."
         }
       },
-      "required": ["moduleId", "strategy"],
+      "required": [
+        "moduleId",
+        "strategy"
+      ],
       "title": "FillParams",
       "type": "object"
     },
@@ -2636,7 +2851,9 @@
           "$ref": "#/$defs/GetNextTipParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "GetNextTipCreate",
       "type": "object"
     },
@@ -2662,7 +2879,10 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "labwareIds"],
+      "required": [
+        "pipetteId",
+        "labwareIds"
+      ],
       "title": "GetNextTipParams",
       "type": "object"
     },
@@ -2697,7 +2917,9 @@
           "$ref": "#/$defs/GetTipPresenceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "GetTipPresenceCreate",
       "type": "object"
     },
@@ -2710,7 +2932,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"],
+      "required": [
+        "pipetteId"
+      ],
       "title": "GetTipPresenceParams",
       "type": "object"
     },
@@ -2745,7 +2969,9 @@
           "$ref": "#/$defs/HomeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "HomeCreate",
       "type": "object"
     },
@@ -2800,7 +3026,9 @@
           "$ref": "#/$defs/IdentifyModuleParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "IdentifyModuleCreate",
       "type": "object"
     },
@@ -2835,7 +3063,11 @@
           "type": "boolean"
         }
       },
-      "required": ["model", "moduleId", "start"],
+      "required": [
+        "model",
+        "moduleId",
+        "start"
+      ],
       "title": "IdentifyModuleParams",
       "type": "object"
     },
@@ -2870,7 +3102,9 @@
           "$ref": "#/$defs/InitializeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "InitializeCreate",
       "type": "object"
     },
@@ -2879,7 +3113,10 @@
       "properties": {
         "measureMode": {
           "description": "Initialize single or multi measurement mode.",
-          "enum": ["single", "multi"],
+          "enum": [
+            "single",
+            "multi"
+          ],
           "title": "Measuremode",
           "type": "string"
         },
@@ -2902,19 +3139,31 @@
           "type": "array"
         }
       },
-      "required": ["moduleId", "measureMode", "sampleWavelengths"],
+      "required": [
+        "moduleId",
+        "measureMode",
+        "sampleWavelengths"
+      ],
       "title": "InitializeParams",
       "type": "object"
     },
     "InstrumentSensorId": {
       "description": "Primary and secondary sensor ids.",
-      "enum": ["primary", "secondary", "both"],
+      "enum": [
+        "primary",
+        "secondary",
+        "both"
+      ],
       "title": "InstrumentSensorId",
       "type": "string"
     },
     "LabwareMovementStrategy": {
       "description": "Strategy to use for labware movement.",
-      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
+      "enum": [
+        "usingGripper",
+        "manualMoveWithPause",
+        "manualMoveWithoutPause"
+      ],
       "title": "LabwareMovementStrategy",
       "type": "string"
     },
@@ -2934,7 +3183,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"],
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
       "title": "LabwareOffsetVector",
       "type": "object"
     },
@@ -3024,7 +3277,11 @@
           "title": "Zoffset"
         }
       },
-      "required": ["zOffset", "mmFromEdge", "speed"],
+      "required": [
+        "zOffset",
+        "mmFromEdge",
+        "speed"
+      ],
       "title": "LiquidClassTouchTipParams",
       "type": "object"
     },
@@ -3087,7 +3344,9 @@
           "$ref": "#/$defs/LiquidProbeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LiquidProbeCreate",
       "type": "object"
     },
@@ -3114,7 +3373,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ],
       "title": "LiquidProbeParams",
       "type": "object"
     },
@@ -3149,7 +3412,9 @@
           "$ref": "#/$defs/LoadLabwareParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LoadLabwareCreate",
       "type": "object"
     },
@@ -3212,7 +3477,12 @@
           "type": "integer"
         }
       },
-      "required": ["location", "loadName", "namespace", "version"],
+      "required": [
+        "location",
+        "loadName",
+        "namespace",
+        "version"
+      ],
       "title": "LoadLabwareParams",
       "type": "object"
     },
@@ -3247,7 +3517,9 @@
           "$ref": "#/$defs/LoadLidParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LoadLidCreate",
       "type": "object"
     },
@@ -3300,7 +3572,12 @@
           "type": "integer"
         }
       },
-      "required": ["location", "loadName", "namespace", "version"],
+      "required": [
+        "location",
+        "loadName",
+        "namespace",
+        "version"
+      ],
       "title": "LoadLidParams",
       "type": "object"
     },
@@ -3335,7 +3612,9 @@
           "$ref": "#/$defs/LoadLidStackParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LoadLidStackCreate",
       "type": "object"
     },
@@ -3406,7 +3685,13 @@
           "type": "integer"
         }
       },
-      "required": ["location", "loadName", "namespace", "version", "quantity"],
+      "required": [
+        "location",
+        "loadName",
+        "namespace",
+        "version",
+        "quantity"
+      ],
       "title": "LoadLidStackParams",
       "type": "object"
     },
@@ -3441,7 +3726,9 @@
           "$ref": "#/$defs/LoadLiquidClassParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LoadLiquidClassCreate",
       "type": "object"
     },
@@ -3458,7 +3745,9 @@
           "description": "The liquid class to store."
         }
       },
-      "required": ["liquidClassRecord"],
+      "required": [
+        "liquidClassRecord"
+      ],
       "title": "LoadLiquidClassParams",
       "type": "object"
     },
@@ -3493,7 +3782,9 @@
           "$ref": "#/$defs/LoadLiquidParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LoadLiquidCreate",
       "type": "object"
     },
@@ -3527,7 +3818,11 @@
           "type": "object"
         }
       },
-      "required": ["liquidId", "labwareId", "volumeByWell"],
+      "required": [
+        "liquidId",
+        "labwareId",
+        "volumeByWell"
+      ],
       "title": "LoadLiquidParams",
       "type": "object"
     },
@@ -3562,7 +3857,9 @@
           "$ref": "#/$defs/LoadModuleParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LoadModuleCreate",
       "type": "object"
     },
@@ -3583,7 +3880,10 @@
           "type": "string"
         }
       },
-      "required": ["model", "location"],
+      "required": [
+        "model",
+        "location"
+      ],
       "title": "LoadModuleParams",
       "type": "object"
     },
@@ -3618,7 +3918,9 @@
           "$ref": "#/$defs/LoadPipetteParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LoadPipetteCreate",
       "type": "object"
     },
@@ -3649,13 +3951,19 @@
           "type": "string"
         }
       },
-      "required": ["pipetteName", "mount"],
+      "required": [
+        "pipetteName",
+        "mount"
+      ],
       "title": "LoadPipetteParams",
       "type": "object"
     },
     "MaintenancePosition": {
       "description": "Maintenance position options.",
-      "enum": ["attachPlate", "attachInstrument"],
+      "enum": [
+        "attachPlate",
+        "attachInstrument"
+      ],
       "title": "MaintenancePosition",
       "type": "string"
     },
@@ -3684,7 +3992,10 @@
           "title": "Volume"
         }
       },
-      "required": ["repetitions", "volume"],
+      "required": [
+        "repetitions",
+        "volume"
+      ],
       "title": "MixParams",
       "type": "object"
     },
@@ -3703,7 +4014,9 @@
           "title": "Params"
         }
       },
-      "required": ["enable"],
+      "required": [
+        "enable"
+      ],
       "title": "MixProperties",
       "type": "object"
     },
@@ -3716,7 +4029,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "ModuleLocation",
       "type": "object"
     },
@@ -3755,7 +4070,11 @@
       "type": "string"
     },
     "MountType": {
-      "enum": ["left", "right", "extension"],
+      "enum": [
+        "left",
+        "right",
+        "extension"
+      ],
       "title": "MountType",
       "type": "string"
     },
@@ -3790,7 +4109,9 @@
           "$ref": "#/$defs/MoveAxesRelativeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveAxesRelativeCreate",
       "type": "object"
     },
@@ -3814,7 +4135,9 @@
           "type": "number"
         }
       },
-      "required": ["axis_map"],
+      "required": [
+        "axis_map"
+      ],
       "title": "MoveAxesRelativeParams",
       "type": "object"
     },
@@ -3849,7 +4172,9 @@
           "$ref": "#/$defs/MoveAxesToParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveAxesToCreate",
       "type": "object"
     },
@@ -3884,7 +4209,9 @@
           "type": "number"
         }
       },
-      "required": ["axis_map"],
+      "required": [
+        "axis_map"
+      ],
       "title": "MoveAxesToParams",
       "type": "object"
     },
@@ -3919,7 +4246,9 @@
           "$ref": "#/$defs/MoveLabwareParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveLabwareCreate",
       "type": "object"
     },
@@ -3976,7 +4305,11 @@
           "description": "Whether to use the gripper to perform the labware movement or to perform a manual movement with an option to pause."
         }
       },
-      "required": ["labwareId", "newLocation", "strategy"],
+      "required": [
+        "labwareId",
+        "newLocation",
+        "strategy"
+      ],
       "title": "MoveLabwareParams",
       "type": "object"
     },
@@ -4011,7 +4344,9 @@
           "$ref": "#/$defs/MoveRelativeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveRelativeCreate",
       "type": "object"
     },
@@ -4033,7 +4368,11 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "axis", "distance"],
+      "required": [
+        "pipetteId",
+        "axis",
+        "distance"
+      ],
       "title": "MoveRelativeParams",
       "type": "object"
     },
@@ -4068,7 +4407,9 @@
           "$ref": "#/$defs/MoveToAddressableAreaParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveToAddressableAreaCreate",
       "type": "object"
     },
@@ -4103,7 +4444,9 @@
           "$ref": "#/$defs/MoveToAddressableAreaForDropTipParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveToAddressableAreaForDropTipCreate",
       "type": "object"
     },
@@ -4156,7 +4499,10 @@
           "type": "number"
         }
       },
-      "required": ["pipetteId", "addressableAreaName"],
+      "required": [
+        "pipetteId",
+        "addressableAreaName"
+      ],
       "title": "MoveToAddressableAreaForDropTipParams",
       "type": "object"
     },
@@ -4205,7 +4551,10 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId", "addressableAreaName"],
+      "required": [
+        "pipetteId",
+        "addressableAreaName"
+      ],
       "title": "MoveToAddressableAreaParams",
       "type": "object"
     },
@@ -4240,7 +4589,9 @@
           "$ref": "#/$defs/MoveToCoordinatesParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveToCoordinatesCreate",
       "type": "object"
     },
@@ -4273,7 +4624,10 @@
           "type": "number"
         }
       },
-      "required": ["pipetteId", "coordinates"],
+      "required": [
+        "pipetteId",
+        "coordinates"
+      ],
       "title": "MoveToCoordinatesParams",
       "type": "object"
     },
@@ -4308,7 +4662,9 @@
           "$ref": "#/$defs/MoveToParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveToCreate",
       "type": "object"
     },
@@ -4343,7 +4699,9 @@
           "$ref": "#/$defs/MoveToMaintenancePositionParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveToMaintenancePositionCreate",
       "type": "object"
     },
@@ -4360,7 +4718,9 @@
           "description": "Gantry mount to move maintenance position."
         }
       },
-      "required": ["mount"],
+      "required": [
+        "mount"
+      ],
       "title": "MoveToMaintenancePositionParams",
       "type": "object"
     },
@@ -4381,7 +4741,10 @@
           "type": "number"
         }
       },
-      "required": ["mount", "destination"],
+      "required": [
+        "mount",
+        "destination"
+      ],
       "title": "MoveToParams",
       "type": "object"
     },
@@ -4416,7 +4779,9 @@
           "$ref": "#/$defs/MoveToWellParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveToWellCreate",
       "type": "object"
     },
@@ -4459,13 +4824,21 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ],
       "title": "MoveToWellParams",
       "type": "object"
     },
     "MovementAxis": {
       "description": "Axis on which to issue a relative movement.",
-      "enum": ["x", "y", "z"],
+      "enum": [
+        "x",
+        "y",
+        "z"
+      ],
       "title": "MovementAxis",
       "type": "string"
     },
@@ -4654,7 +5027,9 @@
           "type": "string"
         }
       },
-      "required": ["labwareId"],
+      "required": [
+        "labwareId"
+      ],
       "title": "OnLabwareLocation",
       "type": "object"
     },
@@ -4689,7 +5064,9 @@
           "$ref": "#/$defs/OpenGripperJawParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "OpenGripperJawCreate",
       "type": "object"
     },
@@ -4730,7 +5107,9 @@
           "$ref": "#/$defs/OpenLabwareLatchParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "OpenLabwareLatchCreate",
       "type": "object"
     },
@@ -4743,7 +5122,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "OpenLabwareLatchParams",
       "type": "object"
     },
@@ -4778,7 +5159,9 @@
           "$ref": "#/$defs/OpenVentParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "OpenVentCreate",
       "type": "object"
     },
@@ -4791,7 +5174,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "OpenVentParams",
       "type": "object"
     },
@@ -4826,7 +5211,9 @@
           "$ref": "#/$defs/PickUpTipParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "PickUpTipCreate",
       "type": "object"
     },
@@ -4853,7 +5240,11 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "labwareId", "wellName"],
+      "required": [
+        "pipetteId",
+        "labwareId",
+        "wellName"
+      ],
       "title": "PickUpTipParams",
       "type": "object"
     },
@@ -4873,7 +5264,11 @@
     },
     "PickUpTipWellOrigin": {
       "description": "The origin of a PickUpTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": ["top", "bottom", "center"],
+      "enum": [
+        "top",
+        "bottom",
+        "center"
+      ],
       "title": "PickUpTipWellOrigin",
       "type": "string"
     },
@@ -4905,7 +5300,12 @@
     },
     "PositionReference": {
       "description": "Positional reference for liquid handling operations.",
-      "enum": ["well-bottom", "well-top", "well-center", "liquid-meniscus"],
+      "enum": [
+        "well-bottom",
+        "well-top",
+        "well-center",
+        "liquid-meniscus"
+      ],
       "title": "PositionReference",
       "type": "string"
     },
@@ -4940,7 +5340,9 @@
           "$ref": "#/$defs/PrepareToAspirateParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "PrepareToAspirateCreate",
       "type": "object"
     },
@@ -4953,7 +5355,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"],
+      "required": [
+        "pipetteId"
+      ],
       "title": "PrepareToAspirateParams",
       "type": "object"
     },
@@ -4988,7 +5392,9 @@
           "$ref": "#/$defs/PressureDispenseParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "PressureDispenseCreate",
       "type": "object"
     },
@@ -5040,7 +5446,13 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "PressureDispenseParams",
       "type": "object"
     },
@@ -5061,7 +5473,10 @@
           "type": "array"
         }
       },
-      "required": ["steps", "repetitions"],
+      "required": [
+        "steps",
+        "repetitions"
+      ],
       "title": "ProfileCycle",
       "type": "object"
     },
@@ -5084,7 +5499,10 @@
           "type": "number"
         }
       },
-      "required": ["celsius", "holdSeconds"],
+      "required": [
+        "celsius",
+        "holdSeconds"
+      ],
       "title": "ProfileStep",
       "type": "object"
     },
@@ -5105,7 +5523,12 @@
         },
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -5116,7 +5539,11 @@
           "type": "string"
         }
       },
-      "required": ["primaryNozzle", "frontRightNozzle", "backLeftNozzle"],
+      "required": [
+        "primaryNozzle",
+        "frontRightNozzle",
+        "backLeftNozzle"
+      ],
       "title": "QuadrantNozzleLayoutConfiguration",
       "type": "object"
     },
@@ -5151,7 +5578,9 @@
           "$ref": "#/$defs/ReadAbsorbanceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "ReadAbsorbanceCreate",
       "type": "object"
     },
@@ -5169,7 +5598,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "ReadAbsorbanceParams",
       "type": "object"
     },
@@ -5204,7 +5635,9 @@
           "$ref": "#/$defs/ReloadLabwareParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "ReloadLabwareCreate",
       "type": "object"
     },
@@ -5217,7 +5650,9 @@
           "type": "string"
         }
       },
-      "required": ["labwareId"],
+      "required": [
+        "labwareId"
+      ],
       "title": "ReloadLabwareParams",
       "type": "object"
     },
@@ -5329,7 +5764,9 @@
           "$ref": "#/$defs/RetractAxisParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "RetractAxisCreate",
       "type": "object"
     },
@@ -5341,7 +5778,9 @@
           "description": "Axis to retract to its home position as quickly as safely possible. The difference between retracting an axis and homing an axis using the home command is that a home will always probe the limit switch and will work as the first motion command a robot will need to execute; On the other hand, retraction will rely on this previously determined  home position to move to it as fast as safely possible. So on the Flex, it will move (fast) the axis to the previously recorded home position and on the OT2, it will move (fast) the axis a safe distance from the previously recorded home position, and then slowly approach the limit switch."
         }
       },
-      "required": ["axis"],
+      "required": [
+        "axis"
+      ],
       "title": "RetractAxisParams",
       "type": "object"
     },
@@ -5458,7 +5897,9 @@
           "$ref": "#/$defs/RetrieveParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "RetrieveCreate",
       "type": "object"
     },
@@ -5491,7 +5932,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "RetrieveParams",
       "type": "object"
     },
@@ -5500,7 +5943,12 @@
       "properties": {
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -5511,7 +5959,9 @@
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"],
+      "required": [
+        "primaryNozzle"
+      ],
       "title": "RowNozzleLayoutConfiguration",
       "type": "object"
     },
@@ -5546,7 +5996,9 @@
           "$ref": "#/$defs/RunExtendedProfileParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "RunExtendedProfileCreate",
       "type": "object"
     },
@@ -5579,7 +6031,10 @@
           "type": "array"
         }
       },
-      "required": ["moduleId", "profileElements"],
+      "required": [
+        "moduleId",
+        "profileElements"
+      ],
       "title": "RunExtendedProfileParams",
       "type": "object"
     },
@@ -5614,7 +6069,9 @@
           "$ref": "#/$defs/RunProfileParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "RunProfileCreate",
       "type": "object"
     },
@@ -5640,7 +6097,10 @@
           "type": "array"
         }
       },
-      "required": ["moduleId", "profile"],
+      "required": [
+        "moduleId",
+        "profile"
+      ],
       "title": "RunProfileParams",
       "type": "object"
     },
@@ -5663,7 +6123,10 @@
           "type": "number"
         }
       },
-      "required": ["celsius", "holdSeconds"],
+      "required": [
+        "celsius",
+        "holdSeconds"
+      ],
       "title": "RunProfileStepParams",
       "type": "object"
     },
@@ -5698,7 +6161,9 @@
           "$ref": "#/$defs/SavePositionParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SavePositionCreate",
       "type": "object"
     },
@@ -5721,7 +6186,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"],
+      "required": [
+        "pipetteId"
+      ],
       "title": "SavePositionParams",
       "type": "object"
     },
@@ -5756,7 +6223,9 @@
           "$ref": "#/$defs/SealPipetteToTipParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SealPipetteToTipCreate",
       "type": "object"
     },
@@ -5795,7 +6264,11 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "labwareId", "wellName"],
+      "required": [
+        "pipetteId",
+        "labwareId",
+        "wellName"
+      ],
       "title": "SealPipetteToTipParams",
       "type": "object"
     },
@@ -5830,7 +6303,9 @@
           "$ref": "#/$defs/SetAndWaitForShakeSpeedParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetAndWaitForShakeSpeedCreate",
       "type": "object"
     },
@@ -5848,7 +6323,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "rpm"],
+      "required": [
+        "moduleId",
+        "rpm"
+      ],
       "title": "SetAndWaitForShakeSpeedParams",
       "type": "object"
     },
@@ -5883,7 +6361,9 @@
           "$ref": "#/$defs/SetRailLightsParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetRailLightsCreate",
       "type": "object"
     },
@@ -5896,7 +6376,9 @@
           "type": "boolean"
         }
       },
-      "required": ["on"],
+      "required": [
+        "on"
+      ],
       "title": "SetRailLightsParams",
       "type": "object"
     },
@@ -5931,7 +6413,9 @@
           "$ref": "#/$defs/SetShakeSpeedParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetShakeSpeedCreate",
       "type": "object"
     },
@@ -5962,7 +6446,10 @@
           "title": "Taskid"
         }
       },
-      "required": ["moduleId", "rpm"],
+      "required": [
+        "moduleId",
+        "rpm"
+      ],
       "title": "SetShakeSpeedParams",
       "type": "object"
     },
@@ -5997,7 +6484,9 @@
           "$ref": "#/$defs/SetStatusBarParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetStatusBarCreate",
       "type": "object"
     },
@@ -6009,7 +6498,9 @@
           "description": "The animation that should be executed on the status bar."
         }
       },
-      "required": ["animation"],
+      "required": [
+        "animation"
+      ],
       "title": "SetStatusBarParams",
       "type": "object"
     },
@@ -6044,7 +6535,9 @@
           "$ref": "#/$defs/SetStoredLabwareParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetStoredLabwareCreate",
       "type": "object"
     },
@@ -6116,7 +6609,10 @@
           "description": "The details of the primary labware (i.e. not the lid or adapter, if any) stored in the stacker."
         }
       },
-      "required": ["moduleId", "primaryLabware"],
+      "required": [
+        "moduleId",
+        "primaryLabware"
+      ],
       "title": "SetStoredLabwareParams",
       "type": "object"
     },
@@ -6151,7 +6647,9 @@
           "$ref": "#/$defs/SetTargetBlockTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetTargetBlockTemperatureCreate",
       "type": "object"
     },
@@ -6189,7 +6687,10 @@
           "type": "string"
         }
       },
-      "required": ["moduleId", "celsius"],
+      "required": [
+        "moduleId",
+        "celsius"
+      ],
       "title": "SetTargetBlockTemperatureParams",
       "type": "object"
     },
@@ -6224,7 +6725,9 @@
           "$ref": "#/$defs/SetTargetLidTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetTargetLidTemperatureCreate",
       "type": "object"
     },
@@ -6247,7 +6750,10 @@
           "type": "string"
         }
       },
-      "required": ["moduleId", "celsius"],
+      "required": [
+        "moduleId",
+        "celsius"
+      ],
       "title": "SetTargetLidTemperatureParams",
       "type": "object"
     },
@@ -6282,7 +6788,9 @@
           "$ref": "#/$defs/SetTipStateParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetTipStateCreate",
       "type": "object"
     },
@@ -6307,7 +6815,11 @@
           "type": "array"
         }
       },
-      "required": ["labwareId", "wellNames", "tipWellState"],
+      "required": [
+        "labwareId",
+        "wellNames",
+        "tipWellState"
+      ],
       "title": "SetTipStateParams",
       "type": "object"
     },
@@ -6460,7 +6972,12 @@
       "properties": {
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -6471,19 +6988,27 @@
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"],
+      "required": [
+        "primaryNozzle"
+      ],
       "title": "SingleNozzleLayoutConfiguration",
       "type": "object"
     },
     "StackerFillEmptyStrategy": {
       "description": "Strategy to use for filling or emptying a stacker.",
-      "enum": ["manualWithPause", "logical"],
+      "enum": [
+        "manualWithPause",
+        "logical"
+      ],
       "title": "StackerFillEmptyStrategy",
       "type": "string"
     },
     "StackerLabwareMovementStrategy": {
       "description": "Strategy to retrieve or store labware.",
-      "enum": ["automatic", "manual"],
+      "enum": [
+        "automatic",
+        "manual"
+      ],
       "title": "StackerLabwareMovementStrategy",
       "type": "string"
     },
@@ -6506,7 +7031,11 @@
           "type": "integer"
         }
       },
-      "required": ["loadName", "namespace", "version"],
+      "required": [
+        "loadName",
+        "namespace",
+        "version"
+      ],
       "title": "StackerStoredLabwareDetails",
       "type": "object"
     },
@@ -6528,7 +7057,9 @@
           "type": "string"
         }
       },
-      "required": ["primaryLabwareId"],
+      "required": [
+        "primaryLabwareId"
+      ],
       "title": "StackerStoredLabwareGroup",
       "type": "object"
     },
@@ -6563,7 +7094,9 @@
           "$ref": "#/$defs/StartRunExtendedProfileParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "StartRunExtendedProfileCreate",
       "type": "object"
     },
@@ -6609,7 +7142,10 @@
           "title": "Taskid"
         }
       },
-      "required": ["moduleId", "profileElements"],
+      "required": [
+        "moduleId",
+        "profileElements"
+      ],
       "title": "StartRunExtendedProfileParams",
       "type": "object"
     },
@@ -6644,7 +7180,9 @@
           "$ref": "#/$defs/StartRunProfileParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "StartRunProfileCreate",
       "type": "object"
     },
@@ -6688,7 +7226,10 @@
           "title": "Taskid"
         }
       },
-      "required": ["moduleId", "profile"],
+      "required": [
+        "moduleId",
+        "profile"
+      ],
       "title": "StartRunProfileParams",
       "type": "object"
     },
@@ -6723,7 +7264,9 @@
           "$ref": "#/$defs/StartSetVacuumPowerParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "StartSetVacuumPowerCreate",
       "type": "object"
     },
@@ -6765,7 +7308,10 @@
           "type": "boolean"
         }
       },
-      "required": ["moduleId", "percentPower"],
+      "required": [
+        "moduleId",
+        "percentPower"
+      ],
       "title": "StartSetVacuumPowerParams",
       "type": "object"
     },
@@ -6800,7 +7346,9 @@
           "$ref": "#/$defs/StartSetVacuumPressureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "StartSetVacuumPressureCreate",
       "type": "object"
     },
@@ -6842,13 +7390,22 @@
           "type": "boolean"
         }
       },
-      "required": ["moduleId", "gaugePressure"],
+      "required": [
+        "moduleId",
+        "gaugePressure"
+      ],
       "title": "StartSetVacuumPressureParams",
       "type": "object"
     },
     "StatusBarAnimation": {
       "description": "Status Bar animation options.",
-      "enum": ["idle", "confirm", "updating", "disco", "off"],
+      "enum": [
+        "idle",
+        "confirm",
+        "updating",
+        "disco",
+        "off"
+      ],
       "title": "StatusBarAnimation",
       "type": "string"
     },
@@ -6883,7 +7440,9 @@
           "$ref": "#/$defs/StopVacuumParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "StopVacuumCreate",
       "type": "object"
     },
@@ -6896,7 +7455,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "StopVacuumParams",
       "type": "object"
     },
@@ -6931,7 +7492,9 @@
           "$ref": "#/$defs/StoreParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "StoreCreate",
       "type": "object"
     },
@@ -6948,7 +7511,10 @@
           "description": "If manual, indicates that labware has been moved to the hopper manually by the user, as required in error recovery."
         }
       },
-      "required": ["moduleId", "strategy"],
+      "required": [
+        "moduleId",
+        "strategy"
+      ],
       "title": "StoreParams",
       "type": "object"
     },
@@ -6979,7 +7545,11 @@
           "description": "Tip position before starting the submerge."
         }
       },
-      "required": ["startPosition", "speed", "delay"],
+      "required": [
+        "startPosition",
+        "speed",
+        "delay"
+      ],
       "title": "Submerge",
       "type": "object"
     },
@@ -7021,19 +7591,30 @@
           "description": "Position reference for tip position."
         }
       },
-      "required": ["positionReference", "offset"],
+      "required": [
+        "positionReference",
+        "offset"
+      ],
       "title": "TipPosition",
       "type": "object"
     },
     "TipPresenceStatus": {
       "description": "Tip presence status reported by a pipette.",
-      "enum": ["present", "absent", "unknown"],
+      "enum": [
+        "present",
+        "absent",
+        "unknown"
+      ],
       "title": "TipPresenceStatus",
       "type": "string"
     },
     "TipRackWellState": {
       "description": "The state of a single tip in a tip rack's well.",
-      "enum": ["clean", "used", "empty"],
+      "enum": [
+        "clean",
+        "used",
+        "empty"
+      ],
       "title": "TipRackWellState",
       "type": "string"
     },
@@ -7068,7 +7649,9 @@
           "$ref": "#/$defs/TouchTipParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "TouchTipCreate",
       "type": "object"
     },
@@ -7111,7 +7694,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ],
       "title": "TouchTipParams",
       "type": "object"
     },
@@ -7130,7 +7717,9 @@
           "title": "Params"
         }
       },
-      "required": ["enable"],
+      "required": [
+        "enable"
+      ],
       "title": "TouchTipProperties",
       "type": "object"
     },
@@ -7165,7 +7754,9 @@
           "$ref": "#/$defs/TryLiquidProbeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "TryLiquidProbeCreate",
       "type": "object"
     },
@@ -7192,7 +7783,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ],
       "title": "TryLiquidProbeParams",
       "type": "object"
     },
@@ -7227,7 +7822,9 @@
           "$ref": "#/$defs/UnsafeBlowOutInPlaceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeBlowOutInPlaceCreate",
       "type": "object"
     },
@@ -7246,7 +7843,10 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "pipetteId"],
+      "required": [
+        "flowRate",
+        "pipetteId"
+      ],
       "title": "UnsafeBlowOutInPlaceParams",
       "type": "object"
     },
@@ -7281,7 +7881,9 @@
           "$ref": "#/$defs/UnsafeDropTipInPlaceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeDropTipInPlaceCreate",
       "type": "object"
     },
@@ -7299,7 +7901,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"],
+      "required": [
+        "pipetteId"
+      ],
       "title": "UnsafeDropTipInPlaceParams",
       "type": "object"
     },
@@ -7334,7 +7938,9 @@
           "$ref": "#/$defs/UnsafeEngageAxesParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeEngageAxesCreate",
       "type": "object"
     },
@@ -7350,7 +7956,9 @@
           "type": "array"
         }
       },
-      "required": ["axes"],
+      "required": [
+        "axes"
+      ],
       "title": "UnsafeEngageAxesParams",
       "type": "object"
     },
@@ -7385,7 +7993,9 @@
           "$ref": "#/$defs/UnsafeFlexStackerCloseLatchParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeFlexStackerCloseLatchCreate",
       "type": "object"
     },
@@ -7398,7 +8008,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "UnsafeFlexStackerCloseLatchParams",
       "type": "object"
     },
@@ -7433,7 +8045,9 @@
           "$ref": "#/$defs/UnsafeFlexStackerManualRetrieveParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeFlexStackerManualRetrieveCreate",
       "type": "object"
     },
@@ -7466,7 +8080,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "UnsafeFlexStackerManualRetrieveParams",
       "type": "object"
     },
@@ -7501,7 +8117,9 @@
           "$ref": "#/$defs/UnsafeFlexStackerOpenLatchParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeFlexStackerOpenLatchCreate",
       "type": "object"
     },
@@ -7514,7 +8132,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "UnsafeFlexStackerOpenLatchParams",
       "type": "object"
     },
@@ -7549,7 +8169,9 @@
           "$ref": "#/$defs/UnsafeFlexStackerPrepareShuttleParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeFlexStackerPrepareShuttleCreate",
       "type": "object"
     },
@@ -7568,7 +8190,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "UnsafeFlexStackerPrepareShuttleParams",
       "type": "object"
     },
@@ -7603,7 +8227,9 @@
           "$ref": "#/$defs/UnsafePlaceLabwareParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafePlaceLabwareCreate",
       "type": "object"
     },
@@ -7634,7 +8260,10 @@
           "title": "Location"
         }
       },
-      "required": ["labwareURI", "location"],
+      "required": [
+        "labwareURI",
+        "location"
+      ],
       "title": "UnsafePlaceLabwareParams",
       "type": "object"
     },
@@ -7669,7 +8298,9 @@
           "$ref": "#/$defs/UnsafeUngripLabwareParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeUngripLabwareCreate",
       "type": "object"
     },
@@ -7710,7 +8341,9 @@
           "$ref": "#/$defs/UnsealPipetteFromTipParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsealPipetteFromTipCreate",
       "type": "object"
     },
@@ -7737,7 +8370,11 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "labwareId", "wellName"],
+      "required": [
+        "pipetteId",
+        "labwareId",
+        "wellName"
+      ],
       "title": "UnsealPipetteFromTipParams",
       "type": "object"
     },
@@ -7772,7 +8409,9 @@
           "$ref": "#/$defs/UpdatePositionEstimatorsParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UpdatePositionEstimatorsCreate",
       "type": "object"
     },
@@ -7788,7 +8427,9 @@
           "type": "array"
         }
       },
-      "required": ["axes"],
+      "required": [
+        "axes"
+      ],
       "title": "UpdatePositionEstimatorsParams",
       "type": "object"
     },
@@ -7812,9 +8453,17 @@
           },
           "title": "Steps",
           "type": "array"
+        },
+        "ventAfter": {
+          "default": null,
+          "title": "Ventafter",
+          "type": "boolean"
         }
       },
-      "required": ["steps", "repetitions"],
+      "required": [
+        "steps",
+        "repetitions"
+      ],
       "title": "VacuumModuleProfileCycle",
       "type": "object"
     },
@@ -7856,7 +8505,9 @@
           "type": "boolean"
         }
       },
-      "required": ["enablePump"],
+      "required": [
+        "enablePump"
+      ],
       "title": "VacuumModuleProfilePowerStep",
       "type": "object"
     },
@@ -7898,7 +8549,9 @@
           "type": "boolean"
         }
       },
-      "required": ["enablePump"],
+      "required": [
+        "enablePump"
+      ],
       "title": "VacuumModuleProfilePressureStep",
       "type": "object"
     },
@@ -7918,7 +8571,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"],
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
       "title": "Vec3f",
       "type": "object"
     },
@@ -7953,7 +8610,9 @@
           "$ref": "#/$defs/VerifyTipPresenceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "VerifyTipPresenceCreate",
       "type": "object"
     },
@@ -7975,7 +8634,10 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "expectedState"],
+      "required": [
+        "pipetteId",
+        "expectedState"
+      ],
       "title": "VerifyTipPresenceParams",
       "type": "object"
     },
@@ -8010,7 +8672,9 @@
           "$ref": "#/$defs/WaitForBlockTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "WaitForBlockTemperatureCreate",
       "type": "object"
     },
@@ -8023,7 +8687,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "WaitForBlockTemperatureParams",
       "type": "object"
     },
@@ -8058,7 +8724,9 @@
           "$ref": "#/$defs/WaitForDurationParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "WaitForDurationCreate",
       "type": "object"
     },
@@ -8076,7 +8744,9 @@
           "type": "number"
         }
       },
-      "required": ["seconds"],
+      "required": [
+        "seconds"
+      ],
       "title": "WaitForDurationParams",
       "type": "object"
     },
@@ -8111,7 +8781,9 @@
           "$ref": "#/$defs/WaitForLidTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "WaitForLidTemperatureCreate",
       "type": "object"
     },
@@ -8124,7 +8796,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "WaitForLidTemperatureParams",
       "type": "object"
     },
@@ -8141,7 +8815,10 @@
         },
         "commandType": {
           "default": "waitForResume",
-          "enum": ["waitForResume", "pause"],
+          "enum": [
+            "waitForResume",
+            "pause"
+          ],
           "title": "Commandtype",
           "type": "string"
         },
@@ -8159,7 +8836,9 @@
           "$ref": "#/$defs/WaitForResumeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "WaitForResumeCreate",
       "type": "object"
     },
@@ -8206,7 +8885,9 @@
           "$ref": "#/$defs/WaitForTasksParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "WaitForTasksCreate",
       "type": "object"
     },
@@ -8222,7 +8903,9 @@
           "type": "array"
         }
       },
-      "required": ["task_ids"],
+      "required": [
+        "task_ids"
+      ],
       "title": "WaitForTasksParams",
       "type": "object"
     },
@@ -8270,7 +8953,12 @@
     },
     "WellOrigin": {
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    MENISCUS: the meniscus-center of the well",
-      "enum": ["top", "bottom", "center", "meniscus"],
+      "enum": [
+        "top",
+        "bottom",
+        "center",
+        "meniscus"
+      ],
       "title": "WellOrigin",
       "type": "string"
     },
@@ -8305,7 +8993,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CloseLidCreate",
       "type": "object"
     },
@@ -8318,7 +9008,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "CloseLidParams",
       "type": "object"
     },
@@ -8353,7 +9045,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "OpenLidCreate",
       "type": "object"
     },
@@ -8366,7 +9060,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "OpenLidParams",
       "type": "object"
     },
@@ -8401,7 +9097,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetTargetTemperatureCreate",
       "type": "object"
     },
@@ -8424,7 +9122,10 @@
           "type": "string"
         }
       },
-      "required": ["moduleId", "celsius"],
+      "required": [
+        "moduleId",
+        "celsius"
+      ],
       "title": "SetTargetTemperatureParams",
       "type": "object"
     },
@@ -8459,7 +9160,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "WaitForTemperatureCreate",
       "type": "object"
     },
@@ -8477,7 +9180,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "WaitForTemperatureParams",
       "type": "object"
     },
@@ -8512,7 +9217,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetTargetTemperatureCreate",
       "type": "object"
     },
@@ -8535,7 +9242,10 @@
           "type": "string"
         }
       },
-      "required": ["moduleId", "celsius"],
+      "required": [
+        "moduleId",
+        "celsius"
+      ],
       "title": "SetTargetTemperatureParams",
       "type": "object"
     },
@@ -8570,7 +9280,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "WaitForTemperatureCreate",
       "type": "object"
     },
@@ -8588,7 +9300,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "WaitForTemperatureParams",
       "type": "object"
     },
@@ -8623,7 +9337,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CloseLidCreate",
       "type": "object"
     },
@@ -8636,7 +9352,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "CloseLidParams",
       "type": "object"
     },
@@ -8671,7 +9389,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "OpenLidCreate",
       "type": "object"
     },
@@ -8684,7 +9404,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "OpenLidParams",
       "type": "object"
     }


### PR DESCRIPTION
## Overview
In order to allow pd to issue vacuum module commands more cleanly, let’s add the option to `vent_after` at the end of a profile cycle as well as a profile step.

The plan is for the papi `run_profile` command to take in a `vent_after` param to vent one final time at the end of an entire profile, so this will be enabled as well without any further protocol engine changes. 