### PR TITLE
fix(protocol-designer): permissive universal lid moves

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -5,6 +5,7 @@ import {
   FLEX_SINGLE_SLOT_ADDRESSABLE_AREAS,
   FLEX_STACKER_MODULE_TYPE,
   FLEX_STAGING_AREA_SLOT_ADDRESSABLE_AREAS,
+  getIsLid,
   getModuleDisplayName,
   OT2_SINGLE_SLOT_ADDRESSABLE_AREAS,
   VACUUM_MODULE_TYPE,
@@ -39,7 +40,10 @@ import { hoverSelection } from '/protocol-designer/ui/steps/actions/actions'
 
 import { getSortedAddressableArea } from './utils'
 
-import type { AddressableAreaName } from '@opentrons/shared-data'
+import type {
+  AddressableAreaName,
+  LabwareDefinition,
+} from '@opentrons/shared-data'
 import type { Option } from '/protocol-designer/top-selectors/labware-locations'
 import type { FieldProps } from '../../types'
 
@@ -122,7 +126,6 @@ export function LabwareLocationField(
   // check lid-compatible labware and modules
   if (isLabwareALid) {
     const def = labwareEntities[labware]?.def
-    console.log(Object.keys(def?.stackingOffsetWithLabware ?? {}))
     const compatibleParentLoadNames = new Set([
       ...(def?.compatibleParentLabware ?? []),
       ...Object.keys(def?.stackingOffsetWithLabware ?? {}),
@@ -136,11 +139,15 @@ export function LabwareLocationField(
             moduleEntities[value].model
           )
         } else if (value in labwareEntities) {
-          isCompatible =
-            compatibleParentLoadNames.has(
-              labwareEntities[value].def.parameters.loadName
-            ) || def.parameters.loadName === 'opentrons_tough_universal_lid'
-          // universal  lid can be moved onto any labware
+          const isCompatibleFromDefinition = compatibleParentLoadNames.has(
+            labwareEntities[value].def.parameters.loadName
+          )
+          const { def: defToMoveTo } = labwareEntities[value]
+          const isAllowedForUniversalLid =
+            def.parameters.loadName === 'opentrons_tough_universal_lid' &&
+            // moving to a non-lid is allowed implicitly
+            !getIsLid(defToMoveTo)
+          isCompatible = isCompatibleFromDefinition || isAllowedForUniversalLid
         }
         return isCompatible
       })
@@ -263,4 +270,8 @@ export function LabwareLocationField(
       menuPlacement="bottom"
     />
   )
+}
+
+const getIsUniversalLid = (def: LabwareDefinition): boolean => {
+  return def.parameters.loadName === 'opentrons_tough_universal_lid'
 }

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -122,6 +122,7 @@ export function LabwareLocationField(
   // check lid-compatible labware and modules
   if (isLabwareALid) {
     const def = labwareEntities[labware]?.def
+    console.log(Object.keys(def?.stackingOffsetWithLabware ?? {}))
     const compatibleParentLoadNames = new Set([
       ...(def?.compatibleParentLabware ?? []),
       ...Object.keys(def?.stackingOffsetWithLabware ?? {}),
@@ -135,9 +136,11 @@ export function LabwareLocationField(
             moduleEntities[value].model
           )
         } else if (value in labwareEntities) {
-          isCompatible = compatibleParentLoadNames.has(
-            labwareEntities[value].def.parameters.loadName
-          )
+          isCompatible =
+            compatibleParentLoadNames.has(
+              labwareEntities[value].def.parameters.loadName
+            ) || def.parameters.loadName === 'opentrons_tough_universal_lid'
+          // universal  lid can be moved onto any labware
         }
         return isCompatible
       })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -40,10 +40,7 @@ import { hoverSelection } from '/protocol-designer/ui/steps/actions/actions'
 
 import { getSortedAddressableArea } from './utils'
 
-import type {
-  AddressableAreaName,
-  LabwareDefinition,
-} from '@opentrons/shared-data'
+import type { AddressableAreaName } from '@opentrons/shared-data'
 import type { Option } from '/protocol-designer/top-selectors/labware-locations'
 import type { FieldProps } from '../../types'
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLabwareTools/LabwareLocationField.tsx
@@ -271,7 +271,3 @@ export function LabwareLocationField(
     />
   )
 }
-
-const getIsUniversalLid = (def: LabwareDefinition): boolean => {
-  return def.parameters.loadName === 'opentrons_tough_universal_lid'
-}


### PR DESCRIPTION
# Overview

This PR exposes available labware as destinations for universal lids. Universal lids are able to be moved to any non-lid labware, in addition to any compatible labware explicitly listed in their definition.

Closes [RQA-5414](https://opentrons.atlassian.net/browse/RQA-5414)

## Test Plan and Hands on Testing

- upload the protocol attached to the ticket
- open the move step with the universal lid as the target
- open the destination field, and verify that labware according to the above are exposed as possible destinations
- export and simulate without errors

## Changelog

- special case universal lid for more permissive moves

## Review requests

see test plan

## Risk assessment

low

[RQA-5414]: https://opentrons.atlassian.net/browse/RQA-5414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ