### PR TITLE
refactor(app): Convert <Breadcrumbs> to CSS Modules

### DIFF
--- a/app/src/organisms/Desktop/Breadcrumbs/breadcrumbs.module.css
+++ b/app/src/organisms/Desktop/Breadcrumbs/breadcrumbs.module.css
@@ -44,9 +44,13 @@
 }
 
 .crumb_active {
+  display: flex;
+  align-items: center;
   color: var(--blue-50);
 }
 
 .crumb_inactive {
+  display: flex;
+  align-items: center;
   color: var(--grey-50);
 }

--- a/app/src/organisms/Desktop/Breadcrumbs/breadcrumbs.module.css
+++ b/app/src/organisms/Desktop/Breadcrumbs/breadcrumbs.module.css
@@ -54,3 +54,8 @@
   align-items: center;
   color: var(--grey-50);
 }
+
+.crumb_name {
+  padding-right: var(--spacing-4);
+  text-transform: none;
+}

--- a/app/src/organisms/Desktop/Breadcrumbs/breadcrumbs.module.css
+++ b/app/src/organisms/Desktop/Breadcrumbs/breadcrumbs.module.css
@@ -7,6 +7,11 @@
   background-color: var(--white);
 }
 
+.crumb_container {
+  display: flex;
+  padding-right: var(--spacing-4);
+}
+
 .text_style {
   display: -webkit-box;
   overflow: hidden;

--- a/app/src/organisms/Desktop/Breadcrumbs/breadcrumbs.module.css
+++ b/app/src/organisms/Desktop/Breadcrumbs/breadcrumbs.module.css
@@ -1,5 +1,5 @@
 .root_container {
-  display: flex !important;
+  display: flex;
   flex-direction: row;
   align-items: flex-start;
   padding: var(--spacing-4) 0 var(--spacing-4) var(--spacing-8);

--- a/app/src/organisms/Desktop/Breadcrumbs/breadcrumbs.module.css
+++ b/app/src/organisms/Desktop/Breadcrumbs/breadcrumbs.module.css
@@ -1,3 +1,12 @@
+.root_container {
+  display: flex !important;
+  flex-direction: row;
+  align-items: flex-start;
+  padding: var(--spacing-4) 0 var(--spacing-4) var(--spacing-8);
+  border-bottom: 1px solid var(--grey-30);
+  background-color: var(--white);
+}
+
 .text_style {
   display: -webkit-box;
   overflow: hidden;

--- a/app/src/organisms/Desktop/Breadcrumbs/index.tsx
+++ b/app/src/organisms/Desktop/Breadcrumbs/index.tsx
@@ -82,7 +82,9 @@ function BreadcrumbsComponent(): JSX.Element | null {
       | null
       | { linkPath: string; crumbName: string | null }
   } = {
-    '/devices': !(isOnDevice ?? false) ? t('devices') : null,
+    '/devices': !(isOnDevice ?? false)
+      ? 'This is very long text the quick brown fox jumps over the lazy dog the quick brown fox jumps over the lazy dog'
+      : null,
     [`/devices/${robotName}`]: robotName,
     [`/devices/${robotName}/robot-settings`]: t('robot_settings'),
     [`/devices/${robotName}/protocol-runs/${runId}`]:

--- a/app/src/organisms/Desktop/Breadcrumbs/index.tsx
+++ b/app/src/organisms/Desktop/Breadcrumbs/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { Link, useLocation, useParams } from 'react-router-dom'
+import clsx from 'clsx'
 
 import {
   ALIGN_CENTER,
@@ -143,14 +144,7 @@ function BreadcrumbsComponent(): JSX.Element | null {
   })
 
   return pathCrumbs.length > 1 ? (
-    <Flex
-      alignItems={ALIGN_FLEX_START}
-      backgroundColor={COLORS.white}
-      borderBottom={BORDERS.lineBorder}
-      flexDirection={DIRECTION_ROW}
-      padding={`${SPACING.spacing4} 0 ${SPACING.spacing4} ${SPACING.spacing8}`}
-      className={styles.text_style}
-    >
+    <div className={clsx(styles.root_container, styles.text_style)}>
       {pathCrumbs.map((crumb, i) => {
         const isLastCrumb = i === pathCrumbs.length - 1
 
@@ -170,7 +164,7 @@ function BreadcrumbsComponent(): JSX.Element | null {
           </Flex>
         )
       })}
-    </Flex>
+    </div>
   ) : null
 }
 

--- a/app/src/organisms/Desktop/Breadcrumbs/index.tsx
+++ b/app/src/organisms/Desktop/Breadcrumbs/index.tsx
@@ -65,9 +65,7 @@ function BreadcrumbsComponent(): JSX.Element | null {
       | null
       | { linkPath: string; crumbName: string | null }
   } = {
-    '/devices': !(isOnDevice ?? false)
-      ? 'This is very long text the quick brown fox jumps over the lazy dog the quick brown fox jumps over the lazy dog'
-      : null,
+    '/devices': !(isOnDevice ?? false) ? t('devices') : null,
     [`/devices/${robotName}`]: robotName,
     [`/devices/${robotName}/robot-settings`]: t('robot_settings'),
     [`/devices/${robotName}/protocol-runs/${runId}`]:

--- a/app/src/organisms/Desktop/Breadcrumbs/index.tsx
+++ b/app/src/organisms/Desktop/Breadcrumbs/index.tsx
@@ -3,18 +3,7 @@ import { useSelector } from 'react-redux'
 import { Link, useLocation, useParams } from 'react-router-dom'
 import clsx from 'clsx'
 
-import {
-  ALIGN_CENTER,
-  ALIGN_FLEX_START,
-  BORDERS,
-  Box,
-  COLORS,
-  DIRECTION_ROW,
-  Flex,
-  Icon,
-  SPACING,
-  TYPOGRAPHY,
-} from '@opentrons/components'
+import { Icon } from '@opentrons/components'
 import { ApiHostProvider } from '@opentrons/react-api-client'
 
 import { useRobot } from '/app/redux-resources/robots'

--- a/app/src/organisms/Desktop/Breadcrumbs/index.tsx
+++ b/app/src/organisms/Desktop/Breadcrumbs/index.tsx
@@ -144,7 +144,7 @@ function BreadcrumbsComponent(): JSX.Element | null {
   })
 
   return pathCrumbs.length > 1 ? (
-    <div className={clsx(styles.root_container, styles.text_style)}>
+    <div className={styles.root_container}>
       {pathCrumbs.map((crumb, i) => {
         const isLastCrumb = i === pathCrumbs.length - 1
 

--- a/app/src/organisms/Desktop/Breadcrumbs/index.tsx
+++ b/app/src/organisms/Desktop/Breadcrumbs/index.tsx
@@ -149,7 +149,7 @@ function BreadcrumbsComponent(): JSX.Element | null {
         const isLastCrumb = i === pathCrumbs.length - 1
 
         return (
-          <Flex key={crumb.linkPath} paddingRight={SPACING.spacing4}>
+          <div className={styles.crumb_container} key={crumb.linkPath}>
             <Link
               className={
                 isLastCrumb ? styles.crumb_link_inactive : styles.crumb_link
@@ -161,7 +161,7 @@ function BreadcrumbsComponent(): JSX.Element | null {
                 isLastCrumb={isLastCrumb}
               />
             </Link>
-          </Flex>
+          </div>
         )
       })}
     </div>

--- a/app/src/organisms/Desktop/Breadcrumbs/index.tsx
+++ b/app/src/organisms/Desktop/Breadcrumbs/index.tsx
@@ -39,13 +39,9 @@ interface CrumbNameProps {
 function CrumbName({ crumbName, isLastCrumb }: CrumbNameProps): JSX.Element {
   return (
     <div className={isLastCrumb ? styles.crumb_inactive : styles.crumb_active}>
-      <Box
-        paddingRight={SPACING.spacing4}
-        textTransform={TYPOGRAPHY.textTransformNone}
-        className={styles.text_style}
-      >
+      <div className={clsx(styles.crumb_name, styles.text_style)}>
         {crumbName}
-      </Box>
+      </div>
       {!isLastCrumb ? (
         <Icon name="caret-right" width="0.25rem" height="0.3125rem" />
       ) : null}

--- a/app/src/organisms/Desktop/Breadcrumbs/index.tsx
+++ b/app/src/organisms/Desktop/Breadcrumbs/index.tsx
@@ -38,10 +38,7 @@ interface CrumbNameProps {
 
 function CrumbName({ crumbName, isLastCrumb }: CrumbNameProps): JSX.Element {
   return (
-    <Flex
-      alignItems={ALIGN_CENTER}
-      className={isLastCrumb ? styles.crumb_inactive : styles.crumb_active}
-    >
+    <div className={isLastCrumb ? styles.crumb_inactive : styles.crumb_active}>
       <Box
         paddingRight={SPACING.spacing4}
         textTransform={TYPOGRAPHY.textTransformNone}
@@ -52,7 +49,7 @@ function CrumbName({ crumbName, isLastCrumb }: CrumbNameProps): JSX.Element {
       {!isLastCrumb ? (
         <Icon name="caret-right" width="0.25rem" height="0.3125rem" />
       ) : null}
-    </Flex>
+    </div>
   )
 }
 


### PR DESCRIPTION
## Overview

This converts the `<Breadcrumbs>` navigation component in the desktop app from our deprecated `<Flex>` and `<Box>` primitives to CSS Modules. This is purely a refactor, with no changes to the styles (yet).

This is in preparation for EXEC-2680.

## Test Plan and Hands on Testing

* [x] It looks identical in the desktop app before and after.
* [x] The overflow behavior is the same when the width of the window is decreased.

## Review requests

None in particular.

## Risk assessment

Low.