### PR TITLE
fix(app): fix empty dashboard view when only QT protocol runs exist

### DIFF
--- a/app/src/organisms/ODD/RobotDashboard/RecentRunProtocolCard.tsx
+++ b/app/src/organisms/ODD/RobotDashboard/RecentRunProtocolCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { formatDistance } from 'date-fns'
@@ -44,14 +44,31 @@ import type { ProtocolResource } from '@opentrons/shared-data'
 
 interface RecentRunProtocolCardProps {
   runData: RunData
+  onCardResolved: (runId: string, isStandard: boolean) => void
 }
 
 export function RecentRunProtocolCard({
   runData,
+  onCardResolved,
 }: RecentRunProtocolCardProps): JSX.Element | null {
   const { data, isLoading } = useProtocolQuery(runData.protocolId ?? null)
   const protocolData = data?.data ?? null
   const isProtocolFetching = isLoading
+  const prevResolvedRef = useRef(false)
+
+  useEffect(() => {
+    if (prevResolvedRef.current) {
+      return
+    }
+    if (isProtocolFetching || protocolData == null) {
+      return
+    }
+
+    prevResolvedRef.current = true
+    const isStandard = protocolData.protocolKind !== 'quick-transfer'
+    onCardResolved(runData.id, isStandard)
+  }, [isProtocolFetching, protocolData, onCardResolved, runData.id])
+
   return protocolData == null ||
     protocolData.protocolKind === 'quick-transfer' ? null : (
     <ProtocolWithLastRun

--- a/app/src/organisms/ODD/RobotDashboard/RecentRunProtocolCarousel.tsx
+++ b/app/src/organisms/ODD/RobotDashboard/RecentRunProtocolCarousel.tsx
@@ -13,6 +13,7 @@ import type { RunData } from '@opentrons/api-client'
 
 interface RecentRunProtocolCarouselProps {
   recentRunsOfUniqueProtocols: RunData[]
+  onCardResolved: (runId: string, isStandard: boolean) => void
 }
 
 const CarouselWrapper = styled.div`
@@ -30,6 +31,7 @@ const CarouselWrapper = styled.div`
 
 export function RecentRunProtocolCarousel({
   recentRunsOfUniqueProtocols,
+  onCardResolved,
 }: RecentRunProtocolCarouselProps): JSX.Element {
   return (
     <CarouselWrapper>
@@ -39,7 +41,11 @@ export function RecentRunProtocolCarousel({
         marginX={SPACING.spacing40}
       >
         {recentRunsOfUniqueProtocols.map(runData => (
-          <RecentRunProtocolCard key={runData.id} runData={runData} />
+          <RecentRunProtocolCard
+            key={runData.id}
+            runData={runData}
+            onCardResolved={onCardResolved}
+          />
         ))}
       </Flex>
     </CarouselWrapper>

--- a/app/src/organisms/ODD/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
+++ b/app/src/organisms/ODD/RobotDashboard/__tests__/RecentRunProtocolCard.test.tsx
@@ -125,6 +125,7 @@ describe('RecentRunProtocolCard', () => {
   beforeEach(() => {
     props = {
       runData: mockRunData,
+      onCardResolved: vi.fn(),
     }
 
     vi.mocked(Skeleton).mockReturnValue(<div>mock Skeleton</div>)
@@ -228,7 +229,7 @@ describe('RecentRunProtocolCard', () => {
     vi.mocked(useNotifyAllRunsQuery).mockReturnValue({
       data: { data: [mockRunData] },
     } as any)
-    const propsWithBadRun = { runData: mockBadRunData }
+    const propsWithBadRun = { runData: mockBadRunData, onCardResolved: vi.fn() }
     vi.mocked(useRerunnableStatusText).mockReturnValue(
       'Run could not be loaded'
     )

--- a/app/src/organisms/ODD/RobotDashboard/__tests__/RecentRunProtocolCarousel.test.tsx
+++ b/app/src/organisms/ODD/RobotDashboard/__tests__/RecentRunProtocolCarousel.test.tsx
@@ -41,6 +41,7 @@ describe('RecentRunProtocolCarousel', () => {
   beforeEach(() => {
     props = {
       recentRunsOfUniqueProtocols: [mockRun as RunData],
+      onCardResolved: vi.fn(),
     }
     vi.mocked(RecentRunProtocolCard).mockReturnValue(
       <div>mock RecentRunProtocolCard</div>

--- a/app/src/pages/ODD/RobotDashboard/__tests__/RobotDashboard.test.tsx
+++ b/app/src/pages/ODD/RobotDashboard/__tests__/RobotDashboard.test.tsx
@@ -1,8 +1,6 @@
 import { MemoryRouter } from 'react-router-dom'
-import { screen } from '@testing-library/react'
+import { act, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-
-import { useAllProtocolsQuery } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
@@ -19,7 +17,6 @@ import { RobotDashboard } from '..'
 import { WelcomeModal } from '../WelcomeModal'
 
 import type { NavigateFunction } from 'react-router-dom'
-import type { ProtocolResource } from '@opentrons/shared-data'
 
 const mockNavigate = vi.fn()
 
@@ -49,23 +46,6 @@ const render = () => {
     }
   )
 }
-const mockProtocol: ProtocolResource = {
-  id: 'mockProtocol1',
-  createdAt: '2022-05-03T21:36:12.494778+00:00',
-  protocolType: 'json',
-  protocolKind: 'standard',
-  robotType: 'OT-3 Standard',
-  metadata: {
-    protocolName: 'yay mock protocol',
-    author: 'engineering',
-    description: 'A short mock protocol',
-    created: 1606853851893,
-    tags: ['unitTest'],
-  },
-  analysisSummaries: [],
-  files: [],
-  key: '26ed5a82-502f-4074-8981-57cdda1d066d',
-}
 const mockRunData = {
   id: 'mockProtocol1',
   createdAt: '2022-05-03T21:36:12.494778+00:00',
@@ -76,7 +56,6 @@ const mockRunData = {
 
 describe('RobotDashboard', () => {
   beforeEach(() => {
-    vi.mocked(useAllProtocolsQuery).mockReturnValue({} as any)
     vi.mocked(useNotifyAllRunsQuery).mockReturnValue({} as any)
     vi.mocked(useMissingProtocolHardware).mockReturnValue({
       missingProtocolHardware: [],
@@ -98,19 +77,37 @@ describe('RobotDashboard', () => {
     expect(vi.mocked(EmptyRecentRun)).toHaveBeenCalled()
   })
 
-  it('should render a recent run protocol carousel', () => {
-    vi.mocked(useAllProtocolsQuery).mockReturnValue({
-      data: {
-        data: [mockProtocol],
-      },
-    } as any)
+  it('should render the carousel while cards are resolving', () => {
     vi.mocked(useNotifyAllRunsQuery).mockReturnValue({
       data: { data: [mockRunData] },
     } as any)
     render()
     expect(vi.mocked(Navigation)).toHaveBeenCalled()
-    screen.getByText('Run again')
     expect(vi.mocked(RecentRunProtocolCarousel)).toHaveBeenCalled()
+  })
+
+  it('should show run again header when cards resolve with standard protocols', () => {
+    vi.mocked(useNotifyAllRunsQuery).mockReturnValue({
+      data: { data: [mockRunData] },
+    } as any)
+    render()
+    const carouselProps = vi.mocked(RecentRunProtocolCarousel).mock.calls[0][0]
+    act(() => {
+      carouselProps.onCardResolved(mockRunData.id, true)
+    })
+    screen.getByText('Run again')
+  })
+
+  it('should show empty recent run when all cards resolve as quick-transfer', () => {
+    vi.mocked(useNotifyAllRunsQuery).mockReturnValue({
+      data: { data: [mockRunData] },
+    } as any)
+    render()
+    const carouselProps = vi.mocked(RecentRunProtocolCarousel).mock.calls[0][0]
+    act(() => {
+      carouselProps.onCardResolved(mockRunData.id, false)
+    })
+    expect(vi.mocked(EmptyRecentRun)).toHaveBeenCalled()
   })
 
   it('should render WelcomeModal component when finish unboxing flow', () => {

--- a/app/src/pages/ODD/RobotDashboard/index.tsx
+++ b/app/src/pages/ODD/RobotDashboard/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
@@ -55,27 +55,54 @@ export function RobotDashboard(): JSX.Element {
     return result
   }, [allRunsQueryData?.data])
 
+  const [standardRunIds, setStandardRunIds] = useState<Set<string>>(
+    () => new Set()
+  )
+  const [resolvedRunIds, setResolvedRunIds] = useState<Set<string>>(
+    () => new Set()
+  )
+
+  const handleCardResolved = useCallback(
+    (runId: string, isStandard: boolean) => {
+      setResolvedRunIds(prev => new Set(prev).add(runId))
+      if (isStandard) {
+        setStandardRunIds(prev => new Set(prev).add(runId))
+      }
+    },
+    []
+  )
+
+  const totalCards = recentRunsOfUniqueProtocols.length
+  const allResolved = resolvedRunIds.size === totalCards
+  const hasStandardProtocols = standardRunIds.size > 0
+
   let contents: JSX.Element = <EmptyRecentRun />
   // GET runs query will error with 503 if database is initializing
   // this should be momentary, and the type of error to come from this endpoint
   // so, all errors will be mapped to an initializing spinner
   if (allRunsQueryError?.code === '503') {
     contents = <ServerInitializing />
-  } else if (recentRunsOfUniqueProtocols.length > 0) {
-    contents = (
-      <>
-        <LegacyStyledText
-          forwardedAs="p"
-          fontWeight={TYPOGRAPHY.fontWeightSemiBold}
-          color={COLORS.grey60}
-        >
-          {t('run_again')}
-        </LegacyStyledText>
-        <RecentRunProtocolCarousel
-          recentRunsOfUniqueProtocols={recentRunsOfUniqueProtocols}
-        />
-      </>
-    )
+  } else if (totalCards > 0) {
+    // When cards are still loading or at least one is standard, show the carousel
+    if (!allResolved || hasStandardProtocols) {
+      contents = (
+        <>
+          {hasStandardProtocols ? (
+            <LegacyStyledText
+              forwardedAs="p"
+              fontWeight={TYPOGRAPHY.fontWeightSemiBold}
+              color={COLORS.grey60}
+            >
+              {t('run_again')}
+            </LegacyStyledText>
+          ) : null}
+          <RecentRunProtocolCarousel
+            recentRunsOfUniqueProtocols={recentRunsOfUniqueProtocols}
+            onCardResolved={handleCardResolved}
+          />
+        </>
+      )
+    }
   }
 
   return (


### PR DESCRIPTION
Closes [RQA-5392](https://opentrons.atlassian.net/browse/RQA-5392)

# Overview

In order to render the recently run protocol cards on the ODD, we need to hit a couple endpoints: first one for getting our recently run info, and then a second for determining whether each run is a quick-transfer protocol. If a protocol is a quick transfer protocol, we don't render a card.

If all runs are quick transfer runs, we effectively show a blank screen, since the logic to determine whether to show the "no protocols" splash screen is dependent on whether runs exist.

There's no straightforward way to solve this issue unfortunately - we have to hit two endpoints no matter what we do, and if we try to get too fancy, we lose the run card skeleton loading state. We're stuck with either making lighter endpoints that hopefully query faster, or we can have each protocol card report up to the dashboard whether it is a quick transfer run or not, and we just not render the cards.

I've went with the frontend exclusive option here. The only downside is we briefly flash loading skeletons for cards that are quick transfer runs before they disappear, but doing so seems reasonable all things considered.

### Current Behavior

https://github.com/user-attachments/assets/c778e6d0-3544-44c4-9e95-0df7cb50ca29

### Fixed Behavior

https://github.com/user-attachments/assets/0dc9b153-f209-4919-a73b-dce39a141354


## Test Plan and Hands on Testing

- See video.

## Changelog

- Fixed the ODD Recently Run Dashboard rendering no content if all recent runs are quick transfer protocol type runs.

## Risk assessment

- low - it's a lot of words for a PR description, but there's nothing here that interesting at the end of the day


[RQA-5392]: https://opentrons.atlassian.net/browse/RQA-5392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ