### PR TITLE
fix(api): module disconnect tolerance

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -17,6 +17,8 @@ from .errors import (
 )
 from .async_serial import AsyncSerial
 
+from opentrons.config import IS_ROBOT
+
 log = logging.getLogger(__name__)
 
 
@@ -658,7 +660,7 @@ class AsyncResponseSerialConnection(SerialConnection):
 
             except BaseException as e:
                 log.error(f"Got an error during send {e}")
-                if retry < retries:
+                if retry < retries and IS_ROBOT:
                     pass
                 else:
                     raise e

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from typing import Type, Literal, AsyncIterator
-
+import os
 from opentrons.drivers.command_builder import CommandBuilder
 
 from .errors import (
@@ -303,8 +303,12 @@ class SerialConnection:
         Returns: None
         """
         await asyncio.sleep(self._retry_wait_time_seconds)
-        await self._serial.close()
-        await self._serial.open()
+        if os.path.exists(self._port):
+            try:
+                await asyncio.wait_for(self._serial.close(), timeout=1)
+                await asyncio.wait_for(self._serial.open(), timeout=1)
+            except BaseException:
+                log.exception("Got an error during reconnect.")
 
     def process_raw_response(self, command: str, response: str) -> str:
         """
@@ -646,12 +650,20 @@ class AsyncResponseSerialConnection(SerialConnection):
         responses: list[str] = []
 
         for retry in range(retries + 1):
-            responses = await self._send_one_retry(data, acks)
-            if responses:
-                return responses
-            log.info(f"{self._name}: retry number {retry}/{retries}")
-            await self.on_retry()
+            try:
+                responses = await self._send_one_retry(data, acks)
+                if responses:
+                    return responses
+                log.info(f"{self._name}: retry number {retry}/{retries}")
 
+            except BaseException as e:
+                log.error(f"Got an error during send {e}")
+                if retry < retries:
+                    pass
+                else:
+                    raise e
+
+            await self.on_retry()
         raise NoResponse(port=self._port, command=data)
 
     async def _send_data(self, data: str, retries: int) -> str:

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -36,7 +36,7 @@ HS_COMMAND_TERMINATOR = "\n"
 HS_ACK = "OK" + HS_COMMAND_TERMINATOR
 HS_ERROR_KEYWORD = "err"
 HS_ASYNC_ERROR_ACK = "async"
-DEFAULT_COMMAND_RETRIES = 0
+DEFAULT_COMMAND_RETRIES = 4
 
 
 class HeaterShakerDriver(AbstractHeaterShakerDriver):
@@ -58,9 +58,11 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
             baud_rate=HS_BAUDRATE,
             timeout=DEFAULT_HS_TIMEOUT,
             ack=HS_ACK,
+            retry_wait_time_seconds=1,
             loop=loop,
             error_keyword=HS_ERROR_KEYWORD,
             async_error_ack=HS_ASYNC_ERROR_ACK,
+            number_of_retries=DEFAULT_COMMAND_RETRIES,
         )
         return cls(connection=connection)
 

--- a/api/src/opentrons/drivers/temp_deck/__init__.py
+++ b/api/src/opentrons/drivers/temp_deck/__init__.py
@@ -1,4 +1,4 @@
-from .driver import TempDeckDriver
+from .driver import TempDeckDriver, DEFAULT_COMMAND_RETRIES
 from .abstract import AbstractTempDeckDriver
 from .simulator import SimulatingDriver
 
@@ -7,4 +7,5 @@ __all__ = [
     "TempDeckDriver",
     "AbstractTempDeckDriver",
     "SimulatingDriver",
+    "DEFAULT_COMMAND_RETRIES",
 ]

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
     from .ot3api import OT3API
 
 
+RECONNECT_ATTEMPTS = 3
+
 log = logging.getLogger(__name__)
 
 MODULE_PORT_REGEX = re.compile(
@@ -65,6 +67,7 @@ class AttachedModulesControl:
         event_callback: Callable[[HardwareEvent], None],
     ) -> None:
         self._available_modules: List[modules.AbstractModule] = []
+        self._recently_removed_modules: List[modules.AbstractModule] = []
         self._api = api
         self._usb = usb
         self._event_callback = event_callback
@@ -105,7 +108,9 @@ class AttachedModulesControl:
 
     @property
     def available_modules(self) -> List[modules.AbstractModule]:
-        return self._available_modules
+        # return both available and recently removed, in case we attempt to grab the device at the same
+        # time it experiences an EMI disconnect
+        return self._available_modules + self._recently_removed_modules
 
     async def clean_up(self) -> None:
         """Clean up all registered modules and emulator scanning tasks (if any)."""
@@ -211,7 +216,52 @@ class AttachedModulesControl:
                 f"Async error callback for module {model} {serial} at {port} for exc {exc} failed"
             )
 
-    async def unregister_modules(
+    def _clear_old_modules(self) -> None:
+        for old_mod in self._recently_removed_modules:
+            # Important: this wants to be after the remove because this may trigger
+            # recursion back to here; we therefore want the module to already be
+            # removed so that the recursion terminates next loop
+            old_mod.disconnected_callback()
+            log.info(f"did not find {old_mod.serial_number}")
+            self._recently_removed_modules.remove(old_mod)
+
+    async def _reconnect_patch(self, attempts_left: int) -> None:
+        if attempts_left == 0:
+            # if the module isn't back then remove it
+            self._clear_old_modules()
+            return
+
+        await asyncio.sleep(1)
+        try:
+            for old_mod in self._recently_removed_modules:
+                log.info(
+                    f"Attempting to find and reconect {old_mod.serial_number} attempt {RECONNECT_ATTEMPTS-attempts_left+1}"
+                )
+                for attached_mod in self._available_modules:
+                    if attached_mod.serial_number == old_mod.serial_number:
+                        log.info(f"Found {old_mod.serial_number} was reconnected")
+                        # module reattached to a new virtual port, create a symlink to it
+                        await attached_mod.cleanup()
+                        if attached_mod.port != old_mod.port:
+                            log.info(
+                                f"module moved from {old_mod.port} to {attached_mod.port}"
+                            )
+                            await old_mod.move_port(
+                                attached_mod.port, attached_mod.usb_port
+                            )
+                        await old_mod.attempt_reconnect()
+                        self._available_modules.remove(attached_mod)
+                        self._available_modules.append(old_mod)
+                        self._recently_removed_modules.remove(old_mod)
+                        self._available_modules = sorted(
+                            self._available_modules, key=modules.AbstractModule.sort_key
+                        )
+        except BaseException:
+            log.exception("Encountered an error during reconnect attempt.")
+        if len(self._recently_removed_modules) > 0:
+            self._api.loop.create_task(self._reconnect_patch(attempts_left - 1))
+
+    async def unregister_modules(  # noqa: C901
         self,
         mods_at_ports: Union[
             List[modules.ModuleAtPort], List[modules.SimulatingModuleAtPort]
@@ -224,7 +274,7 @@ class AttachedModulesControl:
         """
         removed_modules = []
         for mod in mods_at_ports:
-            for attached_mod in self.available_modules:
+            for attached_mod in self._available_modules:
                 if (
                     attached_mod.serial_number == mod.serial
                     or attached_mod.port == mod.port
@@ -233,11 +283,9 @@ class AttachedModulesControl:
 
         for removed_mod in removed_modules:
             try:
+                self._recently_removed_modules.append(removed_mod)
                 self._available_modules.remove(removed_mod)
-                # Important: this wants to be after the remove because this may trigger
-                # recursion back to here; we therefore want the module to already be
-                # removed so that the recursion terminates next loop
-                removed_mod.disconnected_callback()
+
             except ValueError:
                 log.warning(
                     f"Removed Module {removed_mod} not found in attached modules"
@@ -251,6 +299,11 @@ class AttachedModulesControl:
         self._available_modules = sorted(
             self._available_modules, key=modules.AbstractModule.sort_key
         )
+        if len(removed_modules) > 0:
+            if self._api.is_simulator:
+                self._clear_old_modules()
+            else:
+                self._api.loop.create_task(self._reconnect_patch(RECONNECT_ATTEMPTS))
 
     async def register_modules(
         self,

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -6,7 +6,10 @@ from typing import Optional, Mapping, Callable
 from typing_extensions import Final
 
 from opentrons.drivers.rpi_drivers.types import USBPort
-from opentrons.drivers.heater_shaker.driver import HeaterShakerDriver
+from opentrons.drivers.heater_shaker.driver import (
+    HeaterShakerDriver,
+    DEFAULT_COMMAND_RETRIES,
+)
 from opentrons.drivers.heater_shaker.abstract import AbstractHeaterShakerDriver
 from opentrons.drivers.heater_shaker.simulator import SimulatingDriver
 from opentrons.drivers.asyncio.communication.errors import UnhandledGcode
@@ -323,9 +326,27 @@ class HeaterShaker(mod_abc.AbstractModule):
                 while self.temperature > awaiting_temperature:
                     await self._poller.wait_next_poll()
 
-        t = self._loop.create_task(_await_temperature())
-        self.make_cancellable(t)
-        await t
+        await self.run_task_fault_tolerant(_await_temperature, DEFAULT_COMMAND_RETRIES)
+
+    async def move_port(self, port: str, usb_port: USBPort) -> None:
+        self._port = port
+        self._usb_port = usb_port
+
+    async def attempt_reconnect(self) -> None:
+        """Attempt to reestablish connections."""
+        try:
+            if not await self._driver.is_connected():
+                await self.cleanup()
+                self._driver = await HeaterShakerDriver.create(
+                    port=self.port, loop=self.loop
+                )
+                self._reader._driver = self._driver
+            # restart the poller
+            await self._poller.stop()
+            await self._poller.start()
+        except BaseException:
+            log.exception("Got an error when trying to reconnect.")
+            raise
 
     async def set_speed(self, rpm: int) -> None:
         """
@@ -347,21 +368,27 @@ class HeaterShaker(mod_abc.AbstractModule):
             while self.speed_status != SpeedStatus.HOLDING:
                 await self._poller.wait_next_poll()
 
-        task = self._loop.create_task(_wait())
-        self.make_cancellable(task)
-        await task
+        await self.run_task_fault_tolerant(_wait, DEFAULT_COMMAND_RETRIES)
 
     async def _wait_for_labware_latch(
         self, status: HeaterShakerLabwareLatchStatus
     ) -> None:
         """Wait until the hardware reports the labware latch status matches."""
-        while self.labware_latch_status != status:
-            await self._poller.wait_next_poll()
+
+        async def _wait() -> None:
+            while self.labware_latch_status != status:
+                await self._poller.wait_next_poll()
+
+        await self.run_task_fault_tolerant(_wait, DEFAULT_COMMAND_RETRIES)
 
     async def _wait_for_shake_deactivation(self) -> None:
         """Wait until hardware reports that module has stopped shaking and has homed."""
-        while self.speed_status != SpeedStatus.IDLE:
-            await self._poller.wait_next_poll()
+
+        async def _wait() -> None:
+            while self.speed_status != SpeedStatus.IDLE:
+                await self._poller.wait_next_poll()
+
+        await self.run_task_fault_tolerant(_wait, DEFAULT_COMMAND_RETRIES)
 
     async def deactivate(self, must_be_running: bool = True) -> None:
         """Stop heating/cooling; stop shaking and home the plate"""
@@ -412,6 +439,7 @@ class HeaterShakerReader(Reader):
         self.error: Optional[str] = None
         self._driver = driver
         self._handle_error: Callable[[Exception], None] | None = None
+        self._error_debounce = DEFAULT_COMMAND_RETRIES * 4
 
     def register_error_handler(
         self, handle_error: Callable[[Exception], None]
@@ -444,7 +472,13 @@ class HeaterShakerReader(Reader):
     def _set_error(self, exception: Optional[Exception]) -> None:
         if exception is None:
             self.error = None
+            # we read 4 values per read, so we would consume a lot of the debounce every fail
+            self._error_debounce = DEFAULT_COMMAND_RETRIES
         else:
+            log.info(f"error {exception} debounce {self._error_debounce}")
+            self._error_debounce -= 1
+            if self._error_debounce > 0:
+                return
             if self._handle_error:
                 self._handle_error(exception)
             try:

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -28,6 +28,7 @@ from opentrons.hardware_control.modules.types import (
     LiveData,
     HeaterShakerData,
 )
+from opentrons.config import IS_ROBOT
 
 log = logging.getLogger(__name__)
 
@@ -334,6 +335,8 @@ class HeaterShaker(mod_abc.AbstractModule):
 
     async def attempt_reconnect(self) -> None:
         """Attempt to reestablish connections."""
+        if not IS_ROBOT:
+            return
         try:
             if not await self._driver.is_connected():
                 await self.cleanup()
@@ -477,7 +480,7 @@ class HeaterShakerReader(Reader):
         else:
             log.info(f"error {exception} debounce {self._error_debounce}")
             self._error_debounce -= 1
-            if self._error_debounce > 0:
+            if self._error_debounce > 0 and IS_ROBOT:
                 return
             if self._handle_error:
                 self._handle_error(exception)

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -2,7 +2,7 @@ import abc
 import asyncio
 import logging
 import re
-from typing import Any, ClassVar, Mapping, Optional, TypeVar
+from typing import Any, Callable, ClassVar, Coroutine, Mapping, Optional, TypeVar
 from packaging.version import InvalidVersion, parse, Version
 from opentrons.config import IS_ROBOT, ROBOT_FIRMWARE_DIR
 from opentrons.drivers.rpi_drivers.types import USBPort
@@ -251,3 +251,36 @@ class AbstractModule(abc.ABC):
     def cleanup_persistent(self) -> None:
         """Reset any persistent data on the module that should not exist outside of a run."""
         pass
+
+    async def move_port(self, port: str, usb_port: USBPort) -> None:
+        pass
+
+    async def attempt_reconnect(self) -> None:
+        """Attempt to reestablish connections."""
+        pass
+
+    async def run_task_fault_tolerant(
+        self,
+        task_function: Callable[[], Coroutine[Any, Any, None]],
+        debounce_count: int = 4,
+    ) -> None:
+        """Convenience function for module actions where we have to wait for some action to happen.
+        This will end up calling the task function multiple times in the event of a failure.
+        """
+        while debounce_count > 0:
+            try:
+                t = self._loop.create_task(task_function())
+                self.make_cancellable(t)
+                await t
+            except BaseException as e:
+                mod_log.info(
+                    f"error in fault tollerant module call {e} debounce {debounce_count}"
+                )
+                debounce_count -= 1
+                await asyncio.sleep(1)
+                if debounce_count == 0:
+                    # out of retries
+                    raise
+            else:
+                # success
+                return

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -22,6 +22,8 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control.execution_manager import ExecutionManager
 from opentrons.hardware_control.modules import update, mod_abc, types, errors
 
+from opentrons.config import IS_ROBOT
+
 log = logging.getLogger(__name__)
 
 TEMP_POLL_INTERVAL_SECS = 1.0
@@ -291,6 +293,8 @@ class TempDeck(mod_abc.AbstractModule):
 
     async def attempt_reconnect(self) -> None:
         """Attempt to reestablish connections."""
+        if not IS_ROBOT:
+            return
         try:
             if not await self._driver.is_connected():
                 await self.cleanup()

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -318,10 +318,13 @@ class TempDeckReader(Reader):
         self.temperature = Temperature(current=25, target=None)
         self._driver = driver
         self._error_callback: Optional[Callable[[Exception], None]] = None
+        self._debounce_count = DEFAULT_COMMAND_RETRIES
 
     async def read(self) -> None:
         """Read the module's current and target temperatures."""
         self.temperature = await self._driver.get_temperature()
+        # reset on success
+        self._debounce_count = DEFAULT_COMMAND_RETRIES
 
     def set_error_callback(
         self, error_callback: Callable[[Exception], None]
@@ -333,5 +336,11 @@ class TempDeckReader(Reader):
         self._error_callback = None
 
     def on_error(self, exception: Exception) -> None:
+        self._debounce_count -= 1
         if self._error_callback:
-            self._error_callback(exception)
+            if self._debounce_count == 0:
+                log.error(
+                    f"Reader encountered error {exception} but has {self._debounce_count} tries left"
+                )
+            else:
+                self._error_callback(exception)

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -13,6 +13,7 @@ from opentrons.hardware_control.poller import Reader, Poller
 from typing_extensions import Final
 from opentrons.drivers.types import Temperature
 from opentrons.drivers.temp_deck import (
+    DEFAULT_COMMAND_RETRIES,
     SimulatingDriver,
     AbstractTempDeckDriver,
     TempDeckDriver,
@@ -184,9 +185,7 @@ class TempDeck(mod_abc.AbstractModule):
                 while self.temperature > awaiting_temperature:
                     await self._poller.wait_next_poll()
 
-        t = self._loop.create_task(_await_temperature())
-        self.make_cancellable(t)
-        await t
+        await self.run_task_fault_tolerant(_await_temperature, DEFAULT_COMMAND_RETRIES)
 
     async def deactivate(self, must_be_running: bool = True) -> None:
         """Stop heating/cooling and turn off the fan"""
@@ -289,6 +288,25 @@ class TempDeck(mod_abc.AbstractModule):
             return "temperatureModuleV1"
         else:
             return "temperatureModuleV2"
+
+    async def attempt_reconnect(self) -> None:
+        """Attempt to reestablish connections."""
+        try:
+            if not await self._driver.is_connected():
+                await self.cleanup()
+                self._driver = await TempDeckDriver.create(
+                    port=self.port, loop=self.loop
+                )
+                self._reader._driver = self._driver
+            # restart the poller
+            await self._poller.stop()
+            await self._poller.start()
+        except BaseException as e:
+            log.error(f"Got {e} when trying to reconnect.")
+
+    async def move_port(self, port: str, usb_port: USBPort) -> None:
+        self._port = port
+        self._usb_port = usb_port
 
 
 class TempDeckReader(Reader):

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -109,8 +109,11 @@ class Poller:
         try:
             async with self._use_read_lock():
                 await self._reader.read()
-        except asyncio.CancelledError:
-            raise
+        except asyncio.CancelledError as ce:
+            log.error(f"canceled error: {ce}")
+            # cancelled error does not inherit from Exception so lets re-wrap it
+            new_exception = RuntimeError(str(ce)).with_traceback(ce.__traceback__)
+            self._error_callback(new_exception)
         except AbsorbanceReaderDisconnectedError as e:
             self._error_callback(e)
             self._complete_all(e, previous_waiters)

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -7,6 +7,7 @@ from opentrons.hardware_control.modules.errors import AbsorbanceReaderDisconnect
 from opentrons_shared_data.errors.exceptions import ModuleCommunicationError
 from opentrons.drivers.asyncio.communication.errors import SerialException
 
+from opentrons.config import IS_ROBOT
 
 log = logging.getLogger(__name__)
 
@@ -110,6 +111,8 @@ class Poller:
             async with self._use_read_lock():
                 await self._reader.read()
         except asyncio.CancelledError as ce:
+            if not IS_ROBOT:
+                raise
             log.error(f"canceled error: {ce}")
             # cancelled error does not inherit from Exception so lets re-wrap it
             new_exception = RuntimeError(str(ce)).with_traceback(ce.__traceback__)

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -1,5 +1,6 @@
 """Equipment command side-effect logic."""
 
+import logging
 from dataclasses import dataclass
 from typing import Optional, overload, List
 
@@ -50,6 +51,8 @@ from ..types import (
     LoadedLabware,
     OnLabwareLocation,
 )
+
+log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -771,9 +774,17 @@ class EquipmentHandler:
 
         attached_modules = self._hardware_api.attached_modules
         serial_number = self._state_store.modules.get_serial_number(module_id)
+        duplicates = []
         for mod in attached_modules:
             if mod.device_info["serial"] == serial_number:
-                return mod
+                duplicates.append(mod)
+
+        if len(duplicates):
+            if len(duplicates) > 1:
+                log.warn(f"found {len(duplicates)} modules with {serial_number}")
+            # Return the last one, because that should be the recently disconnected one
+            # the recently disconnected one will be the one that doesn't get deleted
+            return duplicates[-1]
 
         raise ModuleNotAttachedError(
             f'No module attached with serial number "{serial_number}"'

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -3,7 +3,7 @@ import pytest
 from _pytest.fixtures import SubRequest
 from mock import AsyncMock, call
 import mock
-
+from unittest.mock import patch
 from opentrons.drivers.asyncio.communication.async_serial import AsyncSerial
 from opentrons.drivers.asyncio.communication.serial_connection import (
     SerialConnection,
@@ -139,9 +139,11 @@ async def test_send_command_with_zero_retries(
     # the retries from the subject.send_data(data, retries=0) method call.
     async_subject._number_of_retries = 1
 
-    with pytest.raises(NoResponse):
-        # We want this to overwrite the internal `_number_of_retries`
-        await async_subject.send_data(data="send data", retries=0)
+    with patch("os.path.exists") as mock_exists:
+        mock_exists.return_value = True
+        with pytest.raises(NoResponse):
+            # We want this to overwrite the internal `_number_of_retries`
+            await async_subject.send_data(data="send data", retries=0)
 
     mock_serial_port.timeout_override.assert_called_once_with("timeout", None)
     mock_serial_port.write.assert_called_once_with(data=b"send data")
@@ -228,7 +230,9 @@ def test_get_error_codes_lowercase(
 
 async def test_on_retry(mock_serial_port: AsyncMock, subject: SerialKind) -> None:
     """It should try to re-open connection."""
-    await subject.on_retry()
+    with patch("os.path.exists") as mock_exists:
+        mock_exists.return_value = True
+        await subject.on_retry()
 
     mock_serial_port.close.assert_called_once()
     mock_serial_port.open.assert_called_once()

--- a/api/tests/opentrons/drivers/heater_shaker/test_driver.py
+++ b/api/tests/opentrons/drivers/heater_shaker/test_driver.py
@@ -28,7 +28,7 @@ async def test_open_lock(
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode(
         gcode="M242"
     )
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
 
 
 async def test_close_lock(
@@ -40,7 +40,7 @@ async def test_close_lock(
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode(
         gcode="M243"
     )
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
 
 
 async def test_get_lock_status(
@@ -55,7 +55,7 @@ async def test_get_lock_status(
         gcode="M241"
     )
 
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
     assert response == HeaterShakerLabwareLatchStatus.IDLE_UNKNOWN
 
 
@@ -70,7 +70,7 @@ async def test_set_temperature(
         .add_gcode(gcode="M104")
         .add_float(prefix="S", value=65.02, precision=2)
     )
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
 
 
 async def test_get_temperature(
@@ -81,7 +81,7 @@ async def test_get_temperature(
     connection.send_command.return_value = "M105 T:91.25 C:54.02 ok\n"
     response = await subject.get_temperature()
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode("M105")
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
     assert response == Temperature(current=54.02, target=91.25)
 
 
@@ -96,7 +96,7 @@ async def test_set_rpm(
         .add_gcode(gcode="M3")
         .add_int(prefix="S", value=2500)
     )
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
 
 
 async def test_get_rpm(
@@ -106,7 +106,7 @@ async def test_get_rpm(
     connection.send_command.return_value = "M123 T:2200 C:2100 ok\n"
     response = await subject.get_rpm()
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode("M123")
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
     assert response == RPM(current=2100, target=2200)
 
 
@@ -115,7 +115,7 @@ async def test_home(subject: driver.HeaterShakerDriver, connection: AsyncMock) -
     connection.send_command.return_value = "G28 ok\n"
     await subject.home()
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode("G28")
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
 
 
 async def test_deactivate_heater(
@@ -125,7 +125,7 @@ async def test_deactivate_heater(
     connection.send_command.return_value = "M106 ok\n"
     await subject.deactivate_heater()
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode("M106")
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
 
 
 async def test_get_device_info(
@@ -143,8 +143,8 @@ async def test_get_device_info(
     reset_reason = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode(
         gcode="M114"
     )
-    connection.send_command.assert_any_call(command=device_info, retries=0)
-    connection.send_command.assert_called_with(command=reset_reason, retries=0)
+    connection.send_command.assert_any_call(command=device_info, retries=4)
+    connection.send_command.assert_called_with(command=reset_reason, retries=4)
 
 
 async def test_enter_bootloader(

--- a/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
@@ -262,8 +262,9 @@ async def test_async_error_response(
     )
     await simulating_module_driver_patched._poller.wait_next_poll()
     decoy.when(await mock_driver.get_temperature()).then_raise(exc)
-    with pytest.raises(Exception):
-        await simulating_module_driver_patched._poller.wait_next_poll()
+    for i in range(5):
+        with pytest.raises(Exception):
+            await simulating_module_driver_patched._poller.wait_next_poll()
     decoy.verify(
         module_error_callback(
             exc, "heaterShakerModuleV1", "/dev/ot_module_sim_heatershaker0", None
@@ -313,8 +314,9 @@ async def test_reader_raises_error_from_get_error(
         "/dev/ot_module_sim_heatershaker0", "ERR:666:you know what it is", "M411"
     )
     decoy.when(await mock_driver.get_error_state()).then_raise(error_state_response)
-    with pytest.raises(ErrorResponse):
-        await simulating_module_driver_patched._poller.wait_next_poll()
+    for i in range(5):
+        with pytest.raises(ErrorResponse):
+            await simulating_module_driver_patched._poller.wait_next_poll()
     decoy.verify(
         module_error_callback(
             error_state_response,


### PR DESCRIPTION
# Overview
Add a temporary fault tolerance for modules.

This will allow for brief disconnections in the module without triggering higher level errors by doing the following:

When a module disconnects, the module_control system will put it into a temporary list and sets a timer, when the timer is done if a module with the same serial number has reappeared in the system, it will move over the serial connections from that new one to the old module, clean up the new module and put the old module back into the available module lists.

This also fixes the async serial driver so that retry's are actually fault tolerant to more than just non-replies.