### PR TITLE
fix(app): fix name robot input error handling and mixing input issue

### DIFF
--- a/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 import Keyboard from 'react-simple-keyboard'
 
@@ -21,15 +21,23 @@ import './index.css'
 interface AlphanumericKeyboardProps {
   onChange: (input: string) => void
   keyboardRef: MutableRefObject<KeyboardReactInterface | null>
+  value?: string
   debug?: boolean
 }
 
 export function AlphanumericKeyboard({
   onChange,
   keyboardRef,
+  value,
   debug = false, // If true, <ENTER> will input a \n
 }: AlphanumericKeyboardProps): JSX.Element {
   const [layoutName, setLayoutName] = useState<LayoutName>('default')
+
+  useEffect(() => {
+    if (value !== undefined && keyboardRef.current != null) {
+      keyboardRef.current.setInput(value)
+    }
+  }, [value, keyboardRef])
   const appLanguage = useSelector(getAppLanguage)
 
   const onKeyPress = (button: string): void => {

--- a/app/src/pages/ODD/NameRobot/index.tsx
+++ b/app/src/pages/ODD/NameRobot/index.tsx
@@ -177,9 +177,7 @@ export function NameRobot(): JSX.Element {
   }
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>): void => {
-    const value = e.target.value as string
-    setNewName(value)
-    keyboardRef.current?.setInput(value)
+    setNewName(e.target.value as string)
     void trigger('newRobotName')
   }
 
@@ -328,6 +326,7 @@ export function NameRobot(): JSX.Element {
                     handleKeyboardChange(input)
                   }}
                   keyboardRef={keyboardRef}
+                  value={newRobotName}
                 />
               )}
             />

--- a/app/src/pages/ODD/NameRobot/index.tsx
+++ b/app/src/pages/ODD/NameRobot/index.tsx
@@ -39,9 +39,13 @@ import {
   removeRobot,
 } from '/app/redux/discovery'
 
+import type { ChangeEvent } from 'react'
 import type { FieldError, Resolver } from 'react-hook-form'
+import type { KeyboardReactInterface } from 'react-simple-keyboard'
 import type { UpdatedRobotName } from '@opentrons/api-client'
 import type { Dispatch, State } from '/app/redux/types'
+
+const MAX_LENGTH = 17
 
 interface FormValues {
   newRobotName: string
@@ -57,7 +61,7 @@ export function NameRobot(): JSX.Element {
   const [newName, setNewName] = useState<string>('')
   const [isShowConfirmRobotName, setIsShowConfirmRobotName] =
     useState<boolean>(false)
-  const keyboardRef = useRef(null)
+  const keyboardRef = useRef<KeyboardReactInterface | null>(null)
   const dispatch = useDispatch<Dispatch>()
   const isUnboxingFlowOngoing = useIsUnboxingFlowOngoing()
 
@@ -79,7 +83,7 @@ export function NameRobot(): JSX.Element {
     let errorMessage: string | undefined
     // In ODD users cannot input letters and numbers from software keyboard
     // so the app only checks the length of input string
-    if (newName.length < 1) {
+    if (newName.length < 1 || newName.length > MAX_LENGTH) {
       errorMessage = t('name_rule_error_name_length')
     }
 
@@ -165,11 +169,23 @@ export function NameRobot(): JSX.Element {
       name: ANALYTICS_RENAME_ROBOT,
       properties: {
         previousRobotName: previousName,
-        newRobotName: newRobotName,
+        newRobotName,
         robotType: FLEX_ROBOT_TYPE,
       },
     })
-    handleSubmit(onSubmit)()
+    void handleSubmit(onSubmit)()
+  }
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    const value = e.target.value as string
+    setNewName(value)
+    keyboardRef.current?.setInput(value)
+    void trigger('newRobotName')
+  }
+
+  const handleKeyboardChange = (input: string): void => {
+    setNewName(input)
+    void trigger('newRobotName')
   }
 
   return (
@@ -277,7 +293,7 @@ export function NameRobot(): JSX.Element {
                     }}
                     onChange={e => {
                       field.onChange(e)
-                      setNewName(e.target.value as string)
+                      handleChange(e)
                     }}
                   />
                 )}
@@ -309,7 +325,7 @@ export function NameRobot(): JSX.Element {
                 <AlphanumericKeyboard
                   onChange={(input: string) => {
                     field.onChange(input)
-                    void trigger('newRobotName')
+                    handleKeyboardChange(input)
                   }}
                   keyboardRef={keyboardRef}
                 />


### PR DESCRIPTION


# Overview
fix name robot input error handling and mixing input issue

close RQA-5387

## Test Plan and Hands on Testing
- settings
- rename robot
- input 18 chars
check the error message shows up
- remove all and input 10 chars by software keyboard and 8 chars by an external keyboard
check the error message shows up

## Changelog
- update onChange

## Review requests


## Risk assessment
low
