### PR TITLE
fix(app): Fix "[Object object]" in "Documentation Required" modal

### DIFF
--- a/app/src/organisms/ODD/DocumentationRequired/DocumentationRequiredModal.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/DocumentationRequiredModal.tsx
@@ -13,7 +13,7 @@ export interface DocumentationRequiredModalResult {
 }
 
 const DocumentationRequiredModalImpl = NiceModal.create(
-  (username: string): JSX.Element => {
+  ({ username }: { username: string }): JSX.Element => {
     const modal = useModal()
 
     const handleConfirm = (note: string): void => {
@@ -45,4 +45,4 @@ const DocumentationRequiredModalImpl = NiceModal.create(
 export const showDocumentationRequiredModal = (
   username: string
 ): Promise<DocumentationRequiredModalResult | null> =>
-  NiceModal.show(DocumentationRequiredModalImpl, username)
+  NiceModal.show(DocumentationRequiredModalImpl, { username })

--- a/app/src/organisms/ODD/DocumentationRequired/DocumentationRequiredModal.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/DocumentationRequiredModal.tsx
@@ -45,7 +45,4 @@ const DocumentationRequiredModalImpl = NiceModal.create(
 export const showDocumentationRequiredModal = (
   username: string
 ): Promise<DocumentationRequiredModalResult | null> =>
-  NiceModal.show(
-    DocumentationRequiredModalImpl,
-    username
-  ) as Promise<DocumentationRequiredModalResult | null>
+  NiceModal.show(DocumentationRequiredModalImpl, username)


### PR DESCRIPTION
## Overview

Closes EXEC-2644. We were accidentally showing "Note for robot audit log by [Object object]". 

## Test Plan and Hands on Testing

<img width="1024" height="600" alt="Screenshot 2026-05-13 at 1 34 09 PM" src="https://github.com/user-attachments/assets/f965f54b-e538-4ef8-9edd-cb9d244e55cb" />

## Changelog

* Fix the syntax for passing props to `NiceModal.show()`.
* Delete an unnecessary `as` clause. This was not actually the cause of the bug. Even without the `as` clause, TypeScript and `nice-modal-react`, for some reason, still do not detect the incorrect prop syntax. 🤷 

## Review requests

None.

## Risk assessment

Low.