### PR TITLE
refactor(api, app, shared-data): Refine `MoveToMaintenancePosition`

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -31,7 +31,7 @@ MoveToMaintenancePositionCommandType = Literal["calibration/moveToMaintenancePos
 class MaintenancePosition(enum.Enum):
     """Maintenance position options."""
 
-    ATTACH_PLATE = "attachPlate"
+    LOWER_Z_AXES = "lowerZAxes"
 
 
 class MoveToMaintenancePositionParams(BaseModel):
@@ -91,7 +91,7 @@ class MoveToMaintenancePositionImplementation(
         )
 
         if params.mount != MountType.EXTENSION:
-            if params.maintenancePosition == MaintenancePosition.ATTACH_PLATE:
+            if params.maintenancePosition == MaintenancePosition.LOWER_Z_AXES:
                 max_motion_range = max_height_z_tip - _MAX_Z_AXIS_MOTION_RANGE
                 await ot3_api.move_axes(
                     {

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -31,7 +31,7 @@ MoveToMaintenancePositionCommandType = Literal["calibration/moveToMaintenancePos
 class MotionModifier(enum.Enum):
     """Motion modifier options for maintenance position moves."""
 
-    LOWER_Z_AXES = "lowerZAxes"
+    LOWER_Z_AXES_SEQUENTIALLY = "lowerZAxesSequentially"
 
 
 class MoveToMaintenancePositionParams(BaseModel):
@@ -91,7 +91,7 @@ class MoveToMaintenancePositionImplementation(
         )
 
         if params.mount != MountType.EXTENSION:
-            if params.motionModifier == MotionModifier.LOWER_Z_AXES:
+            if params.motionModifier == MotionModifier.LOWER_Z_AXES_SEQUENTIALLY:
                 max_motion_range = max_height_z_tip - _MAX_Z_AXIS_MOTION_RANGE
                 await ot3_api.move_axes(
                     {

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -28,8 +28,8 @@ _RIGHT_MOUNT_Z_MARGIN = 20
 MoveToMaintenancePositionCommandType = Literal["calibration/moveToMaintenancePosition"]
 
 
-class MaintenancePosition(enum.Enum):
-    """Maintenance position options."""
+class MotionModifier(enum.Enum):
+    """Motion modifier options for maintenance position moves."""
 
     LOWER_Z_AXES = "lowerZAxes"
 
@@ -42,7 +42,7 @@ class MoveToMaintenancePositionParams(BaseModel):
         description="Gantry mount to move maintenance position.",
     )
 
-    maintenancePosition: Optional[MaintenancePosition] = Field(
+    motionModifier: Optional[MotionModifier] = Field(
         None,
         description="The position the gantry mount needs to move to.",
     )
@@ -91,7 +91,7 @@ class MoveToMaintenancePositionImplementation(
         )
 
         if params.mount != MountType.EXTENSION:
-            if params.maintenancePosition == MaintenancePosition.LOWER_Z_AXES:
+            if params.motionModifier == MotionModifier.LOWER_Z_AXES:
                 max_motion_range = max_height_z_tip - _MAX_Z_AXIS_MOTION_RANGE
                 await ot3_api.move_axes(
                     {

--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -32,7 +32,6 @@ class MaintenancePosition(enum.Enum):
     """Maintenance position options."""
 
     ATTACH_PLATE = "attachPlate"
-    ATTACH_INSTRUMENT = "attachInstrument"
 
 
 class MoveToMaintenancePositionParams(BaseModel):
@@ -43,8 +42,8 @@ class MoveToMaintenancePositionParams(BaseModel):
         description="Gantry mount to move maintenance position.",
     )
 
-    maintenancePosition: MaintenancePosition = Field(
-        MaintenancePosition.ATTACH_INSTRUMENT,
+    maintenancePosition: Optional[MaintenancePosition] = Field(
+        None,
         description="The position the gantry mount needs to move to.",
     )
 
@@ -92,12 +91,7 @@ class MoveToMaintenancePositionImplementation(
         )
 
         if params.mount != MountType.EXTENSION:
-            if params.maintenancePosition == MaintenancePosition.ATTACH_INSTRUMENT:
-                mount = params.mount.to_hw_mount()
-                mount_to_axis = Axis.by_mount(mount)
-                await ot3_api.prepare_for_mount_movement(mount)
-                await ot3_api.disengage_axes([mount_to_axis])
-            else:
+            if params.maintenancePosition == MaintenancePosition.ATTACH_PLATE:
                 max_motion_range = max_height_z_tip - _MAX_Z_AXIS_MOTION_RANGE
                 await ot3_api.move_axes(
                     {
@@ -111,6 +105,11 @@ class MoveToMaintenancePositionImplementation(
                     }
                 )
                 await ot3_api.disengage_axes([Axis.Z_R])
+            else:
+                mount = params.mount.to_hw_mount()
+                mount_to_axis = Axis.by_mount(mount)
+                await ot3_api.prepare_for_mount_movement(mount)
+                await ot3_api.disengage_axes([mount_to_axis])
 
         return SuccessData(
             public=MoveToMaintenancePositionResult(),

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -43,7 +43,7 @@ async def test_calibration_move_to_location_implementation_for_attach_instrument
 ) -> None:
     """Command should get a move to target location and critical point and should verify move_to call."""
     params = MoveToMaintenancePositionParams(
-        mount=mount_type, maintenancePosition=MaintenancePosition.ATTACH_INSTRUMENT
+        mount=mount_type,
     )
 
     decoy.when(
@@ -139,7 +139,6 @@ async def test_calibration_move_to_location_implementation_for_gripper(
     """Command should get a move to target location and critical point and should verify move_to call."""
     params = MoveToMaintenancePositionParams(
         mount=MountType.EXTENSION,
-        maintenancePosition=MaintenancePosition.ATTACH_INSTRUMENT,
     )
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -86,7 +86,7 @@ async def test_calibration_move_to_location_implementation_for_attach_plate(
 ) -> None:
     """Command should get a move to target location and critical point and should verify move_to call."""
     params = MoveToMaintenancePositionParams(
-        mount=mount_type, motionModifier=MotionModifier.LOWER_Z_AXES
+        mount=mount_type, motionModifier=MotionModifier.LOWER_Z_AXES_SEQUENTIALLY
     )
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -86,7 +86,7 @@ async def test_calibration_move_to_location_implementation_for_attach_plate(
 ) -> None:
     """Command should get a move to target location and critical point and should verify move_to call."""
     params = MoveToMaintenancePositionParams(
-        mount=mount_type, maintenancePosition=MaintenancePosition.ATTACH_PLATE
+        mount=mount_type, maintenancePosition=MaintenancePosition.LOWER_Z_AXES
     )
 
     decoy.when(

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -9,7 +9,7 @@ from decoy import Decoy
 
 from opentrons.hardware_control.types import Axis, CriticalPoint
 from opentrons.protocol_engine.commands.calibration.move_to_maintenance_position import (
-    MaintenancePosition,
+    MotionModifier,
     MoveToMaintenancePositionImplementation,
     MoveToMaintenancePositionParams,
     MoveToMaintenancePositionResult,
@@ -86,7 +86,7 @@ async def test_calibration_move_to_location_implementation_for_attach_plate(
 ) -> None:
     """Command should get a move to target location and critical point and should verify move_to call."""
     params = MoveToMaintenancePositionParams(
-        mount=mount_type, maintenancePosition=MaintenancePosition.LOWER_Z_AXES
+        mount=mount_type, motionModifier=MotionModifier.LOWER_Z_AXES
     )
 
     decoy.when(

--- a/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
+++ b/app/src/organisms/ModuleWizardFlows/PlaceAdapter.tsx
@@ -166,7 +166,6 @@ export function PlaceAdapter(props: PlaceAdapterProps): JSX.Element {
         commandType: 'calibration/moveToMaintenancePosition',
         params: {
           mount,
-          maintenancePosition: 'attachInstrument',
         },
       },
     ]

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -230,7 +230,7 @@ export const BeforeBeginning = (
       commandType: 'calibration/moveToMaintenancePosition' as const,
       params: {
         mount: RIGHT,
-        maintenancePosition: 'lowerZAxes',
+        motionModifier: 'lowerZAxes',
       },
     },
   ]

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -230,7 +230,7 @@ export const BeforeBeginning = (
       commandType: 'calibration/moveToMaintenancePosition' as const,
       params: {
         mount: RIGHT,
-        motionModifier: 'lowerZAxes',
+        motionModifier: 'lowerZAxesSequentially',
       },
     },
   ]

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -230,7 +230,7 @@ export const BeforeBeginning = (
       commandType: 'calibration/moveToMaintenancePosition' as const,
       params: {
         mount: RIGHT,
-        maintenancePosition: 'attachPlate',
+        maintenancePosition: 'lowerZAxes',
       },
     },
   ]

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -124,7 +124,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
           commandType: 'calibration/moveToMaintenancePosition' as const,
           params: {
             mount: RIGHT,
-            maintenancePosition: 'lowerZAxes',
+            motionModifier: 'lowerZAxes',
           },
         },
       ],

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -124,7 +124,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
           commandType: 'calibration/moveToMaintenancePosition' as const,
           params: {
             mount: RIGHT,
-            motionModifier: 'lowerZAxes',
+            motionModifier: 'lowerZAxesSequentially',
           },
         },
       ],

--- a/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/DetachPipette.tsx
@@ -124,7 +124,7 @@ export const DetachPipette = (props: DetachPipetteProps): JSX.Element => {
           commandType: 'calibration/moveToMaintenancePosition' as const,
           params: {
             mount: RIGHT,
-            maintenancePosition: 'attachPlate',
+            maintenancePosition: 'lowerZAxes',
           },
         },
       ],

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -164,7 +164,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
             params: {
               mount: nextMount === 'right' ? RIGHT : 'left',
               ...(nextMount === 'both'
-                ? { motionModifier: 'lowerZAxes' as const }
+                ? { motionModifier: 'lowerZAxesSequentially' as const }
                 : {}),
             },
           },

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -164,7 +164,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
             params: {
               mount: nextMount === 'right' ? RIGHT : 'left',
               ...(nextMount === 'both'
-                ? { maintenancePosition: 'lowerZAxes' as const }
+                ? { motionModifier: 'lowerZAxes' as const }
                 : {}),
             },
           },

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -163,8 +163,9 @@ export const Results = (props: ResultsProps): JSX.Element => {
             commandType: 'calibration/moveToMaintenancePosition' as const,
             params: {
               mount: nextMount === 'right' ? RIGHT : 'left',
-              maintenancePosition:
-                nextMount === 'both' ? 'attachPlate' : 'attachInstrument',
+              ...(nextMount === 'both'
+                ? { maintenancePosition: 'attachPlate' as const }
+                : {}),
             },
           },
         ],

--- a/app/src/organisms/PipetteWizardFlows/Results.tsx
+++ b/app/src/organisms/PipetteWizardFlows/Results.tsx
@@ -164,7 +164,7 @@ export const Results = (props: ResultsProps): JSX.Element => {
             params: {
               mount: nextMount === 'right' ? RIGHT : 'left',
               ...(nextMount === 'both'
-                ? { maintenancePosition: 'attachPlate' as const }
+                ? { maintenancePosition: 'lowerZAxes' as const }
                 : {}),
             },
           },

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -345,7 +345,7 @@ describe('BeforeBeginning', () => {
           { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
-            params: { maintenancePosition: 'attachPlate', mount: RIGHT },
+            params: { maintenancePosition: 'lowerZAxes', mount: RIGHT },
           },
         ],
         false

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -345,7 +345,7 @@ describe('BeforeBeginning', () => {
           { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
-            params: { motionModifier: 'lowerZAxes', mount: RIGHT },
+            params: { motionModifier: 'lowerZAxesSequentially', mount: RIGHT },
           },
         ],
         false

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -345,7 +345,7 @@ describe('BeforeBeginning', () => {
           { commandType: 'home' as const, params: {} },
           {
             commandType: 'calibration/moveToMaintenancePosition',
-            params: { maintenancePosition: 'lowerZAxes', mount: RIGHT },
+            params: { motionModifier: 'lowerZAxes', mount: RIGHT },
           },
         ],
         false

--- a/shared-data/command/schemas/17.json
+++ b/shared-data/command/schemas/17.json
@@ -3653,12 +3653,6 @@
       "title": "LoadPipetteParams",
       "type": "object"
     },
-    "MaintenancePosition": {
-      "description": "Maintenance position options.",
-      "enum": ["attachPlate", "attachInstrument"],
-      "title": "MaintenancePosition",
-      "type": "string"
-    },
     "MixParams": {
       "additionalProperties": false,
       "description": "Parameters for mix.",
@@ -3736,6 +3730,12 @@
         "vacuumModuleV1"
       ],
       "title": "ModuleModel",
+      "type": "string"
+    },
+    "MotionModifier": {
+      "description": "Motion modifier options for maintenance position moves.",
+      "enum": ["lowerZAxesSequentially"],
+      "title": "MotionModifier",
       "type": "string"
     },
     "MotorAxis": {
@@ -4350,9 +4350,16 @@
     "MoveToMaintenancePositionParams": {
       "description": "Calibration set up position command parameters.",
       "properties": {
-        "maintenancePosition": {
-          "$ref": "#/$defs/MaintenancePosition",
-          "default": "attachInstrument",
+        "motionModifier": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MotionModifier"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
           "description": "The position the gantry mount needs to move to."
         },
         "mount": {

--- a/shared-data/command/types/calibration.ts
+++ b/shared-data/command/types/calibration.ts
@@ -73,7 +73,7 @@ interface CalibrateGripperResult {
 }
 interface MoveToMaintenancePositionParams {
   mount: GantryMount
-  motionModifier?: 'lowerZAxes'
+  motionModifier?: 'lowerZAxesSequentially'
 }
 interface CalibrateModuleResult {
   moduleOffset: Vector3D

--- a/shared-data/command/types/calibration.ts
+++ b/shared-data/command/types/calibration.ts
@@ -73,7 +73,7 @@ interface CalibrateGripperResult {
 }
 interface MoveToMaintenancePositionParams {
   mount: GantryMount
-  maintenancePosition?: 'attachPlate'
+  maintenancePosition?: 'lowerZAxes'
 }
 interface CalibrateModuleResult {
   moduleOffset: Vector3D

--- a/shared-data/command/types/calibration.ts
+++ b/shared-data/command/types/calibration.ts
@@ -73,7 +73,7 @@ interface CalibrateGripperResult {
 }
 interface MoveToMaintenancePositionParams {
   mount: GantryMount
-  maintenancePosition?: 'lowerZAxes'
+  motionModifier?: 'lowerZAxes'
 }
 interface CalibrateModuleResult {
   moduleOffset: Vector3D

--- a/shared-data/command/types/calibration.ts
+++ b/shared-data/command/types/calibration.ts
@@ -73,7 +73,7 @@ interface CalibrateGripperResult {
 }
 interface MoveToMaintenancePositionParams {
   mount: GantryMount
-  maintenancePosition?: 'attachPlate' | 'attachInstrument'
+  maintenancePosition?: 'attachPlate'
 }
 interface CalibrateModuleResult {
   moduleOffset: Vector3D

--- a/shared-data/protocol/types/schemaV7/command/calibration.ts
+++ b/shared-data/protocol/types/schemaV7/command/calibration.ts
@@ -73,7 +73,7 @@ interface CalibrateGripperResult {
 }
 interface MoveToMaintenancePositionParams {
   mount: GantryMount
-  motionModifier?: 'lowerZAxes'
+  motionModifier?: 'lowerZAxesSequentially'
 }
 interface CalibrateModuleResult {
   moduleOffset: Vector3D

--- a/shared-data/protocol/types/schemaV7/command/calibration.ts
+++ b/shared-data/protocol/types/schemaV7/command/calibration.ts
@@ -73,7 +73,7 @@ interface CalibrateGripperResult {
 }
 interface MoveToMaintenancePositionParams {
   mount: GantryMount
-  maintenancePosition?: 'attachPlate'
+  maintenancePosition?: 'lowerZAxes'
 }
 interface CalibrateModuleResult {
   moduleOffset: Vector3D

--- a/shared-data/protocol/types/schemaV7/command/calibration.ts
+++ b/shared-data/protocol/types/schemaV7/command/calibration.ts
@@ -73,7 +73,7 @@ interface CalibrateGripperResult {
 }
 interface MoveToMaintenancePositionParams {
   mount: GantryMount
-  maintenancePosition?: 'lowerZAxes'
+  motionModifier?: 'lowerZAxes'
 }
 interface CalibrateModuleResult {
   moduleOffset: Vector3D

--- a/shared-data/protocol/types/schemaV7/command/calibration.ts
+++ b/shared-data/protocol/types/schemaV7/command/calibration.ts
@@ -73,7 +73,7 @@ interface CalibrateGripperResult {
 }
 interface MoveToMaintenancePositionParams {
   mount: GantryMount
-  maintenancePosition?: 'attachPlate' | 'attachInstrument'
+  maintenancePosition?: 'attachPlate'
 }
 interface CalibrateModuleResult {
   moduleOffset: Vector3D

--- a/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v7.py
+++ b/shared-data/python/opentrons_shared_data/protocol/models/protocol_schema_v7.py
@@ -59,7 +59,7 @@ class Params(BaseModel):
     homeAfter: Optional[bool] = None
     alternateDropLocation: Optional[bool] = None
     holdTimeSeconds: Optional[float] = None
-    maintenancePosition: Optional[str] = None
+    motionModifier: Optional[str] = None
     pipetteName: Optional[str] = None
     model: Optional[str] = None
     loadName: Optional[str] = None


### PR DESCRIPTION
Closes [RQA-5409](https://opentrons.atlassian.net/browse/RQA-5409)

# Overview

Our `MoveToMaintenancePosition` is an internal `SETUP` command that we'll very soon be expanding upon. The command currently takes parameters such as `ATTACH_PLATE` or `ATTACH_PIPETTE`, however, we'd better scale this interface with a few changes. 

First, instead of thinking of maintenance positions in terms of particular instruments, let's think of moving to a maintenance position involving a baseline move and then additions or subtractions to that baseline move. Doing so gets us out of needing to add new params and affordances for particular instruments that may move in similar fashion. It also makes it more intuitive that not passing in a param actually still moves the robot.

Additionally, let's remove the "baseline" param as an option altogether (this is currently the `ATTACH_PIPETTE` param option). By default, this has always been the baseline position. Removing this param also let's us rename the `MaintenancePosition` param to `MotionModifier`, helping to drive the point home. 

## Test Plan and Hands on Testing

Smoke tested the following attach/detach flows:

- [x] Single mount pipette attachment
- [x] Single mount pipette detachment
- [x] 96 channel attachment
- [x] 96 channel detachment
- [x] Attach 96 channel while single mount pipette is attached

## Risk assessment

- lowish

[RQA-5409]: https://opentrons.atlassian.net/browse/RQA-5409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ