### PR TITLE
feat(protocol-designer): simplify onboarding flow basics

### DIFF
--- a/e2e-testing/automation/pd_pages/deck_config_page.py
+++ b/e2e-testing/automation/pd_pages/deck_config_page.py
@@ -116,3 +116,36 @@ class DeckConfigPage(BasePage):
             fixture_name: Name of the fixture to remove
         """
         self.page.get_by_role("button", name=fixture_name).click()
+
+    def add_waste_chute(self) -> None:
+        """Add a waste chute fixture at cutout D3."""
+        self.select_slot("D3")
+        fixtures_option = self.page.get_by_test_id("Fixtures")
+        self.wait_for_visible(fixtures_option.first)
+        fixtures_option.first.click()
+
+        waste_chute_entry = self.page.get_by_test_id("Waste chute")
+        if waste_chute_entry.count() > 0:
+            self.wait_for_visible(waste_chute_entry.first)
+            waste_chute_entry.first.click()
+
+        waste_chute_fixture = self.page.get_by_test_id("Waste Chute")
+        self.wait_for_visible(waste_chute_fixture.first)
+        waste_chute_fixture.first.click()
+
+    def configure_initial_deck_hardware(self, *, tc: bool, waste_chute: bool) -> None:
+        """Configure thermocycler and waste chute on the onboarding deck step.
+
+        Args:
+            tc: When True, add a Thermocycler Module GEN2 at B1.
+            waste_chute: When True, remove the default trash bin and add a waste chute at D3.
+        """
+        self.expect_module_overview()
+
+        if waste_chute:
+            self.remove_fixture("Trash bin")
+            self.add_waste_chute()
+
+        if tc:
+            self.select_slot("B1")
+            self.select_module("Thermocycler Module GEN2")

--- a/e2e-testing/automation/pd_pages/module_config_page.py
+++ b/e2e-testing/automation/pd_pages/module_config_page.py
@@ -25,26 +25,6 @@ class ModuleConfigPage(BasePage):
         self.wait_for_visible(button.first)
         button.first.click()
 
-    def select_thermocycler(self, has_thermocycler: bool = True) -> None:
-        """Select whether the protocol uses a thermocycler."""
-        test_id = "BasicsButtons_thermocycler_yes" if has_thermocycler else "BasicsButtons_thermocycler_no"
-        button = self.page.get_by_test_id(test_id)
-        if button.count() == 0:
-            label = "Yes" if has_thermocycler else "No"
-            button = self.page.get_by_text(label)
-        self.wait_for_visible(button.first)
-        button.first.click()
-
-    def select_waste_chute(self, has_waste_chute: bool = True) -> None:
-        """Select whether the protocol uses a waste chute."""
-        test_id = "BasicsButtons_wasteChute_yes" if has_waste_chute else "BasicsButtons_wasteChute_no"
-        button = self.page.get_by_test_id(test_id)
-        if button.count() == 0:
-            label = "Yes" if has_waste_chute else "No"
-            button = self.page.get_by_text(label)
-        self.wait_for_visible(button.first)
-        button.first.click()
-
     def confirm_module_selection(self) -> None:
         """Confirm the module selection and proceed."""
         self.click_button("Confirm")

--- a/e2e-testing/tests/pd/test_pd_plate_reader.py
+++ b/e2e-testing/tests/pd/test_pd_plate_reader.py
@@ -118,9 +118,6 @@ def test_flex_onboarding_workflow(page: Page, pd_base_url: str) -> None:
     page.get_by_role("button", name="Save").click()
     # Part 2: Gripper question - "Do you want to move labware automatically with the gripper?"
     page.get_by_text("Yes", exact=True).click()
-    # Part 3: Thermocycler question - "Are you using a Thermocycler in your protocol?"
-    page.get_by_test_id("BasicsButtons_thermocycler_no").get_by_text("No").click()
-    page.get_by_test_id("BasicsButtons_wasteChute_no").get_by_text("No").click()
-    # Now Confirm button should be enabled - click to proceed to Step 2
+    # Confirm basics and proceed to deck hardware configuration
     confirm_button = page.get_by_role("button", name="Confirm")
     confirm_button.click()

--- a/e2e-testing/tests/pd/test_pd_sanity.py
+++ b/e2e-testing/tests/pd/test_pd_sanity.py
@@ -60,17 +60,16 @@ def test_full_onboarding_flow(page: Page, pd_base_url: str, eyes: Eyes | None) -
             checkpoint_name="Pipette Configuration Saved",
             target=eyes.Target.window().fully(),
         )
-    # Module Configuration
+    # Basics configuration (pipette + gripper)
     module_config = ModuleConfigPage(page)
     module_config.select_gripper(True)
-    module_config.select_thermocycler(True)
-    module_config.select_waste_chute(True)
-    print("✓ Pipette and modules configured")
+    print("✓ Pipette and gripper configured")
 
     module_config.confirm_module_selection()
 
     # Deck Configuration
     deck_config = DeckConfigPage(page)
+    deck_config.configure_initial_deck_hardware(tc=True, waste_chute=True)
 
     # Add Heater-Shaker to C1
     deck_config.select_slot("C1")

--- a/e2e-testing/utility.py
+++ b/e2e-testing/utility.py
@@ -4,7 +4,7 @@ import re
 from playwright.sync_api import Error as PlaywrightError
 from playwright.sync_api import Page, TimeoutError, expect
 
-from automation.pd_pages import LandingPage, ProtocolEditorPage
+from automation.pd_pages import DeckConfigPage, LandingPage, ProtocolEditorPage
 
 # Todo add from eyes import eyes_check
 
@@ -116,16 +116,11 @@ def create_new_protocol_flow(pipette: str, gripper: bool, tc: bool, waste_chute:
         page.get_by_test_id("BasicsButtons_gripper_yes").get_by_text("Yes").click()
     else:
         page.get_by_test_id("BasicsButtons_gripper_no").get_by_text("No").click()
-    if tc:
-        page.get_by_test_id("BasicsButtons_thermocycler_yes").get_by_text("Yes").click()
-    else:
-        page.get_by_test_id("BasicsButtons_thermocycler_no").get_by_text("No").click()
-    if waste_chute:
-        page.get_by_test_id("BasicsButtons_wasteChute_yes").get_by_text("Yes").click()
-    else:
-        page.get_by_test_id("BasicsButtons_wasteChute_no").get_by_text("No").click()
     confirm_button = page.get_by_role("button", name="Confirm")
     confirm_button.click()
+
+    deck_config = DeckConfigPage(page)
+    deck_config.configure_initial_deck_hardware(tc=tc, waste_chute=waste_chute)
 
 
 def start_new_create_protocol(page: Page) -> None:

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/TimelineToolbox.tsx
@@ -21,9 +21,7 @@ import {
   LINK_BUTTON_STYLE,
   NAV_BAR_HEIGHT_REM,
 } from '/protocol-designer/components/atoms'
-import { useKitchen } from '/protocol-designer/components/organisms/Kitchen/useKitchen'
 import { getFileMetadata } from '/protocol-designer/file-data/selectors'
-import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
 import {
   END_TERMINAL_ITEM_ID,
   START_TERMINAL_ITEM_ID,
@@ -62,12 +60,6 @@ export function TimelineToolbox({
   const fileMetadata = useSelector(getFileMetadata)
   const navigate = useNavigate()
   const dispatch = useDispatch<ThunkDispatch<any>>()
-  const initialDeckSetup = useSelector(getInitialDeckSetup)
-  const { makeSnackbar } = useKitchen()
-  const { additionalEquipmentOnDeck } = initialDeckSetup
-  const hasTrash = Object.values(additionalEquipmentOnDeck).some(
-    ae => ae.name === 'trashBin' || ae.name === 'wasteChute'
-  )
   const isWidthForBackText = sidebarWidth < SIDEBAR_MIN_WIDTH_FOR_BACK_TEXT
   const protocolName = fileMetadata.protocolName
 
@@ -101,18 +93,14 @@ export function TimelineToolbox({
   )
 
   const handleGoBack = (): void => {
-    if (hasTrash) {
-      navigate('/overview')
-      dispatch(selectTerminalItem(START_TERMINAL_ITEM_ID))
-      dispatch(
-        selectDropdownItem({
-          selection: null,
-          mode: 'clear',
-        })
-      )
-    } else {
-      makeSnackbar(t('starting_deck_state:trash_required') as string)
-    }
+    navigate('/overview')
+    dispatch(selectTerminalItem(START_TERMINAL_ITEM_ID))
+    dispatch(
+      selectDropdownItem({
+        selection: null,
+        mode: 'clear',
+      })
+    )
   }
 
   const name: string =

--- a/protocol-designer/src/pages/Onboarding/SelectBasics.tsx
+++ b/protocol-designer/src/pages/Onboarding/SelectBasics.tsx
@@ -17,11 +17,7 @@ import {
 import {
   FLEX_96_CHANNEL_PIPETTES,
   FLEX_ROBOT_TYPE,
-  THERMOCYCLER_MODULE_TYPE,
-  THERMOCYCLER_MODULE_V2,
-  WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
-import { uuid } from '@opentrons/step-generation'
 
 import { HandleEnter, LINK_BUTTON_STYLE } from '../../components/atoms'
 import { BasicsButtons } from '../../components/molecules'
@@ -45,8 +41,6 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
   const ref = useRef<HTMLDivElement | null>(null)
 
   const pipettesByMount = watch('pipettesByMount')
-  const fixtures = watch('fixtures')
-  const modules = watch('modules')
   const hasGripper = watch('hasGripper')
   const hasThermocycer = watch('hasThermocycler')
   const hasWasteChute = watch('hasWasteChute')
@@ -68,10 +62,7 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
       pipettesByMount.right.tiprackDefURI == null)
 
   const isDisabled =
-    noPipette ||
-    hasGripper == null ||
-    hasThermocycer == null ||
-    hasWasteChute == null
+    noPipette || (robotType === FLEX_ROBOT_TYPE && hasGripper == null)
 
   const resetPipetteFields = (): void => {
     setPipetteType(null)
@@ -113,76 +104,6 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
     setValue('pipettesByMount.right.pipetteName', leftPipetteName)
     setValue('pipettesByMount.left.tiprackDefURI', rightTiprackDefURI)
     setValue('pipettesByMount.right.tiprackDefURI', leftTiprackDefURI)
-  }
-
-  const handlSelectWasteChute = (value: boolean): void => {
-    if (value) {
-      // If adding wasteChute, remove trashBin
-      const updatedFixtures = Object.fromEntries(
-        Object.entries(fixtures).filter(([_, val]) => val.name !== 'trashBin')
-      )
-      updatedFixtures[uuid()] = {
-        cutoutId: WASTE_CHUTE_CUTOUT,
-        name: 'wasteChute',
-        cutoutFixtureId: 'wasteChuteRightAdapterNoCover',
-      }
-
-      setValue('fixtures', updatedFixtures)
-      //  remove any module that might already be in D3
-      const updatedModules = Object.fromEntries(
-        Object.entries(modules).filter(
-          ([_, value]) => value.cutoutId !== WASTE_CHUTE_CUTOUT
-        )
-      )
-      setValue('modules', updatedModules)
-    } else {
-      // If removing wasteChute, filter it out
-      const filteredFixtures =
-        fixtures != null
-          ? Object.fromEntries(
-              Object.entries(fixtures).filter(
-                ([_, val]) => val.name !== 'wasteChute'
-              )
-            )
-          : {}
-
-      filteredFixtures[uuid()] = {
-        cutoutId: 'cutoutA3',
-        name: 'trashBin',
-        cutoutFixtureId: 'trashBinAdapter',
-      }
-
-      setValue('fixtures', filteredFixtures)
-    }
-    setValue('hasWasteChute', value)
-  }
-
-  const handleSelectThermocycler = (value: boolean): void => {
-    if (value) {
-      //   first remove anything that might have been placed previous in slot A1/B1
-      const updatedModules = Object.fromEntries(
-        Object.entries(modules).filter(
-          ([_, value]) => !['A1', 'B1'].includes(value.slot)
-        )
-      )
-      //  then add the thermocycler
-      updatedModules[uuid()] = {
-        model: THERMOCYCLER_MODULE_V2,
-        type: THERMOCYCLER_MODULE_TYPE,
-        slot: 'B1',
-        cutoutFixtureId: 'thermocyclerModuleV2Front',
-        cutoutId: 'cutoutB1',
-      }
-      setValue('modules', updatedModules)
-    } else {
-      const updatedModules = Object.fromEntries(
-        Object.entries(modules).filter(
-          ([_, value]) => value.type !== THERMOCYCLER_MODULE_TYPE
-        )
-      )
-      setValue('modules', updatedModules)
-    }
-    setValue('hasThermocycler', value)
   }
 
   useEffect(
@@ -343,31 +264,6 @@ export function SelectBasics(props: WizardTileProps): JSX.Element {
                 }}
                 selected={hasGripper}
               />
-              {hasGripper != null ? (
-                <Flex
-                  flexDirection={DIRECTION_COLUMN}
-                  gridGap={SPACING.spacing60}
-                >
-                  <BasicsButtons
-                    type="thermocycler"
-                    header={t('are_you_using_thermocycler')}
-                    onChange={value => {
-                      handleSelectThermocycler(value)
-                    }}
-                    selected={hasThermocycer}
-                  />
-                  {hasThermocycer != null ? (
-                    <BasicsButtons
-                      type="wasteChute"
-                      header={t('are_you_using_waste_chute')}
-                      onChange={value => {
-                        handlSelectWasteChute(value)
-                      }}
-                      selected={hasWasteChute}
-                    />
-                  ) : null}
-                </Flex>
-              ) : null}
             </Flex>
           )}
           {/* empty div for scrolling to bottom on form changes */}

--- a/protocol-designer/src/pages/Onboarding/__tests__/SelectBasics.test.tsx
+++ b/protocol-designer/src/pages/Onboarding/__tests__/SelectBasics.test.tsx
@@ -131,20 +131,6 @@ describe('SelectBasics', () => {
     fireEvent.click(screen.getAllByRole('label', { name: 'No' })[0])
     expect(props.setValue).toHaveBeenCalled()
 
-    // thermocycler
-    screen.getByText('Are you using a Thermocycler in your protocol?')
-    fireEvent.click(screen.getAllByRole('label', { name: 'Yes' })[1])
-    expect(props.setValue).toHaveBeenCalled()
-    fireEvent.click(screen.getAllByRole('label', { name: 'No' })[1])
-    expect(props.setValue).toHaveBeenCalled()
-
-    // wasteChute
-    screen.getByText('Are you using a waste chute in your protocol?')
-    fireEvent.click(screen.getAllByRole('label', { name: 'Yes' })[2])
-    expect(props.setValue).toHaveBeenCalled()
-    fireEvent.click(screen.getAllByRole('label', { name: 'No' })[2])
-    expect(props.setValue).toHaveBeenCalled()
-
     //  confirm
     screen.getByRole('button', { name: 'Confirm' })
   })

--- a/protocol-designer/src/pages/Onboarding/constants.ts
+++ b/protocol-designer/src/pages/Onboarding/constants.ts
@@ -17,6 +17,7 @@ import {
 } from '@opentrons/shared-data'
 
 import type { ModuleModel, ModuleType, RobotType } from '@opentrons/shared-data'
+import type { FixtureInfo } from '/protocol-designer/components/organisms'
 import type { Gen, PipetteType, PipetteVolumes } from './types'
 
 export const PIPETTE_GENS: Gen[] = ['GEN1', 'GEN2']
@@ -139,4 +140,10 @@ export const DEFAULT_SLOT_MAP_OT2: { [moduleType in ModuleType]?: string } = {
   [HEATERSHAKER_MODULE_TYPE]: '1',
   [MAGNETIC_MODULE_TYPE]: '1',
   [TEMPERATURE_MODULE_TYPE]: '3',
+}
+
+export const FLEX_TRASH_FIXTURE_INFO: FixtureInfo = {
+  cutoutId: 'cutoutA3',
+  name: 'trashBin',
+  cutoutFixtureId: 'trashBinAdapter',
 }

--- a/protocol-designer/src/pages/Onboarding/index.tsx
+++ b/protocol-designer/src/pages/Onboarding/index.tsx
@@ -37,6 +37,7 @@ import {
 import { actions as steplistActions } from '../../steplist'
 import { uuid } from '../../utils'
 import { AddMetadata } from './AddMetadata'
+import { FLEX_TRASH_FIXTURE_INFO } from './constants'
 import { SelectBasics } from './SelectBasics'
 import { SelectFlexHardware } from './SelectFlexHardware'
 
@@ -85,7 +86,7 @@ const initialFormState: WizardFormState = {
   },
   modules: {},
   hasGripper: null,
-  fixtures: {},
+  fixtures: { [uuid()]: FLEX_TRASH_FIXTURE_INFO },
   hasThermocycler: null,
   hasWasteChute: null,
 }

--- a/protocol-designer/src/steplist/formLevel/errors.ts
+++ b/protocol-designer/src/steplist/formLevel/errors.ts
@@ -85,7 +85,7 @@ export interface FormError {
   location: FormErrorLocationType[]
   //  used for top-level form warnings see formLevel/warnings.tsx
   body?: ReactNode
-  //  for multi-step forms
+  //  for multi-step forms; 0-indexed
   page?: number
   //  for mix and moveLiquid tools
   tab?: LiquidHandlingTab
@@ -658,6 +658,14 @@ const VACUUM_MODULE_ID_REQUIRED: FormError = {
   location: ['field'],
   showOnReopen: true,
 }
+const DROP_TIP_LOCATION_REQUIRED: FormError = {
+  title: 'Select tip drop location',
+  dependentFields: ['dropTip_location'],
+  location: ['field'],
+  page: 3,
+  showOnReopen: true,
+}
+
 export type FormErrorChecker = (
   arg: HydratedFormData,
   moduleEntities?: ModuleEntities
@@ -1652,6 +1660,12 @@ export const vacuumDurationRequired = (
     !pumpDurationTime
     ? VACUUM_DURATION_REQUIRED
     : null
+}
+export const tipDropLocationRequired = (
+  fields: HydratedMixFormData | HydratedMoveLiquidFormData
+): FormError | null => {
+  const { dropTip_location } = fields
+  return dropTip_location == null ? DROP_TIP_LOCATION_REQUIRED : null
 }
 
 export const vacuumModuleIdRequired = (

--- a/protocol-designer/src/steplist/formLevel/index.ts
+++ b/protocol-designer/src/steplist/formLevel/index.ts
@@ -69,6 +69,7 @@ import {
   targetTemperatureRequired,
   temperatureRequired,
   timesRequired,
+  tipDropLocationRequired,
   tiprackRequired,
   tipSelectionRequired,
   transferVolumeMin,
@@ -193,7 +194,8 @@ const stepFormHelperMap: {
       blowoutFlowRateRequired,
       transferVolumeMin,
       pipetteRequired,
-      tipSelectionRequired
+      tipSelectionRequired,
+      tipDropLocationRequired
     ),
     getWarnings: composeWarnings(
       mixTipPositionInTube,
@@ -251,7 +253,8 @@ const stepFormHelperMap: {
       dispenseSubmergeSpeedRequired,
       dispenseRetractSpeedRequired,
       disposalVolumeRequired,
-      tipSelectionRequired
+      tipSelectionRequired,
+      tipDropLocationRequired
     ),
     getWarnings: composeWarnings(
       maxDispenseWellVolume,


### PR DESCRIPTION
# Overview

This PR simplifies the Protocol Designer onboarding flow. We no longer prompt explicit questions regarding whether a user is using a thermocycler or a waste chute-- these will be configured during the hardware configuration step. In addition, we remove the requirement for users to have a trash entity (trash bin or waste chute) in their protocols. As part of this behavior change, we add a form error to enforce a drop tip location to be selected before saving the form (for mix and transfer forms)

Closes EXEC-2449

https://github.com/user-attachments/assets/b108e9b6-0543-492a-b0c6-fb9d54eef2b5


## Test Plan and Hands on Testing

- walk through the onboarding flow for a Flex protocol
- verify that in the "Basics" step, you are no longer prompted to input whether or not you have a thermocycler or waste chute (these can be configured in the following step)
- continue to hardware configuration, and verify that the trash bin remains autopopulated in cutout A3
- remove the trash and finish building the protocol
- enter protocol editor, and navigate back to overview. verify that you are allowed to do so
- navigate back to the editor and create a transfer or mix step. continue to page 4 (tip settings). attempt to save the form without selecting a drop-tip location, and verify that a form error appears on the tip drop field

## Changelog

- simplify onboarding basics page per design/product updates
- remove requirement for trash entity in protocol editor
- add form error requiring tip drop location

## Review requests

see test plan

## Risk assessment

low