### PR TITLE
refactor(app): rename wifi connection components

### DIFF
--- a/app/src/pages/ODD/ConnectViaWifi/WifiAuthenticationSelector.tsx
+++ b/app/src/pages/ODD/ConnectViaWifi/WifiAuthenticationSelector.tsx
@@ -1,30 +1,30 @@
 import { useTranslation } from 'react-i18next'
 
-import { DIRECTION_COLUMN, Flex } from '@opentrons/components'
-
-import { SelectAuthenticationType as SelectAuthenticationTypeComponent } from '/app/organisms/ODD/NetworkSettings'
+import { SelectAuthenticationType } from '/app/organisms/ODD/NetworkSettings'
 import { RobotSetupHeader } from '/app/organisms/ODD/RobotSetupHeader'
+
+import styles from './wifiauthenticationselector.module.css'
 
 import type { WifiSecurityType } from '@opentrons/api-client'
 import type { WifiScreenOption } from './'
 
-interface SelectAuthenticationTypeProps {
+interface WifiAuthenticationSelectorProps {
   handleWifiConnect: () => void
   selectedAuthType: WifiSecurityType
   setCurrentOption: (option: WifiScreenOption) => void
   setSelectedAuthType: (authType: WifiSecurityType) => void
 }
 
-export function SelectAuthenticationType({
+export function WifiAuthenticationSelector({
   handleWifiConnect,
   selectedAuthType,
   setCurrentOption,
   setSelectedAuthType,
-}: SelectAuthenticationTypeProps): JSX.Element {
+}: WifiAuthenticationSelectorProps): JSX.Element {
   const { i18n, t } = useTranslation(['device_settings', 'shared'])
 
   return (
-    <Flex flexDirection={DIRECTION_COLUMN}>
+    <div className={styles.authentication_selector_container}>
       <RobotSetupHeader
         buttonText={i18n.format(t('shared:continue'), 'capitalize')}
         header={t('select_a_security_type')}
@@ -37,10 +37,10 @@ export function SelectAuthenticationType({
             : handleWifiConnect()
         }}
       />
-      <SelectAuthenticationTypeComponent
+      <SelectAuthenticationType
         selectedAuthType={selectedAuthType}
         setSelectedAuthType={setSelectedAuthType}
       />
-    </Flex>
+    </div>
   )
 }

--- a/app/src/pages/ODD/ConnectViaWifi/WifiCredentialForm.tsx
+++ b/app/src/pages/ODD/ConnectViaWifi/WifiCredentialForm.tsx
@@ -1,30 +1,30 @@
 import { useTranslation } from 'react-i18next'
 
-import { DIRECTION_COLUMN, Flex } from '@opentrons/components'
-
 import { WifiPasswordInput } from '/app/organisms/ODD/NetworkSettings'
 import { RobotSetupHeader } from '/app/organisms/ODD/RobotSetupHeader'
+
+import styles from './wificredentialform.module.css'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { WifiScreenOption } from './'
 
-interface SetWifiCredProps {
+interface WifiCredentialFormProps {
   handleConnect: () => void
   password: string
   setCurrentOption: (option: WifiScreenOption) => void
   setPassword: Dispatch<SetStateAction<string>>
 }
 
-export function SetWifiCred({
+export function WifiCredentialForm({
   handleConnect,
   password,
   setCurrentOption,
   setPassword,
-}: SetWifiCredProps): JSX.Element {
+}: WifiCredentialFormProps): JSX.Element {
   const { t } = useTranslation('device_settings')
 
   return (
-    <Flex flexDirection={DIRECTION_COLUMN}>
+    <div className={styles.form_container}>
       <RobotSetupHeader
         buttonText={t('connect')}
         header={t('sign_into_wifi')}
@@ -34,6 +34,6 @@ export function SetWifiCred({
         onClickButton={handleConnect}
       />
       <WifiPasswordInput password={password} setPassword={setPassword} />
-    </Flex>
+    </div>
   )
 }

--- a/app/src/pages/ODD/ConnectViaWifi/index.tsx
+++ b/app/src/pages/ODD/ConnectViaWifi/index.tsx
@@ -16,9 +16,9 @@ import * as RobotApi from '/app/redux/robot-api'
 import { useWifiList } from '/app/resources/networking/hooks'
 
 import { JoinOtherNetwork } from './JoinOtherNetwork'
-import { SelectAuthenticationType } from './SelectAuthenticationType'
-import { SetWifiCred } from './SetWifiCred'
+import { WifiAuthenticationSelector } from './WifiAuthenticationSelector'
 import { WifiConnectStatus } from './WifiConnectStatus'
+import { WifiCredentialForm } from './WifiCredentialForm'
 
 import type { WifiSecurityType } from '@opentrons/api-client'
 import type { State } from '/app/redux/types'
@@ -94,7 +94,7 @@ export function ConnectViaWifi(): JSX.Element {
     )
   } else if (currentOption === 'SelectAuthType') {
     currentScreen = (
-      <SelectAuthenticationType
+      <WifiAuthenticationSelector
         selectedAuthType={selectedAuthType}
         setSelectedAuthType={setSelectedAuthType}
         handleWifiConnect={handleConnect}
@@ -103,7 +103,7 @@ export function ConnectViaWifi(): JSX.Element {
     )
   } else if (currentOption === 'SetWifiCred') {
     currentScreen = (
-      <SetWifiCred
+      <WifiCredentialForm
         password={password}
         setPassword={setPassword}
         setCurrentOption={setCurrentOption}

--- a/app/src/pages/ODD/ConnectViaWifi/wifiauthenticationselector.module.css
+++ b/app/src/pages/ODD/ConnectViaWifi/wifiauthenticationselector.module.css
@@ -1,0 +1,4 @@
+.authentication_selector_container {
+  display: flex;
+  flex-direction: column;
+}

--- a/app/src/pages/ODD/ConnectViaWifi/wificredentialform.module.css
+++ b/app/src/pages/ODD/ConnectViaWifi/wificredentialform.module.css
@@ -1,0 +1,4 @@
+.form_container {
+  display: flex;
+  flex-direction: column;
+}


### PR DESCRIPTION


# Overview
rename wifi connection components and switch from styled-components to CSS Modules

clsoe AUTH-2908 and AUTH-2909

## Test Plan and Hands on Testing


## Changelog
- rename components
- remove Flex

## Review requests

## Risk assessment
low
