### PR TITLE
fix(protocol-designer, step-generation): fix logic for partial column pickup

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -115,7 +115,7 @@ export function SelectTips(
     selectedTiprackId != null
       ? (tipAccessibilityStatus[selectedTiprackId] ?? {})
       : {}
-  // Flat lookup: well mapped to status of the "best" primary covering it.
+  // Flat lookup: well mapped to status of the primary or primaries covering it.
   // Accessible primaries take precedence so cascading members of an accessible
   // group are not incorrectly shown as inaccessible.
   const wellToPrimaryStatus = Object.entries(
@@ -132,9 +132,8 @@ export function SelectTips(
 
   const allWellsAffectedByHover = hoveredWells ?? []
   // The primary (first) well is where the primary nozzle lands. Cascading wells
-  // in the group are picked up by other active nozzles and must not be used as
-  // the basis for accessibility — their individual isSafe checks would
-  // incorrectly flag them as blocked by the primary well's tip.
+  // should not be used as the basis for accessibility since their individual isSafe
+  // checks would incorrectly flag them as blocked by the primary well's tip.
   const primaryHoveredWell = allWellsAffectedByHover[0] ?? null
   const primaryHoveredWellStatus =
     primaryHoveredWell != null
@@ -145,25 +144,28 @@ export function SelectTips(
     well => tipState?.[well] !== EMPTY
   )
 
-  // True when the hovered group is already selected — hovering it means deselect.
-  // In this case the accessibility map is unreliable (tipsToIgnore artifact) so
-  // we bypass it and treat the hover as accessible (shadow shows blue).
   const isHoveringSelectedGroup =
     primaryHoveredWell != null &&
-    selectedTips.some(g => g[0] === primaryHoveredWell)
+    selectedTips.some(group => group[0] === primaryHoveredWell)
 
   const areAllHoveredWellsAccessibleAndOccupied =
     isHoveringSelectedGroup ||
     ((primaryHoveredWellStatus?.isAccessible ?? false) && allGroupWellsHaveTips)
 
   const hoveredWellsInaccessibilityStatus: InaccessibleReason | null = (() => {
-    if (isHoveringSelectedGroup) return null
-    // A null status means the well isn't a registered primary — treat as incomplete.
-    if (primaryHoveredWellStatus == null) return INACCESSIBLE_INCOMPLETE
+    if (isHoveringSelectedGroup) {
+      return null
+    }
+    // A null status means the well isn't a registered primary tip.
+    if (primaryHoveredWellStatus == null) {
+      return INACCESSIBLE_INCOMPLETE
+    }
     if (!primaryHoveredWellStatus.isAccessible) {
       return primaryHoveredWellStatus.inaccessibleReason
     }
-    if (!allGroupWellsHaveTips) return INACCESSIBLE_INCOMPLETE
+    if (!allGroupWellsHaveTips) {
+      return INACCESSIBLE_INCOMPLETE
+    }
     return null
   })()
 
@@ -173,14 +175,12 @@ export function SelectTips(
   // Flat set of all wells currently selected (primary + cascading for each group).
   const flatSelected = new Set(selectedTips.flat())
 
-  // Reverse lookup: any selected well (primary or cascading) → that group's primary.
-  // This lets clicks on cascading wells correctly deselect the owning group.
   const selectedWellToPrimary: Record<string, string> = selectedTips.reduce<
     Record<string, string>
   >((acc, group) => {
     const primary = group[0]
-    group.forEach(w => {
-      acc[w] = primary
+    group.forEach(tip => {
+      acc[tip] = primary
     })
     return acc
   }, {})
@@ -209,16 +209,22 @@ export function SelectTips(
     const owningPrimary = selectedWellToPrimary[wellName]
     const isAlreadySelected = owningPrimary != null
 
-    // For new selections, `wellName` is always a primary (from handleSelectionDone).
+    // for new selections, `wellName` is always a primary (from handleSelectionDone).
     const status = tipAccessibileStatusByWellName[wellName]
 
     if (!isAlreadySelected) {
-      if (!status?.isAccessible) return
+      if (!(status?.isAccessible === true)) {
+        return
+      }
       // Confirm every affected well has a tip — the primary-only isComplete check
       // in the hook is insufficient when some cascading wells may be empty.
       const affectedWells = [...status.affectedWells]
-      if (affectedWells.some(w => tipState?.[w] === EMPTY)) return
-      if (!hasPickupsRemaining) return
+      if (affectedWells.some(w => tipState?.[w] === EMPTY)) {
+        return
+      }
+      if (!hasPickupsRemaining) {
+        return
+      }
     }
 
     setShowErrorBanner(false)
@@ -236,33 +242,31 @@ export function SelectTips(
   const handleHoverWell = (e: WellMouseEvent): void => {
     const { wellName } = e
 
-    // Determine hover group using pre-computed accessibility data:
-    // 1. If the well is part of a selected group, show that group (deselect preview).
-    // 2. If the well is a valid primary, use its pre-computed affectedWells.
+    // determine hover group using pre-computed data:
+    // 1. If the well is part of a selected group, show that group (deselect).
+    // 2. If the well is a valid primary, use its pre-computed affectedWells from
+    // useEMemoizedTipAccessibilityByTipraackIdByWellName.
     // 3. If the well is a cascading member of some primary whose shadow would fall
-    //    outside the current selection, use that primary's group.
+    // outside the current selection, use that primary's group.
     // 4. Fall back to the single well (renders as INACCESSIBLE_INCOMPLETE via null status).
     const owningPrimary = selectedWellToPrimary[wellName] ?? null
     let allHoveredWells: string[]
 
     if (owningPrimary != null) {
-      allHoveredWells = selectedTips.find(g => g[0] === owningPrimary) ?? [
-        wellName,
-      ]
+      allHoveredWells = selectedTips.find(
+        group => group[0] === owningPrimary
+      ) ?? [wellName]
     } else {
       const directStatus = tipAccessibileStatusByWellName[wellName]
       if (directStatus != null) {
         allHoveredWells = directStatus.affectedWells
       } else {
-        // Well is not a valid primary. Use the covering primary's group only when
-        // the shadow (first element) wouldn't land inside the current selection —
-        // snap-back groups can have their first element inside a selected range,
-        // which would confusingly imply a deselect action on hover.
-        const covering = wellToPrimaryStatus[wellName]
-        const coveringFirst = covering?.affectedWells[0]
+        const coveringAccessibilityStatus = wellToPrimaryStatus[wellName]
+        const coveringFirst = coveringAccessibilityStatus?.affectedWells[0]
         allHoveredWells =
-          covering != null && !flatSelected.has(coveringFirst ?? '')
-            ? covering.affectedWells
+          coveringAccessibilityStatus != null &&
+          !flatSelected.has(coveringFirst)
+            ? coveringAccessibilityStatus.affectedWells
             : [wellName]
       }
     }
@@ -312,14 +316,8 @@ export function SelectTips(
     if (!e.shiftKey) {
       const wellsUnderRect = _getWellsFromRect(rect)
 
-      // For single clicks (zero-size rect), delegate to handleClickWell directly.
-      // The SVG onClick fires after mouseup which causes state conflicts, so we
-      // intercept here while hover context is still intact.
+      // single clicks call handleClickWell directly.
       if (rect.x0 === rect.x1 && rect.y0 === rect.y1) {
-        // Use the raw well under the mouse rather than the computed primary from
-        // getEntireWellSelection — snap-back groups (e.g. F1→[D1-H1] in a 5-nozzle
-        // D1 config) would otherwise route clicks on invalid wells to a selected
-        // primary and trigger incorrect deselection.
         const actualClickedWell =
           Object.keys(getCollidingWells(rect))[0] ?? null
         if (actualClickedWell != null) {
@@ -337,11 +335,9 @@ export function SelectTips(
           hasPickupsRemaining
         )
       })
-      const primaryWellsInRect = filteredWellsUnderRect.map(g => g[0])
-      const selectedPrimarySet = new Set(selectedTips.map(g => g[0]))
+      const primaryWellsInRect = filteredWellsUnderRect.map(group => group[0])
+      const selectedPrimarySet = new Set(selectedTips.map(group => group[0]))
 
-      // Guard against vacuous truth: empty filteredWellsUnderRect must not
-      // trigger the "all already selected → remove" branch.
       const allAlreadySelected =
         primaryWellsInRect.length > 0 &&
         primaryWellsInRect.every(p => selectedPrimarySet.has(p))
@@ -352,17 +348,17 @@ export function SelectTips(
 
         if (allAlreadySelected) {
           const toRemove = new Set(primaryWellsInRect)
-          newPrimaries = prevPrimaries.filter(p => !toRemove.has(p))
+          newPrimaries = prevPrimaries.filter(primary => !toRemove.has(primary))
         } else {
           const toAdd = primaryWellsInRect.filter(
-            p => !selectedPrimarySet.has(p)
+            primary => !selectedPrimarySet.has(primary)
           )
           newPrimaries = [...prevPrimaries, ...toAdd]
         }
 
-        return newPrimaries.map(p => {
-          const aff = tipAccessibileStatusByWellName[p]?.affectedWells
-          return aff != null ? [...aff] : [p]
+        return newPrimaries.map(primary => {
+          const aff = tipAccessibileStatusByWellName[primary]?.affectedWells
+          return aff != null ? [...aff] : [primary]
         })
       })
 
@@ -385,30 +381,26 @@ export function SelectTips(
     const tipStatusByWellName =
       tipState != null
         ? Object.entries(tipState).reduce<Record<string, TipType>>(
-            (acc, [wellName, state]) => {
+            (acc, [tipName, state]) => {
               const rawState = TIP_STATE_TO_TIP_TYPE[state]
-              const primaryStatus = wellToPrimaryStatus[wellName]
+              const primaryStatus = wellToPrimaryStatus[tipName]
               let status = rawState
 
               if (!primaryStatus?.isAccessible) {
                 status = rawState === NO ? NO : INACCESSIBLE
               }
 
-              if (flatSelected.has(wellName)) {
+              if (flatSelected.has(tipName)) {
                 // Find the primary of the group this selected well belongs to.
                 const groupContainingWell = selectedTips.find(group =>
-                  group.includes(wellName)
+                  group.includes(tipName)
                 )
-                const primaryOfGroup = groupContainingWell?.[0] ?? wellName
+                const primaryOfGroup = groupContainingWell?.[0] ?? tipName
                 const primaryStatus =
                   tipAccessibileStatusByWellName[primaryOfGroup]
-                // Use physical tip state to detect truly erroneous selections.
-                // The accessibility map's isComplete accounts for tipsToIgnore
-                // (= all selected wells), so every group's own wells appear as
-                // incomplete — a false positive. Only COLLISION is safe to read
-                // from the map since it is independent of tipsToIgnore.
+                // Use physical tip state to account for tipsToIgnore
                 const affectedWells = primaryStatus?.affectedWells ??
-                  groupContainingWell ?? [wellName]
+                  groupContainingWell ?? [tipName]
                 const hasPhysicallyEmptyWell = affectedWells.some(
                   w => tipState?.[w] === EMPTY
                 )
@@ -423,7 +415,7 @@ export function SelectTips(
                   : rawState === USED
                     ? SELECTED_USED
                     : SELECTED
-              } else if (allWellsAffectedByHover.includes(wellName)) {
+              } else if (allWellsAffectedByHover.includes(tipName)) {
                 status =
                   areAllHoveredWellsAccessibleAndOccupied && hasPickupsRemaining
                     ? rawState === USED
@@ -432,7 +424,7 @@ export function SelectTips(
                     : SELECTED_ERROR
               }
 
-              return { ...acc, [wellName]: status }
+              return { ...acc, [tipName]: status }
             },
             {}
           )

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -246,8 +246,9 @@ export function SelectTips(
     let allHoveredWells: string[]
 
     if (owningPrimary != null) {
-      allHoveredWells =
-        selectedTips.find(g => g[0] === owningPrimary) ?? [wellName]
+      allHoveredWells = selectedTips.find(g => g[0] === owningPrimary) ?? [
+        wellName,
+      ]
     } else {
       const directStatus = tipAccessibileStatusByWellName[wellName]
       if (directStatus != null) {
@@ -319,7 +320,8 @@ export function SelectTips(
         // getEntireWellSelection — snap-back groups (e.g. F1→[D1-H1] in a 5-nozzle
         // D1 config) would otherwise route clicks on invalid wells to a selected
         // primary and trigger incorrect deselection.
-        const actualClickedWell = Object.keys(getCollidingWells(rect))[0] ?? null
+        const actualClickedWell =
+          Object.keys(getCollidingWells(rect))[0] ?? null
         if (actualClickedWell != null) {
           handleClickWell(actualClickedWell)
         }
@@ -330,7 +332,8 @@ export function SelectTips(
       const filteredWellsUnderRect = wellsUnderRect.filter(wellGroup => {
         const primaryWell = wellGroup[0]
         return (
-          (tipAccessibileStatusByWellName[primaryWell]?.isAccessible ?? false) &&
+          (tipAccessibileStatusByWellName[primaryWell]?.isAccessible ??
+            false) &&
           hasPickupsRemaining
         )
       })
@@ -397,27 +400,29 @@ export function SelectTips(
                   group.includes(wellName)
                 )
                 const primaryOfGroup = groupContainingWell?.[0] ?? wellName
-                const primaryStatus = tipAccessibileStatusByWellName[primaryOfGroup]
+                const primaryStatus =
+                  tipAccessibileStatusByWellName[primaryOfGroup]
                 // Use physical tip state to detect truly erroneous selections.
                 // The accessibility map's isComplete accounts for tipsToIgnore
                 // (= all selected wells), so every group's own wells appear as
                 // incomplete — a false positive. Only COLLISION is safe to read
                 // from the map since it is independent of tipsToIgnore.
-                const affectedWells =
-                  primaryStatus?.affectedWells ?? groupContainingWell ?? [wellName]
+                const affectedWells = primaryStatus?.affectedWells ??
+                  groupContainingWell ?? [wellName]
                 const hasPhysicallyEmptyWell = affectedWells.some(
                   w => tipState?.[w] === EMPTY
                 )
                 const isGroupInError =
                   (primaryStatus != null &&
                     !primaryStatus.isAccessible &&
-                    primaryStatus.inaccessibleReason === INACCESSIBLE_COLLISION) ||
+                    primaryStatus.inaccessibleReason ===
+                      INACCESSIBLE_COLLISION) ||
                   hasPhysicallyEmptyWell
                 status = isGroupInError
                   ? SELECTED_ERROR
                   : rawState === USED
-                  ? SELECTED_USED
-                  : SELECTED
+                    ? SELECTED_USED
+                    : SELECTED
               } else if (allWellsAffectedByHover.includes(wellName)) {
                 status =
                   areAllHoveredWellsAccessibleAndOccupied && hasPickupsRemaining

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -201,42 +201,34 @@ export function SelectTips(
     return highlightedWells
   }
 
-  // `wellName` is the primary from getEntireWellSelection, but the reverse map
-  // lets us also handle clicks on cascading wells (e.g. clicking B1 when A1's
-  // group A1-E1 is selected should deselect the A1 group).
   const handleClickWell = (wellName: string): void => {
-    // Resolve which primary owns this well in the current selection (if any).
+    // If this well belongs to an already-selected group, deselect that group.
     const owningPrimary = selectedWellToPrimary[wellName]
-    const isAlreadySelected = owningPrimary != null
+    if (owningPrimary != null) {
+      setShowErrorBanner(false)
+      const groupIndex = selectedTips.findIndex(g => g[0] === owningPrimary)
+      setSelectedTips(selectedTips.slice(0, groupIndex))
+      return
+    }
 
-    // for new selections, `wellName` is always a primary (from handleSelectionDone).
-    const status = tipAccessibileStatusByWellName[wellName]
+    // for new selections, lookup primary first
+    // fall back to the covering-primary map for cascading (non-primary) wells.
+    const status =
+      tipAccessibileStatusByWellName[wellName] ?? wellToPrimaryStatus[wellName]
 
-    if (!isAlreadySelected) {
-      if (!(status?.isAccessible === true)) {
-        return
-      }
-      // Confirm every affected well has a tip — the primary-only isComplete check
-      // in the hook is insufficient when some cascading wells may be empty.
-      const affectedWells = [...status.affectedWells]
-      if (affectedWells.some(w => tipState?.[w] === EMPTY)) {
-        return
-      }
-      if (!hasPickupsRemaining) {
-        return
-      }
+    if (!(status?.isAccessible === true)) {
+      return
+    }
+    const affectedWells = [...status.affectedWells]
+    if (affectedWells.some(w => tipState?.[w] === EMPTY)) {
+      return
+    }
+    if (!hasPickupsRemaining) {
+      return
     }
 
     setShowErrorBanner(false)
-
-    if (isAlreadySelected) {
-      // Slice removes the owning group and all later selections.
-      const groupIndex = selectedTips.findIndex(g => g[0] === owningPrimary)
-      setSelectedTips(selectedTips.slice(0, groupIndex))
-    } else {
-      const wellsToSelect = [...(status?.affectedWells ?? [wellName])]
-      setSelectedTips([...selectedTips, wellsToSelect])
-    }
+    setSelectedTips([...selectedTips, affectedWells])
   }
 
   const handleHoverWell = (e: WellMouseEvent): void => {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTips.tsx
@@ -17,15 +17,7 @@ import {
   TIP,
   USED,
 } from '@opentrons/components'
-import {
-  ALL,
-  COLUMN,
-  getPositionFromSlotId,
-  PARTIAL_COLUMN,
-  PARTIAL_NOZZLE_MAP,
-  ROW,
-  SINGLE,
-} from '@opentrons/shared-data'
+import { getPositionFromSlotId } from '@opentrons/shared-data'
 import { EMPTY, getSlotInLocationStack } from '@opentrons/step-generation'
 
 import { LabwareOnDeck } from '/protocol-designer/components/organisms'
@@ -36,10 +28,6 @@ import { getLabwareNicknamesById } from '/protocol-designer/ui/labware/selectors
 import { getCollidingWells } from '/protocol-designer/utils/index'
 
 import {
-  INACCESSIBLE_PARTIAL_TIP,
-  INACCESSIBLE_WELL_SPACING_MISMATCH,
-} from '../NozzleAndWellSelectionModal/constants'
-import {
   getEntireWellSelection,
   getWellNameAtClientPoint,
 } from '../NozzleAndWellSelectionModal/utils'
@@ -47,24 +35,18 @@ import { BaseDeckTipSelection } from './BaseDeckTipSelection'
 import {
   INACCESSIBLE_COLLISION,
   INACCESSIBLE_INCOMPLETE,
-  INACCESSIBLE_TOO_MANY_PICKUPS,
   TIP_STATE_TO_TIP_TYPE,
 } from './constants'
 import { DeckOverlay } from './DeckOverlay'
 import { PipetteShadow } from './PipetteShadows/PipetteShadow'
 import { SelectionLegend } from './SelectionLegend'
 import styles from './tipselectionwizard.module.css'
-import {
-  getAllWellsInColumn,
-  getAllWellsInRow,
-  getViewboxFromSelectedLabware,
-} from './utils'
+import { getViewboxFromSelectedLabware } from './utils'
 
 import type { Dispatch, SetStateAction } from 'react'
 import type { TipType, WellMouseEvent } from '@opentrons/components'
 import type {
   NozzleConfigurationStyle,
-  PartialPrimaryNozzles,
   PipetteV2Specs,
   PrimaryNozzleConfigurationStyle,
 } from '@opentrons/shared-data'
@@ -133,41 +115,75 @@ export function SelectTips(
     selectedTiprackId != null
       ? (tipAccessibilityStatus[selectedTiprackId] ?? {})
       : {}
+  // Flat lookup: well mapped to status of the "best" primary covering it.
+  // Accessible primaries take precedence so cascading members of an accessible
+  // group are not incorrectly shown as inaccessible.
+  const wellToPrimaryStatus = Object.entries(
+    tipAccessibileStatusByWellName
+  ).reduce<Record<string, AccessibilityStatus>>((acc, [, status]) => {
+    status.affectedWells.forEach(well => {
+      const existing = acc[well]
+      if (existing == null || (!existing.isAccessible && status.isAccessible)) {
+        acc[well] = status
+      }
+    })
+    return acc
+  }, {})
 
   const allWellsAffectedByHover = hoveredWells ?? []
+  // The primary (first) well is where the primary nozzle lands. Cascading wells
+  // in the group are picked up by other active nozzles and must not be used as
+  // the basis for accessibility — their individual isSafe checks would
+  // incorrectly flag them as blocked by the primary well's tip.
+  const primaryHoveredWell = allWellsAffectedByHover[0] ?? null
+  const primaryHoveredWellStatus =
+    primaryHoveredWell != null
+      ? tipAccessibileStatusByWellName[primaryHoveredWell]
+      : null
 
-  const areAllHoveredWellsAccessibleAndOccupied = allWellsAffectedByHover.every(
-    well =>
-      tipAccessibileStatusByWellName[well].isAccessible &&
-      tipState?.[well] !== EMPTY
+  const allGroupWellsHaveTips = allWellsAffectedByHover.every(
+    well => tipState?.[well] !== EMPTY
   )
 
-  // lower index means higher priority
-  const inaccessibilityPriority = [
-    INACCESSIBLE_COLLISION,
-    INACCESSIBLE_INCOMPLETE,
-    INACCESSIBLE_TOO_MANY_PICKUPS,
-    INACCESSIBLE_PARTIAL_TIP,
-    INACCESSIBLE_WELL_SPACING_MISMATCH,
-  ]
+  // True when the hovered group is already selected — hovering it means deselect.
+  // In this case the accessibility map is unreliable (tipsToIgnore artifact) so
+  // we bypass it and treat the hover as accessible (shadow shows blue).
+  const isHoveringSelectedGroup =
+    primaryHoveredWell != null &&
+    selectedTips.some(g => g[0] === primaryHoveredWell)
 
-  const hoveredWellsInaccessibilityStatus =
-    allWellsAffectedByHover.reduce<InaccessibleReason | null>((acc, well) => {
-      const { isAccessible, inaccessibleReason } =
-        tipAccessibileStatusByWellName[well]
-      if (isAccessible || inaccessibleReason == null) {
-        return acc
-      }
-      if (acc == null) {
-        return inaccessibleReason
-      }
-      return inaccessibilityPriority.indexOf(inaccessibleReason) <
-        inaccessibilityPriority.indexOf(acc)
-        ? inaccessibleReason
-        : acc
-    }, null)
+  const areAllHoveredWellsAccessibleAndOccupied =
+    isHoveringSelectedGroup ||
+    ((primaryHoveredWellStatus?.isAccessible ?? false) && allGroupWellsHaveTips)
+
+  const hoveredWellsInaccessibilityStatus: InaccessibleReason | null = (() => {
+    if (isHoveringSelectedGroup) return null
+    // A null status means the well isn't a registered primary — treat as incomplete.
+    if (primaryHoveredWellStatus == null) return INACCESSIBLE_INCOMPLETE
+    if (!primaryHoveredWellStatus.isAccessible) {
+      return primaryHoveredWellStatus.inaccessibleReason
+    }
+    if (!allGroupWellsHaveTips) return INACCESSIBLE_INCOMPLETE
+    return null
+  })()
+
   const numPickupsRemaining = numTotalPickups - selectedTips.length
   const hasPickupsRemaining = numPickupsRemaining > 0
+
+  // Flat set of all wells currently selected (primary + cascading for each group).
+  const flatSelected = new Set(selectedTips.flat())
+
+  // Reverse lookup: any selected well (primary or cascading) → that group's primary.
+  // This lets clicks on cascading wells correctly deselect the owning group.
+  const selectedWellToPrimary: Record<string, string> = selectedTips.reduce<
+    Record<string, string>
+  >((acc, group) => {
+    const primary = group[0]
+    group.forEach(w => {
+      acc[w] = primary
+    })
+    return acc
+  }, {})
 
   const _getWellsFromRect: (rect: GenericRect) => string[][] = rect => {
     const wellsInRect = getCollidingWells(rect)
@@ -185,101 +201,70 @@ export function SelectTips(
     return highlightedWells
   }
 
-  const handleUnselectWell = (unselectIndex: number): void => {
-    setSelectedTips(selectedTips.slice(0, unselectIndex))
-  }
-
+  // `wellName` is the primary from getEntireWellSelection, but the reverse map
+  // lets us also handle clicks on cascading wells (e.g. clicking B1 when A1's
+  // group A1-E1 is selected should deselect the A1 group).
   const handleClickWell = (wellName: string): void => {
-    const prevSelectedTipsByIndex = selectedTips.reduce<Record<string, number>>(
-      (acc, tipList, index) => {
-        const innerAcc = tipList.reduce((acc, tip) => {
-          return { ...acc, [tip]: index }
-        }, {})
-        return { ...acc, ...innerAcc }
-      },
-      {}
-    )
-    if (
-      // always allow tip unselection
-      !(wellName in prevSelectedTipsByIndex) &&
-      (tipState?.[wellName] === 'EMPTY' ||
-        !tipAccessibileStatusByWellName[wellName].isAccessible ||
-        (allWellsAffectedByHover.includes(wellName) &&
-          !areAllHoveredWellsAccessibleAndOccupied))
-    ) {
-      return
+    // Resolve which primary owns this well in the current selection (if any).
+    const owningPrimary = selectedWellToPrimary[wellName]
+    const isAlreadySelected = owningPrimary != null
+
+    // For new selections, `wellName` is always a primary (from handleSelectionDone).
+    const status = tipAccessibileStatusByWellName[wellName]
+
+    if (!isAlreadySelected) {
+      if (!status?.isAccessible) return
+      // Confirm every affected well has a tip — the primary-only isComplete check
+      // in the hook is insufficient when some cascading wells may be empty.
+      const affectedWells = [...status.affectedWells]
+      if (affectedWells.some(w => tipState?.[w] === EMPTY)) return
+      if (!hasPickupsRemaining) return
     }
+
     setShowErrorBanner(false)
 
-    if (channels === 1 || nozzles === SINGLE) {
-      if (wellName in prevSelectedTipsByIndex) {
-        const indexToUnselect = prevSelectedTipsByIndex[wellName]
-        handleUnselectWell(indexToUnselect)
-      } else if (hasPickupsRemaining) {
-        setSelectedTips(prevTips => [...prevTips, [wellName]])
-      }
-    } else if (nozzles === PARTIAL_COLUMN) {
-      if (wellName in prevSelectedTipsByIndex) {
-        const indexToUnselect = prevSelectedTipsByIndex[wellName]
-        handleUnselectWell(indexToUnselect)
-      } else if (hasPickupsRemaining) {
-        const totalTipSelection =
-          PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles] ?? 0
-        const allWellsinColumn = getAllWellsInColumn(wellName, labwareDef)
-        const lengthOfColumn = allWellsinColumn.length
-        const allWellsInPartialColumn = allWellsinColumn.slice(
-          0,
-          lengthOfColumn - totalTipSelection
-        )
-        setSelectedTips(prevTips => [...prevTips, allWellsInPartialColumn])
-      }
-    } else if (
-      (channels === 8 && nozzles === ALL) ||
-      (channels === 96 && nozzles === COLUMN)
-    ) {
-      if (wellName in prevSelectedTipsByIndex) {
-        const indexToUnselect = prevSelectedTipsByIndex[wellName]
-        handleUnselectWell(indexToUnselect)
-      } else if (hasPickupsRemaining) {
-        const allWellsInColumn = getAllWellsInColumn(wellName, labwareDef)
-        setSelectedTips(prevTips => {
-          const newTips = [...prevTips]
-          newTips.push(allWellsInColumn)
-          return newTips
-        })
-      }
-    } else if (channels === 96 && nozzles === ROW) {
-      if (wellName in prevSelectedTipsByIndex) {
-        const indexToUnselect = prevSelectedTipsByIndex[wellName]
-        handleUnselectWell(indexToUnselect)
-      } else if (hasPickupsRemaining) {
-        const allWellsInRow = getAllWellsInRow(wellName, labwareDef)
-        setSelectedTips(prevTips => {
-          const newTips = [...prevTips]
-          newTips.push(allWellsInRow)
-          return newTips
-        })
-      }
-    } else if (channels === 96 && nozzles === ALL) {
-      const allWells = Object.keys(labwareDef.wells)
-      if (wellName in prevSelectedTipsByIndex) {
-        const indexToUnselect = prevSelectedTipsByIndex[wellName]
-        handleUnselectWell(indexToUnselect)
-      } else if (hasPickupsRemaining) {
-        setSelectedTips(prevTips => [...prevTips, allWells])
-      }
+    if (isAlreadySelected) {
+      // Slice removes the owning group and all later selections.
+      const groupIndex = selectedTips.findIndex(g => g[0] === owningPrimary)
+      setSelectedTips(selectedTips.slice(0, groupIndex))
+    } else {
+      const wellsToSelect = [...(status?.affectedWells ?? [wellName])]
+      setSelectedTips([...selectedTips, wellsToSelect])
     }
   }
 
   const handleHoverWell = (e: WellMouseEvent): void => {
     const { wellName } = e
-    const allHoveredWells = getEntireWellSelection(
-      wellName,
-      labwareDef.ordering,
-      nozzles,
-      primaryNozzle,
-      channels
-    )
+
+    // Determine hover group using pre-computed accessibility data:
+    // 1. If the well is part of a selected group, show that group (deselect preview).
+    // 2. If the well is a valid primary, use its pre-computed affectedWells.
+    // 3. If the well is a cascading member of some primary whose shadow would fall
+    //    outside the current selection, use that primary's group.
+    // 4. Fall back to the single well (renders as INACCESSIBLE_INCOMPLETE via null status).
+    const owningPrimary = selectedWellToPrimary[wellName] ?? null
+    let allHoveredWells: string[]
+
+    if (owningPrimary != null) {
+      allHoveredWells =
+        selectedTips.find(g => g[0] === owningPrimary) ?? [wellName]
+    } else {
+      const directStatus = tipAccessibileStatusByWellName[wellName]
+      if (directStatus != null) {
+        allHoveredWells = directStatus.affectedWells
+      } else {
+        // Well is not a valid primary. Use the covering primary's group only when
+        // the shadow (first element) wouldn't land inside the current selection —
+        // snap-back groups can have their first element inside a selected range,
+        // which would confusingly imply a deselect action on hover.
+        const covering = wellToPrimaryStatus[wellName]
+        const coveringFirst = covering?.affectedWells[0]
+        allHoveredWells =
+          covering != null && !flatSelected.has(coveringFirst ?? '')
+            ? covering.affectedWells
+            : [wellName]
+      }
+    }
 
     if (leaveTimeoutRef.current) {
       clearTimeout(leaveTimeoutRef.current)
@@ -301,16 +286,15 @@ export function SelectTips(
       leaveTimeoutRef.current = null
     }, 300)
   }
+
   const selectedWellsByIndex = selectedTips.reduce<Record<string, number>>(
-    (acc, tipList, index) => {
-      const innerAcc = tipList.reduce<Record<string, number>>(
-        (acc, tip) => ({ ...acc, [tip]: index }),
-        {}
-      )
-      return { ...acc, ...innerAcc }
-    },
+    (acc, group, index) => ({
+      ...acc,
+      ...Object.fromEntries(group.map(w => [w, index])),
+    }),
     {}
   )
+
   const handleSelectionMove = (e: MouseEvent, rect: GenericRect): void => {
     if (!e.shiftKey) {
       const wellsUnderRect = _getWellsFromRect(rect)
@@ -322,47 +306,67 @@ export function SelectTips(
       }
     }
   }
+
   const handleSelectionDone = (e: MouseEvent, rect: GenericRect): void => {
     if (!e.shiftKey) {
       const wellsUnderRect = _getWellsFromRect(rect)
-      const filteredWellsUnderRect = wellsUnderRect.filter(wellGroup =>
-        wellGroup.every(
-          wellName =>
-            tipAccessibileStatusByWellName[wellName].isAccessible &&
-            hasPickupsRemaining
-        )
-      )
-      setSelectedTips(prev => {
-        const next = [...prev]
-        const selectedFlat = new Set(prev.flat())
-        const allAlreadySelected = filteredWellsUnderRect.every(group =>
-          group.every(well => selectedFlat.has(well))
-        )
 
-        let updated: string[][]
-        // Remove all wells if the entire selection is already selected
-        if (allAlreadySelected) {
-          const keysToRemove = new Set(wellsUnderRect.map(g => g[0]))
-          updated = next.filter(group => !keysToRemove.has(group[0]))
-        } else {
-          // Add additional selected wells if there is a mixture of selected and unselected
-          updated = [...next]
-          wellsUnderRect.forEach(wellGroup => {
-            const primaryWellInGroup = wellGroup[0]
-            const exists = updated.some(
-              wellGroup => wellGroup[0] === primaryWellInGroup
-            )
-            // Add to update list if the well does not currently exist in the list and is accessible
-            if (!exists && selectedWellsByIndex[primaryWellInGroup] !== 1) {
-              updated.push(wellGroup)
-            }
-          })
+      // For single clicks (zero-size rect), delegate to handleClickWell directly.
+      // The SVG onClick fires after mouseup which causes state conflicts, so we
+      // intercept here while hover context is still intact.
+      if (rect.x0 === rect.x1 && rect.y0 === rect.y1) {
+        // Use the raw well under the mouse rather than the computed primary from
+        // getEntireWellSelection — snap-back groups (e.g. F1→[D1-H1] in a 5-nozzle
+        // D1 config) would otherwise route clicks on invalid wells to a selected
+        // primary and trigger incorrect deselection.
+        const actualClickedWell = Object.keys(getCollidingWells(rect))[0] ?? null
+        if (actualClickedWell != null) {
+          handleClickWell(actualClickedWell)
         }
-        return updated
+        return
+      }
+
+      // For drag selections, filter to accessible primaries only.
+      const filteredWellsUnderRect = wellsUnderRect.filter(wellGroup => {
+        const primaryWell = wellGroup[0]
+        return (
+          (tipAccessibileStatusByWellName[primaryWell]?.isAccessible ?? false) &&
+          hasPickupsRemaining
+        )
       })
+      const primaryWellsInRect = filteredWellsUnderRect.map(g => g[0])
+      const selectedPrimarySet = new Set(selectedTips.map(g => g[0]))
+
+      // Guard against vacuous truth: empty filteredWellsUnderRect must not
+      // trigger the "all already selected → remove" branch.
+      const allAlreadySelected =
+        primaryWellsInRect.length > 0 &&
+        primaryWellsInRect.every(p => selectedPrimarySet.has(p))
+
+      setSelectedTips(prev => {
+        const prevPrimaries = prev.map(g => g[0])
+        let newPrimaries: string[]
+
+        if (allAlreadySelected) {
+          const toRemove = new Set(primaryWellsInRect)
+          newPrimaries = prevPrimaries.filter(p => !toRemove.has(p))
+        } else {
+          const toAdd = primaryWellsInRect.filter(
+            p => !selectedPrimarySet.has(p)
+          )
+          newPrimaries = [...prevPrimaries, ...toAdd]
+        }
+
+        return newPrimaries.map(p => {
+          const aff = tipAccessibileStatusByWellName[p]?.affectedWells
+          return aff != null ? [...aff] : [p]
+        })
+      })
+
       setHoveredWells(null)
     }
   }
+
   let controls: JSX.Element = <></>
   const labware = activeDeckSetup.labware[selectedTiprackId ?? '']
   const slot = getSlotInLocationStack(labware.stack)
@@ -380,33 +384,55 @@ export function SelectTips(
         ? Object.entries(tipState).reduce<Record<string, TipType>>(
             (acc, [wellName, state]) => {
               const rawState = TIP_STATE_TO_TIP_TYPE[state]
+              const primaryStatus = wellToPrimaryStatus[wellName]
               let status = rawState
-              if (!tipAccessibileStatusByWellName[wellName].isAccessible) {
+
+              if (!primaryStatus?.isAccessible) {
                 status = rawState === NO ? NO : INACCESSIBLE
               }
-              if (selectedTips.flat().some(tip => tip === wellName)) {
-                const isAccessible =
-                  tipAccessibileStatusByWellName[wellName].isAccessible
-                if (!isAccessible) {
-                  status = SELECTED_ERROR
-                } else {
-                  status = rawState === USED ? SELECTED_USED : SELECTED
-                }
+
+              if (flatSelected.has(wellName)) {
+                // Find the primary of the group this selected well belongs to.
+                const groupContainingWell = selectedTips.find(group =>
+                  group.includes(wellName)
+                )
+                const primaryOfGroup = groupContainingWell?.[0] ?? wellName
+                const primaryStatus = tipAccessibileStatusByWellName[primaryOfGroup]
+                // Use physical tip state to detect truly erroneous selections.
+                // The accessibility map's isComplete accounts for tipsToIgnore
+                // (= all selected wells), so every group's own wells appear as
+                // incomplete — a false positive. Only COLLISION is safe to read
+                // from the map since it is independent of tipsToIgnore.
+                const affectedWells =
+                  primaryStatus?.affectedWells ?? groupContainingWell ?? [wellName]
+                const hasPhysicallyEmptyWell = affectedWells.some(
+                  w => tipState?.[w] === EMPTY
+                )
+                const isGroupInError =
+                  (primaryStatus != null &&
+                    !primaryStatus.isAccessible &&
+                    primaryStatus.inaccessibleReason === INACCESSIBLE_COLLISION) ||
+                  hasPhysicallyEmptyWell
+                status = isGroupInError
+                  ? SELECTED_ERROR
+                  : rawState === USED
+                  ? SELECTED_USED
+                  : SELECTED
               } else if (allWellsAffectedByHover.includes(wellName)) {
-                if (
-                  areAllHoveredWellsAccessibleAndOccupied &&
-                  hasPickupsRemaining
-                ) {
-                  status = rawState === USED ? SELECTED_USED : SELECTED
-                } else {
-                  status = SELECTED_ERROR
-                }
+                status =
+                  areAllHoveredWellsAccessibleAndOccupied && hasPickupsRemaining
+                    ? rawState === USED
+                      ? SELECTED_USED
+                      : SELECTED
+                    : SELECTED_ERROR
               }
+
               return { ...acc, [wellName]: status }
             },
             {}
           )
         : {}
+
     controls = (
       <>
         <DeckOverlay deckDef={deckDef} />
@@ -415,7 +441,6 @@ export function SelectTips(
           x={slotPosition[0]}
           y={slotPosition[1]}
           showHighlightedWells={false}
-          handleClickWell={handleClickWell}
           onMouseEnterWell={handleHoverWell}
           onMouseLeaveWell={handleLeaveWell}
           selectedTipsByIndex={selectedWellsByIndex}
@@ -436,9 +461,7 @@ export function SelectTips(
             hoveredWell={wellShadow ?? ''}
             selectedLabwareId={selectedTiprackId}
             labwareState={activeDeckSetup.labware}
-            isHoveredWellSelected={selectedTips
-              .flat()
-              .some(tip => tip === wellShadow)}
+            isHoveredWellSelected={flatSelected.has(wellShadow)}
             hasPickupsRemaining={hasPickupsRemaining}
             isAccessible={hoveredWellsInaccessibilityStatus == null}
             inaccessibleReason={hoveredWellsInaccessibilityStatus ?? null}

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
@@ -1,7 +1,13 @@
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 
-import { ALL, COLUMN, ROW } from '@opentrons/shared-data'
+import {
+  ALL,
+  COLUMN,
+  PARTIAL_COLUMN,
+  PARTIAL_NOZZLE_MAP,
+  ROW,
+} from '@opentrons/shared-data'
 import {
   getIsSafePickupWithinTiprack,
   getPipetteMovementSafetyStatus,
@@ -21,6 +27,7 @@ import {
 import type {
   ActiveNozzleNumber,
   NozzleConfigurationStyle,
+  PartialPrimaryNozzles,
   PipetteV2Specs,
   PrimaryNozzleConfigurationStyle,
 } from '@opentrons/shared-data'
@@ -29,31 +36,38 @@ import type { AccessibilityStatus, InaccessibleReason } from '../types'
 export const getWellsToCheck = (
   nozzles: NozzleConfigurationStyle,
   wellOrdering: string[][],
-  channels: ActiveNozzleNumber
+  channels: ActiveNozzleNumber,
+  primaryNozzle?: PrimaryNozzleConfigurationStyle
 ): string[] => {
   if (channels === 96 && nozzles === ALL) {
     return [wellOrdering.flat()[0]]
   } else if (nozzles === ROW) {
     return wellOrdering[0]
   } else if (nozzles === COLUMN || (channels === 8 && nozzles === ALL)) {
-    return wellOrdering.map(row => row[0])
+    return wellOrdering.map(col => col[0])
+  } else if (nozzles === PARTIAL_COLUMN && primaryNozzle != null) {
+    const count = PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
+    // Single-column labware has no snap-back; all wells are valid primaries.
+    const isSingleColumn = wellOrdering.length === 1
+    return wellOrdering.flatMap(column => {
+      if (isSingleColumn) return column
+      // Wells beyond (length - count) would snap back to the same final group,
+      // so only the first (length - count + 1) wells are unique primaries.
+      const uniqueCount = Math.max(1, column.length - count + 1)
+      return column.slice(0, uniqueCount)
+    })
   } else {
     return wellOrdering.flat()
   }
 }
 
 /**
- * Returns a record of tip accessibility status by  tiprack id and well name.
- * Example return:
- * {
- *   'tiprack1Id': {
- *     'A1': {isAccessible: true},
- *     'A2': {isAccessible: false, inaccessibleReason: 'incomplete'},
- *   },
- *   'tiprack2Id': {
- *     'A1': {isAccessible: true},
- *     'A2': {isAccessible: false, inaccessibleReason: 'collision'},
- *   },
+ * Returns accessibility status keyed by tiprack id and PRIMARY well name.
+ * Each entry contains `affectedWells` (the full set of wells the pipette
+ * would pick up from that primary target) plus `isAccessible` / `inaccessibleReason`.
+ *
+ * Only primary wells are keys — cascading wells are represented through
+ * `affectedWells` on their respective primary entry.
  */
 export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
   nozzles: NozzleConfigurationStyle
@@ -73,7 +87,6 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
   } = args
   const robotState = useSelector(getRobotStateAtActiveItem)
   const invariantContext = useSelector(getInvariantContext)
-  const { labwareEntities } = invariantContext
 
   return useMemo(
     () => {
@@ -83,6 +96,7 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
       return Object.entries(robotState.labware).reduce<
         Record<string, Record<string, AccessibilityStatus>>
       >((acc, [id, { stack }]) => {
+        const { labwareEntities } = invariantContext
         const { def, labwareDefURI } = labwareEntities[id]
         const isMatchingTiprackOnDeck =
           !stack.includes(OFFDECK) &&
@@ -99,65 +113,72 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
         const wellNamesToCheck = getWellsToCheck(
           nozzles,
           def.ordering,
-          pipetteChannels
+          pipetteChannels,
+          primaryNozzle
         )
         return {
           ...acc,
-          [id]: wellNamesToCheck.reduce((acc, wellName) => {
-            const { isSafe, isComplete } = getIsSafePickupWithinTiprack({
-              tipState,
-              primaryNozzle,
-              channels: pipetteChannels,
-              nozzleConfiguration: nozzles,
-              wellName,
-              tiprackDef: def,
-              tipsToIgnore: selectedTips.flat(),
-            })
-            const isCollision = getPipetteMovementSafetyStatus({
-              robotState,
-              invariantContext,
-              pipetteId,
-              labwareId: id,
-              wellTargetName: wellName,
-              primaryNozzle,
-              nozzleConfiguration: nozzles,
-            }).isSafe
-            const isAccessible = isSafe && isComplete && !isCollision
-            let inaccessibleReason: InaccessibleReason | null = null
-            if (isCollision) {
-              inaccessibleReason = INACCESSIBLE_COLLISION
-            } else if (!isSafe) {
-              inaccessibleReason = INACCESSIBLE_TOO_MANY_PICKUPS
-            } else if (!isComplete) {
-              inaccessibleReason = INACCESSIBLE_INCOMPLETE
-            }
-            const wellGroup = getEntireWellSelection(
-              wellName,
-              def.ordering,
-              nozzles,
-              primaryNozzle,
-              pipetteChannels
-            )
-            const groupEntries = Object.fromEntries(
-              wellGroup.map(well => [
-                well,
-                {
-                  isAccessible,
-                  ...(inaccessibleReason != null ? { inaccessibleReason } : {}),
-                },
-              ])
-            )
+          [id]: wellNamesToCheck.reduce<Record<string, AccessibilityStatus>>(
+            (tiprackAcc, wellName) => {
+              const { isSafe, isComplete } = getIsSafePickupWithinTiprack({
+                tipState,
+                primaryNozzle,
+                channels: pipetteChannels,
+                nozzleConfiguration: nozzles,
+                wellName,
+                tiprackDef: def,
+                tipsToIgnore: selectedTips.flat(),
+              })
+              const isCollision = !getPipetteMovementSafetyStatus({
+                robotState,
+                invariantContext,
+                pipetteId,
+                labwareId: id,
+                wellTargetName: wellName,
+                primaryNozzle,
+                nozzleConfiguration: nozzles,
+              }).isSafe
+              const isAccessible = isSafe && (isComplete === true) && !isCollision
+              const affectedWells = 
+                getEntireWellSelection(
+                  wellName,
+                  def.ordering,
+                  nozzles,
+                  primaryNozzle,
+                  pipetteChannels
+                )
 
-            return {
-              ...acc,
-              ...groupEntries,
-            }
-          }, {}),
+              let status: AccessibilityStatus
+              if (isAccessible) {
+                status = { isAccessible: true, affectedWells }
+              } else {
+                let inaccessibleReason: InaccessibleReason
+                if ( isCollision) {
+                  inaccessibleReason = INACCESSIBLE_COLLISION
+                } else if (!isSafe) {
+                  inaccessibleReason = INACCESSIBLE_TOO_MANY_PICKUPS
+                } else {
+                  inaccessibleReason = INACCESSIBLE_INCOMPLETE
+                }
+                status = { isAccessible: false, affectedWells, inaccessibleReason }
+              }
+
+              return { ...tiprackAcc, [wellName]: status }
+            },
+            {}
+          ),
         }
       }, {})
     },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedTips]
+    [
+      robotState,
+      invariantContext,
+      nozzles,
+      primaryNozzle,
+      pipetteSpecs,
+      pipetteId,
+      tiprackUri,
+      selectedTips,
+    ]
   )
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
@@ -46,14 +46,18 @@ export const getWellsToCheck = (
   } else if (nozzles === COLUMN || (channels === 8 && nozzles === ALL)) {
     return wellOrdering.map(col => col[0])
   } else if (nozzles === PARTIAL_COLUMN && primaryNozzle != null) {
-    const count = PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
-    // Single-column labware has no snap-back; all wells are valid primaries.
+    // partial column config
+    const nozzleCount =
+      PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
     const isSingleColumn = wellOrdering.length === 1
     return wellOrdering.flatMap(column => {
-      if (isSingleColumn) return column
-      // Wells beyond (length - count) would snap back to the same final group,
-      // so only the first (length - count + 1) wells are unique primaries.
-      const uniqueCount = Math.max(1, column.length - count + 1)
+      if (isSingleColumn) {
+        return column
+      }
+      // find only valid primaries such that the nozzles wouldn't "fall off" the labware
+      // for example, if you have 3 nozzles configured, the only valid wells to check
+      // are column wells A-F (targeting G + H does not supply enough wells)
+      const uniqueCount = Math.max(1, column.length - nozzleCount + 1)
       return column.slice(0, uniqueCount)
     })
   } else {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
@@ -88,97 +88,97 @@ export const useMemoizedTipAccessibilityByTiprackIdByWellName = (args: {
   const robotState = useSelector(getRobotStateAtActiveItem)
   const invariantContext = useSelector(getInvariantContext)
 
-  return useMemo(
-    () => {
-      if (robotState == null) {
-        return {}
+  return useMemo(() => {
+    if (robotState == null) {
+      return {}
+    }
+    return Object.entries(robotState.labware).reduce<
+      Record<string, Record<string, AccessibilityStatus>>
+    >((acc, [id, { stack }]) => {
+      const { labwareEntities } = invariantContext
+      const { def, labwareDefURI } = labwareEntities[id]
+      const isMatchingTiprackOnDeck =
+        !stack.includes(OFFDECK) &&
+        def.parameters.isTiprack &&
+        labwareDefURI === tiprackUri
+      if (!isMatchingTiprackOnDeck) {
+        return acc
       }
-      return Object.entries(robotState.labware).reduce<
-        Record<string, Record<string, AccessibilityStatus>>
-      >((acc, [id, { stack }]) => {
-        const { labwareEntities } = invariantContext
-        const { def, labwareDefURI } = labwareEntities[id]
-        const isMatchingTiprackOnDeck =
-          !stack.includes(OFFDECK) &&
-          def.parameters.isTiprack &&
-          labwareDefURI === tiprackUri
-        if (!isMatchingTiprackOnDeck) {
-          return acc
-        }
-        const tipState = robotState?.tipState.tipracks[id] ?? null
-        if (tipState == null) {
-          return acc
-        }
-        const pipetteChannels = pipetteSpecs.channels
-        const wellNamesToCheck = getWellsToCheck(
-          nozzles,
-          def.ordering,
-          pipetteChannels,
-          primaryNozzle
-        )
-        return {
-          ...acc,
-          [id]: wellNamesToCheck.reduce<Record<string, AccessibilityStatus>>(
-            (tiprackAcc, wellName) => {
-              const { isSafe, isComplete } = getIsSafePickupWithinTiprack({
-                tipState,
-                primaryNozzle,
-                channels: pipetteChannels,
-                nozzleConfiguration: nozzles,
-                wellName,
-                tiprackDef: def,
-                tipsToIgnore: selectedTips.flat(),
-              })
-              const isCollision = !getPipetteMovementSafetyStatus({
-                robotState,
-                invariantContext,
-                pipetteId,
-                labwareId: id,
-                wellTargetName: wellName,
-                primaryNozzle,
-                nozzleConfiguration: nozzles,
-              }).isSafe
-              const isAccessible = isSafe && (isComplete === true) && !isCollision
-              const affectedWells = 
-                getEntireWellSelection(
-                  wellName,
-                  def.ordering,
-                  nozzles,
-                  primaryNozzle,
-                  pipetteChannels
-                )
+      const tipState = robotState?.tipState.tipracks[id] ?? null
+      if (tipState == null) {
+        return acc
+      }
+      const pipetteChannels = pipetteSpecs.channels
+      const wellNamesToCheck = getWellsToCheck(
+        nozzles,
+        def.ordering,
+        pipetteChannels,
+        primaryNozzle
+      )
+      return {
+        ...acc,
+        [id]: wellNamesToCheck.reduce<Record<string, AccessibilityStatus>>(
+          (tiprackAcc, wellName) => {
+            const { isSafe, isComplete } = getIsSafePickupWithinTiprack({
+              tipState,
+              primaryNozzle,
+              channels: pipetteChannels,
+              nozzleConfiguration: nozzles,
+              wellName,
+              tiprackDef: def,
+              tipsToIgnore: selectedTips.flat(),
+            })
+            const isCollision = !getPipetteMovementSafetyStatus({
+              robotState,
+              invariantContext,
+              pipetteId,
+              labwareId: id,
+              wellTargetName: wellName,
+              primaryNozzle,
+              nozzleConfiguration: nozzles,
+            }).isSafe
+            const isAccessible = isSafe && isComplete === true && !isCollision
+            const affectedWells = getEntireWellSelection(
+              wellName,
+              def.ordering,
+              nozzles,
+              primaryNozzle,
+              pipetteChannels
+            )
 
-              let status: AccessibilityStatus
-              if (isAccessible) {
-                status = { isAccessible: true, affectedWells }
+            let status: AccessibilityStatus
+            if (isAccessible) {
+              status = { isAccessible: true, affectedWells }
+            } else {
+              let inaccessibleReason: InaccessibleReason
+              if (isCollision) {
+                inaccessibleReason = INACCESSIBLE_COLLISION
+              } else if (!isSafe) {
+                inaccessibleReason = INACCESSIBLE_TOO_MANY_PICKUPS
               } else {
-                let inaccessibleReason: InaccessibleReason
-                if ( isCollision) {
-                  inaccessibleReason = INACCESSIBLE_COLLISION
-                } else if (!isSafe) {
-                  inaccessibleReason = INACCESSIBLE_TOO_MANY_PICKUPS
-                } else {
-                  inaccessibleReason = INACCESSIBLE_INCOMPLETE
-                }
-                status = { isAccessible: false, affectedWells, inaccessibleReason }
+                inaccessibleReason = INACCESSIBLE_INCOMPLETE
               }
+              status = {
+                isAccessible: false,
+                affectedWells,
+                inaccessibleReason,
+              }
+            }
 
-              return { ...tiprackAcc, [wellName]: status }
-            },
-            {}
-          ),
-        }
-      }, {})
-    },
-    [
-      robotState,
-      invariantContext,
-      nozzles,
-      primaryNozzle,
-      pipetteSpecs,
-      pipetteId,
-      tiprackUri,
-      selectedTips,
-    ]
-  )
+            return { ...tiprackAcc, [wellName]: status }
+          },
+          {}
+        ),
+      }
+    }, {})
+  }, [
+    robotState,
+    invariantContext,
+    nozzles,
+    primaryNozzle,
+    pipetteSpecs,
+    pipetteId,
+    tiprackUri,
+    selectedTips,
+  ])
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
@@ -127,24 +127,24 @@ export function TipSelectionWizard(
       labwareEntities,
       validTiprackIds,
     })
-  const isAnySelectedWellTooManyPickups = selectedTips
-    .some(group => {
-      const primaryWell = group[0]
-      const selectedStatus = selectedTiprackStatus[primaryWell]
-      return (
-        selectedStatus != null &&
-        !selectedStatus.isAccessible &&
-        selectedStatus.inaccessibleReason === INACCESSIBLE_TOO_MANY_PICKUPS
-      )
-    })
+  const isAnySelectedWellTooManyPickups = selectedTips.some(group => {
+    const primaryWell = group[0]
+    const selectedStatus = selectedTiprackStatus[primaryWell]
+    return (
+      selectedStatus != null &&
+      !selectedStatus.isAccessible &&
+      selectedStatus.inaccessibleReason === INACCESSIBLE_TOO_MANY_PICKUPS
+    )
+  })
   // Check physical tip state rather than the accessibility map for incompleteness. The map uses
-  // tipsToIgnore as all selected wells, so every selected group's own wells appear as isComplete=false. 
+  // tipsToIgnore as all selected wells, so every selected group's own wells appear as isComplete=false.
   // A group is actaully incomplete only when a well is physically absent in the robot state.
   const isAnySelectedWellIncomplete =
     tipState != null &&
     selectedTips.some(group => {
       const primary = group[0]
-      const affectedWells = selectedTiprackStatus[primary]?.affectedWells ?? group
+      const affectedWells =
+        selectedTiprackStatus[primary]?.affectedWells ?? group
       return affectedWells.some(w => tipState[w] === EMPTY)
     })
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
 import { getDeckDefFromRobotType } from '@opentrons/shared-data'
-import { DIRTY } from '@opentrons/step-generation'
+import { DIRTY, EMPTY } from '@opentrons/step-generation'
 
 import { useKitchen } from '/protocol-designer/components/organisms/Kitchen/useKitchen'
 import { getRobotType } from '/protocol-designer/file-data/selectors'
@@ -13,10 +13,7 @@ import {
   getRobotStateAtActiveItem,
 } from '/protocol-designer/top-selectors/labware-locations'
 
-import {
-  INACCESSIBLE_INCOMPLETE,
-  INACCESSIBLE_TOO_MANY_PICKUPS,
-} from './constants'
+import { INACCESSIBLE_TOO_MANY_PICKUPS } from './constants'
 import { SelectTiprack } from './SelectTiprack'
 import { SelectTips } from './SelectTips'
 import { TipSelectionModal } from './TipSelectionModal'
@@ -78,7 +75,7 @@ export function TipSelectionWizard(
     tiprackSelected
   )
   const [showErrorBanner, setShowErrorBanner] = useState<boolean>(
-    selectedTips.flat().length > 0
+    selectedTips.length > 0
   )
   const robotState = useSelector(getRobotStateAtActiveItem)
   const tipState =
@@ -93,8 +90,18 @@ export function TipSelectionWizard(
 
   const deckDef = getDeckDefFromRobotType(robotType)
 
+  const selectedTiprackStatus =
+    selectedTiprackId != null ? tipAccessibilityStatus[selectedTiprackId] : {}
+
   const isAnySelectedWellUsed =
-    tipState != null && selectedTips.flat().some(tip => tipState[tip] === DIRTY)
+    tipState != null &&
+    selectedTips.some(group => {
+      const primary = group[0]
+      const affectedWells = selectedTiprackStatus[primary]?.affectedWells
+      return affectedWells != null
+        ? [...affectedWells].some(w => tipState[w] === DIRTY)
+        : group.some(w => tipState[w] === DIRTY)
+    })
   const handleSave = (): void => {
     updateFormTiprackSelected(selectedTiprackId)
     updateFormTipsSelected(selectedTips)
@@ -120,23 +127,26 @@ export function TipSelectionWizard(
       labwareEntities,
       validTiprackIds,
     })
-
-  const selectedTiprackStatus =
-    selectedTiprackId != null ? tipAccessibilityStatus[selectedTiprackId] : {}
   const isAnySelectedWellTooManyPickups = selectedTips
-    .flat()
-    .some(
-      tip =>
-        selectedTiprackStatus[tip].inaccessibleReason ===
-        INACCESSIBLE_TOO_MANY_PICKUPS
-    )
-  const isAnySelectedWellIncomplete = selectedTips
-    .flat()
-    .some(
-      tip =>
-        selectedTiprackStatus[tip].inaccessibleReason ===
-        INACCESSIBLE_INCOMPLETE
-    )
+    .some(group => {
+      const primaryWell = group[0]
+      const selectedStatus = selectedTiprackStatus[primaryWell]
+      return (
+        selectedStatus != null &&
+        !selectedStatus.isAccessible &&
+        selectedStatus.inaccessibleReason === INACCESSIBLE_TOO_MANY_PICKUPS
+      )
+    })
+  // Check physical tip state rather than the accessibility map for incompleteness. The map uses
+  // tipsToIgnore as all selected wells, so every selected group's own wells appear as isComplete=false. 
+  // A group is actaully incomplete only when a well is physically absent in the robot state.
+  const isAnySelectedWellIncomplete =
+    tipState != null &&
+    selectedTips.some(group => {
+      const primary = group[0]
+      const affectedWells = selectedTiprackStatus[primary]?.affectedWells ?? group
+      return affectedWells.some(w => tipState[w] === EMPTY)
+    })
 
   const errorReason = ((): TipSelectionBannerReason | null => {
     if (isAnySelectedWellTooManyPickups) {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
@@ -99,8 +99,8 @@ export function TipSelectionWizard(
       const primary = group[0]
       const affectedWells = selectedTiprackStatus[primary]?.affectedWells
       return affectedWells != null
-        ? [...affectedWells].some(w => tipState[w] === DIRTY)
-        : group.some(w => tipState[w] === DIRTY)
+        ? affectedWells.some(tip => tipState[tip] === DIRTY)
+        : group.some(tip => tipState[tip] === DIRTY)
     })
   const handleSave = (): void => {
     updateFormTiprackSelected(selectedTiprackId)
@@ -138,7 +138,7 @@ export function TipSelectionWizard(
   })
   // Check physical tip state rather than the accessibility map for incompleteness. The map uses
   // tipsToIgnore as all selected wells, so every selected group's own wells appear as isComplete=false.
-  // A group is actaully incomplete only when a well is physically absent in the robot state.
+  // A group is actually incomplete only when a well is physically absent in the robot state.
   const isAnySelectedWellIncomplete =
     tipState != null &&
     selectedTips.some(group => {

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/types.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/types.ts
@@ -55,10 +55,22 @@ export type InaccessibleReason =
   | typeof INACCESSIBLE_PARTIAL_TIP
   | typeof INACCESSIBLE_WELL_SPACING_MISMATCH
 
-export interface AccessibilityStatus {
-  isAccessible: boolean
-  inaccessibleReason?: InaccessibleReason
+
+interface AccessibilityStatusBase {
+  affectedWells: string[]
 }
+interface AccessibleStatus extends AccessibilityStatusBase {
+  isAccessible: true
+}
+
+interface InaccessibleStatus extends AccessibilityStatusBase {
+  isAccessible: false
+  inaccessibleReason: InaccessibleReason
+}
+export type AccessibilityStatus = 
+  | AccessibleStatus
+  | InaccessibleStatus
+
 
 export type TipSelectionBannerReason =
   | 'incompletePickup'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/types.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/types.ts
@@ -55,7 +55,6 @@ export type InaccessibleReason =
   | typeof INACCESSIBLE_PARTIAL_TIP
   | typeof INACCESSIBLE_WELL_SPACING_MISMATCH
 
-
 interface AccessibilityStatusBase {
   affectedWells: string[]
 }
@@ -67,10 +66,7 @@ interface InaccessibleStatus extends AccessibilityStatusBase {
   isAccessible: false
   inaccessibleReason: InaccessibleReason
 }
-export type AccessibilityStatus = 
-  | AccessibleStatus
-  | InaccessibleStatus
-
+export type AccessibilityStatus = AccessibleStatus | InaccessibleStatus
 
 export type TipSelectionBannerReason =
   | 'incompletePickup'

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -539,13 +539,31 @@ export const getIsSafePickupWithinTiprack = (args: {
       const targetWellIndex = tipColumnOrdered.indexOf(wellName)
       const targetWellLength =
         PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
+      // Active nozzle positions in the (possibly reversed) column ordering.
+      // Reversed columns grow toward index 0 (H→G→F→...) so active wells are
+      // slice(targetWellIndex - count + 1, targetWellIndex + 1).
+      // Non-reversed (A1 primary) columns grow toward higher indices so active
+      // wells are slice(targetWellIndex, targetWellIndex + count).
+      const activeWells = shouldReverse
+        ? tipColumnOrdered.slice(
+            targetWellIndex - targetWellLength + 1,
+            targetWellIndex + 1
+          )
+        : tipColumnOrdered.slice(
+            targetWellIndex,
+            targetWellIndex + targetWellLength
+          )
       return {
         isSafe: tipColumnOrdered
-          .slice(targetWellIndex + targetWellLength, tipColumnOrdered.length)
+          .slice(targetWellIndex + 1)
           .every(
             well => tipState[well] === EMPTY || tipsToIgnore.includes(well)
           ),
-        isComplete: tipState[wellName] !== EMPTY,
+        // All active nozzle wells must have tips AND must not be claimed by an
+        // earlier selection in the same wizard session (tipsToIgnore).
+        isComplete: activeWells.every(
+          well => tipState[well] !== EMPTY && !tipsToIgnore.includes(well)
+        ),
       }
     }
     // 8 channel pickup, full column


### PR DESCRIPTION
# Overview

This PR adds a variety of bug fixes and refactors for manual tip pickup, specifically pertaining to partial column pickup with an 8-channel pipette.

Closes RQA-5452, Closes RQA-5348

## Test Plan and Hands on Testing

- import the protocols attached to the tickets and verify that you can successfully build the protocol and manually select tips with partial column
- smoke test with other tip configurations for regressions

## Changelog

####  step-generation/src/utils/safePipetteMovements.ts

- `isComplete` previously only checked whether the primary well itself had a tip. Now it checks all active nozzle positions (the full affected wells group), and excludes wells in `tipsToIgnore` so already-selected wells aren't double-counted
- `isSafe` previously used `slice(targetWellIndex + targetWellLength, ...)`, but the reversed-column formula was wrong. I simplified this to `slice(targetWellIndex + 1)` (everything after the primary in the ordered column).

####  hooks/useMemoizedTipAccessibilityByTiprackIdByWellName.ts
- `getWellsToCheck` now handles `PARTIAL_COLUMN`: only emits the "unique primary" wells per column
- each well's entry now precomputes `affectedWells` (the full group of wells affected by that pickup) 
- fixed `isCollision` logic (was `!.isSafe` inverted — bug present in the original). 

#### types.ts
  - refactor acessibility type and add `affectedWells` property

####  SelectTips.tsx
  
- `handleClickWell` replaced to delegate group membership to `affectedWells` from the accessibility map, rather than having separate branches per nozzle config
- `handleHoverWell` now uses a `selectedWellToPrimary` reverse map to correctly identify selected groups
- `handleSelectionDone` for single clicks uses the raw colliding well rather than `getEntireWellSelection`, preventing incorrect deselects on invalid snap-back wells. 
- Selected well rendering uses physical `tipState` (not the accessibility map) to detect errors, avoiding false positives from `tipsToIgnore`
- `hoveredWellsInaccessibilityStatus` short-circuits to null when hovering a selected group, so the shadow renders to deselect state

#### index.tsx
- `isAnySelectedWellIncomplete` now checks physical tipState for EMPTY wells rather than the accessibility map (same tipsToIgnore artifact fix)
- `isAnySelectedWellTooManyPickups` correctly checks only the group primary, not every cascading well
- `isAnySelectedWellUsed` checks the full `affectedWells` group via the accessibility map.

## Review requests

See test plan. Reach out with any questions about the logic updates

## Risk assessment

medium-high. Unfortunately, combing through the core logic of tip selection from these bugs resulted in necessary logical overhauls. I smoke tested with less problematic configurations with success— addressing partial column is the crux of the fix.