### PR TITLE
fix(app, protocol-visualization): account for fixedTrash in active sl…

### DIFF
--- a/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveSlotForLabwareDetails.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/utils/getActiveSlotForLabwareDetails.ts
@@ -42,7 +42,10 @@ export const getActiveSlotForLabwareDetails = (
   )?.entityId
   let slot = null
 
-  if ('labwareId' in currentCommand.params) {
+  if (
+    'labwareId' in currentCommand.params &&
+    currentCommand.params.labwareId !== 'fixedTrash'
+  ) {
     const isTiprack =
       labwareEntities[currentCommand.params.labwareId].def.parameters.isTiprack
     if (!isTiprack) {

--- a/protocol-visualization/src/organisms/utils/getActiveSlotForLabwareDetails.ts
+++ b/protocol-visualization/src/organisms/utils/getActiveSlotForLabwareDetails.ts
@@ -42,7 +42,10 @@ export const getActiveSlotForLabwareDetails = (
   )?.entityId
   let slot = null
 
-  if ('labwareId' in currentCommand.params) {
+  if (
+    'labwareId' in currentCommand.params &&
+    currentCommand.params.labwareId !== 'fixedTrash'
+  ) {
     const isTiprack =
       labwareEntities[currentCommand.params.labwareId].def.parameters.isTiprack
     if (!isTiprack) {


### PR DESCRIPTION
…ot details

# Overview

RQA-5366

the `getActiveSlotForLabwareDetails` logic wasn't accounting for if the labware id was a fixedTrash (legacy ot-2 protocols that counted it as a labware still). so this pr fixes that

## Test Plan and Hands on Testing

its hard to smoke test this on your own, you'd have to make these changes to the ot-2 repo and smoke test with the attached protocol. so just review the code please. the video shows that the whitescreen doesn't occur

https://github.com/user-attachments/assets/f014e580-305d-4b46-9029-39464708525a

## Changelog

make sure the labware id isn't `fixedTrash`

## Risk assessment

low, isolated in PV 