### PR TITLE
fix(server-utils): Reduce memory consumption of migrations

### DIFF
--- a/server-utils/server_utils/persistence/folder_migrator.py
+++ b/server-utils/server_utils/persistence/folder_migrator.py
@@ -72,42 +72,50 @@ class MigrationOrchestrator:
 
         The migration is performed atomically.
 
+        Interrupted migrations may leave behind stray temp files.
+        Call `clean_up_stray_temp_files()` at some point to prune them.
+
         :returns: The path to the latest version subdirectory.
         """
-        current = self._get_current()
-        if current is None:
+        initial_sequence_index = self._get_current()
+        if initial_sequence_index is None:
             sequence = self._migrations
-            previous_output = self._root
+            starting_dir = self._root
         else:
-            sequence = self._migrations[current + 1 :]
-            previous_output = self._root / self._migrations[current].subdirectory
-
-        final_output = (
-            self._root / sequence[-1].subdirectory
-            if len(sequence) > 0
-            else previous_output
-        )
+            sequence = self._migrations[initial_sequence_index + 1 :]
+            starting_dir = (
+                self._root / self._migrations[initial_sequence_index].subdirectory
+            )
 
         _log.info(f"Migrations to perform: {[m.subdirectory for m in sequence]}")
 
+        latest_dir_so_far = starting_dir
         for sequence_index, migration in enumerate(sequence):
-            is_first_migration = sequence_index == 0
-            is_final_migration = sequence_index == len(sequence) - 1
-
-            output_dir = Path(
-                tempfile.mkdtemp(dir=self._root, prefix=self._temp_file_prefix)
+            step_input_dir = latest_dir_so_far
+            step_output_dir = Path(
+                tempfile.mkdtemp(
+                    dir=self._root,
+                    # The _temp_file_prefix part is important so this can be deleted
+                    # by clean_up_stray_temp_files(). The migration.subdirectory part
+                    # is just to make debugging easier.
+                    prefix=f"{self._temp_file_prefix}{migration.subdirectory}-",
+                )
             )
+            step_input_is_initial = sequence_index == 0
+            step_output_is_final = sequence_index == len(sequence) - 1
 
             _log.info(f'Performing migration to "{migration.subdirectory}"...')
-            migration.migrate(source_dir=previous_output, dest_dir=output_dir)
+            migration.migrate(source_dir=step_input_dir, dest_dir=step_output_dir)
+
+            latest_dir_so_far = step_output_dir
 
             # If we're migrating e.g. A -> B -> C -> D, we should treat B and C as
             # as throwaway intermediate steps, deleting them when we're done with them,
-            # to keep peak filesystem usage low.
-            if not is_first_migration:
-                shutil.rmtree(previous_output)
+            # to keep peak filesystem usage low. We should never delete A.
+            if not step_input_is_initial:
+                shutil.rmtree(step_input_dir)
 
-            if is_final_migration:
+            if step_output_is_final:
                 # Promote the temporary directory to be permanent.
                 #
                 # At this point, we have a directory full of files, but we haven't yet moved it into
@@ -120,12 +128,12 @@ class MigrationOrchestrator:
                 # https://stackoverflow.com/questions/37288453/calling-fsync2-after-close2
                 os.sync()
                 # Atomically move the filled directory into place.
-                os.replace(src=output_dir, dst=final_output)
-
-            previous_output = output_dir
+                final_output_dir = self._root / migration.subdirectory
+                os.replace(src=step_output_dir, dst=final_output_dir)
+                latest_dir_so_far = final_output_dir
 
         _log.info("All migrations complete.")
-        return final_output
+        return latest_dir_so_far
 
     def clean_up_stray_temp_files(self) -> None:
         """Delete any abandoned files or directories from prior interrupted work."""

--- a/server-utils/server_utils/persistence/folder_migrator.py
+++ b/server-utils/server_utils/persistence/folder_migrator.py
@@ -59,6 +59,8 @@ class MigrationOrchestrator:
         """
         self._root = root
         self._migrations = migrations
+        if temp_file_prefix == "":
+            raise ValueError("temp_file_prefix must be non-empty.")
         self._temp_file_prefix = temp_file_prefix
 
     def migrate_to_latest(self) -> Path:

--- a/server-utils/server_utils/persistence/folder_migrator.py
+++ b/server-utils/server_utils/persistence/folder_migrator.py
@@ -16,14 +16,13 @@ Where each version has its own isolated subdirectory.
 
 from __future__ import annotations
 
-import contextlib
 import logging
 import os
 import shutil
 import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Final, Generator, List, Union
+from typing import Final, List, Union
 
 _log = logging.getLogger(__name__)
 
@@ -89,36 +88,35 @@ class MigrationOrchestrator:
 
         _log.info(f"Migrations to perform: {[m.subdirectory for m in sequence]}")
 
-        with contextlib.ExitStack() as exit_stack:
-            for sequence_index, migration in enumerate(sequence):
-                is_final_migration = sequence_index == len(sequence) - 1
-                if is_final_migration:
-                    # For the final migration, set things up so that if everything
-                    # goes well, we'll commit its output to persistent storage.
-                    output_dir = exit_stack.enter_context(
-                        _atomic_dir(
-                            destination=self._root / migration.subdirectory,
-                            temp_prefix=self._temp_file_prefix,
-                        )
-                    )
-                else:
-                    # Unlike the final migration, for intermediate migrations,
-                    # we use normal temporary directories in the default system
-                    # location. This is inherently safer in case we crash and leave
-                    # anything behind, and it's also possibly faster (tmpfs instead of
-                    # flash storage).
-                    #
-                    # TODO: Consider freeing each directory when we're done with it.
-                    # e.g. if we're migrating from v1 to v10, we can free the temporary
-                    # directory for v2 as soon as we move past it; we don't need to wait
-                    # for v10 to complete.
-                    output_dir = Path(
-                        exit_stack.enter_context(tempfile.TemporaryDirectory())
-                    )
+        for sequence_index, migration in enumerate(sequence):
+            is_first_migration = sequence_index == 0
+            is_final_migration = sequence_index == len(sequence) - 1
 
-                _log.info(f'Performing migration to "{migration.subdirectory}"...')
-                migration.migrate(source_dir=previous_output, dest_dir=output_dir)
-                previous_output = output_dir
+            output_dir = Path(tempfile.mkdtemp(self._temp_file_prefix))
+
+            _log.info(f'Performing migration to "{migration.subdirectory}"...')
+            migration.migrate(source_dir=previous_output, dest_dir=output_dir)
+
+            # Throw away transient directories to keep filesystem usage low.
+            if not is_first_migration:
+                shutil.rmtree(previous_output)
+
+            if is_final_migration:
+                # Promote the temporary directory to be permanent.
+                #
+                # At this point, we have a directory full of files, but we haven't yet moved it into
+                # place. This os.sync() is a barrier to make sure that the kernel+filesystem don't
+                # reorder the "move into place" part before the "fill it with files" part, which
+                # would break our atomicity if we lost power between the two.
+                #
+                # We do a nuclear-option os.sync() instead of messing with the finer-grained
+                # os.fsync() because os.fsync() is difficult to get right.
+                # https://stackoverflow.com/questions/37288453/calling-fsync2-after-close2
+                os.sync()
+                # Atomically move the filled directory into place.
+                os.replace(src=output_dir, dst=final_output)
+
+            previous_output = output_dir
 
         _log.info("All migrations complete.")
         return final_output
@@ -201,48 +199,6 @@ class Migration(ABC):
         If something goes wrong, this method should signal it by raising an exception.
         The migration sequence will be aborted safely.
         """
-
-
-@contextlib.contextmanager
-def _atomic_dir(destination: Path, temp_prefix: str) -> Generator[Path, None, None]:
-    """Atomically create a directory and its contained files.
-
-    This returns a temporary directory. While the `with`-block is open, you can fill
-    it with files. Then:
-
-    * If the code inside the `with`-block succeeds, the directory is promoted to be
-      non-temporary, by atomically moving it to be at `destination`.
-    * Or, if the code inside the `with`-block raises an exception, the temporary
-      directory is deleted.
-
-    Crashes or shutdowns may leave the temporary directory behind, adjacent to
-    `destination`. Choose a `temp_prefix` that's easily identifiable so you can
-    clean it up in case this happens.
-    """
-    temp_dir = tempfile.mkdtemp(
-        # Manually specify `dir` to keep the temporary directory on the same filesystem
-        # as our target. Otherwise, the rename won't be atomic.
-        dir=destination.parent,
-        prefix=temp_prefix,
-    )
-
-    try:
-        yield Path(temp_dir)
-    except Exception:
-        shutil.rmtree(temp_dir)
-        raise
-    else:
-        # At this point, we have a directory full of files, but we haven't yet moved it into
-        # place. This os.sync() is a barrier to make sure that the kernel+filesystem don't
-        # reorder the "move into place" part before the "fill it with files" part, which
-        # would break our atomicity if we lost power between the two.
-        #
-        # We do a nuclear-option os.sync() instead of messing with the finer-grained
-        # os.fsync() because os.fsync() is difficult to get right.
-        # https://stackoverflow.com/questions/37288453/calling-fsync2-after-close2
-        os.sync()
-        # Atomically move the filled directory into place.
-        os.replace(src=temp_dir, dst=destination)
 
 
 def _validate_bare_name(name: str) -> None:

--- a/server-utils/server_utils/persistence/folder_migrator.py
+++ b/server-utils/server_utils/persistence/folder_migrator.py
@@ -94,7 +94,9 @@ class MigrationOrchestrator:
             is_first_migration = sequence_index == 0
             is_final_migration = sequence_index == len(sequence) - 1
 
-            output_dir = Path(tempfile.mkdtemp(self._temp_file_prefix))
+            output_dir = Path(
+                tempfile.mkdtemp(dir=self._root, prefix=self._temp_file_prefix)
+            )
 
             _log.info(f'Performing migration to "{migration.subdirectory}"...')
             migration.migrate(source_dir=previous_output, dest_dir=output_dir)

--- a/server-utils/server_utils/persistence/folder_migrator.py
+++ b/server-utils/server_utils/persistence/folder_migrator.py
@@ -97,7 +97,9 @@ class MigrationOrchestrator:
             _log.info(f'Performing migration to "{migration.subdirectory}"...')
             migration.migrate(source_dir=previous_output, dest_dir=output_dir)
 
-            # Throw away transient directories to keep filesystem usage low.
+            # If we're migrating e.g. A -> B -> C -> D, we should treat B and C as
+            # as throwaway intermediate steps, deleting them when we're done with them,
+            # to keep peak filesystem usage low.
             if not is_first_migration:
                 shutil.rmtree(previous_output)
 

--- a/server-utils/tests/persistence/test_folder_migrator.py
+++ b/server-utils/tests/persistence/test_folder_migrator.py
@@ -157,9 +157,11 @@ def test_migration_chain_from_intermediate(tmp_path: Path) -> None:
 
 
 def test_aborted_intermediate_migration(tmp_path: Path) -> None:
-    """It should clean up gracefully from exceptions in intermediate migration steps.
+    """It should gracefully handle exceptions in intermediate migration steps.
 
     The directory should be left as it was before the migration started.
+    It's allowed to be polluted with some new temp files,
+    but only if they're marked as such so they can be deleted later.
     """
 
     class MigrationA(Migration):
@@ -178,6 +180,7 @@ def test_aborted_intermediate_migration(tmp_path: Path) -> None:
         def migrate(self, source_dir: Path, dest_dir: Path) -> None:
             assert False, "This should never run."
 
+    temp_prefix = "test-temp-prefix"
     subject = MigrationOrchestrator(
         root=tmp_path,
         migrations=[
@@ -186,7 +189,7 @@ def test_aborted_intermediate_migration(tmp_path: Path) -> None:
             MigrationC("c_dir"),
             MigrationD("d_dir"),
         ],
-        temp_file_prefix="temp",
+        temp_file_prefix=temp_prefix,
     )
 
     (tmp_path / "a_dir").mkdir()
@@ -195,6 +198,12 @@ def test_aborted_intermediate_migration(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="oy vey"):
         subject.migrate_to_latest()
 
+    result_non_temp_children = {
+        child for child in _children(tmp_path) if not child.startswith(temp_prefix)
+    }
+    assert result_non_temp_children == initial_children
+
+    subject.clean_up_stray_temp_files()
     assert _children(tmp_path) == initial_children
 
 
@@ -202,6 +211,8 @@ def test_aborted_final_migration(tmp_path: Path) -> None:
     """It should clean up gracefully from exceptions in the final migration step.
 
     The directory should be left as it was before the migration started.
+    It's allowed to be polluted with some new temp files,
+    but only if they're marked as such so they can be deleted later.
     """
 
     class MigrationA(Migration):
@@ -216,6 +227,7 @@ def test_aborted_final_migration(tmp_path: Path) -> None:
         def migrate(self, source_dir: Path, dest_dir: Path) -> None:
             raise RuntimeError("oy vey")
 
+    temp_prefix = "test-temp-prefix"
     subject = MigrationOrchestrator(
         root=tmp_path,
         migrations=[
@@ -223,7 +235,7 @@ def test_aborted_final_migration(tmp_path: Path) -> None:
             MigrationB("b_dir"),
             MigrationC("c_dir"),
         ],
-        temp_file_prefix="temp",
+        temp_file_prefix=temp_prefix,
     )
 
     (tmp_path / "a_dir").mkdir()
@@ -232,6 +244,12 @@ def test_aborted_final_migration(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="oy vey"):
         subject.migrate_to_latest()
 
+    result_non_temp_children = {
+        child for child in _children(tmp_path) if not child.startswith(temp_prefix)
+    }
+    assert result_non_temp_children == initial_children
+
+    subject.clean_up_stray_temp_files()
     assert _children(tmp_path) == initial_children
 
 

--- a/server-utils/tests/persistence/test_folder_migrator.py
+++ b/server-utils/tests/persistence/test_folder_migrator.py
@@ -104,7 +104,7 @@ def test_migration_chain_from_scratch(tmp_path: Path) -> None:
     result = subject.migrate_to_latest()
 
     assert result == tmp_path / "c_dir"
-    assert {child.name for child in tmp_path.iterdir()} == {"initial_file", "c_dir"}
+    assert _children(tmp_path) == {"initial_file", "c_dir"}
     assert (tmp_path / "c_dir" / "c_file").exists()
 
 
@@ -148,7 +148,7 @@ def test_migration_chain_from_intermediate(tmp_path: Path) -> None:
     result = subject.migrate_to_latest()
 
     assert result == tmp_path / "c_dir"
-    assert {child.name for child in tmp_path.iterdir()} == {
+    assert _children(tmp_path) == {
         "initial_file",
         "a_dir",
         "c_dir",


### PR DESCRIPTION
##  Background

This reduces the peak memory usage required by a server when it runs through a chain of data migrations.

This closes EXEC-2674 and EXEC-2676. The higher-level issue is EXEC-2672.

## Changelog

* The migration now keeps its scratch directories on the real filesystem, in flash memory, instead of in `/tmp`, which is just RAM.
* The migration now deletes its scratch directories as soon as it's done with them, instead of waiting until after the entire migration chain is completed.
* For simplicity, the migration is now allowed to pollute the filesystem with scratch directories if it fails midway through. Formerly, this could already happen under narrow circumstances, and we already had a mechanism (`.clean_up_stray_temp_files()`) for dealing with it. Now, it happens under broader circumstances, and we'll still use that mechanism for dealing with it.

## Test Plan and Hands on Testing

* [x] Test this on a robot and make sure this fixes the problem described in EXEC-2672.

## Review requests

Are there any additional edge cases you can think of to add to the unit tests?

## Risk assessment

High. There's a lot here that can't be covered by unit tests.

* ~~Moving from tmpfs to flash memory might make migrations slower, which might cause timeouts when the server is booting.~~
  * Edit: [Server migrations aren't currently included in the timeout](https://github.com/Opentrons/opentrons/blob/9219763a3d7146bec653ad63f47a8fdd1b17e9e0/robot-server/robot_server/hardware.py#L634-L640), so I think we're good.
* Moving from tmpfs to flash memory will increase flash wear.
* For correct atomicity, this code is sensitive to things like exactly where `os.sync()` is called relative to other things. So we have to be careful about that.