### PR TITLE
refactor(api): make GroupedSteps visible in API 2.29 docs

### DIFF
--- a/api/src/opentrons/protocol_api/_command_annotations.py
+++ b/api/src/opentrons/protocol_api/_command_annotations.py
@@ -1,13 +1,12 @@
 from .core.common import ProtocolCore
 from opentrons.protocols.api_support.types import APIVersion
+from opentrons.protocols.api_support.util import requires_version
 
 
 class GroupedSteps:
-    """Represents a created grouping of steps.
+    """Represents a created grouping of protocol steps.
 
-    *Available for use from API version 2.29 onwards*
-
-    Note: Any new methods added should have API version gating
+    *New in version 2.29*
     """
 
     def __init__(
@@ -18,7 +17,10 @@ class GroupedSteps:
         self._api_version = api_version
         self._annotation_closed = False
 
+    @requires_version(2, 29)
     def end_group(self) -> None:
+        """End a step group begun with
+        [`ProtocolContext.create_and_start_step_group()`][opentrons.protocol_api.ProtocolContext.create_and_start_step_group]."""
         if not self._annotation_closed:
             self._protocol_core.end_step_grouping(annotation_id=self._annotation_id)
             self._annotation_closed = True


### PR DESCRIPTION
# Overview

Some small code changes needed in order to properly reference `GroupedSteps` and the new `end_group()` method in API 2.29 docs. Originally made by @ecormany and moved here as part of a split into two PRs. 

## Test Plan and Hands on Testing



## Changelog

- imports our required version decorator and adds it to the `end_group` method
- docstring changes

## Review requests


## Risk assessment

low, but should be checked.
