### PR TITLE
fix(step-generation): render trashBin correctly

### DIFF
--- a/step-generation/src/utils/constructInvariantContextFromAnalysis.ts
+++ b/step-generation/src/utils/constructInvariantContextFromAnalysis.ts
@@ -233,7 +233,7 @@ export function constructInvariantContextFromAnalysis(
                 location,
               },
             }
-          } else {
+          } else if (addressableAreaName === 'fixedTrash') {
             trashBinEntities = {
               ...acc.trashBinEntities,
               [id]: {


### PR DESCRIPTION
# Overview

this fixes a broken applitools test but also a big bug where the trash bin was rendering under a waste chute for flex protocols

## Test Plan and Hands on Testing

check any protocol in PV that has a trash bin. there shouldn't be a trash bin rendered behidn the waste chute anymore. and applitools should be passing now

[illumina_stranded_mrna_v4 (2).py](https://github.com/user-attachments/files/27768515/illumina_stranded_mrna_v4.2.py)

## Changelog

add more robust check for when a trash bin entity should be constructed

## Risk assessment

high - should fix all the flex protocols that are supposed to render a waste chute instead of a trash bin
