### PR TITLE
fix(usb-bridge): handle serial port close to prevent `EPIPE` errors

### DIFF
--- a/usb-bridge/node-client/src/usb-agent.ts
+++ b/usb-bridge/node-client/src/usb-agent.ts
@@ -154,6 +154,23 @@ function socketEmulatorFromPort(port: SerialPort): Socket {
     }
   }
 
+  // Proactively destroy the socket when the port closes or errors to prevent attempted
+  // writes to a closed port. Doing so ensures errors flow through the normal handling chain.
+  const handlePortClose = (): void => {
+    if (!socket.destroyed) {
+      socket.destroy(new Error('Underlying serial port closed'))
+    }
+  }
+
+  const handlePortError = (err: Error): void => {
+    if (!socket.destroyed) {
+      socket.destroy(err)
+    }
+  }
+
+  port.on('close', handlePortClose)
+  port.on('error', handlePortError)
+
   // since this socket is independent from the port, we can do stuff like "have an activity timeout"
   // without worrying that it will kill the socket
   let currentTimeout: NodeJS.Timeout | null = null
@@ -181,6 +198,8 @@ function socketEmulatorFromPort(port: SerialPort): Socket {
   // closes over the socket
   socket.on('close', () => {
     port.removeListener('data', dataForwarder)
+    port.removeListener('close', handlePortClose)
+    port.removeListener('error', handlePortError)
   })
 
   // some little functions to have the right shape for the http internals


### PR DESCRIPTION
# Overview

When a robot is disconnected via USB (physically unplugged, goes to sleep, etc., etc.), the serial port closes but the app may still have pending HTTP requests in flight. Writes to the closed port result in write `EPIPE` errors that surface as uncaught exceptions and flood Sentry but are otherwise relatively innocuous.

To fix, let's handle these errors gracefully by listening for `close` and `error` events on the serial port and proactively call socket.destroy() with an appropriate error. Doing so ensures no writes are attempted to a closed port and errors flow through the normal handling chain.

## Test Plan and Hands on Testing

- Verified USB connection works normally and disconnecting USB while operations are in flight does not generate EPIPE errors.
- Verified reconnecting the USB results in expected behavior.

## Changelog

- Added graceful handling for `EPIPE` USB originating errors

## Risk assessment

- low given testing methinks
