### PR TITLE
feat(app): Update UI when logins expire

### DIFF
--- a/app/src/redux/robot-auth/__tests__/expirationMiddleware.test.ts
+++ b/app/src/redux/robot-auth/__tests__/expirationMiddleware.test.ts
@@ -1,0 +1,154 @@
+import { configureStore } from '@reduxjs/toolkit'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { rootReducer } from '../../reducer'
+import { expirationMiddleware } from '../expirationMiddleware'
+import { logInOrRefresh } from '../slice'
+
+import type { State } from '../../types'
+
+const T0 = 1000
+
+describe('expirationMiddleware', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({
+      now: T0,
+    })
+  })
+
+  afterEach(() => {
+    // todo(mm, 2026-05-14): It seems like we ought to cancel any pending tasks
+    // here in the cleanup, and/or use a separate middleware instance for each test.
+    // The @reduxjs/toolkit APIs for this confuse me. In the meantime, vi.runAllTimers()
+    // should be enough to make sure no tasks leak between tests.
+    vi.runAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('removes robots from auth state as they expire', async () => {
+    const store = configureStore({
+      reducer: rootReducer,
+      middleware: getDefaultMiddleware => {
+        return getDefaultMiddleware().prepend(expirationMiddleware.middleware)
+      },
+    })
+
+    store.dispatch(
+      logInOrRefresh({
+        robotName: 'robot-a-expires-at-3000',
+        username: 'username',
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+        expiresAt: T0 + 3000,
+      })
+    )
+    store.dispatch(
+      logInOrRefresh({
+        robotName: 'robot-b-expires-at-1000',
+        username: 'username',
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+        expiresAt: T0 + 1000,
+      })
+    )
+    store.dispatch(
+      logInOrRefresh({
+        robotName: 'robot-c-expires-at-2000',
+        username: 'username',
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+        expiresAt: T0 + 2000,
+      })
+    )
+    store.dispatch(
+      logInOrRefresh({
+        robotName: 'robot-d-expires-never',
+        username: 'username',
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+        expiresAt: null,
+      })
+    )
+
+    await vi.advanceTimersByTimeAsync(500) // Now at T0+500.
+    expect(getUnexpiredRobots(store.getState())).toStrictEqual([
+      'robot-a-expires-at-3000',
+      'robot-b-expires-at-1000',
+      'robot-c-expires-at-2000',
+      'robot-d-expires-never',
+    ])
+
+    await vi.advanceTimersByTimeAsync(1000) // Now at T0+1500.
+    expect(getUnexpiredRobots(store.getState())).toStrictEqual([
+      'robot-a-expires-at-3000',
+      'robot-c-expires-at-2000',
+      'robot-d-expires-never',
+    ])
+
+    await vi.advanceTimersByTimeAsync(1000) // Now at T0+2500.
+    expect(getUnexpiredRobots(store.getState())).toStrictEqual([
+      'robot-a-expires-at-3000',
+      'robot-d-expires-never',
+    ])
+
+    await vi.advanceTimersByTimeAsync(1000) // Now at T0+3500.
+    expect(getUnexpiredRobots(store.getState())).toStrictEqual([
+      'robot-d-expires-never',
+    ])
+  })
+
+  it('handles an expiration being postponed (a login being refreshed)', async () => {
+    const store = configureStore({
+      reducer: rootReducer,
+      middleware: getDefaultMiddleware => {
+        return getDefaultMiddleware().prepend(expirationMiddleware.middleware)
+      },
+    })
+
+    store.dispatch(
+      logInOrRefresh({
+        robotName: 'robot-a',
+        username: 'username',
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+        expiresAt: T0 + 1000,
+      })
+    )
+    store.dispatch(
+      logInOrRefresh({
+        robotName: 'robot-b',
+        username: 'username',
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+        expiresAt: T0 + 1000,
+      })
+    )
+
+    await vi.advanceTimersByTimeAsync(500) // Now at T0+500.
+    expect(getUnexpiredRobots(store.getState())).toStrictEqual([
+      'robot-a',
+      'robot-b',
+    ])
+
+    store.dispatch(
+      logInOrRefresh({
+        robotName: 'robot-a',
+        username: 'username',
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+        expiresAt: T0 + 2000,
+      })
+    )
+    await vi.advanceTimersByTimeAsync(1000) // Now at T0+1500.
+    expect(getUnexpiredRobots(store.getState())).toStrictEqual(['robot-a'])
+  })
+
+  it('immediately removes robots added in the past', () => {
+
+  }
+  // it immediately removes robots added in the past
+})
+
+function getUnexpiredRobots(state: State): string[] {
+  return Object.keys(state.robotAuth).sort()
+}

--- a/app/src/redux/robot-auth/__tests__/expirationMiddleware.test.ts
+++ b/app/src/redux/robot-auth/__tests__/expirationMiddleware.test.ts
@@ -143,10 +143,40 @@ describe('expirationMiddleware', () => {
     expect(getUnexpiredRobots(store.getState())).toStrictEqual(['robot-a'])
   })
 
-  it('immediately removes robots added in the past', () => {
+  it('immediately removes robots that expire in the past', async () => {
+    const store = configureStore({
+      reducer: rootReducer,
+      middleware: getDefaultMiddleware => {
+        return getDefaultMiddleware().prepend(expirationMiddleware.middleware)
+      },
+    })
 
-  }
-  // it immediately removes robots added in the past
+    store.dispatch(
+      logInOrRefresh({
+        robotName: 'robot-a',
+        username: 'username',
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+        expiresAt: T0 - 1,
+      })
+    )
+    store.dispatch(
+      logInOrRefresh({
+        robotName: 'robot-b',
+        username: 'username',
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+        expiresAt: T0 + 1000,
+      })
+    )
+
+    expect(getUnexpiredRobots(store.getState())).toStrictEqual([
+      'robot-a',
+      'robot-b',
+    ])
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getUnexpiredRobots(store.getState())).toStrictEqual(['robot-b'])
+  })
 })
 
 function getUnexpiredRobots(state: State): string[] {

--- a/app/src/redux/robot-auth/expirationMiddleware.ts
+++ b/app/src/redux/robot-auth/expirationMiddleware.ts
@@ -1,3 +1,13 @@
+/**
+ * When we're logged in to a robot, and enough time passes that the login expires,
+ * this automatically updates state to reflect the expiration.
+ *
+ * The server is still ultimately responsible for enforcing that a client can't
+ * use an expired access token. So we're not depending on this for security.
+ * This is merely for the benefit of UI that shows whether the user is currently
+ * logged in.
+ */
+
 import { createListenerMiddleware } from '@reduxjs/toolkit'
 
 import { getNextExpiration, logOutOrTimeOut } from './slice'
@@ -23,7 +33,9 @@ expirationMiddleware.startListening.withTypes<State, Dispatch>()({
     // 1. We run a fresh instance of this handler any time there's a change to any
     //    relevant state. See `predicate` above.
     // 2. We make sure there's at most one instance of this handler running at a time,
-    //    the most recent one. So nothing should be able to dispatch based on stale information.
+    //    the most recent one.
+    //
+    // So nothing should be able to dispatch based on stale information.
 
     listenerAPI.cancelActiveListeners()
 

--- a/app/src/redux/robot-auth/expirationMiddleware.ts
+++ b/app/src/redux/robot-auth/expirationMiddleware.ts
@@ -4,9 +4,9 @@ import { getNextExpiration, logOutOrTimeOut } from './slice'
 
 import type { Dispatch, State } from '../types'
 
-export const timeoutMiddleware = createListenerMiddleware()
+export const expirationMiddleware = createListenerMiddleware()
 
-timeoutMiddleware.startListening.withTypes<State, Dispatch>()({
+expirationMiddleware.startListening.withTypes<State, Dispatch>()({
   predicate: (_action, currentState, originalState) => {
     // Run whenever there's a change to the next scheduled expiration.
     // We're relying on having good memoization here.

--- a/app/src/redux/robot-auth/index.ts
+++ b/app/src/redux/robot-auth/index.ts
@@ -1,2 +1,3 @@
 export * from './hooks'
 export * from './slice'
+export * from './timeoutMiddleware'

--- a/app/src/redux/robot-auth/index.ts
+++ b/app/src/redux/robot-auth/index.ts
@@ -1,3 +1,3 @@
 export * from './hooks'
 export * from './slice'
-export * from './timeoutMiddleware'
+export * from './expirationMiddleware'

--- a/app/src/redux/robot-auth/slice.ts
+++ b/app/src/redux/robot-auth/slice.ts
@@ -140,24 +140,24 @@ interface GetNextExpirationResult {
 
 export const getNextExpiration = createSelector(
   (state: State) => state.robotAuth,
-  (robotAuthState: RobotAuthState): GetNextExpirationResult | null => {
-    let result: GetNextExpirationResult | null = null
-    for (const [candidateName, candidateState] of Object.entries(
-      robotAuthState
-    )) {
-      if (
-        candidateState?.expiresAt != null &&
-        (result?.expiresAt == null ||
-          candidateState.expiresAt < result.expiresAt)
-      ) {
-        result = {
-          robotName: candidateName,
-          expiresAt: candidateState.expiresAt,
+  (robotAuthState: RobotAuthState): GetNextExpirationResult | null =>
+    Object.entries(robotAuthState).reduce<GetNextExpirationResult | null>(
+      (acc, [candidateName, candidateState]) => {
+        if (
+          candidateState?.expiresAt != null &&
+          (acc?.expiresAt == null ||
+            candidateState.expiresAt < acc.expiresAt)
+        ) {
+          return {
+            robotName: candidateName,
+            expiresAt: candidateState.expiresAt,
+          }
+        } else {
+          return acc
         }
-      }
-    }
-    return result
-  },
+      },
+      null
+    ),
   {
     memoizeOptions: {
       // Avoid waking up listeners if we return an object that's referentially new

--- a/app/src/redux/robot-auth/slice.ts
+++ b/app/src/redux/robot-auth/slice.ts
@@ -1,6 +1,7 @@
 /** The Redux slice for authorization and authentication. */
 
 import { createSelector, createSlice } from '@reduxjs/toolkit'
+import isEqual from 'lodash/isEqual'
 
 import { type ActionTypesFromSlice } from '../ActionTypesFromSlice'
 import { getLocalRobot } from '../discovery'
@@ -131,3 +132,49 @@ export const getCurrentUsernameForLocalRobot = createSelector(
     return getAuthStateForRobot(state, localRobotName)?.username ?? null
   }
 )
+
+interface GetNextExpirationResult {
+  robotName: string
+  expiresAt: number
+}
+
+export const getNextExpiration = createSelector(
+  (state: State) => state.robotAuth,
+  (robotAuthState: RobotAuthState): GetNextExpirationResult | null => {
+    let result: GetNextExpirationResult | null = null
+    for (const [candidateName, candidateState] of Object.entries(
+      robotAuthState
+    )) {
+      if (
+        candidateState?.expiresAt != null &&
+        (result?.expiresAt == null ||
+          candidateState.expiresAt < result.expiresAt)
+      ) {
+        result = {
+          robotName: candidateName,
+          expiresAt: candidateState.expiresAt,
+        }
+      }
+    }
+    return result
+  },
+  {
+    memoizeOptions: {
+      // Avoid waking up listeners if we return an object that's referentially new
+      // but semantically hasn't changed.
+      resultEqualityCheck: isEqual,
+    },
+  }
+)
+
+/*
+        ([_robotName, perRobotAuthState]) =>
+          perRobotAuthState?.expiresAt != null
+      )
+      .map(([robotName, perRobotAuthState]) => ({
+        robotName,
+        // These non-null assertions should be OK because of the .filter() above.
+        expiresAt: perRobotAuthState!.expiresAt!,
+      }))
+      .sort((a, b) => a.expiresAt - b.expiresAt)
+      */

--- a/app/src/redux/robot-auth/slice.ts
+++ b/app/src/redux/robot-auth/slice.ts
@@ -166,15 +166,3 @@ export const getNextExpiration = createSelector(
     },
   }
 )
-
-/*
-        ([_robotName, perRobotAuthState]) =>
-          perRobotAuthState?.expiresAt != null
-      )
-      .map(([robotName, perRobotAuthState]) => ({
-        robotName,
-        // These non-null assertions should be OK because of the .filter() above.
-        expiresAt: perRobotAuthState!.expiresAt!,
-      }))
-      .sort((a, b) => a.expiresAt - b.expiresAt)
-      */

--- a/app/src/redux/robot-auth/slice.ts
+++ b/app/src/redux/robot-auth/slice.ts
@@ -145,8 +145,7 @@ export const getNextExpiration = createSelector(
       (acc, [candidateName, candidateState]) => {
         if (
           candidateState?.expiresAt != null &&
-          (acc?.expiresAt == null ||
-            candidateState.expiresAt < acc.expiresAt)
+          (acc?.expiresAt == null || candidateState.expiresAt < acc.expiresAt)
         ) {
           return {
             robotName: candidateName,

--- a/app/src/redux/robot-auth/timeoutMiddleware.ts
+++ b/app/src/redux/robot-auth/timeoutMiddleware.ts
@@ -1,0 +1,39 @@
+import { createListenerMiddleware } from '@reduxjs/toolkit'
+
+import { getNextExpiration, logOutOrTimeOut } from './slice'
+
+import type { Dispatch, State } from '../types'
+
+export const timeoutMiddleware = createListenerMiddleware()
+
+timeoutMiddleware.startListening.withTypes<State, Dispatch>()({
+  predicate: (_action, currentState, originalState) => {
+    // Run whenever there's a change to the next scheduled expiration.
+    // We're relying on having good memoization here.
+    return getNextExpiration(currentState) !== getNextExpiration(originalState)
+  },
+  effect: async (_action, listenerAPI) => {
+    // There has been a change to the next scheduled expiration. We'll wait until we
+    // reach the scheduled time, then dispatch an action to reflect the expiration.
+    //
+    // The next scheduled expiration might change again while we're waiting.
+    // For example, the login might get refreshed, which should postpone its expiration.
+    // To account for this:
+    //
+    // 1. We run a fresh instance of this handler any time there's a change to any
+    //    relevant state. See `predicate` above.
+    // 2. We make sure there's at most one instance of this handler running at a time,
+    //    the most recent one. So nothing should be able to dispatch based on stale information.
+
+    listenerAPI.cancelActiveListeners()
+
+    const nextExpiration = getNextExpiration(listenerAPI.getState())
+    if (nextExpiration != null) {
+      const waitDuration = nextExpiration.expiresAt - Date.now()
+      await listenerAPI.delay(waitDuration)
+      listenerAPI.dispatch(
+        logOutOrTimeOut({ robotName: nextExpiration.robotName })
+      )
+    }
+  },
+})

--- a/app/src/redux/store.ts
+++ b/app/src/redux/store.ts
@@ -4,13 +4,18 @@ import { thunk } from 'redux-thunk'
 
 import { rootEpic } from './epic'
 import { rootReducer } from './reducer'
+import { timeoutMiddleware } from './robot-auth/timeoutMiddleware'
 
 import type { StoreEnhancer } from 'redux'
 import type { Action, State } from './types'
 
 const epicMiddleware = createEpicMiddleware<Action, Action, State, any>()
 
-const middleware = applyMiddleware(thunk, epicMiddleware)
+const middleware = applyMiddleware(
+  thunk,
+  epicMiddleware,
+  timeoutMiddleware.middleware
+)
 
 const composeEnhancers =
   (window as any)?.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__?.({ maxAge: 200 }) ??

--- a/app/src/redux/store.ts
+++ b/app/src/redux/store.ts
@@ -4,7 +4,7 @@ import { thunk } from 'redux-thunk'
 
 import { rootEpic } from './epic'
 import { rootReducer } from './reducer'
-import { timeoutMiddleware } from './robot-auth'
+import { expirationMiddleware } from './robot-auth'
 
 import type { StoreEnhancer } from 'redux'
 import type { Action, State } from './types'
@@ -14,7 +14,7 @@ const epicMiddleware = createEpicMiddleware<Action, Action, State, any>()
 const middleware = applyMiddleware(
   thunk,
   epicMiddleware,
-  timeoutMiddleware.middleware
+  expirationMiddleware.middleware
 )
 
 const composeEnhancers =

--- a/app/src/redux/store.ts
+++ b/app/src/redux/store.ts
@@ -4,7 +4,7 @@ import { thunk } from 'redux-thunk'
 
 import { rootEpic } from './epic'
 import { rootReducer } from './reducer'
-import { timeoutMiddleware } from './robot-auth/timeoutMiddleware'
+import { timeoutMiddleware } from './robot-auth'
 
 import type { StoreEnhancer } from 'redux'
 import type { Action, State } from './types'


### PR DESCRIPTION
## Overview

This adds tracking for when the frontend's access tokens are expiring, so, when that happens, we can do things like put the "logged out" overlay back up on the screen.

This closes EXEC-2645.

## Test Plan and Hands on Testing

I've tried this:

1. Edit the hard-coded lifetime to `seconds=30`:

   https://github.com/Opentrons/opentrons/blob/8a28e276d3b99751f265b9961ea11f94b8a4150b/auth-server/auth_server/oauth2/backend.py#L34

2. Set up access control mode and launch the ODD. There should be a lock overlay. Tap it to log in. The lock overlay should go away.
3. Wait 30 seconds.
4. The lock overlay should come back.

## Details

I've implemented this as a [Redux Toolkit listener middleware](https://redux-toolkit.js.org/api/createListenerMiddleware), following [discussion](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/5007933445/Solve+Almost+Every+Problem+With+a+Hammer+Redux+as+the+Primary+State+Management+Solution+for+Our+Applications) that we want to use Redux and Redux Toolkit in general. This turns out...*okay.* 

To me, the natural way to implement this would be to have one JavaScript task per access token, sleeping until that token expires, and then dispatching an expiration action.

I couldn't figure out how to do that inside listener middleware. Redux toolkit gives us ["child tasks"](https://redux-toolkit.js.org/api/createListenerMiddleware#child-tasks), but I didn't see a clean way to keep a list of them and cancel them when they're no longer valid (e.g. when a login is refreshed, postponing the expiration). So instead I wrote this weird thing, where there's at most 1 task, always waiting for the next expiration, whichever robot it belongs to.

But, at least it's well-integrated with Redux and the unit testing is pretty easy.

## Review requests

Is this understandable? Does the listener middleware strategy seem okay? Is there an easier way to do this?

## Risk assessment

Medium. Potentially confusing concurrency stuff. There's room for bugs like accidentally logging people out if there are stale, renegade tasks floating around.