### PR TITLE
fix(app): filter `ERR_NETWORK_IO_SUSPENDED` from Sentry

### DIFF
--- a/app/src/App/sentry.ts
+++ b/app/src/App/sentry.ts
@@ -84,6 +84,7 @@ export const initializeSentry = (isAnalyticsEnabled: boolean): void => {
         if (
           errorMessage.includes('Failed to fetch') ||
           errorMessage.includes('Failed to load resource') ||
+          errorMessage.includes('ERR_NETWORK_IO_SUSPENDED') ||
           errorMessage.includes(
             'video-only background media was paused to save power'
           )


### PR DESCRIPTION
# Overview

Filters out `ERR_NETWORK_IO_SUSPENDED` errors from Sentry reporting. This is an expected, transient network error that generates a bunch of Sentry alerts unnecessarily. 

## Risk assessment

- very low -- just impacts Sentry reporting
