### PR TITLE
feat(api): add papi commands for open/close vent

### DIFF
--- a/api/src/opentrons/legacy_commands/module_commands.py
+++ b/api/src/opentrons/legacy_commands/module_commands.py
@@ -386,3 +386,23 @@ def vacuum_module_start_execute_profile(
         "name": command_types.VACUUM_MODULE_START_EXECUTE_PROFILE,
         "payload": {"text": text},
     }
+
+
+def vacuum_module_open_vent(
+    self: Any,
+) -> command_types.VacuumModuleOpenVentCommand:
+    text = f"Stopping module {self}"
+    return {
+        "name": command_types.VACUUM_MODULE_OPEN_VENT,
+        "payload": {"text": text},
+    }
+
+
+def vacuum_module_close_vent(
+    self: Any,
+) -> command_types.VacuumModuleCloseVentCommand:
+    text = f"Stopping module {self}"
+    return {
+        "name": command_types.VACUUM_MODULE_CLOSE_VENT,
+        "payload": {"text": text},
+    }

--- a/api/src/opentrons/legacy_commands/types.py
+++ b/api/src/opentrons/legacy_commands/types.py
@@ -111,6 +111,8 @@ VACUUM_MODULE_STOP_VACUUM: Final = "command.VACUUM_MODULE_STOP_VACUUM"
 VACUUM_MODULE_START_EXECUTE_PROFILE: Final = (
     "command.VACUUM_MODULE_START_EXECUTE_PROFILE"
 )
+VACUUM_MODULE_OPEN_VENT: Final = "command.VACUUM_MODULE_OPEN_VENT"
+VACUUM_MODULE_CLOSE_VENT: Final = "command.VACUUM_MODULE_CLOSE_VENT"
 
 # Robot #
 ROBOT_MOVE_TO: Final = "command.ROBOT_MOVE_TO"
@@ -479,6 +481,16 @@ class VacuumModuleStopVacuumCommand(TypedDict):
 
 class VacuumModuleStartExecuteProfileCommand(TypedDict):
     name: Literal["command.VACUUM_MODULE_START_EXECUTE_PROFILE"]
+    payload: TextOnlyPayload
+
+
+class VacuumModuleOpenVentCommand(TypedDict):
+    name: Literal["command.VACUUM_MODULE_OPEN_VENT"]
+    payload: TextOnlyPayload
+
+
+class VacuumModuleCloseVentCommand(TypedDict):
+    name: Literal["command.VACUUM_MODULE_CLOSE_VENT"]
     payload: TextOnlyPayload
 
 
@@ -920,6 +932,8 @@ Command = Union[
     VacuumModuleStartSetVacuumPowerCommand,
     VacuumModuleStopVacuumCommand,
     VacuumModuleStartExecuteProfileCommand,
+    VacuumModuleOpenVentCommand,
+    VacuumModuleCloseVentCommand,
     # Task commands
     WaitForTasksCommand,
     CreateTimerCommand,

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -1273,3 +1273,15 @@ class VacuumModuleCore(ModuleCore, AbstractVacuumModuleCore[LabwareCore]):
             engine_client=self._engine_client, task_id=result.taskId
         )
         return start_execute_profile_result
+
+    def open_vent(self) -> None:
+        self._engine_client.execute_command(
+            cmd.vacuum_module.OpenVentParams(moduleId=self.module_id),
+            command_annotations=self._protocol_core.annotation_ids,
+        )
+
+    def close_vent(self) -> None:
+        self._engine_client.execute_command(
+            cmd.vacuum_module.CloseVentParams(moduleId=self.module_id),
+            command_annotations=self._protocol_core.annotation_ids,
+        )

--- a/api/src/opentrons/protocol_api/core/engine/module_core.py
+++ b/api/src/opentrons/protocol_api/core/engine/module_core.py
@@ -1215,8 +1215,7 @@ class VacuumModuleCore(ModuleCore, AbstractVacuumModuleCore[LabwareCore]):
         )
 
     def _convert_vm_profile_steps(
-        self,
-        steps: List[VacuumModuleStep],
+        self, steps: List[VacuumModuleStep], repetitions: int
     ) -> cmd.vacuum_module.ProfileType:
         protocol_engine_steps: cmd.vacuum_module.ProfileType = []
 
@@ -1250,8 +1249,7 @@ class VacuumModuleCore(ModuleCore, AbstractVacuumModuleCore[LabwareCore]):
                     gaugePressureMbar=gauge_pressure_mbar,
                 )
                 protocol_engine_steps.append(pe_pressure_step)
-
-        return protocol_engine_steps
+        return protocol_engine_steps * repetitions
 
     def start_execute_profile(
         self,
@@ -1261,7 +1259,9 @@ class VacuumModuleCore(ModuleCore, AbstractVacuumModuleCore[LabwareCore]):
         """Start the execution of a vacuum module profile and return a task."""
         self._repetitions = repetitions
         self._step_count = len(steps)
-        engine_steps = self._convert_vm_profile_steps(steps)
+        engine_steps = self._convert_vm_profile_steps(
+            steps=steps, repetitions=repetitions
+        )
         result = self._engine_client.execute_command_without_recovery(
             cmd.vacuum_module.StartRunProfileParams(
                 moduleId=self.module_id,

--- a/api/src/opentrons/protocol_api/core/module.py
+++ b/api/src/opentrons/protocol_api/core/module.py
@@ -587,3 +587,15 @@ class AbstractVacuumModuleCore(
         repetitions: int,
     ) -> AbstractTaskCore:
         """Start a vacuum module profile."""
+
+    @abstractmethod
+    def open_vent(
+        self,
+    ) -> None:
+        """Open the vent."""
+
+    @abstractmethod
+    def close_vent(
+        self,
+    ) -> None:
+        """Close the vent."""

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -2010,3 +2010,15 @@ class VacuumModuleContext(ModuleContext):
             repetitions=repetitions,
         )
         return Task(api_version=self._api_version, core=task)
+
+    @requires_version(2, 28)
+    @publish(command=cmds.vacuum_module_open_vent)
+    def open_vent(self) -> None:
+        """Opens the vent."""
+        self._core.open_vent()
+
+    @requires_version(2, 28)
+    @publish(command=cmds.vacuum_module_close_vent)
+    def close_vent(self) -> None:
+        """Closes the vent."""
+        self._core.close_vent()

--- a/api/tests/opentrons/protocol_api/core/engine/test_vacuum_module_core.py
+++ b/api/tests/opentrons/protocol_api/core/engine/test_vacuum_module_core.py
@@ -1,5 +1,7 @@
 """Tests for Flex Stacker Engine Core."""
 
+from typing import List
+
 import pytest
 from decoy import Decoy
 
@@ -11,8 +13,14 @@ from opentrons.hardware_control.modules.types import (
 from opentrons.protocol_api import MAX_SUPPORTED_VERSION
 from opentrons.protocol_api.core.engine.module_core import VacuumModuleCore
 from opentrons.protocol_api.core.engine.protocol import ProtocolCore
+from opentrons.protocol_api.core.engine.tasks import EngineTaskCore
 from opentrons.protocol_engine import commands as cmd
 from opentrons.protocol_engine.clients import SyncClient as EngineClient
+from opentrons.protocols.api_support.types import (
+    VacuumModulePowerStep,
+    VacuumModulePressureStep,
+    VacuumModuleStep,
+)
 
 SyncVacuumModuleHardware = SynchronousAdapter[VacuumModule]
 
@@ -144,6 +152,128 @@ def test_stop_vacuum(
     decoy.verify(
         mock_engine_client.execute_command(
             cmd.vacuum_module.StopVacuumParams(
+                moduleId="1234",
+            ),
+            command_annotations=[],
+        )
+    )
+
+
+def test_start_execute_profile(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: VacuumModuleCore
+) -> None:
+    """Verify that the pe profile command gets called w the correct params."""
+    papi_profile_steps: List[VacuumModuleStep] = [
+        VacuumModulePressureStep(
+            enable_pump=True,
+            hold_time_seconds=143,
+            ramp_rate=2.2,
+            timeout_seconds=200,
+            vent_after=True,
+            gauge_pressure_mbar=-99,
+        ),
+        VacuumModulePowerStep(
+            enable_pump=True,
+            hold_time_seconds=23,
+            ramp_rate=20.9,
+            timeout_seconds=300,
+            vent_after=None,
+            percent_power=40,
+        ),
+        VacuumModulePressureStep(
+            enable_pump=False,
+            hold_time_seconds=324,
+            ramp_rate=2.2,
+            timeout_seconds=200,
+            vent_after=True,
+            gauge_pressure_mbar=-10,
+        ),
+        VacuumModulePowerStep(
+            enable_pump=True,
+            hold_time_seconds=120,
+            ramp_rate=100,
+            timeout_seconds=18,
+            vent_after=False,
+            percent_power=50,
+        ),
+    ]
+    expected_pe_profile_steps: cmd.vacuum_module.ProfileType = [
+        cmd.vacuum_module.VacuumModuleProfilePressureStep(
+            enablePump=True,
+            holdTimeSeconds=143,
+            rampRate=2.2,
+            timeoutSeconds=200,
+            ventAfter=True,
+            gaugePressureMbar=-99,
+        ),
+        cmd.vacuum_module.VacuumModuleProfilePowerStep(
+            enablePump=True,
+            holdTimeSeconds=23,
+            rampRate=20.9,
+            timeoutSeconds=300,
+            ventAfter=None,
+            percentPower=40,
+        ),
+        cmd.vacuum_module.VacuumModuleProfilePressureStep(
+            enablePump=False,
+            holdTimeSeconds=324,
+            rampRate=2.2,
+            timeoutSeconds=200,
+            ventAfter=True,
+            gaugePressureMbar=-10,
+        ),
+        cmd.vacuum_module.VacuumModuleProfilePowerStep(
+            enablePump=True,
+            holdTimeSeconds=120,
+            rampRate=100,
+            timeoutSeconds=18,
+            ventAfter=False,
+            percentPower=50,
+        ),
+    ]
+    repetitions = 3
+
+    task_mock = decoy.mock(cls=EngineTaskCore)
+    decoy.when(
+        mock_engine_client.execute_command_without_recovery(
+            cmd.vacuum_module.StartRunProfileParams(
+                moduleId="1234",
+                profile=expected_pe_profile_steps * repetitions,
+            ),
+            command_annotations=[],
+        )
+    ).then_return(cmd.vacuum_module.StartRunProfileResult(taskId="taskId"))
+    task_mock._id = "taskId"
+    result = subject.start_execute_profile(
+        steps=papi_profile_steps, repetitions=repetitions
+    )
+    assert isinstance(result, EngineTaskCore)
+    assert result._id == "taskId"
+
+
+def test_open_vent(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: VacuumModuleCore
+) -> None:
+    """Make sure pe open vent gets called corrrectly."""
+    subject.open_vent()
+    decoy.verify(
+        mock_engine_client.execute_command(
+            cmd.vacuum_module.OpenVentParams(
+                moduleId="1234",
+            ),
+            command_annotations=[],
+        )
+    )
+
+
+def test_close_vent(
+    decoy: Decoy, mock_engine_client: EngineClient, subject: VacuumModuleCore
+) -> None:
+    """Make sure pe close vent gets called corrrectly."""
+    subject.close_vent()
+    decoy.verify(
+        mock_engine_client.execute_command(
+            cmd.vacuum_module.CloseVentParams(
                 moduleId="1234",
             ),
             command_annotations=[],


### PR DESCRIPTION
## Overview
This adds and wires papi commands for open/close vent. 

It also includes a fix for `start_execute_profile` where the module core function was dropping the `repetitions` parameter.

## Changelog

- add module_core unit tests for `open_vent`, `close_vent`, `start_execute_profile`
- add `open_vent`, `close_vent` at the papi level