### PR TITLE
feat(protocol-designer, shared-data, step-generation): wire up vacuum dock setup functionality

### DIFF
--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -41,9 +41,13 @@ import {
   OT2_ROBOT_TYPE,
   VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
-import { getIsSlotAHopper } from '@opentrons/step-generation'
+import {
+  getIsSlotAHopper,
+  getIsSlotAVacuumDock,
+} from '@opentrons/step-generation'
 
 import { LINK_BUTTON_STYLE } from '/protocol-designer/components/atoms'
+import { VACUUM_MODULE_TYPE_WITH_LABWARE } from '/protocol-designer/constants'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
 import { getOnlyLatestDefs } from '/protocol-designer/labware-defs'
 import { createCustomLabwareDef } from '/protocol-designer/labware-defs/actions'
@@ -58,13 +62,17 @@ import {
   ALL_ORDERED_CATEGORIES,
   CUSTOM_CATEGORY,
 } from '/protocol-designer/pages/Designer/DeckSetup/constants'
-import { getLabwareIsRecommended } from '/protocol-designer/pages/Designer/DeckSetup/utils'
+import {
+  getIsVacuumCollar,
+  getLabwareIsRecommended,
+} from '/protocol-designer/pages/Designer/DeckSetup/utils'
 import { TIPRACK_LID_LOADNAME } from '/protocol-designer/pages/Designer/utils'
 import { selectors as stepFormSelectors } from '/protocol-designer/step-forms'
 import { getPipetteEntities } from '/protocol-designer/step-forms/selectors'
 import { getHas96Channel } from '/protocol-designer/utils'
 import {
   ADAPTER_96_CHANNEL,
+  COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE,
   getLabwareCompatibleWithModule,
 } from '/protocol-designer/utils/labwareModuleCompatibility'
 
@@ -164,11 +172,26 @@ export function SelectLabwareModal(
   const moduleType =
     selectedModuleModel != null ? getModuleType(selectedModuleModel) : null
   const isOnHopper = getIsSlotAHopper(slot)
+  const isOnVacuumDock = getIsSlotAVacuumDock(slot)
+
+  // Check if dock itself has a collar (not the main vacuum area)
+  const vacuumModuleInA3 = Object.values(modulesById).find(
+    module => module.type === VACUUM_MODULE_TYPE && module.slot === 'A3'
+  )
+  const dockHasCollar =
+    vacuumModuleInA3 != null &&
+    isOnVacuumDock &&
+    Object.values(deckSetup.labware).some(labware => {
+      const isOnDock = labware.stack.includes('vacuumDock')
+      const isCollar = getIsVacuumCollar(labware.def)
+      return isOnDock && isCollar
+    })
+
   const initialModules: ModuleOnDeck[] = Object.keys(modulesById).map(
     moduleId => modulesById[moduleId]
   )
   const [filterRecommended, setFilterRecommended] = useState<boolean>(
-    moduleType != null
+    moduleType != null || isOnVacuumDock || isOnHopper
   )
   //    for OT-2 usage only due to H-S collisions
   const isNextToHeaterShaker = initialModules.some(
@@ -186,9 +209,18 @@ export function SelectLabwareModal(
       if (moduleType == null || !getLabwareDefIsStandard(def)) {
         return true
       }
-      return getLabwareCompatibleWithModule(def, moduleType, moduleHasLabware)
+      // for vacuum dock, use dock-specific compatibility
+      if (isOnVacuumDock && moduleType === VACUUM_MODULE_TYPE) {
+        return (
+          COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE[
+            VACUUM_MODULE_TYPE_WITH_LABWARE
+          ].includes(def.parameters.loadName) ||
+          def.metadata.displayCategory === 'wellPlate'
+        )
+      }
+      return getLabwareCompatibleWithModule(def, moduleType)
     },
-    [moduleType, moduleHasLabware]
+    [moduleType, isOnVacuumDock]
   )
 
   const getIsLabwareFiltered = useCallback(
@@ -202,39 +234,44 @@ export function SelectLabwareModal(
       const isAdapter = labwareDef.allowedRoles?.includes('adapter')
       const isLid = labwareDef.allowedRoles?.includes('lid')
       const isAdapter96Channel = parameters.loadName === ADAPTER_96_CHANNEL
+      const isWellPlate = labwareDef.metadata.displayCategory === 'wellPlate'
+      const isVacuumCollar = getIsVacuumCollar(labwareDef)
 
-      const isRecommendedFilter =
-        filterRecommended &&
-        !getLabwareIsRecommended(
-          labwareDef,
-          selectedModuleModel,
-          moduleHasLabware
-        )
-      const isHeightFilter =
-        filterHeight &&
-        getIsLabwareAboveHeight(
-          labwareDef,
-          MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM
-        )
-      const isNotCompatible = !getIsLabwareCompatible(labwareDef)
-      const isIrregularAdapter =
-        isAdapter &&
-        isIrregularSize &&
-        moduleType !== HEATERSHAKER_MODULE_TYPE &&
-        moduleType !== VACUUM_MODULE_TYPE
+      // for vacuum dock, show collars when empty, wellplates when collar present
+      if (isOnVacuumDock) {
+        if (!dockHasCollar) {
+          // no collar on dock yet, so show only collars
+          return !isVacuumCollar
+        }
+        // collar present on dock, so show only wellplates and lids
+        return !isWellPlate && !isLid
+      }
 
-      const isFiltered =
-        isRecommendedFilter ||
-        isHeightFilter ||
-        isNotCompatible ||
-        isIrregularAdapter ||
+      return (
+        (filterRecommended &&
+          !getLabwareIsRecommended(
+            labwareDef,
+            selectedModuleModel,
+            moduleHasLabware,
+            isOnVacuumDock,
+            dockHasCollar
+          )) ||
+        (filterHeight &&
+          getIsLabwareAboveHeight(
+            labwareDef,
+            MAX_LABWARE_HEIGHT_EAST_WEST_HEATER_SHAKER_MM
+          )) ||
+        !getIsLabwareCompatible(labwareDef) ||
+        (isAdapter &&
+          isIrregularSize &&
+          moduleType !== HEATERSHAKER_MODULE_TYPE &&
+          moduleType !== VACUUM_MODULE_TYPE) ||
         (isAdapter96Channel && !has96Channel) ||
         (slot === 'offDeck' && (isAdapter || isLid)) ||
         (PLATE_READER_LOADNAME === parameters.loadName &&
           moduleType !== ABSORBANCE_READER_TYPE) ||
         parameters.loadName === TIPRACK_LID_LOADNAME
-
-      return isFiltered
+      )
     },
     // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -244,7 +281,8 @@ export function SelectLabwareModal(
       getIsLabwareCompatible,
       moduleType,
       slot,
-      moduleHasLabware,
+      isOnVacuumDock,
+      dockHasCollar,
     ]
   )
 

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -107,6 +107,7 @@ export const SlotDetailModal = (
   const isHopper = Object.values(modules).some(
     ({ slot, model }) => slot === slotName && model === FLEX_STACKER_MODULE_V1
   )
+  const isVacuumDock = labwareOnDeck.stack.includes('vacuumDock')
 
   const modalTitle = (
     <Flex alignItems={ALIGN_CENTER} gridGap={SPACING.spacing4}>
@@ -114,7 +115,7 @@ export const SlotDetailModal = (
         {t('labware_in')}
       </StyledText>
       <RobotInfoLabel
-        deckLabel={getDeckLabel(slotName, isHopper, t as TFunction)}
+        deckLabel={getDeckLabel(slotName, isHopper, isVacuumDock, t as TFunction)}
       />
     </Flex>
   )

--- a/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/index.tsx
@@ -115,7 +115,12 @@ export const SlotDetailModal = (
         {t('labware_in')}
       </StyledText>
       <RobotInfoLabel
-        deckLabel={getDeckLabel(slotName, isHopper, isVacuumDock, t as TFunction)}
+        deckLabel={getDeckLabel(
+          slotName,
+          isHopper,
+          isVacuumDock,
+          t as TFunction
+        )}
       />
     </Flex>
   )

--- a/protocol-designer/src/components/organisms/SlotDetailModal/utils.ts
+++ b/protocol-designer/src/components/organisms/SlotDetailModal/utils.ts
@@ -1,3 +1,5 @@
+import { VACUUM_DOCK_DISPLAY_LOCATION } from '/protocol-designer/constants'
+
 import type { TFunction } from 'i18next'
 
 const getRowFromSlotName = (slotName: string): string => slotName.slice(0, 1)
@@ -5,6 +7,7 @@ const getRowFromSlotName = (slotName: string): string => slotName.slice(0, 1)
 export function getDeckLabel(
   slotName: string,
   isHopper: boolean,
+  isVacuumDock: boolean,
   t: TFunction
 ): string {
   if (slotName === 'offDeck') {
@@ -15,6 +18,10 @@ export function getDeckLabel(
     return t('shared:stacker', {
       slot: getRowFromSlotName(slotName),
     })
+  }
+
+  if (isVacuumDock) {
+    return VACUUM_DOCK_DISPLAY_LOCATION
   }
 
   return slotName

--- a/protocol-designer/src/components/organisms/SlotDetailsContainer/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailsContainer/index.tsx
@@ -12,6 +12,7 @@ import {
   getTopLocationInStack,
 } from '@opentrons/step-generation'
 
+import { VACUUM_MODULE_SLOT } from '/protocol-designer/constants'
 import { getLiquidEntities } from '/protocol-designer/step-forms/selectors'
 import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 import * as wellContentsSelectors from '/protocol-designer/top-selectors/well-contents'
@@ -46,11 +47,13 @@ export function SlotDetailsContainer(
   }
   const isSlotAHopper = getIsSlotAHopper(slot)
   const isSlotAVacuumDock = getIsSlotAVacuumDock(slot)
-  const adjustedSlotToFindModule = isSlotAHopper
-    ? FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
-    : isSlotAVacuumDock
-      ? 'A3' // Vacuum dock is always associated with module at A3
-      : slot
+  let adjustedSlotToFindModule = slot
+  if (isSlotAHopper) {
+    adjustedSlotToFindModule =
+      FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
+  } else if (isSlotAVacuumDock) {
+    adjustedSlotToFindModule = VACUUM_MODULE_SLOT
+  }
 
   const {
     modules: deckSetupModules,

--- a/protocol-designer/src/components/organisms/SlotDetailsContainer/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailsContainer/index.tsx
@@ -8,6 +8,7 @@ import {
 import {
   FAKE_HOPPER_LOCATION_MAP,
   getIsSlotAHopper,
+  getIsSlotAVacuumDock,
   getTopLocationInStack,
 } from '@opentrons/step-generation'
 
@@ -44,9 +45,12 @@ export function SlotDetailsContainer(
     return null
   }
   const isSlotAHopper = getIsSlotAHopper(slot)
+  const isSlotAVacuumDock = getIsSlotAVacuumDock(slot)
   const adjustedSlotToFindModule = isSlotAHopper
     ? FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
-    : slot
+    : isSlotAVacuumDock
+      ? 'A3' // Vacuum dock is always associated with module at A3
+      : slot
 
   const {
     modules: deckSetupModules,
@@ -72,7 +76,8 @@ export function SlotDetailsContainer(
   const fullStackFromLabwares = getFullStackFromLabwaresOnDeck(
     Object.values(deckSetupLabwares),
     slot,
-    isSlotAHopper
+    isSlotAHopper,
+    isSlotAVacuumDock
   )
   const topLocationLabwareId =
     fullStackFromLabwares?.length > 0
@@ -125,6 +130,13 @@ export function SlotDetailsContainer(
     )
     labwareIds.forEach(id => {
       labwares.push(deckSetupLabwares[id].def.metadata.displayName)
+    })
+  } else if (isSlotAVacuumDock && fullStackFromLabwares?.length > 0) {
+    // For vacuum dock, show all labware in the stack
+    fullStackFromLabwares.forEach(id => {
+      if (deckSetupLabwares[id] != null) {
+        labwares.push(nickNames[id])
+      }
     })
   } else if (fullStackFromLabwares?.length > 0) {
     fullStackFromLabwares.forEach(id => {

--- a/protocol-designer/src/components/organisms/SlotInformation/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotInformation/index.tsx
@@ -23,18 +23,17 @@ import {
   THERMOCYCLER_MODULE_V2,
 } from '@opentrons/shared-data'
 import {
-  FAKE_VACUUM_DOCK_LOCATION_TO_DECK_SLOT,
   getIsSlotAHopper,
   getIsSlotAVacuumDock,
 } from '@opentrons/step-generation'
 
+import { VACUUM_DOCK_DISPLAY_LOCATION } from '/protocol-designer/constants'
 import { useDeckSetupWindowBreakPoint } from '/protocol-designer/pages/Designer/DeckSetup/utils'
 import { getColumnFromWellName } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils'
 import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
 
 import type { FC } from 'react'
 import type { RobotType } from '@opentrons/shared-data'
-import type { VacuumDockFakeLocationType } from '@opentrons/step-generation'
 
 interface SlotInformationProps {
   location: string
@@ -73,10 +72,7 @@ export const SlotInformation: FC<SlotInformationProps> = ({
       slot: getColumnFromWellName(location),
     })
   } else if (getIsSlotAVacuumDock(location)) {
-    modifiedLocation =
-      FAKE_VACUUM_DOCK_LOCATION_TO_DECK_SLOT[
-        location as VacuumDockFakeLocationType
-      ]
+    modifiedLocation = VACUUM_DOCK_DISPLAY_LOCATION
   }
 
   return (

--- a/protocol-designer/src/components/organisms/SlotInformation/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotInformation/index.tsx
@@ -22,7 +22,11 @@ import {
   THERMOCYCLER_MODULE_V1,
   THERMOCYCLER_MODULE_V2,
 } from '@opentrons/shared-data'
-import { getIsSlotAHopper } from '@opentrons/step-generation'
+import {
+  FAKE_VACUUM_DOCK_LOCATION_TO_DECK_SLOT,
+  getIsSlotAHopper,
+  getIsSlotAVacuumDock,
+} from '@opentrons/step-generation'
 
 import { useDeckSetupWindowBreakPoint } from '/protocol-designer/pages/Designer/DeckSetup/utils'
 import { getColumnFromWellName } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils'
@@ -30,6 +34,7 @@ import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
 
 import type { FC } from 'react'
 import type { RobotType } from '@opentrons/shared-data'
+import type { VacuumDockFakeLocationType } from '@opentrons/step-generation'
 
 interface SlotInformationProps {
   location: string
@@ -67,6 +72,11 @@ export const SlotInformation: FC<SlotInformationProps> = ({
     modifiedLocation = t('stacker', {
       slot: getColumnFromWellName(location),
     })
+  } else if (getIsSlotAVacuumDock(location)) {
+    modifiedLocation =
+      FAKE_VACUUM_DOCK_LOCATION_TO_DECK_SLOT[
+        location as VacuumDockFakeLocationType
+      ]
   }
 
   return (

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -182,6 +182,7 @@ export const VACUUM_DOCK_LABWARE_X_OFFSET = 143
 export const VACUUM_DOCK_ZOOM_OFFSET_POSITION = VACUUM_DOCK_LABWARE_X_OFFSET
 
 export const VACUUM_DOCK_DISPLAY_LOCATION: 'A4' = 'A4'
+export const VACUUM_MODULE_SLOT = 'A3'
 
 export const VACUUM_MODULE_TYPE_WITH_LABWARE: 'vacuumModuleTypeWithLabware' =
   'vacuumModuleTypeWithLabware'

--- a/protocol-designer/src/constants.ts
+++ b/protocol-designer/src/constants.ts
@@ -176,7 +176,12 @@ export const ACCEPTED_PROTOCOL_FILE_TYPES = '.json,.py'
 export const HOPPER_LABWARE_X_OFFSET = 178
 export const HOPPER_ZOOM_OFFSET_POSTITION = 230
 
-// Vacuum dock is in A4, adjacent to module in A3
-// Start with similar offset to hopper, adjust based on testing
-export const VACUUM_DOCK_LABWARE_X_OFFSET = 178
-export const VACUUM_DOCK_ZOOM_OFFSET_POSITION = 230
+// Vacuum dock is in the addressable area vacuumModuleV1DockA4, adjacent to module in A3
+// Module footprint is 143mm, dock starts at that offset
+export const VACUUM_DOCK_LABWARE_X_OFFSET = 143
+export const VACUUM_DOCK_ZOOM_OFFSET_POSITION = VACUUM_DOCK_LABWARE_X_OFFSET
+
+export const VACUUM_DOCK_DISPLAY_LOCATION: 'A4' = 'A4'
+
+export const VACUUM_MODULE_TYPE_WITH_LABWARE: 'vacuumModuleTypeWithLabware' =
+  'vacuumModuleTypeWithLabware'

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
@@ -29,7 +29,9 @@ import {
   TRASH_BIN_ADAPTER_FIXTURE,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
+import { getIsSlotAVacuumDock } from '@opentrons/step-generation'
 
+import { useKitchen } from '../../../components/organisms/Kitchen/useKitchen'
 import {
   DECK_SETUP_TOOLS_WIDTH_REM,
   HOPPER_ZOOM_OFFSET_POSTITION,
@@ -50,6 +52,7 @@ import { DeckSetupToolbox } from './DeckSetupToolbox'
 import {
   animateZoom,
   getCutoutIdForAddressableArea,
+  getIsVacuumModuleFull,
   getSVGContainerWidth,
   zoomInOnCoordinate,
 } from './utils'
@@ -108,6 +111,7 @@ export function DeckSetupContainer(
   const zoomIn = useSelector(selectors.getZoomedInSlot)
   const _disableCollisionWarnings = useSelector(getDisableModuleRestrictions)
   const terminalItemId = useSelector(getSelectedTerminalItemId)
+  const { makeSnackbar } = useKitchen()
 
   const trash = Object.values(activeDeckSetup.additionalEquipmentOnDeck).find(
     ae => ae.name === 'trashBin'
@@ -155,13 +159,14 @@ export function DeckSetupContainer(
     return i < viewBoxNumerical.length - 1 ? acc + `${num} ` : acc + `${num}`
   }, '')
 
-  const _getSlotFromRawLocation = (location: string): string => {
+  // Returns the actual slot/addressable area for positioning
+  const _getSlotForPositioning = (location: string): string => {
     const isOnHopper = location.includes('hopper')
     const isOnVacuumDock = location.includes('vacuumDock')
     return isOnHopper
       ? location.split('hopper')[1]
       : isOnVacuumDock
-        ? location.split('vacuumDock')[1]
+        ? 'vacuumModuleV1DockA4' // Use addressable area for positioning
         : location
   }
 
@@ -178,25 +183,43 @@ export function DeckSetupContainer(
   }
 
   const addEquipment = (location: string): void => {
-    const slot = _getSlotFromRawLocation(location)
+    // Check if vacuum dock is full before opening toolbox
+    const isVacuumDockSlot = getIsSlotAVacuumDock(location)
+    if (isVacuumDockSlot) {
+      const { createdStackForSlot } = getSlotInformation({
+        deckSetup: activeDeckSetup,
+        slot: location,
+        deckDef,
+      })
+      const isDockFull = getIsVacuumModuleFull(
+        createdStackForSlot,
+        activeDeckSetup.labware
+      )
+      if (isDockFull) {
+        makeSnackbar('Labware limit reached for this slot')
+        return
+      }
+    }
+
+    const slotForPositioning = _getSlotForPositioning(location)
     const { createdModuleForSlot, preSelectedFixture } = getSlotInformation({
       deckSetup: activeDeckSetup,
-      slot: location,
+      slot: location, // Keep using fake location for slot info
       deckDef,
     })
 
     const cutoutId =
       getCutoutIdForAddressableArea(
-        slot as AddressableAreaName,
+        slotForPositioning as AddressableAreaName,
         deckDef.cutoutFixtures
       ) ?? null
     if (cutoutId == null) {
       console.error('expected to find a cutoutId but could not')
     }
-    dispatch(selectZoomedIntoSlot({ slot: location, cutout: cutoutId }))
+    dispatch(selectZoomedIntoSlot({ slot: location, cutout: cutoutId })) // Keep using fake location
 
     const zoomInSlotPosition = getPositionFromSlotId(
-      slot ?? '',
+      slotForPositioning ?? '',
       deckDef,
       _getZoomInOffsetFromRawLocation(location)
     )

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupContainer.tsx
@@ -162,21 +162,18 @@ export function DeckSetupContainer(
   // Returns the actual slot/addressable area for positioning
   const _getSlotForPositioning = (location: string): string => {
     const isOnHopper = location.includes('hopper')
-    const isOnVacuumDock = location.includes('vacuumDock')
-    return isOnHopper
-      ? location.split('hopper')[1]
-      : isOnVacuumDock
-        ? 'vacuumModuleV1DockA4' // Use addressable area for positioning
-        : location
+    if (isOnHopper) {
+      return location.split('hopper')[1]
+    }
+    return location
   }
 
   const _getZoomInOffsetFromRawLocation = (location: string): number => {
     const isOnHopper = location.includes('hopper')
-    const isOnVacuumDock = location.includes('vacuumDock')
     if (isOnHopper) {
       return HOPPER_ZOOM_OFFSET_POSTITION
     }
-    if (isOnVacuumDock) {
+    if (getIsSlotAVacuumDock(location)) {
       return VACUUM_DOCK_ZOOM_OFFSET_POSITION
     }
     return 0

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -49,6 +49,7 @@ import {
 import { HighlightLabware } from '../HighlightLabware'
 import { getSlotInformation } from '../utils'
 import { HighlightItems } from './HighlightItems'
+import { useUpdateDeckConfigurationFromStartingDeck } from './hooks/useUpdateDeckConfigurationFromStartingDeck'
 import { HopperLabwareRenders } from './HopperLabwareRenders'
 import { AdapterControls, LabwareControls, SlotControls } from './Overlays'
 import { ActiveLabwareControls } from './Overlays/ActiveLabwareControls'
@@ -123,6 +124,12 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
   const { selectedSlot } = selectedSlotInfo
   const [menuListId, setShowMenuListForId] = useState<DeckSlotId | null>(null)
   const dispatch = useDispatch<any>()
+
+  useUpdateDeckConfigurationFromStartingDeck({
+    activeDeckSetup,
+    robotType,
+  })
+
   const { deckConfig } = useSelector(getDeckConfiguration)
 
   // handling module<>labware compat when moving labware to empty module

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -13,18 +13,21 @@ import {
   inferModuleOrientationFromXCoordinate,
   isAddressableAreaStandardSlot,
   THERMOCYCLER_MODULE_TYPE,
+  VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA,
   VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import {
   FAKE_HOPPER_LOCATION_MAP,
-  FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA,
   getIsSlotAHopper,
   getIsSlotAVacuumDock,
   getSlotInLocationStack,
   VACUUM_DOCK_LOCATION,
 } from '@opentrons/step-generation'
 
-import { HOPPER_LABWARE_X_OFFSET } from '/protocol-designer/constants'
+import {
+  HOPPER_LABWARE_X_OFFSET,
+  VACUUM_MODULE_SLOT,
+} from '/protocol-designer/constants'
 import { getTimelineIsBeingComputed } from '/protocol-designer/file-data/selectors'
 import {
   getDeckConfiguration,
@@ -77,7 +80,6 @@ import type {
   HopperLocationMapKey,
   ModuleTemporalProperties,
   ThermocyclerModuleState,
-  VacuumDockLocationMapKey,
 } from '@opentrons/step-generation'
 import type { FormData } from '../../../form-types'
 import type {
@@ -241,11 +243,6 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
   if (isMenuListIdForHopper) {
     adjustedMenuListId =
       FAKE_HOPPER_LOCATION_MAP[menuListId as HopperLocationMapKey]
-  } else if (isMenuListIdForVacuumDock) {
-    adjustedMenuListId =
-      FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA[
-        menuListId as VacuumDockLocationMapKey
-      ]
   }
 
   let menuListSlotPosition: CoordinateTuple | null = null
@@ -532,7 +529,9 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
       {/* Vacuum dock labware renders positioned independently in addressable area */}
       {allModules
         .filter(
-          module => module.type === VACUUM_MODULE_TYPE && module.slot === 'A3'
+          module =>
+            module.type === VACUUM_MODULE_TYPE &&
+            module.slot === VACUUM_MODULE_SLOT
         )
         .map(vacuumModule => {
           const { vacuumDockTopMostId } = getLabwaresOnModuleFromStack(
@@ -599,7 +598,7 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
               ) : (
                 <SlotControls
                   terminalItemId={terminalItemId}
-                  itemId={'vacuumDockA4'}
+                  itemId={VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA}
                   key={`${vacuumModule.slot}_vacuumDock`}
                   slotPosition={[dockSlotPosition[0], dockSlotPosition[1], 0]}
                   slotBoundingBox={dockBoundingBox}

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupDetails.tsx
@@ -7,6 +7,7 @@ import {
   FLEX_STACKER_MODULE_TYPE,
   getAddressableAreaFromSlotId,
   getModuleDef,
+  getPositionFromAddressableAreaId,
   getPositionFromSlotId,
   inferModuleOrientationFromSlot,
   inferModuleOrientationFromXCoordinate,
@@ -16,16 +17,19 @@ import {
 } from '@opentrons/shared-data'
 import {
   FAKE_HOPPER_LOCATION_MAP,
+  FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA,
   getIsSlotAHopper,
+  getIsSlotAVacuumDock,
   getSlotInLocationStack,
+  VACUUM_DOCK_LOCATION,
 } from '@opentrons/step-generation'
 
-import {
-  HOPPER_LABWARE_X_OFFSET,
-  VACUUM_DOCK_LABWARE_X_OFFSET,
-} from '/protocol-designer/constants'
+import { HOPPER_LABWARE_X_OFFSET } from '/protocol-designer/constants'
 import { getTimelineIsBeingComputed } from '/protocol-designer/file-data/selectors'
-import { getPendingCreationState } from '/protocol-designer/step-forms/selectors'
+import {
+  getDeckConfiguration,
+  getPendingCreationState,
+} from '/protocol-designer/step-forms/selectors'
 
 import { LabwareOnDeck } from '../../../components/organisms'
 import { getSlotsWithCollisions } from '../../../components/organisms/utils'
@@ -53,14 +57,17 @@ import { SlotOverflowMenu } from './SlotOverflowMenu'
 import { SlotWarning } from './SlotWarning'
 import {
   getAdjacentLabware,
+  getIsVacuumCollar,
   getSwapBlockedAdapter,
   getSwapBlockedModule,
 } from './utils'
+import { VacuumDockLabwareRenders } from './VacuumDockLabwareRenders'
 
 import type { ComponentProps, Dispatch, SetStateAction } from 'react'
 import type { ThermocyclerVizProps } from '@opentrons/components'
 import type {
   AddressableAreaName,
+  CoordinateTuple,
   CutoutId,
   DeckDefinition,
   DeckSlotId,
@@ -69,6 +76,7 @@ import type {
   HopperLocationMapKey,
   ModuleTemporalProperties,
   ThermocyclerModuleState,
+  VacuumDockLocationMapKey,
 } from '@opentrons/step-generation'
 import type { FormData } from '../../../form-types'
 import type {
@@ -115,6 +123,8 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
   const { selectedSlot } = selectedSlotInfo
   const [menuListId, setShowMenuListForId] = useState<DeckSlotId | null>(null)
   const dispatch = useDispatch<any>()
+  const { deckConfig } = useSelector(getDeckConfiguration)
+
   // handling module<>labware compat when moving labware to empty module
   // is handled by SlotControls. But when swapping labware when at least
   // one is on a module, we need to be aware of not only what labware is
@@ -217,17 +227,35 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
   const allModules: ModuleOnDeck[] = values(activeDeckSetup.modules)
   const isMenuListIdForHopper =
     menuListId != null && getIsSlotAHopper(menuListId)
-  const adjustedMenuListId = isMenuListIdForHopper
-    ? FAKE_HOPPER_LOCATION_MAP[menuListId as HopperLocationMapKey]
-    : menuListId
-  const menuListSlotPosition =
-    adjustedMenuListId != null
-      ? getPositionFromSlotId(
+  const isMenuListIdForVacuumDock =
+    menuListId != null && getIsSlotAVacuumDock(menuListId)
+
+  let adjustedMenuListId: AddressableAreaName | string | null = menuListId
+  if (isMenuListIdForHopper) {
+    adjustedMenuListId =
+      FAKE_HOPPER_LOCATION_MAP[menuListId as HopperLocationMapKey]
+  } else if (isMenuListIdForVacuumDock) {
+    adjustedMenuListId =
+      FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA[
+        menuListId as VacuumDockLocationMapKey
+      ]
+  }
+
+  let menuListSlotPosition: CoordinateTuple | null = null
+  if (adjustedMenuListId != null) {
+    menuListSlotPosition = isMenuListIdForVacuumDock
+      ? getPositionFromAddressableAreaId({
+          addressableAreaId: adjustedMenuListId as AddressableAreaName,
+          deckDef,
+          deckConfiguration: deckConfig,
+        })
+      : getPositionFromSlotId(
           adjustedMenuListId as string,
           deckDef,
           ...(isMenuListIdForHopper ? [HOPPER_LABWARE_X_OFFSET] : [])
         )
-      : null
+  }
+
   const multichannelWarningSlotIds: AddressableAreaName[] =
     showGen1MultichannelCollisionWarnings
       ? getSlotsWithCollisions(deckDef, allModules)
@@ -315,12 +343,8 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
           }
         }
 
-        const {
-          topMostId,
-          rightBelowTopId,
-          hopperTopMostId,
-          vacuumDockTopMostId,
-        } = getLabwaresOnModuleFromStack(moduleOnDeck.id, allLabwareValues)
+        const { topMostId, rightBelowTopId, hopperTopMostId } =
+          getLabwaresOnModuleFromStack(moduleOnDeck.id, allLabwareValues)
         const labwareInterfaceBoundingBox = {
           xDimension: moduleDef.dimensions.labwareInterfaceXDimension ?? 0,
           yDimension: moduleDef.dimensions.labwareInterfaceYDimension ?? 0,
@@ -493,17 +517,88 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
                   addEquipment={addEquipment}
                 />
               ) : null}
-              {vacuumDockTopMostId == null &&
-              moduleOnDeck.type === VACUUM_MODULE_TYPE ? (
+            </Module>
+          </Fragment>
+        ) : null
+      })}
+
+      {/* Vacuum dock labware renders positioned independently in addressable area */}
+      {allModules
+        .filter(
+          module => module.type === VACUUM_MODULE_TYPE && module.slot === 'A3'
+        )
+        .map(vacuumModule => {
+          const { vacuumDockTopMostId } = getLabwaresOnModuleFromStack(
+            vacuumModule.id,
+            allLabwareValues
+          )
+          const dockLabwareStack =
+            vacuumDockTopMostId != null
+              ? allLabwareValues
+                  .filter(lw => lw.stack.includes(VACUUM_DOCK_LOCATION))
+                  .sort((a, b) => b.stack.length - a.stack.length)
+                  .map(lw => lw.id)
+              : []
+
+          // Check if dock has a collar (same logic as main module area)
+          const dockHasCollar = dockLabwareStack.some(labwareId => {
+            return (
+              activeLabware[labwareId] != null &&
+              getIsVacuumCollar(activeLabware[labwareId].def)
+            )
+          })
+
+          // this should pull the addressable area position for the vacuum dock
+          const dockSlotPosition = getPositionFromAddressableAreaId({
+            addressableAreaId: 'vacuumModuleV1DockA4',
+            deckDef,
+            deckConfiguration: deckConfig,
+          })
+          const topLabware =
+            vacuumDockTopMostId != null
+              ? activeLabware[vacuumDockTopMostId]
+              : null
+          const dockBoundingBox = topLabware
+            ? {
+                xDimension: topLabware.def.dimensions.xDimension,
+                yDimension: topLabware.def.dimensions.yDimension,
+                zDimension: 0,
+              }
+            : (getAddressableAreaFromSlotId('A4', deckDef)?.boundingBox ??
+                // should never hit, but default to standard slot addressable area footprint
+                {
+                  xDimension: 128,
+                  yDimension: 86,
+                  zDimension: 0,
+                })
+
+          return dockSlotPosition != null ? (
+            <Fragment key={`${vacuumModule.id}_dock`}>
+              {dockHasCollar ? (
+                <VacuumDockLabwareRenders
+                  labwaresOnDeck={activeLabware}
+                  dockLabwareStack={dockLabwareStack}
+                  allModules={allModules}
+                  terminalItemId={terminalItemId}
+                  setHover={setHover}
+                  setShowMenuListForId={setShowMenuListForId}
+                  hover={hover}
+                  setHoveredLabware={setHoveredLabware}
+                  setDraggedLabware={setDraggedLabware}
+                  selectedZoomInSlot={selectedZoomInSlot}
+                  x={dockSlotPosition[0]}
+                  y={dockSlotPosition[1]}
+                />
+              ) : (
                 <SlotControls
                   terminalItemId={terminalItemId}
-                  itemId={`vacuumDock${slotId}`}
-                  key={`${moduleOnDeck.slot}_vacuumDock`}
-                  slotPosition={[VACUUM_DOCK_LABWARE_X_OFFSET, 0, 0]}
-                  slotBoundingBox={labwareInterfaceBoundingBox}
-                  moduleType={moduleOnDeck.type}
+                  itemId={'vacuumDockA4'}
+                  key={`${vacuumModule.slot}_vacuumDock`}
+                  slotPosition={[dockSlotPosition[0], dockSlotPosition[1], 0]}
+                  slotBoundingBox={dockBoundingBox}
+                  moduleType={vacuumModule.type}
                   handleDragHover={handleHoverEmptySlot}
-                  slotId={moduleOnDeck.id}
+                  slotId={vacuumModule.id}
                   hover={hover}
                   setHover={setHover}
                   setShowMenuListForId={setShowMenuListForId}
@@ -512,11 +607,10 @@ export function DeckSetupDetails(props: DeckSetupDetailsProps): JSX.Element {
                   stagingAreaAddressableAreas={[]}
                   addEquipment={addEquipment}
                 />
-              ) : null}
-            </Module>
-          </Fragment>
-        ) : null
-      })}
+              )}
+            </Fragment>
+          ) : null
+        })}
 
       {/* on-deck warnings for OT-2 and GEN1 8-channels only */}
       {multichannelWarningSlotIds.map(slotId => {

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
@@ -27,8 +27,6 @@ import {
 } from '@opentrons/shared-data'
 import {
   FAKE_HOPPER_LOCATION_MAP,
-  FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA,
-  FAKE_VACUUM_DOCK_LOCATION_TO_DECK_SLOT,
   getIsSlotAHopper,
   getIsSlotAVacuumDock,
 } from '@opentrons/step-generation'
@@ -45,7 +43,10 @@ import {
   SelectLabwareModal,
 } from '../../../components/organisms'
 import { useKitchen } from '../../../components/organisms/Kitchen/useKitchen'
-import { DECK_SETUP_TOOLS_WIDTH_REM } from '../../../constants'
+import {
+  DECK_SETUP_TOOLS_WIDTH_REM,
+  VACUUM_DOCK_DISPLAY_LOCATION,
+} from '../../../constants'
 import {
   createContainer,
   deleteContainer,
@@ -59,11 +60,7 @@ import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locati
 import { getSlotInformation } from '../utils'
 import { getIsLabwareOnSlotInUse, getIsVacuumModuleFull } from './utils'
 
-import type {
-  HopperLocationMapKey,
-  VacuumDockFakeLocationType,
-  VacuumDockLocationMapKey,
-} from '@opentrons/step-generation'
+import type { HopperLocationMapKey } from '@opentrons/step-generation'
 import type { CreateContainerAboveModuleArgs } from '../../../step-forms/actions/thunks'
 import type { ThunkDispatch } from '../../../types'
 
@@ -115,12 +112,7 @@ export function DeckSetupToolbox(
   }
   const isHopperSlot = getIsSlotAHopper(slot)
   const isVacuumDockSlot = getIsSlotAVacuumDock(slot)
-  // For vacuum dock, use the addressable area, not the deck slot
-  const realSlot = isVacuumDockSlot
-    ? FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA[
-        slot as VacuumDockLocationMapKey
-      ]
-    : slot
+  const realSlot = slot
   const offDeckLabware = deckSetup.labware[slot]
   const isVacuumModule =
     selectedModuleModel != null &&
@@ -327,8 +319,7 @@ export function DeckSetupToolbox(
   if (getIsSlotAHopper(slot)) {
     displaySlot = t('shared:stacker', { slot: getColumnFromWellName(slot) })
   } else if (getIsSlotAVacuumDock(slot)) {
-    displaySlot =
-      FAKE_VACUUM_DOCK_LOCATION_TO_DECK_SLOT[slot as VacuumDockFakeLocationType]
+    displaySlot = VACUUM_DOCK_DISPLAY_LOCATION
   }
 
   const isMultiStack = createdStackForSlot.length > 1

--- a/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/DeckSetupToolbox.tsx
@@ -27,7 +27,10 @@ import {
 } from '@opentrons/shared-data'
 import {
   FAKE_HOPPER_LOCATION_MAP,
+  FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA,
+  FAKE_VACUUM_DOCK_LOCATION_TO_DECK_SLOT,
   getIsSlotAHopper,
+  getIsSlotAVacuumDock,
 } from '@opentrons/step-generation'
 
 import { getColumnFromWellName } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils'
@@ -56,7 +59,11 @@ import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locati
 import { getSlotInformation } from '../utils'
 import { getIsLabwareOnSlotInUse, getIsVacuumModuleFull } from './utils'
 
-import type { HopperLocationMapKey } from '@opentrons/step-generation'
+import type {
+  HopperLocationMapKey,
+  VacuumDockFakeLocationType,
+  VacuumDockLocationMapKey,
+} from '@opentrons/step-generation'
 import type { CreateContainerAboveModuleArgs } from '../../../step-forms/actions/thunks'
 import type { ThunkDispatch } from '../../../types'
 
@@ -107,6 +114,13 @@ export function DeckSetupToolbox(
     return null
   }
   const isHopperSlot = getIsSlotAHopper(slot)
+  const isVacuumDockSlot = getIsSlotAVacuumDock(slot)
+  // For vacuum dock, use the addressable area, not the deck slot
+  const realSlot = isVacuumDockSlot
+    ? FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA[
+        slot as VacuumDockLocationMapKey
+      ]
+    : slot
   const offDeckLabware = deckSetup.labware[slot]
   const isVacuumModule =
     selectedModuleModel != null &&
@@ -142,6 +156,15 @@ export function DeckSetupToolbox(
   const isVacuumModuleFull =
     hasVacuumModuleCreated &&
     getIsVacuumModuleFull(createdStackForSlot, deckSetup.labware)
+
+  // Check if vacuum dock is full by checking both stack and adapter for collar
+  // The dock and main module areas are independently managed
+  // Note: The collar might be in createdAdapterForSlot instead of createdStackForSlot
+  const isVacuumDockFull =
+    isVacuumDockSlot &&
+    (getIsVacuumModuleFull(createdStackForSlot, deckSetup.labware) ||
+      (createdAdapterForSlot != null &&
+        getIsVacuumModuleFull([createdAdapterForSlot.id], deckSetup.labware)))
 
   const slotFull =
     ((createdAdapterForSlot != null && createdStackForSlot.length > 0) ||
@@ -248,7 +271,7 @@ export function DeckSetupToolbox(
     } else {
       dispatch(
         createContainer({
-          slot,
+          slot: realSlot,
           labwareDefURIStack: [
             ...(selectedAdapterDefURI != null ? [selectedAdapterDefURI] : []),
             ...(selectedTopLabware.labwareDefURI != null
@@ -299,9 +322,17 @@ export function DeckSetupToolbox(
       handleClear()
     }
   }
-  const displaySlot = getIsSlotAHopper(slot)
-    ? t('shared:stacker', { slot: getColumnFromWellName(slot) })
-    : slot
+
+  let displaySlot = slot
+  if (getIsSlotAHopper(slot)) {
+    displaySlot = t('shared:stacker', { slot: getColumnFromWellName(slot) })
+  } else if (getIsSlotAVacuumDock(slot)) {
+    displaySlot =
+      FAKE_VACUUM_DOCK_LOCATION_TO_DECK_SLOT[slot as VacuumDockFakeLocationType]
+  }
+
+  const isMultiStack = createdStackForSlot.length > 1
+  const shouldShowTopBottomOfSlotLabels = slotFull || isMultiStack
 
   return (
     <>
@@ -368,13 +399,16 @@ export function DeckSetupToolbox(
               <EmptySelectorButton
                 textAlignment="left"
                 text={
-                  hasNoLabware || hasVacuumModuleCreated
+                  hasNoLabware || hasVacuumModuleCreated || isVacuumDockSlot
                     ? t('add_labware')
                     : t('replace_labware')
                 }
                 iconName="plus"
                 onClick={() => {
-                  if (hasVacuumModuleCreated && isVacuumModuleFull) {
+                  if (
+                    (hasVacuumModuleCreated && isVacuumModuleFull) ||
+                    isVacuumDockFull
+                  ) {
                     makeSnackbar(t('labware_limit_reached') as string)
                   } else {
                     setShowSelectLabwareModal(true)
@@ -396,7 +430,7 @@ export function DeckSetupToolbox(
             />
           ) : (
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing4}>
-              {slotFull ? (
+              {shouldShowTopBottomOfSlotLabels ? (
                 <StyledText
                   desktopStyle="bodyDefaultRegular"
                   color={COLORS.grey60}
@@ -432,7 +466,7 @@ export function DeckSetupToolbox(
                   location={slot}
                 />
               ) : null}
-              {slotFull ? (
+              {shouldShowTopBottomOfSlotLabels ? (
                 <StyledText
                   desktopStyle="bodyDefaultRegular"
                   color={COLORS.grey60}

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
@@ -11,7 +11,7 @@ import {
   StyledText,
 } from '@opentrons/components'
 import { FLEX_STACKER_MODULE_TYPE } from '@opentrons/shared-data'
-import { getIsSlotAHopper } from '@opentrons/step-generation'
+import { getIsSlotAHopper, getIsSlotAVacuumDock } from '@opentrons/step-generation'
 
 import { SlotDetailModal } from '/protocol-designer/components/organisms/SlotDetailModal'
 import { getTimelineIsBeingComputed } from '/protocol-designer/file-data/selectors'
@@ -50,6 +50,7 @@ export function ActiveLabwareControls(
   const pendingCreationStateForHopper = useSelector(getPendingCreationState)
   const timelineIsBeingComputed = useSelector(getTimelineIsBeingComputed)
   const isSlotAHopper = getIsSlotAHopper(itemId)
+  const isSlotAVacuumDock = getIsSlotAVacuumDock(itemId)
   const [showSlotDetailModal, setShowSlotDetailModal] = useState<boolean>(false)
   const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
 
@@ -68,7 +69,8 @@ export function ActiveLabwareControls(
       : getFullStackFromLabwaresOnDeck(
           Object.values(activeDeckSetup.labware),
           itemId,
-          isSlotAHopper
+          isSlotAHopper,
+          isSlotAVacuumDock
         )
 
   const stackerModuleId = fullStack.find(

--- a/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/Overlays/ActiveLabwareControls.tsx
@@ -11,7 +11,10 @@ import {
   StyledText,
 } from '@opentrons/components'
 import { FLEX_STACKER_MODULE_TYPE } from '@opentrons/shared-data'
-import { getIsSlotAHopper, getIsSlotAVacuumDock } from '@opentrons/step-generation'
+import {
+  getIsSlotAHopper,
+  getIsSlotAVacuumDock,
+} from '@opentrons/step-generation'
 
 import { SlotDetailModal } from '/protocol-designer/components/organisms/SlotDetailModal'
 import { getTimelineIsBeingComputed } from '/protocol-designer/file-data/selectors'

--- a/protocol-designer/src/pages/Designer/DeckSetup/VacuumDockLabwareRenders.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/VacuumDockLabwareRenders.tsx
@@ -1,0 +1,116 @@
+import { LabwareOnDeck } from '/protocol-designer/components/organisms'
+
+import { HighlightLabware } from '../HighlightLabware'
+import { LabwareControls } from './Overlays'
+import { ActiveLabwareControls } from './Overlays/ActiveLabwareControls'
+
+import type { Dispatch, SetStateAction } from 'react'
+import type { DeckSlotId } from '@opentrons/shared-data'
+import type {
+  LabwareOnDeck as LabwareOnDeckType,
+  ModuleOnDeck,
+} from '/protocol-designer/step-forms'
+import type { TerminalItemId } from '/protocol-designer/steplist'
+
+interface VacuumDockLabwareRendersProps {
+  labwaresOnDeck: Record<string, LabwareOnDeckType>
+  dockLabwareStack: string[] // Array of labware IDs on the dock
+  allModules: ModuleOnDeck[]
+  terminalItemId: TerminalItemId | null
+  setHover: Dispatch<SetStateAction<string | null>>
+  setShowMenuListForId: Dispatch<SetStateAction<DeckSlotId | null>>
+  hover: string | null
+  setHoveredLabware: Dispatch<
+    SetStateAction<LabwareOnDeckType | null | undefined>
+  >
+  setDraggedLabware: Dispatch<
+    SetStateAction<LabwareOnDeckType | null | undefined>
+  >
+  selectedZoomInSlot?: DeckSlotId
+  x: number
+  y: number
+}
+
+export function VacuumDockLabwareRenders(
+  props: VacuumDockLabwareRendersProps
+): JSX.Element | null {
+  const {
+    labwaresOnDeck,
+    dockLabwareStack,
+    allModules,
+    terminalItemId,
+    setHover,
+    setShowMenuListForId,
+    hover,
+    setHoveredLabware,
+    setDraggedLabware,
+    selectedZoomInSlot,
+    x,
+    y,
+  } = props
+
+  if (dockLabwareStack.length === 0) {
+    return null
+  }
+
+  // Get the top-most labware on the dock
+  const topLabwareId = dockLabwareStack[0]
+  const topLabware = labwaresOnDeck[topLabwareId]
+
+  if (topLabware == null) {
+    return null
+  }
+
+  const labwareInterfaceBoundingBox = {
+    xDimension: topLabware.def.dimensions.xDimension,
+    yDimension: topLabware.def.dimensions.yDimension,
+    zDimension: 0,
+  }
+
+  return (
+    <>
+      {/* Render all labware in the stack (bottom to top) */}
+      {dockLabwareStack
+        .slice()
+        .reverse()
+        .map(labwareId => {
+          const labware = labwaresOnDeck[labwareId]
+          return labware ? (
+            <LabwareOnDeck
+              key={labwareId}
+              x={x}
+              y={y}
+              labwareOnDeck={labware}
+            />
+          ) : null
+        })}
+      <HighlightLabware
+        labwareOnDeck={topLabware}
+        position={[x, y, 0]}
+        isZoomed={selectedZoomInSlot != null}
+      />
+      <LabwareControls
+        terminalItemId={terminalItemId}
+        itemId="vacuumDockA4"
+        setHover={setHover}
+        setShowMenuListForId={setShowMenuListForId}
+        hover={hover}
+        slotPosition={[x, y, 0]}
+        setHoveredLabware={setHoveredLabware}
+        setDraggedLabware={setDraggedLabware}
+        swapBlocked={false}
+        labwareOnDeck={topLabware}
+        isSelected={selectedZoomInSlot != null}
+        allModules={allModules}
+      />
+      <ActiveLabwareControls
+        itemId="vacuumDockA4"
+        slotPosition={[x, y, 0]}
+        hover={hover}
+        setHover={setHover}
+        slotBoundingBox={labwareInterfaceBoundingBox}
+        terminalItemId={terminalItemId}
+      />
+    </>
+  )
+}

--- a/protocol-designer/src/pages/Designer/DeckSetup/VacuumDockLabwareRenders.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/VacuumDockLabwareRenders.tsx
@@ -1,3 +1,5 @@
+import { VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA } from '@opentrons/shared-data'
+
 import { LabwareOnDeck } from '/protocol-designer/components/organisms'
 
 import { HighlightLabware } from '../HighlightLabware'
@@ -70,20 +72,12 @@ export function VacuumDockLabwareRenders(
   return (
     <>
       {/* Render all labware in the stack (bottom to top) */}
-      {dockLabwareStack
-        .slice()
-        .reverse()
-        .map(labwareId => {
-          const labware = labwaresOnDeck[labwareId]
-          return labware ? (
-            <LabwareOnDeck
-              key={labwareId}
-              x={x}
-              y={y}
-              labwareOnDeck={labware}
-            />
-          ) : null
-        })}
+      {[...dockLabwareStack].reverse().map(labwareId => {
+        const labware = labwaresOnDeck[labwareId]
+        return labware ? (
+          <LabwareOnDeck key={labwareId} x={x} y={y} labwareOnDeck={labware} />
+        ) : null
+      })}
       <HighlightLabware
         labwareOnDeck={topLabware}
         position={[x, y, 0]}
@@ -91,7 +85,7 @@ export function VacuumDockLabwareRenders(
       />
       <LabwareControls
         terminalItemId={terminalItemId}
-        itemId="vacuumDockA4"
+        itemId={VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA}
         setHover={setHover}
         setShowMenuListForId={setShowMenuListForId}
         hover={hover}
@@ -104,7 +98,7 @@ export function VacuumDockLabwareRenders(
         allModules={allModules}
       />
       <ActiveLabwareControls
-        itemId="vacuumDockA4"
+        itemId={VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA}
         slotPosition={[x, y, 0]}
         hover={hover}
         setHover={setHover}

--- a/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupToolbox.test.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/__tests__/DeckSetupToolbox.test.tsx
@@ -23,6 +23,7 @@ import {
 import { selectors } from '/protocol-designer/labware-ingred/selectors'
 import {
   getAdditionalEquipment,
+  getDeckConfiguration,
   getLabwareEntities,
   getSavedStepForms,
 } from '/protocol-designer/step-forms/selectors'
@@ -100,6 +101,9 @@ describe('DeckSetupToolbox', () => {
     vi.mocked(
       wellContentsSelectors.getAllWellContentsForActiveItem
     ).mockReturnValue(null)
+    vi.mocked(getDeckConfiguration).mockReturnValue({
+      deckConfig: [],
+    })
   })
   afterEach(() => {
     vi.resetAllMocks()

--- a/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
@@ -29,6 +29,8 @@ import {
   VACUUM_MODULE_V1,
 } from '@opentrons/shared-data'
 
+import { VACUUM_MODULE_TYPE_WITH_LABWARE } from '../../../constants'
+
 import type { ModuleModel } from '@opentrons/shared-data'
 import type { ModuleLabwareCompatibilityKey } from '../../../types'
 
@@ -136,18 +138,18 @@ export const RECOMMENDED_LABWARE_BY_MODULE: {
     'opentrons_tough_1_reservoir_300ml',
     'opentrons_tough_4_reservoir_72ml',
   ],
-
-  // TODO (nd: 2026-05-14): correctly reflect vacuum module compatible labware once they are added to shared-data
+  // TODO (nd: 2026/05/20): audit this once recommended labware is finalized
   [VACUUM_MODULE_TYPE]: [
     'opentrons_vacuum_module_spacer_thingamajig',
-    'opentrons_96_wellplate_200ul_pcr_full_skirt',
     'opentrons_vacuum_module_gen1_collar_tall',
     'opentrons_vacuum_module_gen1_collar_short',
+    'opentrons_96_wellplate_200ul_pcr_full_skirt',
   ],
-  VACUUM_MODULE_TYPE_WITH_LABWARE: [
-    'opentrons_96_wellplate_200ul_pcr_full_skirt',
+  // TODO (nd: 2026/05/20): audit this once recommended labware is finalized
+  [VACUUM_MODULE_TYPE_WITH_LABWARE]: [
     'opentrons_vacuum_module_gen1_collar_tall',
     'opentrons_vacuum_module_gen1_collar_short',
+    'opentrons_96_wellplate_200ul_pcr_full_skirt',
   ],
 }
 

--- a/protocol-designer/src/pages/Designer/DeckSetup/hooks/useUpdateDeckConfigurationFromStartingDeck.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/hooks/useUpdateDeckConfigurationFromStartingDeck.ts
@@ -1,0 +1,75 @@
+import { useEffect, useMemo } from 'react'
+import { useDispatch } from 'react-redux'
+
+import {
+  FLEX_ROBOT_TYPE,
+  STAGING_AREA_RIGHT_SLOT_FIXTURE,
+  TRASH_BIN_ADAPTER_FIXTURE,
+  WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE,
+} from '@opentrons/shared-data'
+
+import { useMemoizedUpdatedDeckConfig } from '/protocol-designer/components/organisms/HardwareConfigurator/hooks/useMemoizedUpdatedDeckConfig'
+import { editDeckConfiguration } from '/protocol-designer/step-forms/actions'
+
+import type {
+  CutoutFixtureId,
+  CutoutId,
+  RobotType,
+} from '@opentrons/shared-data'
+import type { AllTemporalPropertiesForTimelineFrame } from '/protocol-designer/step-forms'
+
+interface UseUpdateDeckConfigurationFromStartingDeckProps {
+  activeDeckSetup: AllTemporalPropertiesForTimelineFrame
+  robotType: RobotType
+}
+
+export function useUpdateDeckConfigurationFromStartingDeck(
+  props: UseUpdateDeckConfigurationFromStartingDeckProps
+): void {
+  const { activeDeckSetup, robotType } = props
+  const dispatch = useDispatch()
+
+  // Compute the correct deck configuration from modules and fixtures
+  // This ensures addressable areas (like vacuum dock) have correct positions on mount
+  const modules = useMemo(() => {
+    return Object.values(activeDeckSetup.modules).reduce((acc, module) => {
+      return { ...acc, [module.id]: module }
+    }, {})
+  }, [activeDeckSetup.modules])
+
+  const fixtures = useMemo(() => {
+    return Object.values(activeDeckSetup.additionalEquipmentOnDeck).reduce(
+      (acc, fixture) => {
+        let cutoutFixtureId: CutoutFixtureId = TRASH_BIN_ADAPTER_FIXTURE
+        if (fixture.name === 'stagingArea') {
+          cutoutFixtureId = STAGING_AREA_RIGHT_SLOT_FIXTURE
+        } else if (fixture.name === 'wasteChute') {
+          cutoutFixtureId = WASTE_CHUTE_RIGHT_ADAPTER_NO_COVER_FIXTURE
+        }
+        return {
+          ...acc,
+          [fixture.id]: {
+            cutoutId: fixture.location as CutoutId,
+            name: fixture.name as 'trashBin' | 'wasteChute' | 'stagingArea',
+            cutoutFixtureId,
+          },
+        }
+      },
+      {}
+    )
+  }, [activeDeckSetup.additionalEquipmentOnDeck])
+
+  // Use the computed deck config directly (don't wait for Redux to update)
+  const deckConfig = useMemoizedUpdatedDeckConfig(modules, fixtures)
+
+  // Also update Redux state for other components that may need it
+  useEffect(() => {
+    if (robotType === FLEX_ROBOT_TYPE) {
+      dispatch(
+        editDeckConfiguration({
+          deckConfig,
+        })
+      )
+    }
+  }, [dispatch, deckConfig, robotType])
+}

--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -62,6 +62,19 @@ const FLEX_TC_SLOTS = ['A1', 'B1']
 
 export type ModuleModelExtended = ModuleModel | 'stagingAreaAndMagneticBlock'
 
+/**
+ * Check if a labware definition is that of a vacuum module collar
+ * @param labwareDef - The labware definition to check
+ * @returns True if the labware definition is a vacuum module collar, false otherwise
+ */
+export function getIsVacuumCollar(labwareDef: LabwareDefinition2): boolean {
+  const loadName = labwareDef.parameters.loadName
+  return (
+    loadName === 'opentrons_vacuum_module_gen1_collar_tall' ||
+    loadName === 'opentrons_vacuum_module_gen1_collar_short'
+  )
+}
+
 export function getCutoutIdForAddressableArea(
   addressableArea: AddressableAreaName,
   cutoutFixtures: CutoutFixture[]
@@ -145,7 +158,9 @@ export function getModuleModelsBySlot(
 export const getLabwareIsRecommended = (
   def: LabwareDefinition2,
   moduleModel?: ModuleModel | null,
-  moduleHasLabware: boolean = false
+  moduleHasLabware?: boolean,
+  isVacuumDock?: boolean,
+  dockHasCollar?: boolean
 ): boolean => {
   //  special-casing the thermocycler module V2 recommended labware since the thermocyclerModuleTypes
   //  have different recommended labware
@@ -153,6 +168,19 @@ export const getLabwareIsRecommended = (
     // permissive early exit if no module passed
     return true
   }
+
+  // For vacuum dock, recommendations depend on whether collar is present
+  if (isVacuumDock) {
+    if (!dockHasCollar) {
+      // No collar is present, so recommend both collars
+      return getIsVacuumCollar(def)
+    }
+    // Collar is present, so recommend tough wellplate
+    return (
+      def.parameters.loadName === 'opentrons_96_wellplate_200ul_pcr_full_skirt'
+    )
+  }
+
   const moduleType = getModuleType(moduleModel)
 
   // For vacuum module, show different labware based on whether module has labware

--- a/protocol-designer/src/pages/Designer/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/__tests__/utils.test.ts
@@ -378,7 +378,10 @@ describe('getUnoccupiedStackOptions', () => {
       additionalEquipmentOnDeck: {},
     }
     expect(
-      getSlotInformation({ deckSetup: mockDeckSetup, slot: 'vacuumDockA4' })
+      getSlotInformation({
+        deckSetup: mockDeckSetup,
+        slot: 'vacuumModuleV1DockA4',
+      })
     ).toEqual({
       matchingLabwareFor4thColumn: null,
       slotPosition: null,

--- a/protocol-designer/src/pages/Designer/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/__tests__/utils.test.ts
@@ -159,6 +159,7 @@ describe('getSlotInformation', () => {
       createdFixtureForSlots: [],
       slotPosition: null,
       isSlotAHopper: false,
+      isSlotAVacuumDock: false,
     })
   })
   it('renders only a labware for ot-2 on slot 2', () => {
@@ -171,6 +172,7 @@ describe('getSlotInformation', () => {
       slotPosition: null,
       createdStackForSlot: [],
       isSlotAHopper: false,
+      isSlotAVacuumDock: false,
     })
   })
   it('renders no items on the slot for a flex', () => {
@@ -188,6 +190,7 @@ describe('getSlotInformation', () => {
       createdFixtureForSlots: [],
       createdStackForSlot: [],
       isSlotAHopper: false,
+      isSlotAVacuumDock: false,
     })
   })
   it('renders the slot as a hopper', () => {
@@ -205,6 +208,7 @@ describe('getSlotInformation', () => {
       createdFixtureForSlots: [],
       createdStackForSlot: [],
       isSlotAHopper: true,
+      isSlotAVacuumDock: false,
     })
   })
   it('renders a trashbin for a Flex on slot A3', () => {
@@ -217,6 +221,7 @@ describe('getSlotInformation', () => {
       preSelectedFixture: 'trashBin',
       createdStackForSlot: [],
       isSlotAHopper: false,
+      isSlotAVacuumDock: false,
     })
   })
   it('renders a h-s, labware and nested labware for a Flex on slot D1', () => {
@@ -230,6 +235,7 @@ describe('getSlotInformation', () => {
       createdStackForSlot: [mockLabOnDeck2Flex.id],
       createdFixtureForSlots: [],
       isSlotAHopper: false,
+      isSlotAVacuumDock: false,
     })
   })
   it('renders the waste chute and staging area for slot D3 for Flex', () => {
@@ -242,6 +248,7 @@ describe('getSlotInformation', () => {
       preSelectedFixture: 'wasteChuteAndStagingArea',
       createdStackForSlot: [],
       isSlotAHopper: false,
+      isSlotAVacuumDock: false,
     })
   })
   it('renders the staging area with waste chute and labware in slot D4 for flex', () => {
@@ -254,6 +261,7 @@ describe('getSlotInformation', () => {
       createdFixtureForSlots: [mockWasteChute, mockStagingArea],
       preSelectedFixture: 'wasteChuteAndStagingArea',
       isSlotAHopper: false,
+      isSlotAVacuumDock: false,
     })
   })
 })
@@ -361,5 +369,23 @@ describe('getUnoccupiedStackOptions', () => {
         t: mockT,
       })
     ).toEqual([])
+  })
+  it('renders the slot as a vacuum dock', () => {
+    const mockDeckSetup: AllTemporalPropertiesForTimelineFrame = {
+      labware: {},
+      pipettes: {},
+      modules: {},
+      additionalEquipmentOnDeck: {},
+    }
+    expect(
+      getSlotInformation({ deckSetup: mockDeckSetup, slot: 'vacuumDockA4' })
+    ).toEqual({
+      matchingLabwareFor4thColumn: null,
+      slotPosition: null,
+      createdFixtureForSlots: [],
+      createdStackForSlot: [],
+      isSlotAHopper: false,
+      isSlotAVacuumDock: true,
+    })
   })
 })

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -18,7 +18,7 @@ import {
 } from '@opentrons/shared-data'
 import {
   FAKE_HOPPER_LOCATION_MAP,
-  FAKE_VACUUM_DOCK_LOCATION_MAP,
+  FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA,
   getFullStackFromLabwares,
   getIsSlotAHopper,
   getIsSlotAVacuumDock,
@@ -55,7 +55,7 @@ import type {
   LabwareEntities,
   LabwareEntity,
   RobotState,
-  VacuumDockLocationMapKey,
+  VacuumDockFakeLocationType,
 } from '@opentrons/step-generation'
 import type {
   AllTemporalPropertiesForTimelineFrame,
@@ -80,6 +80,7 @@ interface SlotInformation {
   matchingLabwareFor4thColumn: LabwareOnDeck | null
   slotPosition: CoordinateTuple | null
   isSlotAHopper: boolean
+  isSlotAVacuumDock: boolean
   createdModuleForSlot?: ModuleOnDeck
   createdAdapterForSlot?: LabwareOnDeck
   createdFixtureForSlots?: AdditionalEquipment[]
@@ -103,7 +104,9 @@ const _getAdjustedSlot = (
   isSlotAHopper: boolean
 ): string => {
   if (isSlotAVacuumDock) {
-    return FAKE_VACUUM_DOCK_LOCATION_MAP[slot as VacuumDockLocationMapKey]
+    return FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA[
+      slot as VacuumDockFakeLocationType
+    ]
   }
   if (isSlotAHopper) {
     return FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
@@ -165,7 +168,8 @@ export const getSlotInformation = (
     : getFullStackFromLabwaresOnDeck(
         Object.values(deckSetupLabware),
         slot,
-        isSlotAHopper
+        isSlotAHopper,
+        isSlotAVacuumDock
       )
   const labwareStackOnSlot =
     fullStackFromLabwares?.filter(
@@ -257,6 +261,7 @@ export const getSlotInformation = (
     preSelectedFixture,
     slotPosition: slotPosition,
     isSlotAHopper,
+    isSlotAVacuumDock,
     matchingLabwareFor4thColumn: matchingLabware,
     createdStackForSlot:
       slot === 'offDeck'

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -18,7 +18,6 @@ import {
 } from '@opentrons/shared-data'
 import {
   FAKE_HOPPER_LOCATION_MAP,
-  FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA,
   getFullStackFromLabwares,
   getIsSlotAHopper,
   getIsSlotAVacuumDock,
@@ -55,7 +54,6 @@ import type {
   LabwareEntities,
   LabwareEntity,
   RobotState,
-  VacuumDockFakeLocationType,
 } from '@opentrons/step-generation'
 import type {
   AllTemporalPropertiesForTimelineFrame,
@@ -104,9 +102,7 @@ const _getAdjustedSlot = (
   isSlotAHopper: boolean
 ): string => {
   if (isSlotAVacuumDock) {
-    return FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA[
-      slot as VacuumDockFakeLocationType
-    ]
+    return slot
   }
   if (isSlotAHopper) {
     return FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]

--- a/protocol-designer/src/types.ts
+++ b/protocol-designer/src/types.ts
@@ -8,6 +8,7 @@ import type {
   THERMOCYCLER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import type { RootState as Analytics } from './analytics'
+import type { VACUUM_MODULE_TYPE_WITH_LABWARE } from './constants'
 import type { RootState as Dismiss } from './dismiss'
 import type { RootState as FeatureFlags } from './feature-flags'
 import type { RootState as FileData } from './file-data'
@@ -77,4 +78,4 @@ export type OT2ModuleType =
 
 export type ModuleLabwareCompatibilityKey =
   | ModuleType
-  | 'VACUUM_MODULE_TYPE_WITH_LABWARE'
+  | typeof VACUUM_MODULE_TYPE_WITH_LABWARE

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -15,7 +15,6 @@ import {
 } from '@opentrons/shared-data'
 import {
   FAKE_HOPPER_LOCATION_MAP,
-  FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA,
   getSlotInLocationStack,
   HOPPER_STACKER_LOCATION,
   PROTOCOL_CONTEXT_NAME,
@@ -40,7 +39,6 @@ import type {
   LabwareEntities,
   ModuleEntity,
   PipetteEntities,
-  VacuumDockLocationMapKey,
 } from '@opentrons/step-generation'
 import type { BoundingRect, GenericRect } from '../collision-types'
 import type {
@@ -475,10 +473,7 @@ export const getFullStackFromLabwaresOnDeck = (
   if (onHopper) {
     slotInStack = FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
   } else if (onVacuumDock) {
-    slotInStack =
-      FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA[
-        slot as VacuumDockLocationMapKey
-      ]
+    slotInStack = slot
   } else {
     slotInStack = slot
   }

--- a/protocol-designer/src/utils/index.ts
+++ b/protocol-designer/src/utils/index.ts
@@ -11,13 +11,14 @@ import {
   isAddressableAreaStandardSlot,
   makeWellSetHelpers,
   STAGING_AREA_RIGHT_SLOT_FIXTURE,
+  VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 import {
   FAKE_HOPPER_LOCATION_MAP,
+  FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA,
   getSlotInLocationStack,
   HOPPER_STACKER_LOCATION,
   PROTOCOL_CONTEXT_NAME,
-  VACUUM_DOCK_FAKE_LOCATION,
   VACUUM_DOCK_LOCATION,
 } from '@opentrons/step-generation'
 
@@ -37,7 +38,9 @@ import type {
   AdditionalEquipmentEntity,
   HopperLocationMapKey,
   LabwareEntities,
+  ModuleEntity,
   PipetteEntities,
+  VacuumDockLocationMapKey,
 } from '@opentrons/step-generation'
 import type { BoundingRect, GenericRect } from '../collision-types'
 import type {
@@ -373,6 +376,7 @@ export function getLocationStackTopToBottom(
   const stack: string[] = []
   const visited = new Set<string>()
   let current: string | undefined = labwareId
+
   while (current != null) {
     // Cycle detection: if we've seen this node before, break to prevent infinite loop
     if (visited.has(current)) {
@@ -390,9 +394,24 @@ export function getLocationStackTopToBottom(
       // So when the node is on the hopper, insert the hopper marker once
       stack.push(HOPPER_STACKER_LOCATION)
     }
-    const isOnVacuumDock = slot === VACUUM_DOCK_FAKE_LOCATION
+    const isOnVacuumDock = slot === 'vacuumModuleV1DockA4'
     if (isOnVacuumDock) {
+      // Vacuum dock stack shape: [labware1, labware2, vacuumDock, moduleId, slot]
+      // So when the node is on the vacuum dock, insert the vacuumDock marker once
       stack.push(VACUUM_DOCK_LOCATION)
+      // Find the vacuum module in A3 (dock is always associated with module in A3)
+      // Check both by slot 'A3' and by looking through all modules for safety
+      let vacuumModuleInA3: ModuleEntity | null = moduleEntities.A3
+      if (vacuumModuleInA3 == null) {
+        // moduleEntities might be keyed by ID instead of slot, search through all
+        vacuumModuleInA3 =
+          Object.values(moduleEntities).find(
+            module => module.type === VACUUM_MODULE_TYPE
+          ) ?? null
+      }
+      if (vacuumModuleInA3 != null) {
+        stack.push(vacuumModuleInA3.id)
+      }
     }
     current = parent
   }
@@ -408,7 +427,7 @@ export const getLabwaresOnModuleFromStack = (
   hopperTopMostId: string | null
   vacuumDockTopMostId: string | null
 } => {
-  // all stacks involving this module and not on the hopper if its a flex stacker and not on the vacuum dock
+  // all stacks involving this module and not on the hopper or vacuum dock
   const allStacks = labware.filter(
     ({ stack }) =>
       stack.includes(moduleId) &&
@@ -449,17 +468,27 @@ export const getLabwaresOnModuleFromStack = (
 export const getFullStackFromLabwaresOnDeck = (
   labwareOnDeck: LabwareOnDeck[],
   slot: DeckSlotId,
-  onHopper: boolean
+  onHopper: boolean,
+  onVacuumDock: boolean = false
 ): string[] => {
-  const slotInStack = onHopper
-    ? FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
-    : slot
+  let slotInStack: AddressableAreaName | string
+  if (onHopper) {
+    slotInStack = FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
+  } else if (onVacuumDock) {
+    slotInStack =
+      FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA[
+        slot as VacuumDockLocationMapKey
+      ]
+  } else {
+    slotInStack = slot
+  }
   return (
     labwareOnDeck
       .filter(
         ({ stack }) =>
           stack.includes(slotInStack as string) &&
-          onHopper === stack.includes(HOPPER_STACKER_LOCATION)
+          onHopper === stack.includes(HOPPER_STACKER_LOCATION) &&
+          onVacuumDock === stack.includes(VACUUM_DOCK_LOCATION)
       )
       .sort((a, b) => b.stack.length - a.stack.length)[0]?.stack ?? []
   )

--- a/protocol-designer/src/utils/labwareModuleCompatibility.ts
+++ b/protocol-designer/src/utils/labwareModuleCompatibility.ts
@@ -10,6 +10,7 @@ import {
   VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
+import { VACUUM_MODULE_TYPE_WITH_LABWARE } from '../constants'
 import { RECOMMENDED_LABWARE_BY_MODULE } from '../pages/Designer/DeckSetup/constants'
 
 import type { LabwareDefinition2 } from '@opentrons/shared-data'
@@ -85,17 +86,18 @@ export const COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE: Record<
     ...RECOMMENDED_LABWARE_BY_MODULE[FLEX_STACKER_MODULE_TYPE],
   ],
 
-  // TODO (nd: 2026-05-14): correctly reflect vacuum module compatible labware once they are added to shared-data
+  // TODO (nd: 2026/05/20): audit this once recommended labware is finalized
   [VACUUM_MODULE_TYPE]: [
     'opentrons_vacuum_module_spacer_thingamajig',
-    'opentrons_96_wellplate_200ul_pcr_full_skirt',
     'opentrons_vacuum_module_gen1_collar_tall',
     'opentrons_vacuum_module_gen1_collar_short',
+    'opentrons_96_wellplate_200ul_pcr_full_skirt',
   ],
-  VACUUM_MODULE_TYPE_WITH_LABWARE: [
-    'opentrons_96_wellplate_200ul_pcr_full_skirt',
+  // TODO (nd: 2026/05/20): audit this once recommended labware is finalized
+  [VACUUM_MODULE_TYPE_WITH_LABWARE]: [
     'opentrons_vacuum_module_gen1_collar_tall',
     'opentrons_vacuum_module_gen1_collar_short',
+    'opentrons_96_wellplate_200ul_pcr_full_skirt',
   ],
 }
 export const getLabwareIsCompatible = (
@@ -143,24 +145,26 @@ const _getLabwareCompatibleWithFlexStacker = (
 
 const _getLabwareCompatibleWithVacuumModule = (
   def: LabwareDefinition2,
-  isOccupied: boolean = false
+  isDock: boolean = false
 ): boolean => {
-  const key = isOccupied
-    ? 'VACUUM_MODULE_TYPE_WITH_LABWARE'
-    : VACUUM_MODULE_TYPE
+  if (isDock) {
+    return (
+      COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE[
+        VACUUM_MODULE_TYPE_WITH_LABWARE
+      ].includes(def.parameters.loadName) ||
+      def.metadata.displayCategory === 'wellPlate'
+    )
+  }
   return (
-    COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE[key].includes(
+    COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE[VACUUM_MODULE_TYPE].includes(
       def.parameters.loadName
-    ) ||
-    def.metadata.displayCategory === 'wellPlate' ||
-    def.metadata.displayCategory === 'reservoir'
+    ) || def.metadata.displayCategory === 'wellPlate'
   )
 }
 
 export const getLabwareCompatibleWithModule = (
   def: LabwareDefinition2,
-  moduleType: ModuleLabwareCompatibilityKey,
-  isOccupied: boolean = false
+  moduleType: ModuleLabwareCompatibilityKey
 ): boolean => {
   switch (moduleType) {
     case FLEX_STACKER_MODULE_TYPE:
@@ -168,7 +172,9 @@ export const getLabwareCompatibleWithModule = (
     case ABSORBANCE_READER_TYPE:
       return _getLabwareCompatibleWithAbsorbanceReader(def)
     case VACUUM_MODULE_TYPE:
-      return _getLabwareCompatibleWithVacuumModule(def, isOccupied)
+      return _getLabwareCompatibleWithVacuumModule(def)
+    case VACUUM_MODULE_TYPE_WITH_LABWARE:
+      return _getLabwareCompatibleWithVacuumModule(def, true)
     default:
       return COMPATIBLE_LABWARE_ALLOWLIST_BY_MODULE_TYPE[moduleType].includes(
         def.parameters.loadName

--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -109,6 +109,7 @@ import type {
   CutoutConfig,
   CutoutConfigMap,
   CutoutFixture,
+  DeckConfiguration,
   DeckDefinition,
   DeckDefinitionWithFakes,
   ModuleModel,
@@ -404,6 +405,50 @@ export function getPositionFromSlotId(
       : null
 
   return slotPosition
+}
+
+export function getPositionFromAddressableAreaId(args: {
+  addressableAreaId: AddressableAreaName
+  deckDef: DeckDefinition
+  deckConfiguration: DeckConfiguration
+}): CoordinateTuple | null {
+  const { addressableAreaId, deckDef, deckConfiguration } = args
+
+  for (const cutoutFixture of deckDef.cutoutFixtures) {
+    const match = Object.entries(cutoutFixture.providesAddressableAreas).find(
+      ([_, providedAA]) => providedAA.includes(addressableAreaId)
+    )
+    const isInDeckConfig = deckConfiguration.some(
+      config => config.cutoutFixtureId === cutoutFixture.id
+    )
+    if (match == null) {
+      continue
+    }
+    const [cutoutMatch] = match
+    if (isInDeckConfig) {
+      const addressableAreaOffset = getAAByAAId(
+        addressableAreaId,
+        deckDef
+      ).offsetFromCutoutFixture
+      const cutoutPosition =
+        deckDef.locations.cutouts.find(cutout => cutout.id === cutoutMatch)
+          ?.position ?? null
+      if (cutoutPosition == null) {
+        continue
+      }
+      return [
+        cutoutPosition[0] + addressableAreaOffset[0],
+        cutoutPosition[1] + addressableAreaOffset[1],
+        cutoutPosition[2] + addressableAreaOffset[2],
+      ]
+    }
+  }
+  console.warn('no match found', {
+    addressableAreaId,
+    deckDef,
+    deckConfiguration,
+  })
+  return [0, 0, 0]
 }
 
 export function getAddressableAreaFromSlotId(

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -8,10 +8,12 @@ import {
   TEMPERATURE_MODULE_TYPE,
   TEMPERATURE_MODULE_V1,
   THERMOCYCLER_MODULE_TYPE,
+  VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA,
   VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import type {
+  AddressableAreaName,
   AddressableOffsetVector,
   DeckSlotId,
   FlexStackerStoredLabwareGroup,
@@ -146,17 +148,6 @@ export const FAKE_HOPPER_LOCATION_MAP = {
 
 export type HopperLocationMapKey = keyof typeof FAKE_HOPPER_LOCATION_MAP
 
-export const VACUUM_DOCK_LOCATION = 'vacuumDock'
-
-export const VACUUM_DOCK_FAKE_LOCATION = 'vacuumDockA4'
-
-export const FAKE_VACUUM_DOCK_LOCATION_MAP = {
-  vacuumDockA4: 'A4',
-}
-
-export type VacuumDockLocationMapKey =
-  keyof typeof FAKE_VACUUM_DOCK_LOCATION_MAP
-
 export const BOTTOM_UP_LABWARE_POOL_KEYS: Array<
   keyof FlexStackerStoredLabwareGroup
 > = ['adapterLabwareId', 'primaryLabwareId', 'lidLabwareId']
@@ -173,6 +164,27 @@ export const SLOT_LOCATIONS_TO_FAKE_HOPPER_LOCATIONS: Record<
   C4: 'hopperC4',
   D4: 'hopperD4',
 }
+
+export const VACUUM_DOCK_LOCATION = 'vacuumDock'
+
+export const VACUUM_DOCK_FAKE_LOCATION: 'vacuumDockA4' = 'vacuumDockA4'
+
+export type VacuumDockFakeLocationType = typeof VACUUM_DOCK_FAKE_LOCATION
+
+export const FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA: Readonly<
+  Record<VacuumDockFakeLocationType, AddressableAreaName>
+> = {
+  vacuumDockA4: VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA,
+}
+
+export const FAKE_VACUUM_DOCK_LOCATION_TO_DECK_SLOT: Readonly<
+  Record<VacuumDockFakeLocationType, DeckSlotId>
+> = {
+  vacuumDockA4: 'A4',
+}
+
+export type VacuumDockLocationMapKey =
+  keyof typeof FAKE_VACUUM_DOCK_LOCATION_TO_DECK_SLOT
 
 export const VACUUM_VENT_OPEN: 'open' = 'open'
 export const VACUUM_VENT_CLOSED: 'closed' = 'closed'

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -8,12 +8,10 @@ import {
   TEMPERATURE_MODULE_TYPE,
   TEMPERATURE_MODULE_V1,
   THERMOCYCLER_MODULE_TYPE,
-  VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA,
   VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import type {
-  AddressableAreaName,
   AddressableOffsetVector,
   DeckSlotId,
   FlexStackerStoredLabwareGroup,
@@ -166,25 +164,6 @@ export const SLOT_LOCATIONS_TO_FAKE_HOPPER_LOCATIONS: Record<
 }
 
 export const VACUUM_DOCK_LOCATION = 'vacuumDock'
-
-export const VACUUM_DOCK_FAKE_LOCATION: 'vacuumDockA4' = 'vacuumDockA4'
-
-export type VacuumDockFakeLocationType = typeof VACUUM_DOCK_FAKE_LOCATION
-
-export const FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA: Readonly<
-  Record<VacuumDockFakeLocationType, AddressableAreaName>
-> = {
-  vacuumDockA4: VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA,
-}
-
-export const FAKE_VACUUM_DOCK_LOCATION_TO_DECK_SLOT: Readonly<
-  Record<VacuumDockFakeLocationType, DeckSlotId>
-> = {
-  vacuumDockA4: 'A4',
-}
-
-export type VacuumDockLocationMapKey =
-  keyof typeof FAKE_VACUUM_DOCK_LOCATION_TO_DECK_SLOT
 
 export const VACUUM_VENT_OPEN: 'open' = 'open'
 export const VACUUM_VENT_CLOSED: 'closed' = 'closed'

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -23,6 +23,7 @@ import {
   ONE_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
   OT2_ROBOT_TYPE,
   SAFE_MOVE_TO_WELL_OFFSET_FROM_TOP_MM,
+  VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA,
 } from '@opentrons/shared-data'
 
 import {
@@ -46,11 +47,9 @@ import {
   COLUMN_4_SLOTS,
   EMPTY,
   FAKE_HOPPER_LOCATION_MAP,
-  FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA,
   HOPPER_FAKE_LOCATIONS,
   HOPPER_STACKER_LOCATION,
   STAGING_AREA_SLOTS,
-  VACUUM_DOCK_FAKE_LOCATION,
   VACUUM_DOCK_LOCATION,
   ZERO_OFFSET,
 } from '../constants'
@@ -75,10 +74,7 @@ import type {
   PrimaryNozzleConfigurationStyle,
   RobotType,
 } from '@opentrons/shared-data'
-import type {
-  HopperLocationMapKey,
-  VacuumDockFakeLocationType,
-} from '../constants'
+import type { HopperLocationMapKey } from '../constants'
 import type {
   CommandCreator,
   CurriedCommandCreator,
@@ -1127,9 +1123,7 @@ const _getMappedLocation = (
   isOnHopper: boolean
 ): string => {
   if (isOnVacuumDock) {
-    return FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA[
-      slot as VacuumDockFakeLocationType
-    ]
+    return slot
   }
   if (isOnHopper) {
     return FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
@@ -1538,7 +1532,7 @@ export const getIsSlotAHopper = (slot: string): boolean => {
 }
 
 export const getIsSlotAVacuumDock = (slot: string): boolean => {
-  return slot === VACUUM_DOCK_FAKE_LOCATION
+  return slot === VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA
 }
 
 export const getLabwareIdOnShuttle = (

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -46,7 +46,7 @@ import {
   COLUMN_4_SLOTS,
   EMPTY,
   FAKE_HOPPER_LOCATION_MAP,
-  FAKE_VACUUM_DOCK_LOCATION_MAP,
+  FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA,
   HOPPER_FAKE_LOCATIONS,
   HOPPER_STACKER_LOCATION,
   STAGING_AREA_SLOTS,
@@ -77,7 +77,7 @@ import type {
 } from '@opentrons/shared-data'
 import type {
   HopperLocationMapKey,
-  VacuumDockLocationMapKey,
+  VacuumDockFakeLocationType,
 } from '../constants'
 import type {
   CommandCreator,
@@ -1127,7 +1127,9 @@ const _getMappedLocation = (
   isOnHopper: boolean
 ): string => {
   if (isOnVacuumDock) {
-    return FAKE_VACUUM_DOCK_LOCATION_MAP[slot as VacuumDockLocationMapKey]
+    return FAKE_VACUUM_DOCK_LOCATION_TO_ADDRESSABLE_AREA[
+      slot as VacuumDockFakeLocationType
+    ]
   }
   if (isOnHopper) {
     return FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]


### PR DESCRIPTION
# Overview

This PR wires up the ability to add and interact with labware on the vacuum module dock in protocol designer.

Closes EXEC-2406

https://github.com/user-attachments/assets/4ab6db31-d7ee-444e-a00e-0261d22fb2b5


## Test Plan and Hands on Testing

This is tough to test without stubbing in dummy labware for the spacer and collar locally 😢 so the best bet is to check out the attached video recording. if you'd like to test locally, I can send over the zipped labware folders that you can unpack.

Also, please review the code. Happy to answer any questions.

## Changelog

- add functionality for adding dock-compatible labware to the vacuum dock
- fix bug in which the correct deck configuration is not available when `DeckSetupDetails` mounts via a new custom hook `useUpdateDeckConfigurationFromStartingDeck`
- add render component for dock labware (analogous to hopper labware renders)
- add a variety of utilities for dock labware positioning and checking stacks for their presence on a dock

## Review requests

see test plan

## Risk assessment

lowish. nearly completely additive 