### PR TITLE
ci(.github): skip Flex/oe-core dispatch for PD release branches

### DIFF
--- a/.github/workflows/start-flex-build.yaml
+++ b/.github/workflows/start-flex-build.yaml
@@ -6,6 +6,8 @@ on:
       - '*internal-release*'
       - 'release*'
       - 'chore_release*'
+      # PD-only release branches do not ship Flex OS; do not dispatch oe-core.
+      - '!chore_release-pd*'
     tags:
       - ot3@*
       - v*


### PR DESCRIPTION
Change in .github/workflows/start-flex-build.yaml: after chore_release*, add !chore_release-pd* (and the short comment) so PD release branches don’t trigger the oe-core Flex build.