### PR TITLE
feat(api): add basic vacuum module papi commands

### DIFF
--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -462,6 +462,7 @@ class VacuumModule(mod_abc.AbstractModule):
             else:
                 await self._execute_cycle_step(step_or_cycle)
 
+    # TODO: implement a wait_for in running profiles
     async def execute_profile(
         self, profile: List[Union[VacuumModuleCycle, VacuumModuleStep]]
     ) -> None:

--- a/api/src/opentrons/legacy_commands/module_commands.py
+++ b/api/src/opentrons/legacy_commands/module_commands.py
@@ -335,3 +335,43 @@ def flex_stacker_fill(
         "name": command_types.FLEX_STACKER_FILL,
         "payload": {"text": text},
     }
+
+
+def vacuum_module_start_set_vacuum_pressure(
+    self: Any,
+    gauge_pressure_mbar: float,
+    duration_s: int | None,
+    ramp_rate: float | None,
+    timeout_s: int | None,
+    vent_after: bool | None,
+) -> command_types.VacuumModuleStartSetVacuumPressureCommand:
+    text = f"Setting module {self} pressure to {gauge_pressure_mbar}: duration_s={duration_s}, ramp_rate={ramp_rate}, timeout_s={timeout_s}, vent_after={vent_after}"
+    return {
+        "name": command_types.VACUUM_MODULE_START_SET_VACUUM_PRESSURE,
+        "payload": {"text": text},
+    }
+
+
+def vacuum_module_start_set_vacuum_power(
+    self: Any,
+    percent_power: float,
+    duration_s: int | None,
+    ramp_rate: float | None,
+    timeout_s: int | None,
+    vent_after: bool | None,
+) -> command_types.VacuumModuleStartSetVacuumPowerCommand:
+    text = f"Setting module {self} power to {percent_power}%: duration_s={duration_s}, ramp_rate={ramp_rate}, timeout_s={timeout_s}, vent_after={vent_after}"
+    return {
+        "name": command_types.VACUUM_MODULE_START_SET_VACUUM_POWER,
+        "payload": {"text": text},
+    }
+
+
+def vacuum_module_stop_vacuum(
+    self: Any,
+) -> command_types.VacuumModuleStopVacuumCommand:
+    text = f"Stopping module {self}"
+    return {
+        "name": command_types.VACUUM_MODULE_STOP_VACUUM,
+        "payload": {"text": text},
+    }

--- a/api/src/opentrons/legacy_commands/types.py
+++ b/api/src/opentrons/legacy_commands/types.py
@@ -101,6 +101,14 @@ FLEX_STACKER_STORE: Final = "command.FLEX_STACKER_STORE"
 FLEX_STACKER_EMPTY: Final = "command.FLEX_STACKER_EMPTY"
 FLEX_STACKER_FILL: Final = "command.FLEX_STACKER_FILL"
 
+VACUUM_MODULE_START_SET_VACUUM_PRESSURE: Final = (
+    "command.VACUUM_MODULE_START_SET_VACUUM_PRESSURE"
+)
+VACUUM_MODULE_START_SET_VACUUM_POWER: Final = (
+    "command.VACUUM_MODULE_START_SET_VACUUM_POWER"
+)
+VACUUM_MODULE_STOP_VACUUM: Final = "command.VACUUM_MODULE_STOP_VACUUM"
+
 # Robot #
 ROBOT_MOVE_TO: Final = "command.ROBOT_MOVE_TO"
 ROBOT_MOVE_AXES_TO: Final = "command.ROBOT_MOVE_AXES_TO"
@@ -448,6 +456,21 @@ class FlexStackerEmptyCommand(TypedDict):
 
 class FlexStackerFillCommand(TypedDict):
     name: Literal["command.FLEX_STACKER_FILL"]
+    payload: TextOnlyPayload
+
+
+class VacuumModuleStartSetVacuumPressureCommand(TypedDict):
+    name: Literal["command.VACUUM_MODULE_START_SET_VACUUM_PRESSURE"]
+    payload: TextOnlyPayload
+
+
+class VacuumModuleStartSetVacuumPowerCommand(TypedDict):
+    name: Literal["command.VACUUM_MODULE_START_SET_VACUUM_POWER"]
+    payload: TextOnlyPayload
+
+
+class VacuumModuleStopVacuumCommand(TypedDict):
+    name: Literal["command.VACUUM_MODULE_STOP_VACUUM"]
     payload: TextOnlyPayload
 
 
@@ -884,6 +907,10 @@ Command = Union[
     FlexStackerStoreCommand,
     FlexStackerEmptyCommand,
     FlexStackerFillCommand,
+    # Vacuum Module commands
+    VacuumModuleStartSetVacuumPressureCommand,
+    VacuumModuleStartSetVacuumPowerCommand,
+    VacuumModuleStopVacuumCommand,
     # Task commands
     WaitForTasksCommand,
     CreateTimerCommand,

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -1157,3 +1157,53 @@ class VacuumModuleCore(ModuleCore, AbstractVacuumModuleCore[LabwareCore]):
     """Vacuum Module core logic implementation for Python protocols."""
 
     _sync_module_hardware: SynchronousAdapter[hw_modules.VacuumModule]
+
+    def start_set_vacuum_pressure(
+        self,
+        gauge_pressure_mbar: float,
+        duration: Optional[int] = None,
+        ramp_rate: Optional[float] = None,
+        timeout_s: Optional[int] = None,
+        vent_after: Optional[bool] = None,
+    ) -> None:
+        """Set vacuum pressure."""
+        self._engine_client.execute_command(
+            cmd.vacuum_module.StartSetVacuumPressureParams(
+                moduleId=self.module_id,
+                gaugePressure=gauge_pressure_mbar,
+                duration=duration,
+                rate=ramp_rate,
+                timeout=timeout_s,
+                ventAfter=vent_after if vent_after is not None else False,
+            ),
+            command_annotations=self._protocol_core.annotation_ids,
+        )
+
+    def start_set_vacuum_power(
+        self,
+        percent_power: int,
+        duration: Optional[int] = None,
+        ramp_rate: Optional[float] = None,
+        timeout_s: Optional[int] = None,
+        vent_after: Optional[bool] = None,
+    ) -> None:
+        """Set vacuum power."""
+        self._engine_client.execute_command(
+            cmd.vacuum_module.StartSetVacuumPowerParams(
+                moduleId=self.module_id,
+                percentPower=percent_power,
+                duration=duration,
+                rate=ramp_rate,
+                timeout=timeout_s,
+                ventAfter=vent_after if vent_after is not None else False,
+            ),
+            command_annotations=self._protocol_core.annotation_ids,
+        )
+
+    def stop_vacuum(
+        self,
+    ) -> None:
+        self._engine_client.execute_command(
+            cmd.vacuum_module.StopVacuumParams(moduleId=self.module_id),
+            command_annotations=self._protocol_core.annotation_ids,
+        )

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -550,3 +550,31 @@ class AbstractVacuumModuleCore(
     @abstractmethod
     def get_serial_number(self) -> str:
         """Get the module's unique hardware serial number."""
+
+    @abstractmethod
+    def start_set_vacuum_pressure(
+        self,
+        gauge_pressure_mbar: float,
+        duration: int | None,
+        ramp_rate: float | None,
+        timeout_s: int | None,
+        vent_after: bool | None,
+    ) -> None:
+        """Set vacuum pressure."""
+
+    @abstractmethod
+    def start_set_vacuum_power(
+        self,
+        percent_power: int,
+        duration: int | None,
+        ramp_rate: float | None,
+        timeout_s: int | None,
+        vent_after: bool | None,
+    ) -> None:
+        """Set vacuum power."""
+
+    @abstractmethod
+    def stop_vacuum(
+        self,
+    ) -> None:
+        """Stop the vacuum pump."""

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1931,3 +1931,44 @@ class VacuumModuleContext(ModuleContext):
             pick_up_offset=_pick_up_offset,
             drop_offset=_drop_offset,
         )
+
+    @requires_version(2, 28)
+    @publish(command=cmds.vacuum_module_start_set_vacuum_pressure)
+    def start_set_vacuum_pressure(
+        self,
+        gauge_pressure_mbar: float,
+        duration_s: Optional[int] = None,
+        ramp_rate: Optional[float] = None,
+        timeout_s: Optional[int] = None,
+        vent_after: Optional[bool] = None,
+    ) -> None:
+        self._core.start_set_vacuum_pressure(
+            gauge_pressure_mbar=gauge_pressure_mbar,
+            duration=duration_s,
+            ramp_rate=ramp_rate,
+            timeout_s=timeout_s,
+            vent_after=vent_after,
+        )
+
+    @requires_version(2, 28)
+    @publish(command=cmds.vacuum_module_start_set_vacuum_power)
+    def start_set_vacuum_power(
+        self,
+        percent_power: int,
+        duration_s: Optional[int] = None,
+        ramp_rate: Optional[float] = None,
+        timeout_s: Optional[int] = None,
+        vent_after: Optional[bool] = None,
+    ) -> None:
+        self._core.start_set_vacuum_power(
+            percent_power=percent_power,
+            duration=duration_s,
+            ramp_rate=ramp_rate,
+            timeout_s=timeout_s,
+            vent_after=vent_after,
+        )
+
+    @requires_version(2, 28)
+    @publish(command=cmds.vacuum_module_stop_vacuum)
+    def stop_vacuum_pump(self) -> None:
+        self._core.stop_vacuum()

--- a/api/tests/opentrons/protocol_api/core/engine/test_vacuum_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_vacuum_module_core.py
@@ -1,0 +1,151 @@
+"""Tests for Flex Stacker Engine Core."""
+
+import pytest
+from decoy import Decoy
+
+from opentrons.hardware_control import SynchronousAdapter
+from opentrons.hardware_control.modules import VacuumModule
+from opentrons.hardware_control.modules.types import (
+    ModuleType,
+)
+from opentrons.protocol_api import MAX_SUPPORTED_VERSION
+from opentrons.protocol_api.core.engine.module_core import VacuumModuleCore
+from opentrons.protocol_api.core.engine.protocol import ProtocolCore
+from opentrons.protocol_engine import commands as cmd
+from opentrons.protocol_engine.clients import SyncClient as EngineClient
+
+SyncVacuumModuleHardware = SynchronousAdapter[VacuumModule]
+
+
+@pytest.fixture
+def mock_engine_client(decoy: Decoy) -> EngineClient:
+    """Get a mock ProtocolEngine synchronous client."""
+    return decoy.mock(cls=EngineClient)
+
+
+@pytest.fixture
+def mock_sync_module_hardware(decoy: Decoy) -> SyncVacuumModuleHardware:
+    """Get a mock synchronous module hardware."""
+    return decoy.mock(name="SyncVacuumModuleHardware")  # type: ignore[no-any-return]
+
+
+@pytest.fixture
+def mock_protocol_core(decoy: Decoy) -> ProtocolCore:
+    """Get a mock protocol core."""
+    mock_protocol_core = decoy.mock(cls=ProtocolCore)
+    decoy.when(mock_protocol_core.annotation_ids).then_return([])
+    return mock_protocol_core
+
+
+@pytest.fixture
+def subject(
+    mock_engine_client: EngineClient,
+    mock_sync_module_hardware: SyncVacuumModuleHardware,
+    mock_protocol_core: ProtocolCore,
+) -> VacuumModuleCore:
+    """Get a Vacuum Module Core test subject."""
+    return VacuumModuleCore(
+        module_id="1234",
+        engine_client=mock_engine_client,
+        api_version=MAX_SUPPORTED_VERSION,
+        sync_module_hardware=mock_sync_module_hardware,
+        protocol_core=mock_protocol_core,
+    )
+
+
+def test_create(
+    decoy: Decoy,
+    mock_engine_client: EngineClient,
+    mock_sync_module_hardware: SyncVacuumModuleHardware,
+    mock_protocol_core: ProtocolCore,
+) -> None:
+    """It should be able to create a Vacuum Module core."""
+    result = VacuumModuleCore(
+        module_id="1234",
+        engine_client=mock_engine_client,
+        api_version=MAX_SUPPORTED_VERSION,
+        sync_module_hardware=mock_sync_module_hardware,
+        protocol_core=mock_protocol_core,
+    )
+
+    assert result.module_id == "1234"
+    assert result.MODULE_TYPE == ModuleType.VACUUM_MODULE
+
+
+def test_start_set_vacuum_pressure(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: VacuumModuleCore
+) -> None:
+    """It should correctly pass along the parameters to the protocol engine command."""
+    gauge_pressure_mbar = -300
+    duration_s = 40
+    ramp_rate = None
+    timeout_s = 100
+    vent_after = False
+
+    subject.start_set_vacuum_pressure(
+        gauge_pressure_mbar=gauge_pressure_mbar,
+        duration=duration_s,
+        ramp_rate=ramp_rate,
+        timeout_s=timeout_s,
+        vent_after=vent_after,
+    )
+    decoy.verify(
+        mock_engine_client.execute_command(
+            cmd.vacuum_module.StartSetVacuumPressureParams(
+                moduleId="1234",
+                gaugePressure=gauge_pressure_mbar,
+                duration=duration_s,
+                rate=ramp_rate,
+                timeout=timeout_s,
+                ventAfter=vent_after,
+            ),
+            command_annotations=[],
+        )
+    )
+
+
+def test_start_set_vacuum_power(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: VacuumModuleCore
+) -> None:
+    """It should correctly pass along the parameters to the protocol engine command."""
+    percent_power = 75
+    duration_s = 39
+    ramp_rate = 1.4
+    timeout_s = 102
+    vent_after = True
+
+    subject.start_set_vacuum_power(
+        percent_power=percent_power,
+        duration=duration_s,
+        ramp_rate=ramp_rate,
+        timeout_s=timeout_s,
+        vent_after=vent_after,
+    )
+    decoy.verify(
+        mock_engine_client.execute_command(
+            cmd.vacuum_module.StartSetVacuumPowerParams(
+                moduleId="1234",
+                percentPower=percent_power,
+                duration=duration_s,
+                rate=ramp_rate,
+                timeout=timeout_s,
+                ventAfter=vent_after,
+            ),
+            command_annotations=[],
+        )
+    )
+
+
+def test_stop_vacuum(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: VacuumModuleCore
+) -> None:
+    """Verify that the protocol engine command gets called correctly.."""
+    subject.stop_vacuum()
+    decoy.verify(
+        mock_engine_client.execute_command(
+            cmd.vacuum_module.StopVacuumParams(
+                moduleId="1234",
+            ),
+            command_annotations=[],
+        )
+    )

--- a/api/tests/opentrons/protocol_api/test_vacuum_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_vacuum_module_context.py
@@ -213,3 +213,85 @@ def test_vacuum_module_move_to_dock_with_options(
             drop_offset=(-1, -2, -3),
         )
     )
+
+
+@pytest.mark.parametrize(
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 28))
+)
+def test_vacuum_module_start_set_vacuum_pressure(
+    decoy: Decoy,
+    subject: VacuumModuleContext,
+    mock_core: VacuumModuleCore,
+) -> None:
+    """Make sure the command parameters get passed to the protocol engine correctly."""
+    gauge_pressure_mbar = -300
+    duration_s = 40
+    ramp_rate = None
+    timeout_s = 100
+    vent_after = None
+
+    subject.start_set_vacuum_pressure(
+        gauge_pressure_mbar=gauge_pressure_mbar,
+        duration_s=duration_s,
+        ramp_rate=ramp_rate,
+        timeout_s=timeout_s,
+        vent_after=vent_after,
+    )
+
+    decoy.verify(
+        mock_core.start_set_vacuum_pressure(
+            gauge_pressure_mbar=gauge_pressure_mbar,
+            duration=duration_s,
+            ramp_rate=ramp_rate,
+            timeout_s=timeout_s,
+            vent_after=vent_after,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 28))
+)
+def test_vacuum_module_start_set_vacuum_power(
+    decoy: Decoy,
+    subject: VacuumModuleContext,
+    mock_core: VacuumModuleCore,
+) -> None:
+    """Make sure the command parameters get passed to the protocol engine correctly."""
+    percent_power = 22
+    duration_s = 40
+    ramp_rate = 1.2
+    timeout_s = 101
+    vent_after = True
+
+    subject.start_set_vacuum_power(
+        percent_power=percent_power,
+        duration_s=duration_s,
+        ramp_rate=ramp_rate,
+        timeout_s=timeout_s,
+        vent_after=vent_after,
+    )
+
+    decoy.verify(
+        mock_core.start_set_vacuum_power(
+            percent_power=percent_power,
+            duration=duration_s,
+            ramp_rate=ramp_rate,
+            timeout_s=timeout_s,
+            vent_after=vent_after,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "api_version", versions_at_or_above(from_version=APIVersion(2, 28))
+)
+def test_vacuum_module_stop_vacuum(
+    decoy: Decoy,
+    subject: VacuumModuleContext,
+    mock_core: VacuumModuleCore,
+) -> None:
+    """Make sure the the protocol engine function gets called correctly."""
+    subject.stop_vacuum_pump()
+
+    decoy.verify(mock_core.stop_vacuum())


### PR DESCRIPTION
## Overview
This pr adds 3 basic vacuum module protocol api commands:
- start_set_vacuum_pressure
- start_set_vacuum_power
- stop_vacuum_pump

`stop_vacuum_pump` calls down to the `StopVacuum` command. I just wanted to make sure it’s clear from the name that this function isn’t specifically related to either pressure control or duty cycle control. 
