### PR TITLE
ci: Show all JS test failures

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -55,7 +55,7 @@ jobs:
   js-unit-test-shards:
     # unit tests for the app's view layer (not the node layer)
     runs-on: 'ubuntu-22.04'
-    name: 'app frontend unit test worker'
+    name: 'app frontend unit tests'
     # these tests take > 30 minutes with a single runner, so split into multiple shards
     # https://vitest.dev/guide/improving-performance.html#sharding
     strategy:
@@ -88,7 +88,7 @@ jobs:
   js-unit-test:
     needs: [js-unit-test-shards]
     runs-on: 'ubuntu-22.04'
-    name: 'app frontend unit tests'
+    name: 'app frontend unit test merge shard results'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/js/setup

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -73,11 +73,8 @@ jobs:
         run: |
           make -C app test-cov test_opts="--shard=${{matrix.shard}}/${{env.SHARD_TOTAL}} --reporter=blob --reporter=default"
           mv coverage/lcov.info coverage/lcov-shard-${{matrix.shard}}.info
-        # We want to see all test failures, so if a test in this shard fails, don't
-        # treat it as an error. Proceed to upload the test report. A subsequent step
-        # should read the merged reports, notice the test failure, and then fail the workflow.
-        continue-on-error: true
       - name: 'Upload frontend test shard result ${{matrix.shard}}/${{env.SHARD_TOTAL}}'
+        if: ${{ !cancelled() }} # Make sure we forward along the report even if there were test failures.
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: frontend-unit-test-result-shard-${{matrix.shard}}

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -64,6 +64,7 @@ jobs:
     env:
       SHARD_TOTAL: 8
     timeout-minutes: 15 # if tests take longer than this, add more shards
+    continue-on-error: true # We want to see all test failures, so keep running all shards even after one fails.
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/js/setup

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -55,7 +55,7 @@ jobs:
   js-unit-test-shards:
     # unit tests for the app's view layer (not the node layer)
     runs-on: 'ubuntu-22.04'
-    name: 'app frontend unit tests'
+    name: 'app frontend unit test worker'
     # these tests take > 30 minutes with a single runner, so split into multiple shards
     # https://vitest.dev/guide/improving-performance.html#sharding
     strategy:
@@ -90,7 +90,7 @@ jobs:
   js-unit-test:
     needs: [js-unit-test-shards]
     runs-on: 'ubuntu-22.04'
-    name: 'app frontend unit test merge shard results'
+    name: 'app frontend unit tests'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/js/setup

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -64,7 +64,6 @@ jobs:
     env:
       SHARD_TOTAL: 8
     timeout-minutes: 15 # if tests take longer than this, add more shards
-    continue-on-error: true # We want to see all test failures, so keep running all shards even after one fails.
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/js/setup
@@ -74,6 +73,10 @@ jobs:
         run: |
           make -C app test-cov test_opts="--shard=${{matrix.shard}}/${{env.SHARD_TOTAL}} --reporter=blob --reporter=default"
           mv coverage/lcov.info coverage/lcov-shard-${{matrix.shard}}.info
+        # We want to see all test failures, so if a test in this shard fails, don't
+        # treat it as an error. Proceed to upload the test report. A subsequent step
+        # should read the merged reports, notice the test failure, and then fail the workflow.
+        continue-on-error: true
       - name: 'Upload frontend test shard result ${{matrix.shard}}/${{env.SHARD_TOTAL}}'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -55,7 +55,7 @@ jobs:
   js-unit-test-shards:
     # unit tests for the app's view layer (not the node layer)
     runs-on: 'ubuntu-22.04'
-    name: 'opentrons app frontend unit tests'
+    name: 'app frontend unit tests'
     # these tests take > 30 minutes with a single runner, so split into multiple shards
     # https://vitest.dev/guide/improving-performance.html#sharding
     strategy:
@@ -90,7 +90,7 @@ jobs:
   js-unit-test:
     needs: [js-unit-test-shards]
     runs-on: 'ubuntu-22.04'
-    name: 'opentrons app frontend unit test merge shard results'
+    name: 'app frontend unit test merge shard results'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: ./.github/actions/js/setup
@@ -118,7 +118,7 @@ jobs:
         exclude:
           - os: 'windows-2022'
             shell: 'app-shell-odd'
-    name: 'opentrons ${{matrix.shell}} unit tests on ${{matrix.os}}'
+    name: '${{matrix.shell}} unit tests on ${{matrix.os}}'
     timeout-minutes: 60
     runs-on: ${{ matrix.os }}
     steps:

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/utils.test.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/utils.test.tsx
@@ -50,6 +50,7 @@ describe('getModuleOptions', () => {
   ] as AttachedModule[]
   it('should get mag block and heater shaker to place on AA A3', () => {
     const result = getModuleOptions('cutoutA3', attachedModules, 'A3', deckDef)
+    expect(false).toBeTruthy()
     expect(result).toEqual([
       [
         {

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/utils.test.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/utils.test.tsx
@@ -50,7 +50,6 @@ describe('getModuleOptions', () => {
   ] as AttachedModule[]
   it('should get mag block and heater shaker to place on AA A3', () => {
     const result = getModuleOptions('cutoutA3', attachedModules, 'A3', deckDef)
-    expect(false).toBeTruthy()
     expect(result).toEqual([
       [
         {


### PR DESCRIPTION
## Overview

For speed, our CI splits our JavaScript tests into multiple parallel jobs, which is good. However, it currently fails the entire workflow as soon as any job fails. So if there are failures in multiple test files, CI may only show us one of them, depending on how the shards happen to get split up.

This adjusts it to run all shards to completion even if any of them fails. Test failures will look something like this:

* ❌ Shard 1
* ✅ Shard 2
* ❌ Shard 3
* ✅ Shard 4
* ❌ Merge shard results

Example: https://github.com/Opentrons/opentrons/actions/runs/25924892127/job/76204288199?pr=21519

## Test Plan and Hands on Testing

* [x] Manually induce a test failure and make sure it still creates a ❌ on this PR.

## Risk assessment

Medium. GitHub Actions can have weird behavior with things like `if:` and `continue-on-error`. We need to make sure that edge cases don't cause problems to get hidden in the GitHub UI, for example if they get mislabeled as "skipped" instead of "failed."