### PR TITLE
refactor(protocol-designer): comment 8.11.0 migration out

### DIFF
--- a/protocol-designer/src/load-file/migration/index.ts
+++ b/protocol-designer/src/load-file/migration/index.ts
@@ -22,7 +22,8 @@ import { migrateFile as migrateFileEightSeven } from './8_7_0'
 import { migrateFile as migrateFileEightEight } from './8_8_0'
 import { isBroken890Export, migrateFile as migrateFileEightNine } from './8_9_0'
 import { migrateFile as migrateFileEightTen } from './8_10_0'
-import { migrateFile as migrateFileEightEleven } from './8_11_0'
+
+// import { migrateFile as migrateFileEightEleven } from './8_11_0'
 
 import type {
   PDProtocolFile,
@@ -87,8 +88,10 @@ export const allMigrationsByVersion: MigrationsByVersion = {
   '8.9.0': migrateFileEightNine,
   // @ts-expect-error
   '8.10.0': migrateFileEightTen,
-  // @ts-expect-error
-  '8.11.0': migrateFileEightEleven,
+  // TODO (nd, 05/28/2026) The feature work scoped in what was previously slated
+  // as release 8.11.0 is coming after an intermediate Flex/OT-2 split release (9.0.0)
+  // I will re-wire up the 8.11.0 migration and rename appropriately to 9.1.0 as that
+  // release approaches.
 }
 export const migration = (
   file: any


### PR DESCRIPTION
# Overview

The feature work scoped in what was previously slated as release 8.11.0 is coming after an intermediate Flex/OT-2 split release (9.0.0). I will re-wire up the 8.11.0 migration and rename appropriately to 9.1.0 as that release approaches.

Closes RQA-5436

## Test Plan and Hands on Testing

just inspect code

## Changelog

- comment out latest migration relevant to vacuum module feature

## Review requests

Do we actually need this, since none of the work done in the migration is surfaced in PD without utilization of the vacuum module, which will be hidden behind a feature flag?

## Risk assessment

low