### PR TITLE
feat(auth-server): Increase the access token timeout to 30 days, for demo purposes

### DIFF
--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -31,7 +31,7 @@ _log = logging.getLogger(__name__)
 _CLIENT_ID = "opentrons_app"
 
 # todo(mm, 2026-01-30): There ought to be some HTTP endpoint to configure this.
-_TOKEN_LIFETIME = timedelta(hours=24)
+_TOKEN_LIFETIME = timedelta(days=30)
 
 
 Backend: TypeAlias = oauthlib.oauth2.LegacyApplicationServer

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -31,7 +31,7 @@ _log = logging.getLogger(__name__)
 _CLIENT_ID = "opentrons_app"
 
 # todo(mm, 2026-01-30): There ought to be some HTTP endpoint to configure this.
-_TOKEN_LIFETIME = timedelta(minutes=3)
+_TOKEN_LIFETIME = timedelta(hours=24)
 
 
 Backend: TypeAlias = oauthlib.oauth2.LegacyApplicationServer


### PR DESCRIPTION
## Overview

Right now, in our in-progress implementation of access control, after user logs in, they get timed out after 3 minutes. That's going to interfere with an upcoming demo—when the timeout is reached, the UI doesn't yet handle it gracefully.

As a quick demo hack, this increases the timeout to 30 days—long enough that it definitely won't be hit during the demo, even if the robot is left on overnight.

The correct solution, which will come later and in several parts, is:

* The timeout needs to be configurable via auth-server's HTTP API, not hard-coded. EXEC-2646.
* The UI needs to gracefully handle being logged out, e.g. by opening a modal to log in again. EXEC-2645, EXEC-2177.
* If there's any user activity, like typing or scrolling, the UI needs to forestall the timeout. EXEC-2179.

## Test Plan and Hands on Testing

None possible, but I think it's a straightforward enough change.

## Review requests

None.

## Risk assessment

Low.
