### PR TITLE
fix(app): downgrade livestream retry log from error to warning

### DIFF
--- a/app/src/pages/Desktop/LivestreamViewer/hooks/useHlsVideo.ts
+++ b/app/src/pages/Desktop/LivestreamViewer/hooks/useHlsVideo.ts
@@ -40,7 +40,7 @@ export function useHlsVideo(
 
   useEffect(() => {
     if (error) {
-      console.error(error)
+      console.warn(error)
     }
   }, [error])
 


### PR DESCRIPTION
# Overview

The livestream viewer logs "Service unavailable. Retrying (N)..." via `console.error` when the HLS stream is temporarily unavailable. This is an expected, gracefully-handled retry scenario, yet Sentry captures these as errors. Since this failure mode is quite chatty, let's downgrade it to a warn and save on tokens.

## Risk assessment

- very low
