### PR TITLE
fix(step-generation): fix nozzle configuration for partial column

### DIFF
--- a/step-generation/src/commandCreators/atomic/__tests__/configureNozzleLayout.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/configureNozzleLayout.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { ALL, COLUMN, fixtureP100096V2Specs } from '@opentrons/shared-data'
+import {
+  ALL,
+  COLUMN,
+  fixtureP100096V2Specs,
+  PARTIAL_COLUMN,
+} from '@opentrons/shared-data'
 
 import { getSuccessResult } from '../../../fixtures'
 import { configureNozzleLayout } from '../configureNozzleLayout'
@@ -87,6 +92,37 @@ mock_pipette.configure_nozzle_layout(
 mock_pipette.configure_nozzle_layout(
     protocol_api.COLUMN,
     start="A12",
+)`.trimStart()
+    )
+  })
+  it('should call configureNozzleLayout with correct params for partial column', () => {
+    const result = configureNozzleLayout(
+      {
+        configurationParams: {
+          primaryNozzle: 'D1',
+          style: PARTIAL_COLUMN,
+        },
+        pipetteId: mockPipette,
+      },
+      invariantContext,
+      robotInitialState
+    )
+    const res = getSuccessResult(result)
+    expect(res.commands).toEqual([
+      {
+        commandType: 'configureNozzleLayout',
+        key: expect.any(String),
+        params: {
+          pipetteId: mockPipette,
+          configurationParams: { primaryNozzle: 'D1', style: PARTIAL_COLUMN },
+        },
+      },
+    ])
+    expect(res.python).toBe(
+      `
+mock_pipette.configure_nozzle_layout(
+    protocol_api.PARTIAL_COLUMN,
+    start="D1", end="H1",
 )`.trimStart()
     )
   })

--- a/step-generation/src/commandCreators/atomic/configureNozzleLayout.ts
+++ b/step-generation/src/commandCreators/atomic/configureNozzleLayout.ts
@@ -26,7 +26,7 @@ export const configureNozzleLayout: CommandCreator<
     pythonArgs = [
       `protocol_api.${style}`,
       ...(primaryNozzle != null
-        ? [`start=${formatPyStr(H1_NOZZLE)}, end=${formatPyStr(primaryNozzle)}`]
+        ? [`start=${formatPyStr(primaryNozzle)}, end=${formatPyStr(H1_NOZZLE)}`]
         : []),
     ]
   } else {


### PR DESCRIPTION
- [x] Rebase off `edge` once #21610 merges

# Overview

In PD, creating steps with partial column configrurations sets the primary nozzle to the back-most nozzle select (example: if 4 nozzles, E1-H1 are configured, the primary nozzle is set to E1). Using this logic, we bubble up the back-most tip and well of a selection group to target. However, the configureNozzleLayout command creator was building the start and end backwards (start H1, end [primarynozzle]).  Here, I correctly start at the primary nozzle, and end at nozzle H1 for partial column configurations.

Closes RQA-5372

## Test Plan and Hands on Testing

- upload protocol attached to ticket and re-export
- verify that nozzle configuration correctly starts at nozzle E1 and ends at nozzle H1
- verify that well and tip targets match accordingly (target well A1, target tip A1) such that nozzle E1 will center itself on those targets

## Changelog

- fix nozzle configuration limit for partial column

## Review requests

see test plan

## Risk assessment

low