### PR TITLE
fix(robot-server): allow posting an action when reasons for interaction is not enabled

### DIFF
--- a/robot-server/robot_server/fastapi_dependencies.py
+++ b/robot-server/robot_server/fastapi_dependencies.py
@@ -2,7 +2,7 @@
 
 from collections.abc import AsyncGenerator
 from datetime import datetime
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastapi import Depends, Request
 
@@ -12,7 +12,6 @@ from server_utils.auth.resource_server.authorization_checker import (
 )
 from server_utils.auth.resource_server.fastapi import get_authorization_checker
 from server_utils.fastapi_utils.documented_interaction import get_supplied_user_notes
-from server_utils.fastapi_utils.models.json_api import RequestModel
 
 from robot_server.service.dependencies import get_current_time
 
@@ -85,23 +84,4 @@ async def _record_documented_interaction(
         DocumentedInteraction(user_notes=user_notes, request_data=request_data),
         resource_id=resource_id,
         recorded_at=created_at,
-    )
-
-
-async def maybe_record_documented_interaction(
-    runId: str,
-    request_body: RequestModel[Any],
-    user_notes: Annotated[str | None, Depends(get_supplied_user_notes)],
-    created_at: Annotated[datetime, Depends(get_current_time)],
-    authorization_checker: Annotated[
-        AuthorizationChecker, Depends(get_authorization_checker)
-    ],
-) -> None:
-    """When auth-server requires it, require audit notes and record the interaction."""
-    await _record_documented_interaction(
-        resource_id=runId,
-        request_data=request_body.data,
-        user_notes=user_notes,
-        created_at=created_at,
-        authorization_checker=authorization_checker,
     )

--- a/robot-server/robot_server/runs/router/actions_router.py
+++ b/robot-server/robot_server/runs/router/actions_router.py
@@ -27,7 +27,7 @@ from robot_server.deck_configuration.fastapi_dependencies import (
 )
 from robot_server.deck_configuration.store import DeckConfigurationStore
 from robot_server.errors.error_responses import ErrorBody, ErrorDetails
-from robot_server.fastapi_dependencies import maybe_record_documented_interaction
+from robot_server.fastapi_dependencies import AuditLogger, get_audit_logger
 from robot_server.maintenance_runs.dependencies import (
     get_maintenance_run_orchestrator_store,
 )
@@ -105,14 +105,12 @@ async def get_run_controller(
         },
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
     },
-    dependencies=[
-        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
-        Depends(maybe_record_documented_interaction),
-    ],
+    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
 )
 async def create_run_action(
     runId: str,
     request_body: RequestModel[RunActionCreate],
+    audit_logger: Annotated[AuditLogger, Depends(get_audit_logger)],
     run_controller: Annotated[RunController, Depends(get_run_controller)],
     action_id: Annotated[str, Depends(get_unique_id)],
     created_at: Annotated[datetime, Depends(get_current_time)],
@@ -139,7 +137,10 @@ async def create_run_action(
         maintenance_run_orchestrator_store: Maintenance run orchestrator store.
         deck_configuration_store: Deck configuration store.
         check_estop: Dependency to verify the estop is in a valid state.
+        audit_logger: Records the action for audit setting requires
+            ``Opentrons-User-Notes``.
     """
+    await audit_logger.log(resource_id=runId, request_data=request_body.data)
     body = request_body.data
     action_type = body.actionType
     if (

--- a/robot-server/tests/runs/router/test_actions_router.py
+++ b/robot-server/tests/runs/router/test_actions_router.py
@@ -9,6 +9,7 @@ from server_utils.fastapi_utils.models.json_api import RequestModel
 
 from robot_server.deck_configuration.store import DeckConfigurationStore
 from robot_server.errors.error_responses import ApiError
+from robot_server.fastapi_dependencies import AuditLogger
 from robot_server.maintenance_runs.maintenance_run_orchestrator_store import (
     MaintenanceRunOrchestratorStore,
 )
@@ -24,9 +25,16 @@ def mock_run_controller(decoy: Decoy) -> RunController:
     return decoy.mock(cls=RunController)
 
 
+@pytest.fixture
+def mock_audit_logger(decoy: Decoy) -> AuditLogger:
+    """Get a fake AuditLogger dependency."""
+    return decoy.mock(cls=AuditLogger)
+
+
 async def test_create_run_action(
     decoy: Decoy,
     mock_run_controller: RunController,
+    mock_audit_logger: AuditLogger,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     mock_deck_configuration_store: DeckConfigurationStore,
 ) -> None:
@@ -59,6 +67,7 @@ async def test_create_run_action(
     result = await create_run_action(
         runId=run_id,
         request_body=request_body,
+        audit_logger=mock_audit_logger,
         run_controller=mock_run_controller,
         action_id=action_id,
         created_at=created_at,
@@ -67,6 +76,10 @@ async def test_create_run_action(
         check_estop=True,
     )
 
+    decoy.verify(
+        await mock_audit_logger.log(resource_id=run_id, request_data=request_body.data),
+        times=1,
+    )
     assert result.content.data == expected_result
     assert result.status_code == 201
 
@@ -74,6 +87,7 @@ async def test_create_run_action(
 async def test_play_action_clears_maintenance_run(
     decoy: Decoy,
     mock_run_controller: RunController,
+    mock_audit_logger: AuditLogger,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     mock_deck_configuration_store: DeckConfigurationStore,
 ) -> None:
@@ -108,6 +122,7 @@ async def test_play_action_clears_maintenance_run(
     result = await create_run_action(
         runId=run_id,
         request_body=request_body,
+        audit_logger=mock_audit_logger,
         run_controller=mock_run_controller,
         action_id=action_id,
         created_at=created_at,
@@ -131,6 +146,7 @@ async def test_play_action_clears_maintenance_run(
 async def test_create_play_action_not_allowed(
     decoy: Decoy,
     mock_run_controller: RunController,
+    mock_audit_logger: AuditLogger,
     exception: Exception,
     expected_error_id: str,
     expected_status_code: int,
@@ -163,6 +179,7 @@ async def test_create_play_action_not_allowed(
         await create_run_action(
             runId=run_id,
             request_body=request_body,
+            audit_logger=mock_audit_logger,
             run_controller=mock_run_controller,
             action_id=action_id,
             created_at=created_at,

--- a/robot-server/tests/test_fastapi_dependencies.py
+++ b/robot-server/tests/test_fastapi_dependencies.py
@@ -12,13 +12,8 @@ from server_utils.auth.resource_server.authorization_checker import (
     AlwaysAllowedAuthorizationChecker,
     MissingUserNotesError,
 )
-from server_utils.fastapi_utils.models.json_api import RequestModel
 
-from robot_server.fastapi_dependencies import (
-    AuditLogger,
-    get_audit_logger,
-    maybe_record_documented_interaction,
-)
+from robot_server.fastapi_dependencies import AuditLogger, get_audit_logger
 from robot_server.runs.action_models import RunActionCreate, RunActionType
 
 _RUN_ID = "run-abc"
@@ -121,11 +116,16 @@ async def test_get_audit_logger_skips_enforcement_for_get() -> None:
 
 
 @pytest.mark.asyncio
-async def test_maybe_record_documented_interaction_records_audit_when_required(
+async def test_audit_logger_log_records_run_action_when_required(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Forwards request notes and data to the checker and writes an audit log entry."""
+    """Run-action audit uses the same AuditLogger.log path as protocol routes."""
     checker = AlwaysAllowedAuthorizationChecker()
+    audit_logger = AuditLogger(
+        user_notes=_USER_NOTES,
+        created_at=_CREATED_AT,
+        authorization_checker=checker,
+    )
     with (
         patch.object(
             checker,
@@ -134,14 +134,9 @@ async def test_maybe_record_documented_interaction_records_audit_when_required(
         ),
         caplog.at_level(logging.INFO, logger=_AUDIT_LOGGER),
     ):
-        await maybe_record_documented_interaction(
-            _RUN_ID,
-            RequestModel(data=_PLAY_ACTION),
-            f"  {_USER_NOTES}  ",
-            _CREATED_AT,
-            authorization_checker=checker,
-        )
+        await audit_logger.log(resource_id=_RUN_ID, request_data=_PLAY_ACTION)
 
+    assert audit_logger.did_log is True
     assert any(
         "Documented interaction" in record.message and _RUN_ID in record.message
         for record in caplog.records
@@ -149,20 +144,20 @@ async def test_maybe_record_documented_interaction_records_audit_when_required(
 
 
 @pytest.mark.asyncio
-async def test_maybe_record_documented_interaction_skips_audit_when_not_required(
+async def test_audit_logger_log_skips_run_action_when_not_required(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """When auth-server does not require notes, no audit entry is recorded."""
+    """When auth-server does not require notes, run-action audit is a no-op."""
     checker = AlwaysAllowedAuthorizationChecker()
+    audit_logger = AuditLogger(
+        user_notes=None,
+        created_at=_CREATED_AT,
+        authorization_checker=checker,
+    )
     with caplog.at_level(logging.INFO, logger=_AUDIT_LOGGER):
-        await maybe_record_documented_interaction(
-            _RUN_ID,
-            RequestModel(data=_PLAY_ACTION),
-            None,
-            _CREATED_AT,
-            authorization_checker=checker,
-        )
+        await audit_logger.log(resource_id=_RUN_ID, request_data=_PLAY_ACTION)
 
+    assert audit_logger.did_log is True
     assert not any(
         "Documented interaction" in record.message for record in caplog.records
     )
@@ -170,11 +165,16 @@ async def test_maybe_record_documented_interaction_skips_audit_when_not_required
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("action_type", [RunActionType.PLAY, RunActionType.PAUSE])
-async def test_maybe_record_documented_interaction_raises_when_notes_required_but_missing(
+async def test_audit_logger_log_raises_when_notes_required_but_missing(
     action_type: RunActionType,
 ) -> None:
     """Run actions without audit notes header are rejected when auth-server requires them."""
     checker = AlwaysAllowedAuthorizationChecker()
+    audit_logger = AuditLogger(
+        user_notes=None,
+        created_at=_CREATED_AT,
+        authorization_checker=checker,
+    )
     with (
         patch.object(
             checker,
@@ -183,39 +183,7 @@ async def test_maybe_record_documented_interaction_raises_when_notes_required_bu
         ),
         pytest.raises(MissingUserNotesError),
     ):
-        await maybe_record_documented_interaction(
-            _RUN_ID,
-            RequestModel(data=RunActionCreate(actionType=action_type)),
-            None,
-            _CREATED_AT,
-            authorization_checker=checker,
+        await audit_logger.log(
+            resource_id=_RUN_ID,
+            request_data=RunActionCreate(actionType=action_type),
         )
-
-
-@pytest.mark.asyncio
-async def test_maybe_record_documented_interaction_records_protocol_upload_audit(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """Forwards header notes and request data to the checker."""
-    checker = AlwaysAllowedAuthorizationChecker()
-    request_data = {"protocolKind": "standard", "fileCount": 2}
-    with (
-        patch.object(
-            checker,
-            "get_require_reason_for_interaction_enabled",
-            new=AsyncMock(return_value=True),
-        ),
-        caplog.at_level(logging.INFO, logger=_AUDIT_LOGGER),
-    ):
-        await maybe_record_documented_interaction(
-            "protocol-1",
-            RequestModel(data=request_data),
-            _USER_NOTES,
-            _CREATED_AT,
-            authorization_checker=checker,
-        )
-
-    assert any(
-        "Documented interaction" in record.message and "protocol-1" in record.message
-        for record in caplog.records
-    )


### PR DESCRIPTION
# Overview

bug fix on edge. 
use get_audit_logger and remove old method. 

## Test Plan and Hands on Testing

Run make dev-backend-flex.
Do not enable access control mode.
Create a run with POST /runs (an empty run is fine).
Try to play the run with POST /runs/{id}/actions.
You should not get a 422 error with "Opentrons-User-Notes is required."

## Risk assessment

low. bug fix
