### PR TITLE
fix(app, protocol-visualization): rearrange svg layering for labware

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabware.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabware.tsx
@@ -58,16 +58,18 @@ export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
           Object.keys(modules).some(moduleId => lw.stack.includes(moduleId)) ||
           labwareEntitiesExtended[id].def.parameters.loadName ===
             PROTOCOL_ENGINE_LID_STACK_LOADNAME
-        )
+        ) {
           return []
-
+        }
         const slot = getSlotInLocationStack(lw.stack)
         const slotPosition = getPositionFromSlotId(slot, deckDef)
         const slotBoundingBox = getAddressableAreaFromSlotId(
           slot,
           deckDef
         )?.boundingBox
-        if (slotPosition == null || slotBoundingBox == null) return []
+        if (slotPosition == null || slotBoundingBox == null) {
+          return []
+        }
 
         const { isActiveLayerVisible } = getActiveLayer(
           id,

--- a/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabware.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/DeckView/DeckViewLabware.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react'
+import { Fragment, useMemo } from 'react'
 
 import { CenterLabwareInSlot, COLORS, StyledText } from '@opentrons/components'
 import {
@@ -51,30 +51,24 @@ export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
   } = props
   const { labware, modules, pipettes } = robotState
 
-  return (
-    <>
-      {Object.entries(labware).map(([id, lw]) => {
+  const labwareEntries = useMemo(
+    () =>
+      Object.entries(labware).flatMap(([id, lw]) => {
         if (
           Object.keys(modules).some(moduleId => lw.stack.includes(moduleId)) ||
-          //  filter out the fake PE lid stack definition!
-          //  we shouldn't be exposing it to users at all
           labwareEntitiesExtended[id].def.parameters.loadName ===
             PROTOCOL_ENGINE_LID_STACK_LOADNAME
-        ) {
-          return null
-        }
+        )
+          return []
+
         const slot = getSlotInLocationStack(lw.stack)
         const slotPosition = getPositionFromSlotId(slot, deckDef)
         const slotBoundingBox = getAddressableAreaFromSlotId(
           slot,
           deckDef
         )?.boundingBox
-        if (slotPosition == null || slotBoundingBox == null) {
-          console.warn(
-            `no slot ${slot} for labware ${Object.keys(labware)[0]}!`
-          )
-          return null
-        }
+        if (slotPosition == null || slotBoundingBox == null) return []
+
         const { isActiveLayerVisible } = getActiveLayer(
           id,
           pipettes,
@@ -82,52 +76,69 @@ export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
         )
         const showCommandSummary =
           isActiveLayerVisible && selectedRunTimeCommand != null
-        return (
-          <Fragment key={id}>
-            <g transform={`translate(${slotPosition[0]}, ${slotPosition[1]})`}>
-              <CenterLabwareInSlot definition={labwareEntitiesExtended[id].def}>
-                <LabwareOnDeck
-                  x={0}
-                  y={0}
-                  robotState={robotState}
-                  labwareDef={labwareEntitiesExtended[id].def}
-                  liquids={liquids}
-                  labwareId={id}
-                  setSelectedSlot={setSelectedSlot}
-                  setHoveredSlot={setHoveredSlot}
-                />
-              </CenterLabwareInSlot>
-            </g>
-            <DeckViewOverlay
-              key={`${slot}_hoveredSlot_labware`}
-              slotId={slot}
-              slotPosition={slotPosition}
-              slotFillColor={COLORS.purple50}
-              robotType={robotType}
-              invariantContext={invariantContext}
-              robotState={robotState}
-              setSelectedSlot={setSelectedSlot}
-              setHoveredSlot={setHoveredSlot}
-              hover={hoveredSlot}
-            >
-              {showCommandSummary ? null : (
-                <StyledText desktopStyle="captionRegular" color={COLORS.white}>
-                  {labwareEntitiesExtended[id]?.nickName ??
-                    labwareEntitiesExtended[id].def.metadata.displayName}
-                </StyledText>
-              )}
-            </DeckViewOverlay>
-            {showCommandSummary ? (
-              <LabwareCommandSummary
-                commandType={selectedRunTimeCommand.commandType}
-                position={slotPosition}
+
+        return [{ id, lw, slot, slotPosition, showCommandSummary }]
+      }),
+    [
+      labware,
+      modules,
+      labwareEntitiesExtended,
+      deckDef,
+      pipettes,
+      selectedRunTimeCommand,
+    ]
+  )
+  return (
+    <>
+      {labwareEntries.map(({ id, slot, slotPosition, showCommandSummary }) => (
+        <Fragment key={id}>
+          <g transform={`translate(${slotPosition[0]}, ${slotPosition[1]})`}>
+            <CenterLabwareInSlot definition={labwareEntitiesExtended[id].def}>
+              <LabwareOnDeck
+                x={0}
+                y={0}
+                robotState={robotState}
                 labwareDef={labwareEntitiesExtended[id].def}
-                showModuleIcon={false}
+                liquids={liquids}
+                labwareId={id}
+                setSelectedSlot={setSelectedSlot}
+                setHoveredSlot={setHoveredSlot}
               />
-            ) : null}
-          </Fragment>
-        )
-      })}
+            </CenterLabwareInSlot>
+          </g>
+          <DeckViewOverlay
+            key={`${slot}_hoveredSlot_labware`}
+            slotId={slot}
+            slotPosition={slotPosition}
+            slotFillColor={COLORS.purple50}
+            robotType={robotType}
+            invariantContext={invariantContext}
+            robotState={robotState}
+            setSelectedSlot={setSelectedSlot}
+            setHoveredSlot={setHoveredSlot}
+            hover={hoveredSlot}
+          >
+            {showCommandSummary ? null : (
+              <StyledText desktopStyle="captionRegular" color={COLORS.white}>
+                {labwareEntitiesExtended[id]?.nickName ??
+                  labwareEntitiesExtended[id].def.metadata.displayName}
+              </StyledText>
+            )}
+          </DeckViewOverlay>
+        </Fragment>
+      ))}
+
+      {labwareEntries.map(({ id, slotPosition, showCommandSummary }) =>
+        showCommandSummary && selectedRunTimeCommand != null ? (
+          <LabwareCommandSummary
+            key={`${id}_summary`}
+            commandType={selectedRunTimeCommand.commandType}
+            position={slotPosition}
+            labwareDef={labwareEntitiesExtended[id].def}
+            showModuleIcon={false}
+          />
+        ) : null
+      )}
     </>
   )
 }

--- a/protocol-visualization/src/organisms/DeckView/DeckViewLabware.tsx
+++ b/protocol-visualization/src/organisms/DeckView/DeckViewLabware.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react'
+import { Fragment, useMemo } from 'react'
 
 import { CenterLabwareInSlot, COLORS, StyledText } from '@opentrons/components'
 import {
@@ -35,7 +35,6 @@ interface DeckViewLabwareProps {
   hoveredSlot: string | null
   selectedRunTimeCommand?: RunTimeCommand
 }
-
 export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
   const {
     robotState,
@@ -51,30 +50,24 @@ export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
   } = props
   const { labware, modules, pipettes } = robotState
 
-  return (
-    <>
-      {Object.entries(labware).map(([id, lw]) => {
+  const labwareEntries = useMemo(
+    () =>
+      Object.entries(labware).flatMap(([id, lw]) => {
         if (
           Object.keys(modules).some(moduleId => lw.stack.includes(moduleId)) ||
-          //  filter out the fake PE lid stack definition!
-          //  we shouldn't be exposing it to users at all
           labwareEntitiesExtended[id].def.parameters.loadName ===
             PROTOCOL_ENGINE_LID_STACK_LOADNAME
-        ) {
-          return null
-        }
+        )
+          return []
+
         const slot = getSlotInLocationStack(lw.stack)
         const slotPosition = getPositionFromSlotId(slot, deckDef)
         const slotBoundingBox = getAddressableAreaFromSlotId(
           slot,
           deckDef
         )?.boundingBox
-        if (slotPosition == null || slotBoundingBox == null) {
-          console.warn(
-            `no slot ${slot} for labware ${Object.keys(labware)[0]}!`
-          )
-          return null
-        }
+        if (slotPosition == null || slotBoundingBox == null) return []
+
         const { isActiveLayerVisible } = getActiveLayer(
           id,
           pipettes,
@@ -82,52 +75,69 @@ export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
         )
         const showCommandSummary =
           isActiveLayerVisible && selectedRunTimeCommand != null
-        return (
-          <Fragment key={id}>
-            <g transform={`translate(${slotPosition[0]}, ${slotPosition[1]})`}>
-              <CenterLabwareInSlot definition={labwareEntitiesExtended[id].def}>
-                <LabwareOnDeck
-                  x={0}
-                  y={0}
-                  robotState={robotState}
-                  labwareDef={labwareEntitiesExtended[id].def}
-                  liquids={liquids}
-                  labwareId={id}
-                  setSelectedSlot={setSelectedSlot}
-                  setHoveredSlot={setHoveredSlot}
-                />
-              </CenterLabwareInSlot>
-            </g>
-            <DeckViewOverlay
-              key={`${slot}_hoveredSlot_labware`}
-              slotId={slot}
-              slotPosition={slotPosition}
-              slotFillColor={COLORS.purple50}
-              robotType={robotType}
-              invariantContext={invariantContext}
-              robotState={robotState}
-              setSelectedSlot={setSelectedSlot}
-              setHoveredSlot={setHoveredSlot}
-              hover={hoveredSlot}
-            >
-              {showCommandSummary ? null : (
-                <StyledText desktopStyle="captionRegular" color={COLORS.white}>
-                  {labwareEntitiesExtended[id]?.nickName ??
-                    labwareEntitiesExtended[id].def.metadata.displayName}
-                </StyledText>
-              )}
-            </DeckViewOverlay>
-            {showCommandSummary ? (
-              <LabwareCommandSummary
-                commandType={selectedRunTimeCommand.commandType}
-                position={slotPosition}
+
+        return [{ id, lw, slot, slotPosition, showCommandSummary }]
+      }),
+    [
+      labware,
+      modules,
+      labwareEntitiesExtended,
+      deckDef,
+      pipettes,
+      selectedRunTimeCommand,
+    ]
+  )
+  return (
+    <>
+      {labwareEntries.map(({ id, slot, slotPosition, showCommandSummary }) => (
+        <Fragment key={id}>
+          <g transform={`translate(${slotPosition[0]}, ${slotPosition[1]})`}>
+            <CenterLabwareInSlot definition={labwareEntitiesExtended[id].def}>
+              <LabwareOnDeck
+                x={0}
+                y={0}
+                robotState={robotState}
                 labwareDef={labwareEntitiesExtended[id].def}
-                showModuleIcon={false}
+                liquids={liquids}
+                labwareId={id}
+                setSelectedSlot={setSelectedSlot}
+                setHoveredSlot={setHoveredSlot}
               />
-            ) : null}
-          </Fragment>
-        )
-      })}
+            </CenterLabwareInSlot>
+          </g>
+          <DeckViewOverlay
+            key={`${slot}_hoveredSlot_labware`}
+            slotId={slot}
+            slotPosition={slotPosition}
+            slotFillColor={COLORS.purple50}
+            robotType={robotType}
+            invariantContext={invariantContext}
+            robotState={robotState}
+            setSelectedSlot={setSelectedSlot}
+            setHoveredSlot={setHoveredSlot}
+            hover={hoveredSlot}
+          >
+            {showCommandSummary ? null : (
+              <StyledText desktopStyle="captionRegular" color={COLORS.white}>
+                {labwareEntitiesExtended[id]?.nickName ??
+                  labwareEntitiesExtended[id].def.metadata.displayName}
+              </StyledText>
+            )}
+          </DeckViewOverlay>
+        </Fragment>
+      ))}
+
+      {labwareEntries.map(({ id, slotPosition, showCommandSummary }) =>
+        showCommandSummary && selectedRunTimeCommand != null ? (
+          <LabwareCommandSummary
+            key={`${id}_summary`}
+            commandType={selectedRunTimeCommand.commandType}
+            position={slotPosition}
+            labwareDef={labwareEntitiesExtended[id].def}
+            showModuleIcon={false}
+          />
+        ) : null
+      )}
     </>
   )
 }

--- a/protocol-visualization/src/organisms/DeckView/DeckViewLabware.tsx
+++ b/protocol-visualization/src/organisms/DeckView/DeckViewLabware.tsx
@@ -57,16 +57,18 @@ export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
           Object.keys(modules).some(moduleId => lw.stack.includes(moduleId)) ||
           labwareEntitiesExtended[id].def.parameters.loadName ===
             PROTOCOL_ENGINE_LID_STACK_LOADNAME
-        )
+        ) {
           return []
-
+        }
         const slot = getSlotInLocationStack(lw.stack)
         const slotPosition = getPositionFromSlotId(slot, deckDef)
         const slotBoundingBox = getAddressableAreaFromSlotId(
           slot,
           deckDef
         )?.boundingBox
-        if (slotPosition == null || slotBoundingBox == null) return []
+        if (slotPosition == null || slotBoundingBox == null) {
+          return []
+        }
 
         const { isActiveLayerVisible } = getActiveLayer(
           id,


### PR DESCRIPTION
# Overview

closes RQA-5363

refactors the svg layer rendering for the command text summaries so they show on top of the labware render

## Test Plan and Hands on Testing

Once again, you're going to have to trust me that this works based off of this screenshot because i wasn't gonna add this whole new analysis file to `js-package-testing` just for this... 

but please review the code

<img width="1022" height="766" alt="Screenshot 2026-05-13 at 07 46 31" src="https://github.com/user-attachments/assets/6cf4b2f1-4aed-43ff-86ca-66a8bad96ccf" />


## Changelog

pull the logic in a memo above jsx and map through the labware twice so the svg command summary layer always renders after the labware

## Risk assessment

medium, affects PV for both ot-2 and flex and updates in both the app and pv directories