### PR TITLE
fix(step-generation): forDropTip check to account for fixedTrash

### DIFF
--- a/step-generation/src/getNextRobotStateAndWarnings/forDropTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forDropTip.ts
@@ -30,7 +30,9 @@ export function forDropTip(
   const tiprackDef = invariantContext.labwareEntities[labwareId]?.def
   if (tiprackDef == null || !getIsTiprack(tiprackDef)) {
     //  early exit if the labware isn't a tiprack or dropping tip into the fixedTrash
-    return
+    console.warn(
+      `forDropTip expected ${labwareId} to have definition and to be a tiprack`
+    )
   } else {
     // TODO (nd 08/12/2025): handle tip (re)placement more elegantly depending on pipette specs and selected nozzles
     if (nozzleConfiguration === SINGLE) {

--- a/step-generation/src/getNextRobotStateAndWarnings/forDropTip.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forDropTip.ts
@@ -27,60 +27,59 @@ export function forDropTip(
     targetWellName: string
   ): string[] | undefined =>
     ordering.find(column => column.includes(targetWellName))
-  const tiprackDef = invariantContext.labwareEntities[labwareId].def
+  const tiprackDef = invariantContext.labwareEntities[labwareId]?.def
   if (tiprackDef == null || !getIsTiprack(tiprackDef)) {
-    throw new Error(
-      `forDropTip expected ${labwareId} to have definition and to be a tiprack`
-    )
-  }
-
-  // TODO (nd 08/12/2025): handle tip (re)placement more elegantly depending on pipette specs and selected nozzles
-  if (nozzleConfiguration === SINGLE) {
-    tipState.tipracks[labwareId][wellName] = DIRTY
-  } else if (nozzleConfiguration === COLUMN) {
-    const allWells =
-      getTiprackColumnForWell(tiprackDef.ordering, wellName) ?? []
-    allWells.forEach(
-      wellName => (tipState.tipracks[labwareId][wellName] = DIRTY)
-    )
-  } else if (nozzleConfiguration === ALL) {
-    if (pipetteSpec.channels === 96) {
-      const allTips: string[] = tiprackDef.ordering.reduce(
-        (acc, wells) => acc.concat(wells),
-        []
-      )
-      allTips.forEach(function (wellName) {
-        tipState.tipracks[labwareId][wellName] = DIRTY
-      })
-    } else {
-      const allWells =
-        getTiprackColumnForWell(tiprackDef.ordering, wellName) ?? []
-      allWells.forEach(
-        wellName => (tipState.tipracks[labwareId][wellName] = DIRTY)
-      )
-    }
+    //  early exit if the labware isn't a tiprack or dropping tip into the fixedTrash
+    return
   } else {
-    // Fallback for unexpected nozzle configurations.
-    if (pipetteSpec.channels === 1) {
+    // TODO (nd 08/12/2025): handle tip (re)placement more elegantly depending on pipette specs and selected nozzles
+    if (nozzleConfiguration === SINGLE) {
       tipState.tipracks[labwareId][wellName] = DIRTY
-    } else if (pipetteSpec.channels === 96) {
-      const allTips: string[] = tiprackDef.ordering.reduce(
-        (acc, wells) => acc.concat(wells),
-        []
-      )
-      allTips.forEach(function (wellName) {
-        tipState.tipracks[labwareId][wellName] = DIRTY
-      })
-    } else {
+    } else if (nozzleConfiguration === COLUMN) {
       const allWells =
         getTiprackColumnForWell(tiprackDef.ordering, wellName) ?? []
       allWells.forEach(
         wellName => (tipState.tipracks[labwareId][wellName] = DIRTY)
       )
+    } else if (nozzleConfiguration === ALL) {
+      if (pipetteSpec.channels === 96) {
+        const allTips: string[] = tiprackDef.ordering.reduce(
+          (acc, wells) => acc.concat(wells),
+          []
+        )
+        allTips.forEach(function (wellName) {
+          tipState.tipracks[labwareId][wellName] = DIRTY
+        })
+      } else {
+        const allWells =
+          getTiprackColumnForWell(tiprackDef.ordering, wellName) ?? []
+        allWells.forEach(
+          wellName => (tipState.tipracks[labwareId][wellName] = DIRTY)
+        )
+      }
+    } else {
+      // Fallback for unexpected nozzle configurations.
+      if (pipetteSpec.channels === 1) {
+        tipState.tipracks[labwareId][wellName] = DIRTY
+      } else if (pipetteSpec.channels === 96) {
+        const allTips: string[] = tiprackDef.ordering.reduce(
+          (acc, wells) => acc.concat(wells),
+          []
+        )
+        allTips.forEach(function (wellName) {
+          tipState.tipracks[labwareId][wellName] = DIRTY
+        })
+      } else {
+        const allWells =
+          getTiprackColumnForWell(tiprackDef.ordering, wellName) ?? []
+        allWells.forEach(
+          wellName => (tipState.tipracks[labwareId][wellName] = DIRTY)
+        )
+      }
     }
-  }
 
-  // set pipette most recently accessed labware and well
-  robotState.pipettes[pipetteId].entityId = labwareId
-  robotState.pipettes[pipetteId].wellName = wellName
+    // set pipette most recently accessed labware and well
+    robotState.pipettes[pipetteId].entityId = labwareId
+    robotState.pipettes[pipetteId].wellName = wellName
+  }
 }


### PR DESCRIPTION
# Overview

closes RQA-5366

fixes a bug in `forDropTip` where we weren't accounting for dropping tip into a fixed trash... the check before was too harsh, so we just early return instead of throwing an error

## Test Plan and Hands on Testing

Ugh so annoyign to smoke test this on your own, just trust that it works! here is a screen recording. Basically, since I didn't wanna upload the analysis file for the protocol attached to the ticket to `js-package-testing`, i just made these changes in the ot-2 repo and smoke tested from there. but look, it works!

https://github.com/user-attachments/assets/831ea3ff-d379-46a1-afe6-32d9565cb4d7

## Changelog

null check for tiprack def + early exit instead of throwing an error

## Risk assessment

medium, this affect step-generation `forDropTip` command creator which is used for all return tips and older protocols that use dropTip instead of the move to addressable areas...

additionally, there might be a bug in PD because of this?? we should keep an eye out on importing older protocols in PD that still use `dropTip` as a command...
