### PR TITLE
feat(protocol-designer, shared-data): wire up vacuum module in deck thumbnail

### DIFF
--- a/protocol-designer/src/components/organisms/SlotDetailsContainer/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotDetailsContainer/index.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux'
 import {
   FLEX_STACKER_MODULE_TYPE,
   getModuleDisplayName,
+  VACUUM_MODULE_A3_ADDRESSABLE_AREA,
 } from '@opentrons/shared-data'
 import {
   FAKE_HOPPER_LOCATION_MAP,
@@ -47,11 +48,12 @@ export function SlotDetailsContainer(
   }
   const isSlotAHopper = getIsSlotAHopper(slot)
   const isSlotAVacuumDock = getIsSlotAVacuumDock(slot)
+  const isVacuumModuleMainArea = slot === VACUUM_MODULE_A3_ADDRESSABLE_AREA
   let adjustedSlotToFindModule = slot
   if (isSlotAHopper) {
     adjustedSlotToFindModule =
       FAKE_HOPPER_LOCATION_MAP[slot as HopperLocationMapKey]
-  } else if (isSlotAVacuumDock) {
+  } else if (isSlotAVacuumDock || isVacuumModuleMainArea) {
     adjustedSlotToFindModule = VACUUM_MODULE_SLOT
   }
 
@@ -78,7 +80,9 @@ export function SlotDetailsContainer(
   )
   const fullStackFromLabwares = getFullStackFromLabwaresOnDeck(
     Object.values(deckSetupLabwares),
-    slot,
+    // need to special case this for now, since the main vacuum addressable area maps to slot A3 for stack logic
+    // this will not be necessary once addressable areas are the source of truth in an upcoming large-scale refactor
+    isVacuumModuleMainArea ? VACUUM_MODULE_SLOT : slot,
     isSlotAHopper,
     isSlotAVacuumDock
   )

--- a/protocol-designer/src/components/organisms/SlotInformation/index.tsx
+++ b/protocol-designer/src/components/organisms/SlotInformation/index.tsx
@@ -21,13 +21,17 @@ import {
   TC_MODULE_LOCATION_OT3,
   THERMOCYCLER_MODULE_V1,
   THERMOCYCLER_MODULE_V2,
+  VACUUM_MODULE_A3_ADDRESSABLE_AREA,
 } from '@opentrons/shared-data'
 import {
   getIsSlotAHopper,
   getIsSlotAVacuumDock,
 } from '@opentrons/step-generation'
 
-import { VACUUM_DOCK_DISPLAY_LOCATION } from '/protocol-designer/constants'
+import {
+  VACUUM_DOCK_DISPLAY_LOCATION,
+  VACUUM_MODULE_SLOT,
+} from '/protocol-designer/constants'
 import { useDeckSetupWindowBreakPoint } from '/protocol-designer/pages/Designer/DeckSetup/utils'
 import { getColumnFromWellName } from '/protocol-designer/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils'
 import lineClampStyles from '/protocol-designer/styles/lineclamp.module.css'
@@ -73,6 +77,8 @@ export const SlotInformation: FC<SlotInformationProps> = ({
     })
   } else if (getIsSlotAVacuumDock(location)) {
     modifiedLocation = VACUUM_DOCK_DISPLAY_LOCATION
+  } else if (location === VACUUM_MODULE_A3_ADDRESSABLE_AREA) {
+    modifiedLocation = VACUUM_MODULE_SLOT
   }
 
   return (

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnail.tsx
@@ -28,10 +28,15 @@ import {
   OT2_ROBOT_TYPE,
   STAGING_AREA_CUTOUTS,
   TRASH_BIN_ADAPTER_FIXTURE,
+  VACUUM_MODULE_TYPE,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 
-import { getInitialDeckSetup } from '../../step-forms/selectors'
+import {
+  getDeckConfiguration,
+  getInitialDeckSetup,
+} from '../../step-forms/selectors'
+import { useUpdateDeckConfigurationFromStartingDeck } from '../Designer/DeckSetup/hooks/useUpdateDeckConfigurationFromStartingDeck'
 import { DeckThumbnailDetails } from './DeckThumbnailDetails'
 
 import type { Dispatch, SetStateAction } from 'react'
@@ -64,6 +69,11 @@ interface DeckThumbnailProps {
 export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
   const { hoverSlot, setHoverSlot, robotType } = props
   const initialDeckSetup = useSelector(getInitialDeckSetup)
+  const { deckConfig } = useSelector(getDeckConfiguration)
+  useUpdateDeckConfigurationFromStartingDeck({
+    activeDeckSetup: initialDeckSetup,
+    robotType,
+  })
   const deckDef = useMemo(() => getDeckDefFromRobotType(robotType), [robotType])
   const trash = Object.values(initialDeckSetup.additionalEquipmentOnDeck).find(
     ae => ae.name === 'trashBin'
@@ -103,6 +113,9 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
 
   const hasFlexStacker = Object.values(initialDeckSetup.modules).some(
     module => getModuleType(module.model) === FLEX_STACKER_MODULE_TYPE
+  )
+  const hasVacuumModule = Object.values(initialDeckSetup.modules).some(
+    module => getModuleType(module.model) === VACUUM_MODULE_TYPE
   )
   const flexStackerLocations = Object.values(initialDeckSetup.modules)
     .filter(stacker => stacker.type === FLEX_STACKER_MODULE_TYPE)
@@ -216,12 +229,20 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
                     )
                   : null}
                 {wasteChuteFixtures.map(fixture => (
-                  <WasteChuteFixture
-                    key={fixture.id}
-                    cutoutId={fixture.location as typeof WASTE_CHUTE_CUTOUT}
-                    deckDefinition={deckDef}
-                    fixtureBaseColor={lightFill}
-                  />
+                  <Fragment key={fixture.id}>
+                    <SingleSlotFixture
+                      cutoutId={fixture.location as typeof WASTE_CHUTE_CUTOUT}
+                      deckDefinition={deckDef}
+                      slotClipColor={COLORS.transparent}
+                      fixtureBaseColor={lightFill}
+                      showSlotClips={false}
+                    />
+                    <WasteChuteFixture
+                      cutoutId={fixture.location as typeof WASTE_CHUTE_CUTOUT}
+                      deckDefinition={deckDef}
+                      fixtureBaseColor={lightFill}
+                    />
+                  </Fragment>
                 ))}
                 {wasteChuteStagingAreaFixtures.map(fixture => (
                   <WasteChuteStagingAreaFixture
@@ -243,13 +264,14 @@ export function DeckThumbnail(props: DeckThumbnailProps): JSX.Element {
               stagingAreaCutoutIds={stagingAreaFixturesAndStacker.map(
                 areas => areas.location as CutoutId
               )}
+              deckConfig={deckConfig}
               {...{
                 deckDef,
               }}
             />
             <SlotLabels
               robotType={robotType}
-              show4thColumn={stagingAreaFixtures.length > 0}
+              show4thColumn={stagingAreaFixtures.length > 0 || hasVacuumModule}
             />
           </>
         )}

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnailDetails.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnailDetails.tsx
@@ -167,7 +167,9 @@ export const DeckThumbnailDetails = (
             deckDef,
             deckConfiguration: deckConfig,
           })
-          if (dockSlotPosition == null) return null
+          if (dockSlotPosition == null) {
+            return null
+          }
           const dockLabware = allLabware
             .filter(
               lw =>

--- a/protocol-designer/src/pages/ProtocolOverview/DeckThumbnailDetails.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/DeckThumbnailDetails.tsx
@@ -6,12 +6,19 @@ import {
   FLEX_STACKER_MODULE_TYPE,
   getAddressableAreaFromSlotId,
   getModuleDef,
+  getPositionFromAddressableAreaId,
   getPositionFromSlotId,
   inferModuleOrientationFromXCoordinate,
   isAddressableAreaStandardSlot,
   THERMOCYCLER_MODULE_TYPE,
+  VACUUM_MODULE_A3_ADDRESSABLE_AREA,
+  VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA,
+  VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
-import { getSlotInLocationStack } from '@opentrons/step-generation'
+import {
+  getSlotInLocationStack,
+  VACUUM_DOCK_LOCATION,
+} from '@opentrons/step-generation'
 
 import { HOPPER_LABWARE_X_OFFSET } from '/protocol-designer/constants'
 
@@ -29,6 +36,7 @@ import { SlotHover } from './SlotHover'
 import type { Dispatch, SetStateAction } from 'react'
 import type {
   CutoutId,
+  DeckConfiguration,
   DeckDefinition,
   RobotType,
 } from '@opentrons/shared-data'
@@ -41,6 +49,7 @@ interface DeckSetupDetailsProps {
   hover: string | null
   setHover: Dispatch<SetStateAction<string | null>>
   robotType: RobotType
+  deckConfig: DeckConfiguration
 }
 
 export const DeckThumbnailDetails = (
@@ -53,6 +62,7 @@ export const DeckThumbnailDetails = (
     robotType,
     hover,
     setHover,
+    deckConfig,
   } = props
   const slotIdsBlockedBySpanning = getSlotIdsBlockedBySpanningForThermocycler(
     initialDeckSetup,
@@ -73,6 +83,7 @@ export const DeckThumbnailDetails = (
           return null
         }
         const moduleDef = getModuleDef(model)
+        const { type: moduleType } = moduleState
         const { topMostId, rightBelowTopId, hopperTopMostId } =
           getLabwaresOnModuleFromStack(id, allLabware)
         return (
@@ -127,20 +138,64 @@ export const DeckThumbnailDetails = (
                   hover={hover}
                   setHover={setHover}
                   slotPosition={[0, 0, 0]}
-                  slotId={slotId}
+                  slotId={
+                    moduleState.type === VACUUM_MODULE_TYPE
+                      ? VACUUM_MODULE_A3_ADDRESSABLE_AREA
+                      : slotId
+                  }
                 />
-                <SlotHover
-                  robotType={robotType}
-                  hover={hover}
-                  setHover={setHover}
-                  slotPosition={[HOPPER_LABWARE_X_OFFSET, 0, 0]}
-                  slotId={`hopper${slotId}`}
-                />
+                {moduleType === FLEX_STACKER_MODULE_TYPE ? (
+                  <SlotHover
+                    robotType={robotType}
+                    hover={hover}
+                    setHover={setHover}
+                    slotPosition={[HOPPER_LABWARE_X_OFFSET, 0, 0]}
+                    slotId={`hopper${slotId}`}
+                  />
+                ) : null}
               </>
             </Module>
           </Fragment>
         )
       })}
+      {/* vacuum dock labware rendered at addressable area position rather than within module */}
+      {allModules
+        .filter(module => module.type === VACUUM_MODULE_TYPE)
+        .map(vacuumModule => {
+          const dockSlotPosition = getPositionFromAddressableAreaId({
+            addressableAreaId: VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA,
+            deckDef,
+            deckConfiguration: deckConfig,
+          })
+          if (dockSlotPosition == null) return null
+          const dockLabware = allLabware
+            .filter(
+              lw =>
+                lw.stack.includes(vacuumModule.id) &&
+                lw.stack.includes(VACUUM_DOCK_LOCATION)
+            )
+            .sort((a, b) => a.stack.length - b.stack.length)
+          return (
+            <Fragment key={`${vacuumModule.id}_dock`}>
+              {dockLabware.map(lw => (
+                <LabwareOnDeck
+                  key={lw.id}
+                  x={dockSlotPosition[0]}
+                  y={dockSlotPosition[1]}
+                  labwareOnDeck={lw}
+                />
+              ))}
+              {/* SlotHover rendered after labware so it appears on top in SVG */}
+              <SlotHover
+                robotType={robotType}
+                hover={hover}
+                setHover={setHover}
+                slotPosition={dockSlotPosition}
+                slotId={VACUUM_MODULE_DOCK_A4_ADDRESSABLE_AREA}
+              />
+            </Fragment>
+          )
+        })}
       {/* all labware on deck NOT those in modules */}
       {allLabware.map(labware => {
         if (

--- a/protocol-designer/src/pages/ProtocolOverview/__tests__/DeckThumbnail.test.tsx
+++ b/protocol-designer/src/pages/ProtocolOverview/__tests__/DeckThumbnail.test.tsx
@@ -12,7 +12,10 @@ import {
 
 import { renderWithProviders } from '../../../__testing-utils__'
 import { LabwareOnDeck } from '../../../components/organisms'
-import { getInitialDeckSetup } from '../../../step-forms/selectors'
+import {
+  getDeckConfiguration,
+  getInitialDeckSetup,
+} from '../../../step-forms/selectors'
 import { DeckThumbnail } from '../DeckThumbnail'
 
 import type { ComponentProps } from 'react'
@@ -22,6 +25,9 @@ import type { LabwareDefinition2 } from '@opentrons/shared-data'
 vi.mock('../../../components/organisms')
 vi.mock('../../../file-data/selectors')
 vi.mock('../../../step-forms/selectors')
+vi.mock(
+  '../../Designer/DeckSetup/hooks/useUpdateDeckConfigurationFromStartingDeck'
+)
 vi.mock('@opentrons/components', async importOriginal => {
   const actual = await importOriginal<typeof Components>()
   return {
@@ -46,6 +52,7 @@ describe('DeckThumbnail', () => {
       robotType: FLEX_ROBOT_TYPE,
     }
     vi.mocked(LabwareOnDeck).mockReturnValue(<div>mock LabwareOnDeck</div>)
+    vi.mocked(getDeckConfiguration).mockReturnValue({ deckConfig: [] } as any)
     vi.mocked(getInitialDeckSetup).mockReturnValue({
       modules: {},
       additionalEquipmentOnDeck: {},

--- a/shared-data/js/helpers/slotHovers.ts
+++ b/shared-data/js/helpers/slotHovers.ts
@@ -1,5 +1,7 @@
+import { VACUUM_MODULE_ADDRESSABLE_AREAS } from '..'
+
 import type { CoordinateTuple } from '..'
-import type { CutoutId } from '../../deck'
+import type { AddressableAreaName, CutoutId } from '../../deck'
 
 interface HoverDimensions {
   width: number
@@ -9,7 +11,6 @@ interface HoverDimensions {
 }
 
 const FOURTH_COLUMN_SLOTS = ['A4', 'B4', 'C4', 'D4']
-
 export const getFlexHoverDimensions = (
   columnFourLocations: string[],
   cutoutId: CutoutId,
@@ -26,6 +27,20 @@ export const getFlexHoverDimensions = (
   const X_DIMENSION_4TH_COLUMN_SLOTS = 175.0
   const Y_DIMENSION = hasTCOnSlot ? 294.0 : 106.0
 
+  const yAdjustment = -10
+  const ySlotPosition = slotPosition[1] + yAdjustment
+  const xSlotPosition = slotPosition[0] + X_ADJUSTMENT
+
+  // vacuum module addressable areas are single-slot sized (128 × 86 mm bounding box)
+  if (VACUUM_MODULE_ADDRESSABLE_AREAS.includes(slotId as AddressableAreaName)) {
+    return {
+      width: X_DIMENSION_MIDDLE_SLOTS,
+      height: Y_DIMENSION,
+      x: xSlotPosition,
+      y: ySlotPosition,
+    }
+  }
+
   const slotFromCutout = slotId
   const isLeftSideofDeck =
     slotFromCutout === 'A1' ||
@@ -33,10 +48,7 @@ export const getFlexHoverDimensions = (
     slotFromCutout === 'C1' ||
     slotFromCutout === 'D1'
   const xAdjustment = isLeftSideofDeck ? X_ADJUSTMENT_LEFT_SIDE : X_ADJUSTMENT
-  const xSlotPosition = slotPosition[0] + xAdjustment
-
-  const yAdjustment = -10
-  const ySlotPosition = slotPosition[1] + yAdjustment
+  const xAdjustedSlotPosition = slotPosition[0] + xAdjustment
 
   const isMiddleOfDeck =
     slotId === 'A2' || slotId === 'B2' || slotId === 'C2' || slotId === 'D2'
@@ -47,7 +59,7 @@ export const getFlexHoverDimensions = (
   } else if (FOURTH_COLUMN_SLOTS.includes(slotId)) {
     xDimension = X_DIMENSION_4TH_COLUMN_SLOTS
   }
-  const x = hasTCOnSlot ? xSlotPosition + 20 : xSlotPosition
+  const x = hasTCOnSlot ? xAdjustedSlotPosition + 20 : xAdjustedSlotPosition
   const y = hasTCOnSlot ? ySlotPosition - 70 : ySlotPosition
 
   return { width: xDimension, height: Y_DIMENSION, x, y }


### PR DESCRIPTION
# Overview

This PR adds vacuum module functionality to DeckThumbnail in the Protocol Designer > Protocol Overview page. It also fixes 2 found bugs wherein 1) the waste chute fixture did not render, and 2) stacker hopper SlotHovers rendered when no hopper was added.

Closes EXEC-2685

https://github.com/user-attachments/assets/5a5d72da-b3be-4072-b41c-31ea01d85e92

## Test Plan and Hands on Testing

- upload or create a protocol with a vacuum module and a waste chute
- verify that you can hover the vacuum module in DeckThumbnail (Protocol Overview page)
- verify that the waste chute cutout fixture renders
- verify that no "ghost" stacker hopper slot hovers are visible when hovering the right margin of the deck

## Changelog

- add vacuum module main module and dock support to DeckThumbnail
- translate vacuum main module addressable area to A3 in SlotInformation
- fix hopper and waste chute hover bugs
- update tests

## Review requests

see test plan

## Risk assessment

low