### PR TITLE
feat(api): add vacuum duration to GET_PRESSURE_STATE for the vacuum module.

### DIFF
--- a/api/src/opentrons/drivers/vacuum_module/driver.py
+++ b/api/src/opentrons/drivers/vacuum_module/driver.py
@@ -68,7 +68,7 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
     @classmethod
     def parse_get_pressure_state(cls, response: str) -> VacuumState:
         """Parse the get pressure state."""
-        pattern = r"T:(?P<T>-?\d.+) C:(?P<C>-?\d.+) A:(?P<A>\d.+) B:(?P<B>\d.+) H:(?P<H>\d.+) E:(?P<E>\d) V:(?P<V>\d)"
+        pattern = r"T:(?P<T>-?\d.+) C:(?P<C>-?\d.+) A:(?P<A>\d.+) B:(?P<B>\d.+) H:(?P<H>\d.+) E:(?P<E>\d) D:(?P<D>\d+) V:(?P<V>\d)"
         _RE = re.compile(rf"^{GCODE.GET_PRESSURE_STATE} {pattern}$")
         match = _RE.match(response)
         if not match:
@@ -80,6 +80,7 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
             float(match.group("B")),
             float(match.group("H")),
             bool(int(match.group("E"))),
+            int(match.group("D")),
             VentState(int(match.group("V"))),
         )
 

--- a/api/src/opentrons/drivers/vacuum_module/simulator.py
+++ b/api/src/opentrons/drivers/vacuum_module/simulator.py
@@ -22,6 +22,7 @@ class SimulatingDriver(AbstractVacuumModuleDriver):
         self.vent_state = VentState.OPENED
         self.vacuum_on = False
         self.pump_enabled = False
+        self.duration = 0
         self.pressure_sensor_enabled = False
         self.target_pressure = 0.0
         self.current_pressure = 0.0
@@ -97,6 +98,7 @@ class SimulatingDriver(AbstractVacuumModuleDriver):
         """Engage or release the vacuum until a desired internal pressure is reached."""
         self.vacuum_on = enable_vacuum
         self.target_pressure = gauge_pressure_mbar or self.target_pressure
+        self.duration = duration_s or 0
 
     async def get_vacuum_state(self) -> VacuumState:
         """Get the pressure state."""
@@ -107,6 +109,7 @@ class SimulatingDriver(AbstractVacuumModuleDriver):
             0,
             0,
             self.vacuum_on,
+            self.duration,
             self.vent_state,
         )
 

--- a/api/src/opentrons/drivers/vacuum_module/types.py
+++ b/api/src/opentrons/drivers/vacuum_module/types.py
@@ -110,6 +110,7 @@ class VacuumState:
     pressure_abs_b: float
     pressure_atm: float
     vacuum_enabled: bool
+    vacuum_duration: int
     vent_state: VentState
 
 

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -493,6 +493,7 @@ class VacuumModuleReader(Reader):
             pressure_abs_b=0,
             pressure_atm=0,
             vacuum_enabled=False,
+            vacuum_duration=0,
             vent_state=VentState.CLOSED,
         )
         self.pump_state: PumpState = PumpState(

--- a/api/tests/opentrons/drivers/vacuum_module/test_driver.py
+++ b/api/tests/opentrons/drivers/vacuum_module/test_driver.py
@@ -182,7 +182,7 @@ async def test_get_vacuum_state(
 ) -> None:
     """It should send a get pressure command"""
     connection.send_command.return_value = (
-        "M121 T:400.0 C:988.0 A:989.3 B:988.6 H:992.5 E:1 V:0"
+        "M121 T:400.0 C:988.0 A:989.3 B:988.6 H:992.5 E:1 D:10 V:0"
     )
 
     pressure_state = await subject.get_vacuum_state()
@@ -192,12 +192,12 @@ async def test_get_vacuum_state(
     connection.reset_mock()
 
     assert pressure_state == types.VacuumState(
-        400, 988, 989.3, 988.6, 992.5, True, types.VentState.CLOSED
+        400, 988, 989.3, 988.6, 992.5, True, 10, types.VentState.CLOSED
     )
 
     # test idle
     connection.send_command.return_value = (
-        "M121 T:0.0 C:0.0 A:989.3 B:988.6 H:992.5 E:0 V:1"
+        "M121 T:0.0 C:0.0 A:989.3 B:988.6 H:992.5 E:0 D:0 V:1"
     )
 
     pressure_state = await subject.get_vacuum_state()
@@ -207,7 +207,7 @@ async def test_get_vacuum_state(
     connection.reset_mock()
 
     assert pressure_state == types.VacuumState(
-        0, 0, 989.3, 988.6, 992.5, False, types.VentState.OPENED
+        0, 0, 989.3, 988.6, 992.5, False, 0, types.VentState.OPENED
     )
 
 

--- a/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
@@ -389,6 +389,7 @@ async def test_update_pump_state(
             pressure_abs_b=0,
             pressure_atm=0,
             vacuum_enabled=False,
+            vacuum_duration=0,
             vent_state=VentState.CLOSED,
         )
     ],


### PR DESCRIPTION
# Overview

We need to keep track of how long the vacuum module will be under pressure when the `duration_s` argument is used in the `set_vacuum_state` function. This will allow us to easily monitor the task while the task is on, which is required for properly running the `StartRunProfile` Protocol Engine command.

## Test Plan and Hands on Testing

- Make sure that we can properly parse the response from the gcode

## Changelog

- Add duration (D) to the GET_PRESSURE_STATE (M121) GCODE of the vacuum module to keep track of vacuum duration.

## Review requests
## Risk assessment