### PR TITLE
Chore(.github): add hw-testing-reviewers hook

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,3 +14,4 @@
 /shared-data/python @Opentrons/py
 /shared-data/python_tests @Opentrons/py
 /shared-data/**/*.py @Opentrons/py
+/hardware-testing/** @Opentrons/hw-testing-reviewers


### PR DESCRIPTION
# Overview
We want to have a little better visibility into what goes on in hardware-testing among the people working on that project.