### PR TITLE
fix(app): Capitalize English language name in software keyboard

### DIFF
--- a/app/src/atoms/SoftwareKeyboard/FullKeyboard/__tests__/FullKeyboard.test.tsx
+++ b/app/src/atoms/SoftwareKeyboard/FullKeyboard/__tests__/FullKeyboard.test.tsx
@@ -270,7 +270,7 @@ describe('FullKeyboard', () => {
     expect(globeKey).toBeDefined()
     fireEvent.click(globeKey!)
 
-    expect(screen.getByRole('button', { name: 'english (us)' })).toBeDefined()
+    expect(screen.getByRole('button', { name: 'English (US)' })).toBeDefined()
     expect(
       screen.getAllByRole('button', { name: 'return' }).length
     ).toBeGreaterThan(0)

--- a/app/src/atoms/SoftwareKeyboard/FullKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/FullKeyboard/index.tsx
@@ -19,7 +19,7 @@ import './index.css'
 
 const SPECIAL_LAYOUT_KEYS = ['{numbers}', '{abc}', '{shift}', '{symbols}']
 const PREVIEW_LABEL_RENDERING_DURATION_MS = 800
-const PREVIEW_LABEL_EN = 'english (us)'
+const PREVIEW_LABEL_EN = 'English (US)'
 const PREVIEW_LABEL_CH = '简体拼音'
 
 // TODO (kk:04/05/2024) add debug to make debugging easy


### PR DESCRIPTION
# Overview

The string `english (us)` was appearing when switching languages on the ODD software keyboard. The string needed to be properly capitalized: `English (US)`. 

## Test Plan and Hands on Testing

Automated test covers this case-sensitive string.
Appears properly in dev ODD.
<img width="2048" height="1201" alt="Screenshot 2026-05-13 at 10 16 38 AM (2)" src="https://github.com/user-attachments/assets/f6fc63f9-72a4-4af8-8027-cd7e0af5e6f7" />


## Changelog

One line each to change constant and corresponding test.

## Review requests

🔠 

## Risk assessment

v v low