### PR TITLE
refactor(components): Rename --border-radius-200 to --border-radius-full

### DIFF
--- a/.cursor/skills/css-modules/SKILL.md
+++ b/.cursor/skills/css-modules/SKILL.md
@@ -123,7 +123,7 @@ All tokens are defined in `components/src/styles/global.css`. **Always use these
 
 ### Border Radius
 
-`--border-radius-2`, `--border-radius-4`, `--border-radius-8`, `--border-radius-12`, `--border-radius-16`, `--border-radius-40`, `--border-radius-200` (pill/circle)
+`--border-radius-2`, `--border-radius-4`, `--border-radius-8`, `--border-radius-12`, `--border-radius-16`, `--border-radius-40`, `--border-radius-full` (pill/circle)
 
 ### Typography
 

--- a/app/src/organisms/ODD/Navigation/navigation.module.css
+++ b/app/src/organisms/ODD/Navigation/navigation.module.css
@@ -47,7 +47,7 @@
   height: 3.75rem;
   flex: none;
   align-content: center;
-  border-radius: var(--border-radius-200);
+  border-radius: var(--border-radius-full);
   background-color: var(--black-90);
   color: var(--white);
   font-size: var(--font-size-28);

--- a/components/src/helix-design-system/borders.ts
+++ b/components/src/helix-design-system/borders.ts
@@ -9,6 +9,10 @@ export const borderRadius8 = '8px'
 export const borderRadius12 = '12px'
 export const borderRadius16 = '16px'
 export const borderRadius40 = '40px'
+/**
+ * Round to a pill or full circle. The exact value here is arbitrary and might change.
+ * It just needs to be greater than the element's width and height.
+ */
 export const borderRadiusFull = '200px'
 
 /**

--- a/components/src/styles/global.css
+++ b/components/src/styles/global.css
@@ -125,7 +125,9 @@
   --border-radius-12: 0.75rem; /* 12px */
   --border-radius-16: 1rem; /* 16px */
   --border-radius-40: 2.5rem; /* 40px */
-  --border-radius-200: 50rem; /* 200px */
+  /* Round to a pill or full circle. The exact value here is arbitrary and might
+  change. It just needs to be greater than the element's width and height. */
+  --border-radius-full: 50rem; /* 200px */
 
   /* font-size */
   --font-size-80: 5rem; /* 80px */

--- a/components/src/styles/global.css
+++ b/components/src/styles/global.css
@@ -127,7 +127,7 @@
   --border-radius-40: 2.5rem; /* 40px */
   /* Round to a pill or full circle. The exact value here is arbitrary and might
   change. It just needs to be greater than the element's width and height. */
-  --border-radius-full: 50rem; /* 200px */
+  --border-radius-full: 50rem;
 
   /* font-size */
   --font-size-80: 5rem; /* 80px */

--- a/components/src/styles/global.css
+++ b/components/src/styles/global.css
@@ -125,6 +125,7 @@
   --border-radius-12: 0.75rem; /* 12px */
   --border-radius-16: 1rem; /* 16px */
   --border-radius-40: 2.5rem; /* 40px */
+
   /* Round to a pill or full circle. The exact value here is arbitrary and might
   change. It just needs to be greater than the element's width and height. */
   --border-radius-full: 50rem;


### PR DESCRIPTION
## Overview

This renames our `--border-radius-200` CSS variable to `--border-radius-full`. This matches what it's named [in TypeScript](https://github.com/Opentrons/opentrons/blob/adc0ebdeb36f4eab88cf52e2c4d46ea7464dce31/components/src/helix-design-system/borders.ts#L12), and what it's named in Figma. It seems like 200px is an arbitrary value—it may as well have been 99999px.

## Test Plan and Hands on Testing

None needed.

## Changelog

Just find+replace.

## Review requests

None.

## Risk assessment

Low.