### PR TITLE
feat(step-generation): update vacuum profile python args

### DIFF
--- a/step-generation/src/commandCreators/atomic/__tests__/vacuumStartRunProfile.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/vacuumStartRunProfile.test.ts
@@ -90,7 +90,7 @@ describe('vacuumStartRunProfile', () => {
 mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
     profile=[
         {
-            "gauge_pressure": 55,
+            "gauge_pressure_mbar": 55,
             "hold_time_seconds": 12,
             "vent_after": False,
         }
@@ -138,7 +138,7 @@ mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
 mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
     profile=[
         {
-            "power_percent": 30,
+            "percent_power": 30,
             "hold_time_seconds": 5,
             "vent_after": False,
         }

--- a/step-generation/src/utils/vacuumPythonArgs/__tests__/getVacuumProfileStepString.test.ts
+++ b/step-generation/src/utils/vacuumPythonArgs/__tests__/getVacuumProfileStepString.test.ts
@@ -17,7 +17,7 @@ describe('getVacuumProfileStepString', () => {
     expect(getVacuumProfileStepString(profile)).toEqual([
       `profile=[
     {
-        "gauge_pressure": 55,
+        "gauge_pressure_mbar": 55,
         "hold_time_seconds": 12,
         "vent_after": False,
     }
@@ -33,7 +33,7 @@ describe('getVacuumProfileStepString', () => {
     expect(getVacuumProfileStepString(profile)).toEqual([
       `profile=[
     {
-        "power_percent": 30,
+        "percent_power": 30,
         "hold_time_seconds": 5,
         "vent_after": False,
     }
@@ -59,7 +59,7 @@ describe('getVacuumProfileStepString', () => {
     expect(getVacuumProfileStepString(profile)).toEqual([
       `profile=[
     {
-        "gauge_pressure": 30,
+        "gauge_pressure_mbar": 30,
         "hold_time_seconds": 5,
         "vent_after": False,
     }
@@ -86,12 +86,12 @@ describe('getVacuumProfileStepString', () => {
     expect(getVacuumProfileStepString(profile)).toEqual([
       `profile=[
     {
-        "gauge_pressure": 10,
+        "gauge_pressure_mbar": 10,
         "hold_time_seconds": 1,
         "vent_after": False,
     },
     {
-        "gauge_pressure": 20,
+        "gauge_pressure_mbar": 20,
         "hold_time_seconds": 2,
         "vent_after": False,
     }
@@ -123,17 +123,17 @@ describe('getVacuumProfileStepString', () => {
     expect(getVacuumProfileStepString(profile)).toEqual([
       `profile=[
     {
-        "gauge_pressure": 100,
+        "gauge_pressure_mbar": 100,
         "hold_time_seconds": 1,
         "vent_after": False,
     },
     {
-        "power_percent": 30,
+        "percent_power": 30,
         "hold_time_seconds": 5,
         "vent_after": False,
     },
     {
-        "power_percent": 30,
+        "percent_power": 30,
         "hold_time_seconds": 5,
         "vent_after": False,
     }
@@ -165,12 +165,12 @@ describe('getVacuumProfileStepString', () => {
     expect(getVacuumProfileStepString(profile)).toEqual([
       `profile=[
     {
-        "gauge_pressure": 1,
+        "gauge_pressure_mbar": 1,
         "hold_time_seconds": 1,
         "vent_after": False,
     },
     {
-        "power_percent": 50,
+        "percent_power": 50,
         "hold_time_seconds": 2,
         "vent_after": True,
     }

--- a/step-generation/src/utils/vacuumPythonArgs/getVacuumProfileStepString.ts
+++ b/step-generation/src/utils/vacuumPythonArgs/getVacuumProfileStepString.ts
@@ -39,14 +39,14 @@ const _getVacuumProfileAtomicStepString = (
   if ('gaugePressureMbar' in step) {
     const { gaugePressureMbar } = step
     return formatPyDict({
-      gauge_pressure: gaugePressureMbar,
+      gauge_pressure_mbar: gaugePressureMbar,
       ...baseDict,
       vent_after: ventAfter,
     })
   }
   const { percentPower } = step
   return formatPyDict({
-    power_percent: Number(percentPower),
+    percent_power: Number(percentPower),
     ...baseDict,
     vent_after: ventAfter,
   })


### PR DESCRIPTION
# Overview

This PR updates Python args in vacuum profile command creator Python emission.

Closes EXEC-2608

## Test Plan and Hands on Testing
[test_module_profile.py](https://github.com/user-attachments/files/28368740/test_module_profile.py)

- create or import a protocol with a gauge pressure vacuum profile and a percent power vacuum profile
- export and inspect python args (`gauge_pressure_mbar` and `percent_power`)

## Changelog

- update Python emitted from vacuum profile command creator

## Review requests

see test plan

## Risk assessment

⬇️ 