### PR TITLE
feat(api): Implement hardware subprocess entrypoint service notifications

### DIFF
--- a/api/src/opentrons/hardware_control/pyro_utils/pyro_process_entry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/pyro_process_entry.py
@@ -1,5 +1,13 @@
+"""Entrypoint for the Hardware API subprocess, hosts the Thread Managed hardware resource and a Pyro daemon to serve requests."""
+
+import argparse
 import asyncio
 import logging
+import threading
+import time
+from typing import Any
+
+import Pyro5.api as pyro
 
 from opentrons.config import feature_flags as ff
 from opentrons.config import robot_configs
@@ -15,28 +23,48 @@ from opentrons.util.pyro.pyro_daemon_utility import create_pyro_daemon
 log = logging.getLogger(__name__)
 
 
-def _build_thread_manager() -> ThreadManager[OT3API]:
-    return ThreadManager(
-        OT3API.build_hardware_controller,
-        use_usb_bus=ff.rear_panel_integration(),
-        feature_flags=HardwareFeatureFlags.build_from_ff(),
-    )
+def hardware_process_notify_up() -> bool:
+    """Notify systemd that the current service is up and running.
+
+    This was based off an identical systemd notification utility on server_utils.
+    On dev machines without systemd, this will no-op. On dev machines that happen to be
+    running Linux and systemd, this will actually send the notification, but that
+    should be harmless.
+    """
+    try:
+        import systemd.daemon  # type: ignore
+
+        systemd.daemon.notify("READY=1")
+
+    except ImportError:
+        pass
+    return True
 
 
-async def _build_api(use_simulator: bool = False) -> ThreadManager[OT3API]:
-    tm = _build_thread_manager()
+def _build_thread_manager(use_simulator: bool) -> ThreadManager[OT3API]:
+    """Build a Thread Managed hardware api or simulated hardware api."""
+    if use_simulator:
+        return ThreadManager(
+            OT3API.build_hardware_simulator,
+            feature_flags=HardwareFeatureFlags.build_from_ff(),
+        )
+    else:
+        return ThreadManager(
+            OT3API.build_hardware_controller,
+            use_usb_bus=ff.rear_panel_integration(),
+            feature_flags=HardwareFeatureFlags.build_from_ff(),
+        )
+
+
+async def _build_api(use_simulator: bool) -> ThreadManager[OT3API]:
+    """Build a hardware API within a ThreadManager and ensure it is ready for async requests on it's event loop."""
+    tm = _build_thread_manager(use_simulator)
     await tm.managed_thread_ready_async()
-
-    async def _do_update() -> None:
-        async for update in tm.update_firmware():
-            log.info(f"Update: {update.subsystem.name}: {update.progress}%")
-
-    await _do_update()
 
     return tm
 
 
-def build_and_run_hwc_pyro() -> None:
+async def build_and_run_hwc_pyro(simulate: bool) -> None:
     """Build an instance of the OT3API and provide it to the Pyro Daemon Factory as a resource"""
     robot_conf = robot_configs.load()
     logging_config.log_init(robot_conf.log_level)
@@ -45,14 +73,55 @@ def build_and_run_hwc_pyro() -> None:
     log.info("Building OT-3 API Instance")
 
     # todo(chb: 2026-02-18): Make this support simulated hardware controller - important for unit tests
-    ot3api = asyncio.run(_build_api(use_simulator=False))
+    ot3api = await _build_api(use_simulator=simulate)
 
-    # todo(chb: 2026-02-18): For the PYRONAMEs registered with the nameserver, do we want them to live in a centralized location (shared-data)?
-    log.info("Creating Pyro Daemon for OT3API")
-    create_pyro_daemon(
-        pyroname="OT3API", resource=ot3api, registry=register_hardware_types
+    def _daemon_request_loop(pyroname: str, resource: Any, registry: Any) -> None:
+        # todo(chb: 2026-02-18): For the PYRONAMEs registered with the nameserver, do we want them to live in a centralized location (shared-data)?
+        log.info("Creating Pyro Daemon for OT3API")
+        create_pyro_daemon(pyroname=pyroname, resource=resource, registry=registry)
+
+    daemon_request_thread = threading.Thread(
+        target=_daemon_request_loop,
+        args=("OT3API", ot3api, register_hardware_types),
+        daemon=True,
     )
+
+    daemon_request_thread.start()
+
+    # Alert the systemd service that this process has spun up as soon as the resource is on the nameserver
+    service_notified = False
+    start_time = time.monotonic()
+    with pyro.locate_ns() as ns:
+        while time.monotonic() - start_time < 60:
+            if "OT3API" in ns.list():
+                service_notified = hardware_process_notify_up()
+                break
+            time.sleep(0.01)
+    if not service_notified:
+        raise RuntimeError(
+            "Hardware process failed to verify registration with Pyro daemon."
+        )
+
+    # Handle firmware updates on the hardware api
+    async def _do_update() -> None:
+        async for update in ot3api.update_firmware():
+            log.info(f"Update: {update.subsystem.name}: {update.progress}%")
+
+    await _do_update()
+
+    # Gracefully join the daemon request loop thread
+    daemon_request_thread.join()
 
 
 if __name__ == "__main__":
-    build_and_run_hwc_pyro()
+    parser = argparse.ArgumentParser(
+        description="Starts and runs the hardware subprocess and a Pyro daemon to handle requests."
+        " Requires a nameserver to be running."
+    )
+    parser.add_argument(
+        "--simulate",
+        required=False,
+        default=False,
+        help="Flag to determine if the process should run with a hardware simulator or active hardware.",
+    )
+    asyncio.run(build_and_run_hwc_pyro(parser.parse_args().simulate))


### PR DESCRIPTION
# Overview

Because of updates on the systemd service implementation for the opentrons-hardware-api we need to be sure to send a systemd notification based on [this PR](https://github.com/Opentrons/oe-core/pull/310). Alongside this we can now boot the hardware api service in simulate mode, and the entrypoint checks to make sure that the pyro daemon is up and running before notifying it's systemd service of readiness. Finally, we are no longer blocking the daemon startup with firmware updates.

Dev Note: This PR should merge before the oe-core PR

## Test Plan and Hands on Testing
- [x] Put current opentrons-hardware-api service build on robot and push this branch, ensure service boots correctly and can be interacted with
- [x] Boot in simulate mode, ensure OT3API hardware simulator can be interacted with
- [x] Test on a full run

## Changelog
- Updated hardware api entrypoint to user systemd service notification
- Added in simulate support!


## Review requests

## Risk assessment
Low - only effects the systemd service for our new opentrons-hardware-api service