### PR TITLE
fix(server-utils): check for acm enabled and required reasons for interaction

### DIFF
--- a/robot-server/robot_server/fastapi_dependencies.py
+++ b/robot-server/robot_server/fastapi_dependencies.py
@@ -64,7 +64,7 @@ async def get_audit_logger(
         return
     if (
         not audit_logger.did_log
-        and await authorization_checker.get_require_reason_for_interaction_enabled()
+        and await authorization_checker.is_reason_for_interaction_required()
     ):
         raise RuntimeError(
             "Internal error: the endpoint forgot to send anything to the audit log."

--- a/robot-server/tests/test_fastapi_dependencies.py
+++ b/robot-server/tests/test_fastapi_dependencies.py
@@ -41,7 +41,7 @@ async def test_audit_logger_log_records_when_required(
     with (
         patch.object(
             checker,
-            "get_require_reason_for_interaction_enabled",
+            "is_require_reason_for_interaction_enabled",
             new=AsyncMock(return_value=True),
         ),
         caplog.at_level(logging.INFO, logger=_AUDIT_LOGGER),
@@ -64,7 +64,7 @@ async def test_get_audit_logger_raises_when_required_but_forgot_to_log() -> None
     checker = AlwaysAllowedAuthorizationChecker()
     with patch.object(
         checker,
-        "get_require_reason_for_interaction_enabled",
+        "is_require_reason_for_interaction_enabled",
         new=AsyncMock(return_value=True),
     ):
         generator: AsyncGenerator[AuditLogger, None] = get_audit_logger(
@@ -101,7 +101,7 @@ async def test_get_audit_logger_skips_enforcement_for_get() -> None:
     checker = AlwaysAllowedAuthorizationChecker()
     with patch.object(
         checker,
-        "get_require_reason_for_interaction_enabled",
+        "is_require_reason_for_interaction_enabled",
         new=AsyncMock(return_value=True),
     ):
         generator = get_audit_logger(
@@ -129,7 +129,7 @@ async def test_audit_logger_log_records_run_action_when_required(
     with (
         patch.object(
             checker,
-            "get_require_reason_for_interaction_enabled",
+            "is_require_reason_for_interaction_enabled",
             new=AsyncMock(return_value=True),
         ),
         caplog.at_level(logging.INFO, logger=_AUDIT_LOGGER),
@@ -178,7 +178,7 @@ async def test_audit_logger_log_raises_when_notes_required_but_missing(
     with (
         patch.object(
             checker,
-            "get_require_reason_for_interaction_enabled",
+            "is_require_reason_for_interaction_enabled",
             new=AsyncMock(return_value=True),
         ),
         pytest.raises(MissingUserNotesError),

--- a/robot-server/tests/test_fastapi_dependencies.py
+++ b/robot-server/tests/test_fastapi_dependencies.py
@@ -41,7 +41,7 @@ async def test_audit_logger_log_records_when_required(
     with (
         patch.object(
             checker,
-            "is_require_reason_for_interaction_enabled",
+            "is_reason_for_interaction_required",
             new=AsyncMock(return_value=True),
         ),
         caplog.at_level(logging.INFO, logger=_AUDIT_LOGGER),
@@ -64,7 +64,7 @@ async def test_get_audit_logger_raises_when_required_but_forgot_to_log() -> None
     checker = AlwaysAllowedAuthorizationChecker()
     with patch.object(
         checker,
-        "is_require_reason_for_interaction_enabled",
+        "is_reason_for_interaction_required",
         new=AsyncMock(return_value=True),
     ):
         generator: AsyncGenerator[AuditLogger, None] = get_audit_logger(
@@ -101,7 +101,7 @@ async def test_get_audit_logger_skips_enforcement_for_get() -> None:
     checker = AlwaysAllowedAuthorizationChecker()
     with patch.object(
         checker,
-        "is_require_reason_for_interaction_enabled",
+        "is_reason_for_interaction_required",
         new=AsyncMock(return_value=True),
     ):
         generator = get_audit_logger(
@@ -129,7 +129,7 @@ async def test_audit_logger_log_records_run_action_when_required(
     with (
         patch.object(
             checker,
-            "is_require_reason_for_interaction_enabled",
+            "is_reason_for_interaction_required",
             new=AsyncMock(return_value=True),
         ),
         caplog.at_level(logging.INFO, logger=_AUDIT_LOGGER),
@@ -178,7 +178,7 @@ async def test_audit_logger_log_raises_when_notes_required_but_missing(
     with (
         patch.object(
             checker,
-            "is_require_reason_for_interaction_enabled",
+            "is_reason_for_interaction_required",
             new=AsyncMock(return_value=True),
         ),
         pytest.raises(MissingUserNotesError),

--- a/server-utils/server_utils/auth/resource_server/authorization_checker.py
+++ b/server-utils/server_utils/auth/resource_server/authorization_checker.py
@@ -199,6 +199,17 @@ class AuthServerAuthorizationChecker(AuthorizationChecker):
                 return AuthorizedResult(username=token_info.username)
 
     @override
+    async def get_require_reason_for_interaction_enabled(self) -> bool:
+        """Require reason only when access control (ACM) is on and the setting is enabled."""
+        access_control_enabled = (
+            await self._client.get_auth_settings()
+        ).data.accessControlEnabled
+        if not access_control_enabled:
+            return False
+        settings = await self.get_require_reason_for_interaction_settings()
+        return settings.data.requireReasonForInteraction
+
+    @override
     async def get_require_reason_for_interaction_settings(
         self,
     ) -> RequireReasonForInteractionSettingsResponse:

--- a/server-utils/server_utils/auth/resource_server/authorization_checker.py
+++ b/server-utils/server_utils/auth/resource_server/authorization_checker.py
@@ -73,7 +73,7 @@ class AuthorizationChecker(ABC):
         """Return require-reason-for-interaction settings."""
         pass
 
-    async def get_require_reason_for_interaction_enabled(self) -> bool:
+    async def is_reason_for_interaction_required(self) -> bool:
         """Return whether auth-server requires a reason for interaction."""
         settings = await self.get_require_reason_for_interaction_settings()
         return settings.data.requireReasonForInteraction
@@ -90,12 +90,12 @@ class AuthorizationChecker(ABC):
 
         Params:
             require_reason_for_interaction: When ``None``, read from auth-server
-                settings via ``get_require_reason_for_interaction_enabled()``. Callers
+                settings via ``is_require_reason_for_interaction_enabled()``. Callers
                 that already resolved the setting locally may pass an explicit value.
         """
         if require_reason_for_interaction is None:
             require_reason_for_interaction = (
-                await self.get_require_reason_for_interaction_enabled()
+                await self.is_reason_for_interaction_required()
             )
         if not require_reason_for_interaction:
             return
@@ -199,7 +199,7 @@ class AuthServerAuthorizationChecker(AuthorizationChecker):
                 return AuthorizedResult(username=token_info.username)
 
     @override
-    async def get_require_reason_for_interaction_enabled(self) -> bool:
+    async def is_reason_for_interaction_required(self) -> bool:
         """Require reason only when access control (ACM) is on and the setting is enabled."""
         access_control_enabled = (
             await self._client.get_auth_settings()

--- a/server-utils/server_utils/auth/resource_server/authorization_checker.py
+++ b/server-utils/server_utils/auth/resource_server/authorization_checker.py
@@ -90,7 +90,7 @@ class AuthorizationChecker(ABC):
 
         Params:
             require_reason_for_interaction: When ``None``, read from auth-server
-                settings via ``is_require_reason_for_interaction_enabled()``. Callers
+                settings via ``is_reason_for_interaction_required()``. Callers
                 that already resolved the setting locally may pass an explicit value.
         """
         if require_reason_for_interaction is None:

--- a/server-utils/tests/auth/resource_server/test_authorization_checker.py
+++ b/server-utils/tests/auth/resource_server/test_authorization_checker.py
@@ -66,8 +66,33 @@ class TestAuthServerAuthorizationChecker:
         decoy.when(
             await mock_client.get_require_reason_for_interaction_settings()
         ).then_return(expected)
+        decoy.when(await mock_client.get_auth_settings()).then_return(
+            AuthSettingsResponse(
+                data=AuthSettingsResponseData(accessControlEnabled=True)
+            )
+        )
         assert await subject.get_require_reason_for_interaction_settings() == expected
         assert await subject.get_require_reason_for_interaction_enabled() is True
+
+    async def test_get_require_reason_disabled_when_access_control_off(
+        self, mock_client: Client, decoy: Decoy
+    ) -> None:
+        subject = AuthServerAuthorizationChecker(mock_client)
+        decoy.when(
+            await mock_client.get_require_reason_for_interaction_settings()
+        ).then_return(
+            RequireReasonForInteractionSettingsResponse(
+                data=RequireReasonForInteractionSettingsResponseData(
+                    requireReasonForInteraction=True
+                )
+            )
+        )
+        decoy.when(await mock_client.get_auth_settings()).then_return(
+            AuthSettingsResponse(
+                data=AuthSettingsResponseData(accessControlEnabled=False)
+            )
+        )
+        assert await subject.get_require_reason_for_interaction_enabled() is False
 
     async def test_check_given_no_token(
         self, mock_client: Client, decoy: Decoy

--- a/server-utils/tests/auth/resource_server/test_authorization_checker.py
+++ b/server-utils/tests/auth/resource_server/test_authorization_checker.py
@@ -32,7 +32,7 @@ class TestAlwaysAllowedAuthorizationChecker:
         subject = AlwaysAllowedAuthorizationChecker()
         settings = await subject.get_require_reason_for_interaction_settings()
         assert settings.data.requireReasonForInteraction is False
-        assert await subject.get_require_reason_for_interaction_enabled() is False
+        assert await subject.is_reason_for_interaction_required() is False
 
     async def test_check(self) -> None:
         subject = AlwaysAllowedAuthorizationChecker()
@@ -72,7 +72,7 @@ class TestAuthServerAuthorizationChecker:
             )
         )
         assert await subject.get_require_reason_for_interaction_settings() == expected
-        assert await subject.get_require_reason_for_interaction_enabled() is True
+        assert await subject.is_reason_for_interaction_required() is True
 
     async def test_get_require_reason_disabled_when_access_control_off(
         self, mock_client: Client, decoy: Decoy
@@ -92,7 +92,7 @@ class TestAuthServerAuthorizationChecker:
                 data=AuthSettingsResponseData(accessControlEnabled=False)
             )
         )
-        assert await subject.get_require_reason_for_interaction_enabled() is False
+        assert await subject.is_reason_for_interaction_required() is False
 
     async def test_check_given_no_token(
         self, mock_client: Client, decoy: Decoy

--- a/server-utils/tests/auth/resource_server/test_documented_interaction.py
+++ b/server-utils/tests/auth/resource_server/test_documented_interaction.py
@@ -97,7 +97,7 @@ async def test_record_documented_interaction_writes_audit_log(
     with (
         patch.object(
             subject,
-            "get_require_reason_for_interaction_enabled",
+            "is_require_reason_for_interaction_enabled",
             new=AsyncMock(return_value=True),
         ),
         caplog.at_level(logging.INFO, logger=audit_logger),

--- a/server-utils/tests/auth/resource_server/test_documented_interaction.py
+++ b/server-utils/tests/auth/resource_server/test_documented_interaction.py
@@ -70,9 +70,7 @@ async def test_record_documented_interaction_raises_when_notes_missing(
     mock_client = decoy.mock(cls=Client)
     subject = AuthServerAuthorizationChecker(mock_client)
     decoy.when(await mock_client.get_auth_settings()).then_return(
-        AuthSettingsResponse(
-            data=AuthSettingsResponseData(accessControlEnabled=True)
-        )
+        AuthSettingsResponse(data=AuthSettingsResponseData(accessControlEnabled=True))
     )
     decoy.when(
         await mock_client.get_require_reason_for_interaction_settings()
@@ -132,9 +130,7 @@ async def test_record_documented_interaction_accepts_notes_from_request_model(
     mock_client = decoy.mock(cls=Client)
     subject = AuthServerAuthorizationChecker(mock_client)
     decoy.when(await mock_client.get_auth_settings()).then_return(
-        AuthSettingsResponse(
-            data=AuthSettingsResponseData(accessControlEnabled=True)
-        )
+        AuthSettingsResponse(data=AuthSettingsResponseData(accessControlEnabled=True))
     )
     decoy.when(
         await mock_client.get_require_reason_for_interaction_settings()

--- a/server-utils/tests/auth/resource_server/test_documented_interaction.py
+++ b/server-utils/tests/auth/resource_server/test_documented_interaction.py
@@ -9,6 +9,8 @@ from decoy import Decoy
 from pydantic import BaseModel
 
 from server_utils.auth.resource_server.auth_server import (
+    AuthSettingsResponse,
+    AuthSettingsResponseData,
     Client,
     RequireReasonForInteractionSettingsResponse,
     RequireReasonForInteractionSettingsResponseData,
@@ -67,6 +69,11 @@ async def test_record_documented_interaction_raises_when_notes_missing(
     """Missing user notes are rejected when require-reason-for-interaction is on."""
     mock_client = decoy.mock(cls=Client)
     subject = AuthServerAuthorizationChecker(mock_client)
+    decoy.when(await mock_client.get_auth_settings()).then_return(
+        AuthSettingsResponse(
+            data=AuthSettingsResponseData(accessControlEnabled=True)
+        )
+    )
     decoy.when(
         await mock_client.get_require_reason_for_interaction_settings()
     ).then_return(
@@ -97,7 +104,7 @@ async def test_record_documented_interaction_writes_audit_log(
     with (
         patch.object(
             subject,
-            "is_require_reason_for_interaction_enabled",
+            "is_reason_for_interaction_required",
             new=AsyncMock(return_value=True),
         ),
         caplog.at_level(logging.INFO, logger=audit_logger),
@@ -124,6 +131,11 @@ async def test_record_documented_interaction_accepts_notes_from_request_model(
     """``DocumentedInteraction.from_request_model`` records payload data and header notes."""
     mock_client = decoy.mock(cls=Client)
     subject = AuthServerAuthorizationChecker(mock_client)
+    decoy.when(await mock_client.get_auth_settings()).then_return(
+        AuthSettingsResponse(
+            data=AuthSettingsResponseData(accessControlEnabled=True)
+        )
+    )
     decoy.when(
         await mock_client.get_require_reason_for_interaction_settings()
     ).then_return(


### PR DESCRIPTION
# Overview

bug fix on edge
enable required reasons for interaction only if acm is enabled 

## Risk assessment

low. bug fix