### PR TITLE
refactor(app): Update Device Details page "no connection to robot" UI

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -47,7 +47,7 @@
   "current_temp": "Current: {{temp}} °C",
   "current_version": "Current Version",
   "deck_cal_missing": "Pipette Offset calibration missing. Calibrate deck first.",
-  "deck_configuration": "Deck Configuration",
+  "deck_configuration": "{{robotName}} Deck Configuration",
   "deck_configuration_is_not_available_when_robot_is_busy": "Deck configuration is not available when the robot is busy",
   "deck_configuration_is_not_available_when_run_is_in_progress": "Deck configuration is not available when run is in progress",
   "deck_fixture_setup_instructions": "Deck fixture setup instructions",

--- a/app/src/organisms/Desktop/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Desktop/Devices/InstrumentsAndModules.tsx
@@ -4,11 +4,10 @@ import {
   ALIGN_CENTER,
   ALIGN_FLEX_START,
   Banner,
-  COLORS,
   DIRECTION_COLUMN,
   Flex,
+  InfoScreen,
   JUSTIFY_CENTER,
-  LegacyStyledText,
   SIZE_3,
   SPACING,
   StyledText,
@@ -276,23 +275,7 @@ export function InstrumentsAndModules({
             </Flex>
           </Flex>
         ) : (
-          <Flex
-            alignItems={ALIGN_CENTER}
-            flexDirection={DIRECTION_COLUMN}
-            gridGap={SPACING.spacing12}
-            justifyContent={JUSTIFY_CENTER}
-            minHeight={SIZE_3}
-            padding={SPACING.spacing12}
-          >
-            {/* TODO(bh, 2022-10-20): insert "offline" image when provided by illustrator */}
-            <LegacyStyledText
-              forwardedAs="p"
-              color={COLORS.grey40}
-              id="InstrumentsAndModules_offline"
-            >
-              {t('offline_instruments_and_modules')}
-            </LegacyStyledText>
-          </Flex>
+          <InfoScreen content={t('offline_instruments_and_modules')} />
         )}
       </Flex>
     </Flex>

--- a/app/src/organisms/Desktop/Devices/InstrumentsAndModules.tsx
+++ b/app/src/organisms/Desktop/Devices/InstrumentsAndModules.tsx
@@ -129,6 +129,7 @@ export function InstrumentsAndModules({
       flexDirection={DIRECTION_COLUMN}
       width="100%"
       gap={SPACING.spacing16}
+      paddingBottom={SPACING.spacing12}
     >
       <StyledText desktopStyle="bodyLargeSemiBold">
         {t('instruments_and_modules')}

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns.tsx
@@ -68,7 +68,7 @@ export function RecentProtocolRuns({
         alignItems={ALIGN_CENTER}
         flexDirection={DIRECTION_COLUMN}
         minHeight={SIZE_4}
-        paddingX={SPACING.spacing16}
+        padding={SPACING.spacing16}
         width="100%"
       >
         {isRobotViewable && allRunsMutable && allRunsMutable?.length > 0 && (

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns.tsx
@@ -8,6 +8,7 @@ import {
   DIRECTION_COLUMN,
   DISPLAY_FLEX,
   Flex,
+  InfoScreen,
   JUSTIFY_FLEX_START,
   LegacyStyledText,
   SIZE_4,
@@ -144,16 +145,7 @@ export function RecentProtocolRuns({
           </>
         )}
         {!isRobotViewable && (
-          <LegacyStyledText
-            forwardedAs="p"
-            alignItems={ALIGN_CENTER}
-            color={COLORS.grey50}
-            display={DISPLAY_FLEX}
-            flex="1 0"
-            id="RecentProtocolRuns_offline"
-          >
-            {t('offline_recent_protocol_runs')}
-          </LegacyStyledText>
+          <InfoScreen content={t('offline_recent_protocol_runs')} />
         )}
         {isRobotViewable && allRunsMutable?.length === 0 && (
           <LegacyStyledText

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/DeviceDetailsDeckConfiguration.test.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/DeviceDetailsDeckConfiguration.test.tsx
@@ -112,7 +112,7 @@ describe('DeviceDetailsDeckConfiguration', () => {
 
   it('should render text and button', () => {
     render(props)
-    screen.getByText('Deck Configuration')
+    screen.getByText('otie Deck Configuration')
     screen.getByRole('button', { name: 'Setup Instructions' })
     screen.getByText('Location')
     screen.getByText('Deck hardware')

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/index.tsx
@@ -12,6 +12,7 @@ import {
   DIRECTION_COLUMN,
   DIRECTION_ROW,
   Flex,
+  InfoScreen,
   JUSTIFY_CENTER,
   JUSTIFY_SPACE_BETWEEN,
   LegacyStyledText,
@@ -209,7 +210,7 @@ export function DeviceDetailsDeckConfiguration({
           borderBottom={BORDERS.lineBorder}
         >
           <StyledText desktopStyle="bodyLargeSemiBold">
-            {t('deck_configuration')}
+            {t('deck_configuration', { robotName })}
           </StyledText>
           <Link
             role="button"
@@ -326,9 +327,7 @@ export function DeviceDetailsDeckConfiguration({
             paddingBottom={SPACING.spacing24}
             width="100%"
           >
-            <LegacyStyledText forwardedAs="p" color={COLORS.grey40}>
-              {t('offline_deck_configuration')}
-            </LegacyStyledText>
+            <InfoScreen content={t('offline_deck_configuration')} />
           </Flex>
         )}
       </Flex>

--- a/app/src/pages/Desktop/Devices/DeviceDetails/DeviceDetailsComponent.tsx
+++ b/app/src/pages/Desktop/Devices/DeviceDetails/DeviceDetailsComponent.tsx
@@ -30,6 +30,7 @@ interface DeviceDetailsComponentProps {
   robotName: string
 }
 
+// TODO(jh, 05-21-2026): Containers utilized in this tree do not match designs. Update to match.
 export function DeviceDetailsComponent({
   robotName,
 }: DeviceDetailsComponentProps): JSX.Element {


### PR DESCRIPTION
Closes [EXEC-2689](https://opentrons.atlassian.net/browse/EXEC-2689)

# Overview

We'd like to update the Devices page's "no connection UI" to better match Designs. Unfortunately, the component layout of the page is quite different from our Design spec, so matching CSS 1:1 is quite a large refactor given timetables, but we can at least get 90% of the way there with a few one-off padding adjustments. We plan to refactor this page to match Designs more precisely for the next release, ticket [here](https://opentrons.atlassian.net/browse/EXEC-2690).

### Current UI

<img width="1023" height="765" alt="Screenshot 2026-05-21 at 10 58 16 AM" src="https://github.com/user-attachments/assets/bae6eae3-c966-4112-ae9e-f54b553e5f12" />

### Refactored UI

<img width="1021" height="773" alt="Screenshot 2026-05-21 at 10 57 05 AM" src="https://github.com/user-attachments/assets/49548449-e332-421d-b669-c40de74ca868" />

## Test Plan and Hands on Testing

- See images.

## Risk assessment

- very low, just UI and slight copy adjustments. The UI adjustments are done on a granular level without touching the root elements of the entire page.


[EXEC-2689]: https://opentrons.atlassian.net/browse/EXEC-2689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ