### PR TITLE
refactor(app): Split up auth actions for debuggability

### DIFF
--- a/app/src/App/hooks/useRefreshAccessTokenOnActivity.ts
+++ b/app/src/App/hooks/useRefreshAccessTokenOnActivity.ts
@@ -10,7 +10,7 @@ import { OPENTRONS_USB } from '/app/redux/discovery'
 import {
   getAuthStateForRobot,
   getMostRecentRobotName,
-  logInOrRefresh,
+  refreshLogin,
   useAccessTokenForRobot,
 } from '/app/redux/robot-auth'
 import { appShellUSBRequestor } from '/app/redux/shell/remote'
@@ -67,7 +67,7 @@ export function useRefreshAccessTokenOnActivity(): void {
       const expiresIn = response.data.expires_in ?? null
       const expiresAt = expiresIn != null ? Date.now() + expiresIn : null
       dispatch(
-        logInOrRefresh({
+        refreshLogin({
           robotName,
           username: authState.username,
           accessToken: response.data.access_token,

--- a/app/src/organisms/ODD/OnDeviceLogin/hooks/__tests__/useStoreLoginState.test.ts
+++ b/app/src/organisms/ODD/OnDeviceLogin/hooks/__tests__/useStoreLoginState.test.ts
@@ -2,7 +2,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { logInOrRefresh } from '/app/redux/robot-auth'
+import { logIn } from '/app/redux/robot-auth'
 
 import { useStoreLoginState } from '../useStoreLoginState'
 
@@ -41,7 +41,7 @@ describe('useStoreLoginState', () => {
     })
 
     expect(mockDispatch).toHaveBeenCalledWith(
-      logInOrRefresh({
+      logIn({
         username: 'test-user',
         robotName: 'local-robot',
         accessToken: 'access-token',

--- a/app/src/organisms/ODD/OnDeviceLogin/hooks/useStoreLoginState.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/hooks/useStoreLoginState.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { getLocalRobot } from '/app/redux/discovery'
-import { logInOrRefresh } from '/app/redux/robot-auth'
+import { logIn } from '/app/redux/robot-auth'
 
 import type { OAuth2TokenResponse } from '@opentrons/api-client'
 import type { State } from '/app/redux/types'
@@ -33,7 +33,7 @@ export function useStoreLoginState(): (
       }
 
       dispatch(
-        logInOrRefresh({
+        logIn({
           username,
           robotName: localRobotName,
           accessToken: successfulLoginResponse.access_token,

--- a/app/src/pages/ODD/Account/__tests__/hooks.test.tsx
+++ b/app/src/pages/ODD/Account/__tests__/hooks.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useSelfQuery } from '@opentrons/react-api-client'
 
 import { getLocalRobot } from '/app/redux/discovery'
-import { getLocalRobotAuthState, logOutOrTimeOut } from '/app/redux/robot-auth'
+import { getLocalRobotAuthState, logOut } from '/app/redux/robot-auth'
 
 import { useAccountInfo, useLogOut } from '../hooks'
 
@@ -154,7 +154,7 @@ describe('useLogOut', () => {
     result.current()
 
     expect(store.dispatch).toHaveBeenCalledWith(
-      logOutOrTimeOut({ robotName: 'my-robot' })
+      logOut({ robotName: 'my-robot' })
     )
   })
 

--- a/app/src/pages/ODD/Account/hooks.ts
+++ b/app/src/pages/ODD/Account/hooks.ts
@@ -4,7 +4,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useSelfQuery } from '@opentrons/react-api-client'
 
 import { getLocalRobot } from '/app/redux/discovery'
-import { getLocalRobotAuthState, logOutOrTimeOut } from '/app/redux/robot-auth'
+import { getLocalRobotAuthState, logOut } from '/app/redux/robot-auth'
 
 import type { State } from '/app/redux/types'
 
@@ -36,16 +36,16 @@ export function useLogOut(): () => void {
   const localRobotName = useSelector(
     (state: State) => getLocalRobot(state)?.name ?? null
   )
-  const logOut = useCallback(() => {
+  const logOutCallback = useCallback(() => {
     if (localRobotName == null) {
       console.warn("Couldn't determine the local robot.")
     } else {
       dispatch(
-        logOutOrTimeOut({
+        logOut({
           robotName: localRobotName,
         })
       )
     }
   }, [dispatch, localRobotName])
-  return logOut
+  return logOutCallback
 }

--- a/app/src/redux/robot-auth/__tests__/expirationMiddleware.test.ts
+++ b/app/src/redux/robot-auth/__tests__/expirationMiddleware.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { rootReducer } from '../../reducer'
 import { expirationMiddleware } from '../expirationMiddleware'
-import { logInOrRefresh } from '../slice'
+import { logIn, refreshLogin } from '../slice'
 
 import type { State } from '../../types'
 
@@ -34,7 +34,7 @@ describe('expirationMiddleware', () => {
     })
 
     store.dispatch(
-      logInOrRefresh({
+      logIn({
         robotName: 'robot-a-expires-at-3000',
         username: 'username',
         accessToken: 'accessToken',
@@ -43,7 +43,7 @@ describe('expirationMiddleware', () => {
       })
     )
     store.dispatch(
-      logInOrRefresh({
+      logIn({
         robotName: 'robot-b-expires-at-1000',
         username: 'username',
         accessToken: 'accessToken',
@@ -52,7 +52,7 @@ describe('expirationMiddleware', () => {
       })
     )
     store.dispatch(
-      logInOrRefresh({
+      logIn({
         robotName: 'robot-c-expires-at-2000',
         username: 'username',
         accessToken: 'accessToken',
@@ -61,7 +61,7 @@ describe('expirationMiddleware', () => {
       })
     )
     store.dispatch(
-      logInOrRefresh({
+      logIn({
         robotName: 'robot-d-expires-never',
         username: 'username',
         accessToken: 'accessToken',
@@ -108,7 +108,7 @@ describe('expirationMiddleware', () => {
     })
 
     store.dispatch(
-      logInOrRefresh({
+      logIn({
         robotName: 'robot-a',
         username: 'username',
         accessToken: 'accessToken',
@@ -132,7 +132,7 @@ describe('expirationMiddleware', () => {
     })
 
     store.dispatch(
-      logInOrRefresh({
+      logIn({
         robotName: 'robot-a',
         username: 'username',
         accessToken: 'accessToken',
@@ -141,7 +141,7 @@ describe('expirationMiddleware', () => {
       })
     )
     store.dispatch(
-      logInOrRefresh({
+      logIn({
         robotName: 'robot-b',
         username: 'username',
         accessToken: 'accessToken',
@@ -157,7 +157,7 @@ describe('expirationMiddleware', () => {
     ])
 
     store.dispatch(
-      logInOrRefresh({
+      refreshLogin({
         robotName: 'robot-a',
         username: 'username',
         accessToken: 'accessToken',
@@ -178,7 +178,7 @@ describe('expirationMiddleware', () => {
     })
 
     store.dispatch(
-      logInOrRefresh({
+      logIn({
         robotName: 'robot-a',
         username: 'username',
         accessToken: 'accessToken',
@@ -187,7 +187,7 @@ describe('expirationMiddleware', () => {
       })
     )
     store.dispatch(
-      logInOrRefresh({
+      logIn({
         robotName: 'robot-b',
         username: 'username',
         accessToken: 'accessToken',

--- a/app/src/redux/robot-auth/__tests__/reducer.test.ts
+++ b/app/src/redux/robot-auth/__tests__/reducer.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from 'vitest'
 
 import {
   INITIAL_ROBOT_AUTH_STATE,
-  logInOrRefresh,
-  logOutOrTimeOut,
+  logIn,
+  logOut,
+  refreshLogin,
   robotAuthReducer,
 } from '../slice'
 
@@ -25,7 +26,7 @@ describe('robotAuthReducer', () => {
     // Log in to first robot:
     state = robotAuthReducer(
       INITIAL_ROBOT_AUTH_STATE,
-      logInOrRefresh({
+      logIn({
         robotName: 'testRobotNameA',
         username: 'testUserA',
         accessToken: 'testAccessTokenA',
@@ -48,7 +49,7 @@ describe('robotAuthReducer', () => {
     // Log in to second robot:
     state = robotAuthReducer(
       state,
-      logInOrRefresh({
+      logIn({
         robotName: 'testRobotNameB',
         username: 'testUserB',
         accessToken: 'testAccessTokenB',
@@ -77,7 +78,7 @@ describe('robotAuthReducer', () => {
     // Refresh login for first robot:
     state = robotAuthReducer(
       state,
-      logInOrRefresh({
+      refreshLogin({
         robotName: 'testRobotNameA',
         username: 'testUserARefreshed',
         accessToken: 'testAccessTokenARefreshed',
@@ -125,7 +126,7 @@ describe('robotAuthReducer', () => {
 
     const newState = robotAuthReducer(
       initialState,
-      logOutOrTimeOut({
+      logOut({
         robotName: 'testRobotNameB',
       })
     )

--- a/app/src/redux/robot-auth/expirationMiddleware.ts
+++ b/app/src/redux/robot-auth/expirationMiddleware.ts
@@ -1,6 +1,6 @@
 import { createListenerMiddleware } from '@reduxjs/toolkit'
 
-import { getNextExpiration, logOutOrTimeOut } from './slice'
+import { getNextExpiration, timeOutLogin } from './slice'
 
 import type { ListenerEffectAPI } from '@reduxjs/toolkit'
 import type { Dispatch, State } from '../types'
@@ -45,7 +45,7 @@ expirationMiddleware.startListening.withTypes<State, Dispatch>()({
       const waitDuration = nextExpiration.expiresAt - Date.now()
       await longDelay(listenerAPI, waitDuration)
       listenerAPI.dispatch(
-        logOutOrTimeOut({ robotName: nextExpiration.robotName })
+        timeOutLogin({ robotName: nextExpiration.robotName })
       )
     }
   },

--- a/app/src/redux/robot-auth/slice.ts
+++ b/app/src/redux/robot-auth/slice.ts
@@ -6,7 +6,7 @@ import isEqual from 'lodash/isEqual'
 import { type ActionTypesFromSlice } from '../ActionTypesFromSlice'
 import { getLocalRobot } from '../discovery'
 
-import type { PayloadAction } from '@reduxjs/toolkit'
+import type { Draft, PayloadAction } from '@reduxjs/toolkit'
 import type { State } from '/app/redux/types'
 
 export interface RobotAuthState {
@@ -61,22 +61,49 @@ const robotAuthSlice = createSlice({
   name: 'robotAuth',
   initialState: INITIAL_ROBOT_AUTH_STATE,
   reducers: {
-    logInOrRefresh(stateDraft, action: PayloadAction<LogInOrRefreshPayload>) {
-      const { robotName, ...robotAuthState } = action.payload
-      stateDraft.perRobotAuthStates[robotName] = robotAuthState
-      stateDraft.mostRecentRobotName = robotName
+    logIn: (stateDraft, action: PayloadAction<LogInOrRefreshPayload>) => {
+      logInOrRefresh(stateDraft, action.payload)
     },
-    logOutOrTimeOut(stateDraft, action: PayloadAction<LogOutOrTimeOutPayload>) {
-      // dynamic-delete is normal and fine with Immer and Redux.
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-      delete stateDraft.perRobotAuthStates[action.payload.robotName]
+    refreshLogin: (
+      stateDraft,
+      action: PayloadAction<LogInOrRefreshPayload>
+    ) => {
+      logInOrRefresh(stateDraft, action.payload)
+    },
+    logOut: (stateDraft, action: PayloadAction<LogOutOrTimeOutPayload>) => {
+      logOutOrTimeOut(stateDraft, action.payload)
+    },
+    timeOutLogin: (
+      stateDraft,
+      action: PayloadAction<LogOutOrTimeOutPayload>
+    ) => {
+      logOutOrTimeOut(stateDraft, action.payload)
     },
   },
 })
 
+function logInOrRefresh(
+  stateDraft: Draft<RobotAuthState>,
+  payload: LogInOrRefreshPayload
+): void {
+  const { robotName, ...robotAuthState } = payload
+  stateDraft.perRobotAuthStates[robotName] = robotAuthState
+  stateDraft.mostRecentRobotName = robotName
+}
+
+function logOutOrTimeOut(
+  stateDraft: Draft<RobotAuthState>,
+  payload: LogOutOrTimeOutPayload
+): void {
+  // dynamic-delete is normal and fine with Immer and Redux.
+  // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+  delete stateDraft.perRobotAuthStates[payload.robotName]
+}
+
 export const robotAuthReducer = robotAuthSlice.reducer
 
-export const { logInOrRefresh, logOutOrTimeOut } = robotAuthSlice.actions
+export const { logIn, refreshLogin, logOut, timeOutLogin } =
+  robotAuthSlice.actions
 
 export type RobotAuthAction = ActionTypesFromSlice<
   typeof robotAuthSlice.actions


### PR DESCRIPTION
## Overview

In our Redux reducer, refreshing an existing login is implemented exactly the same as logging in for the first time. And getting timed out is implemented exactly the same as logging out explicitly. So those actions have, so far, been combined. However, for debugging (and perhaps analytics), it's helpful to split them up, like `logIn`, `refreshLogin`, `logOut`, and `timeOutLogin`, to make it more clear where the action came from.

## Test Plan and Hands on Testing

* [x] Checked that these show up sensibly in the Redux dev tools.

## Review requests

Are these new names clear?

## Risk assessment

Very low.