### PR TITLE
docs(api): step grouping in API 2.29

### DIFF
--- a/api/src/opentrons/protocol_api/_command_annotations.py
+++ b/api/src/opentrons/protocol_api/_command_annotations.py
@@ -1,13 +1,12 @@
 from .core.common import ProtocolCore
 from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.api_support.util import requires_version
 
 
 class GroupedSteps:
-    """Represents a created grouping of steps.
+    """Represents a created grouping of protocol steps.
 
-    *Available for use from API version 2.29 onwards*
-
-    Note: Any new methods added should have API version gating
+    *New in version 2.29*
     """
 
     def __init__(
@@ -18,7 +17,10 @@ class GroupedSteps:
         self._api_version = api_version
         self._annotation_closed = False
 
+    @requires_version(2, 29)
     def end_group(self) -> None:
+        """End a step group begun with
+        [`ProtocolContext.create_and_start_step_group()`][opentrons.protocol_api.ProtocolContext.create_and_start_step_group]."""
         if not self._annotation_closed:
             self._protocol_core.end_step_grouping(annotation_id=self._annotation_id)
             self._annotation_closed = True

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1928,7 +1928,7 @@ class ProtocolContext(CommandPublisher):
     def group_steps(
         self, name: str, description: Optional[str] = None
     ) -> Iterator[None]:
-        """Group commands together for visualization in run previews and the run log.
+        """Groups commands together for visualization in your Python protocol or in the Opentrons App.
         This method is a [context manager](https://docs.python.org/3/reference/compound_stmts.html#the-with-statement)
         that uses the `with` syntax. All commands within this block will be grouped together.
 
@@ -1948,9 +1948,9 @@ class ProtocolContext(CommandPublisher):
     def create_and_start_step_group(
         self, name: str, description: Optional[str] = None
     ) -> GroupedSteps:
-        """Starts a grouping of commands for visualization in run previews and the run log.
-        This returns a step group object which can then be closed by calling
-        [`end_group()`][opentrons.protocol_api.GroupedSteps.close_group].
+        """Starts a group of commands for visualization in your Pytyon protocol or in the Opentrons App.
+        This returns a step group object, which can be closed by calling
+        [`end_group()`][opentrons.protocol_api.GroupedSteps.end_group].
 
         Grouping steps together has no effect on protocol execution.
 

--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1948,9 +1948,9 @@ class ProtocolContext(CommandPublisher):
     def create_and_start_step_group(
         self, name: str, description: Optional[str] = None
     ) -> GroupedSteps:
-        """Starts a group of commands for visualization in your Pytyon protocol or in the Opentrons App.
-        This returns a step group object, which can be closed by calling
-        [`end_group()`][opentrons.protocol_api.GroupedSteps.end_group].
+        """Starts a group of commands for visualization in your Python protocol or in the Opentrons App.
+        This returns a [`GroupedSteps`][opentrons.protocol_api._command_annotations.GroupedSteps] object, which can be closed by calling
+        [`end_group()`][opentrons.protocol_api._command_annotations.GroupedSteps.end_group].
 
         Grouping steps together has no effect on protocol execution.
 

--- a/docs/python-api/docs/groups.md
+++ b/docs/python-api/docs/groups.md
@@ -8,7 +8,7 @@ Step grouping lets you organize groups of commands within your Python protocols.
 - the context manager [`group_steps()`][opentrons.protocol_api.ProtocolContext.group_steps], which uses `with` syntax.
 - the paired [`create_and_start_step_group()`][opentrons.protocol_api.ProtocolContext.create_and_start_step_group] and [`end_group()`][opentrons.protocol_api._command_annotations.GroupedSteps.end_group] commands.
 
-The examples on this page demonstrate using either method to create step groups that are visible in your Python protocol file, or in [visualization][../flex/protocol-viz.md] in the Opentrons App. 
+The examples on this page demonstrate using either method to create step groups that are visible in your Python protocol file, or in [visualization](../flex/opentrons-app/protocol-viz.md) in the Opentrons App.
 
 !!! note
     Step grouping doesn't affect the execution of your protocol. It's simply a way to organize writing and assessing your Python protocols.

--- a/docs/python-api/docs/groups.md
+++ b/docs/python-api/docs/groups.md
@@ -6,7 +6,7 @@ description: "Use step grouping to organize groups of commands in Python protoco
 Step grouping lets you organize groups of commands within your Python protocols. This can be especially helpful when writing or working with long protocols. Beginning with API version 9.1.0, use commands to separate groups of steps:
 
 - the context manager [`group_steps()`][opentrons.protocol_api.ProtocolContext.group_steps], which uses `with` syntax.
-- the paired [`create_and_start_step_group()`][opentrons.protocol_api.ProtocolContext.create_and_start_step_group] and [`end_group()`][opentrons.protocol_api.GroupedSteps.end_group] commands.
+- the paired [`create_and_start_step_group()`][opentrons.protocol_api.ProtocolContext.create_and_start_step_group] and [`end_group()`][opentrons.protocol_api._command_annotations.GroupedSteps.end_group] commands.
 
 The examples on this page demonstrate using either method to create step groups that are visible in your Python protocol file, or in [visualization][../flex/protocol-viz.md] in the Opentrons App. 
 
@@ -32,7 +32,7 @@ with protocol_context.group_steps(name="Aspirate and Dispense Buffer", descripti
 
 Each command you add inside the `with` block becomes a part of the step group.
 
-The second example uses the [`create_and_start_step_group()`][opentrons.protocol_api.ProtocolContext.create_and_start_step_group] command to create a group of steps. Because this command isn't a context manager, you'll need to include the [`end_step_group][opentrons.protocol_api.GroupedSteps.end_group] command to close your step group. 
+The second example uses the [`create_and_start_step_group()`][opentrons.protocol_api.ProtocolContext.create_and_start_step_group] command to create a group of steps. Because this command isn't a context manager, you'll need to include the [`end_step_group][opentrons.protocol_api._command_annotations.GroupedSteps.end_group] command to close your step group.
 
 ```python
 

--- a/docs/python-api/docs/groups.md
+++ b/docs/python-api/docs/groups.md
@@ -1,0 +1,58 @@
+---
+title: "Python API: Step Grouping"
+description: "Use step grouping to organize groups of commands in Python protocols."
+---
+
+Step grouping lets you organize groups of commands within your Python protocols. This can be especially helpful when writing or working with long protocols. Beginning with API version 9.1.0, use commands to separate groups of steps:
+
+- the context manager [`group_steps()`][opentrons.protocol_api.ProtocolContext.group_steps], which uses `with` syntax.
+- the paired [`create_and_start_step_group()`][opentrons.protocol_api.ProtocolContext.create_and_start_step_group] and [`end_group()`][opentrons.protocol_api.GroupedSteps.end_group] commands.
+
+The examples on this page demonstrate using either method to create step groups that are visible in your Python protocol file, or in [visualization][../flex/protocol-viz.md] in the Opentrons App. 
+
+!!! note
+    Step grouping doesn't affect the execution of your protocol. It's simply a way to organize writing and assessing your Python protocols.
+
+The first example uses the context manager [`ProtocolContext.group_steps()`][opentrons.protocol_api.ProtocolContext.group_steps] to create a group of steps, contained inside a `with` block:
+
+```python
+
+# create a step group for aspirating and dispensing steps
+
+with protocol_context.group_steps(name="Aspirate and Dispense Buffer", description="Transfer liquid from reservoir to well plate"):
+    pipette.pick_up_tip()
+    pipette.aspirate(
+        volume=50,
+        source=reservoir['A1'].bottom(z=1),
+        dest=plate['A1']
+    )
+    pipette.drop_tip
+```
+*New in version 2.29*
+
+Each command you add inside the `with` block becomes a part of the step group.
+
+The second example uses the [`create_and_start_step_group()`][opentrons.protocol_api.ProtocolContext.create_and_start_step_group] command to create a group of steps. Because this command isn't a context manager, you'll need to include the [`end_step_group][opentrons.protocol_api.GroupedSteps.end_group] command to close your step group. 
+
+```python
+
+## create a step group for aspirating and dispensing steps
+
+step_group_1 = protocol_context.create_and_start_step_group(
+    name="Aspirate and Dispense Buffer",
+    description="Do X, Y, and Z")
+
+pipette.pick_up_tip()
+pipette.aspirate(
+        volume=50,
+        source=reservoir['A1'].bottom(z=1),
+        dest=plate['A1']
+    )
+    pipette.drop_tip
+
+step_group_1.end_group()
+```
+*New in version 2.29*
+
+
+** idea: screenshot of step grouping in protocol viz? show why this is truly useful? + of course, some text as well

--- a/docs/python-api/docs/reference/protocols.md
+++ b/docs/python-api/docs/reference/protocols.md
@@ -13,4 +13,4 @@ description: "Protocol context, metadata, and protocol-level API reference."
 
 ::: opentrons.protocol_api.Task
 
-::: opentrons.protocol_api.GroupedSteps
+::: opentrons.protocol_api._command_annotations.GroupedSteps

--- a/docs/python-api/docs/reference/protocols.md
+++ b/docs/python-api/docs/reference/protocols.md
@@ -10,7 +10,7 @@ description: "Protocol context, metadata, and protocol-level API reference."
         - "!location_cache"
         - "!cleanup"
         - "!clear_commands"
-        - "!group_steps"
-        - "!create_and_start_step_group"
 
 ::: opentrons.protocol_api.Task
+
+::: opentrons.protocol_api.GroupedSteps

--- a/docs/python-api/mkdocs.yml
+++ b/docs/python-api/mkdocs.yml
@@ -46,6 +46,7 @@ nav:
       - Using Parameter Values: runtime-parameters/using-values.md
       - "Use Case: Sample Count": runtime-parameters/use-case-sample-count.md
       - "Use Case: Dry Run": runtime-parameters/use-case-dry-run.md
+      - "Use Case: Cherrypicking": runtime-parameters/use-case-cherrypicking.md
       - Parameter Style Guide: runtime-parameters/style.md
   - Step Grouping: groups.md
   - Advanced Control:

--- a/docs/python-api/mkdocs.yml
+++ b/docs/python-api/mkdocs.yml
@@ -46,8 +46,8 @@ nav:
       - Using Parameter Values: runtime-parameters/using-values.md
       - "Use Case: Sample Count": runtime-parameters/use-case-sample-count.md
       - "Use Case: Dry Run": runtime-parameters/use-case-dry-run.md
-      - "Use Case: Cherrypicking": runtime-parameters/use-case-cherrypicking.md
       - Parameter Style Guide: runtime-parameters/style.md
+  - Step Grouping: groups.md
   - Advanced Control:
       - Advanced Control: advanced-control/index.md
       - Jupyter Notebook: advanced-control/jupyter.md


### PR DESCRIPTION
# Overview

Adding step grouping to the docs for API 2.29. 

## Test Plan and Hands on Testing

sandbox (will update with link when build errors are fixed)

## Changelog

- small updates to existing API reference entries
- new Step Grouping article in API docs

## Review requests



## Risk assessment

low.
