### PR TITLE
chore(protocol-visualization): Bump lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@testing-library/user-event": "14.6.1",
     "@types/fernet": "^0.4.3",
     "@types/glob": "7.1.3",
-    "@types/lodash": "4.17.24",
     "@types/netmask": "^1.0.30",
     "@types/node": "^25.6.0",
     "@types/react": "18.2.51",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1323,8 +1323,8 @@ importers:
         specifier: 2.1.1
         version: 2.1.1
       lodash:
-        specifier: 4.17.21
-        version: 4.17.21
+        specifier: 4.18.1
+        version: 4.18.1
       react:
         specifier: 18.2.0
         version: 18.2.0
@@ -8498,9 +8498,6 @@ packages:
 
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -17535,7 +17532,7 @@ snapshots:
       fs-minipass: 3.0.3
       glob: 10.5.0
       lru-cache: 10.4.3
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-collect: 2.0.1
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
@@ -19895,7 +19892,7 @@ snapshots:
 
   fs-minipass@3.0.3:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   fs.realpath@1.0.0: {}
 
@@ -20071,7 +20068,7 @@ snapshots:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
       minimatch: 9.0.5
-      minipass: 7.1.2
+      minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -21234,8 +21231,6 @@ snapshots:
 
   lodash.truncate@4.4.2: {}
 
-  lodash@4.17.21: {}
-
   lodash@4.18.1: {}
 
   log-symbols@4.1.0:
@@ -21830,7 +21825,7 @@ snapshots:
 
   minipass-collect@2.0.1:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   minipass-fetch@2.1.2:
     dependencies:
@@ -21842,7 +21837,7 @@ snapshots:
 
   minipass-fetch@4.0.1:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-sized: 1.0.3
       minizlib: 3.1.0
     optionalDependencies:
@@ -24130,7 +24125,7 @@ snapshots:
 
   ssri@12.0.0:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   ssri@9.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,9 +74,6 @@ importers:
       '@types/glob':
         specifier: 7.1.3
         version: 7.1.3
-      '@types/lodash':
-        specifier: 4.17.24
-        version: 4.17.24
       '@types/netmask':
         specifier: ^1.0.30
         version: 1.0.30
@@ -1319,6 +1316,9 @@ importers:
       '@opentrons/step-generation':
         specifier: link:../step-generation
         version: link:../step-generation
+      '@types/lodash':
+        specifier: 4.17.24
+        version: 4.17.24
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -1346,6 +1346,9 @@ importers:
       '@opentrons/shared-data':
         specifier: link:../shared-data
         version: link:../shared-data
+      '@types/lodash':
+        specifier: 4.17.24
+        version: 4.17.24
       axios:
         specifier: ^0.21.1
         version: 0.21.4
@@ -14217,7 +14220,7 @@ snapshots:
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   '@jest/schemas@30.0.5':
     dependencies:
@@ -21378,7 +21381,7 @@ snapshots:
       '@npmcli/agent': 3.0.0
       cacache: 19.0.1
       http-cache-semantics: 4.2.0
-      minipass: 7.1.2
+      minipass: 7.1.3
       minipass-fetch: 4.0.1
       minipass-flush: 1.0.5
       minipass-pipeline: 1.2.4
@@ -21874,7 +21877,7 @@ snapshots:
 
   minizlib@3.1.0:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   mixpanel-browser@2.22.1: {}
 

--- a/protocol-visualization/package.json
+++ b/protocol-visualization/package.json
@@ -37,6 +37,7 @@
     "@opentrons/components": "link:../components",
     "@opentrons/shared-data": "link:../shared-data",
     "@opentrons/step-generation": "link:../step-generation",
+    "@types/lodash": "4.17.24",
     "clsx": "2.1.1",
     "lodash": "4.18.1",
     "react-window": "2.2.4"

--- a/protocol-visualization/package.json
+++ b/protocol-visualization/package.json
@@ -38,7 +38,7 @@
     "@opentrons/shared-data": "link:../shared-data",
     "@opentrons/step-generation": "link:../step-generation",
     "clsx": "2.1.1",
-    "react-window": "2.2.4",
-    "lodash": "4.17.21"
+    "lodash": "4.18.1",
+    "react-window": "2.2.4"
   }
 }

--- a/react-api-client/package.json
+++ b/react-api-client/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@opentrons/api-client": "link:../api-client",
     "@opentrons/shared-data": "link:../shared-data",
+    "@types/lodash": "4.17.24",
     "axios": "^0.21.1",
     "lodash": "4.18.1",
     "react-query": "3.35.0"


### PR DESCRIPTION
## Overview

This updates lodash in protocol-visualization from 4.17.21 to 4.18.1, bringing it in line with other projects. This resolves a few security alerts.

This also makes sure @types/lodash is installed explicitly in each project that uses lodash, instead of falling back to a single top-level installation. This is just for consistency.

## Test Plan and Hands on Testing

Just CI.

## Review requests

None.

## Risk assessment

Low.
