### PR TITLE
feat(app): Rename "access control mode" in user-facing copy to "compliance ready software"

### DIFF
--- a/app/src/assets/localization/en/anonymous.json
+++ b/app/src/assets/localization/en/anonymous.json
@@ -22,7 +22,7 @@
   "delete_protocol_from_app": "Delete the protocol, make changes to address the error, and resend the protocol to this robot from the desktop app.",
   "delete_transfer_from_app": "Delete the quick transfer, make changes to address the error, and recreate this transfer on the robot display.",
   "door_circuit_error_description": "Ensure that the robot door and stacker doors are closed. Ensure proper installation of replacement window and all access panels or stackers. Verify robot is closed and try again or contact support.",
-  "enter_this_key_into_the_app": "Enter this key into the robot app to verify this robot's identity and enable access control mode.",
+  "enter_this_key_into_the_app": "Enter this key into the robot app to verify this robot's identity and enable Compliance Ready Software.",
   "error_boundary_description": "You need to restart the touchscreen. Contact support for assistance.",
   "estop_pressed_description": "First, safely clear the deck of any labware or spills. Then, twist the E-stop button clockwise. Finally, have the robot move the gantry to its home position.",
   "find_your_robot": "Find your robot in the Devices section of the app to install software updates.",

--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -1,5 +1,5 @@
 {
-  "__dev_internal__accessControlMode": "Enable frontend for access control mode",
+  "__dev_internal__accessControlMode": "Enable frontend for Compliance Ready Software (access control mode)",
   "__dev_internal__enableLabwareCreator": "Enable App Labware Creator",
   "__dev_internal__enableRunNotes": "Display Notes During a Protocol Run",
   "__dev_internal__forceHttpPolling": "Poll all network requests instead of using MQTT",

--- a/app/src/assets/localization/en/branded.json
+++ b/app/src/assets/localization/en/branded.json
@@ -22,7 +22,7 @@
   "delete_protocol_from_app": "Delete the protocol, make changes to address the error, and resend the protocol to this robot from the Opentrons App.",
   "delete_transfer_from_app": "Delete the quick transfer, make changes to address the error, and recreate this transfer on the Flex display.",
   "door_circuit_error_description": "Ensure that the Flex door and stacker doors are closed. Ensure proper installation of replacement window and all access panels or stackers. Verify robot is closed and try again or contact support.",
-  "enter_this_key_into_the_app": "Enter this key into the Opentrons App to verify this robot's identity and enable access control mode.",
+  "enter_this_key_into_the_app": "Enter this key into the Opentrons App to verify this robot's identity and enable Compliance Ready Software.",
   "error_boundary_description": "You need to restart the touchscreen. Then download the robot logs from the Opentrons App and send them to support@opentrons.com for assistance.",
   "estop_pressed_description": "First, safely clear the deck of any labware or spills. Then, twist the E-stop button clockwise. Finally, have Flex move the gantry to its home position.",
   "find_your_robot": "Find your robot in the Opentrons App to install software updates.",


### PR DESCRIPTION
## Overview

"Access control mode" is being renamed to "compliance ready software." This updates the UX copy that we have so far.

This doesn't change any of our internal variable names. That's a bigger task and will have to be a separate PR.

## Test Plan and Hands on Testing

None needed.

## Review requests

None.

## Risk assessment

Low.