### PR TITLE
feat(protocol-designer, step-generation): wire up move labware functionality with vacuum module

### DIFF
--- a/protocol-designer/src/assets/localization/en/shared.json
+++ b/protocol-designer/src/assets/localization/en/shared.json
@@ -144,6 +144,7 @@
   "updated_protocol_designer": "We've updated Protocol Designer!",
   "user_settings": "User Settings",
   "uses_standard_namespace": "Opentrons verified labware",
+  "vacuum_dock": "Vacuum Module GEN1 Dock",
   "version": "Version {{version}}",
   "view_release_notes": "View release notes",
   "warning": "WARNING:",

--- a/protocol-designer/src/components/organisms/StepSummary/index.tsx
+++ b/protocol-designer/src/components/organisms/StepSummary/index.tsx
@@ -13,6 +13,7 @@ import {
   getModuleDisplayName,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
+import { getIsSlotAVacuumDock } from '@opentrons/step-generation'
 
 import { formatTime } from '/protocol-designer/pages/Designer/utils'
 import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
@@ -269,7 +270,8 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
     }
 
     case 'moveLabware': {
-      const { labware, newLocation, useGripper } = currentStep
+      const { labware, newLocation: newLocationRaw, useGripper } = currentStep
+      const newLocation = newLocationRaw as string
       const labwareName = labwareNicknamesById[labware]
       let newLocationName = newLocation
       if (newLocation in modules) {
@@ -280,6 +282,8 @@ export function StepSummary(props: StepSummaryProps): JSX.Element | null {
         newLocationName = t('off_deck')
       } else if (newLocation === WASTE_CHUTE_CUTOUT) {
         newLocationName = t('shared:wasteChute')
+      } else if (getIsSlotAVacuumDock(newLocation)) {
+        newLocationName = t('shared:vacuum_dock')
       }
       stepSummaryContent = (
         <StyledTrans

--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux'
 import {
   FLEX_STACKER_MODULE_TYPE,
   getAddressableAreaFromSlotId,
+  getPositionFromAddressableAreaId,
   getPositionFromSlotId,
   inferModuleOrientationFromXCoordinate,
   STANDARD_FLEX_SLOTS,
@@ -12,7 +13,11 @@ import {
   THERMOCYCLER_MODULE_V2,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
-import { getSlotInLocationStack } from '@opentrons/step-generation'
+import {
+  getIsSlotAVacuumDock,
+  getSlotInLocationStack,
+  VACUUM_DOCK_ADDRESSABLE_AREA,
+} from '@opentrons/step-generation'
 
 import {
   FLEX_STACKER_IN_HOPPER_ACTIONS,
@@ -20,6 +25,7 @@ import {
 } from '/protocol-designer/constants'
 import { getLabwaresOnModuleFromStack } from '/protocol-designer/utils'
 
+import { getDeckConfiguration } from '../../../step-forms/selectors'
 import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
 import {
   getHoveredDropdownItem,
@@ -63,6 +69,7 @@ const SLOTS = [
   'C4',
   'D4',
   'cutoutD3',
+  VACUUM_DOCK_ADDRESSABLE_AREA,
 ]
 
 export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
@@ -73,6 +80,7 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
   )
   const hoveredItem = useSelector(getHoveredDropdownItem)
   const selectedDropdownItems = useSelector(getSelectedDropdownItem)
+  const { deckConfig } = useSelector(getDeckConfiguration)
 
   if (
     hoveredItem == null &&
@@ -132,7 +140,13 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
     const tcModel = Object.values(modules).find(
       module => module.type === THERMOCYCLER_MODULE_TYPE
     )?.model
-    const position = getPositionFromSlotId(labwareSlot, deckDef)
+    const position = getIsSlotAVacuumDock(labwareSlot)
+      ? getPositionFromAddressableAreaId({
+          addressableAreaId: VACUUM_DOCK_ADDRESSABLE_AREA,
+          deckDef,
+          deckConfiguration: deckConfig,
+        })
+      : getPositionFromSlotId(labwareSlot, deckDef)
     if (position != null) {
       let tcPosition: CoordinateTuple = FLEX_TC_POSITION
       if (labwareSlot === '7') {
@@ -319,10 +333,18 @@ export function HighlightItems(props: HighlightItemsProps): JSX.Element | null {
         return items
       }
 
+      const slotPosition = getIsSlotAVacuumDock(addressableArea.id)
+        ? getPositionFromAddressableAreaId({
+            addressableAreaId: VACUUM_DOCK_ADDRESSABLE_AREA,
+            deckDef,
+            deckConfiguration: deckConfig,
+          })
+        : getPositionFromSlotId(addressableArea.id, deckDef)
+
       items.push(
         <DeckItemHighlight
           slotBoundingBox={addressableArea.boundingBox}
-          slotPosition={getPositionFromSlotId(addressableArea.id, deckDef)}
+          slotPosition={slotPosition}
           itemId={addressableArea.id}
         />
       )

--- a/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
+++ b/protocol-designer/src/pages/Designer/DeckSetup/HighlightItems.tsx
@@ -23,10 +23,10 @@ import {
   FLEX_STACKER_IN_HOPPER_ACTIONS,
   HOPPER_LABWARE_X_OFFSET,
 } from '/protocol-designer/constants'
+import { getDeckConfiguration } from '/protocol-designer/step-forms/selectors'
+import { getDeckSetupForActiveItem } from '/protocol-designer/top-selectors/labware-locations'
 import { getLabwaresOnModuleFromStack } from '/protocol-designer/utils'
 
-import { getDeckConfiguration } from '../../../step-forms/selectors'
-import { getDeckSetupForActiveItem } from '../../../top-selectors/labware-locations'
 import {
   getHoveredDropdownItem,
   getSelectedDropdownItem,

--- a/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/utils.ts
@@ -599,7 +599,9 @@ export function getHighlightLabwareAndModules(
         const moduleIdUnderLabwareToUse =
           item.id != null &&
           labware[item.id] != null &&
-          getIsAdapter(item.id, labware)
+          getIsAdapter(item.id, labware) &&
+          // collars are unique adapters in that they can be moved around the deck
+          !getIsVacuumCollar(labware[item.id].def)
             ? getModuleIdFromStack(labware[item.id].stack, modules)
             : null
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -5,16 +5,22 @@ import {
   FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS,
   FLEX_STACKER_MODULE_TYPE,
   FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
+  getModuleDisplayName,
   OT2_SINGLE_SLOT_ADDRESSABLE_AREAS,
+  VACUUM_MODULE_TYPE,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 import {
   getFullStackFromLabwares,
   getSlotInLocationStack,
+  VACUUM_DOCK_ADDRESSABLE_AREA,
+  VACUUM_DOCK_LOCATION,
 } from '@opentrons/step-generation'
 
 import { DropdownStepFormField } from '/protocol-designer/components/molecules'
+import { VACUUM_MODULE_SLOT } from '/protocol-designer/constants'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
+import { getIsVacuumCollar } from '/protocol-designer/pages/Designer/DeckSetup/utils'
 import {
   getUnoccupiedStackOptions,
   TIPRACK_LID_LOADNAME,
@@ -161,6 +167,66 @@ export function LabwareLocationField(
           robotState?.modules?.[value]?.moduleState.type !==
           FLEX_STACKER_MODULE_TYPE
       )
+  }
+
+  const isLabwareAVacuumCollar =
+    labwareEntities[labware] != null &&
+    getIsVacuumCollar(labwareEntities[labware].def)
+
+  // only vacuum collars can be moved directly to the vacuum dock
+  if (!isLabwareAVacuumCollar) {
+    unoccupiedLabwareLocationsOptions =
+      unoccupiedLabwareLocationsOptions.filter(
+        ({ value }) => value !== VACUUM_DOCK_ADDRESSABLE_AREA
+      )
+  } else if (isLabwareAVacuumCollar && robotState != null) {
+    const vacuumModuleEntry = Object.entries(moduleEntities).find(
+      ([, entity]) => entity.type === VACUUM_MODULE_TYPE
+    )
+    if (vacuumModuleEntry != null) {
+      const [vacuumModuleId, vacuumModuleEntity] = vacuumModuleEntry
+      // labware physically on the main module slot ("A3")
+      const labwareOnModule = Object.entries(robotState.labware).filter(
+        ([, lw]) =>
+          lw.stack.includes(vacuumModuleId) &&
+          !lw.stack.includes(VACUUM_DOCK_LOCATION)
+      )
+      const moduleHasLabware = labwareOnModule.length > 0
+      const moduleHasNoCollar = !labwareOnModule.some(([lwId]) => {
+        return (
+          labwareEntities[lwId] != null &&
+          getIsVacuumCollar(labwareEntities[lwId].def)
+        )
+      })
+
+      // offer the vacuum module as a destination when it has labware and no collar yet
+      // forMoveLabware will build the full stack including existing module labware
+      const shouldOfferVacuumModule = moduleHasLabware && moduleHasNoCollar
+      if (shouldOfferVacuumModule) {
+        const isVacuumModuleAlreadyIncluded =
+          unoccupiedLabwareLocationsOptions.some(
+            opt => opt.value === vacuumModuleId
+          )
+        if (!isVacuumModuleAlreadyIncluded) {
+          unoccupiedLabwareLocationsOptions = [
+            ...unoccupiedLabwareLocationsOptions,
+            {
+              name: getModuleDisplayName(vacuumModuleEntity.model),
+              value: vacuumModuleId,
+              deckLabel: VACUUM_MODULE_SLOT,
+            },
+          ]
+        }
+      }
+
+      // collar can only go to the vacuum dock or the vacuum module main area (when eligible)
+      unoccupiedLabwareLocationsOptions =
+        unoccupiedLabwareLocationsOptions.filter(
+          ({ value }) =>
+            value === VACUUM_DOCK_ADDRESSABLE_AREA ||
+            (shouldOfferVacuumModule && value === vacuumModuleId)
+        )
+    }
   }
 
   const optionsSorted =

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -191,7 +191,6 @@ export function LabwareLocationField(
           lw.stack.includes(vacuumModuleId) &&
           !lw.stack.includes(VACUUM_DOCK_LOCATION)
       )
-      const moduleHasLabware = labwareOnModule.length > 0
       const moduleHasNoCollar = !labwareOnModule.some(([lwId]) => {
         return (
           labwareEntities[lwId] != null &&
@@ -199,10 +198,10 @@ export function LabwareLocationField(
         )
       })
 
-      // offer the vacuum module as a destination when it has labware and no collar yet
-      // forMoveLabware will build the full stack including existing module labware
-      const shouldOfferVacuumModule = moduleHasLabware && moduleHasNoCollar
-      if (shouldOfferVacuumModule) {
+      // offer the vacuum module as a destination when it has no collar yet
+      // (empty module is valid — collar can sit directly on the module)
+      // forMoveLabware will build the full stack including any existing module labware
+      if (moduleHasNoCollar) {
         const isVacuumModuleAlreadyIncluded =
           unoccupiedLabwareLocationsOptions.some(
             opt => opt.value === vacuumModuleId
@@ -224,7 +223,7 @@ export function LabwareLocationField(
         unoccupiedLabwareLocationsOptions.filter(
           ({ value }) =>
             value === VACUUM_DOCK_ADDRESSABLE_AREA ||
-            (shouldOfferVacuumModule && value === vacuumModuleId)
+            (moduleHasNoCollar && value === vacuumModuleId)
         )
     }
   }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -191,7 +191,7 @@ export function LabwareLocationField(
           lw.stack.includes(vacuumModuleId) &&
           !lw.stack.includes(VACUUM_DOCK_LOCATION)
       )
-      const moduleHasNoCollar = !labwareOnModule.some(([lwId]) => {
+      const vacuumModuleHasNoCollar = !labwareOnModule.some(([lwId]) => {
         return (
           labwareEntities[lwId] != null &&
           getIsVacuumCollar(labwareEntities[lwId].def)
@@ -201,10 +201,10 @@ export function LabwareLocationField(
       // offer the vacuum module as a destination when it has no collar yet
       // (empty module is valid — collar can sit directly on the module)
       // forMoveLabware will build the full stack including any existing module labware
-      if (moduleHasNoCollar) {
+      if (vacuumModuleHasNoCollar) {
         const isVacuumModuleAlreadyIncluded =
           unoccupiedLabwareLocationsOptions.some(
-            opt => opt.value === vacuumModuleId
+            ({ value }) => value === vacuumModuleId
           )
         if (!isVacuumModuleAlreadyIncluded) {
           unoccupiedLabwareLocationsOptions = [
@@ -223,7 +223,7 @@ export function LabwareLocationField(
         unoccupiedLabwareLocationsOptions.filter(
           ({ value }) =>
             value === VACUUM_DOCK_ADDRESSABLE_AREA ||
-            (moduleHasNoCollar && value === vacuumModuleId)
+            (vacuumModuleHasNoCollar && value === vacuumModuleId)
         )
     }
   }

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -26,6 +26,7 @@ import {
 
 import {
   HOPPER_LABWARE_X_OFFSET,
+  VACUUM_DOCK_DISPLAY_LOCATION,
   VACUUM_DOCK_LABWARE_X_OFFSET,
 } from '/protocol-designer/constants'
 
@@ -38,6 +39,7 @@ import {
   getFullStackFromLabwaresOnDeck,
   getStagingAreaAddressableAreas,
 } from '../../utils'
+import { getIsVacuumCollar } from './DeckSetup/utils'
 
 import type { DropdownOption } from '@opentrons/components'
 import type {
@@ -325,10 +327,21 @@ const getLabwareInfo = (
 ): { nickName: string; latestSlot: string } => {
   const { modules } = activeDeckSetup
   const stack = activeDeckSetup.labware[labwareId]?.stack
-  const latestSlot =
-    stack != null
-      ? resolveSlotLocation(modules, stack, robotType)
-      : 'unknown slot'
+  let latestSlot: string = ''
+
+  // First resolve the slot from the stack
+  if (stack != null) {
+    latestSlot = resolveSlotLocation(modules, stack, robotType)
+  } else {
+    latestSlot = 'unknown slot'
+  }
+
+  // Then check if it's a vacuum dock and transform to display location
+  const isSlotAVacuumDock = getIsSlotAVacuumDock(latestSlot)
+  if (isSlotAVacuumDock) {
+    latestSlot = VACUUM_DOCK_DISPLAY_LOCATION
+  }
+
   const name = nicknamesById[labwareId]
   let nickName: string = name
   if (latestSlot != null && latestSlot !== 'offDeck') {
@@ -389,6 +402,7 @@ export const useLabwareDropdownOptions = (
         deckSlot === 'fixedTrash'
 
       const isAdapter = def.allowedRoles?.includes('adapter') ?? false
+      const isVacuumCollar = getIsVacuumCollar(def)
       const { nickName, latestSlot } = getLabwareInfo(
         nicknamesById,
         activeDeckSetup,
@@ -406,11 +420,14 @@ export const useLabwareDropdownOptions = (
       const options: DropdownOption[] =
         isInaccessible ||
         (type === 'labware' && isOnStacker) ||
-        isAdapter ||
+        (isAdapter && !isVacuumCollar) ||
         isLabwareInTrash ||
         (type === 'labware' && (isTiprack || isLid)) ||
         isFilterOffDeck ||
-        (type === 'moveLabware' && !isTopOfStack && !isLabwareLidCombo) ||
+        (type === 'moveLabware' &&
+          !isTopOfStack &&
+          !isVacuumCollar &&
+          !isLabwareLidCombo) ||
         (type === 'labware' && !isTopOfStack)
           ? acc
           : [

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -329,14 +329,14 @@ const getLabwareInfo = (
   const stack = activeDeckSetup.labware[labwareId]?.stack
   let latestSlot: string = ''
 
-  // First resolve the slot from the stack
+  // resolve the slot from the stack
   if (stack != null) {
     latestSlot = resolveSlotLocation(modules, stack, robotType)
   } else {
     latestSlot = 'unknown slot'
   }
 
-  // Then check if it's a vacuum dock and transform to display location
+  // check if it's a vacuum dock and transform to display location
   const isSlotAVacuumDock = getIsSlotAVacuumDock(latestSlot)
   if (isSlotAVacuumDock) {
     latestSlot = VACUUM_DOCK_DISPLAY_LOCATION

--- a/protocol-designer/src/pages/Designer/utils.ts
+++ b/protocol-designer/src/pages/Designer/utils.ts
@@ -333,6 +333,7 @@ const getLabwareInfo = (
   if (stack != null) {
     latestSlot = resolveSlotLocation(modules, stack, robotType)
   } else {
+    console.warn(`Could not find slot for labware ${labwareId}`)
     latestSlot = 'unknown slot'
   }
 
@@ -417,7 +418,7 @@ export const useLabwareDropdownOptions = (
         (type === 'labware' || (type === 'moveLabware' && useGripper))
 
       //  TODO: refactor this to be easier to read
-      const options: DropdownOption[] =
+      const shouldExclude =
         isInaccessible ||
         (type === 'labware' && isOnStacker) ||
         (isAdapter && !isVacuumCollar) ||
@@ -429,20 +430,17 @@ export const useLabwareDropdownOptions = (
           !isVacuumCollar &&
           !isLabwareLidCombo) ||
         (type === 'labware' && !isTopOfStack)
-          ? acc
-          : [
-              ...acc,
-              {
-                name: nickName,
-                value: labwareId,
-                deckLabel: latestSlot,
-              },
-            ]
-
-      //  filter out moving adapters, and labware in
-      //  waste chute for moveLabware, labware off-deck and
-      //  labware that is a tiprack for the labware dropdown only
-      return options
+      if (shouldExclude) {
+        return acc
+      }
+      return [
+        ...acc,
+        {
+          name: nickName,
+          value: labwareId,
+          deckLabel: latestSlot,
+        },
+      ]
     },
     []
   )

--- a/protocol-designer/src/steplist/fieldLevel/index.ts
+++ b/protocol-designer/src/steplist/fieldLevel/index.ts
@@ -1,4 +1,7 @@
-import { getTrashBinAddressableAreaName } from '@opentrons/step-generation'
+import {
+  getIsSlotAVacuumDock,
+  getTrashBinAddressableAreaName,
+} from '@opentrons/step-generation'
 
 import { getStagingAreaAddressableAreas } from '../../utils'
 import {
@@ -145,6 +148,8 @@ const getLabwareLocation = (
       )
     }
     return { addressableAreaName }
+  } else if (getIsSlotAVacuumDock(newLocationString)) {
+    return { addressableAreaName: newLocationString as AddressableAreaName }
   } else {
     return { slotName: newLocationString }
   }

--- a/protocol-designer/src/top-selectors/labware-locations/index.ts
+++ b/protocol-designer/src/top-selectors/labware-locations/index.ts
@@ -14,6 +14,8 @@ import {
   TC_MODULE_LOCATION_OT2,
   TC_MODULE_LOCATION_OT3,
   THERMOCYCLER_MODULE_TYPE,
+  VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA,
+  VACUUM_MODULE_TYPE,
   WASTE_CHUTE_ADDRESSABLE_AREAS,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
@@ -25,7 +27,7 @@ import {
   getTopLocationInStack,
 } from '@opentrons/step-generation'
 
-import { OFFDECK } from '../../constants'
+import { OFFDECK, VACUUM_DOCK_DISPLAY_LOCATION } from '../../constants'
 import { selectors as fileDataSelectors } from '../../file-data'
 import { getRobotType } from '../../file-data/selectors'
 import { selectors as stepFormSelectors } from '../../step-forms'
@@ -292,6 +294,21 @@ export const getUnoccupiedLabwareLocationOptions: Selector<Option[] | null> =
           )
       )
 
+      const isVacuumModuleOnDeck = Object.values(modules).some(
+        ({ moduleState }) => moduleState.type === VACUUM_MODULE_TYPE
+      )
+      const isDockOpen = !Object.values(labware).some(({ stack }) =>
+        stack.includes(VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA)
+      )
+      const vacuumDockOption =
+        isVacuumModuleOnDeck && isDockOpen
+          ? {
+              name: 'Vacuum Module Dock A4',
+              value: VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA,
+              deckLabel: VACUUM_DOCK_DISPLAY_LOCATION,
+            }
+          : null
+
       const unoccupiedSlotOptions = allSlotIds.reduce<Option[]>(
         (acc, slotId) => {
           const isTrashSlot =
@@ -338,6 +355,7 @@ export const getUnoccupiedLabwareLocationOptions: Selector<Option[] | null> =
         ...unoccupiedAdapterOptions,
         ...unoccupiedModuleOptions,
         ...unoccupiedSlotOptions,
+        ...(vacuumDockOption != null ? [vacuumDockOption] : []),
         offDeck,
       ]
     }

--- a/protocol-designer/src/ui/modules/__tests__/utils.test.ts
+++ b/protocol-designer/src/ui/modules/__tests__/utils.test.ts
@@ -11,7 +11,6 @@ import {
   TC_MODULE_LOCATION_OT3,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
-  VACUUM_MODULE_LOCATION,
   VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
@@ -20,11 +19,6 @@ import { getModuleDisplayLocation } from '../utils'
 import type { ModuleOnDeck } from '/protocol-designer/step-forms'
 
 describe('getModuleDisplayLocation', () => {
-  it('returns the correct display location for a vacuum module', () => {
-    const moduleOnDeck = { type: VACUUM_MODULE_TYPE } as ModuleOnDeck
-    const result = getModuleDisplayLocation(moduleOnDeck, OT2_ROBOT_TYPE)
-    expect(result).toEqual(VACUUM_MODULE_LOCATION)
-  })
   it('returns the correct display location for a thermocycler module on OT-2', () => {
     const moduleOnDeck = { type: THERMOCYCLER_MODULE_TYPE } as ModuleOnDeck
     const result = getModuleDisplayLocation(moduleOnDeck, OT2_ROBOT_TYPE)
@@ -41,6 +35,7 @@ describe('getModuleDisplayLocation', () => {
     HEATERSHAKER_MODULE_TYPE,
     ABSORBANCE_READER_TYPE,
     FLEX_STACKER_MODULE_TYPE,
+    VACUUM_MODULE_TYPE,
   ].forEach(type => {
     it(`returns the slot for ${type}`, () => {
       const moduleOnDeck = {

--- a/protocol-designer/src/ui/modules/utils.ts
+++ b/protocol-designer/src/ui/modules/utils.ts
@@ -13,7 +13,6 @@ import {
   TC_MODULE_LOCATION_OT3,
   TEMPERATURE_MODULE_TYPE,
   THERMOCYCLER_MODULE_TYPE,
-  VACUUM_MODULE_LOCATION,
   VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
@@ -88,9 +87,6 @@ export const getModuleDisplayLocation = (
   robotType: RobotType
 ): string => {
   const { type, slot } = moduleOnDeck
-  if (type === VACUUM_MODULE_TYPE) {
-    return VACUUM_MODULE_LOCATION
-  }
   if (type === THERMOCYCLER_MODULE_TYPE) {
     return robotType === FLEX_ROBOT_TYPE
       ? TC_MODULE_LOCATION_OT3

--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -11,6 +11,7 @@ import {
   MOVABLE_TRASH_ADDRESSABLE_AREAS,
   OT2_ROBOT_TYPE,
   THERMOCYCLER_MODULE_TYPE,
+  VACUUM_MODULE_TYPE,
   WASTE_CHUTE_ADDRESSABLE_AREAS,
 } from '@opentrons/shared-data'
 
@@ -20,6 +21,7 @@ import {
   formatPyStr,
   getCutoutIdByAddressableArea,
   getIsLabwareCompatibleWithStack,
+  getIsSlotAVacuumDock,
   getLabwareHasLiquid,
   getLargestStackInSlot,
   getNearestParentInStack,
@@ -322,7 +324,9 @@ export const moveLabware: CommandCreator<MoveLabwareParams> = (
       : []
 
     const cutoutIdFromAddressableAreaName =
-      !isWasteChuteLocation && !is4thColumnSlot
+      !isWasteChuteLocation &&
+      !is4thColumnSlot &&
+      !getIsSlotAVacuumDock(newLocation.addressableAreaName)
         ? getCutoutIdByAddressableArea(
             newLocation.addressableAreaName as AddressableAreaName,
             isOt2TrashLocation ? 'fixedTrashSlot' : 'trashBinAdapter',
@@ -346,6 +350,19 @@ export const moveLabware: CommandCreator<MoveLabwareParams> = (
       location = trashBinEntities[matchingTrashId]?.pythonName ?? ''
     } else if (matchingTrashId == null && isWasteChuteLocation) {
       location = Object.values(wasteChuteEntities)[0]?.pythonName ?? ''
+    } else if (getIsSlotAVacuumDock(newLocation.addressableAreaName)) {
+      // Python location for the vacuum dock is a property of its module named `manifold_dock`
+      const [foundVacuumModuleId] =
+        Object.entries(prevRobotState.modules).find(
+          ([, module]) => module.moduleState.type === VACUUM_MODULE_TYPE
+        ) ?? []
+      if (
+        foundVacuumModuleId != null &&
+        moduleEntities[foundVacuumModuleId] != null
+      ) {
+        const { pythonName } = moduleEntities[foundVacuumModuleId]
+        location = `${pythonName}.manifold_dock`
+      }
     } else {
       location = ''
     }

--- a/step-generation/src/constants.ts
+++ b/step-generation/src/constants.ts
@@ -8,6 +8,7 @@ import {
   TEMPERATURE_MODULE_TYPE,
   TEMPERATURE_MODULE_V1,
   THERMOCYCLER_MODULE_TYPE,
+  VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA,
   VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
@@ -163,7 +164,13 @@ export const SLOT_LOCATIONS_TO_FAKE_HOPPER_LOCATIONS: Record<
   D4: 'hopperD4',
 }
 
+// Vacuum dock location marker (used in labware stack to indicate labware is on vacuum dock)
+// TODO (nd: 05/21/2026): refactor this; we should be able to rely simply on the actual dock addressable area name
 export const VACUUM_DOCK_LOCATION = 'vacuumDock'
+
+// The actual addressable area for the vacuum dock (re-exported for convenience)
+export const VACUUM_DOCK_ADDRESSABLE_AREA =
+  VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA
 
 export const VACUUM_VENT_OPEN: 'open' = 'open'
 export const VACUUM_VENT_CLOSED: 'closed' = 'closed'

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -6,13 +6,15 @@ import {
   getIsLid,
   getIsPipettableLabware,
   locationIsOffDeck,
+  VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
-import { BOTTOM_UP_LABWARE_POOL_KEYS } from '../constants'
+import { BOTTOM_UP_LABWARE_POOL_KEYS, VACUUM_DOCK_LOCATION } from '../constants'
 import { TOUCHED_PIPETTABLE_LABWARE } from '../types'
 import {
   getFlexStackerShuttleAddressableArea,
   getFullStackFromLabwares,
+  getIsSlotAVacuumDock,
   getLargestStackInSlot,
   getSlotInLocationStack,
 } from '../utils'
@@ -176,6 +178,19 @@ export function forMoveLabware(
       FLEX_STACKER_MODULE_TYPE
     ) {
       newLocationStack.push(modules[newLocation.moduleId].slot)
+    } else if (
+      invariantContext.moduleEntities[newLocation.moduleId]?.type ===
+      VACUUM_MODULE_TYPE
+    ) {
+      // For vacuum module: stack onto whatever is currently on the module's main slot
+      // so that [collar, ...existingModuleLabware, moduleId, slot] is built correctly
+      const moduleSlot = modules[newLocation.moduleId].slot
+      const existingStack = getLargestStackInSlot(labware, moduleSlot)
+      if (existingStack.length > 0) {
+        newLocationStack.push(...existingStack)
+      } else {
+        newLocationStack.push(newLocation.moduleId, moduleSlot)
+      }
     } else {
       newLocationStack.push(
         newLocation.moduleId,
@@ -203,7 +218,19 @@ export function forMoveLabware(
     const labwareIdStack = labware[labwareId].stack
     newLocationStack.push(...labwareIdStack)
   } else if ('addressableAreaName' in newLocation) {
-    newLocationStack.push(newLocation.addressableAreaName)
+    if (getIsSlotAVacuumDock(newLocation.addressableAreaName)) {
+      const vacuumModuleId = Object.entries(modules).find(
+        ([moduleId]) =>
+          invariantContext.moduleEntities[moduleId]?.type === VACUUM_MODULE_TYPE
+      )?.[0]
+      newLocationStack.push(VACUUM_DOCK_LOCATION)
+      if (vacuumModuleId != null) {
+        newLocationStack.push(vacuumModuleId)
+      }
+      newLocationStack.push(newLocation.addressableAreaName)
+    } else {
+      newLocationStack.push(newLocation.addressableAreaName)
+    }
   }
   labwareToMove.forEach((id, i) => {
     if (labware[id] != null) {
@@ -235,6 +262,20 @@ export function forMoveLabware(
     )
     if (shuttleAa != null) {
       stackedOnNodeForMovedPrimary = { addressableAreaName: shuttleAa }
+    }
+  } else if (
+    typeof newLocation === 'object' &&
+    newLocation !== null &&
+    'moduleId' in newLocation &&
+    invariantContext.moduleEntities[newLocation.moduleId]?.type ===
+      VACUUM_MODULE_TYPE
+  ) {
+    // The collar stacks onto the topmost existing labware on the module, not the module itself
+    const moduleSlot = modules[newLocation.moduleId].slot
+    const existingStack = getLargestStackInSlot(labware, moduleSlot)
+    const topOnModule = existingStack.length > 0 ? existingStack[0] : null
+    if (topOnModule != null && topOnModule in labwareEntities) {
+      stackedOnNodeForMovedPrimary = { labwareId: topOnModule }
     }
   }
   robotState.labware[labwareId].stackedOnNode = stackedOnNodeForMovedPrimary

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -273,9 +273,13 @@ export function forMoveLabware(
     // The collar stacks onto the topmost existing labware on the module, not the module itself
     const moduleSlot = modules[newLocation.moduleId].slot
     const existingStack = getLargestStackInSlot(labware, moduleSlot)
-    const topOnModule = existingStack.length > 0 ? existingStack[0] : null
-    if (topOnModule != null && topOnModule in labwareEntities) {
-      stackedOnNodeForMovedPrimary = { labwareId: topOnModule }
+    const topLabwareIdOnModule =
+      existingStack.length > 0 ? existingStack[0] : null
+    if (
+      topLabwareIdOnModule != null &&
+      topLabwareIdOnModule in labwareEntities
+    ) {
+      stackedOnNodeForMovedPrimary = { labwareId: topLabwareIdOnModule }
     }
   }
   robotState.labware[labwareId].stackedOnNode = stackedOnNodeForMovedPrimary


### PR DESCRIPTION
# Overview

This PR adds the ability to move labware to and from the vacuum main module area and dock. It supports moving combinations of collars and child plates/lids, and provides safety checks for legitimate collar positions, as well as legitimate labware for the main module and dock. It also builds the correct Python emission for the unique move labware PAPI method for moving to a dock (`vacuumModule.manifold_dock`).

Closes EXEC-2683

https://github.com/user-attachments/assets/44d0d0d6-214e-4545-9aa0-56930bb00565


## Test Plan and Hands on Testing

This PR, unfortunately, requires not-yet-existent labware to test in practice (Collar definitions will be added [here](https://github.com/Opentrons/opentrons/pull/21567)). I've recorded a video to demonstrate behavior, and can supply dummy labware for any reviewers.

[move labware test protocol](https://github.com/user-attachments/files/28312472/vac_test_move_labware.py)

### Movement compatibility rules

#### Collar destinations (source labware is a collar)  
  - Can only move to the vacuum dock or the vacuum module main area
  - The module main area is only offered as a destination if no collar is present

#### Collar compatibility
  - Collar definitions include stackingOffsetWithLabware entries for both the wellplate and the spacer, so either can be the collar's parent

#### Non-collar labware
  - Cannot be moved to the vacuum dock (filtered from destination options)

#### Wellplate accessibility
  - A wellplate on the vacuum module is movable when it is the topmost item on the module (in practice: exposed collection plate or filter plate)
  - A wellplate is _not_ when a collar sits on top of it (collection plate scenario)

#### Dock stack format   
  - [collar, moduleId, 'vacuumModuleV1DockA4'] — module ID is included so stack.includes(moduleId) returns all labware associated with the module across both main slot and dock

## Changelog

- add new filters and logic for vacuum module compatibility as mentioned above
- update step summary to accommodate vacuum dock
- update `HighlightItems` for vacuum dock
- special case collars in movement utilities since they are adapters that can be moved
- populate vacuum dock option if available in active deck setup in `getUnoccupiedLabwareLocationOptions` selector
- de-special-case the vacuum module display location, since it maintains two independent locations (A3 and A4 separately, not A3+A4)
- update logic in state updater `forMoveLabware` for vacuum module

## Review requests

see test plan

## Risk assessment

lowish. additive logic to `moveLabware`/`forMoveLabware` for vacuum module. existing tests and smoke testing should cover us 