### PR TITLE
fix(ci): handle workflow_dispatch event for docs build

### DIFF
--- a/scripts/static-deploy/deploy_ci_config.py
+++ b/scripts/static-deploy/deploy_ci_config.py
@@ -43,6 +43,7 @@ WORKFLOW_NAME_DOCS = "API docs build"
 # GitHub Actions event names (GITHUB_EVENT_NAME).
 GITHUB_EVENT_PULL_REQUEST = "pull_request"
 GITHUB_EVENT_PUSH = "push"
+GITHUB_EVENT_WORKFLOW_DISPATCH = "workflow_dispatch"
 
 # Deployment target environment (match deploy_types.Environment).
 ENV_SANDBOX: Environment = "sandbox"
@@ -192,6 +193,14 @@ def _determine_environment_and_prefix(event_name: str, ref_type: str, ref_name: 
             return ENV_SANDBOX, ref_name
         if ref_name_lower.startswith(TAG_PRODUCTION_REF_PREFIXES):
             return ENV_PRODUCTION, ref_name
+        return ENV_SANDBOX, ref_name
+
+    if event_name == GITHUB_EVENT_WORKFLOW_DISPATCH:
+        if ref_type == REF_TYPE_TAG:
+            raise ValueError(
+                "workflow_dispatch is only supported for branch refs. "
+                "Use a push tag trigger for staging or production deployments."
+            )
         return ENV_SANDBOX, ref_name
 
     raise ValueError(f"No deployment configuration found for event: {event_name}, ref_type: {ref_type}")

--- a/scripts/static-deploy/deploy_ci_config.py
+++ b/scripts/static-deploy/deploy_ci_config.py
@@ -203,8 +203,7 @@ def _determine_environment_and_prefix(event_name: str, ref_type: str, ref_name: 
     if event_name == GITHUB_EVENT_WORKFLOW_DISPATCH:
         if ref_type == REF_TYPE_TAG:
             raise ValueError(
-                "workflow_dispatch is only supported for branch refs. "
-                "Use a push tag trigger for staging or production deployments."
+                "workflow_dispatch is only supported for branch refs. Use a push tag trigger for staging or production deployments."
             )
         return ENV_SANDBOX, ref_name
 

--- a/scripts/static-deploy/deploy_ci_config.py
+++ b/scripts/static-deploy/deploy_ci_config.py
@@ -169,6 +169,18 @@ def _determine_application(ref_type: str, ref_name: str) -> str:
     )
 
 
+def _environment_and_prefix_for_tag(ref_name: str) -> tuple[str, str]:
+    """Resolve environment and sandbox prefix from a tag ref name."""
+    ref_name_lower = ref_name.lower()
+    if ref_name_lower.startswith(TAG_STAGING_ENV_PREFIX):
+        return ENV_STAGING, ref_name
+    if ref_name_lower.startswith(TAG_PD_TEST_SANDBOX_PREFIX):
+        return ENV_SANDBOX, ref_name
+    if ref_name_lower.startswith(TAG_PRODUCTION_REF_PREFIXES):
+        return ENV_PRODUCTION, ref_name
+    return ENV_SANDBOX, ref_name
+
+
 def _determine_environment_and_prefix(event_name: str, ref_type: str, ref_name: str, head_ref: Optional[str]) -> tuple[str, str]:
     """Determine environment and sandbox prefix from event context."""
     if event_name == GITHUB_EVENT_PULL_REQUEST:
@@ -186,14 +198,7 @@ def _determine_environment_and_prefix(event_name: str, ref_type: str, ref_name: 
         return ENV_SANDBOX, ref_name
 
     if event_name == GITHUB_EVENT_PUSH and ref_type == REF_TYPE_TAG:
-        ref_name_lower = ref_name.lower()
-        if ref_name_lower.startswith(TAG_STAGING_ENV_PREFIX):
-            return ENV_STAGING, ref_name
-        if ref_name_lower.startswith(TAG_PD_TEST_SANDBOX_PREFIX):
-            return ENV_SANDBOX, ref_name
-        if ref_name_lower.startswith(TAG_PRODUCTION_REF_PREFIXES):
-            return ENV_PRODUCTION, ref_name
-        return ENV_SANDBOX, ref_name
+        return _environment_and_prefix_for_tag(ref_name)
 
     if event_name == GITHUB_EVENT_WORKFLOW_DISPATCH:
         if ref_type == REF_TYPE_TAG:

--- a/scripts/static-deploy/tests/test_deploy_ci_config.py
+++ b/scripts/static-deploy/tests/test_deploy_ci_config.py
@@ -359,6 +359,42 @@ def test_resolve_ci_config_uppercase_tag():
     assert config.relative_artifact_dir == "/build/docs"
 
 
+def test_resolve_ci_config_workflow_dispatch_branch():
+    """Branch-based workflow_dispatch resolves to sandbox with ref_name as prefix."""
+    env = {
+        "GITHUB_EVENT_NAME": "workflow_dispatch",
+        "GITHUB_REF": "refs/heads/wip-my-feature",
+        "GITHUB_REF_NAME": "wip-my-feature",
+        "GITHUB_WORKFLOW": "Docs build and deploy",
+        "RELATIVE_ARTIFACT_DIR": "../../dist",
+        "GITHUB_HEAD_REF": "",
+    }
+
+    with patch.dict(os.environ, env, clear=False):
+        config = resolve_ci_config()
+
+    assert config.application == "mkdocs"
+    assert config.environment == "sandbox"
+    assert config.sandbox_prefix == "wip-my-feature"
+    assert config.relative_artifact_dir == "../../dist"
+
+
+def test_resolve_ci_config_workflow_dispatch_tag_raises():
+    """Tag-based workflow_dispatch raises ValueError; use push tag trigger instead."""
+    env = {
+        "GITHUB_EVENT_NAME": "workflow_dispatch",
+        "GITHUB_REF": "refs/tags/staging-mkdocs-v1.0.0",
+        "GITHUB_REF_NAME": "staging-mkdocs-v1.0.0",
+        "GITHUB_WORKFLOW": "Docs build and deploy",
+        "RELATIVE_ARTIFACT_DIR": "../../dist",
+        "GITHUB_HEAD_REF": "",
+    }
+
+    with patch.dict(os.environ, env, clear=False):
+        with pytest.raises(ValueError, match="workflow_dispatch is only supported for branch refs"):
+            resolve_ci_config()
+
+
 def test_resolve_ci_config_lowercase_tag():
     """Test CI config resolution handles fully lowercase tags."""
     env = {


### PR DESCRIPTION
## Overview

The `workflow_dispatch:` trigger added to `docs-build-deploy.yaml` in #21054 was never wired up to the Python deployment script, so it wouldn't do anything (except fail).

This PR updates the script to handle the intended use case of deploying WIP docs branches to sandbox before opening a PR.

## Test Plan and Hands on Testing

Automated tests:

- Added `test_resolve_ci_config_workflow_dispatch_branch`: confirms a branch dispatch resolves to `sandbox` with the branch name as the prefix.
- Added `test_resolve_ci_config_workflow_dispatch_tag_raises`: confirms a tag dispatch raises a `ValueError` with a message pointing to the push-tag path.

[Manually tested the workflow](https://github.com/Opentrons/opentrons/actions/runs/26053718680) on a sub-branch of this one.

## Changelog

🤖 
- `deploy_ci_config.py`: added `GITHUB_EVENT_WORKFLOW_DISPATCH` constant and a handler that routes branch dispatches to sandbox and rejects tag dispatches with a clear error message.
- `tests/test_deploy_ci_config.py`: two new test cases covering the above behavior.

## Review requests

Seems good? Matches our other CI patterns?

## Risk assessment

Low.