### PR TITLE
chore(js): Update js-package-testing lockfile

### DIFF
--- a/js-package-testing/pnpm-lock.yaml
+++ b/js-package-testing/pnpm-lock.yaml
@@ -4,21 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-catalogs:
-  default:
-    '@types/react-dom':
-      specifier: 18.2.0
-      version: 18.2.0
-    react:
-      specifier: 18.2.0
-      version: 18.2.0
-    react-dom:
-      specifier: 18.2.0
-      version: 18.2.0
-    react-i18next:
-      specifier: 14.0.0
-      version: 14.0.0
-
 overrides:
   '@opentrons/components': link:pack/opentrons-components
   '@opentrons/shared-data': link:pack/opentrons-shared-data
@@ -48,13 +33,13 @@ importers:
         specifier: ^19.8.3
         version: 19.9.2
       react:
-        specifier: 'catalog:'
+        specifier: 18.2.0
         version: 18.2.0
       react-dom:
-        specifier: 'catalog:'
+        specifier: 18.2.0
         version: 18.2.0(react@18.2.0)
       react-i18next:
-        specifier: 'catalog:'
+        specifier: 14.0.0
         version: 14.0.0(i18next@19.9.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@applitools/eyes-playwright':
@@ -67,7 +52,7 @@ importers:
         specifier: 18.2.51
         version: 18.2.51
       '@types/react-dom':
-        specifier: 'catalog:'
+        specifier: 18.2.0
         version: 18.2.0
       '@vitejs/plugin-react':
         specifier: 4.2.0


### PR DESCRIPTION
## Overview

Since commit 722a06543bbc2eceb02544880e6f6d659dfa4f19, we're [currently getting](https://github.com/Opentrons/opentrons/actions/runs/26455884290/job/77889598328) this error in CI:

```
Cannot proceed with the frozen installation. The current "catalogs" configuration doesn't match the value found in the lockfile

Update your lockfile using "pnpm install --no-frozen-lockfile"
```

## Test Plan and Hands on Testing

CI, I guess?

## Changelog

In the js-package-testing subdirectory, run the  the suggested `pnpm install --no-frozen-lockfile` command in the js-package-testing subdirectory.

## Review requests

Is this right? This undoes some work done by commit 722a06543bbc2eceb02544880e6f6d659dfa4f19.

## Risk assessment

I have no idea.