### PR TITLE
feat(robot-server): Implement Pyro compatible door watcher callback for Default Run Orchestrator

### DIFF
--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -5,6 +5,9 @@ import logging
 from typing import Callable, Dict, List, Mapping, Optional, Sequence, Union
 
 from opentrons.config import feature_flags
+from opentrons.config import (
+    feature_flags as ff,
+)
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import (
     AsynchronousModuleErrorNotification,
@@ -66,6 +69,7 @@ from .run_process import DirectedRunProcess
 from .run_process_pyro_provider import RunProcessPyroProvider
 from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.service.legacy.models.settings import CameraCaptureImageSettings
+from robot_server.service.pyro_utils.resource_utilities import get_pyro_resource
 
 _log = logging.getLogger(__name__)
 
@@ -205,6 +209,15 @@ class RunOrchestratorStore:
             self.run_coordinator.run_id if self._run_coordinator is not None else None
         )
 
+    def default_run_orchestrator_door_watcher_callback_route_for_proxy(
+        self, event: HardwareEvent
+    ) -> None:
+        """Callback to expose the default run orchestrator door watcher callback to a remote processes."""
+        assert self._default_run_orchestrator is not None
+        self._default_run_orchestrator._protocol_engine._door_watcher._handle_proxy_hardware_door_event(
+            event
+        )
+
     # TODO(mc, 2022-03-21): this resource locking is insufficient;
     # come up with something more sophisticated without race condition holes.
     async def get_default_orchestrator(self) -> RunOrchestrator:
@@ -220,6 +233,13 @@ class RunOrchestratorStore:
         ):
             raise RunConflictError("A run is currently active")
 
+        proxy_door_callback = None
+        if ff.hardware_subprocess_enabled():
+            pyro_resource = get_pyro_resource()
+            proxy_door_callback = (
+                pyro_resource.get_default_run_orchestrator_door_watcher_callback()
+            )
+
         default_orchestrator = self._default_run_orchestrator
         if default_orchestrator is None:
             engine = await create_protocol_engine(
@@ -233,6 +253,7 @@ class RunOrchestratorStore:
                 # for example, there would be no equivalent to the `POST /runs/{id}/actions`
                 # endpoint to resume normal operation.
                 error_recovery_policy=error_recovery_policy.never_recover,
+                proxy_of_callback_for_handling_door_events=proxy_door_callback,
             )
             self._default_run_orchestrator = RunOrchestrator.build_orchestrator(
                 protocol_engine=engine, hardware_api=self._hardware_api

--- a/robot-server/robot_server/service/pyro_utils/pyro_resource.py
+++ b/robot-server/robot_server/service/pyro_utils/pyro_resource.py
@@ -176,6 +176,19 @@ class RobotServerPyroResource:
                 "Cannot provider a maintenance run door watcher from the RobotServerPyroResource without a MaintenanceRunOrchestratorStore."
             )
 
+    @pyro_behavior(specialty_func=convert_result_to_proxy, apply_local=False)
+    def get_default_run_orchestrator_door_watcher_callback(
+        self,
+    ) -> HardwareEventHandler:
+        """Get a door watcher callback from a non-subprocess Default Run Orchestrator."""
+        orchestrator_store = self._run_orchestrator_store
+        if orchestrator_store is not None:
+            return orchestrator_store.default_run_orchestrator_door_watcher_callback_route_for_proxy
+        else:
+            raise RuntimeError(
+                "Cannot provider a default run orchestrator door watcher from the RobotServerPyroResource without a RunOrchestratorStore."
+            )
+
     async def get_deck_configuration(self) -> DeckConfigurationType:
         """Provide the current recognized DeckConfiguration of the robot server."""
 

--- a/robot-server/tests/service/pyro_utils/test_pyro_resource.py
+++ b/robot-server/tests/service/pyro_utils/test_pyro_resource.py
@@ -185,6 +185,12 @@ async def test_run_hardware_event_callback(
 
     assert isinstance(result, ClientPyroFunctionWrapper)
 
+    default_run_door_watcher_result = ot3api.register_callback(
+        robot_server_resource.get_default_run_orchestrator_door_watcher_callback()
+    )
+
+    assert isinstance(default_run_door_watcher_result, ClientPyroFunctionWrapper)
+
 
 async def test_maintenance_run_hardware_event_callback(
     ot3_hardware_api: OT3API,


### PR DESCRIPTION
# Overview

The default run orchestrator, similar to maintenance runs, will not for the time being be a separate run process. This means it needed a route to hookup a proxy-safe door watcher callback as well. This should allow the operation of a default run even when subprocess mode is enabled.

## Test Plan and Hands on Testing
- [x] Extend unit test coverage
- [x] Live flex test for default run orchestrator through homing outside run, drop tip wizard use

## Changelog
Implemented a RobotServerPyroResource route for the default run orchestrator door watcher callback

## Review requests

## Risk assessment
Low - follows the same pattern as maintenance runs.