### PR TITLE
feat(protocol-designer): expose changing settings for running vacuum

### DIFF
--- a/protocol-designer/src/assets/localization/en/protocol_steps.json
+++ b/protocol-designer/src/assets/localization/en/protocol_steps.json
@@ -355,6 +355,7 @@
         "label": "Select the state to change",
         "options": {
           "pump": {
+            "change": "Change vacuum pump settings",
             "off": "Turn off Vacuum pump",
             "on": "Turn on Vacuum pump"
           },

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumControls.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumControls.tsx
@@ -102,6 +102,9 @@ export function VacuumControls(props: VacuumControlsProps): JSX.Element {
     />
   )
 
+  const isPumpOn =
+    vacuumModuleState?.currentPumpActivity.type === 'indefiniteHold'
+
   // Pump / Vent
   if (formData.programType === VACUUM_PROGRAM_STATE) {
     sections.push(
@@ -109,18 +112,20 @@ export function VacuumControls(props: VacuumControlsProps): JSX.Element {
         key="state-type"
         title={t('vacuum.controls.state.label')}
         options={[
-          ...[
-            vacuumModuleState?.currentPumpActivity == null ||
-            vacuumModuleState.currentPumpActivity.type === 'pumpDeactivated'
-              ? {
-                  label: t('vacuum.controls.state.options.pump.on'),
-                  value: VACUUM_STATE_PUMP_ON,
-                }
-              : {
+          ...(isPumpOn
+            ? [
+                {
                   label: t('vacuum.controls.state.options.pump.off'),
                   value: VACUUM_STATE_PUMP_OFF,
                 },
-          ],
+              ]
+            : []),
+          {
+            label: t(
+              `vacuum.controls.state.options.pump.${isPumpOn ? 'change' : 'on'}`
+            ),
+            value: VACUUM_STATE_PUMP_ON,
+          },
           {
             label: t(`vacuum.controls.state.options.vent.${ventToSwitch}`),
             value: ventToSwitch,


### PR DESCRIPTION
# Overview

For an indefintely held pump, we should allow chanigng the pump settings in the step form.
<img width="358" height="841" alt="Screenshot 2026-05-28 at 4 51 00 PM" src="https://github.com/user-attachments/assets/1c27f8ff-2ef4-44e6-89bd-73a4e30ff82b" />

Closes EXEC-2698

## Test Plan and Hands on Testing

- create or import a vacuum profile in which the most recent vacuum pump step was an indefinite pump hold
- duplicate or create a new vacuum step
- verify that there is an option to change the vacuum pump settings for the running pump

## Changelog

- maintain a button for setting the vacuum pump even if the pump is on 

## Review requests

see test plan

## Risk assessment

low