### PR TITLE
(e2e-testing): Make fewer GitHub actions when setting up e2e-testing

### DIFF
--- a/.github/workflows/pd-e2e-test.yaml
+++ b/.github/workflows/pd-e2e-test.yaml
@@ -44,7 +44,7 @@ jobs:
   e2e-test-local:
     name: 'E2E tests against local build'
     runs-on: 'ubuntu-24.04'
-    timeout-minutes: 20
+    timeout-minutes: 15
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -78,14 +78,6 @@ jobs:
           APPLITOOLS_BATCH_ID: ${{ github.run_id }}-${{ github.run_attempt }}
           APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
         run: make test-pd-local
-
-      - name: 'Notify Slack on failed run'
-        if: failure()
-        uses: ./.github/actions/simple-build-alert
-        with:
-          status: 'failure'
-          workflow_name: 'PD E2E tests against local build'
-          webhook_url: ${{ secrets.Applitools_Slack_Webhook_URL}}
       - name: 'Upload test results'
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/.github/workflows/pd-e2e-test.yaml
+++ b/.github/workflows/pd-e2e-test.yaml
@@ -22,6 +22,8 @@ on:
       - 'e2e-testing/uv.lock'
       - 'e2e-testing/pyproject.toml'
       - 'e2e-testing/conftest.py'
+      - 'e2e-testing/pd_server.py'
+      - 'e2e-testing/Makefile'
       - 'e2e-testing/eyes.py'
       - 'e2e-testing/pytest.ini'
       - 'e2e-testing/automation/pd_pages/**'
@@ -42,7 +44,7 @@ jobs:
   e2e-test-local:
     name: 'E2E tests against local build'
     runs-on: 'ubuntu-24.04'
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -71,10 +73,12 @@ jobs:
       - name: 'Run E2E tests against local build'
         working-directory: e2e-testing
         env:
-          # Eyes baseline branch = PR merge target (pull_request). workflow_dispatch falls back to ref_name.
           APPLITOOLS_BRANCH: ${{ github.base_ref || github.ref_name }}
+          # Stable per workflow run so pytest-xdist workers share one Applitools batch (not random).
+          APPLITOOLS_BATCH_ID: ${{ github.run_id }}-${{ github.run_attempt }}
           APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
         run: make test-pd-local
+
       - name: 'Notify Slack on failed run'
         if: failure()
         uses: ./.github/actions/simple-build-alert

--- a/.github/workflows/pd-e2e-test.yaml
+++ b/.github/workflows/pd-e2e-test.yaml
@@ -75,7 +75,13 @@ jobs:
           APPLITOOLS_BRANCH: ${{ github.base_ref || github.ref_name }}
           APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
         run: make test-pd-local
-
+      - name: 'Notify Slack on failed run'
+        if: failure()
+        uses: ./.github/actions/simple-build-alert
+        with:
+          status: 'failure'
+          workflow_name: 'PD E2E tests against local build'
+          webhook_url: ${{ secrets.Applitools_Slack_Webhook_URL}}
       - name: 'Upload test results'
         if: always()
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0

--- a/e2e-testing/Makefile
+++ b/e2e-testing/Makefile
@@ -1,5 +1,7 @@
 # e2e-testing makefile
 
+SHELL := bash
+
 # Environment selection (local, sandbox, staging, prod)
 TEST_ENV ?= local
 

--- a/e2e-testing/Makefile
+++ b/e2e-testing/Makefile
@@ -3,6 +3,9 @@
 # Environment selection (local, sandbox, staging, prod)
 TEST_ENV ?= local
 
+# Parallel pytest workers (override: make test-pd-local XDIST_ARGS="-n 0")
+XDIST_ARGS ?= -n 2 --dist loadscope
+
 .PHONY: setup
 setup:
 	uv sync --frozen
@@ -23,7 +26,7 @@ lint:
 
 .PHONY: typecheck
 typecheck:
-	uv run mypy automation tests conftest.py
+	uv run mypy automation tests conftest.py pd_server.py
 
 .PHONY: prep
 prep: 
@@ -34,11 +37,23 @@ prep:
 .PHONY: check
 check: lint typecheck
 
+.PHONY: serve-pd
+serve-pd:
+	uv run python pd_server.py
+
 .PHONY: test-pd-local
 test-pd-local:
-	@# Always print the summary banner, but preserve pytest's exit code.
-	@status=0; \
-	TEST_ENV=local uv run pytest -m pdE2E $(PYTEST_ARGS) || status=$$?; \
+	@# Local dev: run `make serve-pd` in another terminal first (needed for xdist).
+	@# CI (CI=true): builds and serves PD via pd_server.py, then runs pytest.
+	@set -euo pipefail; \
+	status=0; \
+	if [ "$${CI:-}" = "true" ]; then \
+	  echo "Starting Protocol Designer via make serve-pd..."; \
+	  $(MAKE) serve-pd & pd_pid=$$!; \
+	  trap 'kill $$pd_pid 2>/dev/null || true; wait $$pd_pid 2>/dev/null || true' EXIT INT TERM; \
+	  uv run python pd_server.py --wait || exit 1; \
+	fi; \
+	TEST_ENV=local uv run pytest -m pdE2E $(XDIST_ARGS) $(PYTEST_ARGS) || status=$$?; \
 	echo ""; \
 	echo "---------------------------------------------------------"; \
 	echo "🧪 Tests Finished!"; \
@@ -56,9 +71,9 @@ troubleshoot:
 
 .PHONY: test-pd-local-headed
 test-pd-local-headed:
-	@echo "Example to run one test: "
-	@echo "make test-pd-local PYTEST_ARGS=\"-k test_flex_onboarding_workflow\""
-	TEST_ENV=local HEADLESS=false uv run pytest -m pdE2E $(PYTEST_ARGS)
+	@# Headed debugging: always sequential (no xdist); use PYTEST_ARGS="-k ..." for one test.
+	@echo "Example: make test-pd-local-headed PYTEST_ARGS=\"-k test_pd_home\""
+	TEST_ENV=local HEADLESS=false uv run pytest -m pdE2E -n 0 $(PYTEST_ARGS)
 
 # TODO: Implement sandbox testing with branch-specific URL
 .PHONY: test-pd-sandbox

--- a/e2e-testing/README.md
+++ b/e2e-testing/README.md
@@ -16,9 +16,12 @@ End-to-end tests for the Opentrons **Protocol Designer (PD)** and **Labware Libr
    make setup test-setup
    ```
 
-2. **Run tests to recreate the failure locally:**
+2. **Run PD e2e tests locally** (two terminals — same server script as CI):
 
    ```bash
+   # Terminal 1
+   make serve-pd
+   # Terminal 2
    make test-pd-local
    ```
 
@@ -36,8 +39,8 @@ End-to-end tests for the Opentrons **Protocol Designer (PD)** and **Labware Libr
 
 ## Tips
 
-- run `make -C protocol-designer serve` and `make -C labware-library serve` in separate terminals to keep local apps running while you develop tests. This keeps the test framework from spinning them up each test run. This only works if you are not making changes to the PD or LL code. `make serve` does not hot reload.
-- If you **are** making changes to PD or LL code, let the test suite handle starting/stopping the apps as needed.
+- run `make serve-pd` (from `e2e-testing/`) in a separate terminal before `make test-pd-local` when developing locally (required for pytest-xdist). In CI, `make test-pd-local` starts `serve-pd` automatically when `CI=true`.
+- Labware Library local tests still start the app from pytest when nothing is running on the expected ports.
 - use `page.highlight(selector)` to debug selectors in headed mode
 - have the Playwright MCP installed in your dev environment so that you may prompt agents to run the test and then use the Playwright MCP to recreate test steps and fix the test code. Example prompt: `Run test x and inspect the output and test code and then use the Playwright MCP to fix the test code, explaining as you go`
 
@@ -46,9 +49,11 @@ End-to-end tests for the Opentrons **Protocol Designer (PD)** and **Labware Libr
 ### Protocol Designer (PD)
 
 ```bash
-make test-pd-local                               # Headless, chromium
-make test-pd-local-headed                        # Headed, 250ms slow-mo
-make test-pd-local PYTEST_ARGS="-k test_name"    # Run one test
+make serve-pd                                    # Terminal 1: start PD (required for local)
+make test-pd-local                               # Terminal 2: headless, 2 workers (default)
+make test-pd-local PYTEST_ARGS="-k test_name"    # Parallel + filter one test
+make test-pd-local XDIST_ARGS="-n 0"             # Sequential (debugging)
+make test-pd-local-headed                        # Headed, sequential (-n 0), one test via -k
 make test-pd-staging                             # Against staging
 make test-pd-prod                                # Against production
 make test-pd-debug                               # Headed, 1000ms slow-mo, verbose
@@ -81,12 +86,7 @@ make codegen URL=<url>       # Record against a custom URL
 @pytest.mark.parametrize("pd_base_url", ["http://localhost:5178/", "https://designer.opentrons.com"])
 ```
 
-**Note:** Local tests automatically:
-
-- Look for an already-running server on the expected ports
-- Build and serve the app via `make -C ../protocol-designer serve` or `make -C ../labware-library serve` if nothing is running
-- Wait for the server to be ready
-- Clean up the server after tests complete if it was started by the test suite
+**PD server:** `e2e-testing/pd_server.py` via `make serve-pd` runs `make serve` in `protocol-designer/` (build + preview in one step). There is no separate `make dist` step, dist cache, or CI-only bash to start PD. CI uses `./.github/actions/js/setup` then `make test-pd-local` (which starts `serve-pd` when `CI=true`). LL tests still auto-start from pytest when needed.
 
 ### Custom Environment
 
@@ -127,7 +127,7 @@ Tests use the **Page Object Model** pattern for maintainability:
 
 | Fixture       | Scope    | Purpose                                                                                        |
 | ------------- | -------- | ---------------------------------------------------------------------------------------------- |
-| `pd_base_url` | session  | Resolves PD URL; starts local preview server when `TEST_ENV=local`                             |
+| `pd_base_url` | session  | Resolves PD URL; discovers local preview server when `TEST_ENV=local` (start with `make serve-pd`) |
 | `ll_base_url` | session  | Resolves LL URL; starts local preview server when `TEST_ENV=local`                             |
 | `page`        | function | Creates a Playwright page, navigates to the correct app URL based on test markers, saves video |
 | `eyes`        | function | Applitools Eyes session (or `None` when disabled)                                              |
@@ -138,11 +138,12 @@ Tests use the **Page Object Model** pattern for maintainability:
 | -------------------- | ------- | ------------------------------------- |
 | `TEST_ENV`           | `local` | `local`, `staging`, `prod`, `sandbox` |
 | `HEADLESS`           | (unset) | `true` / `false`; overrides default   |
-| `SKIP_SERVER_START`  | `false` | Skip automatic server build+serve     |
-| `PD_SERVER_URL`      | auto    | Override PD URL                       |
+| `PD_SERVER_URL`      | auto    | Override PD URL when server is already running |
+| `SKIP_SERVER_START`  | `false` | Skip LL automatic server build+serve only      |
 | `LL_SERVER_URL`      | auto    | Override LL URL                       |
 | `LL_SERVER_PORT`     | `4176`  | Preferred port for LL local server    |
 | `APPLITOOLS_API_KEY` | (unset) | Enable Applitools visual checks       |
+| `APPLITOOLS_BATCH_ID` | (unset) | One batch per run; CI sets `run_id-run_attempt` so xdist workers match |
 
 ## Development Workflow
 

--- a/e2e-testing/README.md
+++ b/e2e-testing/README.md
@@ -125,24 +125,24 @@ Tests use the **Page Object Model** pattern for maintainability:
 
 ### Key Fixtures (conftest.py)
 
-| Fixture       | Scope    | Purpose                                                                                        |
-| ------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| Fixture       | Scope    | Purpose                                                                                            |
+| ------------- | -------- | -------------------------------------------------------------------------------------------------- |
 | `pd_base_url` | session  | Resolves PD URL; discovers local preview server when `TEST_ENV=local` (start with `make serve-pd`) |
-| `ll_base_url` | session  | Resolves LL URL; starts local preview server when `TEST_ENV=local`                             |
-| `page`        | function | Creates a Playwright page, navigates to the correct app URL based on test markers, saves video |
-| `eyes`        | function | Applitools Eyes session (or `None` when disabled)                                              |
+| `ll_base_url` | session  | Resolves LL URL; starts local preview server when `TEST_ENV=local`                                 |
+| `page`        | function | Creates a Playwright page, navigates to the correct app URL based on test markers, saves video     |
+| `eyes`        | function | Applitools Eyes session (or `None` when disabled)                                                  |
 
 ### Environment Variables
 
-| Variable             | Default | Notes                                 |
-| -------------------- | ------- | ------------------------------------- |
-| `TEST_ENV`           | `local` | `local`, `staging`, `prod`, `sandbox` |
-| `HEADLESS`           | (unset) | `true` / `false`; overrides default   |
-| `PD_SERVER_URL`      | auto    | Override PD URL when server is already running |
-| `SKIP_SERVER_START`  | `false` | Skip LL automatic server build+serve only      |
-| `LL_SERVER_URL`      | auto    | Override LL URL                       |
-| `LL_SERVER_PORT`     | `4176`  | Preferred port for LL local server    |
-| `APPLITOOLS_API_KEY` | (unset) | Enable Applitools visual checks       |
+| Variable              | Default | Notes                                                                  |
+| --------------------- | ------- | ---------------------------------------------------------------------- |
+| `TEST_ENV`            | `local` | `local`, `staging`, `prod`, `sandbox`                                  |
+| `HEADLESS`            | (unset) | `true` / `false`; overrides default                                    |
+| `PD_SERVER_URL`       | auto    | Override PD URL when server is already running                         |
+| `SKIP_SERVER_START`   | `false` | Skip LL automatic server build+serve only                              |
+| `LL_SERVER_URL`       | auto    | Override LL URL                                                        |
+| `LL_SERVER_PORT`      | `4176`  | Preferred port for LL local server                                     |
+| `APPLITOOLS_API_KEY`  | (unset) | Enable Applitools visual checks                                        |
 | `APPLITOOLS_BATCH_ID` | (unset) | One batch per run; CI sets `run_id-run_attempt` so xdist workers match |
 
 ## Development Workflow

--- a/e2e-testing/conftest.py
+++ b/e2e-testing/conftest.py
@@ -5,7 +5,6 @@ import re
 import select
 import subprocess
 import time
-import urllib.request
 import uuid
 from collections.abc import Generator
 from pathlib import Path
@@ -19,6 +18,13 @@ from _pytest.python import Function
 from playwright.sync_api import BrowserContext, Page, Video
 from playwright.sync_api import Error as PlaywrightError
 
+from pd_server import (
+    PD_SERVER_PORTS,
+    find_running_server,
+    is_http_server_running,
+    verify_server_identity,
+    wait_for_server_ready,
+)
 from utility import troubleshoot_and_pause
 
 # Expose fixtures defined in e2e-testing/eyes.py (e.g. the `eyes` fixture).
@@ -210,80 +216,21 @@ def browser_type_launch_args(pytestconfig: pytest.Config) -> dict[str, Any]:
     }
 
 
-PD_SERVER_PORTS = [4173, 4174, 4175]
 LL_SERVER_PORTS = [4176, 4177, 4178]
 
-# Substrings expected in the HTML <title> of each app.  Used by
-# ``_verify_server_identity`` to confirm the right application is serving.
-_APP_TITLE_FINGERPRINTS: dict[str, str] = {
-    "pd": "Protocol Designer",
-    "ll": "Labware Library",
-}
 
+def _resolve_pd_local_url() -> str:
+    """Return a local PD base URL; fail fast if no server is running."""
+    existing_server = find_running_server(PD_SERVER_PORTS, app="pd")
+    if existing_server:
+        os.environ["PD_SERVER_URL"] = existing_server
+        return existing_server
 
-def _is_http_server_running(url: str, timeout: int = 1) -> bool:
-    """Check if any HTTP server is already responding at the given URL."""
-    try:
-        urllib.request.urlopen(url, timeout=timeout)
-        return True
-    except Exception:
-        return False
+    override = os.environ.get("PD_SERVER_URL", "").rstrip("/")
+    if override:
+        return override
 
-
-def _verify_server_identity(url: str, app: Literal["pd", "ll"], timeout: int = 2) -> bool:
-    """Return True if the server at *url* is serving the expected application.
-
-    Fetches the root page and checks that the HTML ``<title>`` contains the
-    fingerprint string for the requested app.  This prevents one app from
-    being mistaken for the other when they happen to share ports.
-    """
-    fingerprint = _APP_TITLE_FINGERPRINTS[app]
-    try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
-            # Read a limited chunk — the <title> is near the top of the page.
-            body = resp.read(4096).decode("utf-8", errors="replace")
-            return fingerprint.lower() in body.lower()
-    except Exception:
-        return False
-
-
-def _find_running_server(
-    ports_to_check: list[int],
-    app: Literal["pd", "ll"] | None = None,
-) -> str | None:
-    """Find a running server on localhost for the given port list.
-
-    When *app* is provided the server's HTML title is checked to confirm
-    the correct application is serving.  A server that responds but serves
-    the wrong app is skipped with a warning.
-    """
-    for port in ports_to_check:
-        url = f"http://localhost:{port}"
-        if _is_http_server_running(url):
-            if app is not None and not _verify_server_identity(url, app):
-                print(
-                    f"\n⚠️  Server on {url} is responding but does not look like "
-                    f"{app.upper()} (expected '{_APP_TITLE_FINGERPRINTS[app]}' in "
-                    f"<title>).  Skipping."
-                )
-                continue
-            return url
-    return None
-
-
-def _wait_for_server_ready(
-    ports_to_check: list[int],
-    timeout: int = 240,
-    app: Literal["pd", "ll"] | None = None,
-) -> str | None:
-    """Wait for a local server to become available on any of the given ports."""
-    start = time.monotonic()
-    while time.monotonic() - start < timeout:
-        running_server = _find_running_server(ports_to_check, app=app)
-        if running_server:
-            return running_server
-        time.sleep(1)
-    return None
+    pytest.fail("No Protocol Designer server found on localhost. From e2e-testing/, start one with: make serve-pd")
 
 
 def _get_suite_for_test(request: FixtureRequest) -> Literal["pd", "ll", "none"]:
@@ -302,115 +249,11 @@ def _get_suite_for_test(request: FixtureRequest) -> Literal["pd", "ll", "none"]:
     return "none"
 
 
-def _start_pd_server() -> Generator[str, None, None]:
-    """Start or reuse a local Protocol Designer preview server."""
-    skip_server = os.environ.get("SKIP_SERVER_START", "false").lower() == "true"
-
-    existing_server = _find_running_server(PD_SERVER_PORTS, app="pd")
-    if existing_server:
-        print(f"\n✓ Protocol Designer already running on {existing_server}, skipping startup")
-        os.environ["PD_SERVER_URL"] = existing_server
-        yield existing_server
-        return
-
-    if skip_server:
-        fallback_url = os.environ.get("PD_SERVER_URL", "http://localhost:4173")
-        print(
-            "\n⚠️  SKIP_SERVER_START is set and no existing server detected; "
-            "returning fallback URL without starting preview server."
-        )
-        yield fallback_url
-        return
-
-    print("\nStarting protocol-designer preview server...")
-    print("Building Protocol Designer (this may take 2-3 minutes)...")
-    print("=" * 80)
-
-    # Start the preview server (vite preview serves production build)
-    server_process = subprocess.Popen(
-        ["make", "-C", "../protocol-designer", "serve"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-
-    # Wait for server to be ready, checking common ports
-    max_attempts = 120
-    ports_to_try = PD_SERVER_PORTS
-    output_lines = []
-    server_url = None
-
-    for attempt in range(max_attempts):
-        if server_process.poll() is not None:
-            if server_process.stdout:
-                remaining_output = server_process.stdout.read()
-                if remaining_output:
-                    print(remaining_output, end="")
-                    output_lines.append(remaining_output)
-            print(f"\n❌ Server process exited unexpectedly with code {server_process.returncode}")
-            raise Exception(
-                f"Server process exited with code {server_process.returncode}. Check output above for errors."
-            )
-
-        if server_process.stdout and select.select([server_process.stdout], [], [], 0.1)[0]:
-            line = server_process.stdout.readline()
-            if line:
-                print(line, end="")
-                output_lines.append(line)
-
-        for port in ports_to_try:
-            try:
-                test_url = f"http://localhost:{port}"
-                urllib.request.urlopen(test_url, timeout=1)
-                if not _verify_server_identity(test_url, "pd"):
-                    continue
-                print(f"✅ Preview server is ready on {test_url}")
-                server_url = test_url
-                break
-            except Exception:
-                pass
-
-        if server_url:
-            break
-
-        if attempt > 0 and attempt % 10 == 0:
-            elapsed = attempt * 2
-            print(f"  Still waiting for server... ({elapsed}s elapsed)")
-
-        if attempt == max_attempts - 1:
-            print(f"\n❌ Server failed to start after {max_attempts * 2} seconds")
-            server_process.kill()
-            raise Exception(
-                f"Preview server failed to start on any port: {ports_to_try}. "
-                f"Waited {max_attempts * 2} seconds. Check output above for errors."
-            )
-        time.sleep(2)
-
-    print("=" * 80)
-    assert server_url is not None
-    os.environ["PD_SERVER_URL"] = server_url
-
-    try:
-        yield server_url
-    finally:
-        if server_process:
-            print("\nStopping dev server...")
-            server_process.terminate()
-            try:
-                server_process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                print("⚠️  Preview server did not exit in time; sending SIGKILL.")
-                server_process.kill()
-                server_process.wait(timeout=5)
-            if server_process.stdout:
-                server_process.stdout.close()
-
-
 def _start_ll_server() -> Generator[str, None, None]:
     """Start or reuse a local Labware Library preview server."""
     skip_server = os.environ.get("SKIP_SERVER_START", "false").lower() == "true"
 
-    existing_server = _find_running_server(LL_SERVER_PORTS, app="ll")
+    existing_server = find_running_server(LL_SERVER_PORTS, app="ll")
     if existing_server:
         print(f"\n✓ Labware Library already running on {existing_server}, skipping startup")
         os.environ["LL_SERVER_URL"] = existing_server
@@ -467,16 +310,14 @@ def _start_ll_server() -> Generator[str, None, None]:
                 output_lines.append(line)
 
         for port in ports_to_try:
-            try:
-                test_url = f"http://localhost:{port}"
-                urllib.request.urlopen(test_url, timeout=1)
-                if not _verify_server_identity(test_url, "ll"):
-                    continue
-                print(f"✅ Labware Library preview server is ready on {test_url}")
-                server_url = test_url
-                break
-            except Exception:
-                pass
+            test_url = f"http://localhost:{port}"
+            if not is_http_server_running(test_url):
+                continue
+            if not verify_server_identity(test_url, "ll"):
+                continue
+            print(f"✅ Labware Library preview server is ready on {test_url}")
+            server_url = test_url
+            break
 
         if server_url:
             break
@@ -528,7 +369,8 @@ def pd_base_url(pytestconfig: pytest.Config) -> Generator[str, None, None]:
         yield remote_url
         return
 
-    yield from _start_pd_server()
+    url = _resolve_pd_local_url()
+    yield url
 
 
 @pytest.fixture(scope="session")
@@ -584,7 +426,7 @@ def page(context: BrowserContext, request: FixtureRequest) -> Generator[Page, No
             identity_app = "ll"
         else:
             identity_app = None
-        restored_url = _wait_for_server_ready(ports_to_check, app=identity_app)
+        restored_url = wait_for_server_ready(ports_to_check, app=identity_app)
         if not restored_url:
             raise
 

--- a/e2e-testing/pd_server.py
+++ b/e2e-testing/pd_server.py
@@ -1,0 +1,238 @@
+"""Start and manage a local Protocol Designer preview server for e2e tests.
+
+Run via ``make serve-pd`` from e2e-testing/. Pytest discovers an already-running
+server; it does not start PD itself (required for pytest-xdist).
+
+Locally and in CI use the same entrypoint: ``make serve-pd`` (runs ``make serve``
+in protocol-designer, which builds and serves in one step).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import select
+import signal
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+from typing import Literal
+
+PD_SERVER_PORTS = [4173, 4174, 4175]
+
+APP_TITLE_FINGERPRINTS: dict[str, str] = {
+    "pd": "Protocol Designer",
+    "ll": "Labware Library",
+}
+
+E2E_DIR = Path(__file__).resolve().parent
+PD_MAKE_DIR = E2E_DIR.parent / "protocol-designer"
+
+MAX_START_ATTEMPTS = 120
+POLL_INTERVAL_SECONDS = 2
+
+
+def is_http_server_running(url: str, timeout: int = 1) -> bool:
+    """Return True if an HTTP server responds at *url*."""
+    try:
+        urllib.request.urlopen(url, timeout=timeout)
+        return True
+    except Exception:
+        return False
+
+
+def verify_server_identity(url: str, app: Literal["pd", "ll"], timeout: int = 2) -> bool:
+    """Return True if *url* serves the expected app (checked via HTML ``<title>``)."""
+    fingerprint = APP_TITLE_FINGERPRINTS[app]
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            body = resp.read(4096).decode("utf-8", errors="replace")
+            return fingerprint.lower() in body.lower()
+    except Exception:
+        return False
+
+
+def find_running_server(
+    ports_to_check: list[int],
+    app: Literal["pd", "ll"] | None = None,
+) -> str | None:
+    """Return the URL of a running server on localhost, or None."""
+    for port in ports_to_check:
+        url = f"http://localhost:{port}"
+        if is_http_server_running(url):
+            if app is not None and not verify_server_identity(url, app):
+                print(
+                    f"\n⚠️  Server on {url} is responding but does not look like "
+                    f"{app.upper()} (expected '{APP_TITLE_FINGERPRINTS[app]}' in "
+                    f"<title>).  Skipping."
+                )
+                continue
+            return url
+    return None
+
+
+def wait_for_server_ready(
+    ports_to_check: list[int],
+    timeout: int = 240,
+    app: Literal["pd", "ll"] | None = None,
+) -> str | None:
+    """Poll until a server is available on one of *ports_to_check*, or timeout."""
+    start = time.monotonic()
+    while time.monotonic() - start < timeout:
+        running_server = find_running_server(ports_to_check, app=app)
+        if running_server:
+            return running_server
+        time.sleep(1)
+    return None
+
+
+def _pd_serve_command() -> list[str]:
+    return ["make", "-C", str(PD_MAKE_DIR), "serve"]
+
+
+def _wait_for_new_pd_server(
+    server_process: subprocess.Popen[str],
+    ports_to_try: list[int],
+) -> str:
+    """Block until the preview server is ready or the child process exits."""
+    server_url: str | None = None
+
+    for attempt in range(MAX_START_ATTEMPTS):
+        if server_process.poll() is not None:
+            if server_process.stdout:
+                remaining_output = server_process.stdout.read()
+                if remaining_output:
+                    print(remaining_output, end="")
+            print(f"\n❌ Server process exited unexpectedly with code {server_process.returncode}")
+            raise RuntimeError(
+                f"Server process exited with code {server_process.returncode}. Check output above for errors."
+            )
+
+        if server_process.stdout and select.select([server_process.stdout], [], [], 0.1)[0]:
+            line = server_process.stdout.readline()
+            if line:
+                print(line, end="")
+
+        for port in ports_to_try:
+            test_url = f"http://localhost:{port}"
+            if not is_http_server_running(test_url):
+                continue
+            if not verify_server_identity(test_url, "pd"):
+                continue
+            print(f"✅ Protocol Designer is ready on {test_url}")
+            server_url = test_url
+            break
+
+        if server_url:
+            break
+
+        if attempt > 0 and attempt % 10 == 0:
+            elapsed = attempt * POLL_INTERVAL_SECONDS
+            print(f"  Still waiting for server... ({elapsed}s elapsed)")
+
+        if attempt == MAX_START_ATTEMPTS - 1:
+            print(f"\n❌ Server failed to start after {MAX_START_ATTEMPTS * POLL_INTERVAL_SECONDS} seconds")
+            server_process.kill()
+            raise RuntimeError(
+                f"Protocol Designer failed to start on any port: {ports_to_try}. "
+                f"Waited {MAX_START_ATTEMPTS * POLL_INTERVAL_SECONDS} seconds."
+            )
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+    assert server_url is not None
+    return server_url
+
+
+def _stop_server_process(server_process: subprocess.Popen[str]) -> None:
+    print("\nStopping Protocol Designer server...")
+    server_process.terminate()
+    try:
+        server_process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        print("⚠️  Server did not exit in time; sending SIGKILL.")
+        server_process.kill()
+        server_process.wait(timeout=5)
+    if server_process.stdout:
+        server_process.stdout.close()
+
+
+def run_pd_server() -> int:
+    """Start PD via ``make serve`` if needed, then block until interrupted."""
+    existing_server = find_running_server(PD_SERVER_PORTS, app="pd")
+    if existing_server:
+        print(f"\n✓ Protocol Designer already running on {existing_server}")
+        os.environ["PD_SERVER_URL"] = existing_server
+        print(f"PD_SERVER_URL={existing_server}")
+        return 0
+
+    print("\nStarting Protocol Designer (make serve — build and preview)...")
+    print("This may take 2-3 minutes...")
+    print("=" * 80)
+
+    server_process = subprocess.Popen(
+        _pd_serve_command(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    try:
+        server_url = _wait_for_new_pd_server(server_process, PD_SERVER_PORTS)
+    except RuntimeError:
+        return 1
+
+    print("=" * 80)
+    os.environ["PD_SERVER_URL"] = server_url
+    print(f"PD_SERVER_URL={server_url}")
+    print("Press Ctrl+C to stop the server.")
+
+    def _handle_signal(signum: int, frame: object | None) -> None:
+        _stop_server_process(server_process)
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    try:
+        server_process.wait()
+    except KeyboardInterrupt:
+        _stop_server_process(server_process)
+        return 0
+
+    if server_process.returncode not in (0, None):
+        return server_process.returncode or 1
+    return 0
+
+
+def wait_for_pd_server(timeout: int = 240) -> int:
+    """Block until PD responds on a known port, then exit (for CI/Makefile orchestration)."""
+    server_url = wait_for_server_ready(PD_SERVER_PORTS, timeout=timeout, app="pd")
+    if not server_url:
+        print(f"\n❌ Protocol Designer not ready after {timeout}s")
+        return 1
+    os.environ["PD_SERVER_URL"] = server_url
+    print(f"PD_SERVER_URL={server_url}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run Protocol Designer for e2e tests (make serve in protocol-designer/)."
+    )
+    parser.add_argument(
+        "--wait",
+        action="store_true",
+        help="Wait until PD is reachable, print URL, and exit (does not start a server).",
+    )
+    args = parser.parse_args()
+
+    if args.wait:
+        return wait_for_pd_server()
+
+    return run_pd_server()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/e2e-testing/pyproject.toml
+++ b/e2e-testing/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pytest-html>=4.1.1",
     "pytest-playwright>=0.6.2",
     "pytest-timeout>=2.3.1",
+    "pytest-xdist>=3.8.0",
     "python-dotenv>=1.2.1",
     "ruff>=0.14.2",
 ]

--- a/e2e-testing/uv.lock
+++ b/e2e-testing/uv.lock
@@ -112,6 +112,7 @@ dependencies = [
     { name = "pytest-html" },
     { name = "pytest-playwright" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "python-dotenv" },
     { name = "ruff" },
 ]
@@ -125,8 +126,18 @@ requires-dist = [
     { name = "pytest-html", specifier = ">=4.1.1" },
     { name = "pytest-playwright", specifier = ">=0.6.2" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "python-dotenv", specifier = ">=1.2.1" },
     { name = "ruff", specifier = ">=0.14.2" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -487,6 +498,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -45,7 +45,7 @@ dev: export NODE_OPTIONS := --max-old-space-size=8192
 dev:
 	vite serve
 
-# production assets server
+# production assets server (build + preview; used by e2e-testing/pd_server.py)
 .PHONY: serve
 serve: export NODE_OPTIONS := --max-old-space-size=8192
 serve: all


### PR DESCRIPTION
# Overview
Broke pd_server out of conftest.py and added Xdist 
https://opentrons.atlassian.net/browse/RQA-5458

## Python/Make setup edits
- Add 2 runners using xdist. 
- [Xdist](https://testingwithedd.github.io/testing/playwright/2024/07/05/parallelize-playwright-with-xdist.htm)
- Added a new file called pd_server.py to be the PD server. 
- Made a small adjustment so that both Xdist runners are in the same applitools batch 

# Testing

- e2e-testing along used to take 12 minutes
- Now it takes 5 minutes
- Reran tests to ensure that e2e-testing still used the pd cache. 
- Used Applitools to ensure batching worked the same way
