### PR TITLE
chore(labware-library): Remove unused jszip dependency

### DIFF
--- a/labware-library/package.json
+++ b/labware-library/package.json
@@ -37,7 +37,6 @@
     "core-js": "3.2.1",
     "file-saver": "2.0.1",
     "formik": "2.1.4",
-    "jszip": "3.2.2",
     "lodash": "4.18.1",
     "mixpanel-browser": "2.29.1",
     "query-string": "6.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1013,9 +1013,6 @@ importers:
       formik:
         specifier: 2.1.4
         version: 2.1.4(react@18.2.0)
-      jszip:
-        specifier: 3.2.2
-        version: 3.2.2
       lodash:
         specifier: 4.18.1
         version: 4.18.1


### PR DESCRIPTION
## Overview

labware-library used to export zip files. It now only exports a single .json file, meaning its dependency on jszip is unused.

## Test Plan and Hands on Testing

Testing is currently blocked by AUTH-2910, but I will resolve that and, before merging this, check that file imports and exports still work.

## Review requests

None.

## Risk assessment

Low.