### PR TITLE
fix(app): Fix spurious logouts when the login expiration time is long

### DIFF
--- a/app/src/redux/robot-auth/__tests__/expirationMiddleware.test.ts
+++ b/app/src/redux/robot-auth/__tests__/expirationMiddleware.test.ts
@@ -97,6 +97,32 @@ describe('expirationMiddleware', () => {
     ])
   })
 
+  it('handles long (> int32 max) expiration times', async () => {
+    const int32Max = 0x7fffffff
+
+    const store = configureStore({
+      reducer: rootReducer,
+      middleware: getDefaultMiddleware => {
+        return getDefaultMiddleware().prepend(expirationMiddleware.middleware)
+      },
+    })
+
+    store.dispatch(
+      logInOrRefresh({
+        robotName: 'robot-a',
+        username: 'username',
+        accessToken: 'accessToken',
+        refreshToken: 'refreshToken',
+        expiresAt: T0 + int32Max + 1000,
+      })
+    )
+
+    await vi.advanceTimersByTimeAsync(int32Max + 500) // Now at T0+int32Max+500.
+    expect(getUnexpiredRobots(store.getState())).toStrictEqual(['robot-a'])
+    await vi.advanceTimersByTimeAsync(1000) // Now at T0+int32Max+1500.
+    expect(getUnexpiredRobots(store.getState())).toStrictEqual([])
+  })
+
   it('handles an expiration being postponed (a login being refreshed)', async () => {
     const store = configureStore({
       reducer: rootReducer,

--- a/app/src/redux/robot-auth/expirationMiddleware.ts
+++ b/app/src/redux/robot-auth/expirationMiddleware.ts
@@ -8,7 +8,7 @@
  * logged in.
  */
 
-import { createListenerMiddleware } from '@reduxjs/toolkit'
+import { createListenerMiddleware, ListenerEffectAPI } from '@reduxjs/toolkit'
 
 import { getNextExpiration, logOutOrTimeOut } from './slice'
 
@@ -42,10 +42,25 @@ expirationMiddleware.startListening.withTypes<State, Dispatch>()({
     const nextExpiration = getNextExpiration(listenerAPI.getState())
     if (nextExpiration != null) {
       const waitDuration = nextExpiration.expiresAt - Date.now()
-      await listenerAPI.delay(waitDuration)
+      await longDelay(listenerAPI, waitDuration)
       listenerAPI.dispatch(
         logOutOrTimeOut({ robotName: nextExpiration.robotName })
       )
     }
   },
 })
+
+// JS's window.setTimeout() function, and by extension Redux's listenerAPI.delay()
+// function, can't handle durations bigger than an int32, so we need this workaround.
+// Durations probably be this long in production, but they might be in testing.
+async function longDelay(
+  listenerAPI: ListenerEffectAPI<State, Dispatch>,
+  waitDuration: number
+): Promise<void> {
+  const int32Max = 0x7fffffff
+  while (waitDuration > int32Max) {
+    await listenerAPI.delay(int32Max)
+    waitDuration -= int32Max
+  }
+  await listenerAPI.delay(waitDuration)
+}

--- a/app/src/redux/robot-auth/expirationMiddleware.ts
+++ b/app/src/redux/robot-auth/expirationMiddleware.ts
@@ -1,3 +1,10 @@
+import { createListenerMiddleware } from '@reduxjs/toolkit'
+
+import { getNextExpiration, logOutOrTimeOut } from './slice'
+
+import type { ListenerEffectAPI } from '@reduxjs/toolkit'
+import type { Dispatch, State } from '../types'
+
 /**
  * When we're logged in to a robot, and enough time passes that the login expires,
  * this automatically updates state to reflect the expiration.
@@ -7,12 +14,6 @@
  * This is merely for the benefit of UI that shows whether the user is currently
  * logged in.
  */
-
-import { createListenerMiddleware, ListenerEffectAPI } from '@reduxjs/toolkit'
-
-import { getNextExpiration, logOutOrTimeOut } from './slice'
-
-import type { Dispatch, State } from '../types'
 
 export const expirationMiddleware = createListenerMiddleware()
 


### PR DESCRIPTION
## Overview

When the frontend logs in to a robot, the backend decides for how long the login will remain valid. The frontend keeps track of that so it can show a logged-out UI when the expiration is reached.

This fixes an integer overflow bug that was causing this to misbehave for long expiration times, greater than ~25 days (2^31 milliseconds). The timeout would trigger immediately.

## Test Plan and Hands on Testing

* [x] The timeout doesn't trigger immediately anymore.

## Changelog

If we're sleeping for more than 2^31-1 milliseconds, break it up into multiple smaller sleeps.

## Review requests

None in particular.

## Risk assessment

Low.