### PR TITLE
docs: flex-manual-add-linux-usb-note

### DIFF
--- a/docs/flex/docs/installation/first-run.md
+++ b/docs/flex/docs/installation/first-run.md
@@ -74,6 +74,12 @@ Connect the provided USB A-to-B cable to the robot's USB-B port and an open port
 
 To proceed with setup, the connected computer must have the Opentrons App installed *and running*. For details on installing the Opentrons App, see the [App Installation section][app-installation].
 
+!!! note "Note for Linux Users"
+    If the Opentrons App shows “Not connected via USB” on Ubuntu, open a terminal and give your user account permission to access the robot’s USB port.
+
+    1. From the terminal, run `sudo usermod -a -G dialout $USER`
+    2. Log out of your Linux account entirely (or restart your computer) and log back in for the change to take effect.
+
 ## Install software updates
 
 Now that you've connected to a network or computer, the robot can check for software and firmware updates and download them if needed. If there is an update, it may take a few minutes to install. Once the update is complete, the robot will restart.


### PR DESCRIPTION
# Overview

This is a small note that addresses what may be more of an edge case than a common event. Ubuntu Linux users may see the Flex is not connected when using USB. This is due to a permissions issue. The text in the note shows how to add permissions that fixes the problem.

This may even be a problem that's too small to bother with and we just close this as `won't do`. 

See the linked jira issue below.

**Sandbox:** https://sandbox.docs.opentrons.com/flex-manual-add-linux-permissions-note/flex/installation/first-run/#usb

RTC-643

## Test Plan and Hands on Testing

No Linux. Can't test code. It came from Seth, so should be legit.

## Changelog

Adds a "Note" admonition to `installation/first-run.md` under the "USB" header.

```
!!! note "Note for Linux Users"
    If the Opentrons App shows “Not connected via USB” on Ubuntu, open a terminal and give your user account permission to access the robot’s USB port.

    1. From the terminal, run `sudo usermod -a -G dialout $USER`
    2. Log out of your Linux account entirely (or restart your computer) and log back in for the change to take effect.
```

## Review requests

n/a

## Risk assessment

Low.
