### PR TITLE
feat(update-server, server-utils, app): Add affordances for UI-driven software shutdown

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -305,6 +305,8 @@
   "resets_cannot_be_undone": "Resets cannot be undone",
   "restart_now": "Restart now?",
   "restart_robot_confirmation_description": "<span>It will take a few minutes for <bold>{{robotName}}</bold> to restart.</span>",
+  "shutdown_now": "Shutdown now?",
+  "shutdown_robot_confirmation_description": "<span><bold>{{robotName}}</bold> will shut down.</span>",
   "restart_taking_too_long": "{{robotName}} is taking longer than expected to restart. Check the Advanced tab of its settings page to see whether it updated successfully. If the robot is unresponsive, restart it manually.",
   "restarting_robot": "Install complete, robot restarting...",
   "restore_to_default": "Restore to default",

--- a/app/src/assets/localization/en/robot_controls.json
+++ b/app/src/assets/localization/en/robot_controls.json
@@ -10,5 +10,6 @@
   "restart_button": "restart",
   "restart_description": "Restart robot.",
   "restart_label": "Restart robot",
+  "shutdown_label": "Shutdown robot",
   "title": "robot controls"
 }

--- a/app/src/assets/localization/en/shared.json
+++ b/app/src/assets/localization/en/shared.json
@@ -64,6 +64,7 @@
   "reset_all": "Reset all",
   "restart": "restart",
   "resume": "resume",
+  "shutdown": "shutdown",
   "return": "return",
   "reverse": "Reverse alphabetical",
   "robot_is_analyzing": "Robot is analyzing",

--- a/app/src/organisms/Desktop/Devices/RobotOverviewOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOverviewOverflowMenu.tsx
@@ -20,7 +20,10 @@ import {
   useMenuHandleClickOutside,
   useMountEffect,
 } from '@opentrons/components'
-import { useSetLightsMutation } from '@opentrons/react-api-client'
+import {
+  useCreateLiveCommandMutation,
+  useSetLightsMutation,
+} from '@opentrons/react-api-client'
 
 import { getTopPortalEl } from '/app/App/portal'
 import { Divider } from '/app/atoms/structure'
@@ -73,14 +76,23 @@ export const RobotOverviewOverflowMenu = (
   const dispatch = useDispatch<Dispatch>()
   const isFlex = useIsFlex(robot.name)
   const { setLights } = useSetLightsMutation()
+  const { createLiveCommand } = useCreateLiveCommandMutation()
 
   const handleClickRestart: MouseEventHandler<HTMLButtonElement> = () => {
     dispatch(restartRobot(robot.name))
   }
 
   const handleClickShutdown: MouseEventHandler<HTMLButtonElement> = () => {
-    setLights({ on: false })
-    dispatch(shutdownRobot(robot.name))
+    createLiveCommand({
+      command: { commandType: 'setStatusBar', params: { animation: 'off' } },
+    })
+      .catch(() => {
+        console.warn('Failed to set status bar animation to off')
+      })
+      .finally(() => {
+        setLights({ on: false })
+        dispatch(shutdownRobot(robot.name))
+      })
   }
 
   const handleClickHomeGantry: MouseEventHandler<HTMLButtonElement> = () => {

--- a/app/src/organisms/Desktop/Devices/RobotOverviewOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOverviewOverflowMenu.tsx
@@ -20,13 +20,13 @@ import {
   useMenuHandleClickOutside,
   useMountEffect,
 } from '@opentrons/components'
+import { useSetLightsMutation } from '@opentrons/react-api-client'
 
 import { getTopPortalEl } from '/app/App/portal'
 import { Divider } from '/app/atoms/structure'
 import { ChooseProtocolSlideout } from '/app/organisms/Desktop/ChooseProtocolSlideout'
 import { RobotCertImportModal } from '/app/organisms/Desktop/RobotCertImport/RobotCertImportModal'
-import { useIsRobotBusy } from '/app/redux-resources/robots'
-import { useIsFlex } from '/app/redux-resources/robots'
+import { useIsFlex, useIsRobotBusy } from '/app/redux-resources/robots'
 import * as Config from '/app/redux/config'
 import { CONNECTABLE, REACHABLE, UNREACHABLE } from '/app/redux/discovery'
 import { restartRobot, shutdownRobot } from '/app/redux/robot-admin'
@@ -72,12 +72,14 @@ export const RobotOverviewOverflowMenu = (
 
   const dispatch = useDispatch<Dispatch>()
   const isFlex = useIsFlex(robot.name)
+  const { setLights } = useSetLightsMutation()
 
   const handleClickRestart: MouseEventHandler<HTMLButtonElement> = () => {
     dispatch(restartRobot(robot.name))
   }
 
   const handleClickShutdown: MouseEventHandler<HTMLButtonElement> = () => {
+    setLights({ on: false })
     dispatch(shutdownRobot(robot.name))
   }
 
@@ -235,6 +237,7 @@ export const RobotOverviewOverflowMenu = (
                 robot.name
               )}`}
             >
+              {/* TODO(jh, 05-18-26): Update after Design finalizes implementation */}
               {t('robot_controls:shutdown_label')}
             </MenuItem>
           ) : null}

--- a/app/src/organisms/Desktop/Devices/RobotOverviewOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOverviewOverflowMenu.tsx
@@ -26,9 +26,10 @@ import { Divider } from '/app/atoms/structure'
 import { ChooseProtocolSlideout } from '/app/organisms/Desktop/ChooseProtocolSlideout'
 import { RobotCertImportModal } from '/app/organisms/Desktop/RobotCertImport/RobotCertImportModal'
 import { useIsRobotBusy } from '/app/redux-resources/robots'
+import { useIsFlex } from '/app/redux-resources/robots'
 import * as Config from '/app/redux/config'
 import { CONNECTABLE, REACHABLE, UNREACHABLE } from '/app/redux/discovery'
-import { restartRobot } from '/app/redux/robot-admin'
+import { restartRobot, shutdownRobot } from '/app/redux/robot-admin'
 import { home, ROBOT } from '/app/redux/robot-controls'
 import { useIsRobotOnWrongVersionOfSoftware } from '/app/redux/robot-update'
 import { checkShellUpdate } from '/app/redux/shell'
@@ -70,9 +71,14 @@ export const RobotOverviewOverflowMenu = (
   const isEstopNotDisengaged = useIsEstopNotDisengaged(robot.name)
 
   const dispatch = useDispatch<Dispatch>()
+  const isFlex = useIsFlex(robot.name)
 
   const handleClickRestart: MouseEventHandler<HTMLButtonElement> = () => {
     dispatch(restartRobot(robot.name))
+  }
+
+  const handleClickShutdown: MouseEventHandler<HTMLButtonElement> = () => {
+    dispatch(shutdownRobot(robot.name))
   }
 
   const handleClickHomeGantry: MouseEventHandler<HTMLButtonElement> = () => {
@@ -221,6 +227,17 @@ export const RobotOverviewOverflowMenu = (
           >
             {t('robot_controls:restart_label')}
           </MenuItem>
+          {isFlex ? (
+            <MenuItem
+              disabled={isRobotUnavailable || isEstopNotDisengaged}
+              onClick={handleClickShutdown}
+              data-testid={`RobotOverviewOverflowMenu_shutdownRobot_${String(
+                robot.name
+              )}`}
+            >
+              {t('robot_controls:shutdown_label')}
+            </MenuItem>
+          ) : null}
           <Divider marginY="0" />
           <MenuItem
             onClick={() => {

--- a/app/src/organisms/ODD/Navigation/NavigationMenu.tsx
+++ b/app/src/organisms/ODD/Navigation/NavigationMenu.tsx
@@ -18,9 +18,11 @@ import {
 
 import { getTopPortalEl } from '/app/App/portal'
 import { home, ROBOT } from '/app/redux/robot-controls'
+import { useIsFlex } from '/app/redux-resources/robots'
 import { useLights } from '/app/resources/devices'
 
 import { RestartRobotConfirmationModal } from './RestartRobotConfirmationModal'
+import { ShutdownRobotConfirmationModal } from './ShutdownRobotConfirmationModal'
 
 import type { MouseEventHandler } from 'react'
 import type { Dispatch } from '/app/redux/types'
@@ -40,11 +42,20 @@ export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
     showRestartRobotConfirmationModal,
     setShowRestartRobotConfirmationModal,
   ] = useState<boolean>(false)
+  const [
+    showShutdownRobotConfirmationModal,
+    setShowShutdownRobotConfirmationModal,
+  ] = useState<boolean>(false)
 
   const navigate = useNavigate()
+  const isFlex = useIsFlex(robotName)
 
   const handleRestart = (): void => {
     setShowRestartRobotConfirmationModal(true)
+  }
+
+  const handleShutdown = (): void => {
+    setShowShutdownRobotConfirmationModal(true)
   }
 
   const handleHomeGantry = (): void => {
@@ -59,6 +70,14 @@ export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
           robotName={robotName}
           setShowRestartRobotConfirmationModal={
             setShowRestartRobotConfirmationModal
+          }
+        />
+      ) : null}
+      {showShutdownRobotConfirmationModal ? (
+        <ShutdownRobotConfirmationModal
+          robotName={robotName}
+          setShowShutdownRobotConfirmationModal={
+            setShowShutdownRobotConfirmationModal
           }
         />
       ) : null}
@@ -96,6 +115,25 @@ export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
             </LegacyStyledText>
           </Flex>
         </MenuItem>
+        {isFlex ? (
+          <MenuItem key="shutdown" onClick={handleShutdown}>
+            <Flex alignItems={ALIGN_CENTER}>
+              <Icon
+                name="no-icon"
+                size="2.5rem"
+                color={COLORS.black90}
+                aria-label="shutdown_icon"
+              />
+              <LegacyStyledText
+                forwardedAs="h4"
+                fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+                marginLeft={SPACING.spacing12}
+              >
+                {t('robot_controls:shutdown_label')}
+              </LegacyStyledText>
+            </Flex>
+          </MenuItem>
+        ) : null}
         <MenuItem
           key="deck-configuration"
           onClick={() => {

--- a/app/src/organisms/ODD/Navigation/NavigationMenu.tsx
+++ b/app/src/organisms/ODD/Navigation/NavigationMenu.tsx
@@ -17,8 +17,8 @@ import {
 } from '@opentrons/components'
 
 import { getTopPortalEl } from '/app/App/portal'
-import { home, ROBOT } from '/app/redux/robot-controls'
 import { useIsFlex } from '/app/redux-resources/robots'
+import { home, ROBOT } from '/app/redux/robot-controls'
 import { useLights } from '/app/resources/devices'
 
 import { RestartRobotConfirmationModal } from './RestartRobotConfirmationModal'
@@ -129,6 +129,7 @@ export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
                 fontWeight={TYPOGRAPHY.fontWeightSemiBold}
                 marginLeft={SPACING.spacing12}
               >
+                {/* TODO(jh, 05-18-26): Update after Design finalizes implementation */}
                 {t('robot_controls:shutdown_label')}
               </LegacyStyledText>
             </Flex>

--- a/app/src/organisms/ODD/Navigation/ShutdownRobotConfirmationModal.tsx
+++ b/app/src/organisms/ODD/Navigation/ShutdownRobotConfirmationModal.tsx
@@ -9,7 +9,10 @@ import {
   LegacyStyledText,
   SPACING,
 } from '@opentrons/components'
-import { useSetLightsMutation } from '@opentrons/react-api-client'
+import {
+  useCreateLiveCommandMutation,
+  useSetLightsMutation,
+} from '@opentrons/react-api-client'
 
 import { SmallButton } from '/app/atoms/buttons'
 import { OddModal } from '/app/molecules/OddModal'
@@ -37,6 +40,7 @@ export function ShutdownRobotConfirmationModal({
   }
   const dispatch = useDispatch<Dispatch>()
   const { setLights } = useSetLightsMutation()
+  const { createLiveCommand } = useCreateLiveCommandMutation()
 
   return (
     <OddModal header={modalHeader}>
@@ -72,8 +76,19 @@ export function ShutdownRobotConfirmationModal({
             buttonType="alert"
             buttonText={i18n.format(t('shared:shutdown'), 'capitalize')}
             onClick={() => {
-              setLights({ on: false })
-              dispatch(shutdownRobot(robotName))
+              createLiveCommand({
+                command: {
+                  commandType: 'setStatusBar',
+                  params: { animation: 'off' },
+                },
+              })
+                .catch(() => {
+                  console.warn('Failed to set status bar animation to off')
+                })
+                .finally(() => {
+                  setLights({ on: false })
+                  dispatch(shutdownRobot(robotName))
+                })
             }}
           />
         </Flex>

--- a/app/src/organisms/ODD/Navigation/ShutdownRobotConfirmationModal.tsx
+++ b/app/src/organisms/ODD/Navigation/ShutdownRobotConfirmationModal.tsx
@@ -1,0 +1,77 @@
+import { Trans, useTranslation } from 'react-i18next'
+import { useDispatch } from 'react-redux'
+
+import {
+  COLORS,
+  DIRECTION_COLUMN,
+  DIRECTION_ROW,
+  Flex,
+  LegacyStyledText,
+  SPACING,
+} from '@opentrons/components'
+
+import { SmallButton } from '/app/atoms/buttons'
+import { OddModal } from '/app/molecules/OddModal'
+import { shutdownRobot } from '/app/redux/robot-admin'
+
+import type { OddModalHeaderBaseProps } from '/app/molecules/OddModal/types'
+import type { Dispatch } from '/app/redux/types'
+
+interface ShutdownRobotConfirmationModalProps {
+  robotName: string
+  setShowShutdownRobotConfirmationModal: (
+    showShutdownRobotConfirmationModal: boolean
+  ) => void
+}
+export function ShutdownRobotConfirmationModal({
+  robotName,
+  setShowShutdownRobotConfirmationModal,
+}: ShutdownRobotConfirmationModalProps): JSX.Element {
+  const { i18n, t } = useTranslation(['device_settings', 'shared'])
+  const modalHeader: OddModalHeaderBaseProps = {
+    title: t('shutdown_now'),
+    iconName: 'ot-alert',
+    iconColor: COLORS.yellow50,
+  }
+  const dispatch = useDispatch<Dispatch>()
+
+  return (
+    <OddModal header={modalHeader}>
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        gridGap={SPACING.spacing32}
+        width="100%"
+      >
+        <Trans
+          t={t}
+          i18nKey="shutdown_robot_confirmation_description"
+          values={{ robotName: robotName }}
+          components={{
+            bold: <strong />,
+            span: (
+              <LegacyStyledText
+                forwardedAs="p"
+                data-testid="shutdown_robot_confirmation_description"
+              />
+            ),
+          }}
+        />
+        <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing8}>
+          <SmallButton
+            flex="1"
+            buttonText={t('shared:go_back')}
+            onClick={() => {
+              setShowShutdownRobotConfirmationModal(false)
+            }}
+          />
+          <SmallButton
+            flex="1"
+            buttonType="alert"
+            buttonText={i18n.format(t('shared:shutdown'), 'capitalize')}
+            onClick={() => dispatch(shutdownRobot(robotName))}
+          />
+        </Flex>
+      </Flex>
+    </OddModal>
+  )
+}

--- a/app/src/organisms/ODD/Navigation/ShutdownRobotConfirmationModal.tsx
+++ b/app/src/organisms/ODD/Navigation/ShutdownRobotConfirmationModal.tsx
@@ -9,6 +9,7 @@ import {
   LegacyStyledText,
   SPACING,
 } from '@opentrons/components'
+import { useSetLightsMutation } from '@opentrons/react-api-client'
 
 import { SmallButton } from '/app/atoms/buttons'
 import { OddModal } from '/app/molecules/OddModal'
@@ -29,11 +30,13 @@ export function ShutdownRobotConfirmationModal({
 }: ShutdownRobotConfirmationModalProps): JSX.Element {
   const { i18n, t } = useTranslation(['device_settings', 'shared'])
   const modalHeader: OddModalHeaderBaseProps = {
+    // TODO(jh, 05-18-26): Update after Design finalizes implementation
     title: t('shutdown_now'),
     iconName: 'ot-alert',
     iconColor: COLORS.yellow50,
   }
   const dispatch = useDispatch<Dispatch>()
+  const { setLights } = useSetLightsMutation()
 
   return (
     <OddModal header={modalHeader}>
@@ -68,7 +71,10 @@ export function ShutdownRobotConfirmationModal({
             flex="1"
             buttonType="alert"
             buttonText={i18n.format(t('shared:shutdown'), 'capitalize')}
-            onClick={() => dispatch(shutdownRobot(robotName))}
+            onClick={() => {
+              setLights({ on: false })
+              dispatch(shutdownRobot(robotName))
+            }}
           />
         </Flex>
       </Flex>

--- a/app/src/organisms/ODD/Navigation/__tests__/NavigationMenu.test.tsx
+++ b/app/src/organisms/ODD/Navigation/__tests__/NavigationMenu.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { useIsFlex } from '/app/redux-resources/robots'
 import { home } from '/app/redux/robot-controls'
 import { useLights } from '/app/resources/devices'
 
@@ -15,7 +16,9 @@ import type { NavigateFunction } from 'react-router-dom'
 vi.mock('/app/redux/robot-admin')
 vi.mock('/app/redux/robot-controls')
 vi.mock('/app/resources/devices')
+vi.mock('/app/redux-resources/robots')
 vi.mock('../RestartRobotConfirmationModal')
+vi.mock('../ShutdownRobotConfirmationModal')
 
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async importOriginal => {
@@ -46,6 +49,7 @@ describe('NavigationMenu', () => {
       lightsOn: false,
       toggleLights: mockToggleLights,
     })
+    vi.mocked(useIsFlex).mockReturnValue(true)
     vi.mocked(RestartRobotConfirmationModal).mockReturnValue(
       <div>mock RestartRobotConfirmationModal</div>
     )

--- a/app/src/redux/robot-admin/__fixtures__/index.ts
+++ b/app/src/redux/robot-admin/__fixtures__/index.ts
@@ -37,6 +37,38 @@ export const mockRestartFailureMeta = {
   status: 500,
 }
 
+export const mockShutdownSuccess = {
+  host: mockRobot,
+  method: 'POST' as Method,
+  path: '/server/shutdown',
+  ok: true,
+  status: 200,
+  body: { message: 'shutting down in 1s' },
+}
+
+export const mockShutdownSuccessMeta = {
+  method: 'POST' as Method,
+  path: '/server/shutdown',
+  ok: true,
+  status: 200,
+}
+
+export const mockShutdownFailure = {
+  host: mockRobot,
+  method: 'POST' as Method,
+  path: '/server/shutdown',
+  ok: false,
+  status: 500,
+  body: { message: 'AH' },
+}
+
+export const mockShutdownFailureMeta = {
+  method: 'POST' as Method,
+  path: '/server/shutdown',
+  ok: false,
+  status: 500,
+}
+
 export const mockResetOptions = [
   { id: 'foo', name: 'Foo', description: 'foobar' },
   { id: 'bar', name: 'Bar', description: 'barfoo' },

--- a/app/src/redux/robot-admin/__tests__/actions.test.ts
+++ b/app/src/redux/robot-admin/__tests__/actions.test.ts
@@ -44,6 +44,36 @@ describe('robot admin actions', () => {
       },
     },
     {
+      name: 'robotAdmin:SHUTDOWN',
+      creator: Actions.shutdownRobot,
+      args: ['robotName'],
+      expected: {
+        type: 'robotAdmin:SHUTDOWN',
+        payload: { robotName: 'robotName' },
+        meta: { robot: true },
+      },
+    },
+    {
+      name: 'robotAdmin:SHUTDOWN_SUCCESS',
+      creator: Actions.shutdownRobotSuccess,
+      args: ['robotName', { requestId: 'foo' }],
+      expected: {
+        type: 'robotAdmin:SHUTDOWN_SUCCESS',
+        payload: { robotName: 'robotName' },
+        meta: { requestId: 'foo' } as any,
+      },
+    },
+    {
+      name: 'robotAdmin:SHUTDOWN_FAILURE',
+      creator: Actions.shutdownRobotFailure,
+      args: ['robotName', { message: 'AH' }, { requestId: 'foo' }],
+      expected: {
+        type: 'robotAdmin:SHUTDOWN_FAILURE',
+        payload: { robotName: 'robotName', error: { message: 'AH' } },
+        meta: { requestId: 'foo' } as any,
+      },
+    },
+    {
       name: 'robotAdmin:FETCH_RESET_CONFIG_OPTIONS',
       creator: Actions.fetchResetConfigOptions,
       args: ['robotName'],

--- a/app/src/redux/robot-admin/actions.ts
+++ b/app/src/redux/robot-admin/actions.ts
@@ -28,7 +28,9 @@ export const restartRobotFailure = (
   meta,
 })
 
-export const shutdownRobot = (robotName: string): Types.ShutdownRobotAction => ({
+export const shutdownRobot = (
+  robotName: string
+): Types.ShutdownRobotAction => ({
   type: Constants.SHUTDOWN,
   payload: { robotName },
   meta: { robot: true },

--- a/app/src/redux/robot-admin/actions.ts
+++ b/app/src/redux/robot-admin/actions.ts
@@ -28,6 +28,31 @@ export const restartRobotFailure = (
   meta,
 })
 
+export const shutdownRobot = (robotName: string): Types.ShutdownRobotAction => ({
+  type: Constants.SHUTDOWN,
+  payload: { robotName },
+  meta: { robot: true },
+})
+
+export const shutdownRobotSuccess = (
+  robotName: string,
+  meta: RobotApiRequestMeta | {}
+): Types.ShutdownRobotSuccessAction => ({
+  type: Constants.SHUTDOWN_SUCCESS,
+  payload: { robotName },
+  meta,
+})
+
+export const shutdownRobotFailure = (
+  robotName: string,
+  error: {},
+  meta: RobotApiRequestMeta
+): Types.ShutdownRobotFailureAction => ({
+  type: Constants.SHUTDOWN_FAILURE,
+  payload: { robotName, error },
+  meta,
+})
+
 export const fetchResetConfigOptions = (
   robotName: string
 ): Types.FetchResetConfigOptionsAction => ({

--- a/app/src/redux/robot-admin/constants.ts
+++ b/app/src/redux/robot-admin/constants.ts
@@ -17,6 +17,14 @@ export const RESTART_SUCCESS: 'robotAdmin:RESTART_SUCCESS' =
 export const RESTART_FAILURE: 'robotAdmin:RESTART_FAILURE' =
   'robotAdmin:RESTART_FAILURE'
 
+export const SHUTDOWN: 'robotAdmin:SHUTDOWN' = 'robotAdmin:SHUTDOWN'
+
+export const SHUTDOWN_SUCCESS: 'robotAdmin:SHUTDOWN_SUCCESS' =
+  'robotAdmin:SHUTDOWN_SUCCESS'
+
+export const SHUTDOWN_FAILURE: 'robotAdmin:SHUTDOWN_FAILURE' =
+  'robotAdmin:SHUTDOWN_FAILURE'
+
 export const FETCH_RESET_CONFIG_OPTIONS: 'robotAdmin:FETCH_RESET_CONFIG_OPTIONS' =
   'robotAdmin:FETCH_RESET_CONFIG_OPTIONS'
 
@@ -45,6 +53,8 @@ export const SYNC_SYSTEM_TIME: 'robotAdmin:SYNC_SYSTEM_TIME' =
 export const LABWARE_OFFSETS_PATH: '/labwareOffsets' = '/labwareOffsets'
 
 export const RESTART_PATH: '/server/restart' = '/server/restart'
+
+export const SHUTDOWN_PATH: '/server/shutdown' = '/server/shutdown'
 
 export const SETTINGS_RESET_PATH: '/settings/reset' = '/settings/reset'
 

--- a/app/src/redux/robot-admin/epic/__tests__/shutdownEpic.test.ts
+++ b/app/src/redux/robot-admin/epic/__tests__/shutdownEpic.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { runEpicTest, setupEpicTestMocks } from '/app/redux/robot-api/__utils__'
+
+import * as Fixtures from '../../__fixtures__'
+import * as Actions from '../../actions'
+import { shutdownEpic } from '../shutdownEpic'
+
+import type { Action } from '../../../types'
+
+describe('robotAdminEpic handles shutting down', () => {
+  it('calls POST /server/shutdown', () => {
+    const mocks = setupEpicTestMocks(
+      robotName => Actions.shutdownRobot(robotName),
+      Fixtures.mockShutdownSuccess
+    )
+
+    runEpicTest<Action>(mocks, ({ hot, expectObservable, flush }) => {
+      const action$ = hot('--a', { a: mocks.action })
+      const state$ = hot('s-s', { s: mocks.state })
+      const output$ = shutdownEpic(action$, state$)
+
+      expectObservable(output$)
+      flush()
+
+      expect(mocks.fetchRobotApi).toHaveBeenCalledWith(mocks.robot, {
+        method: 'POST',
+        path: '/server/shutdown',
+      })
+    })
+  })
+
+  it('maps successful response to SHUTDOWN_SUCCESS', () => {
+    const mocks = setupEpicTestMocks(
+      robotName => Actions.shutdownRobot(robotName),
+      Fixtures.mockShutdownSuccess
+    )
+
+    runEpicTest<Action>(mocks, ({ hot, expectObservable }) => {
+      const action$ = hot('--a', { a: mocks.action })
+      const state$ = hot('s-s', { s: mocks.state })
+      const output$ = shutdownEpic(action$, state$)
+
+      expectObservable(output$).toBe('--a', {
+        a: Actions.shutdownRobotSuccess(mocks.robot.name, {
+          ...mocks.meta,
+          response: Fixtures.mockShutdownSuccessMeta,
+        }),
+      })
+    })
+  })
+
+  it('maps failed response to SHUTDOWN_FAILURE', () => {
+    const mocks = setupEpicTestMocks(
+      robotName => Actions.shutdownRobot(robotName),
+      Fixtures.mockShutdownFailure
+    )
+
+    runEpicTest<Action>(mocks, ({ hot, expectObservable }) => {
+      const action$ = hot('--a', { a: mocks.action })
+      const state$ = hot('s-s', { s: mocks.state })
+      const output$ = shutdownEpic(action$, state$)
+
+      expectObservable(output$).toBe('--a', {
+        a: Actions.shutdownRobotFailure(
+          mocks.robot.name,
+          { message: 'AH' },
+          { ...mocks.meta, response: Fixtures.mockShutdownFailureMeta }
+        ),
+      })
+    })
+  })
+})

--- a/app/src/redux/robot-admin/epic/__tests__/shutdownEpic.test.ts
+++ b/app/src/redux/robot-admin/epic/__tests__/shutdownEpic.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import { runEpicTest, setupEpicTestMocks } from '/app/redux/robot-api/__utils__'
 

--- a/app/src/redux/robot-admin/epic/index.ts
+++ b/app/src/redux/robot-admin/epic/index.ts
@@ -3,6 +3,7 @@ import { combineEpics } from 'redux-observable'
 import { fetchResetOptionsEpic } from './fetchResetOptionsEpic'
 import { resetConfigEpic, restartOnResetConfigEpic } from './resetConfigEpic'
 import { restartEpic, startDiscoveryOnRestartEpic } from './restartEpic'
+import { shutdownEpic } from './shutdownEpic'
 import { syncSystemTimeEpic } from './syncSystemTimeEpic'
 import { trackRestartsEpic } from './trackRestartsEpic'
 
@@ -11,6 +12,7 @@ import type { Epic } from '../../types'
 export const robotAdminEpic = combineEpics<Epic>(
   restartEpic,
   startDiscoveryOnRestartEpic,
+  shutdownEpic,
   fetchResetOptionsEpic,
   resetConfigEpic,
   restartOnResetConfigEpic,

--- a/app/src/redux/robot-admin/epic/shutdownEpic.ts
+++ b/app/src/redux/robot-admin/epic/shutdownEpic.ts
@@ -12,9 +12,9 @@ import type {
 import type { Action, Epic } from '../../types'
 import type { ShutdownRobotAction } from '../types'
 
-const mapActionToRequest: ActionToRequestMapper<ShutdownRobotAction> = (
-  action
-) => {
+const mapActionToRequest: ActionToRequestMapper<
+  ShutdownRobotAction
+> = action => {
   return { method: POST, path: Constants.SHUTDOWN_PATH }
 }
 

--- a/app/src/redux/robot-admin/epic/shutdownEpic.ts
+++ b/app/src/redux/robot-admin/epic/shutdownEpic.ts
@@ -1,0 +1,48 @@
+import { ofType } from 'redux-observable'
+
+import { POST } from '../../robot-api/constants'
+import { mapToRobotApiRequest } from '../../robot-api/operators'
+import * as Actions from '../actions'
+import * as Constants from '../constants'
+
+import type {
+  ActionToRequestMapper,
+  ResponseToActionMapper,
+} from '../../robot-api/operators'
+import type { Action, Epic } from '../../types'
+import type { ShutdownRobotAction } from '../types'
+
+const mapActionToRequest: ActionToRequestMapper<ShutdownRobotAction> = (
+  action
+) => {
+  return { method: POST, path: Constants.SHUTDOWN_PATH }
+}
+
+const mapResponseToAction: ResponseToActionMapper<ShutdownRobotAction> = (
+  response,
+  originalAction
+) => {
+  const { host, body, ...responseMeta } = response
+  const { robot: _, ...prevMeta } = originalAction.meta
+  const meta = { ...prevMeta, response: responseMeta }
+
+  return response.ok
+    ? Actions.shutdownRobotSuccess(host.name, meta)
+    : Actions.shutdownRobotFailure(
+        host.name,
+        body as Record<string, unknown>,
+        meta
+      )
+}
+
+export const shutdownEpic: Epic = (action$, state$) => {
+  return action$.pipe(
+    ofType<Action, ShutdownRobotAction>(Constants.SHUTDOWN),
+    mapToRobotApiRequest(
+      state$,
+      a => a.payload.robotName,
+      mapActionToRequest,
+      mapResponseToAction
+    )
+  )
+}

--- a/app/src/redux/robot-admin/types.ts
+++ b/app/src/redux/robot-admin/types.ts
@@ -65,6 +65,24 @@ export interface RestartRobotFailureAction {
   meta: RobotApiRequestMeta
 }
 
+export interface ShutdownRobotAction {
+  type: 'robotAdmin:SHUTDOWN'
+  payload: { robotName: string }
+  meta: Partial<RobotApiRequestMeta & { robot: true }>
+}
+
+export interface ShutdownRobotSuccessAction {
+  type: 'robotAdmin:SHUTDOWN_SUCCESS'
+  payload: { robotName: string }
+  meta: RobotApiRequestMeta | {}
+}
+
+export interface ShutdownRobotFailureAction {
+  type: 'robotAdmin:SHUTDOWN_FAILURE'
+  payload: { robotName: string; error: {} }
+  meta: RobotApiRequestMeta
+}
+
 export interface FetchResetConfigOptionsAction {
   type: 'robotAdmin:FETCH_RESET_CONFIG_OPTIONS'
   payload: { robotName: string }
@@ -112,6 +130,9 @@ export type RobotAdminAction =
   | RestartStatusChangedAction
   | RestartRobotSuccessAction
   | RestartRobotFailureAction
+  | ShutdownRobotAction
+  | ShutdownRobotSuccessAction
+  | ShutdownRobotFailureAction
   | FetchResetConfigOptionsAction
   | FetchResetConfigOptionsSuccessAction
   | FetchResetConfigOptionsFailureAction

--- a/server-utils/server_utils/auth/scopes.py
+++ b/server-utils/server_utils/auth/scopes.py
@@ -34,6 +34,11 @@ class Scope(enum.Enum):
         "Restart the robot.",
     )
 
+    SHUTDOWN_WRITE = (
+        "shutdown.write",
+        "Shut down the robot.",
+    )
+
     ROBOT_CONTROL_WRITE = (
         "robot_control.write",
         (

--- a/update-server/otupdate/common/constants.py
+++ b/update-server/otupdate/common/constants.py
@@ -8,6 +8,9 @@ APP_VARIABLE_PREFIX = "com.opentrons.otupdate.buildroot."
 RESTART_LOCK_NAME = APP_VARIABLE_PREFIX + "restartlock"
 #: Name for the asyncio lock in the application dictlike
 
+SHUTDOWN_LOCK_NAME = APP_VARIABLE_PREFIX + "shutdownlock"
+#: Name for the asyncio lock in the application dictlike
+
 DEVICE_BOOT_ID_NAME = APP_VARIABLE_PREFIX + "boot_id"
 #: A random string that changes every time the device boots.
 #:

--- a/update-server/otupdate/common/control.py
+++ b/update-server/otupdate/common/control.py
@@ -16,7 +16,7 @@ from aiohttp import web
 from server_utils.auth.scopes import Scope
 
 from . import auth
-from .constants import DEVICE_BOOT_ID_NAME, RESTART_LOCK_NAME
+from .constants import DEVICE_BOOT_ID_NAME, RESTART_LOCK_NAME, SHUTDOWN_LOCK_NAME
 from .name_management import get_name_synchronizer
 
 LOG = logging.getLogger(__name__)
@@ -24,6 +24,10 @@ LOG = logging.getLogger(__name__)
 
 def _do_restart():
     subprocess.check_call(["reboot"])
+
+
+def _do_shutdown():
+    subprocess.check_call(["shutdown", "-h", "now"])
 
 
 @auth.require_scopes(Scope.RESTART_WRITE)
@@ -35,6 +39,17 @@ async def restart(request: web.Request) -> web.Response:
     async with request.app[RESTART_LOCK_NAME]:
         asyncio.get_event_loop().call_later(1, _do_restart)
     return web.json_response({"message": "Restarting in 1s"}, status=200)
+
+
+@auth.require_scopes(Scope.SHUTDOWN_WRITE)
+async def shutdown(request: web.Request) -> web.Response:
+    """Shut down the robot.
+
+    Blocks while the shutdown lock is held.
+    """
+    async with request.app[SHUTDOWN_LOCK_NAME]:
+        asyncio.get_event_loop().call_later(1, _do_shutdown)
+    return web.json_response({"message": "Shutting down in 1s"}, status=200)
 
 
 def build_health_endpoint(

--- a/update-server/otupdate/openembedded/__init__.py
+++ b/update-server/otupdate/openembedded/__init__.py
@@ -63,6 +63,7 @@ async def get_app(
 
     app[config.CONFIG_VARNAME] = config_obj
     app[constants.RESTART_LOCK_NAME] = asyncio.Lock()
+    app[constants.SHUTDOWN_LOCK_NAME] = asyncio.Lock()
     app[constants.DEVICE_BOOT_ID_NAME] = boot_id
 
     rfs = RootFSInterface()
@@ -85,6 +86,7 @@ async def get_app(
             web.post("/server/update/{session}/file", update.file_upload),
             web.post("/server/update/{session}/commit", update.commit),
             web.post("/server/restart", control.restart),
+            web.post("/server/shutdown", control.shutdown),
             web.get("/server/ssh_keys", ssh_key_management.list_keys),
             web.post("/server/ssh_keys", ssh_key_management.add),
             web.post("/server/ssh_keys/from_local", ssh_key_management.add_from_local),
@@ -125,6 +127,7 @@ def health_response(version_dict: Mapping[str, str]) -> Mapping[str, Any]:
         "capabilities": {
             "systemUpdate": "/server/update/begin",
             "restart": "/server/restart",
+            "shutdown": "/server/shutdown",
         },
         "robotModel": constants.MODEL_OT3,
     }

--- a/update-server/tests/openembedded/test_control.py
+++ b/update-server/tests/openembedded/test_control.py
@@ -1,11 +1,14 @@
 """test the openembedded endpoints in otupdate.common.control"""
 
+import asyncio
 from typing import Dict
+from unittest import mock
 
 # Avoid pytest trying to collect TestClient because it begins with "Test".
 from aiohttp.test_utils import TestClient as HTTPTestClient
 from decoy import Decoy
 
+from otupdate.common import control
 from otupdate.common.name_management import NameSynchronizer
 
 
@@ -28,7 +31,22 @@ async def test_health(
         "capabilities": {
             "systemUpdate": "/server/update/begin",
             "restart": "/server/restart",
+            "shutdown": "/server/shutdown",
         },
         "serialNumber": "unknown",
         "robotModel": "OT-3 Standard",
     }
+
+
+async def test_shutdown(test_cli: HTTPTestClient, monkeypatch) -> None:
+    """It should shut down the robot"""
+    shutdown_mock = mock.Mock()
+
+    monkeypatch.setattr(control, "_do_shutdown", shutdown_mock)
+    resp = await test_cli.post("/server/shutdown")
+
+    assert resp.status == 200
+    assert await resp.json() == {"message": "Shutting down in 1s"}
+    assert not shutdown_mock.called
+    await asyncio.sleep(1.01)
+    assert shutdown_mock.called


### PR DESCRIPTION
Works toward [EXEC-2649](https://opentrons.atlassian.net/browse/EXEC-2649)

# Overview

Adds the ability to shutdown the robot's Linux OS from two entry points, one of the desktop app and one on the ODD. We turn off the lights and the status bar prior to shutting down the robot to more explicitly convey that the robot is in a "powered off" state. 

NOTE: The frontend implementation is a placeholder until Design finalizes UI decisions. 

<img width="1023" height="767" alt="Screenshot 2026-05-18 at 8 42 39 AM" src="https://github.com/user-attachments/assets/d8bb92df-28a9-473c-9a6d-57ebf89c6e16" />

<img width="749" height="442" alt="Screenshot 2026-05-18 at 8 59 03 AM" src="https://github.com/user-attachments/assets/22e06846-b682-424a-8ef2-cd079b4a8e6a" />


## Test Plan and Hands on Testing

- See images.
- Verified the lights turn off and the Linux OS shuts down as expected when acted upon through the desktop app and ODD. 

## Review requests

- Are we ok with the visual feedback for "the robot is powered off", i.e. the status bar and lights turned off?

## Changelog

- Added an option to shutdown the robot on the desktop app and ODD.

## Risk assessment

- relatively low - code changes are orthogonal and the work is patterned 

[EXEC-2649]: https://opentrons.atlassian.net/browse/EXEC-2649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ