### PR TITLE
fix(app): fix secondary window's abort

### DIFF
--- a/step-generation/src/utils/__tests__/misc.test.ts
+++ b/step-generation/src/utils/__tests__/misc.test.ts
@@ -459,6 +459,20 @@ describe('getFullStackFromLabwares', () => {
     const largestStack = getFullStackFromLabwares(labware, slot, undefined)
     expect(largestStack).toEqual(['labwareId2', 'labwareId1', 'D3'])
   })
+
+  it('return empty array if no labwares in slot', () => {
+    const labware = {
+      labwareId1: {
+        stack: [],
+      },
+      labwareId2: {
+        stack: [],
+      },
+    }
+    const slot = 'D3'
+    const largestStack = getFullStackFromLabwares(labware, slot, undefined)
+    expect(largestStack).toEqual([])
+  })
 })
 
 describe('flex stacker deck slot helpers', () => {

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -1167,14 +1167,19 @@ export const getFullStackFromLabwares = (
       lw.stack.includes(HOPPER_STACKER_LOCATION) === isOnHopper &&
       lw.stack.includes(VACUUM_DOCK_LOCATION) === isOnVacuumDock
   )
+  if (labwareStack.length === 0) {
+    return []
+  }
+
   if (isOnHopper) {
-    return labwareStack.reverse()[0].stack ?? []
+    return labwareStack.at(-1)?.stack ?? []
   }
   if (isOnVacuumDock) {
-    return labwareStack.reverse()[0].stack ?? []
+    return labwareStack.at(-1)?.stack ?? []
   }
   return (
-    labwareStack.sort((a, b) => b.stack.length - a.stack.length)[0]?.stack ?? []
+    labwareStack.toSorted((a, b) => b.stack.length - a.stack.length)[0]
+      ?.stack ?? []
   )
 }
 


### PR DESCRIPTION


# Overview
fix secondary window's abort.
the issue is caused by an empty array.


<img width="1132" height="513" alt="Screenshot 2026-05-19 at 4 33 57 PM" src="https://github.com/user-attachments/assets/1151e060-c0a4-4bb2-a0ef-ba30a80ed4f6" />


https://github.com/user-attachments/assets/78c96207-c660-45f0-85d6-ab86f4d9bf20



close RQA-5413

## Test Plan and Hands on Testing
- import the protocol that is attached to the ticket
- visualize the protocol
- go to step 4
- click the C4 slot

## Changelog
- add length check
- remove destructive method
- add a test

## Review requests


## Risk assessment
low
