### PR TITLE
refactor(auth-server): Remove underscores from test credentials

### DIFF
--- a/auth-server/auth_server/users/user_data_manager.py
+++ b/auth-server/auth_server/users/user_data_manager.py
@@ -75,14 +75,14 @@ class UserDataManager:
         """Insert default placeholder users if they don't already exist."""
         defaults = [
             User(
-                username="test_admin",
-                hashed_password=password_hash.hash("test_admin_password"),
+                username="testadmin",
+                hashed_password=password_hash.hash("testadminpassword"),
                 full_name="Test Admin",
                 account_type=AccountType.ADMIN,
             ),
             User(
-                username="test_user",
-                hashed_password=password_hash.hash("test_user_password"),
+                username="testuser",
+                hashed_password=password_hash.hash("testuserpassword"),
                 full_name="Test User",
                 account_type=AccountType.USER,
             ),

--- a/auth-server/tests/integration/conftest.py
+++ b/auth-server/tests/integration/conftest.py
@@ -3,8 +3,8 @@ import pytest
 
 from ..dev_server import DevServer
 
-_ADMIN_USERNAME = "test_admin"
-_ADMIN_PASSWORD = "test_admin_password"
+_ADMIN_USERNAME = "testadmin"
+_ADMIN_PASSWORD = "testadminpassword"
 _CLIENT_ID = "opentrons_app"
 
 

--- a/auth-server/tests/integration/test_failed_login_lockout.tavern.yaml
+++ b/auth-server/tests/integration/test_failed_login_lockout.tavern.yaml
@@ -47,7 +47,7 @@ stages:
       data: &wrong_credentials
         client_id: opentrons_app
         grant_type: password
-        username: test_user
+        username: testuser
         password: not_the_right_password
     response:
       status_code: 400
@@ -87,8 +87,8 @@ stages:
       data: &correct_credentials
         client_id: opentrons_app
         grant_type: password
-        username: test_user
-        password: test_user_password
+        username: testuser
+        password: testuserpassword
     response:
       status_code: 400
       json: &locked_out_response
@@ -112,15 +112,15 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: password
-        username: test_admin
-        password: test_admin_password
+        username: testadmin
+        password: testadminpassword
     response:
       status_code: 200
 
   - name: Use admin credentials to see the lockout
     request:
       method: GET
-      url: '{run_server.base_url}/auth/users/byUsername/test_user'
+      url: '{run_server.base_url}/auth/users/byUsername/testuser'
       headers:
         Authorization: '{admin_access_token}'
     response:
@@ -134,7 +134,7 @@ stages:
   - name: Use admin credentials to clear the lockout
     request:
       method: PATCH
-      url: '{run_server.base_url}/auth/users/byUsername/test_user'
+      url: '{run_server.base_url}/auth/users/byUsername/testuser'
       headers:
         Authorization: '{admin_access_token}'
       json:
@@ -230,8 +230,8 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: password
-        username: test_admin
-        password: test_admin_password
+        username: testadmin
+        password: testadminpassword
     response:
       status_code: 200
 
@@ -254,8 +254,8 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: password
-        username: test_user
-        password: test_user_password
+        username: testuser
+        password: testuserpassword
     response:
       status_code: 200
 

--- a/auth-server/tests/integration/test_oauth_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_oauth_flows.tavern.yaml
@@ -13,8 +13,8 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: password
-        username: test_admin
-        password: test_admin_password
+        username: testadmin
+        password: testadminpassword
     response:
       status_code: 200
       json:
@@ -39,7 +39,7 @@ stages:
       status_code: 200
       json:
         active: true
-        username: test_admin
+        username: testadmin
         scope: *returned_scope
 
   - name: Introspect the refresh token and confirm it's inactive (only access tokens are active)
@@ -88,7 +88,7 @@ stages:
       status_code: 200
       json:
         active: true
-        username: test_admin
+        username: testadmin
         scope: *returned_scope
 
   - name: Introspect the new refresh token and confirm it's inactive (only access tokens are active)
@@ -120,9 +120,9 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: password
-        username: test_user
-        password: test_user_password
-        scope: robot_control.write users.write # test_user is not authorized for users.write.
+        username: testuser
+        password: testuserpassword
+        scope: robot_control.write users.write # testuser is not authorized for users.write.
     response:
       status_code: 400
       json:
@@ -137,8 +137,8 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: password
-        username: test_user
-        password: test_user_password
+        username: testuser
+        password: testuserpassword
     response:
       status_code: 200
       json:
@@ -161,7 +161,7 @@ stages:
         client_id: opentrons_app
         grant_type: refresh_token
         refresh_token: '{refresh_token}'
-        scope: robot_control.write users.write # test_user is not authorized for users.write.
+        scope: robot_control.write users.write # testuser is not authorized for users.write.
     response:
       status_code: 400
       json:
@@ -185,9 +185,9 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: password
-        username: test_admin
-        password: test_admin_password
-        # test_admin would also be authorized for a bunch of other scopes.
+        username: testadmin
+        password: testadminpassword
+        # testadmin would also be authorized for a bunch of other scopes.
         # This should narrow it to just robot_control.write.
         scope: &requested_scope_1 robot_control.write
     response:
@@ -208,8 +208,8 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: password
-        username: test_admin
-        password: test_admin_password
+        username: testadmin
+        password: testadminpassword
     response:
       status_code: 200
       json:
@@ -258,7 +258,7 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: password
-        username: test_admin
+        username: testadmin
         password: not_the_right_password
     response:
       status_code: 400
@@ -334,8 +334,8 @@ stages:
       data:
         client_id: unrecognized_client
         grant_type: password
-        username: test_admin
-        password: test_admin_password
+        username: testadmin
+        password: testadminpassword
     response:
       status_code: 401
       json:
@@ -372,8 +372,8 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: password
-        username: test_admin
-        password: test_admin_password
+        username: testadmin
+        password: testadminpassword
         scope: unrecognized_scope
     response:
       status_code: 400
@@ -389,8 +389,8 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: password
-        username: test_admin
-        password: test_admin_password
+        username: testadmin
+        password: testadminpassword
     response:
       status_code: 200
       json:
@@ -439,8 +439,8 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: '{grant_type}'
-        username: test_admin
-        password: test_admin_password
+        username: testadmin
+        password: testadminpassword
     response:
       status_code: 400
       json:

--- a/auth-server/tests/integration/test_protected_resource_access.tavern.yaml
+++ b/auth-server/tests/integration/test_protected_resource_access.tavern.yaml
@@ -21,8 +21,8 @@ stages:
       url: '{run_server.base_url}/auth/users'
       json:
         data:
-          userName: test_user
-          password: test_user_password
+          userName: testuser
+          password: testuserpassword
           fullName: Test User
           accountType: user
     response:
@@ -33,8 +33,8 @@ stages:
       method: POST
       json:
         data:
-          userName: test_user
-          password: test_user_password
+          userName: testuser
+          password: testuserpassword
           fullName: Test User
           accountType: user
       url: '{run_server.base_url}/auth/users'
@@ -50,8 +50,8 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: password
-        username: test_admin
-        password: test_admin_password
+        username: testadmin
+        password: testadminpassword
         scope: users.read.others # Omit users.write.
     response:
       status_code: 200
@@ -71,8 +71,8 @@ stages:
       url: '{run_server.base_url}/auth/users'
       json:
         data:
-          userName: test_user
-          password: test_user_password
+          userName: testuser
+          password: testuserpassword
           fullName: Test User
           accountType: user
       headers:
@@ -87,8 +87,8 @@ stages:
       data:
         client_id: opentrons_app
         grant_type: password
-        username: test_admin
-        password: test_admin_password
+        username: testadmin
+        password: testadminpassword
         scope: users.write
     response:
       status_code: 200
@@ -108,8 +108,8 @@ stages:
       url: '{run_server.base_url}/auth/users'
       json:
         data:
-          userName: test_user_new
-          password: test_user_password
+          userName: testuser_new
+          password: testuserpassword
           fullName: Test User
           accountType: user
       headers:

--- a/auth-server/tests/users/test_user_data_manager.py
+++ b/auth-server/tests/users/test_user_data_manager.py
@@ -350,9 +350,9 @@ def test_update_user_not_found_raises(
 
 def test_update_user_empty_username_raises(manager: UserDataManager) -> None:
     with pytest.raises(InvalidInputError, match="userName"):
-        manager.update_user("test_admin", new_username="")
+        manager.update_user("testadmin", new_username="")
 
 
 def test_update_user_short_password_raises(manager: UserDataManager) -> None:
     with pytest.raises(InvalidInputError, match="at least 8 characters"):
-        manager.update_user("test_admin", new_password="short")
+        manager.update_user("testadmin", new_password="short")


### PR DESCRIPTION
## Overview

For testing and development, we currently have hard-coded credentials:

* `test_admin` / `test_admin_password`
* `test_user` / `test_user_password`

The underscores make these really annoying to type on the ODD's keyboard. So this removes the underscores.

## Test Plan and Hands on Testing

* [x] Test the login flow without underscores.

## Review requests

Is this what we want?

## Risk assessment

Low.