### PR TITLE
refactor(auth-server,api-client,app): Rename "userName" to "username"

### DIFF
--- a/api-client/src/auth/users/types.ts
+++ b/api-client/src/auth/users/types.ts
@@ -1,7 +1,7 @@
 export type AuthUserAccountType = 'admin' | 'user' | 'auditor' | 'service'
 
 export interface AuthUser {
-  userName: string
+  username: string
   fullName: string
   accountType: AuthUserAccountType
   scopes: string[]

--- a/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.stories.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.stories.tsx
@@ -43,7 +43,7 @@ type Story = StoryObj<typeof DocumentationRequiredComponent>
 
 export const DocumentationRequired: Story = {
   args: {
-    userName: 'John Doe',
+    username: 'John Doe',
     onBack: action('onBack'),
     onConfirm: action('onConfirm'),
   },

--- a/app/src/pages/ODD/Account/__tests__/hooks.test.tsx
+++ b/app/src/pages/ODD/Account/__tests__/hooks.test.tsx
@@ -74,7 +74,7 @@ describe('useAccountInfo', () => {
     vi.mocked(useSelfQuery).mockReturnValue({
       data: {
         data: {
-          userName: 'test-user',
+          username: 'test-user',
           fullName: 'Test User Name',
           accountType: 'user',
           scopes: [],

--- a/auth-server/auth_server/users/models.py
+++ b/auth-server/auth_server/users/models.py
@@ -42,7 +42,7 @@ ACCOUNT_TYPE_TO_SCOPES: dict[AccountType, set[Scope]] = {
 class UserCreate(BaseModel):
     """Request body for creating a user."""
 
-    userName: Annotated[str, Field(..., description="The username of the user.")]
+    username: Annotated[str, Field(..., description="The username of the user.")]
     password: Annotated[SecretStr, Field(..., description="The password for the user.")]
     fullName: Annotated[str, Field(..., description="The full name of the user.")]
     accountType: Annotated[
@@ -53,7 +53,7 @@ class UserCreate(BaseModel):
 class UpdateUser(BaseModel):
     """Request body for updating a user."""
 
-    userName: Annotated[
+    username: Annotated[
         str | None,
         Field(description="The username of the user."),
     ] = None
@@ -87,7 +87,7 @@ class UpdateUser(BaseModel):
 class UserResponse(BaseModel):
     """Response body for a user (no password)."""
 
-    userName: str
+    username: str
     fullName: str
     accountType: AccountType
     scopes: list[str]

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -51,7 +51,7 @@ async def post_users(
     user_create = request_body.data
     try:
         new_user = user_data_manager.create_user(
-            username=user_create.userName,
+            username=user_create.username,
             password=user_create.password.get_secret_value(),
             full_name=user_create.fullName,
             account_type=user_create.accountType,
@@ -74,7 +74,7 @@ async def post_users(
 
 @PydanticResponse.wrap_route(
     router.get,
-    path="/auth/users/byUsername/{userName}",
+    path="/auth/users/byUsername/{username}",
     summary="Get a user",
     description="Get a specific user, identified by their unique username.",
     responses={
@@ -84,14 +84,14 @@ async def post_users(
     dependencies=[fastapi.Depends(require_scopes(Scope.USERS_READ_OTHERS))],
 )
 async def get_user(
-    userName: str,
+    username: str,
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)
     ],
 ) -> PydanticResponse[SimpleBody[UserResponse]]:
     """Get a user by its unique identifier."""
     try:
-        user = user_data_manager.get_user(userName)
+        user = user_data_manager.get_user(username)
     except UserNotFoundError:
         raise fastapi.HTTPException(
             status_code=fastapi.status.HTTP_404_NOT_FOUND,
@@ -105,7 +105,7 @@ async def get_user(
 
 @PydanticResponse.wrap_route(
     router.delete,
-    path="/auth/users/byUsername/{userName}",
+    path="/auth/users/byUsername/{username}",
     summary="Delete a user",
     description="Delete a specific user, identified by their unique username.",
     responses={
@@ -114,14 +114,14 @@ async def get_user(
     dependencies=[fastapi.Depends(require_scopes(Scope.USERS_WRITE))],
 )
 async def delete_user(
-    userName: str,
+    username: str,
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)
     ],
 ) -> PydanticResponse[SimpleEmptyBody]:
     """Delete a user by its unique identifier."""
     try:
-        user_data_manager.delete_user(userName)
+        user_data_manager.delete_user(username)
     except UserNotFoundError:
         raise fastapi.HTTPException(
             status_code=fastapi.status.HTTP_404_NOT_FOUND,
@@ -135,7 +135,7 @@ async def delete_user(
 
 @PydanticResponse.wrap_route(
     router.patch,
-    path="/auth/users/byUsername/{userName}",
+    path="/auth/users/byUsername/{username}",
     summary="Update a user",
     description="Update a specific user, identified by their unique username.",
     responses={
@@ -145,7 +145,7 @@ async def delete_user(
 )
 async def update_user(
     request_body: RequestModel[UpdateUser],
-    userName: str,
+    username: str,
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)
     ],
@@ -154,8 +154,8 @@ async def update_user(
     update_data = request_body.data
     try:
         updated_user = user_data_manager.update_user(
-            userName,
-            new_username=update_data.userName,
+            username,
+            new_username=update_data.username,
             new_password=update_data.password.get_secret_value()
             if update_data.password is not None
             else None,

--- a/auth-server/auth_server/users/user_data_manager.py
+++ b/auth-server/auth_server/users/user_data_manager.py
@@ -26,14 +26,14 @@ class InvalidInputError(ValueError):
 
 
 def _validate_fields(
-    user_name: str | None = None,
+    username: str | None = None,
     password: str | None = None,
     full_name: str | None = None,
     account_type: str | None = None,
 ) -> None:
     """Validate that provided fields are non-empty and passwords meet length requirements."""
     for field_name, value in [
-        ("username", user_name),
+        ("username", username),
         ("password", password),
         ("fullName", full_name),
         ("accountType", account_type),
@@ -98,7 +98,7 @@ class UserDataManager:
     ) -> UserResponse:
         """Validate inputs, check for duplicates, and create a new user."""
         _validate_fields(
-            user_name=username,
+            username=username,
             password=password,
             full_name=full_name,
             account_type=account_type,
@@ -139,7 +139,7 @@ class UserDataManager:
     ) -> UserResponse:
         """Validate inputs, then update a user or raise UserNotFoundError."""
         _validate_fields(
-            user_name=new_username,
+            username=new_username,
             password=new_password,
             full_name=new_full_name,
             account_type=new_account_type,

--- a/auth-server/auth_server/users/user_data_manager.py
+++ b/auth-server/auth_server/users/user_data_manager.py
@@ -33,7 +33,7 @@ def _validate_fields(
 ) -> None:
     """Validate that provided fields are non-empty and passwords meet length requirements."""
     for field_name, value in [
-        ("userName", user_name),
+        ("username", user_name),
         ("password", password),
         ("fullName", full_name),
         ("accountType", account_type),
@@ -61,7 +61,7 @@ class UserDataManager:
         account_type = AccountType(user.account_type)
 
         return UserResponse(
-            userName=user.username,
+            username=user.username,
             fullName=user.full_name,
             accountType=account_type,
             scopes=sorted(

--- a/auth-server/tests/integration/test_protected_resource_access.tavern.yaml
+++ b/auth-server/tests/integration/test_protected_resource_access.tavern.yaml
@@ -21,7 +21,7 @@ stages:
       url: '{run_server.base_url}/auth/users'
       json:
         data:
-          userName: testuser
+          username: testuser
           password: testuserpassword
           fullName: Test User
           accountType: user
@@ -33,7 +33,7 @@ stages:
       method: POST
       json:
         data:
-          userName: testuser
+          username: testuser
           password: testuserpassword
           fullName: Test User
           accountType: user
@@ -71,7 +71,7 @@ stages:
       url: '{run_server.base_url}/auth/users'
       json:
         data:
-          userName: testuser
+          username: testuser
           password: testuserpassword
           fullName: Test User
           accountType: user
@@ -108,7 +108,7 @@ stages:
       url: '{run_server.base_url}/auth/users'
       json:
         data:
-          userName: testuser_new
+          username: testuser_new
           password: testuserpassword
           fullName: Test User
           accountType: user

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -14,7 +14,7 @@ stages:
       url: '{run_server.base_url}/auth/users'
       json:
         data:
-          userName: test_new_user
+          username: test_new_user
           password: securepassword123
           fullName: Test New User
           accountType: user
@@ -24,7 +24,7 @@ stages:
       status_code: 201
       json:
         data:
-          userName: test_new_user
+          username: test_new_user
           fullName: Test New User
           accountType: user
           locked: false
@@ -39,7 +39,7 @@ stages:
         Authorization: '{admin_access_token}'
       json:
         data:
-          userName: test_new_user_password_less_than_8_characters
+          username: test_new_user_password_less_than_8_characters
           password: '1234567'
           fullName: Test New User
           accountType: user
@@ -60,7 +60,7 @@ stages:
         data:
           accountType: user
           fullName: Test New User
-          userName: test_new_user
+          username: test_new_user
           locked: false
           scopes: !force_original_structure '{user_scopes_list}'
           resetPassword: false
@@ -81,7 +81,7 @@ stages:
         data:
           accountType: admin
           fullName: Test New User Updated
-          userName: test_new_user
+          username: test_new_user
           locked: false
           scopes: !force_original_structure '{admin_scopes_list}'
           resetPassword: false
@@ -92,7 +92,7 @@ stages:
       url: '{run_server.base_url}/auth/users/byUsername/test_new_user'
       json:
         data:
-          userName: test_new_user_updated
+          username: test_new_user_updated
           password: securepassword123
       headers:
         Authorization: '{admin_access_token}'
@@ -102,7 +102,7 @@ stages:
         data:
           accountType: admin
           fullName: Test New User Updated
-          userName: test_new_user_updated
+          username: test_new_user_updated
           locked: false
           scopes: !force_original_structure '{admin_scopes_list}'
           resetPassword: false
@@ -122,7 +122,7 @@ stages:
         data:
           accountType: admin
           fullName: Test New User Updated
-          userName: test_new_user_updated
+          username: test_new_user_updated
           locked: false
           scopes: !force_original_structure '{admin_scopes_list}'
           resetPassword: true
@@ -139,7 +139,7 @@ stages:
         data:
           accountType: admin
           fullName: Test New User Updated
-          userName: test_new_user_updated
+          username: test_new_user_updated
           locked: false
           scopes: !force_original_structure '{admin_scopes_list}'
           resetPassword: true
@@ -210,7 +210,7 @@ stages:
       url: '{run_server.base_url}/auth/users'
       json:
         data:
-          userName: regular_user_1
+          username: regular_user_1
           password: securepassword123
           fullName: Regular User 1
           accountType: user
@@ -228,7 +228,7 @@ stages:
       url: '{run_server.base_url}/auth/users'
       json:
         data:
-          userName: regular_user_2
+          username: regular_user_2
           password: securepassword123
           fullName: Regular User 2
           accountType: user

--- a/auth-server/tests/users/test_user_data_manager.py
+++ b/auth-server/tests/users/test_user_data_manager.py
@@ -94,7 +94,7 @@ def test_create_user_success(
         account_type=AccountType.USER,
     )
     assert result == UserResponse(
-        userName="new_user",
+        username="new_user",
         fullName="New User",
         accountType=AccountType.USER,
         scopes=sorted(
@@ -125,7 +125,7 @@ def test_create_user_hashes_password(
         account_type=AccountType.USER,
     )
     assert result == UserResponse(
-        userName="hash_check",
+        username="hash_check",
         fullName="X",
         accountType=AccountType.USER,
         scopes=sorted(
@@ -152,7 +152,7 @@ def test_create_user_duplicate_raises(
 
 
 def test_create_user_empty_username_raises(manager: UserDataManager) -> None:
-    with pytest.raises(InvalidInputError, match="userName"):
+    with pytest.raises(InvalidInputError, match="username"):
         manager.create_user(
             username="",
             password="validpass123",
@@ -205,7 +205,7 @@ def test_get_user_returns_existing(
     decoy.when(mock_store.get("admin")).then_return(expected)
     result = manager.get_user("admin")
     assert result == UserResponse(
-        userName="admin",
+        username="admin",
         fullName="Full Name",
         accountType=AccountType.ADMIN,
         scopes=sorted(
@@ -232,7 +232,7 @@ def test_get_user_locked_when_failed_logins_reach_limit(
     manager = UserDataManager(user_store=mock_store, settings_store=mock_settings)
     result = manager.get_user("alice")
     assert result == UserResponse(
-        userName="alice",
+        username="alice",
         fullName="Alice",
         accountType=AccountType.USER,
         scopes=sorted(
@@ -300,7 +300,7 @@ def test_update_user_username(
         "old_name", new_username="new_name", reset_password=False
     )
     assert result == UserResponse(
-        userName="new_name",
+        username="new_name",
         fullName="Name Test",
         accountType=AccountType.USER,
         scopes=sorted(
@@ -349,7 +349,7 @@ def test_update_user_not_found_raises(
 
 
 def test_update_user_empty_username_raises(manager: UserDataManager) -> None:
-    with pytest.raises(InvalidInputError, match="userName"):
+    with pytest.raises(InvalidInputError, match="username"):
         manager.update_user("testadmin", new_username="")
 
 


### PR DESCRIPTION
## Overview

In some places, we were inconsistent whether we were calling it a "user name" (two words) or "username" (one word). It seems like "username" is more common in the wider world of software, so this switches everything to that.

## Test Plan and Hands on Testing

* [x] Logins still work.

## Review requests

None.

## Risk assessment

Low. These APIs haven't been released yet.
