### PR TITLE
feat(app): Keep the user logged in while they're active

### DIFF
--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -37,6 +37,7 @@ import { appShellUSBRequestor } from '/app/redux/shell/remote'
 
 import { ProtocolVisualization } from '../pages/Desktop/Protocols/ProtocolVisualization'
 import { DesktopAppFallback } from './DesktopAppFallback'
+import { useRefreshAccessTokenOnActivity } from './hooks/useRefreshAccessTokenOnActivity'
 import { useSoftwareUpdatePoll } from './hooks/useSoftwareUpdatePoll'
 import { Navbar } from './Navbar'
 import { ModalPortalRoot } from './portal'
@@ -46,6 +47,7 @@ import type { RouteProps } from './types'
 
 export const DesktopApp = (): JSX.Element => {
   useSoftwareUpdatePoll()
+  useRefreshAccessTokenOnActivity()
   const [isEmergencyStopModalDismissed, setIsEmergencyStopModalDismissed] =
     useState<boolean>(false)
 

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -67,6 +67,7 @@ import {
   useScrollRef,
 } from './hooks/useModuleAttachedToast'
 import { useProtocolReceiptToast } from './hooks/useProtocolReceiptToast'
+import { useRefreshAccessTokenOnActivity } from './hooks/useRefreshAccessTokenOnActivity'
 import { useSoftwareUpdatePoll } from './hooks/useSoftwareUpdatePoll'
 import { SharedScrollRefProvider } from './ODDProviders/ScrollRefProvider'
 import { ODDTopLevelRedirects } from './ODDTopLevelRedirects'
@@ -200,6 +201,8 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
       )
     }
   }, [dispatch, isIdle, userSetBrightness])
+
+  useRefreshAccessTokenOnActivity()
 
   const isShellReady = useSelector(getIsShellReady)
 

--- a/app/src/App/__tests__/DesktopApp.test.tsx
+++ b/app/src/App/__tests__/DesktopApp.test.tsx
@@ -28,6 +28,7 @@ import { DesktopApp } from '../DesktopApp'
 import { useSoftwareUpdatePoll } from '../hooks/useSoftwareUpdatePoll'
 
 import type { LocalizationProviderProps } from '/app/LocalizationProvider'
+import type { State } from '/app/redux/types'
 
 vi.mock('/app/LocalizationProvider')
 vi.mock('/app/organisms/Desktop/Breadcrumbs')
@@ -46,11 +47,16 @@ vi.mock('../hooks/useSoftwareUpdatePoll')
 vi.mock('/app/pages/Desktop/Protocols/ProtocolVisualization')
 
 const render = (path = '/') => {
-  return renderWithProviders(
+  return renderWithProviders<State>(
     <MemoryRouter initialEntries={[path]} initialIndex={0}>
       <DesktopApp />
     </MemoryRouter>,
-    { i18nInstance: i18n }
+    {
+      initialState: {
+        robotAuth: { mostRecentRobotName: null, perRobotAuthStates: {} },
+      } satisfies Partial<State> as State,
+      i18nInstance: i18n,
+    }
   )
 }
 

--- a/app/src/App/__tests__/OnDeviceDisplayApp.test.tsx
+++ b/app/src/App/__tests__/OnDeviceDisplayApp.test.tsx
@@ -43,6 +43,7 @@ import { OnDeviceDisplayApp } from '../OnDeviceDisplayApp'
 import type { HostConfig } from '@opentrons/api-client'
 import type * as ReactApiClient from '@opentrons/react-api-client'
 import type { OnDeviceDisplaySettings } from '/app/redux/config/schema-types'
+import type { State } from '/app/redux/types'
 import type { LocalizationProviderProps } from '../../LocalizationProvider'
 
 vi.mock('@opentrons/react-api-client', async importOriginal => {
@@ -97,11 +98,16 @@ const mockSettings = {
 } as OnDeviceDisplaySettings
 
 const render = (path = '/') => {
-  return renderWithProviders(
+  return renderWithProviders<State>(
     <MemoryRouter initialEntries={[path]} initialIndex={0}>
       <OnDeviceDisplayApp />
     </MemoryRouter>,
-    { i18nInstance: i18n }
+    {
+      initialState: {
+        robotAuth: { mostRecentRobotName: null, perRobotAuthStates: {} },
+      } satisfies Partial<State> as State,
+      i18nInstance: i18n,
+    }
   )
 }
 

--- a/app/src/App/hooks/__tests__/useThrottler.test.ts
+++ b/app/src/App/hooks/__tests__/useThrottler.test.ts
@@ -1,0 +1,97 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useThrottler } from '../useThrottler'
+
+describe('useThrottler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetAllMocks()
+  })
+
+  it('does not call the function again until the interval has passed', () => {
+    const throttleMS = 1000
+    const { result } = renderHook(() => useThrottler(throttleMS))
+    const toCall = vi.fn()
+
+    act(() => {
+      result.current.maybeCall(toCall)
+      result.current.maybeCall(toCall)
+      result.current.maybeCall(toCall)
+    })
+    expect(toCall).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      vi.advanceTimersByTime(throttleMS + 1)
+      result.current.maybeCall(toCall)
+      result.current.maybeCall(toCall)
+      result.current.maybeCall(toCall)
+    })
+    expect(toCall).toHaveBeenCalledTimes(2)
+
+    act(() => {
+      vi.advanceTimersByTime(throttleMS + 1)
+      result.current.maybeCall(toCall)
+      result.current.maybeCall(toCall)
+      result.current.maybeCall(toCall)
+    })
+    expect(toCall).toHaveBeenCalledTimes(3)
+  })
+
+  it('uses the updated interval after rerender', () => {
+    const { rerender, result } = renderHook(
+      ({ throttleMS }) => useThrottler(throttleMS),
+      { initialProps: { throttleMS: 1000 } }
+    )
+    const toCall = vi.fn()
+
+    act(() => {
+      result.current.maybeCall(toCall)
+      result.current.maybeCall(toCall)
+      result.current.maybeCall(toCall)
+    })
+    expect(toCall).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+      result.current.maybeCall(toCall)
+      result.current.maybeCall(toCall)
+      result.current.maybeCall(toCall)
+    })
+    expect(toCall).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      rerender({ throttleMS: 100 })
+    })
+    act(() => {
+      result.current.maybeCall(toCall)
+      result.current.maybeCall(toCall)
+      result.current.maybeCall(toCall)
+    })
+    expect(toCall).toHaveBeenCalledTimes(2)
+
+    act(() => {
+      vi.advanceTimersByTime(101)
+      result.current.maybeCall(toCall)
+      result.current.maybeCall(toCall)
+      result.current.maybeCall(toCall)
+    })
+    expect(toCall).toHaveBeenCalledTimes(3)
+  })
+
+  it('keeps the same maybeCall reference when throttleMS is unchanged', () => {
+    const throttleMS = 1000
+    const { rerender, result } = renderHook(
+      ({ throttleMS }) => useThrottler(throttleMS),
+      { initialProps: { throttleMS } }
+    )
+
+    const initialMaybeCall = result.current.maybeCall
+    rerender({ throttleMS })
+    expect(result.current.maybeCall).toBe(initialMaybeCall)
+  })
+})

--- a/app/src/App/hooks/useRefreshAccessTokenOnActivity.ts
+++ b/app/src/App/hooks/useRefreshAccessTokenOnActivity.ts
@@ -1,0 +1,113 @@
+import { useCallback, useMemo, useRef } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { getOAuth2Token, OAUTH2_CLIENT_ID } from '@opentrons/api-client'
+
+import { useThrottler } from '/app/App/hooks/useThrottler'
+import { useActivityListener } from '/app/local-resources/dom-utils/hooks/useActivityListener'
+import { useRobot } from '/app/redux-resources/robots'
+import { OPENTRONS_USB } from '/app/redux/discovery'
+import {
+  getAuthStateForRobot,
+  getMostRecentRobotName,
+  logInOrRefresh,
+  useAccessTokenForRobot,
+} from '/app/redux/robot-auth'
+import { appShellUSBRequestor } from '/app/redux/shell/remote'
+
+import type { HostConfig, RefreshRequest } from '@opentrons/api-client'
+import type { State } from '/app/redux/types'
+
+const THROTTLE_SEC = 30
+
+/**
+ * This keeps the user logged in to their robot while they're actively using the UI.
+ * It sends periodic auth refresh requests while there is activity like typing and
+ * clicking.
+ *
+ * This should be called once per app. It depends on having access to Redux state,
+ * but does not depend on being inside an <ApiHostProvider>.
+ */
+export function useRefreshAccessTokenOnActivity(): void {
+  const dispatch = useDispatch()
+
+  const robotName = useSelector(getMostRecentRobotName)
+  const hostConfig = useHostConfigForRobot(robotName)
+  const authState = useSelector((state: State) =>
+    robotName != null ? getAuthStateForRobot(state, robotName) : null
+  )
+
+  // We're implementing our own limiter for at most one request in flight, instead of
+  // using React Query and its `.isLoading` state. We do this because React Query's
+  // `useMutation()` triggers a re-render every time the request state changes,
+  // which would be totally unnecessary in our usage here, and especially disruptive
+  // since this hook lives so high in the component hierarchy. `useQuery()` has a
+  // `select` option to solve this problem, but `useMutation()` doesn't. :\
+  const isRequestInFlight = useRef<boolean>(false)
+
+  const handleThrottledActivity = useCallback(async () => {
+    if (
+      isRequestInFlight.current ||
+      hostConfig == null ||
+      robotName == null ||
+      authState?.refreshToken == null
+    ) {
+      return
+    }
+
+    const request: RefreshRequest = {
+      grant_type: 'refresh_token',
+      refresh_token: authState.refreshToken,
+      client_id: OAUTH2_CLIENT_ID,
+    }
+
+    isRequestInFlight.current = true
+    try {
+      const response = await getOAuth2Token(hostConfig, request)
+      const expiresIn = response.data.expires_in ?? null
+      const expiresAt = expiresIn != null ? Date.now() + expiresIn : null
+      dispatch(
+        logInOrRefresh({
+          robotName,
+          username: authState.username,
+          accessToken: response.data.access_token,
+          refreshToken: response.data.refresh_token ?? null,
+          expiresAt,
+        })
+      )
+    } finally {
+      isRequestInFlight.current = false
+    }
+  }, [authState, dispatch, hostConfig, robotName])
+
+  const activityThrottler = useThrottler(THROTTLE_SEC * 1000)
+  const handleActivity = useCallback(() => {
+    activityThrottler.maybeCall(() => {
+      void handleThrottledActivity()
+    })
+  }, [handleThrottledActivity, activityThrottler])
+
+  useActivityListener(handleActivity)
+}
+
+function useHostConfigForRobot(robotName: string | null): HostConfig | null {
+  const robot = useRobot(robotName)
+  const token = useAccessTokenForRobot(robotName)
+
+  const result = useMemo<HostConfig | null>(() => {
+    if (robot?.ip == null) {
+      return null
+    } else {
+      // todo(mm, 2026-05-20): Deduplicate this. https://opentrons.atlassian.net/browse/AUTH-2856
+      return {
+        hostname: robot.ip,
+        port: robot.port,
+        requestor:
+          robot.ip === OPENTRONS_USB ? appShellUSBRequestor : undefined,
+        token,
+      }
+    }
+  }, [robot, token])
+
+  return result
+}

--- a/app/src/App/hooks/useThrottler.ts
+++ b/app/src/App/hooks/useThrottler.ts
@@ -1,0 +1,38 @@
+import { useCallback, useMemo, useRef } from 'react'
+
+export interface Throttler {
+  /**
+   * Call toCall if it's been long enough since the last time. Otherwise, no-op.
+   */
+  maybeCall: (toCall: () => void) => void
+}
+
+/**
+ * Limits how frequently a function is called.
+ *
+ * The advantage of using this over Lodash's throttle() or debounce() is that with
+ * this, you can change the function being throttled without resetting the timer.
+ * This tends to play more nicely with React, where our functions have to change
+ * frequently because they're closures over changing state.
+ */
+export function useThrottler(throttleMS: number): Throttler {
+  const lastCalledAt = useRef<number | null>(null)
+
+  const maybeCall: Throttler['maybeCall'] = useCallback(
+    toCall => {
+      // performance.now() instead of Date.now() for monotonicity.
+      const now = performance.now()
+      if (
+        lastCalledAt.current == null ||
+        now - lastCalledAt.current > throttleMS
+      ) {
+        lastCalledAt.current = now
+        toCall()
+      }
+    },
+    [throttleMS]
+  )
+
+  const result: Throttler = useMemo(() => ({ maybeCall }), [maybeCall])
+  return result
+}

--- a/app/src/redux/robot-auth/__tests__/expirationMiddleware.test.ts
+++ b/app/src/redux/robot-auth/__tests__/expirationMiddleware.test.ts
@@ -206,5 +206,5 @@ describe('expirationMiddleware', () => {
 })
 
 function getUnexpiredRobots(state: State): string[] {
-  return Object.keys(state.robotAuth).sort()
+  return Object.keys(state.robotAuth.perRobotAuthStates).sort()
 }

--- a/app/src/redux/robot-auth/__tests__/reducer.test.ts
+++ b/app/src/redux/robot-auth/__tests__/reducer.test.ts
@@ -13,7 +13,10 @@ describe('robotAuthReducer', () => {
   it('uses empty object as initial state', () => {
     expect(
       robotAuthReducer(undefined, { type: 'not-handled' } as any)
-    ).toStrictEqual({})
+    ).toStrictEqual({
+      perRobotAuthStates: {},
+      mostRecentRobotName: null,
+    } satisfies RobotAuthState)
   })
 
   it('handles logins and login refreshes', () => {
@@ -31,13 +34,16 @@ describe('robotAuthReducer', () => {
       })
     )
     expect(state).toStrictEqual({
-      testRobotNameA: {
-        username: 'testUserA',
-        accessToken: 'testAccessTokenA',
-        refreshToken: 'testRefreshTokenA',
-        expiresAt: 1234,
+      perRobotAuthStates: {
+        testRobotNameA: {
+          username: 'testUserA',
+          accessToken: 'testAccessTokenA',
+          refreshToken: 'testRefreshTokenA',
+          expiresAt: 1234,
+        },
       },
-    })
+      mostRecentRobotName: 'testRobotNameA',
+    } satisfies typeof state)
 
     // Log in to second robot:
     state = robotAuthReducer(
@@ -51,19 +57,22 @@ describe('robotAuthReducer', () => {
       })
     )
     expect(state).toStrictEqual({
-      testRobotNameA: {
-        username: 'testUserA',
-        accessToken: 'testAccessTokenA',
-        refreshToken: 'testRefreshTokenA',
-        expiresAt: 1234,
+      perRobotAuthStates: {
+        testRobotNameA: {
+          username: 'testUserA',
+          accessToken: 'testAccessTokenA',
+          refreshToken: 'testRefreshTokenA',
+          expiresAt: 1234,
+        },
+        testRobotNameB: {
+          username: 'testUserB',
+          accessToken: 'testAccessTokenB',
+          refreshToken: null,
+          expiresAt: 5678,
+        },
       },
-      testRobotNameB: {
-        username: 'testUserB',
-        accessToken: 'testAccessTokenB',
-        refreshToken: null,
-        expiresAt: 5678,
-      },
-    })
+      mostRecentRobotName: 'testRobotNameB',
+    } satisfies typeof state)
 
     // Refresh login for first robot:
     state = robotAuthReducer(
@@ -77,35 +86,41 @@ describe('robotAuthReducer', () => {
       })
     )
     expect(state).toStrictEqual({
-      testRobotNameA: {
-        username: 'testUserARefreshed',
-        accessToken: 'testAccessTokenARefreshed',
-        refreshToken: 'testRefreshTokenARefreshed',
-        expiresAt: 4321,
+      perRobotAuthStates: {
+        testRobotNameA: {
+          username: 'testUserARefreshed',
+          accessToken: 'testAccessTokenARefreshed',
+          refreshToken: 'testRefreshTokenARefreshed',
+          expiresAt: 4321,
+        },
+        testRobotNameB: {
+          username: 'testUserB',
+          accessToken: 'testAccessTokenB',
+          refreshToken: null,
+          expiresAt: 5678,
+        },
       },
-      testRobotNameB: {
-        username: 'testUserB',
-        accessToken: 'testAccessTokenB',
-        refreshToken: null,
-        expiresAt: 5678,
-      },
-    })
+      mostRecentRobotName: 'testRobotNameA',
+    } satisfies typeof state)
   })
 
   it('handles logouts', () => {
     const initialState: RobotAuthState = {
-      testRobotNameA: {
-        username: 'testUserA',
-        accessToken: 'testAccessTokenA',
-        refreshToken: 'testRefreshTokenA',
-        expiresAt: 1234,
+      perRobotAuthStates: {
+        testRobotNameA: {
+          username: 'testUserA',
+          accessToken: 'testAccessTokenA',
+          refreshToken: 'testRefreshTokenA',
+          expiresAt: 1234,
+        },
+        testRobotNameB: {
+          username: 'testUserB',
+          accessToken: 'testAccessTokenB',
+          refreshToken: 'testRefreshTokenB',
+          expiresAt: 5678,
+        },
       },
-      testRobotNameB: {
-        username: 'testUserB',
-        accessToken: 'testAccessTokenB',
-        refreshToken: 'testRefreshTokenB',
-        expiresAt: 5678,
-      },
+      mostRecentRobotName: 'testRobotNameB',
     }
 
     const newState = robotAuthReducer(
@@ -115,7 +130,10 @@ describe('robotAuthReducer', () => {
       })
     )
     expect(newState).toStrictEqual({
-      testRobotNameA: initialState.testRobotNameA,
-    })
+      perRobotAuthStates: {
+        testRobotNameA: initialState.perRobotAuthStates.testRobotNameA,
+      },
+      mostRecentRobotName: 'testRobotNameB',
+    } satisfies typeof newState)
   })
 })

--- a/app/src/redux/robot-auth/__tests__/selectors.test.ts
+++ b/app/src/redux/robot-auth/__tests__/selectors.test.ts
@@ -4,6 +4,7 @@ import {
   getAuthStateForRobot,
   getIsLoggedInToLocalRobot,
   getLocalRobotAuthState,
+  getMostRecentRobotName,
 } from '../slice'
 
 import type {
@@ -11,10 +12,17 @@ import type {
   DiscoveryClientRobotAddress,
 } from '@opentrons/discovery-client'
 import type { State } from '../../types'
+import type { RobotAuthState } from '../slice'
+
+function makeTestState(robotAuth: RobotAuthState): State {
+  return {
+    robotAuth,
+  } satisfies Partial<State> as State
+}
 
 describe('robot auth selectors', () => {
-  const stateWithRobotA = {
-    robotAuth: {
+  const stateWithRobotA = makeTestState({
+    perRobotAuthStates: {
       robotA: {
         username: 'alice',
         accessToken: 'token-a',
@@ -22,9 +30,13 @@ describe('robot auth selectors', () => {
         expiresAt: 1234,
       },
     },
-  } as unknown as State
+    mostRecentRobotName: 'robotA',
+  })
 
-  const emptyRobotAuthState = { robotAuth: {} } as unknown as State
+  const emptyRobotAuthState = makeTestState({
+    perRobotAuthStates: {},
+    mostRecentRobotName: null,
+  })
 
   describe('getAuthStateForRobot', () => {
     it('returns null when robot is not in state', () => {
@@ -68,12 +80,13 @@ describe('robot auth selectors', () => {
           },
         },
         robotAuth: {
-          [localRobot.name]: authState,
+          perRobotAuthStates: { [localRobot.name]: authState },
+          mostRecentRobotName: null,
         },
       } satisfies Partial<State> as State
 
       expect(getLocalRobotAuthState(state)).toStrictEqual(
-        state.robotAuth[localRobot.name]
+        state.robotAuth.perRobotAuthStates[localRobot.name]
       )
       expect(getIsLoggedInToLocalRobot(state)).toStrictEqual(true)
     })
@@ -85,7 +98,8 @@ describe('robot auth selectors', () => {
           robotsByName: {},
         },
         robotAuth: {
-          [localRobot.name]: authState,
+          perRobotAuthStates: { [localRobot.name]: authState },
+          mostRecentRobotName: null,
         },
       } satisfies Partial<State> as State
 
@@ -100,11 +114,32 @@ describe('robot auth selectors', () => {
             [localRobot.name]: localRobot,
           },
         },
-        robotAuth: {},
+        robotAuth: { perRobotAuthStates: {}, mostRecentRobotName: null },
       } satisfies Partial<State> as State
 
       expect(getLocalRobotAuthState(state)).toStrictEqual(null)
       expect(getIsLoggedInToLocalRobot(state)).toStrictEqual(false)
+    })
+  })
+
+  describe('getMostRecentRobotName', () => {
+    it('returns the most recent robot name', () => {
+      expect(
+        getMostRecentRobotName(
+          makeTestState({
+            perRobotAuthStates: {},
+            mostRecentRobotName: null,
+          })
+        )
+      ).toStrictEqual(null)
+      expect(
+        getMostRecentRobotName(
+          makeTestState({
+            perRobotAuthStates: {},
+            mostRecentRobotName: 'Otie',
+          })
+        )
+      ).toStrictEqual('Otie')
     })
   })
 })

--- a/app/src/redux/robot-auth/expirationMiddleware.ts
+++ b/app/src/redux/robot-auth/expirationMiddleware.ts
@@ -53,7 +53,7 @@ expirationMiddleware.startListening.withTypes<State, Dispatch>()({
 
 // JS's window.setTimeout() function, and by extension Redux's listenerAPI.delay()
 // function, can't handle durations bigger than an int32, so we need this workaround.
-// Durations probably be this long in production, but they might be in testing.
+// Durations probably won't be this long in production, but they might be in testing.
 async function longDelay(
   listenerAPI: ListenerEffectAPI<State, Dispatch>,
   waitDuration: number

--- a/app/src/redux/robot-auth/slice.ts
+++ b/app/src/redux/robot-auth/slice.ts
@@ -10,7 +10,12 @@ import type { PayloadAction } from '@reduxjs/toolkit'
 import type { State } from '/app/redux/types'
 
 export interface RobotAuthState {
-  [robotName: string]: PerRobotAuthState | undefined
+  perRobotAuthStates: {
+    [robotName: string]: PerRobotAuthState | undefined
+  }
+
+  /** The robotName of the robot that's most recently been logged into. */
+  mostRecentRobotName: string | null
 }
 
 interface PerRobotAuthState {
@@ -33,7 +38,10 @@ interface PerRobotAuthState {
   expiresAt: number | null
 }
 
-export const INITIAL_ROBOT_AUTH_STATE: RobotAuthState = {}
+export const INITIAL_ROBOT_AUTH_STATE: RobotAuthState = {
+  perRobotAuthStates: {},
+  mostRecentRobotName: null,
+}
 
 /** Stores the result of logging in to a robot, of refreshing an existing login. */
 interface LogInOrRefreshPayload {
@@ -53,14 +61,15 @@ const robotAuthSlice = createSlice({
   name: 'robotAuth',
   initialState: INITIAL_ROBOT_AUTH_STATE,
   reducers: {
-    logInOrRefresh(state, action: PayloadAction<LogInOrRefreshPayload>) {
+    logInOrRefresh(stateDraft, action: PayloadAction<LogInOrRefreshPayload>) {
       const { robotName, ...robotAuthState } = action.payload
-      state[robotName] = robotAuthState
+      stateDraft.perRobotAuthStates[robotName] = robotAuthState
+      stateDraft.mostRecentRobotName = robotName
     },
-    logOutOrTimeOut(state, action: PayloadAction<LogOutOrTimeOutPayload>) {
+    logOutOrTimeOut(stateDraft, action: PayloadAction<LogOutOrTimeOutPayload>) {
       // dynamic-delete is normal and fine with Immer and Redux.
       // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-      delete state[action.payload.robotName]
+      delete stateDraft.perRobotAuthStates[action.payload.robotName]
     },
   },
 })
@@ -77,7 +86,7 @@ export function getAuthStateForRobot(
   state: State,
   robotName: string
 ): PerRobotAuthState | null {
-  return state.robotAuth?.[robotName] ?? null
+  return state.robotAuth?.perRobotAuthStates[robotName] ?? null
 }
 
 /**
@@ -97,6 +106,11 @@ export const getLocalRobotAuthState = createSelector(
       return getAuthStateForRobot(state, localRobotName)
     }
   }
+)
+
+export const getMostRecentRobotName = createSelector(
+  (state: State) => state,
+  (state: State): string | null => state.robotAuth.mostRecentRobotName
 )
 
 export const getLocalRobotAccessToken = createSelector(
@@ -139,9 +153,11 @@ interface GetNextExpirationResult {
 }
 
 export const getNextExpiration = createSelector(
-  (state: State) => state.robotAuth,
-  (robotAuthState: RobotAuthState): GetNextExpirationResult | null =>
-    Object.entries(robotAuthState).reduce<GetNextExpirationResult | null>(
+  (state: State) => state.robotAuth.perRobotAuthStates,
+  (
+    perRobotAuthStates: RobotAuthState['perRobotAuthStates']
+  ): GetNextExpirationResult | null =>
+    Object.entries(perRobotAuthStates).reduce<GetNextExpirationResult | null>(
       (acc, [candidateName, candidateState]) => {
         if (
           candidateState?.expiresAt != null &&


### PR DESCRIPTION
## Overview

This closes EXEC-2179.

## Test Plan and Hands on Testing

ODD:

* [x] It sends a refresh request every 30 seconds while there's user activity, keeping the login alive.
* [x] It doesn't send a refresh request while there's no user activity, allowing the login to expire.
* [x] It doesn't send more than one refresh request every 30 seconds.
* [x] It doesn't allow there to be more than one request at a time, if a request takes longer than 30 seconds for some reason. This can be tested by adding a sleep to the server code.
* [ ] It doesn't cause unnecessary rerenders. The easiest way to test this is probably with console logs or the React dev tools. But also, be on the lookout for queries reverting to their loading state.
  * As I'm looking at this again, this might be a losing battle. We can avoid rerenders any time the query state changes, but as long as this is a hook, we'll always have rerenders somewhere, like if the `mostRecentRobot` selector returns a new value.

Desktop app: Not possible to test yet because we haven't yet implemented the login UI.

## Changelog

Whenever there's a user event, like clicking or typing, we do an OAuth 2 token refresh. We send our refresh token to the server, and the server replies with a new access token, a new refresh token, and an updated expiration time. We store the new tokens so they'll automatically be used by subsequent requests to the robot API.

We throttle the user events, so we only do this at most every 30 seconds.

We only track and keep alive the _most recent_ robot login. This is basically for implementation simplicity. Compared to keeping *all* logins alive, this avoids having to manage *n* HTTP request lifecycles. Compared to keeping just the _active_ login alive, this avoids having to determine which robot is "active"—which is an ill-defined notion, and which seems difficult to determine in places like the desktop app's "Devices" tab or "Choose a robot" slideout.

## Review requests

Fundamental questions:

* Does it seem like a good idea to keep the _most recent_ login alive?

Implementation questions:

* Is there a better name than `useRefreshAccessTokenOnActivity()`?
* Is my `useThrottler()` hook sensible? It feels like something that should already exist elsewhere, but I couldn't find anything.
* Is it sensible for `useRefreshAccessTokenOnActivity()` to implement its own tracking for in-flight requests, and avoid using React Query? Again, this feels like something that I shouldn't have to invent myself, but see the comment in the code about avoiding re-renders.


## Risk assessment

Medium. This hook lives high up, and it subscribes to a firehose of DOM events. We need to be pretty careful about rerendering too often or sending network requests too often.