### PR TITLE
perf(app): Use passive event listeners for tracking user activity

### DIFF
--- a/app/src/local-resources/dom-utils/hooks/useActivityListener.ts
+++ b/app/src/local-resources/dom-utils/hooks/useActivityListener.ts
@@ -26,7 +26,7 @@ export function useActivityListener(
 ): void {
   useEffect(() => {
     events.forEach(event => {
-      document.addEventListener(event, onActivity)
+      document.addEventListener(event, onActivity, { passive: true })
     })
 
     return () => {


### PR DESCRIPTION
## Overview

`useActivityListener()` tracks "any user activity" in the frontend. It's currently used for dimming the on-device display after a period of inactivity. It will also soon be used for keeping the user's login active while the user is actively using the UI.

This enables [`passive: true`](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#using_passive_listeners) on all of its event listeners, to keep them out of the critical path for handling user events like clicking and scrolling. This may slightly improve framerate and reduce latency for user interaction.

## Test Plan and Hands on Testing

None needed.

## Review requests

None.

## Risk assessment

Low.

`passive: true` is guaranteed to be safe here: because we pass no arguments to `onActivity`, it's impossible for `onActivity` to call `event.preventDefault()`.