### PR TITLE
chore(mono): Incremental mergeback of `chore_release-pd-8.10.2` into `chore_release-9.1.0`

### DIFF
--- a/protocol-designer/src/labware-ingred/reducers/index.ts
+++ b/protocol-designer/src/labware-ingred/reducers/index.ts
@@ -211,6 +211,9 @@ export const containers: Reducer<ContainersState, any> = handleActions(
           allLabwareDefs,
           latestDefs
         )
+        if (latestLabwareId == null) {
+          return acc
+        }
 
         acc[latestLabwareId] = {
           nickname: labwareLoadInfo.displayName,
@@ -360,6 +363,9 @@ export const ingredLocations: Reducer<LocationsState, any> = handleActions(
             allLabwareDefs,
             latestDefs
           )
+          if (latestLabwareId == null) {
+            return acc
+          }
           acc[latestLabwareId] = liquidIngredient
           return acc
         },

--- a/protocol-designer/src/labware-ingred/utils.ts
+++ b/protocol-designer/src/labware-ingred/utils.ts
@@ -140,11 +140,14 @@ const ADDITIONAL_EQUIPMENT_TYPES = ['wasteChute', 'trashBin']
 
 export const getMigratedLabwareId = (
   // labware or trash-like entity ID
-  oldEntityId: string,
+  oldEntityId: string | null,
   labware: Labware,
   allLabwareDefs: Record<string, LabwareDefinition2>,
   latestDefs: LabwareDefByDefURI
-): string => {
+): string | null => {
+  if (oldEntityId == null) {
+    return null
+  }
   // Check if this is an additional equipment ID (e.g., waste chute, trash bin)
   // These are stored in additionalEquipmentOnDeck, not in labware, so return unchanged
   const isAdditionalEquipment = ADDITIONAL_EQUIPMENT_TYPES.some(type =>

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -399,6 +399,9 @@ export const savedStepForms = (
           allLabware,
           latestDefs
         )
+        if (updatedLabwareId == null) {
+          return acc
+        }
         // The `location` can be a labwareId too, so update its version as well.
         // (We only recently realized that we need to update `location`, so there are
         // probably saved protocols out there where we hadn't updated `location` and


### PR DESCRIPTION
# Overview

An incremental mergeback of `chore_release-pd-8.10.2` into `chore_release-9.1.0`. No merge conflicts.