### PR TITLE
feat(protocol-desinger, step-generation): vacuum module labware addition (main module)

### DIFF
--- a/protocol-designer/src/assets/localization/en/starting_deck_state.json
+++ b/protocol-designer/src/assets/localization/en/starting_deck_state.json
@@ -48,6 +48,7 @@
   "here": "here.",
   "labware_already_in_slot": "Labware already in this slot cannot be combined with other labware.",
   "labware_compatible_lids": "Compatible labware lids",
+  "labware_limit_reached": "Labware limit reached for this slot",
   "labware_quantity": "Labware quantity",
   "labware": "Labware",
   "lid": "Lids",

--- a/protocol-designer/src/components/organisms/LabwareCard/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareCard/index.tsx
@@ -118,7 +118,8 @@ export function LabwareCard(props: LabwareCardProps): JSX.Element {
         {showOverflowMenu ? (
           <LabwareCardOverflowMenu
             setShowOverflowMenu={setShowOverflowMenu}
-            labwareIds={filteredStack}
+            // fixes bug where deleting a labware from its overflow menu deletes all non-adapter labware in the stack
+            labwareIds={quantity === 1 ? [labware.id] : filteredStack}
             lidId={lidId}
           />
         ) : null}

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabware.tsx
@@ -9,7 +9,11 @@ import {
   ListButtonAccordionContainer,
   SPACING,
 } from '@opentrons/components'
-import { FLEX_STACKER_MODULE_V1, getMaxPoolCount } from '@opentrons/shared-data'
+import {
+  FLEX_STACKER_MODULE_V1,
+  getMaxPoolCount,
+  VACUUM_MODULE_TYPE,
+} from '@opentrons/shared-data'
 
 import { getOnlyLatestDefs } from '../../../labware-defs'
 import { getCustomLabwareDefsByURI } from '../../../labware-defs/selectors'
@@ -29,7 +33,7 @@ import { getIsNestedDefinitionALid } from './utils'
 
 import type { ChangeEvent } from 'react'
 import type { StackingProps } from '@opentrons/components'
-import type { LabwareDefinition2 } from '@opentrons/shared-data'
+import type { LabwareDefinition2, ModuleType } from '@opentrons/shared-data'
 import type { CategoryExpand } from '../../../pages/Designer/DeckSetup/DeckSetupToolbox'
 import type { ThunkDispatch } from '../../../types'
 import type { LabwareInfo } from './index'
@@ -43,6 +47,7 @@ interface SelectLabwareProps {
   searchFilter: (termToCheck: string) => boolean
   getIsLabwareFiltered: (labwareDef: LabwareDefinition2) => boolean
   universalLid?: [string, LabwareDefinition2]
+  moduleType: ModuleType | null
 }
 export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
   const {
@@ -54,6 +59,7 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
     universalLid,
     getIsLabwareFiltered,
     searchFilter,
+    moduleType,
   } = props
   const dispatch = useDispatch<ThunkDispatch<any>>()
   const { t } = useTranslation(['starting_deck_state', 'shared'])
@@ -103,6 +109,12 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
           labwareDefURI: null,
         })
       )
+      // Clear adapter selection when selecting standalone labware
+      dispatch(
+        selectAdapter({
+          adapterDefURI: null,
+        })
+      )
     }
   }
 
@@ -130,6 +142,8 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
                     const { loadName, isTiprack } = parameters
 
                     const isAdapter = def.allowedRoles?.includes('adapter')
+                    const isVacuumModule = moduleType === VACUUM_MODULE_TYPE
+                    // Don't offer lids for vacuum module labware
                     const stackingLabwareDefUris = getStackerDefinitions(
                       {
                         ...defs,
@@ -151,6 +165,7 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
                     const stackingProps: StackingProps | null =
                       isOnHopper ||
                       (stackingLabwareDefUris.length === 1 &&
+                        !isVacuumModule &&
                         slot !== 'offDeck')
                         ? {
                             inputTitle: t('labware_quantity'),
@@ -211,7 +226,8 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
                           isSelected={
                             (isAdapter && uri === selectedAdapterDefURI) ||
                             (!isAdapter &&
-                              uri === selectedTopLabware.labwareDefURI)
+                              uri === selectedTopLabware.labwareDefURI &&
+                              selectedAdapterDefURI == null)
                           }
                         />
                         <SelectLabwareOnAdapter
@@ -229,7 +245,11 @@ export function SelectLabware(props: SelectLabwareProps): JSX.Element | null {
                           isAdapter={isAdapter ?? false}
                           category={category}
                           loadName={loadName}
-                          lidURIs={isOnHopper ? [] : stackingLabwareDefUris}
+                          lidURIs={
+                            isOnHopper || isVacuumModule
+                              ? []
+                              : stackingLabwareDefUris
+                          }
                         />
                       </Fragment>
                     ) : null

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabwareOnAdapter.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/SelectLabwareOnAdapter.tsx
@@ -179,17 +179,24 @@ export function SelectLabwareOnAdapter(
               const nestedDef =
                 defs[nestedDefUri] ?? customLabwareDefs[nestedDefUri]
 
+              // don't show lid option for vacuum module adapters
+              const isVacuumModuleAdapter =
+                loadName === 'opentrons_vacuum_module_spacer_thingamajig'
+
               const stackingLabwareDefUris = getStackerDefinitions(
                 {
                   ...defs,
                   ...customLabwareDefs,
                 },
-                universalLid?.[0],
+                ...(isVacuumModuleAdapter ? [] : [universalLid?.[0]]),
                 nestedDef.parameters.loadName,
                 nestedDef.metadata.displayCategory
               )
+
               const stackingProps: StackingProps | null =
-                stackingLabwareDefUris.length === 1 && slot !== 'offDeck'
+                stackingLabwareDefUris.length === 1 &&
+                slot !== 'offDeck' &&
+                !isVacuumModuleAdapter
                   ? {
                       inputTitle: t('labware_quantity'),
                       errorMessage: t('unsupported_range'),
@@ -242,14 +249,16 @@ export function SelectLabwareOnAdapter(
                       nestedDefUri === selectedTopLabware.labwareDefURI
                     }
                   />
-                  <SelectLidOnLabware
-                    lidLoadNames={lidLoadNames}
-                    parentLabwareURI={nestedDefUri}
-                    isAdapter={false}
-                    category={category}
-                    loadName={loadName}
-                    lidURIs={stackingLabwareDefUris}
-                  />
+                  {!isVacuumModuleAdapter && (
+                    <SelectLidOnLabware
+                      lidLoadNames={lidLoadNames}
+                      parentLabwareURI={nestedDefUri}
+                      isAdapter={false}
+                      category={category}
+                      loadName={loadName}
+                      lidURIs={stackingLabwareDefUris}
+                    />
+                  )}
                 </Fragment>
               )
             })}

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -205,7 +205,11 @@ export function SelectLabwareModal(
 
       const isRecommendedFilter =
         filterRecommended &&
-        !getLabwareIsRecommended(labwareDef, selectedModuleModel, moduleHasLabware)
+        !getLabwareIsRecommended(
+          labwareDef,
+          selectedModuleModel,
+          moduleHasLabware
+        )
       const isHeightFilter =
         filterHeight &&
         getIsLabwareAboveHeight(
@@ -234,7 +238,14 @@ export function SelectLabwareModal(
     },
     // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filterRecommended, filterHeight, getIsLabwareCompatible, moduleType, slot, moduleHasLabware]
+    [
+      filterRecommended,
+      filterHeight,
+      getIsLabwareCompatible,
+      moduleType,
+      slot,
+      moduleHasLabware,
+    ]
   )
 
   const labwareByCategory = useMemo(

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -39,6 +39,7 @@ import {
   HEATERSHAKER_MODULE_TYPE,
   MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM,
   OT2_ROBOT_TYPE,
+  VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import { getIsSlotAHopper } from '@opentrons/step-generation'
 
@@ -47,6 +48,11 @@ import { getRobotType } from '/protocol-designer/file-data/selectors'
 import { getOnlyLatestDefs } from '/protocol-designer/labware-defs'
 import { createCustomLabwareDef } from '/protocol-designer/labware-defs/actions'
 import { getCustomLabwareDefsByURI } from '/protocol-designer/labware-defs/selectors'
+import {
+  selectAdapter,
+  selectLid,
+  selectTopLabware,
+} from '/protocol-designer/labware-ingred/actions'
 import { selectors } from '/protocol-designer/labware-ingred/selectors'
 import {
   ALL_ORDERED_CATEGORIES,
@@ -85,6 +91,7 @@ interface SelectLabwareModalProps {
   onClose: () => void
   onConfirm: () => void
   slotFull: boolean
+  moduleHasLabware?: boolean
 }
 
 export interface LabwareInfo {
@@ -95,7 +102,7 @@ export interface LabwareInfo {
 export function SelectLabwareModal(
   props: SelectLabwareModalProps
 ): JSX.Element {
-  const { slot, onClose, onConfirm, slotFull } = props
+  const { slot, onClose, onConfirm, slotFull, moduleHasLabware = false } = props
   const { t } = useTranslation(['starting_deck_state', 'shared'])
   const robotType = useSelector(getRobotType)
   const [error, setError] = useState<string | null>(null)
@@ -144,6 +151,10 @@ export function SelectLabwareModal(
   const handleResetLabwareTools = (): void => {
     setUserCategoryExpandState(allCategoriesCollapsed)
     setSearchTerm('')
+    // Clear all selections when closing modal without saving
+    dispatch(selectAdapter({ adapterDefURI: null }))
+    dispatch(selectTopLabware({ labwareDefURI: null }))
+    dispatch(selectLid({ labwareDefURI: null }))
   }
 
   const searchFilter = (termToCheck: string): boolean =>
@@ -175,9 +186,9 @@ export function SelectLabwareModal(
       if (moduleType == null || !getLabwareDefIsStandard(def)) {
         return true
       }
-      return getLabwareCompatibleWithModule(def, moduleType)
+      return getLabwareCompatibleWithModule(def, moduleType, moduleHasLabware)
     },
-    [moduleType]
+    [moduleType, moduleHasLabware]
   )
 
   const getIsLabwareFiltered = useCallback(
@@ -191,29 +202,39 @@ export function SelectLabwareModal(
       const isAdapter = labwareDef.allowedRoles?.includes('adapter')
       const isLid = labwareDef.allowedRoles?.includes('lid')
       const isAdapter96Channel = parameters.loadName === ADAPTER_96_CHANNEL
-      return (
-        (filterRecommended &&
-          !getLabwareIsRecommended(labwareDef, selectedModuleModel)) ||
-        (filterHeight &&
-          getIsLabwareAboveHeight(
-            labwareDef,
-            MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM
-          )) ||
-        !getIsLabwareCompatible(labwareDef) ||
-        (isAdapter &&
-          isIrregularSize &&
-          moduleType !== HEATERSHAKER_MODULE_TYPE) ||
+
+      const isRecommendedFilter =
+        filterRecommended &&
+        !getLabwareIsRecommended(labwareDef, selectedModuleModel, moduleHasLabware)
+      const isHeightFilter =
+        filterHeight &&
+        getIsLabwareAboveHeight(
+          labwareDef,
+          MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM
+        )
+      const isNotCompatible = !getIsLabwareCompatible(labwareDef)
+      const isIrregularAdapter =
+        isAdapter &&
+        isIrregularSize &&
+        moduleType !== HEATERSHAKER_MODULE_TYPE &&
+        moduleType !== VACUUM_MODULE_TYPE
+
+      const isFiltered =
+        isRecommendedFilter ||
+        isHeightFilter ||
+        isNotCompatible ||
+        isIrregularAdapter ||
         (isAdapter96Channel && !has96Channel) ||
-        // NOTE (2026-03-30, RC): this is a temporary filter to prevent loading lids off deck until this is allowed in PAPI
         (slot === 'offDeck' && (isAdapter || isLid)) ||
         (PLATE_READER_LOADNAME === parameters.loadName &&
           moduleType !== ABSORBANCE_READER_TYPE) ||
         parameters.loadName === TIPRACK_LID_LOADNAME
-      )
+
+      return isFiltered
     },
     // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filterRecommended, filterHeight, getIsLabwareCompatible, moduleType, slot]
+    [filterRecommended, filterHeight, getIsLabwareCompatible, moduleType, slot, moduleHasLabware]
   )
 
   const labwareByCategory = useMemo(
@@ -478,6 +499,7 @@ export function SelectLabwareModal(
               searchFilter={searchFilter}
               getIsLabwareFiltered={getIsLabwareFiltered}
               universalLid={universalLid}
+              moduleType={moduleType}
             />
           )}
         </Flex>

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -175,3 +175,8 @@ export const ACCEPTED_PROTOCOL_FILE_TYPES = '.json,.py'
 
 export const HOPPER_LABWARE_X_OFFSET = 178
 export const HOPPER_ZOOM_OFFSET_POSTITION = 230
+
+// Vacuum dock is in A4, adjacent to module in A3
+// Start with similar offset to hopper, adjust based on testing
+export const VACUUM_DOCK_LABWARE_X_OFFSET = 178
+export const VACUUM_DOCK_ZOOM_OFFSET_POSITION = 230

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
@@ -33,6 +33,7 @@ import {
 import {
   DECK_SETUP_TOOLS_WIDTH_REM,
   HOPPER_ZOOM_OFFSET_POSTITION,
+  VACUUM_DOCK_ZOOM_OFFSET_POSITION,
 } from '../../../constants'
 import { getDisableModuleRestrictions } from '../../../feature-flags/selectors'
 import {
@@ -154,9 +155,30 @@ export function DeckSetupContainer(
     return i < viewBoxNumerical.length - 1 ? acc + `${num} ` : acc + `${num}`
   }, '')
 
-  const addEquipment = (location: string): void => {
+  const _getSlotFromRawLocation = (location: string): string => {
     const isOnHopper = location.includes('hopper')
-    const slot = isOnHopper ? location.split('hopper')[1] : location
+    const isOnVacuumDock = location.includes('vacuumDock')
+    return isOnHopper
+      ? location.split('hopper')[1]
+      : isOnVacuumDock
+        ? location.split('vacuumDock')[1]
+        : location
+  }
+
+  const _getZoomInOffsetFromRawLocation = (location: string): number => {
+    const isOnHopper = location.includes('hopper')
+    const isOnVacuumDock = location.includes('vacuumDock')
+    if (isOnHopper) {
+      return HOPPER_ZOOM_OFFSET_POSTITION
+    }
+    if (isOnVacuumDock) {
+      return VACUUM_DOCK_ZOOM_OFFSET_POSITION
+    }
+    return 0
+  }
+
+  const addEquipment = (location: string): void => {
+    const slot = _getSlotFromRawLocation(location)
     const { createdModuleForSlot, preSelectedFixture } = getSlotInformation({
       deckSetup: activeDeckSetup,
       slot: location,
@@ -176,7 +198,7 @@ export function DeckSetupContainer(
     const zoomInSlotPosition = getPositionFromSlotId(
       slot ?? '',
       deckDef,
-      ...(isOnHopper ? [HOPPER_ZOOM_OFFSET_POSTITION] : [])
+      _getZoomInOffsetFromRawLocation(location)
     )
     if (zoomInSlotPosition != null) {
       const zoomedInViewBox = zoomInOnCoordinate({

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -12,6 +12,7 @@ import {
   inferModuleOrientationFromXCoordinate,
   isAddressableAreaStandardSlot,
   THERMOCYCLER_MODULE_TYPE,
+  VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import {
   FAKE_HOPPER_LOCATION_MAP,
@@ -19,7 +20,10 @@ import {
   getSlotInLocationStack,
 } from '@opentrons/step-generation'
 
-import { HOPPER_LABWARE_X_OFFSET } from '/protocol-designer/constants'
+import {
+  HOPPER_LABWARE_X_OFFSET,
+  VACUUM_DOCK_LABWARE_X_OFFSET,
+} from '/protocol-designer/constants'
 import { getTimelineIsBeingComputed } from '/protocol-designer/file-data/selectors'
 import { getPendingCreationState } from '/protocol-designer/step-forms/selectors'
 
@@ -311,8 +315,12 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
           }
         }
 
-        const { topMostId, rightBelowTopId, hopperTopMostId } =
-          getLabwaresOnModuleFromStack(moduleOnDeck.id, allLabwareValues)
+        const {
+          topMostId,
+          rightBelowTopId,
+          hopperTopMostId,
+          vacuumDockTopMostId,
+        } = getLabwaresOnModuleFromStack(moduleOnDeck.id, allLabwareValues)
         const labwareInterfaceBoundingBox = {
           xDimension: moduleDef.dimensions.labwareInterfaceXDimension ?? 0,
           yDimension: moduleDef.dimensions.labwareInterfaceYDimension ?? 0,
@@ -472,6 +480,26 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
                   itemId={`hopper${slotId}`}
                   key={`${moduleOnDeck.slot}_flexHopper`}
                   slotPosition={[HOPPER_LABWARE_X_OFFSET, 0, 0]}
+                  slotBoundingBox={labwareInterfaceBoundingBox}
+                  moduleType={moduleOnDeck.type}
+                  handleDragHover={handleHoverEmptySlot}
+                  slotId={moduleOnDeck.id}
+                  hover={hover}
+                  setHover={setHover}
+                  setShowMenuListForId={setShowMenuListForId}
+                  isSelected={selectedZoomInSlot != null}
+                  deckDef={deckDef}
+                  stagingAreaAddressableAreas={[]}
+                  addEquipment={addEquipment}
+                />
+              ) : null}
+              {vacuumDockTopMostId == null &&
+              moduleOnDeck.type === VACUUM_MODULE_TYPE ? (
+                <SlotControls
+                  terminalItemId={terminalItemId}
+                  itemId={`vacuumDock${slotId}`}
+                  key={`${moduleOnDeck.slot}_vacuumDock`}
+                  slotPosition={[VACUUM_DOCK_LABWARE_X_OFFSET, 0, 0]}
                   slotBoundingBox={labwareInterfaceBoundingBox}
                   moduleType={moduleOnDeck.type}
                   handleDragHover={handleHoverEmptySlot}

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
@@ -368,7 +368,8 @@ export function DeckSetupToolbox(
               <EmptySelectorButton
                 textAlignment="left"
                 text={
-                  hasNoLabware || (hasVacuumModuleCreated && !isVacuumModuleFull)
+                  hasNoLabware ||
+                  (hasVacuumModuleCreated && !isVacuumModuleFull)
                     ? t('add_labware')
                     : t('replace_labware')
                 }

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
@@ -41,6 +41,7 @@ import {
   LabwareCard,
   SelectLabwareModal,
 } from '../../../components/organisms'
+import { useKitchen } from '../../../components/organisms/Kitchen/useKitchen'
 import { DECK_SETUP_TOOLS_WIDTH_REM } from '../../../constants'
 import {
   createContainer,
@@ -87,6 +88,7 @@ export function DeckSetupToolbox(
   const { slot } = selectedSlot
   const [showSelectLabwareModal, setShowSelectLabwareModal] =
     useState<boolean>(false)
+  const { makeSnackbar } = useKitchen()
   const isOnPlateReader = selectedModuleModel === ABSORBANCE_READER_V1
   const {
     createdAdapterForSlot,
@@ -142,10 +144,9 @@ export function DeckSetupToolbox(
     getIsVacuumModuleFull(createdStackForSlot, deckSetup.labware)
 
   const slotFull =
-    (((createdAdapterForSlot != null && createdStackForSlot.length > 0) ||
+    ((createdAdapterForSlot != null && createdStackForSlot.length > 0) ||
       (createdStackForSlot.length > 0 && deckSetup.labware[slot] != null)) &&
-      !isVacuumModule) ||
-    isVacuumModuleFull
+    !isVacuumModule
 
   const hasNoLabware =
     (createdAdapterForSlot == null && createdStackForSlot.length === 0) ||
@@ -197,13 +198,12 @@ export function DeckSetupToolbox(
       (createdAdapterForSlot != null || createdStackForSlot.length > 0)
 
     //  handle clear for if you are changing the adapter/labware combo
-    // For vacuum modules, only clear if it's full (replace behavior)
-    // Otherwise, use additive behavior
-    if (!isOffDeck && (!isVacuumModule || isVacuumModuleFull)) {
+    // For vacuum modules, use additive behavior (never clear)
+    if (!isOffDeck && !isVacuumModule) {
       handleClear()
     }
     //  NOTE: labware on the Flex Stacker shuttle is not on any module ;)
-    if (hasModule && (!vacuumModuleHasLabware || isVacuumModuleFull)) {
+    if (hasModule && !vacuumModuleHasLabware) {
       let flexStackerInfo: CreateContainerAboveModuleArgs['stackerInfo']
       if (isModuleStacker) {
         flexStackerInfo = isOnShuttle
@@ -228,8 +228,8 @@ export function DeckSetupToolbox(
           stackerInfo: flexStackerInfo,
         })
       )
-    } else if (vacuumModuleHasLabware && !isVacuumModuleFull) {
-      // For vacuum module with existing labware (not full), add new labware on top
+    } else if (vacuumModuleHasLabware) {
+      // For vacuum module with existing labware, add new labware on top
       const topLabwareId =
         createdStackForSlot.length > 0
           ? createdStackForSlot[0] // Get the top item (first in array)
@@ -368,14 +368,17 @@ export function DeckSetupToolbox(
               <EmptySelectorButton
                 textAlignment="left"
                 text={
-                  hasNoLabware ||
-                  (hasVacuumModuleCreated && !isVacuumModuleFull)
+                  hasNoLabware || hasVacuumModuleCreated
                     ? t('add_labware')
                     : t('replace_labware')
                 }
                 iconName="plus"
                 onClick={() => {
-                  setShowSelectLabwareModal(true)
+                  if (hasVacuumModuleCreated && isVacuumModuleFull) {
+                    makeSnackbar(t('labware_limit_reached') as string)
+                  } else {
+                    setShowSelectLabwareModal(true)
+                  }
                 }}
               />
             </Flex>

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
@@ -23,6 +23,7 @@ import {
   ABSORBANCE_READER_V1,
   FLEX_STACKER_MODULE_TYPE,
   getModuleType,
+  VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import {
   FAKE_HOPPER_LOCATION_MAP,
@@ -52,7 +53,7 @@ import { createContainerAboveModule } from '../../../step-forms/actions/thunks'
 import { getSavedStepForms } from '../../../step-forms/selectors'
 import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
 import { getSlotInformation } from '../utils'
-import { getIsLabwareOnSlotInUse } from './utils'
+import { getIsLabwareOnSlotInUse, getIsVacuumModuleFull } from './utils'
 
 import type { HopperLocationMapKey } from '@opentrons/step-generation'
 import type { CreateContainerAboveModuleArgs } from '../../../step-forms/actions/thunks'
@@ -105,6 +106,12 @@ export function DeckSetupToolbox(
   }
   const isHopperSlot = getIsSlotAHopper(slot)
   const offDeckLabware = deckSetup.labware[slot]
+  const isVacuumModule =
+    selectedModuleModel != null &&
+    getModuleType(selectedModuleModel) === VACUUM_MODULE_TYPE
+  const hasVacuumModuleCreated =
+    createdModuleForSlot != null &&
+    getModuleType(createdModuleForSlot.model) === VACUUM_MODULE_TYPE
   const handleResetToolbox = (): void => {
     dispatch(
       editSlotInfo({
@@ -130,9 +137,15 @@ export function DeckSetupToolbox(
       ? createdModuleForSlot.moduleState.labwareInHopper
       : null
 
+  const isVacuumModuleFull =
+    hasVacuumModuleCreated &&
+    getIsVacuumModuleFull(createdStackForSlot, deckSetup.labware)
+
   const slotFull =
-    (createdAdapterForSlot != null && createdStackForSlot.length > 0) ||
-    (createdStackForSlot.length > 0 && deckSetup.labware[slot] != null)
+    (((createdAdapterForSlot != null && createdStackForSlot.length > 0) ||
+      (createdStackForSlot.length > 0 && deckSetup.labware[slot] != null)) &&
+      !isVacuumModule) ||
+    isVacuumModuleFull
 
   const hasNoLabware =
     (createdAdapterForSlot == null && createdStackForSlot.length === 0) ||
@@ -172,17 +185,25 @@ export function DeckSetupToolbox(
   const handleConfirm = (): void => {
     const isOffDeck = slot === 'offDeck'
     const hasModule = selectedModuleModel != null
+    const isVacuumModule =
+      selectedModuleModel != null &&
+      getModuleType(selectedModuleModel) === VACUUM_MODULE_TYPE
     const isModuleStacker =
       selectedModuleModel != null &&
       getModuleType(selectedModuleModel) === FLEX_STACKER_MODULE_TYPE
     const isOnShuttle = !isHopperSlot && isModuleStacker
+    const vacuumModuleHasLabware =
+      isVacuumModule &&
+      (createdAdapterForSlot != null || createdStackForSlot.length > 0)
 
     //  handle clear for if you are changing the adapter/labware combo
-    if (!isOffDeck) {
+    // For vacuum modules, only clear if it's full (replace behavior)
+    // Otherwise, use additive behavior
+    if (!isOffDeck && (!isVacuumModule || isVacuumModuleFull)) {
       handleClear()
     }
     //  NOTE: labware on the Flex Stacker shuttle is not on any module ;)
-    if (hasModule) {
+    if (hasModule && (!vacuumModuleHasLabware || isVacuumModuleFull)) {
       let flexStackerInfo: CreateContainerAboveModuleArgs['stackerInfo']
       if (isModuleStacker) {
         flexStackerInfo = isOnShuttle
@@ -205,6 +226,23 @@ export function DeckSetupToolbox(
             lidDefURI: selectedLidLabware,
           },
           stackerInfo: flexStackerInfo,
+        })
+      )
+    } else if (vacuumModuleHasLabware && !isVacuumModuleFull) {
+      // For vacuum module with existing labware (not full), add new labware on top
+      const topLabwareId =
+        createdStackForSlot.length > 0
+          ? createdStackForSlot[0] // Get the top item (first in array)
+          : createdAdapterForSlot?.id
+      dispatch(
+        createContainer({
+          slot: topLabwareId,
+          labwareDefURIStack: [
+            ...(selectedAdapterDefURI != null ? [selectedAdapterDefURI] : []),
+            ...(selectedTopLabware.labwareDefURI != null
+              ? [selectedTopLabware.labwareDefURI]
+              : []),
+          ],
         })
       )
     } else {
@@ -264,6 +302,7 @@ export function DeckSetupToolbox(
   const displaySlot = getIsSlotAHopper(slot)
     ? t('shared:stacker', { slot: getColumnFromWellName(slot) })
     : slot
+
   return (
     <>
       {showSelectLabwareModal ? (
@@ -274,6 +313,10 @@ export function DeckSetupToolbox(
           }}
           onConfirm={handleConfirmSelection}
           slotFull={slotFull}
+          moduleHasLabware={
+            isVacuumModule &&
+            (createdAdapterForSlot != null || createdStackForSlot.length > 0)
+          }
         />
       ) : null}
       {isLabwareOnSlotInUse && showDeleteEntityInUseModal ? (
@@ -324,7 +367,11 @@ export function DeckSetupToolbox(
             <Flex width={FLEX_MAX_CONTENT}>
               <EmptySelectorButton
                 textAlignment="left"
-                text={hasNoLabware ? t('add_labware') : t('replace_labware')}
+                text={
+                  hasNoLabware || (hasVacuumModuleCreated && !isVacuumModuleFull)
+                    ? t('add_labware')
+                    : t('replace_labware')
+                }
                 iconName="plus"
                 onClick={() => {
                   setShowSelectLabwareModal(true)
@@ -353,26 +400,28 @@ export function DeckSetupToolbox(
                   {t('top_slot')}
                 </StyledText>
               ) : null}
-              {createdStackForSlot.length > 0 ? (
-                <LabwareCard
-                  labware={
-                    deckSetup.labware[
-                      createdStackForSlot[0] // select top most labware in the stack
-                    ]
-                  }
-                  {...(createdLidForSlot != null &&
-                  createdStackForSlot.includes(createdLidForSlot?.id)
-                    ? {}
-                    : { lidId: createdLidForSlot?.id })}
-                  quantity={
-                    labwareInHopper != null
-                      ? labwareInHopper.length
-                      : createdStackForSlot.length
-                  }
-                  location={slot}
-                />
-              ) : null}
-              {createdAdapterForSlot != null ? (
+              {createdStackForSlot.length > 0
+                ? createdStackForSlot.map((labwareId, index) => (
+                    <LabwareCard
+                      key={labwareId}
+                      labware={deckSetup.labware[labwareId]}
+                      {...(createdLidForSlot != null &&
+                      createdStackForSlot.includes(createdLidForSlot?.id) &&
+                      labwareId === createdLidForSlot?.id
+                        ? {}
+                        : index === 0 && createdLidForSlot != null
+                          ? { lidId: createdLidForSlot?.id }
+                          : {})}
+                      quantity={
+                        labwareInHopper != null && index === 0
+                          ? labwareInHopper.length
+                          : 1
+                      }
+                      location={slot}
+                    />
+                  ))
+                : null}
+              {createdAdapterForSlot != null && !hasVacuumModuleCreated ? (
                 <LabwareCard
                   labware={createdAdapterForSlot}
                   quantity={1}

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/SlotControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/SlotControls.tsx
@@ -17,7 +17,10 @@ import {
   FLEX_STACKER_MODULE_TYPE,
   getCutoutIdFromAddressableArea,
 } from '@opentrons/shared-data'
-import { getIsSlotAHopper } from '@opentrons/step-generation'
+import {
+  getIsSlotAHopper,
+  getIsSlotAVacuumDock,
+} from '@opentrons/step-generation'
 
 import { DND_TYPES } from '/protocol-designer/constants'
 import { selectors as labwareDefSelectors } from '/protocol-designer/labware-defs'
@@ -73,9 +76,10 @@ export const SlotControls = (props: SlotControlsProps): JSX.Element | null => {
   const customLabwareDefs = useSelector(
     labwareDefSelectors.getCustomLabwareDefsByURI
   )
+  const isSlotAVacuumDock = getIsSlotAVacuumDock(itemId)
   const isSlotAHopper = getIsSlotAHopper(itemId)
   const additionalEquipment = useSelector(getAdditionalEquipmentEntities)
-  const cutoutId = isSlotAHopper
+  const cutoutId = isSlotAHopper || isSlotAVacuumDock
     ? null
     : getCutoutIdFromAddressableArea(itemId, deckDef)
   const trashSlots = Object.values(additionalEquipment)

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/SlotControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/SlotControls.tsx
@@ -79,9 +79,10 @@ export const SlotControls = (props: SlotControlsProps): JSX.Element | null => {
   const isSlotAVacuumDock = getIsSlotAVacuumDock(itemId)
   const isSlotAHopper = getIsSlotAHopper(itemId)
   const additionalEquipment = useSelector(getAdditionalEquipmentEntities)
-  const cutoutId = isSlotAHopper || isSlotAVacuumDock
-    ? null
-    : getCutoutIdFromAddressableArea(itemId, deckDef)
+  const cutoutId =
+    isSlotAHopper || isSlotAVacuumDock
+      ? null
+      : getCutoutIdFromAddressableArea(itemId, deckDef)
   const trashSlots = Object.values(additionalEquipment)
     .filter(ae => ae.name === 'trashBin' || ae.name === 'wasteChute')
     ?.map(ae => ae.location as CutoutId)

--- a/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
@@ -29,7 +29,8 @@ import {
   VACUUM_MODULE_V1,
 } from '@opentrons/shared-data'
 
-import type { ModuleModel, ModuleType } from '@opentrons/shared-data'
+import type { ModuleModel } from '@opentrons/shared-data'
+import type { ModuleLabwareCompatibilityKey } from '../../../types'
 
 export const FLEX_MODULE_MODELS: ModuleModel[] = [
   ABSORBANCE_READER_V1,
@@ -77,7 +78,9 @@ export const ORDERED_CATEGORIES: string[] = [
 export const CUSTOM_CATEGORY = 'custom'
 export const ALL_ORDERED_CATEGORIES = [CUSTOM_CATEGORY, ...ORDERED_CATEGORIES]
 
-export const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
+export const RECOMMENDED_LABWARE_BY_MODULE: {
+  [K in ModuleLabwareCompatibilityKey]: string[]
+} = {
   [TEMPERATURE_MODULE_TYPE]: [
     'opentrons_24_aluminumblock_generic_2ml_screwcap',
     'opentrons_96_well_aluminum_block',
@@ -133,7 +136,17 @@ export const RECOMMENDED_LABWARE_BY_MODULE: { [K in ModuleType]: string[] } = {
     'opentrons_tough_1_reservoir_300ml',
     'opentrons_tough_4_reservoir_72ml',
   ],
-  [VACUUM_MODULE_TYPE]: [],
+
+  // TODO (nd: 2026-05-14): correctly reflect vacuum module compatible labware once they are added to shared-data
+  [VACUUM_MODULE_TYPE]: [
+    'opentrons_vacuum_module_spacer_thingamajig',
+    'opentrons_96_wellplate_200ul_pcr_full_skirt',
+  ],
+  VACUUM_MODULE_TYPE_WITH_LABWARE: [
+    'opentrons_96_wellplate_200ul_pcr_full_skirt',
+    'opentrons_vacuum_module_gen1_collar_tall',
+    'opentrons_vacuum_module_gen1_collar_short',
+  ],
 }
 
 export const MOAM_MODELS_WITH_FF: ModuleModel[] = [TEMPERATURE_MODULE_V2]

--- a/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
@@ -141,6 +141,8 @@ export const RECOMMENDED_LABWARE_BY_MODULE: {
   [VACUUM_MODULE_TYPE]: [
     'opentrons_vacuum_module_spacer_thingamajig',
     'opentrons_96_wellplate_200ul_pcr_full_skirt',
+    'opentrons_vacuum_module_gen1_collar_tall',
+    'opentrons_vacuum_module_gen1_collar_short',
   ],
   VACUUM_MODULE_TYPE_WITH_LABWARE: [
     'opentrons_96_wellplate_200ul_pcr_full_skirt',

--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -14,6 +14,7 @@ import {
   TEMPERATURE_MODULE_V2,
   THERMOCYCLER_MODULE_TYPE,
   THERMOCYCLER_MODULE_V2,
+  VACUUM_MODULE_TYPE,
   VACUUM_MODULE_V1,
 } from '@opentrons/shared-data'
 import { getSlotInLocationStack } from '@opentrons/step-generation'
@@ -143,7 +144,8 @@ export function getModuleModelsBySlot(
 
 export const getLabwareIsRecommended = (
   def: LabwareDefinition2,
-  moduleModel?: ModuleModel | null
+  moduleModel?: ModuleModel | null,
+  moduleHasLabware: boolean = false
 ): boolean => {
   //  special-casing the thermocycler module V2 recommended labware since the thermocyclerModuleTypes
   //  have different recommended labware
@@ -152,6 +154,27 @@ export const getLabwareIsRecommended = (
     return true
   }
   const moduleType = getModuleType(moduleModel)
+
+  // For vacuum module, show different labware based on whether module has labware
+  if (moduleType === VACUUM_MODULE_TYPE) {
+    if (moduleHasLabware) {
+      // Show collars and wellplates when module already has labware
+      return (
+        def.parameters.loadName ===
+          'opentrons_vacuum_module_gen1_collar_tall' ||
+        def.parameters.loadName ===
+          'opentrons_vacuum_module_gen1_collar_short' ||
+        def.parameters.loadName ===
+          'opentrons_96_wellplate_200ul_pcr_full_skirt'
+      )
+    } else {
+      // Show spacer and wellplate for empty module
+      return RECOMMENDED_LABWARE_BY_MODULE[moduleType].includes(
+        def.parameters.loadName
+      )
+    }
+  }
+
   return moduleModel === THERMOCYCLER_MODULE_V2
     ? def.parameters.loadName === 'opentrons_96_wellplate_200ul_pcr_full_skirt'
     : RECOMMENDED_LABWARE_BY_MODULE[moduleType].includes(
@@ -174,6 +197,20 @@ export const getLabwareCompatibleWithAdapter = (
         stackingOffsetWithLabware?.[adapterLoadName] != null
     )
     .map(([labwareDefUri]) => labwareDefUri)
+}
+
+export const getIsVacuumModuleFull = (
+  labwareStack: string[],
+  deckSetupLabware: AllTemporalPropertiesForTimelineFrame['labware']
+): boolean => {
+  // Vacuum module is considered "full" if it contains any collar adapter
+  return labwareStack.some(labwareId => {
+    const loadName = deckSetupLabware[labwareId]?.def.parameters.loadName
+    return (
+      loadName === 'opentrons_vacuum_module_gen1_collar_tall' ||
+      loadName === 'opentrons_vacuum_module_gen1_collar_short'
+    )
+  })
 }
 
 const getStackerDefinitionsFromLoadName = (

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -14,15 +14,21 @@ import {
   TC_MODULE_LOCATION_OT2,
   TC_MODULE_LOCATION_OT3,
   THERMOCYCLER_MODULE_TYPE,
+  VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import {
   FAKE_HOPPER_LOCATION_MAP,
+  FAKE_VACUUM_DOCK_LOCATION_MAP,
   getFullStackFromLabwares,
   getIsSlotAHopper,
+  getIsSlotAVacuumDock,
   getSlotInLocationStack,
 } from '@opentrons/step-generation'
 
-import { HOPPER_LABWARE_X_OFFSET } from '/protocol-designer/constants'
+import {
+  HOPPER_LABWARE_X_OFFSET,
+  VACUUM_DOCK_LABWARE_X_OFFSET,
+} from '/protocol-designer/constants'
 
 import { getRobotType } from '../../file-data/selectors'
 import { getLabwareEntities } from '../../step-forms/selectors'
@@ -49,6 +55,7 @@ import type {
   LabwareEntities,
   LabwareEntity,
   RobotState,
+  VacuumDockLocationMapKey,
 } from '@opentrons/step-generation'
 import type {
   AllTemporalPropertiesForTimelineFrame,
@@ -90,6 +97,33 @@ interface SlotInformationProps {
 const FOURTH_COLUMN_SLOTS = ['A4', 'B4', 'C4', 'D4']
 const FOURTH_COLUMN_CONVERSION = { A4: 'A3', B4: 'B3', C4: 'C3', D4: 'D3' }
 
+const _getAdjustedSlot = (
+  slot: DeckSlot,
+  isSlotAVacuumDock: boolean,
+  isSlotAHopper: boolean
+): string => {
+  if (isSlotAVacuumDock) {
+    return FAKE_VACUUM_DOCK_LOCATION_MAP[slot as VacuumDockLocationMapKey]
+  }
+  if (isSlotAHopper) {
+    return FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
+  }
+  return slot
+}
+const _getOffsetFromSlot = (
+  slot: DeckSlot,
+  isSlotAVacuumDock: boolean,
+  isSlotAHopper: boolean
+): number => {
+  if (isSlotAVacuumDock) {
+    return VACUUM_DOCK_LABWARE_X_OFFSET
+  }
+  if (isSlotAHopper) {
+    return HOPPER_LABWARE_X_OFFSET
+  }
+  return 0
+}
+
 export const getSlotInformation = (
   props: SlotInformationProps
 ): SlotInformation => {
@@ -109,16 +143,15 @@ export const getSlotInformation = (
     .filter(def => def.allowedRoles?.includes('lid'))
     ?.map(def => def.parameters.loadName)
   const offDeckLabware = deckSetupLabware[slot]
+  const isSlotAVacuumDock = getIsSlotAVacuumDock(slot)
   const isSlotAHopper = getIsSlotAHopper(slot)
-  const adjustedSlot = isSlotAHopper
-    ? FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
-    : slot
+  const adjustedSlot = _getAdjustedSlot(slot, isSlotAVacuumDock, isSlotAHopper)
   const slotPosition =
     deckDef != null && offDeckLabware == null
       ? getPositionFromSlotId(
-          adjustedSlot as string,
+          adjustedSlot,
           deckDef,
-          ...(isSlotAHopper ? [HOPPER_LABWARE_X_OFFSET] : [])
+          _getOffsetFromSlot(slot, isSlotAVacuumDock, isSlotAHopper)
         )
       : null
   const createdModuleForSlot = Object.values(deckSetupModules).find(
@@ -167,11 +200,15 @@ export const getSlotInformation = (
       : deckSetupLabware[id]?.def.parameters.loadName === TIPRACK_LID_LOADNAME
   )
 
+  // For vacuum module, don't separate adapters from the stack since multiple adapters can be stacked
+  const isVacuumModule = createdModuleForSlot?.type === VACUUM_MODULE_TYPE
+
   const bottomMostLabware =
     deckSetupLabware[
       labwareIdsFromFullStack[labwareIdsFromFullStack.length - 1]
     ]
   const createdAdapterForSlot =
+    !isVacuumModule &&
     bottomMostLabware != null &&
     bottomMostLabware.def.allowedRoles?.includes('adapter')
       ? bottomMostLabware

--- a/protocol-designer/src/types.ts
+++ b/protocol-designer/src/types.ts
@@ -2,6 +2,7 @@ import type { FC } from 'react'
 import type {
   HEATERSHAKER_MODULE_TYPE,
   MAGNETIC_MODULE_TYPE,
+  ModuleType,
   NozzleConfigurationStyle,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
@@ -73,3 +74,7 @@ export type OT2ModuleType =
   | typeof TEMPERATURE_MODULE_TYPE
   | typeof THERMOCYCLER_MODULE_TYPE
   | typeof HEATERSHAKER_MODULE_TYPE
+
+export type ModuleLabwareCompatibilityKey =
+  | ModuleType
+  | 'VACUUM_MODULE_TYPE_WITH_LABWARE'

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -17,6 +17,8 @@ import {
   getSlotInLocationStack,
   HOPPER_STACKER_LOCATION,
   PROTOCOL_CONTEXT_NAME,
+  VACUUM_DOCK_FAKE_LOCATION,
+  VACUUM_DOCK_LOCATION,
 } from '@opentrons/step-generation'
 
 import type { WellGroup } from '@opentrons/components'
@@ -388,6 +390,10 @@ export function getLocationStackTopToBottom(
       // So when the node is on the hopper, insert the hopper marker once
       stack.push(HOPPER_STACKER_LOCATION)
     }
+    const isOnVacuumDock = slot === VACUUM_DOCK_FAKE_LOCATION
+    if (isOnVacuumDock) {
+      stack.push(VACUUM_DOCK_LOCATION)
+    }
     current = parent
   }
   return stack
@@ -400,11 +406,14 @@ export const getLabwaresOnModuleFromStack = (
   topMostId: string | null
   rightBelowTopId: string | null
   hopperTopMostId: string | null
+  vacuumDockTopMostId: string | null
 } => {
-  // all stacks involving this module and not on the hopper if its a flex stacker
+  // all stacks involving this module and not on the hopper if its a flex stacker and not on the vacuum dock
   const allStacks = labware.filter(
     ({ stack }) =>
-      stack.includes(moduleId) && !stack.includes(HOPPER_STACKER_LOCATION)
+      stack.includes(moduleId) &&
+      !stack.includes(HOPPER_STACKER_LOCATION) &&
+      !stack.includes(VACUUM_DOCK_LOCATION)
   )
   const largestStack = allStacks.sort(
     (a, b) => b.stack.length - a.stack.length
@@ -421,10 +430,19 @@ export const getLabwaresOnModuleFromStack = (
   const largestStackOnHopper = allStacksOnHopper.sort(
     (a, b) => b.stack.length - a.stack.length
   )[0]
+  // all stacks involving the vacuum dock if there is one
+  const allStacksOnVacuumDock = labware.filter(
+    ({ stack }) =>
+      stack.includes(moduleId) && stack.includes(VACUUM_DOCK_LOCATION)
+  )
+  const largestStackOnVacuumDock = allStacksOnVacuumDock.sort(
+    (a, b) => b.stack.length - a.stack.length
+  )[0]
   return {
     topMostId: largestStack?.stack[0],
     rightBelowTopId: isTopMostIdALid ? largestStack?.stack[1] : null,
     hopperTopMostId: largestStackOnHopper?.stack[0],
+    vacuumDockTopMostId: largestStackOnVacuumDock?.stack[0],
   }
 }
 

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -89,6 +89,8 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE: Record<
   [VACUUM_MODULE_TYPE]: [
     'opentrons_vacuum_module_spacer_thingamajig',
     'opentrons_96_wellplate_200ul_pcr_full_skirt',
+    'opentrons_vacuum_module_gen1_collar_tall',
+    'opentrons_vacuum_module_gen1_collar_short',
   ],
   VACUUM_MODULE_TYPE_WITH_LABWARE: [
     'opentrons_96_wellplate_200ul_pcr_full_skirt',

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -12,16 +12,17 @@ import {
 
 import { RECOMMENDED_LABWARE_BY_MODULE } from '../pages/Designer/DeckSetup/constants'
 
-import type { LabwareDefinition2, ModuleType } from '@opentrons/shared-data'
+import type { LabwareDefinition2 } from '@opentrons/shared-data'
 import type { LabwareDefByDefURI } from '../labware-defs'
 import type { LabwareOnDeck } from '../step-forms'
+import type { ModuleLabwareCompatibilityKey } from '../types'
 
 // NOTE: this does not distinguish btw versions. Standard labware only (assumes namespace is 'opentrons')
 
 const PLATE_READER_MAX_LABWARE_Z_MM = 16
 
 export const COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE: Record<
-  ModuleType,
+  ModuleLabwareCompatibilityKey,
   Readonly<string[]>
 > = {
   [TEMPERATURE_MODULE_TYPE]: [
@@ -83,12 +84,21 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE: Record<
   [FLEX_STACKER_MODULE_TYPE]: [
     ...RECOMMENDED_LABWARE_BY_MODULE[FLEX_STACKER_MODULE_TYPE],
   ],
-  // TODO (nd: 02/04/2026): configure this for vacuum module
-  [VACUUM_MODULE_TYPE]: [],
+
+  // TODO (nd: 2026-05-14): correctly reflect vacuum module compatible labware once they are added to shared-data
+  [VACUUM_MODULE_TYPE]: [
+    'opentrons_vacuum_module_spacer_thingamajig',
+    'opentrons_96_wellplate_200ul_pcr_full_skirt',
+  ],
+  VACUUM_MODULE_TYPE_WITH_LABWARE: [
+    'opentrons_96_wellplate_200ul_pcr_full_skirt',
+    'opentrons_vacuum_module_gen1_collar_tall',
+    'opentrons_vacuum_module_gen1_collar_short',
+  ],
 }
 export const getLabwareIsCompatible = (
   def: LabwareDefinition2,
-  moduleType: ModuleType
+  moduleType: ModuleLabwareCompatibilityKey
 ): boolean => {
   console.assert(
     moduleType in COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE,
@@ -129,15 +139,34 @@ const _getLabwareCompatibleWithFlexStacker = (
   def.metadata.displayCategory === 'wellPlate' ||
   def.metadata.displayCategory === 'reservoir'
 
+const _getLabwareCompatibleWithVacuumModule = (
+  def: LabwareDefinition2,
+  isOccupied: boolean = false
+): boolean => {
+  const key = isOccupied
+    ? 'VACUUM_MODULE_TYPE_WITH_LABWARE'
+    : VACUUM_MODULE_TYPE
+  return (
+    COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE[key].includes(
+      def.parameters.loadName
+    ) ||
+    def.metadata.displayCategory === 'wellPlate' ||
+    def.metadata.displayCategory === 'reservoir'
+  )
+}
+
 export const getLabwareCompatibleWithModule = (
   def: LabwareDefinition2,
-  moduleType: ModuleType
+  moduleType: ModuleLabwareCompatibilityKey,
+  isOccupied: boolean = false
 ): boolean => {
   switch (moduleType) {
     case FLEX_STACKER_MODULE_TYPE:
       return _getLabwareCompatibleWithFlexStacker(def)
     case ABSORBANCE_READER_TYPE:
       return _getLabwareCompatibleWithAbsorbanceReader(def)
+    case VACUUM_MODULE_TYPE:
+      return _getLabwareCompatibleWithVacuumModule(def, isOccupied)
     default:
       return COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE[moduleType].includes(
         def.parameters.loadName

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -146,6 +146,16 @@ export const FAKE_HOPPER_LOCATION_MAP = {
 
 export type HopperLocationMapKey = keyof typeof FAKE_HOPPER_LOCATION_MAP
 
+export const VACUUM_DOCK_LOCATION = 'vacuumDock'
+
+export const VACUUM_DOCK_FAKE_LOCATION = 'vacuumDockA4'
+
+export const FAKE_VACUUM_DOCK_LOCATION_MAP = {
+  vacuumDockA4: 'A4',
+}
+
+export type VacuumDockLocationMapKey = keyof typeof FAKE_VACUUM_DOCK_LOCATION_MAP
+
 export const BOTTOM_UP_LABWARE_POOL_KEYS: Array<
   keyof FlexStackerStoredLabwareGroup
 > = ['adapterLabwareId', 'primaryLabwareId', 'lidLabwareId']

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -154,7 +154,8 @@ export const FAKE_VACUUM_DOCK_LOCATION_MAP = {
   vacuumDockA4: 'A4',
 }
 
-export type VacuumDockLocationMapKey = keyof typeof FAKE_VACUUM_DOCK_LOCATION_MAP
+export type VacuumDockLocationMapKey =
+  keyof typeof FAKE_VACUUM_DOCK_LOCATION_MAP
 
 export const BOTTOM_UP_LABWARE_POOL_KEYS: Array<
   keyof FlexStackerStoredLabwareGroup

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -46,9 +46,12 @@ import {
   COLUMN_4_SLOTS,
   EMPTY,
   FAKE_HOPPER_LOCATION_MAP,
+  FAKE_VACUUM_DOCK_LOCATION_MAP,
   HOPPER_FAKE_LOCATIONS,
   HOPPER_STACKER_LOCATION,
   STAGING_AREA_SLOTS,
+  VACUUM_DOCK_FAKE_LOCATION,
+  VACUUM_DOCK_LOCATION,
   ZERO_OFFSET,
 } from '../constants'
 import { curryCommandCreator } from './curryCommandCreator'
@@ -72,7 +75,10 @@ import type {
   PrimaryNozzleConfigurationStyle,
   RobotType,
 } from '@opentrons/shared-data'
-import type { HopperLocationMapKey } from '../constants'
+import type {
+  HopperLocationMapKey,
+  VacuumDockLocationMapKey,
+} from '../constants'
 import type {
   CommandCreator,
   CurriedCommandCreator,
@@ -1115,6 +1121,20 @@ export const getModuleIdFromRobotStateStack = (
   return stack?.find(id => modules[id] != null) ?? null
 }
 
+const _getMappedLocation = (
+  slot: string,
+  isOnVacuumDock: boolean,
+  isOnHopper: boolean
+): string => {
+  if (isOnVacuumDock) {
+    return FAKE_VACUUM_DOCK_LOCATION_MAP[slot as VacuumDockLocationMapKey]
+  }
+  if (isOnHopper) {
+    return FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
+  }
+  return slot
+}
+
 /**
  * Get the full stack in a slot given labware state
  * If the slot is offDeck, the offDeckOverrideId must be provided to override the offDeck slot,
@@ -1137,17 +1157,20 @@ export const getFullStackFromLabwares = (
     )
     return []
   }
+  const isOnVacuumDock = getIsSlotAVacuumDock(slot)
   const isOnHopper = getIsSlotAHopper(slot)
-  const mappedLocation = isOnHopper
-    ? FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
-    : slot
+  const mappedLocation = _getMappedLocation(slot, isOnVacuumDock, isOnHopper)
   const labwareStack = Object.values(labware).filter(
     lw =>
       lw.stack.includes(mappedLocation) &&
       (offDeckOverrideId == null || lw.stack.includes(offDeckOverrideId)) &&
-      lw.stack.includes(HOPPER_STACKER_LOCATION) === isOnHopper
+      lw.stack.includes(HOPPER_STACKER_LOCATION) === isOnHopper &&
+      lw.stack.includes(VACUUM_DOCK_LOCATION) === isOnVacuumDock
   )
   if (isOnHopper) {
+    return labwareStack.reverse()[0].stack ?? []
+  }
+  if (isOnVacuumDock) {
     return labwareStack.reverse()[0].stack ?? []
   }
   return (
@@ -1510,6 +1533,10 @@ export const getLabwareIdOnHopper = (
 
 export const getIsSlotAHopper = (slot: string): boolean => {
   return HOPPER_FAKE_LOCATIONS.includes(slot)
+}
+
+export const getIsSlotAVacuumDock = (slot: string): boolean => {
+  return slot === VACUUM_DOCK_FAKE_LOCATION
 }
 
 export const getLabwareIdOnShuttle = (


### PR DESCRIPTION
# Overview


This PR introduces the logic to add labware to the vacuum module (main manifold on "Slot A3" position). Dock logic will be handled in a followup. Note that new labware is not added here, and the loadnames referenced in this PR are subject to change.

The logic is as follows (first pass here, to be confirmed with product and design):
- an empty vacuum module should accommodate a spacer and/or a collection plate
- once the above is configured, the vacuum module should be able to accommodate adding additional labware, being the collar and optionally a filterplate on top of the collar

EXEC-2405

https://github.com/user-attachments/assets/8fda126a-ca30-4e8b-895b-1fec6bc4a936


## Test Plan and Hands on Testing

Live testing requires the collar and spacer labware definitions to be added, so for now, please inspect the code and smoke test that non-vacuum labware addition is not affected.

I attached a video above depicting the functionality with stubbed definitions locally.

## Changelog

- split logic for vacuum module addition and add framework for dock labware addition (follows similar pattern to stacker hopper)
- add two-step addition logic for the vacuum module, accommodating 1) a spacer and/or collection plate, and 2) a collar and optionally a filter plate

## Review requests


## Risk assessment

lowish. does touch core labware addition logic, but branches for vacuum module