### PR TITLE
refactor(usb-bridge): suppress expected destroy error in USB agent

### DIFF
--- a/usb-bridge/node-client/src/usb-agent.ts
+++ b/usb-bridge/node-client/src/usb-agent.ts
@@ -290,7 +290,8 @@ class SerialPortHttpAgent extends http.Agent {
 
   destroy(): void {
     this.destroyed = true
-    this.port.destroy(new Error('Agent was destroyed'))
+    this.log('debug', 'Agent was destroyed')
+    this.port.destroy()
   }
 
   createSocket(


### PR DESCRIPTION
# Overview

An expected, chatty error in USB agent bubbles up to Sentry, consuming a lot of our tokens. Since we don't need this log to be an `Error` class explicitly, let's just refactor it to a debug log.

## Risk assessment

- very low
