### PR TITLE
fix(robot-server): Ensure robot server pyro daemon only begins in subprocess mode

### DIFF
--- a/robot-server/robot_server/service/pyro_utils/pyro_resource.py
+++ b/robot-server/robot_server/service/pyro_utils/pyro_resource.py
@@ -7,6 +7,9 @@ import logging
 import threading
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
+from opentrons.config import (
+    feature_flags as ff,
+)
 from opentrons.hardware_control.types import HardwareEvent, HardwareEventHandler
 from opentrons.protocol_engine.resources.camera_provider import (
     CameraProvider,
@@ -229,14 +232,16 @@ def start_initializing_pyro_resource(app_state: AppState) -> None:
     resource = RobotServerPyroResource(loop=asyncio.get_event_loop())
     robot_server_pyro_resource_accessor.set_on(app_state, resource)
 
-    pyro_daemon_thread = threading.Thread(
-        target=_start_and_run_pyro_daemon,
-        name="RobotServerResourceThread",
-        args=(),
-        kwargs={
-            "pyroname": RS_PYRONAME,
-            "registry": register_robot_server_types,
-        },
-        daemon=True,
-    )
-    pyro_daemon_thread.start()
+    # Only spin up a request handling daemon if subprocess mode is enabled
+    if ff.hardware_subprocess_enabled():
+        pyro_daemon_thread = threading.Thread(
+            target=_start_and_run_pyro_daemon,
+            name="RobotServerResourceThread",
+            args=(),
+            kwargs={
+                "pyroname": RS_PYRONAME,
+                "registry": register_robot_server_types,
+            },
+            daemon=True,
+        )
+        pyro_daemon_thread.start()

--- a/robot-server/tests/runs/test_run_process.py
+++ b/robot-server/tests/runs/test_run_process.py
@@ -168,8 +168,11 @@ async def _host_pyro_nameserver_and_ot3api(
 async def test_run_process_proxy(
     mock_app_state: AppState,
     ot3_hardware_api: OT3API,
+    mock_feature_flags: None,
+    decoy: Decoy,
 ) -> None:
     """Test the run process pyro creation and a proxy can be created that returns data and async commands can be called."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
     ot3_async, rs_async = await _host_pyro_nameserver_and_ot3api(
         ot3_hardware_api, mock_app_state
     )

--- a/robot-server/tests/service/pyro_utils/test_pyro_resource.py
+++ b/robot-server/tests/service/pyro_utils/test_pyro_resource.py
@@ -160,14 +160,13 @@ async def test_run_hardware_event_callback(
 
     It should be provided to the hardware event handler, and recieves a callback proxy in response.
     """
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
     ot3_async, rs_async = await _host_pyro_nameserver_and_ot3api(
         hw_api=ot3_hardware_api, app_state=mock_app_state
     )
     # Cast the two Async proxies on the nameserver as a locally useful type
     ot3api = cast(OT3API, ot3_async)
     robot_server_resource = cast(pyro_resource.RobotServerPyroResource, rs_async)
-
-    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
 
     run_store = RunOrchestratorStore(
         hardware_api=ot3api,
@@ -197,14 +196,13 @@ async def test_maintenance_run_hardware_event_callback(
 
     It should be provided to the hardware event handler, and recieves a callback proxy in response.
     """
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
     ot3_async, rs_async = await _host_pyro_nameserver_and_ot3api(
         hw_api=ot3_hardware_api, app_state=mock_app_state
     )
     # Cast the two Async proxies on the nameserver as a locally useful type
     ot3api = cast(OT3API, ot3_async)
     robot_server_resource = cast(pyro_resource.RobotServerPyroResource, rs_async)
-
-    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
 
     maintenance_run_store = MaintenanceRunOrchestratorStore(
         hardware_api=ot3api,
@@ -230,6 +228,7 @@ async def test_camera_provider(
     decoy: Decoy,
 ) -> None:
     """Enforce that the RobotServerPyroResource provides a Proxy of the CameraProvider."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
     ot3_async, rs_async = await _host_pyro_nameserver_and_ot3api(
         hw_api=ot3_hardware_api, app_state=mock_app_state
     )
@@ -260,6 +259,7 @@ async def test_file_provider(
     decoy: Decoy,
 ) -> None:
     """Enforce that the RobotServerPyroResource provides a Proxy of the FileProvider."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
     ot3_async, rs_async = await _host_pyro_nameserver_and_ot3api(
         hw_api=ot3_hardware_api, app_state=mock_app_state
     )
@@ -303,6 +303,7 @@ async def test_deck_config(
     decoy: Decoy,
 ) -> None:
     """Enforce that the RobotServerPyroResource provides the DeckConfigurationType."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
     ot3_async, rs_async = await _host_pyro_nameserver_and_ot3api(
         hw_api=ot3_hardware_api, app_state=mock_app_state
     )
@@ -326,6 +327,7 @@ async def test_notify_publisher(
     decoy: Decoy,
 ) -> None:
     """Enforce that the RobotServerPyroResource provides a Proxy of the Notify Publisher."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
     ot3_async, rs_async = await _host_pyro_nameserver_and_ot3api(
         hw_api=ot3_hardware_api, app_state=mock_app_state
     )


### PR DESCRIPTION
# Overview

Before we were eagerly beginning a Pyro daemon on the robot server on app setup, regardless of subprocess mode being enabled. This was seen as passive since the pyro nameserver is always available on a Flex, even outside of subprocess mode, and because the robot server acts as an ambient source of resources to other potential subprocesses. 

However, given the dev server does not have a pyro nameserver, this was causing errors when running `make dev-backend-flex`. The solution currently is to gate spinning up the daemon behind the same feature flag that gates other subprocess behavior on the robot-server. Of note, we still create the `RobotServerPyroResource` instance that is tracked in app state so that related services across the robot server which register information to the `RobotServerPyroResource` can continue to do so without also having to utilize feature flags to block off behavior.

## Test Plan and Hands on Testing
- [x] Ensure `make dev-backend-flex` runs without issue
- [x] Ensure subprocess mode runs on a Flex can run uninterrupted with these changes

## Changelog
Addition of feature flag validation to `start_initializing_pyro_resource`

## Review requests
Do we think we should also add in a check for the `protocol_subprocess_enabled` feature flag here? In theory, no subprocesses will ever exist without the hardware subprocess being enabled, so it's the only check that truly matters in this case.

## Risk assessment
Low - fixes some blocking behavior introduced by Pyro changes
