### PR TITLE
chore update eslint ignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -17,6 +17,7 @@ storybook-static
 
 # js-package-testing
 js-package-testing/pack/**
+js-package-testing/test-results/**
 
 # python projects and tools
 **/.mypy_cache/**

--- a/.eslintignore
+++ b/.eslintignore
@@ -15,6 +15,9 @@
 # components library
 storybook-static
 
+# js-package-testing
+js-package-testing/pack/**
+
 # python projects and tools
 **/.mypy_cache/**
 **/.pytest_cache/**


### PR DESCRIPTION
# Overview
add `js-package-testing/pack/**` and `js-package-testing/test-results/**` to `.eslintignore` since they aren't on GitHub

before
there are 18 errors from `js-package-testing/pack`

after
```shell
✖ 5147 problems (0 errors, 5147 warnings)
  0 errors and 845 warnings potentially fixable with the `--fix` option.

pnpm exec prettier --ignore-path .eslintignore --check ".*.@(js|ts|tsx|yml|mjs|mts)" "**/*.@(ts|tsx|js|mts|mjs|json|md|yml)"
Checking formatting...
All matched files use Prettier code style!
Execution time: 162.67s     
```

## Test Plan and Hands on Testing
- `make lint-js`
no errors

## Changelog
- update `.eslintignore`

## Review requests

## Risk assessment
low
