### PR TITLE
feat(api, app, shared-data): Add motion modifier to enable lowering the mount z-axis

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
+++ b/api/src/opentrons/protocol_engine/commands/calibration/move_to_maintenance_position.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 # These offsets supplied from HW
 _ATTACH_POINT = Point(x=0, y=110)
 _MAX_Z_AXIS_MOTION_RANGE = 215
+# These offsets are estimated by eyeballing
+_INSTRUMENT_ATTACH_Z_POINT = 400.0
 _LEFT_MOUNT_Z_MARGIN = 5
 # Move the right mount a bit higher than the left so the user won't forget to unscrew
 _RIGHT_MOUNT_Z_MARGIN = 20
@@ -32,6 +34,7 @@ class MotionModifier(enum.Enum):
     """Motion modifier options for maintenance position moves."""
 
     LOWER_Z_AXES_SEQUENTIALLY = "lowerZAxesSequentially"
+    LOWER_MOUNT_Z_AXIS = "lowerMountZAxis"
 
 
 class MoveToMaintenancePositionParams(BaseModel):
@@ -109,6 +112,14 @@ class MoveToMaintenancePositionImplementation(
                 mount = params.mount.to_hw_mount()
                 mount_to_axis = Axis.by_mount(mount)
                 await ot3_api.prepare_for_mount_movement(mount)
+
+                if params.motionModifier == MotionModifier.LOWER_MOUNT_Z_AXIS:
+                    await ot3_api.move_axes(
+                        {
+                            mount_to_axis: _INSTRUMENT_ATTACH_Z_POINT,
+                        }
+                    )
+
                 await ot3_api.disengage_axes([mount_to_axis])
 
         return SuccessData(

--- a/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
+++ b/api/tests/opentrons/protocol_engine/commands/calibration/test_move_to_maintenance_position.py
@@ -130,6 +130,55 @@ async def test_calibration_move_to_location_implementation_for_attach_plate(
 
 
 @pytest.mark.ot3_only
+@pytest.mark.parametrize("mount_type", [MountType.LEFT, MountType.RIGHT])
+async def test_calibration_move_to_location_for_lower_mount_z_axis(
+    decoy: Decoy,
+    subject: MoveToMaintenancePositionImplementation,
+    state_view: StateView,
+    ot3_hardware_api: OT3API,
+    mount_type: MountType,
+) -> None:
+    """Command should prepare mount, lower the mount's z-axis, and disengage."""
+    params = MoveToMaintenancePositionParams(
+        mount=mount_type, motionModifier=MotionModifier.LOWER_MOUNT_Z_AXIS
+    )
+
+    decoy.when(
+        await ot3_hardware_api.gantry_position(
+            Mount.LEFT, critical_point=CriticalPoint.MOUNT
+        )
+    ).then_return(Point(x=1, y=2, z=250))
+
+    decoy.when(ot3_hardware_api.get_instrument_max_height(Mount.LEFT)).then_return(300)
+
+    result = await subject.execute(params=params)
+    assert result == SuccessData(
+        public=MoveToMaintenancePositionResult(),
+    )
+
+    hw_mount = mount_type.to_hw_mount()
+    mount_to_axis = Axis.by_mount(hw_mount)
+    decoy.verify(
+        await ot3_hardware_api.prepare_for_mount_movement(Mount.LEFT),
+        await ot3_hardware_api.retract(Mount.LEFT),
+        await ot3_hardware_api.move_to(
+            mount=Mount.LEFT,
+            abs_position=Point(x=0, y=110, z=250),
+            critical_point=CriticalPoint.MOUNT,
+        ),
+        await ot3_hardware_api.prepare_for_mount_movement(hw_mount),
+        await ot3_hardware_api.move_axes(
+            {
+                mount_to_axis: 400.0,
+            }
+        ),
+        await ot3_hardware_api.disengage_axes(
+            [mount_to_axis],
+        ),
+    )
+
+
+@pytest.mark.ot3_only
 async def test_calibration_move_to_location_implementation_for_gripper(
     decoy: Decoy,
     subject: MoveToMaintenancePositionImplementation,

--- a/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/PipetteWizardFlows/BeforeBeginning.tsx
@@ -187,6 +187,9 @@ export const BeforeBeginning = (
   )
 
   const handleOnClickCalibrateOrDetach = (): void => {
+    const is96Channel =
+      attachedPipettes[mount]?.instrumentName === 'p1000_96' ||
+      attachedPipettes[mount]?.instrumentName === 'p200_96'
     let moveToFrontCommands: CreateCommand[] = [
       {
         commandType: 'loadPipette' as const,
@@ -201,6 +204,9 @@ export const BeforeBeginning = (
         commandType: 'calibration/moveToMaintenancePosition' as const,
         params: {
           mount,
+          ...(is96Channel
+            ? { motionModifier: 'lowerMountZAxis' as const }
+            : {}),
         },
       },
     ]

--- a/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
+++ b/app/src/organisms/PipetteWizardFlows/MountingPlate.tsx
@@ -39,6 +39,7 @@ export const MountingPlate = (
           commandType: 'calibration/moveToMaintenancePosition' as const,
           params: {
             mount: LEFT,
+            motionModifier: 'lowerMountZAxis',
           },
         },
       ],

--- a/app/src/organisms/PipetteWizardFlows/__tests__/MountingPlate.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/MountingPlate.test.tsx
@@ -57,7 +57,7 @@ describe('MountingPlate', () => {
           },
           {
             commandType: 'calibration/moveToMaintenancePosition',
-            params: { mount: LEFT },
+            params: { mount: LEFT, motionModifier: 'lowerMountZAxis' },
           },
         ],
         false

--- a/shared-data/command/schemas/17.json
+++ b/shared-data/command/schemas/17.json
@@ -9,9 +9,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "addressableAreaName"
-      ],
+      "required": ["addressableAreaName"],
       "title": "AddressableAreaLocation",
       "type": "object"
     },
@@ -31,11 +29,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ],
+      "required": ["x", "y", "z"],
       "title": "AddressableOffsetVector",
       "type": "object"
     },
@@ -70,9 +64,7 @@
           "$ref": "#/$defs/AirGapInPlaceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "AirGapInPlaceCreate",
       "type": "object"
     },
@@ -110,11 +102,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["flowRate", "volume", "pipetteId"],
       "title": "AirGapInPlaceParams",
       "type": "object"
     },
@@ -162,9 +150,7 @@
           "$ref": "#/$defs/AspirateParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "AspirateCreate",
       "type": "object"
     },
@@ -199,9 +185,7 @@
           "$ref": "#/$defs/AspirateInPlaceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "AspirateInPlaceCreate",
       "type": "object"
     },
@@ -239,11 +223,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["flowRate", "volume", "pipetteId"],
       "title": "AspirateInPlaceParams",
       "type": "object"
     },
@@ -295,13 +275,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
       "title": "AspirateParams",
       "type": "object"
     },
@@ -449,9 +423,7 @@
           "$ref": "#/$defs/AspirateWhileTrackingParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "AspirateWhileTrackingCreate",
       "type": "object"
     },
@@ -512,13 +484,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
       "title": "AspirateWhileTrackingParams",
       "type": "object"
     },
@@ -553,9 +519,7 @@
           "$ref": "#/$defs/BlowOutParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "BlowOutCreate",
       "type": "object"
     },
@@ -590,9 +554,7 @@
           "$ref": "#/$defs/BlowOutInPlaceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "BlowOutInPlaceCreate",
       "type": "object"
     },
@@ -611,10 +573,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "pipetteId"
-      ],
+      "required": ["flowRate", "pipetteId"],
       "title": "BlowOutInPlaceParams",
       "type": "object"
     },
@@ -647,22 +606,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "flowRate", "pipetteId"],
       "title": "BlowOutParams",
       "type": "object"
     },
     "BlowoutLocation": {
       "description": "Location for blowout during a transfer function.",
-      "enum": [
-        "source",
-        "destination",
-        "trash"
-      ],
+      "enum": ["source", "destination", "trash"],
       "title": "BlowoutLocation",
       "type": "string"
     },
@@ -701,10 +651,7 @@
           "description": "Location well or trash entity for blow out."
         }
       },
-      "required": [
-        "location",
-        "flowRate"
-      ],
+      "required": ["location", "flowRate"],
       "title": "BlowoutParams",
       "type": "object"
     },
@@ -723,9 +670,7 @@
           "title": "Params"
         }
       },
-      "required": [
-        "enable"
-      ],
+      "required": ["enable"],
       "title": "BlowoutProperties",
       "type": "object"
     },
@@ -760,9 +705,7 @@
           "$ref": "#/$defs/CSVWriteRowParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CSVWriteRowCreate",
       "type": "object"
     },
@@ -783,10 +726,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "fileId",
-        "rowData"
-      ],
+      "required": ["fileId", "rowData"],
       "title": "CSVWriteRowParams",
       "type": "object"
     },
@@ -821,9 +761,7 @@
           "$ref": "#/$defs/CalibrateGripperParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CalibrateGripperCreate",
       "type": "object"
     },
@@ -840,17 +778,12 @@
           "title": "Otherjawoffset"
         }
       },
-      "required": [
-        "jaw"
-      ],
+      "required": ["jaw"],
       "title": "CalibrateGripperParams",
       "type": "object"
     },
     "CalibrateGripperParamsJaw": {
-      "enum": [
-        "front",
-        "rear"
-      ],
+      "enum": ["front", "rear"],
       "title": "CalibrateGripperParamsJaw",
       "type": "string"
     },
@@ -885,9 +818,7 @@
           "$ref": "#/$defs/CalibrateModuleParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CalibrateModuleCreate",
       "type": "object"
     },
@@ -909,11 +840,7 @@
           "description": "The instrument mount used to calibrate the module."
         }
       },
-      "required": [
-        "moduleId",
-        "labwareId",
-        "mount"
-      ],
+      "required": ["moduleId", "labwareId", "mount"],
       "title": "CalibrateModuleParams",
       "type": "object"
     },
@@ -948,9 +875,7 @@
           "$ref": "#/$defs/CalibratePipetteParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CalibratePipetteCreate",
       "type": "object"
     },
@@ -962,9 +887,7 @@
           "description": "Instrument mount to calibrate."
         }
       },
-      "required": [
-        "mount"
-      ],
+      "required": ["mount"],
       "title": "CalibratePipetteParams",
       "type": "object"
     },
@@ -999,9 +922,7 @@
           "$ref": "#/$defs/CaptureImageParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CaptureImageCreate",
       "type": "object"
     },
@@ -1146,9 +1067,7 @@
           "$ref": "#/$defs/CloseGripperJawParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CloseGripperJawCreate",
       "type": "object"
     },
@@ -1195,9 +1114,7 @@
           "$ref": "#/$defs/CloseLabwareLatchParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CloseLabwareLatchCreate",
       "type": "object"
     },
@@ -1210,9 +1127,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "CloseLabwareLatchParams",
       "type": "object"
     },
@@ -1247,9 +1162,7 @@
           "$ref": "#/$defs/CloseVentParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CloseVentCreate",
       "type": "object"
     },
@@ -1262,9 +1175,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "CloseVentParams",
       "type": "object"
     },
@@ -1273,12 +1184,7 @@
       "properties": {
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -1289,19 +1195,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ],
+      "required": ["primaryNozzle"],
       "title": "ColumnNozzleLayoutConfiguration",
       "type": "object"
     },
     "CommandIntent": {
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": [
-        "protocol",
-        "setup",
-        "fixit"
-      ],
+      "enum": ["protocol", "setup", "fixit"],
       "title": "CommandIntent",
       "type": "string"
     },
@@ -1336,9 +1236,7 @@
           "$ref": "#/$defs/CommentParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CommentCreate",
       "type": "object"
     },
@@ -1351,9 +1249,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "message"
-      ],
+      "required": ["message"],
       "title": "CommentParams",
       "type": "object"
     },
@@ -1388,9 +1284,7 @@
           "$ref": "#/$defs/ConfigureForVolumeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "ConfigureForVolumeCreate",
       "type": "object"
     },
@@ -1414,10 +1308,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "pipetteId",
-        "volume"
-      ],
+      "required": ["pipetteId", "volume"],
       "title": "ConfigureForVolumeParams",
       "type": "object"
     },
@@ -1452,9 +1343,7 @@
           "$ref": "#/$defs/ConfigureNozzleLayoutParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "ConfigureNozzleLayoutCreate",
       "type": "object"
     },
@@ -1487,10 +1376,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "configurationParams"
-      ],
+      "required": ["pipetteId", "configurationParams"],
       "title": "ConfigureNozzleLayoutParams",
       "type": "object"
     },
@@ -1532,11 +1418,7 @@
           "title": "Z"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ],
+      "required": ["x", "y", "z"],
       "title": "Coordinate",
       "type": "object"
     },
@@ -1571,9 +1453,7 @@
           "$ref": "#/$defs/CreateCSVParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CreateCSVCreate",
       "type": "object"
     },
@@ -1591,10 +1471,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "fileName",
-        "columns"
-      ],
+      "required": ["fileName", "columns"],
       "title": "CreateCSVParams",
       "type": "object"
     },
@@ -1629,9 +1506,7 @@
           "$ref": "#/$defs/CreateTimerParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CreateTimerCreate",
       "type": "object"
     },
@@ -1657,9 +1532,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "time"
-      ],
+      "required": ["time"],
       "title": "CreateTimerParams",
       "type": "object"
     },
@@ -1694,9 +1567,7 @@
           "$ref": "#/$defs/CustomParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CustomCreate",
       "type": "object"
     },
@@ -1738,9 +1609,7 @@
           "$ref": "#/$defs/DeactivateBlockParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DeactivateBlockCreate",
       "type": "object"
     },
@@ -1753,9 +1622,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "DeactivateBlockParams",
       "type": "object"
     },
@@ -1790,9 +1657,7 @@
           "$ref": "#/$defs/DeactivateHeaterParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DeactivateHeaterCreate",
       "type": "object"
     },
@@ -1805,9 +1670,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "DeactivateHeaterParams",
       "type": "object"
     },
@@ -1842,9 +1705,7 @@
           "$ref": "#/$defs/DeactivateLidParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DeactivateLidCreate",
       "type": "object"
     },
@@ -1857,9 +1718,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "DeactivateLidParams",
       "type": "object"
     },
@@ -1894,9 +1753,7 @@
           "$ref": "#/$defs/DeactivateShakerParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DeactivateShakerCreate",
       "type": "object"
     },
@@ -1909,9 +1766,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "DeactivateShakerParams",
       "type": "object"
     },
@@ -1946,9 +1801,7 @@
           "$ref": "#/$defs/DeactivateTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DeactivateTemperatureCreate",
       "type": "object"
     },
@@ -1961,9 +1814,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "DeactivateTemperatureParams",
       "type": "object"
     },
@@ -1983,11 +1834,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ],
+      "required": ["x", "y", "z"],
       "title": "DeckPoint",
       "type": "object"
     },
@@ -1999,9 +1846,7 @@
           "description": "A slot on the robot's deck.\n\nThe plain numbers like `\"5\"` are for the OT-2, and the coordinates like `\"C2\"` are for the Flex.\n\nWhen you provide one of these values, you can use either style. It will automatically be converted to match the robot.\n\nWhen one of these values is returned, it will always match the robot."
         }
       },
-      "required": [
-        "slotName"
-      ],
+      "required": ["slotName"],
       "title": "DeckSlotLocation",
       "type": "object"
     },
@@ -2055,9 +1900,7 @@
           "title": "Duration"
         }
       },
-      "required": [
-        "duration"
-      ],
+      "required": ["duration"],
       "title": "DelayParams",
       "type": "object"
     },
@@ -2076,9 +1919,7 @@
           "title": "Params"
         }
       },
-      "required": [
-        "enable"
-      ],
+      "required": ["enable"],
       "title": "DelayProperties",
       "type": "object"
     },
@@ -2113,9 +1954,7 @@
           "$ref": "#/$defs/DisengageParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DisengageCreate",
       "type": "object"
     },
@@ -2128,9 +1967,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "DisengageParams",
       "type": "object"
     },
@@ -2165,9 +2002,7 @@
           "$ref": "#/$defs/DispenseParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DispenseCreate",
       "type": "object"
     },
@@ -2202,9 +2037,7 @@
           "$ref": "#/$defs/DispenseInPlaceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DispenseInPlaceCreate",
       "type": "object"
     },
@@ -2247,11 +2080,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["flowRate", "volume", "pipetteId"],
       "title": "DispenseInPlaceParams",
       "type": "object"
     },
@@ -2308,13 +2137,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
       "title": "DispenseParams",
       "type": "object"
     },
@@ -2349,9 +2172,7 @@
           "$ref": "#/$defs/DispenseWhileTrackingParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DispenseWhileTrackingCreate",
       "type": "object"
     },
@@ -2417,13 +2238,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
       "title": "DispenseWhileTrackingParams",
       "type": "object"
     },
@@ -2458,9 +2273,7 @@
           "$ref": "#/$defs/DropTipParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DropTipCreate",
       "type": "object"
     },
@@ -2495,9 +2308,7 @@
           "$ref": "#/$defs/DropTipInPlaceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "DropTipInPlaceCreate",
       "type": "object"
     },
@@ -2515,9 +2326,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ],
+      "required": ["pipetteId"],
       "title": "DropTipInPlaceParams",
       "type": "object"
     },
@@ -2559,11 +2368,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareId",
-        "wellName"
-      ],
+      "required": ["pipetteId", "labwareId", "wellName"],
       "title": "DropTipParams",
       "type": "object"
     },
@@ -2583,12 +2388,7 @@
     },
     "DropTipWellOrigin": {
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": [
-        "top",
-        "bottom",
-        "center",
-        "default"
-      ],
+      "enum": ["top", "bottom", "center", "default"],
       "title": "DropTipWellOrigin",
       "type": "string"
     },
@@ -2623,9 +2423,7 @@
           "$ref": "#/$defs/EmptyParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "EmptyCreate",
       "type": "object"
     },
@@ -2662,10 +2460,7 @@
           "description": "How to empty the stacker. If manualWithPause, pause the protocol until the client sends an interaction, and mark the labware pool as empty thereafter. If logical, do not pause but immediately apply the specified count."
         }
       },
-      "required": [
-        "moduleId",
-        "strategy"
-      ],
+      "required": ["moduleId", "strategy"],
       "title": "EmptyParams",
       "type": "object"
     },
@@ -2700,9 +2495,7 @@
           "$ref": "#/$defs/EngageParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "EngageCreate",
       "type": "object"
     },
@@ -2720,10 +2513,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId",
-        "height"
-      ],
+      "required": ["moduleId", "height"],
       "title": "EngageParams",
       "type": "object"
     },
@@ -2758,9 +2548,7 @@
           "$ref": "#/$defs/FillParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "FillCreate",
       "type": "object"
     },
@@ -2813,10 +2601,7 @@
           "description": "How to fill the stacker. If manualWithPause, pause the protocol until the client sends an interaction, and apply the new specified count thereafter. If logical, do not pause but immediately apply the specified count."
         }
       },
-      "required": [
-        "moduleId",
-        "strategy"
-      ],
+      "required": ["moduleId", "strategy"],
       "title": "FillParams",
       "type": "object"
     },
@@ -2851,9 +2636,7 @@
           "$ref": "#/$defs/GetNextTipParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "GetNextTipCreate",
       "type": "object"
     },
@@ -2879,10 +2662,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareIds"
-      ],
+      "required": ["pipetteId", "labwareIds"],
       "title": "GetNextTipParams",
       "type": "object"
     },
@@ -2917,9 +2697,7 @@
           "$ref": "#/$defs/GetTipPresenceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "GetTipPresenceCreate",
       "type": "object"
     },
@@ -2932,9 +2710,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ],
+      "required": ["pipetteId"],
       "title": "GetTipPresenceParams",
       "type": "object"
     },
@@ -2969,9 +2745,7 @@
           "$ref": "#/$defs/HomeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "HomeCreate",
       "type": "object"
     },
@@ -3026,9 +2800,7 @@
           "$ref": "#/$defs/IdentifyModuleParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "IdentifyModuleCreate",
       "type": "object"
     },
@@ -3063,11 +2835,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "model",
-        "moduleId",
-        "start"
-      ],
+      "required": ["model", "moduleId", "start"],
       "title": "IdentifyModuleParams",
       "type": "object"
     },
@@ -3102,9 +2870,7 @@
           "$ref": "#/$defs/InitializeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "InitializeCreate",
       "type": "object"
     },
@@ -3113,10 +2879,7 @@
       "properties": {
         "measureMode": {
           "description": "Initialize single or multi measurement mode.",
-          "enum": [
-            "single",
-            "multi"
-          ],
+          "enum": ["single", "multi"],
           "title": "Measuremode",
           "type": "string"
         },
@@ -3139,31 +2902,19 @@
           "type": "array"
         }
       },
-      "required": [
-        "moduleId",
-        "measureMode",
-        "sampleWavelengths"
-      ],
+      "required": ["moduleId", "measureMode", "sampleWavelengths"],
       "title": "InitializeParams",
       "type": "object"
     },
     "InstrumentSensorId": {
       "description": "Primary and secondary sensor ids.",
-      "enum": [
-        "primary",
-        "secondary",
-        "both"
-      ],
+      "enum": ["primary", "secondary", "both"],
       "title": "InstrumentSensorId",
       "type": "string"
     },
     "LabwareMovementStrategy": {
       "description": "Strategy to use for labware movement.",
-      "enum": [
-        "usingGripper",
-        "manualMoveWithPause",
-        "manualMoveWithoutPause"
-      ],
+      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
       "title": "LabwareMovementStrategy",
       "type": "string"
     },
@@ -3183,11 +2934,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ],
+      "required": ["x", "y", "z"],
       "title": "LabwareOffsetVector",
       "type": "object"
     },
@@ -3277,11 +3024,7 @@
           "title": "Zoffset"
         }
       },
-      "required": [
-        "zOffset",
-        "mmFromEdge",
-        "speed"
-      ],
+      "required": ["zOffset", "mmFromEdge", "speed"],
       "title": "LiquidClassTouchTipParams",
       "type": "object"
     },
@@ -3344,9 +3087,7 @@
           "$ref": "#/$defs/LiquidProbeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LiquidProbeCreate",
       "type": "object"
     },
@@ -3373,11 +3114,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "pipetteId"],
       "title": "LiquidProbeParams",
       "type": "object"
     },
@@ -3412,9 +3149,7 @@
           "$ref": "#/$defs/LoadLabwareParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LoadLabwareCreate",
       "type": "object"
     },
@@ -3477,12 +3212,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "location",
-        "loadName",
-        "namespace",
-        "version"
-      ],
+      "required": ["location", "loadName", "namespace", "version"],
       "title": "LoadLabwareParams",
       "type": "object"
     },
@@ -3517,9 +3247,7 @@
           "$ref": "#/$defs/LoadLidParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LoadLidCreate",
       "type": "object"
     },
@@ -3572,12 +3300,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "location",
-        "loadName",
-        "namespace",
-        "version"
-      ],
+      "required": ["location", "loadName", "namespace", "version"],
       "title": "LoadLidParams",
       "type": "object"
     },
@@ -3612,9 +3335,7 @@
           "$ref": "#/$defs/LoadLidStackParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LoadLidStackCreate",
       "type": "object"
     },
@@ -3685,13 +3406,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "location",
-        "loadName",
-        "namespace",
-        "version",
-        "quantity"
-      ],
+      "required": ["location", "loadName", "namespace", "version", "quantity"],
       "title": "LoadLidStackParams",
       "type": "object"
     },
@@ -3726,9 +3441,7 @@
           "$ref": "#/$defs/LoadLiquidClassParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LoadLiquidClassCreate",
       "type": "object"
     },
@@ -3745,9 +3458,7 @@
           "description": "The liquid class to store."
         }
       },
-      "required": [
-        "liquidClassRecord"
-      ],
+      "required": ["liquidClassRecord"],
       "title": "LoadLiquidClassParams",
       "type": "object"
     },
@@ -3782,9 +3493,7 @@
           "$ref": "#/$defs/LoadLiquidParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LoadLiquidCreate",
       "type": "object"
     },
@@ -3818,11 +3527,7 @@
           "type": "object"
         }
       },
-      "required": [
-        "liquidId",
-        "labwareId",
-        "volumeByWell"
-      ],
+      "required": ["liquidId", "labwareId", "volumeByWell"],
       "title": "LoadLiquidParams",
       "type": "object"
     },
@@ -3857,9 +3562,7 @@
           "$ref": "#/$defs/LoadModuleParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LoadModuleCreate",
       "type": "object"
     },
@@ -3880,10 +3583,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "model",
-        "location"
-      ],
+      "required": ["model", "location"],
       "title": "LoadModuleParams",
       "type": "object"
     },
@@ -3918,9 +3618,7 @@
           "$ref": "#/$defs/LoadPipetteParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "LoadPipetteCreate",
       "type": "object"
     },
@@ -3951,10 +3649,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteName",
-        "mount"
-      ],
+      "required": ["pipetteName", "mount"],
       "title": "LoadPipetteParams",
       "type": "object"
     },
@@ -3983,10 +3678,7 @@
           "title": "Volume"
         }
       },
-      "required": [
-        "repetitions",
-        "volume"
-      ],
+      "required": ["repetitions", "volume"],
       "title": "MixParams",
       "type": "object"
     },
@@ -4005,9 +3697,7 @@
           "title": "Params"
         }
       },
-      "required": [
-        "enable"
-      ],
+      "required": ["enable"],
       "title": "MixProperties",
       "type": "object"
     },
@@ -4020,9 +3710,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "ModuleLocation",
       "type": "object"
     },
@@ -4046,10 +3734,7 @@
     },
     "MotionModifier": {
       "description": "Motion modifier options for maintenance position moves.",
-      "enum": [
-        "lowerZAxesSequentially",
-        "lowerMountZAxis"
-      ],
+      "enum": ["lowerZAxesSequentially", "lowerMountZAxis"],
       "title": "MotionModifier",
       "type": "string"
     },
@@ -4070,11 +3755,7 @@
       "type": "string"
     },
     "MountType": {
-      "enum": [
-        "left",
-        "right",
-        "extension"
-      ],
+      "enum": ["left", "right", "extension"],
       "title": "MountType",
       "type": "string"
     },
@@ -4109,9 +3790,7 @@
           "$ref": "#/$defs/MoveAxesRelativeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveAxesRelativeCreate",
       "type": "object"
     },
@@ -4135,9 +3814,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "axis_map"
-      ],
+      "required": ["axis_map"],
       "title": "MoveAxesRelativeParams",
       "type": "object"
     },
@@ -4172,9 +3849,7 @@
           "$ref": "#/$defs/MoveAxesToParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveAxesToCreate",
       "type": "object"
     },
@@ -4209,9 +3884,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "axis_map"
-      ],
+      "required": ["axis_map"],
       "title": "MoveAxesToParams",
       "type": "object"
     },
@@ -4246,9 +3919,7 @@
           "$ref": "#/$defs/MoveLabwareParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveLabwareCreate",
       "type": "object"
     },
@@ -4305,11 +3976,7 @@
           "description": "Whether to use the gripper to perform the labware movement or to perform a manual movement with an option to pause."
         }
       },
-      "required": [
-        "labwareId",
-        "newLocation",
-        "strategy"
-      ],
+      "required": ["labwareId", "newLocation", "strategy"],
       "title": "MoveLabwareParams",
       "type": "object"
     },
@@ -4344,9 +4011,7 @@
           "$ref": "#/$defs/MoveRelativeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveRelativeCreate",
       "type": "object"
     },
@@ -4368,11 +4033,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "axis",
-        "distance"
-      ],
+      "required": ["pipetteId", "axis", "distance"],
       "title": "MoveRelativeParams",
       "type": "object"
     },
@@ -4407,9 +4068,7 @@
           "$ref": "#/$defs/MoveToAddressableAreaParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveToAddressableAreaCreate",
       "type": "object"
     },
@@ -4444,9 +4103,7 @@
           "$ref": "#/$defs/MoveToAddressableAreaForDropTipParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveToAddressableAreaForDropTipCreate",
       "type": "object"
     },
@@ -4499,10 +4156,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "pipetteId",
-        "addressableAreaName"
-      ],
+      "required": ["pipetteId", "addressableAreaName"],
       "title": "MoveToAddressableAreaForDropTipParams",
       "type": "object"
     },
@@ -4551,10 +4205,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "pipetteId",
-        "addressableAreaName"
-      ],
+      "required": ["pipetteId", "addressableAreaName"],
       "title": "MoveToAddressableAreaParams",
       "type": "object"
     },
@@ -4589,9 +4240,7 @@
           "$ref": "#/$defs/MoveToCoordinatesParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveToCoordinatesCreate",
       "type": "object"
     },
@@ -4624,10 +4273,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "pipetteId",
-        "coordinates"
-      ],
+      "required": ["pipetteId", "coordinates"],
       "title": "MoveToCoordinatesParams",
       "type": "object"
     },
@@ -4662,9 +4308,7 @@
           "$ref": "#/$defs/MoveToParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveToCreate",
       "type": "object"
     },
@@ -4699,9 +4343,7 @@
           "$ref": "#/$defs/MoveToMaintenancePositionParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveToMaintenancePositionCreate",
       "type": "object"
     },
@@ -4725,9 +4367,7 @@
           "description": "Gantry mount to move maintenance position."
         }
       },
-      "required": [
-        "mount"
-      ],
+      "required": ["mount"],
       "title": "MoveToMaintenancePositionParams",
       "type": "object"
     },
@@ -4748,10 +4388,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "mount",
-        "destination"
-      ],
+      "required": ["mount", "destination"],
       "title": "MoveToParams",
       "type": "object"
     },
@@ -4786,9 +4423,7 @@
           "$ref": "#/$defs/MoveToWellParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "MoveToWellCreate",
       "type": "object"
     },
@@ -4831,21 +4466,13 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "pipetteId"],
       "title": "MoveToWellParams",
       "type": "object"
     },
     "MovementAxis": {
       "description": "Axis on which to issue a relative movement.",
-      "enum": [
-        "x",
-        "y",
-        "z"
-      ],
+      "enum": ["x", "y", "z"],
       "title": "MovementAxis",
       "type": "string"
     },
@@ -5034,9 +4661,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId"
-      ],
+      "required": ["labwareId"],
       "title": "OnLabwareLocation",
       "type": "object"
     },
@@ -5071,9 +4696,7 @@
           "$ref": "#/$defs/OpenGripperJawParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "OpenGripperJawCreate",
       "type": "object"
     },
@@ -5114,9 +4737,7 @@
           "$ref": "#/$defs/OpenLabwareLatchParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "OpenLabwareLatchCreate",
       "type": "object"
     },
@@ -5129,9 +4750,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "OpenLabwareLatchParams",
       "type": "object"
     },
@@ -5166,9 +4785,7 @@
           "$ref": "#/$defs/OpenVentParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "OpenVentCreate",
       "type": "object"
     },
@@ -5181,9 +4798,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "OpenVentParams",
       "type": "object"
     },
@@ -5218,9 +4833,7 @@
           "$ref": "#/$defs/PickUpTipParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "PickUpTipCreate",
       "type": "object"
     },
@@ -5247,11 +4860,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareId",
-        "wellName"
-      ],
+      "required": ["pipetteId", "labwareId", "wellName"],
       "title": "PickUpTipParams",
       "type": "object"
     },
@@ -5271,11 +4880,7 @@
     },
     "PickUpTipWellOrigin": {
       "description": "The origin of a PickUpTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": [
-        "top",
-        "bottom",
-        "center"
-      ],
+      "enum": ["top", "bottom", "center"],
       "title": "PickUpTipWellOrigin",
       "type": "string"
     },
@@ -5307,12 +4912,7 @@
     },
     "PositionReference": {
       "description": "Positional reference for liquid handling operations.",
-      "enum": [
-        "well-bottom",
-        "well-top",
-        "well-center",
-        "liquid-meniscus"
-      ],
+      "enum": ["well-bottom", "well-top", "well-center", "liquid-meniscus"],
       "title": "PositionReference",
       "type": "string"
     },
@@ -5347,9 +4947,7 @@
           "$ref": "#/$defs/PrepareToAspirateParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "PrepareToAspirateCreate",
       "type": "object"
     },
@@ -5362,9 +4960,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ],
+      "required": ["pipetteId"],
       "title": "PrepareToAspirateParams",
       "type": "object"
     },
@@ -5399,9 +4995,7 @@
           "$ref": "#/$defs/PressureDispenseParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "PressureDispenseCreate",
       "type": "object"
     },
@@ -5453,13 +5047,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "flowRate",
-        "volume",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
       "title": "PressureDispenseParams",
       "type": "object"
     },
@@ -5480,10 +5068,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "steps",
-        "repetitions"
-      ],
+      "required": ["steps", "repetitions"],
       "title": "ProfileCycle",
       "type": "object"
     },
@@ -5506,10 +5091,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "celsius",
-        "holdSeconds"
-      ],
+      "required": ["celsius", "holdSeconds"],
       "title": "ProfileStep",
       "type": "object"
     },
@@ -5530,12 +5112,7 @@
         },
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -5546,11 +5123,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle",
-        "frontRightNozzle",
-        "backLeftNozzle"
-      ],
+      "required": ["primaryNozzle", "frontRightNozzle", "backLeftNozzle"],
       "title": "QuadrantNozzleLayoutConfiguration",
       "type": "object"
     },
@@ -5585,9 +5158,7 @@
           "$ref": "#/$defs/ReadAbsorbanceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "ReadAbsorbanceCreate",
       "type": "object"
     },
@@ -5605,9 +5176,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "ReadAbsorbanceParams",
       "type": "object"
     },
@@ -5642,9 +5211,7 @@
           "$ref": "#/$defs/ReloadLabwareParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "ReloadLabwareCreate",
       "type": "object"
     },
@@ -5657,9 +5224,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId"
-      ],
+      "required": ["labwareId"],
       "title": "ReloadLabwareParams",
       "type": "object"
     },
@@ -5771,9 +5336,7 @@
           "$ref": "#/$defs/RetractAxisParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "RetractAxisCreate",
       "type": "object"
     },
@@ -5785,9 +5348,7 @@
           "description": "Axis to retract to its home position as quickly as safely possible. The difference between retracting an axis and homing an axis using the home command is that a home will always probe the limit switch and will work as the first motion command a robot will need to execute; On the other hand, retraction will rely on this previously determined  home position to move to it as fast as safely possible. So on the Flex, it will move (fast) the axis to the previously recorded home position and on the OT2, it will move (fast) the axis a safe distance from the previously recorded home position, and then slowly approach the limit switch."
         }
       },
-      "required": [
-        "axis"
-      ],
+      "required": ["axis"],
       "title": "RetractAxisParams",
       "type": "object"
     },
@@ -5904,9 +5465,7 @@
           "$ref": "#/$defs/RetrieveParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "RetrieveCreate",
       "type": "object"
     },
@@ -5939,9 +5498,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "RetrieveParams",
       "type": "object"
     },
@@ -5950,12 +5507,7 @@
       "properties": {
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -5966,9 +5518,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ],
+      "required": ["primaryNozzle"],
       "title": "RowNozzleLayoutConfiguration",
       "type": "object"
     },
@@ -6003,9 +5553,7 @@
           "$ref": "#/$defs/RunExtendedProfileParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "RunExtendedProfileCreate",
       "type": "object"
     },
@@ -6038,10 +5586,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "moduleId",
-        "profileElements"
-      ],
+      "required": ["moduleId", "profileElements"],
       "title": "RunExtendedProfileParams",
       "type": "object"
     },
@@ -6076,9 +5621,7 @@
           "$ref": "#/$defs/RunProfileParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "RunProfileCreate",
       "type": "object"
     },
@@ -6104,10 +5647,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "moduleId",
-        "profile"
-      ],
+      "required": ["moduleId", "profile"],
       "title": "RunProfileParams",
       "type": "object"
     },
@@ -6130,10 +5670,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "celsius",
-        "holdSeconds"
-      ],
+      "required": ["celsius", "holdSeconds"],
       "title": "RunProfileStepParams",
       "type": "object"
     },
@@ -6168,9 +5705,7 @@
           "$ref": "#/$defs/SavePositionParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SavePositionCreate",
       "type": "object"
     },
@@ -6193,9 +5728,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ],
+      "required": ["pipetteId"],
       "title": "SavePositionParams",
       "type": "object"
     },
@@ -6230,9 +5763,7 @@
           "$ref": "#/$defs/SealPipetteToTipParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SealPipetteToTipCreate",
       "type": "object"
     },
@@ -6271,11 +5802,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareId",
-        "wellName"
-      ],
+      "required": ["pipetteId", "labwareId", "wellName"],
       "title": "SealPipetteToTipParams",
       "type": "object"
     },
@@ -6310,9 +5837,7 @@
           "$ref": "#/$defs/SetAndWaitForShakeSpeedParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetAndWaitForShakeSpeedCreate",
       "type": "object"
     },
@@ -6330,10 +5855,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "moduleId",
-        "rpm"
-      ],
+      "required": ["moduleId", "rpm"],
       "title": "SetAndWaitForShakeSpeedParams",
       "type": "object"
     },
@@ -6368,9 +5890,7 @@
           "$ref": "#/$defs/SetRailLightsParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetRailLightsCreate",
       "type": "object"
     },
@@ -6383,9 +5903,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "on"
-      ],
+      "required": ["on"],
       "title": "SetRailLightsParams",
       "type": "object"
     },
@@ -6420,9 +5938,7 @@
           "$ref": "#/$defs/SetShakeSpeedParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetShakeSpeedCreate",
       "type": "object"
     },
@@ -6453,10 +5969,7 @@
           "title": "Taskid"
         }
       },
-      "required": [
-        "moduleId",
-        "rpm"
-      ],
+      "required": ["moduleId", "rpm"],
       "title": "SetShakeSpeedParams",
       "type": "object"
     },
@@ -6491,9 +6004,7 @@
           "$ref": "#/$defs/SetStatusBarParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetStatusBarCreate",
       "type": "object"
     },
@@ -6505,9 +6016,7 @@
           "description": "The animation that should be executed on the status bar."
         }
       },
-      "required": [
-        "animation"
-      ],
+      "required": ["animation"],
       "title": "SetStatusBarParams",
       "type": "object"
     },
@@ -6542,9 +6051,7 @@
           "$ref": "#/$defs/SetStoredLabwareParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetStoredLabwareCreate",
       "type": "object"
     },
@@ -6616,10 +6123,7 @@
           "description": "The details of the primary labware (i.e. not the lid or adapter, if any) stored in the stacker."
         }
       },
-      "required": [
-        "moduleId",
-        "primaryLabware"
-      ],
+      "required": ["moduleId", "primaryLabware"],
       "title": "SetStoredLabwareParams",
       "type": "object"
     },
@@ -6654,9 +6158,7 @@
           "$ref": "#/$defs/SetTargetBlockTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetTargetBlockTemperatureCreate",
       "type": "object"
     },
@@ -6694,10 +6196,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ],
+      "required": ["moduleId", "celsius"],
       "title": "SetTargetBlockTemperatureParams",
       "type": "object"
     },
@@ -6732,9 +6231,7 @@
           "$ref": "#/$defs/SetTargetLidTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetTargetLidTemperatureCreate",
       "type": "object"
     },
@@ -6757,10 +6254,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ],
+      "required": ["moduleId", "celsius"],
       "title": "SetTargetLidTemperatureParams",
       "type": "object"
     },
@@ -6795,9 +6289,7 @@
           "$ref": "#/$defs/SetTipStateParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetTipStateCreate",
       "type": "object"
     },
@@ -6822,11 +6314,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "labwareId",
-        "wellNames",
-        "tipWellState"
-      ],
+      "required": ["labwareId", "wellNames", "tipWellState"],
       "title": "SetTipStateParams",
       "type": "object"
     },
@@ -6979,12 +6467,7 @@
       "properties": {
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": [
-            "A1",
-            "H1",
-            "A12",
-            "H12"
-          ],
+          "enum": ["A1", "H1", "A12", "H12"],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -6995,27 +6478,19 @@
           "type": "string"
         }
       },
-      "required": [
-        "primaryNozzle"
-      ],
+      "required": ["primaryNozzle"],
       "title": "SingleNozzleLayoutConfiguration",
       "type": "object"
     },
     "StackerFillEmptyStrategy": {
       "description": "Strategy to use for filling or emptying a stacker.",
-      "enum": [
-        "manualWithPause",
-        "logical"
-      ],
+      "enum": ["manualWithPause", "logical"],
       "title": "StackerFillEmptyStrategy",
       "type": "string"
     },
     "StackerLabwareMovementStrategy": {
       "description": "Strategy to retrieve or store labware.",
-      "enum": [
-        "automatic",
-        "manual"
-      ],
+      "enum": ["automatic", "manual"],
       "title": "StackerLabwareMovementStrategy",
       "type": "string"
     },
@@ -7038,11 +6513,7 @@
           "type": "integer"
         }
       },
-      "required": [
-        "loadName",
-        "namespace",
-        "version"
-      ],
+      "required": ["loadName", "namespace", "version"],
       "title": "StackerStoredLabwareDetails",
       "type": "object"
     },
@@ -7064,9 +6535,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "primaryLabwareId"
-      ],
+      "required": ["primaryLabwareId"],
       "title": "StackerStoredLabwareGroup",
       "type": "object"
     },
@@ -7101,9 +6570,7 @@
           "$ref": "#/$defs/StartRunExtendedProfileParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "StartRunExtendedProfileCreate",
       "type": "object"
     },
@@ -7149,10 +6616,7 @@
           "title": "Taskid"
         }
       },
-      "required": [
-        "moduleId",
-        "profileElements"
-      ],
+      "required": ["moduleId", "profileElements"],
       "title": "StartRunExtendedProfileParams",
       "type": "object"
     },
@@ -7187,9 +6651,7 @@
           "$ref": "#/$defs/StartRunProfileParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "StartRunProfileCreate",
       "type": "object"
     },
@@ -7233,10 +6695,7 @@
           "title": "Taskid"
         }
       },
-      "required": [
-        "moduleId",
-        "profile"
-      ],
+      "required": ["moduleId", "profile"],
       "title": "StartRunProfileParams",
       "type": "object"
     },
@@ -7271,9 +6730,7 @@
           "$ref": "#/$defs/StartSetVacuumPowerParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "StartSetVacuumPowerCreate",
       "type": "object"
     },
@@ -7315,10 +6772,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "moduleId",
-        "percentPower"
-      ],
+      "required": ["moduleId", "percentPower"],
       "title": "StartSetVacuumPowerParams",
       "type": "object"
     },
@@ -7353,9 +6807,7 @@
           "$ref": "#/$defs/StartSetVacuumPressureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "StartSetVacuumPressureCreate",
       "type": "object"
     },
@@ -7397,22 +6849,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "moduleId",
-        "gaugePressure"
-      ],
+      "required": ["moduleId", "gaugePressure"],
       "title": "StartSetVacuumPressureParams",
       "type": "object"
     },
     "StatusBarAnimation": {
       "description": "Status Bar animation options.",
-      "enum": [
-        "idle",
-        "confirm",
-        "updating",
-        "disco",
-        "off"
-      ],
+      "enum": ["idle", "confirm", "updating", "disco", "off"],
       "title": "StatusBarAnimation",
       "type": "string"
     },
@@ -7447,9 +6890,7 @@
           "$ref": "#/$defs/StopVacuumParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "StopVacuumCreate",
       "type": "object"
     },
@@ -7462,9 +6903,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "StopVacuumParams",
       "type": "object"
     },
@@ -7499,9 +6938,7 @@
           "$ref": "#/$defs/StoreParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "StoreCreate",
       "type": "object"
     },
@@ -7518,10 +6955,7 @@
           "description": "If manual, indicates that labware has been moved to the hopper manually by the user, as required in error recovery."
         }
       },
-      "required": [
-        "moduleId",
-        "strategy"
-      ],
+      "required": ["moduleId", "strategy"],
       "title": "StoreParams",
       "type": "object"
     },
@@ -7552,11 +6986,7 @@
           "description": "Tip position before starting the submerge."
         }
       },
-      "required": [
-        "startPosition",
-        "speed",
-        "delay"
-      ],
+      "required": ["startPosition", "speed", "delay"],
       "title": "Submerge",
       "type": "object"
     },
@@ -7598,30 +7028,19 @@
           "description": "Position reference for tip position."
         }
       },
-      "required": [
-        "positionReference",
-        "offset"
-      ],
+      "required": ["positionReference", "offset"],
       "title": "TipPosition",
       "type": "object"
     },
     "TipPresenceStatus": {
       "description": "Tip presence status reported by a pipette.",
-      "enum": [
-        "present",
-        "absent",
-        "unknown"
-      ],
+      "enum": ["present", "absent", "unknown"],
       "title": "TipPresenceStatus",
       "type": "string"
     },
     "TipRackWellState": {
       "description": "The state of a single tip in a tip rack's well.",
-      "enum": [
-        "clean",
-        "used",
-        "empty"
-      ],
+      "enum": ["clean", "used", "empty"],
       "title": "TipRackWellState",
       "type": "string"
     },
@@ -7656,9 +7075,7 @@
           "$ref": "#/$defs/TouchTipParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "TouchTipCreate",
       "type": "object"
     },
@@ -7701,11 +7118,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "pipetteId"],
       "title": "TouchTipParams",
       "type": "object"
     },
@@ -7724,9 +7137,7 @@
           "title": "Params"
         }
       },
-      "required": [
-        "enable"
-      ],
+      "required": ["enable"],
       "title": "TouchTipProperties",
       "type": "object"
     },
@@ -7761,9 +7172,7 @@
           "$ref": "#/$defs/TryLiquidProbeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "TryLiquidProbeCreate",
       "type": "object"
     },
@@ -7790,11 +7199,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "labwareId",
-        "wellName",
-        "pipetteId"
-      ],
+      "required": ["labwareId", "wellName", "pipetteId"],
       "title": "TryLiquidProbeParams",
       "type": "object"
     },
@@ -7829,9 +7234,7 @@
           "$ref": "#/$defs/UnsafeBlowOutInPlaceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeBlowOutInPlaceCreate",
       "type": "object"
     },
@@ -7850,10 +7253,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "flowRate",
-        "pipetteId"
-      ],
+      "required": ["flowRate", "pipetteId"],
       "title": "UnsafeBlowOutInPlaceParams",
       "type": "object"
     },
@@ -7888,9 +7288,7 @@
           "$ref": "#/$defs/UnsafeDropTipInPlaceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeDropTipInPlaceCreate",
       "type": "object"
     },
@@ -7908,9 +7306,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId"
-      ],
+      "required": ["pipetteId"],
       "title": "UnsafeDropTipInPlaceParams",
       "type": "object"
     },
@@ -7945,9 +7341,7 @@
           "$ref": "#/$defs/UnsafeEngageAxesParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeEngageAxesCreate",
       "type": "object"
     },
@@ -7963,9 +7357,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "axes"
-      ],
+      "required": ["axes"],
       "title": "UnsafeEngageAxesParams",
       "type": "object"
     },
@@ -8000,9 +7392,7 @@
           "$ref": "#/$defs/UnsafeFlexStackerCloseLatchParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeFlexStackerCloseLatchCreate",
       "type": "object"
     },
@@ -8015,9 +7405,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "UnsafeFlexStackerCloseLatchParams",
       "type": "object"
     },
@@ -8052,9 +7440,7 @@
           "$ref": "#/$defs/UnsafeFlexStackerManualRetrieveParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeFlexStackerManualRetrieveCreate",
       "type": "object"
     },
@@ -8087,9 +7473,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "UnsafeFlexStackerManualRetrieveParams",
       "type": "object"
     },
@@ -8124,9 +7508,7 @@
           "$ref": "#/$defs/UnsafeFlexStackerOpenLatchParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeFlexStackerOpenLatchCreate",
       "type": "object"
     },
@@ -8139,9 +7521,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "UnsafeFlexStackerOpenLatchParams",
       "type": "object"
     },
@@ -8176,9 +7556,7 @@
           "$ref": "#/$defs/UnsafeFlexStackerPrepareShuttleParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeFlexStackerPrepareShuttleCreate",
       "type": "object"
     },
@@ -8197,9 +7575,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "UnsafeFlexStackerPrepareShuttleParams",
       "type": "object"
     },
@@ -8234,9 +7610,7 @@
           "$ref": "#/$defs/UnsafePlaceLabwareParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafePlaceLabwareCreate",
       "type": "object"
     },
@@ -8267,10 +7641,7 @@
           "title": "Location"
         }
       },
-      "required": [
-        "labwareURI",
-        "location"
-      ],
+      "required": ["labwareURI", "location"],
       "title": "UnsafePlaceLabwareParams",
       "type": "object"
     },
@@ -8305,9 +7676,7 @@
           "$ref": "#/$defs/UnsafeUngripLabwareParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsafeUngripLabwareCreate",
       "type": "object"
     },
@@ -8348,9 +7717,7 @@
           "$ref": "#/$defs/UnsealPipetteFromTipParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UnsealPipetteFromTipCreate",
       "type": "object"
     },
@@ -8377,11 +7744,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "labwareId",
-        "wellName"
-      ],
+      "required": ["pipetteId", "labwareId", "wellName"],
       "title": "UnsealPipetteFromTipParams",
       "type": "object"
     },
@@ -8416,9 +7779,7 @@
           "$ref": "#/$defs/UpdatePositionEstimatorsParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "UpdatePositionEstimatorsCreate",
       "type": "object"
     },
@@ -8434,9 +7795,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "axes"
-      ],
+      "required": ["axes"],
       "title": "UpdatePositionEstimatorsParams",
       "type": "object"
     },
@@ -8467,10 +7826,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "steps",
-        "repetitions"
-      ],
+      "required": ["steps", "repetitions"],
       "title": "VacuumModuleProfileCycle",
       "type": "object"
     },
@@ -8512,9 +7868,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "enablePump"
-      ],
+      "required": ["enablePump"],
       "title": "VacuumModuleProfilePowerStep",
       "type": "object"
     },
@@ -8556,9 +7910,7 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "enablePump"
-      ],
+      "required": ["enablePump"],
       "title": "VacuumModuleProfilePressureStep",
       "type": "object"
     },
@@ -8578,11 +7930,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "x",
-        "y",
-        "z"
-      ],
+      "required": ["x", "y", "z"],
       "title": "Vec3f",
       "type": "object"
     },
@@ -8617,9 +7965,7 @@
           "$ref": "#/$defs/VerifyTipPresenceParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "VerifyTipPresenceCreate",
       "type": "object"
     },
@@ -8641,10 +7987,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "pipetteId",
-        "expectedState"
-      ],
+      "required": ["pipetteId", "expectedState"],
       "title": "VerifyTipPresenceParams",
       "type": "object"
     },
@@ -8679,9 +8022,7 @@
           "$ref": "#/$defs/WaitForBlockTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "WaitForBlockTemperatureCreate",
       "type": "object"
     },
@@ -8694,9 +8035,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "WaitForBlockTemperatureParams",
       "type": "object"
     },
@@ -8731,9 +8070,7 @@
           "$ref": "#/$defs/WaitForDurationParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "WaitForDurationCreate",
       "type": "object"
     },
@@ -8751,9 +8088,7 @@
           "type": "number"
         }
       },
-      "required": [
-        "seconds"
-      ],
+      "required": ["seconds"],
       "title": "WaitForDurationParams",
       "type": "object"
     },
@@ -8788,9 +8123,7 @@
           "$ref": "#/$defs/WaitForLidTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "WaitForLidTemperatureCreate",
       "type": "object"
     },
@@ -8803,9 +8136,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "WaitForLidTemperatureParams",
       "type": "object"
     },
@@ -8822,10 +8153,7 @@
         },
         "commandType": {
           "default": "waitForResume",
-          "enum": [
-            "waitForResume",
-            "pause"
-          ],
+          "enum": ["waitForResume", "pause"],
           "title": "Commandtype",
           "type": "string"
         },
@@ -8843,9 +8171,7 @@
           "$ref": "#/$defs/WaitForResumeParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "WaitForResumeCreate",
       "type": "object"
     },
@@ -8892,9 +8218,7 @@
           "$ref": "#/$defs/WaitForTasksParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "WaitForTasksCreate",
       "type": "object"
     },
@@ -8910,9 +8234,7 @@
           "type": "array"
         }
       },
-      "required": [
-        "task_ids"
-      ],
+      "required": ["task_ids"],
       "title": "WaitForTasksParams",
       "type": "object"
     },
@@ -8960,12 +8282,7 @@
     },
     "WellOrigin": {
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    MENISCUS: the meniscus-center of the well",
-      "enum": [
-        "top",
-        "bottom",
-        "center",
-        "meniscus"
-      ],
+      "enum": ["top", "bottom", "center", "meniscus"],
       "title": "WellOrigin",
       "type": "string"
     },
@@ -9000,9 +8317,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CloseLidCreate",
       "type": "object"
     },
@@ -9015,9 +8330,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "CloseLidParams",
       "type": "object"
     },
@@ -9052,9 +8365,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "OpenLidCreate",
       "type": "object"
     },
@@ -9067,9 +8378,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "OpenLidParams",
       "type": "object"
     },
@@ -9104,9 +8413,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetTargetTemperatureCreate",
       "type": "object"
     },
@@ -9129,10 +8436,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ],
+      "required": ["moduleId", "celsius"],
       "title": "SetTargetTemperatureParams",
       "type": "object"
     },
@@ -9167,9 +8471,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "WaitForTemperatureCreate",
       "type": "object"
     },
@@ -9187,9 +8489,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "WaitForTemperatureParams",
       "type": "object"
     },
@@ -9224,9 +8524,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "SetTargetTemperatureCreate",
       "type": "object"
     },
@@ -9249,10 +8547,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId",
-        "celsius"
-      ],
+      "required": ["moduleId", "celsius"],
       "title": "SetTargetTemperatureParams",
       "type": "object"
     },
@@ -9287,9 +8582,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "WaitForTemperatureCreate",
       "type": "object"
     },
@@ -9307,9 +8600,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "WaitForTemperatureParams",
       "type": "object"
     },
@@ -9344,9 +8635,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "CloseLidCreate",
       "type": "object"
     },
@@ -9359,9 +8648,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "CloseLidParams",
       "type": "object"
     },
@@ -9396,9 +8683,7 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidParams"
         }
       },
-      "required": [
-        "params"
-      ],
+      "required": ["params"],
       "title": "OpenLidCreate",
       "type": "object"
     },
@@ -9411,9 +8696,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "moduleId"
-      ],
+      "required": ["moduleId"],
       "title": "OpenLidParams",
       "type": "object"
     }

--- a/shared-data/command/schemas/17.json
+++ b/shared-data/command/schemas/17.json
@@ -9,7 +9,9 @@
           "type": "string"
         }
       },
-      "required": ["addressableAreaName"],
+      "required": [
+        "addressableAreaName"
+      ],
       "title": "AddressableAreaLocation",
       "type": "object"
     },
@@ -29,7 +31,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"],
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
       "title": "AddressableOffsetVector",
       "type": "object"
     },
@@ -64,7 +70,9 @@
           "$ref": "#/$defs/AirGapInPlaceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "AirGapInPlaceCreate",
       "type": "object"
     },
@@ -102,7 +110,11 @@
           "type": "number"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"],
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "AirGapInPlaceParams",
       "type": "object"
     },
@@ -150,7 +162,9 @@
           "$ref": "#/$defs/AspirateParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "AspirateCreate",
       "type": "object"
     },
@@ -185,7 +199,9 @@
           "$ref": "#/$defs/AspirateInPlaceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "AspirateInPlaceCreate",
       "type": "object"
     },
@@ -223,7 +239,11 @@
           "type": "number"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"],
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "AspirateInPlaceParams",
       "type": "object"
     },
@@ -275,7 +295,13 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "AspirateParams",
       "type": "object"
     },
@@ -423,7 +449,9 @@
           "$ref": "#/$defs/AspirateWhileTrackingParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "AspirateWhileTrackingCreate",
       "type": "object"
     },
@@ -484,7 +512,13 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "AspirateWhileTrackingParams",
       "type": "object"
     },
@@ -519,7 +553,9 @@
           "$ref": "#/$defs/BlowOutParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "BlowOutCreate",
       "type": "object"
     },
@@ -554,7 +590,9 @@
           "$ref": "#/$defs/BlowOutInPlaceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "BlowOutInPlaceCreate",
       "type": "object"
     },
@@ -573,7 +611,10 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "pipetteId"],
+      "required": [
+        "flowRate",
+        "pipetteId"
+      ],
       "title": "BlowOutInPlaceParams",
       "type": "object"
     },
@@ -606,13 +647,22 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "pipetteId"
+      ],
       "title": "BlowOutParams",
       "type": "object"
     },
     "BlowoutLocation": {
       "description": "Location for blowout during a transfer function.",
-      "enum": ["source", "destination", "trash"],
+      "enum": [
+        "source",
+        "destination",
+        "trash"
+      ],
       "title": "BlowoutLocation",
       "type": "string"
     },
@@ -651,7 +701,10 @@
           "description": "Location well or trash entity for blow out."
         }
       },
-      "required": ["location", "flowRate"],
+      "required": [
+        "location",
+        "flowRate"
+      ],
       "title": "BlowoutParams",
       "type": "object"
     },
@@ -670,7 +723,9 @@
           "title": "Params"
         }
       },
-      "required": ["enable"],
+      "required": [
+        "enable"
+      ],
       "title": "BlowoutProperties",
       "type": "object"
     },
@@ -705,7 +760,9 @@
           "$ref": "#/$defs/CSVWriteRowParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CSVWriteRowCreate",
       "type": "object"
     },
@@ -726,7 +783,10 @@
           "type": "array"
         }
       },
-      "required": ["fileId", "rowData"],
+      "required": [
+        "fileId",
+        "rowData"
+      ],
       "title": "CSVWriteRowParams",
       "type": "object"
     },
@@ -761,7 +821,9 @@
           "$ref": "#/$defs/CalibrateGripperParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CalibrateGripperCreate",
       "type": "object"
     },
@@ -778,12 +840,17 @@
           "title": "Otherjawoffset"
         }
       },
-      "required": ["jaw"],
+      "required": [
+        "jaw"
+      ],
       "title": "CalibrateGripperParams",
       "type": "object"
     },
     "CalibrateGripperParamsJaw": {
-      "enum": ["front", "rear"],
+      "enum": [
+        "front",
+        "rear"
+      ],
       "title": "CalibrateGripperParamsJaw",
       "type": "string"
     },
@@ -818,7 +885,9 @@
           "$ref": "#/$defs/CalibrateModuleParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CalibrateModuleCreate",
       "type": "object"
     },
@@ -840,7 +909,11 @@
           "description": "The instrument mount used to calibrate the module."
         }
       },
-      "required": ["moduleId", "labwareId", "mount"],
+      "required": [
+        "moduleId",
+        "labwareId",
+        "mount"
+      ],
       "title": "CalibrateModuleParams",
       "type": "object"
     },
@@ -875,7 +948,9 @@
           "$ref": "#/$defs/CalibratePipetteParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CalibratePipetteCreate",
       "type": "object"
     },
@@ -887,7 +962,9 @@
           "description": "Instrument mount to calibrate."
         }
       },
-      "required": ["mount"],
+      "required": [
+        "mount"
+      ],
       "title": "CalibratePipetteParams",
       "type": "object"
     },
@@ -922,7 +999,9 @@
           "$ref": "#/$defs/CaptureImageParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CaptureImageCreate",
       "type": "object"
     },
@@ -1067,7 +1146,9 @@
           "$ref": "#/$defs/CloseGripperJawParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CloseGripperJawCreate",
       "type": "object"
     },
@@ -1114,7 +1195,9 @@
           "$ref": "#/$defs/CloseLabwareLatchParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CloseLabwareLatchCreate",
       "type": "object"
     },
@@ -1127,7 +1210,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "CloseLabwareLatchParams",
       "type": "object"
     },
@@ -1162,7 +1247,9 @@
           "$ref": "#/$defs/CloseVentParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CloseVentCreate",
       "type": "object"
     },
@@ -1175,7 +1262,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "CloseVentParams",
       "type": "object"
     },
@@ -1184,7 +1273,12 @@
       "properties": {
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -1195,13 +1289,19 @@
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"],
+      "required": [
+        "primaryNozzle"
+      ],
       "title": "ColumnNozzleLayoutConfiguration",
       "type": "object"
     },
     "CommandIntent": {
       "description": "Run intent for a given command.\n\nProps:\n    PROTOCOL: the command is part of the protocol run itself.\n    SETUP: the command is part of the setup phase of a run.",
-      "enum": ["protocol", "setup", "fixit"],
+      "enum": [
+        "protocol",
+        "setup",
+        "fixit"
+      ],
       "title": "CommandIntent",
       "type": "string"
     },
@@ -1236,7 +1336,9 @@
           "$ref": "#/$defs/CommentParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CommentCreate",
       "type": "object"
     },
@@ -1249,7 +1351,9 @@
           "type": "string"
         }
       },
-      "required": ["message"],
+      "required": [
+        "message"
+      ],
       "title": "CommentParams",
       "type": "object"
     },
@@ -1284,7 +1388,9 @@
           "$ref": "#/$defs/ConfigureForVolumeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "ConfigureForVolumeCreate",
       "type": "object"
     },
@@ -1308,7 +1414,10 @@
           "type": "number"
         }
       },
-      "required": ["pipetteId", "volume"],
+      "required": [
+        "pipetteId",
+        "volume"
+      ],
       "title": "ConfigureForVolumeParams",
       "type": "object"
     },
@@ -1343,7 +1452,9 @@
           "$ref": "#/$defs/ConfigureNozzleLayoutParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "ConfigureNozzleLayoutCreate",
       "type": "object"
     },
@@ -1376,7 +1487,10 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "configurationParams"],
+      "required": [
+        "pipetteId",
+        "configurationParams"
+      ],
       "title": "ConfigureNozzleLayoutParams",
       "type": "object"
     },
@@ -1418,7 +1532,11 @@
           "title": "Z"
         }
       },
-      "required": ["x", "y", "z"],
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
       "title": "Coordinate",
       "type": "object"
     },
@@ -1453,7 +1571,9 @@
           "$ref": "#/$defs/CreateCSVParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CreateCSVCreate",
       "type": "object"
     },
@@ -1471,7 +1591,10 @@
           "type": "string"
         }
       },
-      "required": ["fileName", "columns"],
+      "required": [
+        "fileName",
+        "columns"
+      ],
       "title": "CreateCSVParams",
       "type": "object"
     },
@@ -1506,7 +1629,9 @@
           "$ref": "#/$defs/CreateTimerParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CreateTimerCreate",
       "type": "object"
     },
@@ -1532,7 +1657,9 @@
           "type": "number"
         }
       },
-      "required": ["time"],
+      "required": [
+        "time"
+      ],
       "title": "CreateTimerParams",
       "type": "object"
     },
@@ -1567,7 +1694,9 @@
           "$ref": "#/$defs/CustomParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CustomCreate",
       "type": "object"
     },
@@ -1609,7 +1738,9 @@
           "$ref": "#/$defs/DeactivateBlockParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DeactivateBlockCreate",
       "type": "object"
     },
@@ -1622,7 +1753,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "DeactivateBlockParams",
       "type": "object"
     },
@@ -1657,7 +1790,9 @@
           "$ref": "#/$defs/DeactivateHeaterParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DeactivateHeaterCreate",
       "type": "object"
     },
@@ -1670,7 +1805,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "DeactivateHeaterParams",
       "type": "object"
     },
@@ -1705,7 +1842,9 @@
           "$ref": "#/$defs/DeactivateLidParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DeactivateLidCreate",
       "type": "object"
     },
@@ -1718,7 +1857,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "DeactivateLidParams",
       "type": "object"
     },
@@ -1753,7 +1894,9 @@
           "$ref": "#/$defs/DeactivateShakerParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DeactivateShakerCreate",
       "type": "object"
     },
@@ -1766,7 +1909,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "DeactivateShakerParams",
       "type": "object"
     },
@@ -1801,7 +1946,9 @@
           "$ref": "#/$defs/DeactivateTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DeactivateTemperatureCreate",
       "type": "object"
     },
@@ -1814,7 +1961,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "DeactivateTemperatureParams",
       "type": "object"
     },
@@ -1834,7 +1983,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"],
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
       "title": "DeckPoint",
       "type": "object"
     },
@@ -1846,7 +1999,9 @@
           "description": "A slot on the robot's deck.\n\nThe plain numbers like `\"5\"` are for the OT-2, and the coordinates like `\"C2\"` are for the Flex.\n\nWhen you provide one of these values, you can use either style. It will automatically be converted to match the robot.\n\nWhen one of these values is returned, it will always match the robot."
         }
       },
-      "required": ["slotName"],
+      "required": [
+        "slotName"
+      ],
       "title": "DeckSlotLocation",
       "type": "object"
     },
@@ -1900,7 +2055,9 @@
           "title": "Duration"
         }
       },
-      "required": ["duration"],
+      "required": [
+        "duration"
+      ],
       "title": "DelayParams",
       "type": "object"
     },
@@ -1919,7 +2076,9 @@
           "title": "Params"
         }
       },
-      "required": ["enable"],
+      "required": [
+        "enable"
+      ],
       "title": "DelayProperties",
       "type": "object"
     },
@@ -1954,7 +2113,9 @@
           "$ref": "#/$defs/DisengageParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DisengageCreate",
       "type": "object"
     },
@@ -1967,7 +2128,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "DisengageParams",
       "type": "object"
     },
@@ -2002,7 +2165,9 @@
           "$ref": "#/$defs/DispenseParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DispenseCreate",
       "type": "object"
     },
@@ -2037,7 +2202,9 @@
           "$ref": "#/$defs/DispenseInPlaceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DispenseInPlaceCreate",
       "type": "object"
     },
@@ -2080,7 +2247,11 @@
           "type": "number"
         }
       },
-      "required": ["flowRate", "volume", "pipetteId"],
+      "required": [
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "DispenseInPlaceParams",
       "type": "object"
     },
@@ -2137,7 +2308,13 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "DispenseParams",
       "type": "object"
     },
@@ -2172,7 +2349,9 @@
           "$ref": "#/$defs/DispenseWhileTrackingParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DispenseWhileTrackingCreate",
       "type": "object"
     },
@@ -2238,7 +2417,13 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "DispenseWhileTrackingParams",
       "type": "object"
     },
@@ -2273,7 +2458,9 @@
           "$ref": "#/$defs/DropTipParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DropTipCreate",
       "type": "object"
     },
@@ -2308,7 +2495,9 @@
           "$ref": "#/$defs/DropTipInPlaceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "DropTipInPlaceCreate",
       "type": "object"
     },
@@ -2326,7 +2515,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"],
+      "required": [
+        "pipetteId"
+      ],
       "title": "DropTipInPlaceParams",
       "type": "object"
     },
@@ -2368,7 +2559,11 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "labwareId", "wellName"],
+      "required": [
+        "pipetteId",
+        "labwareId",
+        "wellName"
+      ],
       "title": "DropTipParams",
       "type": "object"
     },
@@ -2388,7 +2583,12 @@
     },
     "DropTipWellOrigin": {
       "description": "The origin of a DropTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    DEFAULT: the default drop-tip location of the well,\n        based on pipette configuration and length of the tip.",
-      "enum": ["top", "bottom", "center", "default"],
+      "enum": [
+        "top",
+        "bottom",
+        "center",
+        "default"
+      ],
       "title": "DropTipWellOrigin",
       "type": "string"
     },
@@ -2423,7 +2623,9 @@
           "$ref": "#/$defs/EmptyParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "EmptyCreate",
       "type": "object"
     },
@@ -2460,7 +2662,10 @@
           "description": "How to empty the stacker. If manualWithPause, pause the protocol until the client sends an interaction, and mark the labware pool as empty thereafter. If logical, do not pause but immediately apply the specified count."
         }
       },
-      "required": ["moduleId", "strategy"],
+      "required": [
+        "moduleId",
+        "strategy"
+      ],
       "title": "EmptyParams",
       "type": "object"
     },
@@ -2495,7 +2700,9 @@
           "$ref": "#/$defs/EngageParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "EngageCreate",
       "type": "object"
     },
@@ -2513,7 +2720,10 @@
           "type": "string"
         }
       },
-      "required": ["moduleId", "height"],
+      "required": [
+        "moduleId",
+        "height"
+      ],
       "title": "EngageParams",
       "type": "object"
     },
@@ -2548,7 +2758,9 @@
           "$ref": "#/$defs/FillParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "FillCreate",
       "type": "object"
     },
@@ -2601,7 +2813,10 @@
           "description": "How to fill the stacker. If manualWithPause, pause the protocol until the client sends an interaction, and apply the new specified count thereafter. If logical, do not pause but immediately apply the specified count."
         }
       },
-      "required": ["moduleId", "strategy"],
+      "required": [
+        "moduleId",
+        "strategy"
+      ],
       "title": "FillParams",
       "type": "object"
     },
@@ -2636,7 +2851,9 @@
           "$ref": "#/$defs/GetNextTipParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "GetNextTipCreate",
       "type": "object"
     },
@@ -2662,7 +2879,10 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "labwareIds"],
+      "required": [
+        "pipetteId",
+        "labwareIds"
+      ],
       "title": "GetNextTipParams",
       "type": "object"
     },
@@ -2697,7 +2917,9 @@
           "$ref": "#/$defs/GetTipPresenceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "GetTipPresenceCreate",
       "type": "object"
     },
@@ -2710,7 +2932,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"],
+      "required": [
+        "pipetteId"
+      ],
       "title": "GetTipPresenceParams",
       "type": "object"
     },
@@ -2745,7 +2969,9 @@
           "$ref": "#/$defs/HomeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "HomeCreate",
       "type": "object"
     },
@@ -2800,7 +3026,9 @@
           "$ref": "#/$defs/IdentifyModuleParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "IdentifyModuleCreate",
       "type": "object"
     },
@@ -2835,7 +3063,11 @@
           "type": "boolean"
         }
       },
-      "required": ["model", "moduleId", "start"],
+      "required": [
+        "model",
+        "moduleId",
+        "start"
+      ],
       "title": "IdentifyModuleParams",
       "type": "object"
     },
@@ -2870,7 +3102,9 @@
           "$ref": "#/$defs/InitializeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "InitializeCreate",
       "type": "object"
     },
@@ -2879,7 +3113,10 @@
       "properties": {
         "measureMode": {
           "description": "Initialize single or multi measurement mode.",
-          "enum": ["single", "multi"],
+          "enum": [
+            "single",
+            "multi"
+          ],
           "title": "Measuremode",
           "type": "string"
         },
@@ -2902,19 +3139,31 @@
           "type": "array"
         }
       },
-      "required": ["moduleId", "measureMode", "sampleWavelengths"],
+      "required": [
+        "moduleId",
+        "measureMode",
+        "sampleWavelengths"
+      ],
       "title": "InitializeParams",
       "type": "object"
     },
     "InstrumentSensorId": {
       "description": "Primary and secondary sensor ids.",
-      "enum": ["primary", "secondary", "both"],
+      "enum": [
+        "primary",
+        "secondary",
+        "both"
+      ],
       "title": "InstrumentSensorId",
       "type": "string"
     },
     "LabwareMovementStrategy": {
       "description": "Strategy to use for labware movement.",
-      "enum": ["usingGripper", "manualMoveWithPause", "manualMoveWithoutPause"],
+      "enum": [
+        "usingGripper",
+        "manualMoveWithPause",
+        "manualMoveWithoutPause"
+      ],
       "title": "LabwareMovementStrategy",
       "type": "string"
     },
@@ -2934,7 +3183,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"],
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
       "title": "LabwareOffsetVector",
       "type": "object"
     },
@@ -3024,7 +3277,11 @@
           "title": "Zoffset"
         }
       },
-      "required": ["zOffset", "mmFromEdge", "speed"],
+      "required": [
+        "zOffset",
+        "mmFromEdge",
+        "speed"
+      ],
       "title": "LiquidClassTouchTipParams",
       "type": "object"
     },
@@ -3087,7 +3344,9 @@
           "$ref": "#/$defs/LiquidProbeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LiquidProbeCreate",
       "type": "object"
     },
@@ -3114,7 +3373,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ],
       "title": "LiquidProbeParams",
       "type": "object"
     },
@@ -3149,7 +3412,9 @@
           "$ref": "#/$defs/LoadLabwareParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LoadLabwareCreate",
       "type": "object"
     },
@@ -3212,7 +3477,12 @@
           "type": "integer"
         }
       },
-      "required": ["location", "loadName", "namespace", "version"],
+      "required": [
+        "location",
+        "loadName",
+        "namespace",
+        "version"
+      ],
       "title": "LoadLabwareParams",
       "type": "object"
     },
@@ -3247,7 +3517,9 @@
           "$ref": "#/$defs/LoadLidParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LoadLidCreate",
       "type": "object"
     },
@@ -3300,7 +3572,12 @@
           "type": "integer"
         }
       },
-      "required": ["location", "loadName", "namespace", "version"],
+      "required": [
+        "location",
+        "loadName",
+        "namespace",
+        "version"
+      ],
       "title": "LoadLidParams",
       "type": "object"
     },
@@ -3335,7 +3612,9 @@
           "$ref": "#/$defs/LoadLidStackParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LoadLidStackCreate",
       "type": "object"
     },
@@ -3406,7 +3685,13 @@
           "type": "integer"
         }
       },
-      "required": ["location", "loadName", "namespace", "version", "quantity"],
+      "required": [
+        "location",
+        "loadName",
+        "namespace",
+        "version",
+        "quantity"
+      ],
       "title": "LoadLidStackParams",
       "type": "object"
     },
@@ -3441,7 +3726,9 @@
           "$ref": "#/$defs/LoadLiquidClassParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LoadLiquidClassCreate",
       "type": "object"
     },
@@ -3458,7 +3745,9 @@
           "description": "The liquid class to store."
         }
       },
-      "required": ["liquidClassRecord"],
+      "required": [
+        "liquidClassRecord"
+      ],
       "title": "LoadLiquidClassParams",
       "type": "object"
     },
@@ -3493,7 +3782,9 @@
           "$ref": "#/$defs/LoadLiquidParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LoadLiquidCreate",
       "type": "object"
     },
@@ -3527,7 +3818,11 @@
           "type": "object"
         }
       },
-      "required": ["liquidId", "labwareId", "volumeByWell"],
+      "required": [
+        "liquidId",
+        "labwareId",
+        "volumeByWell"
+      ],
       "title": "LoadLiquidParams",
       "type": "object"
     },
@@ -3562,7 +3857,9 @@
           "$ref": "#/$defs/LoadModuleParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LoadModuleCreate",
       "type": "object"
     },
@@ -3583,7 +3880,10 @@
           "type": "string"
         }
       },
-      "required": ["model", "location"],
+      "required": [
+        "model",
+        "location"
+      ],
       "title": "LoadModuleParams",
       "type": "object"
     },
@@ -3618,7 +3918,9 @@
           "$ref": "#/$defs/LoadPipetteParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "LoadPipetteCreate",
       "type": "object"
     },
@@ -3649,7 +3951,10 @@
           "type": "string"
         }
       },
-      "required": ["pipetteName", "mount"],
+      "required": [
+        "pipetteName",
+        "mount"
+      ],
       "title": "LoadPipetteParams",
       "type": "object"
     },
@@ -3678,7 +3983,10 @@
           "title": "Volume"
         }
       },
-      "required": ["repetitions", "volume"],
+      "required": [
+        "repetitions",
+        "volume"
+      ],
       "title": "MixParams",
       "type": "object"
     },
@@ -3697,7 +4005,9 @@
           "title": "Params"
         }
       },
-      "required": ["enable"],
+      "required": [
+        "enable"
+      ],
       "title": "MixProperties",
       "type": "object"
     },
@@ -3710,7 +4020,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "ModuleLocation",
       "type": "object"
     },
@@ -3734,7 +4046,10 @@
     },
     "MotionModifier": {
       "description": "Motion modifier options for maintenance position moves.",
-      "enum": ["lowerZAxesSequentially"],
+      "enum": [
+        "lowerZAxesSequentially",
+        "lowerMountZAxis"
+      ],
       "title": "MotionModifier",
       "type": "string"
     },
@@ -3755,7 +4070,11 @@
       "type": "string"
     },
     "MountType": {
-      "enum": ["left", "right", "extension"],
+      "enum": [
+        "left",
+        "right",
+        "extension"
+      ],
       "title": "MountType",
       "type": "string"
     },
@@ -3790,7 +4109,9 @@
           "$ref": "#/$defs/MoveAxesRelativeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveAxesRelativeCreate",
       "type": "object"
     },
@@ -3814,7 +4135,9 @@
           "type": "number"
         }
       },
-      "required": ["axis_map"],
+      "required": [
+        "axis_map"
+      ],
       "title": "MoveAxesRelativeParams",
       "type": "object"
     },
@@ -3849,7 +4172,9 @@
           "$ref": "#/$defs/MoveAxesToParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveAxesToCreate",
       "type": "object"
     },
@@ -3884,7 +4209,9 @@
           "type": "number"
         }
       },
-      "required": ["axis_map"],
+      "required": [
+        "axis_map"
+      ],
       "title": "MoveAxesToParams",
       "type": "object"
     },
@@ -3919,7 +4246,9 @@
           "$ref": "#/$defs/MoveLabwareParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveLabwareCreate",
       "type": "object"
     },
@@ -3976,7 +4305,11 @@
           "description": "Whether to use the gripper to perform the labware movement or to perform a manual movement with an option to pause."
         }
       },
-      "required": ["labwareId", "newLocation", "strategy"],
+      "required": [
+        "labwareId",
+        "newLocation",
+        "strategy"
+      ],
       "title": "MoveLabwareParams",
       "type": "object"
     },
@@ -4011,7 +4344,9 @@
           "$ref": "#/$defs/MoveRelativeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveRelativeCreate",
       "type": "object"
     },
@@ -4033,7 +4368,11 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "axis", "distance"],
+      "required": [
+        "pipetteId",
+        "axis",
+        "distance"
+      ],
       "title": "MoveRelativeParams",
       "type": "object"
     },
@@ -4068,7 +4407,9 @@
           "$ref": "#/$defs/MoveToAddressableAreaParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveToAddressableAreaCreate",
       "type": "object"
     },
@@ -4103,7 +4444,9 @@
           "$ref": "#/$defs/MoveToAddressableAreaForDropTipParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveToAddressableAreaForDropTipCreate",
       "type": "object"
     },
@@ -4156,7 +4499,10 @@
           "type": "number"
         }
       },
-      "required": ["pipetteId", "addressableAreaName"],
+      "required": [
+        "pipetteId",
+        "addressableAreaName"
+      ],
       "title": "MoveToAddressableAreaForDropTipParams",
       "type": "object"
     },
@@ -4205,7 +4551,10 @@
           "type": "boolean"
         }
       },
-      "required": ["pipetteId", "addressableAreaName"],
+      "required": [
+        "pipetteId",
+        "addressableAreaName"
+      ],
       "title": "MoveToAddressableAreaParams",
       "type": "object"
     },
@@ -4240,7 +4589,9 @@
           "$ref": "#/$defs/MoveToCoordinatesParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveToCoordinatesCreate",
       "type": "object"
     },
@@ -4273,7 +4624,10 @@
           "type": "number"
         }
       },
-      "required": ["pipetteId", "coordinates"],
+      "required": [
+        "pipetteId",
+        "coordinates"
+      ],
       "title": "MoveToCoordinatesParams",
       "type": "object"
     },
@@ -4308,7 +4662,9 @@
           "$ref": "#/$defs/MoveToParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveToCreate",
       "type": "object"
     },
@@ -4343,7 +4699,9 @@
           "$ref": "#/$defs/MoveToMaintenancePositionParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveToMaintenancePositionCreate",
       "type": "object"
     },
@@ -4367,7 +4725,9 @@
           "description": "Gantry mount to move maintenance position."
         }
       },
-      "required": ["mount"],
+      "required": [
+        "mount"
+      ],
       "title": "MoveToMaintenancePositionParams",
       "type": "object"
     },
@@ -4388,7 +4748,10 @@
           "type": "number"
         }
       },
-      "required": ["mount", "destination"],
+      "required": [
+        "mount",
+        "destination"
+      ],
       "title": "MoveToParams",
       "type": "object"
     },
@@ -4423,7 +4786,9 @@
           "$ref": "#/$defs/MoveToWellParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "MoveToWellCreate",
       "type": "object"
     },
@@ -4466,13 +4831,21 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ],
       "title": "MoveToWellParams",
       "type": "object"
     },
     "MovementAxis": {
       "description": "Axis on which to issue a relative movement.",
-      "enum": ["x", "y", "z"],
+      "enum": [
+        "x",
+        "y",
+        "z"
+      ],
       "title": "MovementAxis",
       "type": "string"
     },
@@ -4661,7 +5034,9 @@
           "type": "string"
         }
       },
-      "required": ["labwareId"],
+      "required": [
+        "labwareId"
+      ],
       "title": "OnLabwareLocation",
       "type": "object"
     },
@@ -4696,7 +5071,9 @@
           "$ref": "#/$defs/OpenGripperJawParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "OpenGripperJawCreate",
       "type": "object"
     },
@@ -4737,7 +5114,9 @@
           "$ref": "#/$defs/OpenLabwareLatchParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "OpenLabwareLatchCreate",
       "type": "object"
     },
@@ -4750,7 +5129,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "OpenLabwareLatchParams",
       "type": "object"
     },
@@ -4785,7 +5166,9 @@
           "$ref": "#/$defs/OpenVentParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "OpenVentCreate",
       "type": "object"
     },
@@ -4798,7 +5181,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "OpenVentParams",
       "type": "object"
     },
@@ -4833,7 +5218,9 @@
           "$ref": "#/$defs/PickUpTipParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "PickUpTipCreate",
       "type": "object"
     },
@@ -4860,7 +5247,11 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "labwareId", "wellName"],
+      "required": [
+        "pipetteId",
+        "labwareId",
+        "wellName"
+      ],
       "title": "PickUpTipParams",
       "type": "object"
     },
@@ -4880,7 +5271,11 @@
     },
     "PickUpTipWellOrigin": {
       "description": "The origin of a PickUpTipWellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well",
-      "enum": ["top", "bottom", "center"],
+      "enum": [
+        "top",
+        "bottom",
+        "center"
+      ],
       "title": "PickUpTipWellOrigin",
       "type": "string"
     },
@@ -4912,7 +5307,12 @@
     },
     "PositionReference": {
       "description": "Positional reference for liquid handling operations.",
-      "enum": ["well-bottom", "well-top", "well-center", "liquid-meniscus"],
+      "enum": [
+        "well-bottom",
+        "well-top",
+        "well-center",
+        "liquid-meniscus"
+      ],
       "title": "PositionReference",
       "type": "string"
     },
@@ -4947,7 +5347,9 @@
           "$ref": "#/$defs/PrepareToAspirateParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "PrepareToAspirateCreate",
       "type": "object"
     },
@@ -4960,7 +5362,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"],
+      "required": [
+        "pipetteId"
+      ],
       "title": "PrepareToAspirateParams",
       "type": "object"
     },
@@ -4995,7 +5399,9 @@
           "$ref": "#/$defs/PressureDispenseParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "PressureDispenseCreate",
       "type": "object"
     },
@@ -5047,7 +5453,13 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "flowRate", "volume", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "flowRate",
+        "volume",
+        "pipetteId"
+      ],
       "title": "PressureDispenseParams",
       "type": "object"
     },
@@ -5068,7 +5480,10 @@
           "type": "array"
         }
       },
-      "required": ["steps", "repetitions"],
+      "required": [
+        "steps",
+        "repetitions"
+      ],
       "title": "ProfileCycle",
       "type": "object"
     },
@@ -5091,7 +5506,10 @@
           "type": "number"
         }
       },
-      "required": ["celsius", "holdSeconds"],
+      "required": [
+        "celsius",
+        "holdSeconds"
+      ],
       "title": "ProfileStep",
       "type": "object"
     },
@@ -5112,7 +5530,12 @@
         },
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -5123,7 +5546,11 @@
           "type": "string"
         }
       },
-      "required": ["primaryNozzle", "frontRightNozzle", "backLeftNozzle"],
+      "required": [
+        "primaryNozzle",
+        "frontRightNozzle",
+        "backLeftNozzle"
+      ],
       "title": "QuadrantNozzleLayoutConfiguration",
       "type": "object"
     },
@@ -5158,7 +5585,9 @@
           "$ref": "#/$defs/ReadAbsorbanceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "ReadAbsorbanceCreate",
       "type": "object"
     },
@@ -5176,7 +5605,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "ReadAbsorbanceParams",
       "type": "object"
     },
@@ -5211,7 +5642,9 @@
           "$ref": "#/$defs/ReloadLabwareParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "ReloadLabwareCreate",
       "type": "object"
     },
@@ -5224,7 +5657,9 @@
           "type": "string"
         }
       },
-      "required": ["labwareId"],
+      "required": [
+        "labwareId"
+      ],
       "title": "ReloadLabwareParams",
       "type": "object"
     },
@@ -5336,7 +5771,9 @@
           "$ref": "#/$defs/RetractAxisParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "RetractAxisCreate",
       "type": "object"
     },
@@ -5348,7 +5785,9 @@
           "description": "Axis to retract to its home position as quickly as safely possible. The difference between retracting an axis and homing an axis using the home command is that a home will always probe the limit switch and will work as the first motion command a robot will need to execute; On the other hand, retraction will rely on this previously determined  home position to move to it as fast as safely possible. So on the Flex, it will move (fast) the axis to the previously recorded home position and on the OT2, it will move (fast) the axis a safe distance from the previously recorded home position, and then slowly approach the limit switch."
         }
       },
-      "required": ["axis"],
+      "required": [
+        "axis"
+      ],
       "title": "RetractAxisParams",
       "type": "object"
     },
@@ -5465,7 +5904,9 @@
           "$ref": "#/$defs/RetrieveParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "RetrieveCreate",
       "type": "object"
     },
@@ -5498,7 +5939,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "RetrieveParams",
       "type": "object"
     },
@@ -5507,7 +5950,12 @@
       "properties": {
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -5518,7 +5966,9 @@
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"],
+      "required": [
+        "primaryNozzle"
+      ],
       "title": "RowNozzleLayoutConfiguration",
       "type": "object"
     },
@@ -5553,7 +6003,9 @@
           "$ref": "#/$defs/RunExtendedProfileParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "RunExtendedProfileCreate",
       "type": "object"
     },
@@ -5586,7 +6038,10 @@
           "type": "array"
         }
       },
-      "required": ["moduleId", "profileElements"],
+      "required": [
+        "moduleId",
+        "profileElements"
+      ],
       "title": "RunExtendedProfileParams",
       "type": "object"
     },
@@ -5621,7 +6076,9 @@
           "$ref": "#/$defs/RunProfileParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "RunProfileCreate",
       "type": "object"
     },
@@ -5647,7 +6104,10 @@
           "type": "array"
         }
       },
-      "required": ["moduleId", "profile"],
+      "required": [
+        "moduleId",
+        "profile"
+      ],
       "title": "RunProfileParams",
       "type": "object"
     },
@@ -5670,7 +6130,10 @@
           "type": "number"
         }
       },
-      "required": ["celsius", "holdSeconds"],
+      "required": [
+        "celsius",
+        "holdSeconds"
+      ],
       "title": "RunProfileStepParams",
       "type": "object"
     },
@@ -5705,7 +6168,9 @@
           "$ref": "#/$defs/SavePositionParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SavePositionCreate",
       "type": "object"
     },
@@ -5728,7 +6193,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"],
+      "required": [
+        "pipetteId"
+      ],
       "title": "SavePositionParams",
       "type": "object"
     },
@@ -5763,7 +6230,9 @@
           "$ref": "#/$defs/SealPipetteToTipParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SealPipetteToTipCreate",
       "type": "object"
     },
@@ -5802,7 +6271,11 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "labwareId", "wellName"],
+      "required": [
+        "pipetteId",
+        "labwareId",
+        "wellName"
+      ],
       "title": "SealPipetteToTipParams",
       "type": "object"
     },
@@ -5837,7 +6310,9 @@
           "$ref": "#/$defs/SetAndWaitForShakeSpeedParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetAndWaitForShakeSpeedCreate",
       "type": "object"
     },
@@ -5855,7 +6330,10 @@
           "type": "number"
         }
       },
-      "required": ["moduleId", "rpm"],
+      "required": [
+        "moduleId",
+        "rpm"
+      ],
       "title": "SetAndWaitForShakeSpeedParams",
       "type": "object"
     },
@@ -5890,7 +6368,9 @@
           "$ref": "#/$defs/SetRailLightsParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetRailLightsCreate",
       "type": "object"
     },
@@ -5903,7 +6383,9 @@
           "type": "boolean"
         }
       },
-      "required": ["on"],
+      "required": [
+        "on"
+      ],
       "title": "SetRailLightsParams",
       "type": "object"
     },
@@ -5938,7 +6420,9 @@
           "$ref": "#/$defs/SetShakeSpeedParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetShakeSpeedCreate",
       "type": "object"
     },
@@ -5969,7 +6453,10 @@
           "title": "Taskid"
         }
       },
-      "required": ["moduleId", "rpm"],
+      "required": [
+        "moduleId",
+        "rpm"
+      ],
       "title": "SetShakeSpeedParams",
       "type": "object"
     },
@@ -6004,7 +6491,9 @@
           "$ref": "#/$defs/SetStatusBarParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetStatusBarCreate",
       "type": "object"
     },
@@ -6016,7 +6505,9 @@
           "description": "The animation that should be executed on the status bar."
         }
       },
-      "required": ["animation"],
+      "required": [
+        "animation"
+      ],
       "title": "SetStatusBarParams",
       "type": "object"
     },
@@ -6051,7 +6542,9 @@
           "$ref": "#/$defs/SetStoredLabwareParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetStoredLabwareCreate",
       "type": "object"
     },
@@ -6123,7 +6616,10 @@
           "description": "The details of the primary labware (i.e. not the lid or adapter, if any) stored in the stacker."
         }
       },
-      "required": ["moduleId", "primaryLabware"],
+      "required": [
+        "moduleId",
+        "primaryLabware"
+      ],
       "title": "SetStoredLabwareParams",
       "type": "object"
     },
@@ -6158,7 +6654,9 @@
           "$ref": "#/$defs/SetTargetBlockTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetTargetBlockTemperatureCreate",
       "type": "object"
     },
@@ -6196,7 +6694,10 @@
           "type": "string"
         }
       },
-      "required": ["moduleId", "celsius"],
+      "required": [
+        "moduleId",
+        "celsius"
+      ],
       "title": "SetTargetBlockTemperatureParams",
       "type": "object"
     },
@@ -6231,7 +6732,9 @@
           "$ref": "#/$defs/SetTargetLidTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetTargetLidTemperatureCreate",
       "type": "object"
     },
@@ -6254,7 +6757,10 @@
           "type": "string"
         }
       },
-      "required": ["moduleId", "celsius"],
+      "required": [
+        "moduleId",
+        "celsius"
+      ],
       "title": "SetTargetLidTemperatureParams",
       "type": "object"
     },
@@ -6289,7 +6795,9 @@
           "$ref": "#/$defs/SetTipStateParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetTipStateCreate",
       "type": "object"
     },
@@ -6314,7 +6822,11 @@
           "type": "array"
         }
       },
-      "required": ["labwareId", "wellNames", "tipWellState"],
+      "required": [
+        "labwareId",
+        "wellNames",
+        "tipWellState"
+      ],
       "title": "SetTipStateParams",
       "type": "object"
     },
@@ -6467,7 +6979,12 @@
       "properties": {
         "primaryNozzle": {
           "description": "The primary nozzle to use in the layout configuration. This nozzle will update the critical point of the current pipette. For now, this is also the back left corner of your rectangle.",
-          "enum": ["A1", "H1", "A12", "H12"],
+          "enum": [
+            "A1",
+            "H1",
+            "A12",
+            "H12"
+          ],
           "title": "Primarynozzle",
           "type": "string"
         },
@@ -6478,19 +6995,27 @@
           "type": "string"
         }
       },
-      "required": ["primaryNozzle"],
+      "required": [
+        "primaryNozzle"
+      ],
       "title": "SingleNozzleLayoutConfiguration",
       "type": "object"
     },
     "StackerFillEmptyStrategy": {
       "description": "Strategy to use for filling or emptying a stacker.",
-      "enum": ["manualWithPause", "logical"],
+      "enum": [
+        "manualWithPause",
+        "logical"
+      ],
       "title": "StackerFillEmptyStrategy",
       "type": "string"
     },
     "StackerLabwareMovementStrategy": {
       "description": "Strategy to retrieve or store labware.",
-      "enum": ["automatic", "manual"],
+      "enum": [
+        "automatic",
+        "manual"
+      ],
       "title": "StackerLabwareMovementStrategy",
       "type": "string"
     },
@@ -6513,7 +7038,11 @@
           "type": "integer"
         }
       },
-      "required": ["loadName", "namespace", "version"],
+      "required": [
+        "loadName",
+        "namespace",
+        "version"
+      ],
       "title": "StackerStoredLabwareDetails",
       "type": "object"
     },
@@ -6535,7 +7064,9 @@
           "type": "string"
         }
       },
-      "required": ["primaryLabwareId"],
+      "required": [
+        "primaryLabwareId"
+      ],
       "title": "StackerStoredLabwareGroup",
       "type": "object"
     },
@@ -6570,7 +7101,9 @@
           "$ref": "#/$defs/StartRunExtendedProfileParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "StartRunExtendedProfileCreate",
       "type": "object"
     },
@@ -6616,7 +7149,10 @@
           "title": "Taskid"
         }
       },
-      "required": ["moduleId", "profileElements"],
+      "required": [
+        "moduleId",
+        "profileElements"
+      ],
       "title": "StartRunExtendedProfileParams",
       "type": "object"
     },
@@ -6651,7 +7187,9 @@
           "$ref": "#/$defs/StartRunProfileParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "StartRunProfileCreate",
       "type": "object"
     },
@@ -6695,7 +7233,10 @@
           "title": "Taskid"
         }
       },
-      "required": ["moduleId", "profile"],
+      "required": [
+        "moduleId",
+        "profile"
+      ],
       "title": "StartRunProfileParams",
       "type": "object"
     },
@@ -6730,7 +7271,9 @@
           "$ref": "#/$defs/StartSetVacuumPowerParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "StartSetVacuumPowerCreate",
       "type": "object"
     },
@@ -6772,7 +7315,10 @@
           "type": "boolean"
         }
       },
-      "required": ["moduleId", "percentPower"],
+      "required": [
+        "moduleId",
+        "percentPower"
+      ],
       "title": "StartSetVacuumPowerParams",
       "type": "object"
     },
@@ -6807,7 +7353,9 @@
           "$ref": "#/$defs/StartSetVacuumPressureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "StartSetVacuumPressureCreate",
       "type": "object"
     },
@@ -6849,13 +7397,22 @@
           "type": "boolean"
         }
       },
-      "required": ["moduleId", "gaugePressure"],
+      "required": [
+        "moduleId",
+        "gaugePressure"
+      ],
       "title": "StartSetVacuumPressureParams",
       "type": "object"
     },
     "StatusBarAnimation": {
       "description": "Status Bar animation options.",
-      "enum": ["idle", "confirm", "updating", "disco", "off"],
+      "enum": [
+        "idle",
+        "confirm",
+        "updating",
+        "disco",
+        "off"
+      ],
       "title": "StatusBarAnimation",
       "type": "string"
     },
@@ -6890,7 +7447,9 @@
           "$ref": "#/$defs/StopVacuumParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "StopVacuumCreate",
       "type": "object"
     },
@@ -6903,7 +7462,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "StopVacuumParams",
       "type": "object"
     },
@@ -6938,7 +7499,9 @@
           "$ref": "#/$defs/StoreParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "StoreCreate",
       "type": "object"
     },
@@ -6955,7 +7518,10 @@
           "description": "If manual, indicates that labware has been moved to the hopper manually by the user, as required in error recovery."
         }
       },
-      "required": ["moduleId", "strategy"],
+      "required": [
+        "moduleId",
+        "strategy"
+      ],
       "title": "StoreParams",
       "type": "object"
     },
@@ -6986,7 +7552,11 @@
           "description": "Tip position before starting the submerge."
         }
       },
-      "required": ["startPosition", "speed", "delay"],
+      "required": [
+        "startPosition",
+        "speed",
+        "delay"
+      ],
       "title": "Submerge",
       "type": "object"
     },
@@ -7028,19 +7598,30 @@
           "description": "Position reference for tip position."
         }
       },
-      "required": ["positionReference", "offset"],
+      "required": [
+        "positionReference",
+        "offset"
+      ],
       "title": "TipPosition",
       "type": "object"
     },
     "TipPresenceStatus": {
       "description": "Tip presence status reported by a pipette.",
-      "enum": ["present", "absent", "unknown"],
+      "enum": [
+        "present",
+        "absent",
+        "unknown"
+      ],
       "title": "TipPresenceStatus",
       "type": "string"
     },
     "TipRackWellState": {
       "description": "The state of a single tip in a tip rack's well.",
-      "enum": ["clean", "used", "empty"],
+      "enum": [
+        "clean",
+        "used",
+        "empty"
+      ],
       "title": "TipRackWellState",
       "type": "string"
     },
@@ -7075,7 +7656,9 @@
           "$ref": "#/$defs/TouchTipParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "TouchTipCreate",
       "type": "object"
     },
@@ -7118,7 +7701,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ],
       "title": "TouchTipParams",
       "type": "object"
     },
@@ -7137,7 +7724,9 @@
           "title": "Params"
         }
       },
-      "required": ["enable"],
+      "required": [
+        "enable"
+      ],
       "title": "TouchTipProperties",
       "type": "object"
     },
@@ -7172,7 +7761,9 @@
           "$ref": "#/$defs/TryLiquidProbeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "TryLiquidProbeCreate",
       "type": "object"
     },
@@ -7199,7 +7790,11 @@
           "type": "string"
         }
       },
-      "required": ["labwareId", "wellName", "pipetteId"],
+      "required": [
+        "labwareId",
+        "wellName",
+        "pipetteId"
+      ],
       "title": "TryLiquidProbeParams",
       "type": "object"
     },
@@ -7234,7 +7829,9 @@
           "$ref": "#/$defs/UnsafeBlowOutInPlaceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeBlowOutInPlaceCreate",
       "type": "object"
     },
@@ -7253,7 +7850,10 @@
           "type": "string"
         }
       },
-      "required": ["flowRate", "pipetteId"],
+      "required": [
+        "flowRate",
+        "pipetteId"
+      ],
       "title": "UnsafeBlowOutInPlaceParams",
       "type": "object"
     },
@@ -7288,7 +7888,9 @@
           "$ref": "#/$defs/UnsafeDropTipInPlaceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeDropTipInPlaceCreate",
       "type": "object"
     },
@@ -7306,7 +7908,9 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId"],
+      "required": [
+        "pipetteId"
+      ],
       "title": "UnsafeDropTipInPlaceParams",
       "type": "object"
     },
@@ -7341,7 +7945,9 @@
           "$ref": "#/$defs/UnsafeEngageAxesParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeEngageAxesCreate",
       "type": "object"
     },
@@ -7357,7 +7963,9 @@
           "type": "array"
         }
       },
-      "required": ["axes"],
+      "required": [
+        "axes"
+      ],
       "title": "UnsafeEngageAxesParams",
       "type": "object"
     },
@@ -7392,7 +8000,9 @@
           "$ref": "#/$defs/UnsafeFlexStackerCloseLatchParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeFlexStackerCloseLatchCreate",
       "type": "object"
     },
@@ -7405,7 +8015,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "UnsafeFlexStackerCloseLatchParams",
       "type": "object"
     },
@@ -7440,7 +8052,9 @@
           "$ref": "#/$defs/UnsafeFlexStackerManualRetrieveParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeFlexStackerManualRetrieveCreate",
       "type": "object"
     },
@@ -7473,7 +8087,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "UnsafeFlexStackerManualRetrieveParams",
       "type": "object"
     },
@@ -7508,7 +8124,9 @@
           "$ref": "#/$defs/UnsafeFlexStackerOpenLatchParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeFlexStackerOpenLatchCreate",
       "type": "object"
     },
@@ -7521,7 +8139,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "UnsafeFlexStackerOpenLatchParams",
       "type": "object"
     },
@@ -7556,7 +8176,9 @@
           "$ref": "#/$defs/UnsafeFlexStackerPrepareShuttleParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeFlexStackerPrepareShuttleCreate",
       "type": "object"
     },
@@ -7575,7 +8197,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "UnsafeFlexStackerPrepareShuttleParams",
       "type": "object"
     },
@@ -7610,7 +8234,9 @@
           "$ref": "#/$defs/UnsafePlaceLabwareParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafePlaceLabwareCreate",
       "type": "object"
     },
@@ -7641,7 +8267,10 @@
           "title": "Location"
         }
       },
-      "required": ["labwareURI", "location"],
+      "required": [
+        "labwareURI",
+        "location"
+      ],
       "title": "UnsafePlaceLabwareParams",
       "type": "object"
     },
@@ -7676,7 +8305,9 @@
           "$ref": "#/$defs/UnsafeUngripLabwareParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsafeUngripLabwareCreate",
       "type": "object"
     },
@@ -7717,7 +8348,9 @@
           "$ref": "#/$defs/UnsealPipetteFromTipParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UnsealPipetteFromTipCreate",
       "type": "object"
     },
@@ -7744,7 +8377,11 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "labwareId", "wellName"],
+      "required": [
+        "pipetteId",
+        "labwareId",
+        "wellName"
+      ],
       "title": "UnsealPipetteFromTipParams",
       "type": "object"
     },
@@ -7779,7 +8416,9 @@
           "$ref": "#/$defs/UpdatePositionEstimatorsParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "UpdatePositionEstimatorsCreate",
       "type": "object"
     },
@@ -7795,7 +8434,9 @@
           "type": "array"
         }
       },
-      "required": ["axes"],
+      "required": [
+        "axes"
+      ],
       "title": "UpdatePositionEstimatorsParams",
       "type": "object"
     },
@@ -7826,7 +8467,10 @@
           "type": "boolean"
         }
       },
-      "required": ["steps", "repetitions"],
+      "required": [
+        "steps",
+        "repetitions"
+      ],
       "title": "VacuumModuleProfileCycle",
       "type": "object"
     },
@@ -7868,7 +8512,9 @@
           "type": "boolean"
         }
       },
-      "required": ["enablePump"],
+      "required": [
+        "enablePump"
+      ],
       "title": "VacuumModuleProfilePowerStep",
       "type": "object"
     },
@@ -7910,7 +8556,9 @@
           "type": "boolean"
         }
       },
-      "required": ["enablePump"],
+      "required": [
+        "enablePump"
+      ],
       "title": "VacuumModuleProfilePressureStep",
       "type": "object"
     },
@@ -7930,7 +8578,11 @@
           "type": "number"
         }
       },
-      "required": ["x", "y", "z"],
+      "required": [
+        "x",
+        "y",
+        "z"
+      ],
       "title": "Vec3f",
       "type": "object"
     },
@@ -7965,7 +8617,9 @@
           "$ref": "#/$defs/VerifyTipPresenceParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "VerifyTipPresenceCreate",
       "type": "object"
     },
@@ -7987,7 +8641,10 @@
           "type": "string"
         }
       },
-      "required": ["pipetteId", "expectedState"],
+      "required": [
+        "pipetteId",
+        "expectedState"
+      ],
       "title": "VerifyTipPresenceParams",
       "type": "object"
     },
@@ -8022,7 +8679,9 @@
           "$ref": "#/$defs/WaitForBlockTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "WaitForBlockTemperatureCreate",
       "type": "object"
     },
@@ -8035,7 +8694,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "WaitForBlockTemperatureParams",
       "type": "object"
     },
@@ -8070,7 +8731,9 @@
           "$ref": "#/$defs/WaitForDurationParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "WaitForDurationCreate",
       "type": "object"
     },
@@ -8088,7 +8751,9 @@
           "type": "number"
         }
       },
-      "required": ["seconds"],
+      "required": [
+        "seconds"
+      ],
       "title": "WaitForDurationParams",
       "type": "object"
     },
@@ -8123,7 +8788,9 @@
           "$ref": "#/$defs/WaitForLidTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "WaitForLidTemperatureCreate",
       "type": "object"
     },
@@ -8136,7 +8803,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "WaitForLidTemperatureParams",
       "type": "object"
     },
@@ -8153,7 +8822,10 @@
         },
         "commandType": {
           "default": "waitForResume",
-          "enum": ["waitForResume", "pause"],
+          "enum": [
+            "waitForResume",
+            "pause"
+          ],
           "title": "Commandtype",
           "type": "string"
         },
@@ -8171,7 +8843,9 @@
           "$ref": "#/$defs/WaitForResumeParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "WaitForResumeCreate",
       "type": "object"
     },
@@ -8218,7 +8892,9 @@
           "$ref": "#/$defs/WaitForTasksParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "WaitForTasksCreate",
       "type": "object"
     },
@@ -8234,7 +8910,9 @@
           "type": "array"
         }
       },
-      "required": ["task_ids"],
+      "required": [
+        "task_ids"
+      ],
       "title": "WaitForTasksParams",
       "type": "object"
     },
@@ -8282,7 +8960,12 @@
     },
     "WellOrigin": {
       "description": "Origin of WellLocation offset.\n\nProps:\n    TOP: the top-center of the well\n    BOTTOM: the bottom-center of the well\n    CENTER: the middle-center of the well\n    MENISCUS: the meniscus-center of the well",
-      "enum": ["top", "bottom", "center", "meniscus"],
+      "enum": [
+        "top",
+        "bottom",
+        "center",
+        "meniscus"
+      ],
       "title": "WellOrigin",
       "type": "string"
     },
@@ -8317,7 +9000,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__absorbance_reader__close_lid__CloseLidParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CloseLidCreate",
       "type": "object"
     },
@@ -8330,7 +9015,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "CloseLidParams",
       "type": "object"
     },
@@ -8365,7 +9052,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__absorbance_reader__open_lid__OpenLidParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "OpenLidCreate",
       "type": "object"
     },
@@ -8378,7 +9067,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "OpenLidParams",
       "type": "object"
     },
@@ -8413,7 +9104,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__set_target_temperature__SetTargetTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetTargetTemperatureCreate",
       "type": "object"
     },
@@ -8436,7 +9129,10 @@
           "type": "string"
         }
       },
-      "required": ["moduleId", "celsius"],
+      "required": [
+        "moduleId",
+        "celsius"
+      ],
       "title": "SetTargetTemperatureParams",
       "type": "object"
     },
@@ -8471,7 +9167,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__heater_shaker__wait_for_temperature__WaitForTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "WaitForTemperatureCreate",
       "type": "object"
     },
@@ -8489,7 +9187,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "WaitForTemperatureParams",
       "type": "object"
     },
@@ -8524,7 +9224,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__temperature_module__set_target_temperature__SetTargetTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "SetTargetTemperatureCreate",
       "type": "object"
     },
@@ -8547,7 +9249,10 @@
           "type": "string"
         }
       },
-      "required": ["moduleId", "celsius"],
+      "required": [
+        "moduleId",
+        "celsius"
+      ],
       "title": "SetTargetTemperatureParams",
       "type": "object"
     },
@@ -8582,7 +9287,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__temperature_module__wait_for_temperature__WaitForTemperatureParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "WaitForTemperatureCreate",
       "type": "object"
     },
@@ -8600,7 +9307,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "WaitForTemperatureParams",
       "type": "object"
     },
@@ -8635,7 +9344,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__thermocycler__close_lid__CloseLidParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "CloseLidCreate",
       "type": "object"
     },
@@ -8648,7 +9359,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "CloseLidParams",
       "type": "object"
     },
@@ -8683,7 +9396,9 @@
           "$ref": "#/$defs/opentrons__protocol_engine__commands__thermocycler__open_lid__OpenLidParams"
         }
       },
-      "required": ["params"],
+      "required": [
+        "params"
+      ],
       "title": "OpenLidCreate",
       "type": "object"
     },
@@ -8696,7 +9411,9 @@
           "type": "string"
         }
       },
-      "required": ["moduleId"],
+      "required": [
+        "moduleId"
+      ],
       "title": "OpenLidParams",
       "type": "object"
     }

--- a/shared-data/command/types/calibration.ts
+++ b/shared-data/command/types/calibration.ts
@@ -73,7 +73,7 @@ interface CalibrateGripperResult {
 }
 interface MoveToMaintenancePositionParams {
   mount: GantryMount
-  motionModifier?: 'lowerZAxesSequentially'
+  motionModifier?: 'lowerZAxesSequentially' | 'lowerMountZAxis'
 }
 interface CalibrateModuleResult {
   moduleOffset: Vector3D

--- a/shared-data/protocol/types/schemaV7/command/calibration.ts
+++ b/shared-data/protocol/types/schemaV7/command/calibration.ts
@@ -73,7 +73,7 @@ interface CalibrateGripperResult {
 }
 interface MoveToMaintenancePositionParams {
   mount: GantryMount
-  motionModifier?: 'lowerZAxesSequentially'
+  motionModifier?: 'lowerZAxesSequentially' | 'lowerMountZAxis'
 }
 interface CalibrateModuleResult {
   moduleOffset: Vector3D


### PR DESCRIPTION
Closes [RQA-5399](https://opentrons.atlassian.net/browse/RQA-5399)

# Overview

During attachment and detachment flows for the 96 channel, we'd like to lower the mount axes to make it easier for users to interact with the pipette. We add a new `MotionModifer`, called `lowerMountZAxis`. We apply this modifier to all places in the 96ch is attached or detachment. 

## Test Plan and Hands on Testing

- [x] Single mount pipette attachment
- [x] Single mount pipette detachment
- [x] 96 channel attachment
- [x] 96 channel detachment
- [x] Attach 96 channel while single mount pipette is attached

## Changelog

- Added a mount axis lower motion during the attach and detach pipette steps of the pipette wizard flows.

## Risk assessment

- medium-ish. It's tricky to audit all the spots the 96ch descends or does not descend, but I think the test plan gets most of them. Worst comes to worst, there is one or two places where the pipette should descend but does not.


[RQA-5399]: https://opentrons.atlassian.net/browse/RQA-5399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ