### PR TITLE
fix(api): Add module disconnect tolerance

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/async_serial.py
+++ b/api/src/opentrons/drivers/asyncio/communication/async_serial.py
@@ -54,6 +54,8 @@ class AsyncSerial:
             executor=executor,
             loop=loop,
             reset_buffer_before_write=reset_buffer_before_write,
+            baud_rate=baud_rate,
+            timeout=timeout,
         )
 
     def __init__(
@@ -62,6 +64,8 @@ class AsyncSerial:
         executor: ThreadPoolExecutor,
         loop: asyncio.AbstractEventLoop,
         reset_buffer_before_write: bool,
+        baud_rate: int,
+        timeout: Optional[float],
     ) -> None:
         """
         Constructor
@@ -75,6 +79,8 @@ class AsyncSerial:
         self._executor = executor
         self._loop = loop
         self._reset_buffer_before_write = reset_buffer_before_write
+        self._baud_rate = baud_rate
+        self._timeout = timeout
 
     async def read_until(self, match: bytes) -> bytes:
         """
@@ -162,6 +168,11 @@ class AsyncSerial:
     def reset_output_buffer(self) -> None:
         """Reset the output buffer"""
         self._serial.reset_output_buffer()
+
+    def get_timeout(self, timeout_property: TimeoutProperties) -> float:
+        """Get the underlying timeout."""
+        # we always build with a timeout so the "or" is just for typing.
+        return getattr(self._serial, timeout_property) or 5.0
 
     async def set_timeout(
         self, timeout_property: TimeoutProperties, timeout: Optional[float]

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -662,12 +662,15 @@ class AsyncResponseSerialConnection(SerialConnection):
                     return responses
                 log.info(f"{self._name}: retry number {retry}/{retries}")
 
-            except BaseException:
+            except Exception:
                 log.exception("Got an error during send")
                 if retry < retries and not self._closed_on_purpose:
                     pass
                 else:
                     raise
+            except asyncio.CancelledError:
+                log.exception("Asyncio canceled")
+                raise
 
             await self.on_retry()
         raise NoResponse(port=self._port, command=data)

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -17,6 +17,8 @@ from .errors import (
 )
 from opentrons.drivers.command_builder import CommandBuilder
 
+from opentrons.config import IS_ROBOT
+
 log = logging.getLogger(__name__)
 
 
@@ -661,7 +663,7 @@ class AsyncResponseSerialConnection(SerialConnection):
 
             except BaseException as e:
                 log.error(f"Got an error during send {e}")
-                if retry < retries:
+                if retry < retries and IS_ROBOT:
                     pass
                 else:
                     raise e

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from typing import AsyncIterator, Literal, Type
 
 from .async_serial import AsyncSerial
@@ -303,8 +304,12 @@ class SerialConnection:
         Returns: None
         """
         await asyncio.sleep(self._retry_wait_time_seconds)
-        await self._serial.close()
-        await self._serial.open()
+        if os.path.exists(self._port):
+            try:
+                await asyncio.wait_for(self._serial.close(), timeout=1)
+                await asyncio.wait_for(self._serial.open(), timeout=1)
+            except BaseException:
+                log.exception("Got an error during reconnect.")
 
     def process_raw_response(self, command: str, response: str) -> str:
         """
@@ -648,12 +653,20 @@ class AsyncResponseSerialConnection(SerialConnection):
         responses: list[str] = []
 
         for retry in range(retries + 1):
-            responses = await self._send_one_retry(data, acks)
-            if responses:
-                return responses
-            log.info(f"{self._name}: retry number {retry}/{retries}")
-            await self.on_retry()
+            try:
+                responses = await self._send_one_retry(data, acks)
+                if responses:
+                    return responses
+                log.info(f"{self._name}: retry number {retry}/{retries}")
 
+            except BaseException as e:
+                log.error(f"Got an error during send {e}")
+                if retry < retries:
+                    pass
+                else:
+                    raise e
+
+            await self.on_retry()
         raise NoResponse(port=self._port, command=data)
 
     async def _send_data(self, data: str, retries: int) -> str:

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -15,7 +15,6 @@ from .errors import (
     NoResponse,
     UnhandledGcode,
 )
-from opentrons.config import IS_ROBOT
 from opentrons.drivers.command_builder import CommandBuilder
 
 log = logging.getLogger(__name__)
@@ -662,7 +661,7 @@ class AsyncResponseSerialConnection(SerialConnection):
 
             except BaseException as e:
                 log.error(f"Got an error during send {e}")
-                if retry < retries and IS_ROBOT:
+                if retry < retries:
                     pass
                 else:
                     raise

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -299,6 +299,29 @@ class SerialConnection:
             # If no specific error code was found, raise a generic ErrorResponse
             raise ErrorResponse(port=self._port, response=response)
 
+    async def update_port(self, new_port: str) -> None:
+        """Try to change the underling port path.
+
+        This should only be used temporarily, it is triggered during the reconnect patch in module_control
+        to allow the on_retry method to connect to the new port so it has a chance at successfully retrying
+        to send a command. Module control can't clean up this instance until that retry loop has succeeded or
+        hit its limit. Module Control then tears down this instance on success or failure and rebuilds a new
+        driver."""
+        log.info(
+            f"Changing port from {self._port} to {new_port} while open({await self._serial.is_open()})"
+        )
+
+        if await self._serial.is_open():
+            await self._serial.close()
+        self._serial = await self._build_serial(
+            port=new_port,
+            baud_rate=self._serial._baud_rate,
+            timeout=self._serial.get_timeout("timeout"),
+            loop=self._serial._loop,
+            reset_buffer_before_write=self._serial._reset_buffer_before_write,
+        )
+        self._port = new_port
+
     async def on_retry(self) -> None:
         """
         Opportunity for derived classes to perform action between retries. Default

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -133,6 +133,7 @@ class SerialConnection:
         self._error_keyword = error_keyword.lower()
         self._alarm_keyword = alarm_keyword.lower()
         self._error_codes = error_codes
+        self._closed_on_purpose = False
 
     async def send_command(
         self, command: CommandBuilder, retries: int = 0, timeout: float | None = None
@@ -228,10 +229,12 @@ class SerialConnection:
 
     async def open(self) -> None:
         """Open the connection."""
+        self._closed_on_purpose = False
         await self._serial.open()
 
     async def close(self) -> None:
         """Close the connection."""
+        self._closed_on_purpose = True
         await self._serial.close()
 
     async def is_open(self) -> bool:
@@ -659,9 +662,9 @@ class AsyncResponseSerialConnection(SerialConnection):
                     return responses
                 log.info(f"{self._name}: retry number {retry}/{retries}")
 
-            except BaseException as e:
-                log.error(f"Got an error during send {e}")
-                if retry < retries:
+            except BaseException:
+                log.exception("Got an error during send")
+                if retry < retries and not self._closed_on_purpose:
                     pass
                 else:
                     raise

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -665,7 +665,7 @@ class AsyncResponseSerialConnection(SerialConnection):
                 if retry < retries and IS_ROBOT:
                     pass
                 else:
-                    raise e
+                    raise
 
             await self.on_retry()
         raise NoResponse(port=self._port, command=data)

--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -15,9 +15,8 @@ from .errors import (
     NoResponse,
     UnhandledGcode,
 )
-from opentrons.drivers.command_builder import CommandBuilder
-
 from opentrons.config import IS_ROBOT
+from opentrons.drivers.command_builder import CommandBuilder
 
 log = logging.getLogger(__name__)
 

--- a/api/src/opentrons/drivers/heater_shaker/abstract.py
+++ b/api/src/opentrons/drivers/heater_shaker/abstract.py
@@ -79,3 +79,7 @@ class AbstractHeaterShakerDriver(ABC):
     async def get_error_state(self) -> None:
         """Raise if the module is in an error state."""
         ...
+
+    async def move_port(self, new_port: str) -> None:
+        """Try to change the port of the underling connection."""
+        pass

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -215,3 +215,7 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
             ),
             acks=2,
         )
+
+    async def move_port(self, new_port: str) -> None:
+        """Try to change the port of the underling connection."""
+        await self._connection.update_port(new_port)

--- a/api/src/opentrons/drivers/heater_shaker/driver.py
+++ b/api/src/opentrons/drivers/heater_shaker/driver.py
@@ -37,7 +37,7 @@ HS_COMMAND_TERMINATOR = "\n"
 HS_ACK = "OK" + HS_COMMAND_TERMINATOR
 HS_ERROR_KEYWORD = "err"
 HS_ASYNC_ERROR_ACK = "async"
-DEFAULT_COMMAND_RETRIES = 0
+DEFAULT_COMMAND_RETRIES = 4
 
 
 class HeaterShakerDriver(AbstractHeaterShakerDriver):
@@ -59,9 +59,11 @@ class HeaterShakerDriver(AbstractHeaterShakerDriver):
             baud_rate=HS_BAUDRATE,
             timeout=DEFAULT_HS_TIMEOUT,
             ack=HS_ACK,
+            retry_wait_time_seconds=1,
             loop=loop,
             error_keyword=HS_ERROR_KEYWORD,
             async_error_ack=HS_ASYNC_ERROR_ACK,
+            number_of_retries=DEFAULT_COMMAND_RETRIES,
         )
         return cls(connection=connection)
 

--- a/api/src/opentrons/drivers/temp_deck/__init__.py
+++ b/api/src/opentrons/drivers/temp_deck/__init__.py
@@ -1,9 +1,10 @@
 from .abstract import AbstractTempDeckDriver
-from .driver import TempDeckDriver
+from .driver import DEFAULT_COMMAND_RETRIES, TempDeckDriver
 from .simulator import SimulatingDriver
 
 __all__ = [
     "TempDeckDriver",
     "AbstractTempDeckDriver",
     "SimulatingDriver",
+    "DEFAULT_COMMAND_RETRIES",
 ]

--- a/api/src/opentrons/drivers/thermocycler/__init__.py
+++ b/api/src/opentrons/drivers/thermocycler/__init__.py
@@ -1,8 +1,14 @@
 from .abstract import AbstractThermocyclerDriver
-from .driver import ThermocyclerDriver, ThermocyclerDriverFactory, ThermocyclerDriverV2
+from .driver import (
+    DEFAULT_COMMAND_RETRIES,
+    ThermocyclerDriver,
+    ThermocyclerDriverFactory,
+    ThermocyclerDriverV2,
+)
 from .simulator import SimulatingDriver
 
 __all__ = [
+    "DEFAULT_COMMAND_RETRIES",
     "ThermocyclerDriver",
     "ThermocyclerDriverV2",
     "ThermocyclerDriverFactory",

--- a/api/src/opentrons/hardware_control/abstract_device.py
+++ b/api/src/opentrons/hardware_control/abstract_device.py
@@ -112,6 +112,15 @@ class AbstractDevice(abc.ABC):
         """
         pass
 
+    async def soft_cleanup(self) -> None:
+        """Clean up the module instance.
+
+        Clean up, i.e. stop pollers, disconnect serial, etc in preparation for
+        object destruction. Normally calls cleanup but a device manager can override this to not
+        send a pyro notification if it wants to be fault tolerant.
+        """
+        await self.cleanup()
+
     def event_listener(self, event: Any) -> None:
         """Listen for events and update the module state."""
         pass

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import re
 from glob import glob
-from typing import TYPE_CHECKING, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, AsyncGenerator, Callable, List, Optional, Union
 
 from opentrons_shared_data.errors.exceptions import EnumeratedError
 
@@ -91,6 +92,7 @@ class AttachedModulesControl:
         self._api = api
         self._usb = usb
         self._event_callback = event_callback
+        self._reconnect_lock: Optional["asyncio.Lock"] = None
         if not IS_ROBOT and not api.is_simulator:
             # Start task that registers emulated modules.
             self._emulation_listen_task: asyncio.Task[None] | None = (
@@ -246,15 +248,23 @@ class AttachedModulesControl:
                 f"Async error callback for module {model} {serial} at {port} for exc {exc} failed"
             )
 
+    @contextlib.asynccontextmanager
+    async def _use_reconnect_lock(self) -> AsyncGenerator[None, None]:
+        self._reconnect_lock = self._reconnect_lock or asyncio.Lock()
+
+        async with self._reconnect_lock:
+            yield
+
     async def _clear_old_modules(self) -> None:
-        for old_mod in self._recently_removed_modules:
-            # Important: this wants to be after the remove because this may trigger
-            # recursion back to here; we therefore want the module to already be
-            # removed so that the recursion terminates next loop
-            old_mod.disconnected_callback()
-            log.info(f"did not find {old_mod.serial_number}")
-            self._recently_removed_modules.remove(old_mod)
-            await old_mod.cleanup()
+        async with self._use_reconnect_lock():
+            for old_mod in self._recently_removed_modules:
+                # Important: this wants to be after the remove because this may trigger
+                # recursion back to here; we therefore want the module to already be
+                # removed so that the recursion terminates next loop
+                old_mod.disconnected_callback()
+                log.info(f"did not find {old_mod.serial_number}")
+                self._recently_removed_modules.remove(old_mod)
+                await old_mod.cleanup()
 
     async def _reconnect_patch(self) -> None:
         try:
@@ -264,7 +274,8 @@ class AttachedModulesControl:
                     if attached_mod.serial_number == old_mod.serial_number:
                         log.info(f"Found {old_mod.serial_number} was reconnected")
                         # module reattached to a new virtual port, create a symlink to it
-                        await attached_mod.cleanup()
+                        await attached_mod.soft_cleanup()
+                        await old_mod.soft_cleanup()
                         if attached_mod.port != old_mod.port:
                             log.info(
                                 f"module moved from {old_mod.port} to {attached_mod.port}"
@@ -387,7 +398,9 @@ class AttachedModulesControl:
                 log.exception(
                     f"Failed to build device {device.name} at port {device.port}: {e}"
                 )
-        await self._reconnect_patch()
+        if len(new_devices_at_ports) > 0:
+            async with self._use_reconnect_lock():
+                await self._reconnect_patch()
         self._available_peripherals = sorted(
             self._available_peripherals, key=peripherals.AbstractPeripheral.sort_key
         )

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -44,6 +44,8 @@ if TYPE_CHECKING:
     from .ot3api import OT3API
 
 
+RECONNECT_ATTEMPTS = 3
+
 log = logging.getLogger(__name__)
 
 MODULE_PORT_REGEX = re.compile(
@@ -86,6 +88,7 @@ class AttachedModulesControl:
     ) -> None:
         self._available_modules: List[modules.AbstractModule] = []
         self._available_peripherals: List[peripherals.AbstractPeripheral] = []
+        self._recently_removed_modules: List[modules.AbstractModule] = []
         self._api = api
         self._usb = usb
         self._event_callback = event_callback
@@ -124,7 +127,9 @@ class AttachedModulesControl:
 
     @property
     def available_modules(self) -> List[modules.AbstractModule]:
-        return self._available_modules
+        # return both available and recently removed, in case we attempt to grab the device at the same
+        # time it experiences an EMI disconnect
+        return self._available_modules + self._recently_removed_modules
 
     @property
     def available_peripherals(self) -> List[peripherals.AbstractPeripheral]:
@@ -242,7 +247,52 @@ class AttachedModulesControl:
                 f"Async error callback for module {model} {serial} at {port} for exc {exc} failed"
             )
 
-    async def unregister_devices(
+    def _clear_old_modules(self) -> None:
+        for old_mod in self._recently_removed_modules:
+            # Important: this wants to be after the remove because this may trigger
+            # recursion back to here; we therefore want the module to already be
+            # removed so that the recursion terminates next loop
+            old_mod.disconnected_callback()
+            log.info(f"did not find {old_mod.serial_number}")
+            self._recently_removed_modules.remove(old_mod)
+
+    async def _reconnect_patch(self, attempts_left: int) -> None:
+        if attempts_left == 0:
+            # if the module isn't back then remove it
+            self._clear_old_modules()
+            return
+
+        await asyncio.sleep(1)
+        try:
+            for old_mod in self._recently_removed_modules:
+                log.info(
+                    f"Attempting to find and reconect {old_mod.serial_number} attempt {RECONNECT_ATTEMPTS-attempts_left+1}"
+                )
+                for attached_mod in self._available_modules:
+                    if attached_mod.serial_number == old_mod.serial_number:
+                        log.info(f"Found {old_mod.serial_number} was reconnected")
+                        # module reattached to a new virtual port, create a symlink to it
+                        await attached_mod.cleanup()
+                        if attached_mod.port != old_mod.port:
+                            log.info(
+                                f"module moved from {old_mod.port} to {attached_mod.port}"
+                            )
+                            await old_mod.move_port(
+                                attached_mod.port, attached_mod.usb_port
+                            )
+                        await old_mod.attempt_reconnect()
+                        self._available_modules.remove(attached_mod)
+                        self._available_modules.append(old_mod)
+                        self._recently_removed_modules.remove(old_mod)
+                        self._available_modules = sorted(
+                            self._available_modules, key=modules.AbstractModule.sort_key
+                        )
+        except BaseException:
+            log.exception("Encountered an error during reconnect attempt.")
+        if len(self._recently_removed_modules) > 0:
+            self._api.loop.create_task(self._reconnect_patch(attempts_left - 1))
+
+    async def unregister_devices(  # noqa: C901
         self,
         devices_at_ports: Union[
             List[modules.ModuleAtPort], List[modules.SimulatingModuleAtPort]
@@ -254,8 +304,9 @@ class AttachedModulesControl:
         Remove any modules that are no longer found by aionotify.
         """
         removed_devices = []
+        start_reconnect_task = False
         for dev in devices_at_ports:
-            for attached_dev in self.available_modules + self.available_peripherals:
+            for attached_dev in self._available_modules + self.available_peripherals:
                 if (
                     attached_dev.serial_number == dev.serial
                     or attached_dev.port == dev.port
@@ -266,15 +317,18 @@ class AttachedModulesControl:
                 if removed_dev in self._available_modules and isinstance(
                     removed_dev, modules.AbstractModule
                 ):
+                    self._recently_removed_modules.append(removed_dev)
                     self._available_modules.remove(removed_dev)
+                    start_reconnect_task=True
                 if removed_dev in self._available_peripherals and isinstance(
                     removed_dev, peripherals.AbstractPeripheral
                 ):
                     self._available_peripherals.remove(removed_dev)
-                # Important: this wants to be after the remove because this may trigger
-                # recursion back to here; we therefore want the module to already be
-                # removed so that the recursion terminates next loop
-                removed_dev.disconnected_callback()
+                    # Important: this wants to be after the remove because this may trigger
+                    # recursion back to here; we therefore want the module to already be
+                    # removed so that the recursion terminates next loop
+                    removed_dev.disconnected_callback()
+
             except ValueError:
                 log.warning(
                     f"Removed Device {removed_dev} not found in attached device"
@@ -290,6 +344,11 @@ class AttachedModulesControl:
         self._available_peripherals = sorted(
             self._available_peripherals, key=peripherals.AbstractPeripheral.sort_key
         )
+        if start_reconnect_task:
+            if self._api.is_simulator:
+                self._clear_old_modules()
+            else:
+                self._api.loop.create_task(self._reconnect_patch(RECONNECT_ATTEMPTS))
 
     async def register_devices(
         self,

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -43,8 +43,7 @@ if TYPE_CHECKING:
     from .api import API
     from .ot3api import OT3API
 
-
-RECONNECT_ATTEMPTS = 3
+CLEANUP_DELAY_S = 3.0
 
 log = logging.getLogger(__name__)
 
@@ -257,13 +256,10 @@ class AttachedModulesControl:
             self._recently_removed_modules.remove(old_mod)
             await old_mod.cleanup()
 
-    async def _reconnect_patch(self, attempts_left: int) -> None:
-        await asyncio.sleep(1)
+    async def _reconnect_patch(self) -> None:
         try:
             for old_mod in self._recently_removed_modules:
-                log.info(
-                    f"Attempting to find and reconect {old_mod.serial_number} attempt {RECONNECT_ATTEMPTS - attempts_left + 1}"
-                )
+                log.info(f"Attempting to find and reconect {old_mod.serial_number}")
                 for attached_mod in self._available_modules:
                     if attached_mod.serial_number == old_mod.serial_number:
                         log.info(f"Found {old_mod.serial_number} was reconnected")
@@ -285,13 +281,6 @@ class AttachedModulesControl:
                         )
         except BaseException:
             log.exception("Encountered an error during reconnect attempt.")
-        if len(self._recently_removed_modules) > 0:
-            if attempts_left == 1:
-                # if the module isn't back then remove it
-                await self._clear_old_modules()
-                return
-            else:
-                await self._reconnect_patch(attempts_left - 1)
 
     async def unregister_devices(  # noqa: C901
         self,
@@ -305,7 +294,7 @@ class AttachedModulesControl:
         Remove any modules that are no longer found by aionotify.
         """
         removed_devices = []
-        start_reconnect_task = False
+        start_cleanup_task = False
         for dev in devices_at_ports:
             for attached_dev in self._available_modules + self.available_peripherals:
                 if (
@@ -320,7 +309,7 @@ class AttachedModulesControl:
                 ):
                     self._recently_removed_modules.append(removed_dev)
                     self._available_modules.remove(removed_dev)
-                    start_reconnect_task = True
+                    start_cleanup_task = True
                 if removed_dev in self._available_peripherals and isinstance(
                     removed_dev, peripherals.AbstractPeripheral
                 ):
@@ -344,11 +333,11 @@ class AttachedModulesControl:
         self._available_peripherals = sorted(
             self._available_peripherals, key=peripherals.AbstractPeripheral.sort_key
         )
-        if start_reconnect_task:
-            if self._api.is_simulator:
-                await self._clear_old_modules()
-            else:
-                self._api.loop.create_task(self._reconnect_patch(RECONNECT_ATTEMPTS))
+        if start_cleanup_task:
+            delay = 0.1 if self._api.is_simulator else CLEANUP_DELAY_S
+            self._api.loop.call_later(
+                delay, lambda: asyncio.create_task(self._clear_old_modules())
+            )
 
     async def register_devices(
         self,
@@ -398,6 +387,7 @@ class AttachedModulesControl:
                 log.exception(
                     f"Failed to build device {device.name} at port {device.port}: {e}"
                 )
+        await self._reconnect_patch()
         self._available_peripherals = sorted(
             self._available_peripherals, key=peripherals.AbstractPeripheral.sort_key
         )

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -247,7 +247,7 @@ class AttachedModulesControl:
                 f"Async error callback for module {model} {serial} at {port} for exc {exc} failed"
             )
 
-    def _clear_old_modules(self) -> None:
+    async def _clear_old_modules(self) -> None:
         for old_mod in self._recently_removed_modules:
             # Important: this wants to be after the remove because this may trigger
             # recursion back to here; we therefore want the module to already be
@@ -255,18 +255,19 @@ class AttachedModulesControl:
             old_mod.disconnected_callback()
             log.info(f"did not find {old_mod.serial_number}")
             self._recently_removed_modules.remove(old_mod)
+            await old_mod.cleanup()
 
     async def _reconnect_patch(self, attempts_left: int) -> None:
         if attempts_left == 0:
             # if the module isn't back then remove it
-            self._clear_old_modules()
+            await self._clear_old_modules()
             return
 
         await asyncio.sleep(1)
         try:
             for old_mod in self._recently_removed_modules:
                 log.info(
-                    f"Attempting to find and reconect {old_mod.serial_number} attempt {RECONNECT_ATTEMPTS-attempts_left+1}"
+                    f"Attempting to find and reconect {old_mod.serial_number} attempt {RECONNECT_ATTEMPTS - attempts_left + 1}"
                 )
                 for attached_mod in self._available_modules:
                     if attached_mod.serial_number == old_mod.serial_number:
@@ -319,7 +320,7 @@ class AttachedModulesControl:
                 ):
                     self._recently_removed_modules.append(removed_dev)
                     self._available_modules.remove(removed_dev)
-                    start_reconnect_task=True
+                    start_reconnect_task = True
                 if removed_dev in self._available_peripherals and isinstance(
                     removed_dev, peripherals.AbstractPeripheral
                 ):
@@ -328,16 +329,15 @@ class AttachedModulesControl:
                     # recursion back to here; we therefore want the module to already be
                     # removed so that the recursion terminates next loop
                     removed_dev.disconnected_callback()
+                    log.info(
+                        f"Device {removed_dev.name()} detached from port {removed_dev.port}"
+                    )
+                    await removed_dev.cleanup()
 
             except ValueError:
                 log.warning(
                     f"Removed Device {removed_dev} not found in attached device"
                 )
-        for removed_dev in removed_devices:
-            log.info(
-                f"Device {removed_dev.name()} detached from port {removed_dev.port}"
-            )
-            await removed_dev.cleanup()
         self._available_modules = sorted(
             self._available_modules, key=modules.AbstractModule.sort_key
         )
@@ -346,7 +346,7 @@ class AttachedModulesControl:
         )
         if start_reconnect_task:
             if self._api.is_simulator:
-                self._clear_old_modules()
+                await self._clear_old_modules()
             else:
                 self._api.loop.create_task(self._reconnect_patch(RECONNECT_ATTEMPTS))
 

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -273,9 +273,11 @@ class AttachedModulesControl:
                 for attached_mod in self._available_modules:
                     if attached_mod.serial_number == old_mod.serial_number:
                         log.info(f"Found {old_mod.serial_number} was reconnected")
-                        # module reattached to a new virtual port, create a symlink to it
-                        await attached_mod.soft_cleanup()
-                        await old_mod.soft_cleanup()
+                        # Move the port before cleaning up the old instance.
+                        # this will give it a chance to successfully retry sending whatever command
+                        # if it was disconnected in the middle of sending a command.
+                        # if it was in the middle of sending a command, it cant cleanup until that retry loop
+                        # succeeds or hits its limit
                         if attached_mod.port != old_mod.port:
                             log.info(
                                 f"module moved from {old_mod.port} to {attached_mod.port}"
@@ -283,6 +285,8 @@ class AttachedModulesControl:
                             await old_mod.move_port(
                                 attached_mod.port, attached_mod.usb_port
                             )
+                        await attached_mod.soft_cleanup()
+                        await old_mod.soft_cleanup()
                         await old_mod.attempt_reconnect()
                         self._available_modules.remove(attached_mod)
                         self._available_modules.append(old_mod)

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -258,11 +258,6 @@ class AttachedModulesControl:
             await old_mod.cleanup()
 
     async def _reconnect_patch(self, attempts_left: int) -> None:
-        if attempts_left == 0:
-            # if the module isn't back then remove it
-            await self._clear_old_modules()
-            return
-
         await asyncio.sleep(1)
         try:
             for old_mod in self._recently_removed_modules:
@@ -291,7 +286,12 @@ class AttachedModulesControl:
         except BaseException:
             log.exception("Encountered an error during reconnect attempt.")
         if len(self._recently_removed_modules) > 0:
-            self._api.loop.create_task(self._reconnect_patch(attempts_left - 1))
+            if attempts_left == 1:
+                # if the module isn't back then remove it
+                await self._clear_old_modules()
+                return
+            else:
+                await self._reconnect_patch(attempts_left - 1)
 
     async def unregister_devices(  # noqa: C901
         self,

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -33,6 +33,7 @@ from opentrons.util.pyro.pyro_synchronous_adapter import (
     pyro_behavior,
     remove_pyro_synchronous_object,
 )
+from opentrons.config import IS_ROBOT
 
 log = logging.getLogger(__name__)
 
@@ -340,6 +341,8 @@ class HeaterShaker(mod_abc.AbstractModule):
 
     async def attempt_reconnect(self) -> None:
         """Attempt to reestablish connections."""
+        if not IS_ROBOT:
+            return
         try:
             if not await self._driver.is_connected():
                 await self.cleanup()
@@ -483,7 +486,7 @@ class HeaterShakerReader(Reader):
         else:
             log.info(f"error {exception} debounce {self._error_debounce}")
             self._error_debounce -= 1
-            if self._error_debounce > 0:
+            if self._error_debounce > 0 and IS_ROBOT:
                 return
             if self._handle_error:
                 self._handle_error(exception)

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -146,12 +146,16 @@ class HeaterShaker(mod_abc.AbstractModule):
     def _handle_error(self, error: Exception) -> None:
         self.error_callback(error)
 
-    @pyro_behavior(specialty_func=remove_pyro_synchronous_object, apply_local=True)
-    async def cleanup(self) -> None:
-        """Stop the poller task"""
+    async def _cleanup(self) -> None:
+        """Stop the poller task."""
         self._unsubscribe_reader()
         await self._poller.stop()
         await self._driver.disconnect()
+
+    @pyro_behavior(specialty_func=remove_pyro_synchronous_object, apply_local=True)
+    async def cleanup(self) -> None:
+        """Stop the poller task."""
+        await self._cleanup()
 
     @classmethod
     def name(cls) -> str:
@@ -345,7 +349,7 @@ class HeaterShaker(mod_abc.AbstractModule):
             return
         try:
             if not await self._driver.is_connected():
-                await self.cleanup()
+                await self._cleanup()
                 self._driver = await HeaterShakerDriver.create(
                     port=self.port, loop=self.loop
                 )

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -8,7 +8,10 @@ from typing_extensions import Final
 
 from opentrons.drivers.asyncio.communication.errors import UnhandledGcode
 from opentrons.drivers.heater_shaker.abstract import AbstractHeaterShakerDriver
-from opentrons.drivers.heater_shaker.driver import HeaterShakerDriver
+from opentrons.drivers.heater_shaker.driver import (
+    DEFAULT_COMMAND_RETRIES,
+    HeaterShakerDriver,
+)
 from opentrons.drivers.heater_shaker.simulator import SimulatingDriver
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.types import RPM, HeaterShakerLabwareLatchStatus, Temperature
@@ -329,9 +332,27 @@ class HeaterShaker(mod_abc.AbstractModule):
                 while self.temperature > awaiting_temperature:
                     await self._poller.wait_next_poll()
 
-        t = self._loop.create_task(_await_temperature())
-        self.make_cancellable(t)
-        await t
+        await self.run_task_fault_tolerant(_await_temperature, DEFAULT_COMMAND_RETRIES)
+
+    async def move_port(self, port: str, usb_port: USBPort) -> None:
+        self._port = port
+        self._usb_port = usb_port
+
+    async def attempt_reconnect(self) -> None:
+        """Attempt to reestablish connections."""
+        try:
+            if not await self._driver.is_connected():
+                await self.cleanup()
+                self._driver = await HeaterShakerDriver.create(
+                    port=self.port, loop=self.loop
+                )
+                self._reader._driver = self._driver
+            # restart the poller
+            await self._poller.stop()
+            await self._poller.start()
+        except BaseException:
+            log.exception("Got an error when trying to reconnect.")
+            raise
 
     async def set_speed(self, rpm: int) -> None:
         """
@@ -353,21 +374,27 @@ class HeaterShaker(mod_abc.AbstractModule):
             while self.speed_status != SpeedStatus.HOLDING:
                 await self._poller.wait_next_poll()
 
-        task = self._loop.create_task(_wait())
-        self.make_cancellable(task)
-        await task
+        await self.run_task_fault_tolerant(_wait, DEFAULT_COMMAND_RETRIES)
 
     async def _wait_for_labware_latch(
         self, status: HeaterShakerLabwareLatchStatus
     ) -> None:
         """Wait until the hardware reports the labware latch status matches."""
-        while self.labware_latch_status != status:
-            await self._poller.wait_next_poll()
+
+        async def _wait() -> None:
+            while self.labware_latch_status != status:
+                await self._poller.wait_next_poll()
+
+        await self.run_task_fault_tolerant(_wait, DEFAULT_COMMAND_RETRIES)
 
     async def _wait_for_shake_deactivation(self) -> None:
         """Wait until hardware reports that module has stopped shaking and has homed."""
-        while self.speed_status != SpeedStatus.IDLE:
-            await self._poller.wait_next_poll()
+
+        async def _wait() -> None:
+            while self.speed_status != SpeedStatus.IDLE:
+                await self._poller.wait_next_poll()
+
+        await self.run_task_fault_tolerant(_wait, DEFAULT_COMMAND_RETRIES)
 
     async def deactivate(self, must_be_running: bool = True) -> None:
         """Stop heating/cooling; stop shaking and home the plate"""
@@ -418,6 +445,7 @@ class HeaterShakerReader(Reader):
         self.error: Optional[str] = None
         self._driver = driver
         self._handle_error: Callable[[Exception], None] | None = None
+        self._error_debounce = DEFAULT_COMMAND_RETRIES * 4
 
     def register_error_handler(
         self, handle_error: Callable[[Exception], None]
@@ -450,7 +478,13 @@ class HeaterShakerReader(Reader):
     def _set_error(self, exception: Optional[Exception]) -> None:
         if exception is None:
             self.error = None
+            # we read 4 values per read, so we would consume a lot of the debounce every fail
+            self._error_debounce = DEFAULT_COMMAND_RETRIES
         else:
+            log.info(f"error {exception} debounce {self._error_debounce}")
+            self._error_debounce -= 1
+            if self._error_debounce > 0:
+                return
             if self._handle_error:
                 self._handle_error(exception)
             try:

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -6,6 +6,7 @@ from typing import Callable, Mapping, Optional
 
 from typing_extensions import Final
 
+from opentrons.config import IS_ROBOT
 from opentrons.drivers.asyncio.communication.errors import UnhandledGcode
 from opentrons.drivers.heater_shaker.abstract import AbstractHeaterShakerDriver
 from opentrons.drivers.heater_shaker.driver import (
@@ -33,7 +34,6 @@ from opentrons.util.pyro.pyro_synchronous_adapter import (
     pyro_behavior,
     remove_pyro_synchronous_object,
 )
-from opentrons.config import IS_ROBOT
 
 log = logging.getLogger(__name__)
 

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -342,6 +342,7 @@ class HeaterShaker(mod_abc.AbstractModule):
     async def move_port(self, port: str, usb_port: USBPort) -> None:
         self._port = port
         self._usb_port = usb_port
+        await self._driver.move_port(port)
 
     async def attempt_reconnect(self) -> None:
         """Attempt to reestablish connections."""

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -146,7 +146,7 @@ class HeaterShaker(mod_abc.AbstractModule):
     def _handle_error(self, error: Exception) -> None:
         self.error_callback(error)
 
-    async def _cleanup(self) -> None:
+    async def soft_cleanup(self) -> None:
         """Stop the poller task."""
         self._unsubscribe_reader()
         await self._poller.stop()
@@ -155,7 +155,7 @@ class HeaterShaker(mod_abc.AbstractModule):
     @pyro_behavior(specialty_func=remove_pyro_synchronous_object, apply_local=True)
     async def cleanup(self) -> None:
         """Stop the poller task."""
-        await self._cleanup()
+        await self.soft_cleanup()
 
     @classmethod
     def name(cls) -> str:
@@ -345,13 +345,12 @@ class HeaterShaker(mod_abc.AbstractModule):
 
     async def attempt_reconnect(self) -> None:
         """Attempt to reestablish connections."""
+        log.info("attempting reconnect.")
         try:
-            if not await self._driver.is_connected():
-                await self._cleanup()
-                self._driver = await HeaterShakerDriver.create(
-                    port=self.port, loop=self.loop
-                )
-                self._reader._driver = self._driver
+            self._driver = await HeaterShakerDriver.create(
+                port=self.port, loop=self.loop
+            )
+            self._reader._driver = self._driver
             # restart the poller
             await self._poller.stop()
             await self._poller.start()

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -345,8 +345,6 @@ class HeaterShaker(mod_abc.AbstractModule):
 
     async def attempt_reconnect(self) -> None:
         """Attempt to reestablish connections."""
-        if not IS_ROBOT:
-            return
         try:
             if not await self._driver.is_connected():
                 await self._cleanup()

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -217,9 +217,9 @@ class AbstractModule(AbstractDevice):
                 t = self._loop.create_task(task_function())
                 self.make_cancellable(t)
                 await t
-            except BaseException as e:
-                mod_log.info(
-                    f"error in fault tollerant module call {e} debounce {debounce_count}"
+            except BaseException:
+                mod_log.exception(
+                    f"error in fault tollerant module call debounce {debounce_count}"
                 )
                 debounce_count -= 1
                 await asyncio.sleep(1)

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -2,7 +2,7 @@ import abc
 import asyncio
 import logging
 import re
-from typing import ClassVar, Optional, TypeVar
+from typing import Any, Callable, ClassVar, Coroutine, Mapping, Optional, TypeVar
 
 from packaging.version import InvalidVersion, Version, parse
 
@@ -196,3 +196,36 @@ class AbstractModule(AbstractDevice):
     def bootloader(self) -> UploadFunction:
         """Method used to upload file to this module's bootloader."""
         pass
+
+    async def move_port(self, port: str, usb_port: USBPort) -> None:
+        pass
+
+    async def attempt_reconnect(self) -> None:
+        """Attempt to reestablish connections."""
+        pass
+
+    async def run_task_fault_tolerant(
+        self,
+        task_function: Callable[[], Coroutine[Any, Any, None]],
+        debounce_count: int = 4,
+    ) -> None:
+        """Convenience function for module actions where we have to wait for some action to happen.
+        This will end up calling the task function multiple times in the event of a failure.
+        """
+        while debounce_count > 0:
+            try:
+                t = self._loop.create_task(task_function())
+                self.make_cancellable(t)
+                await t
+            except BaseException as e:
+                mod_log.info(
+                    f"error in fault tollerant module call {e} debounce {debounce_count}"
+                )
+                debounce_count -= 1
+                await asyncio.sleep(1)
+                if debounce_count == 0:
+                    # out of retries
+                    raise
+            else:
+                # success
+                return

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -219,7 +219,7 @@ class AbstractModule(AbstractDevice):
                 await t
             except BaseException:
                 mod_log.exception(
-                    f"error in fault tollerant module call debounce {debounce_count}"
+                    f"error in fault tolerant module call debounce {debounce_count}"
                 )
                 debounce_count -= 1
                 await asyncio.sleep(1)

--- a/api/src/opentrons/hardware_control/modules/mod_abc.py
+++ b/api/src/opentrons/hardware_control/modules/mod_abc.py
@@ -2,7 +2,7 @@ import abc
 import asyncio
 import logging
 import re
-from typing import Any, Callable, ClassVar, Coroutine, Mapping, Optional, TypeVar
+from typing import Any, Callable, ClassVar, Coroutine, Optional, TypeVar
 
 from packaging.version import InvalidVersion, Version, parse
 

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Optional
 
 from typing_extensions import Final
 
+from opentrons.config import IS_ROBOT
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.temp_deck import (
     DEFAULT_COMMAND_RETRIES,
@@ -26,8 +27,6 @@ from opentrons.util.pyro.pyro_synchronous_adapter import (
     pyro_behavior,
     remove_pyro_synchronous_object,
 )
-
-from opentrons.config import IS_ROBOT
 
 log = logging.getLogger(__name__)
 

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -8,6 +8,7 @@ from typing_extensions import Final
 
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.temp_deck import (
+    DEFAULT_COMMAND_RETRIES,
     AbstractTempDeckDriver,
     SimulatingDriver,
     TempDeckDriver,
@@ -190,9 +191,7 @@ class TempDeck(mod_abc.AbstractModule):
                 while self.temperature > awaiting_temperature:
                     await self._poller.wait_next_poll()
 
-        t = self._loop.create_task(_await_temperature())
-        self.make_cancellable(t)
-        await t
+        await self.run_task_fault_tolerant(_await_temperature, DEFAULT_COMMAND_RETRIES)
 
     async def deactivate(self, must_be_running: bool = True) -> None:
         """Stop heating/cooling and turn off the fan"""
@@ -295,6 +294,25 @@ class TempDeck(mod_abc.AbstractModule):
             return "temperatureModuleV1"
         else:
             return "temperatureModuleV2"
+
+    async def attempt_reconnect(self) -> None:
+        """Attempt to reestablish connections."""
+        try:
+            if not await self._driver.is_connected():
+                await self.cleanup()
+                self._driver = await TempDeckDriver.create(
+                    port=self.port, loop=self.loop
+                )
+                self._reader._driver = self._driver
+            # restart the poller
+            await self._poller.stop()
+            await self._poller.start()
+        except BaseException as e:
+            log.error(f"Got {e} when trying to reconnect.")
+
+    async def move_port(self, port: str, usb_port: USBPort) -> None:
+        self._port = port
+        self._usb_port = usb_port
 
 
 class TempDeckReader(Reader):

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -324,10 +324,13 @@ class TempDeckReader(Reader):
         self.temperature = Temperature(current=25, target=None)
         self._driver = driver
         self._error_callback: Optional[Callable[[Exception], None]] = None
+        self._debounce_count = DEFAULT_COMMAND_RETRIES
 
     async def read(self) -> None:
         """Read the module's current and target temperatures."""
         self.temperature = await self._driver.get_temperature()
+        # reset on success
+        self._debounce_count = DEFAULT_COMMAND_RETRIES
 
     def set_error_callback(
         self, error_callback: Callable[[Exception], None]
@@ -339,5 +342,11 @@ class TempDeckReader(Reader):
         self._error_callback = None
 
     def on_error(self, exception: Exception) -> None:
+        self._debounce_count -= 1
         if self._error_callback:
-            self._error_callback(exception)
+            if self._debounce_count == 0:
+                log.error(
+                    f"Reader encountered error {exception} but has {self._debounce_count} tries left"
+                )
+            else:
+                self._error_callback(exception)

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -130,7 +130,7 @@ class TempDeck(mod_abc.AbstractModule):
         self._poller = poller
         self._reader.set_error_callback(self.error_callback)
 
-    async def _cleanup(self) -> None:
+    async def soft_cleanup(self) -> None:
         """Stop the poller task."""
         await self._poller.stop()
         await self._driver.disconnect()
@@ -138,7 +138,7 @@ class TempDeck(mod_abc.AbstractModule):
     @pyro_behavior(specialty_func=remove_pyro_synchronous_object, apply_local=True)
     async def cleanup(self) -> None:
         """Stop the poller task."""
-        await self._cleanup()
+        await self.soft_cleanup()
 
     @classmethod
     def name(cls) -> str:
@@ -306,7 +306,6 @@ class TempDeck(mod_abc.AbstractModule):
             return
         try:
             if not await self._driver.is_connected():
-                await self._cleanup()
                 self._driver = await TempDeckDriver.create(
                     port=self.port, loop=self.loop
                 )

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -130,11 +130,15 @@ class TempDeck(mod_abc.AbstractModule):
         self._poller = poller
         self._reader.set_error_callback(self.error_callback)
 
-    @pyro_behavior(specialty_func=remove_pyro_synchronous_object, apply_local=True)
-    async def cleanup(self) -> None:
+    async def _cleanup(self) -> None:
         """Stop the poller task."""
         await self._poller.stop()
         await self._driver.disconnect()
+
+    @pyro_behavior(specialty_func=remove_pyro_synchronous_object, apply_local=True)
+    async def cleanup(self) -> None:
+        """Stop the poller task."""
+        await self._cleanup()
 
     @classmethod
     def name(cls) -> str:
@@ -302,7 +306,7 @@ class TempDeck(mod_abc.AbstractModule):
             return
         try:
             if not await self._driver.is_connected():
-                await self.cleanup()
+                await self._cleanup()
                 self._driver = await TempDeckDriver.create(
                     port=self.port, loop=self.loop
                 )

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -27,6 +27,8 @@ from opentrons.util.pyro.pyro_synchronous_adapter import (
     remove_pyro_synchronous_object,
 )
 
+from opentrons.config import IS_ROBOT
+
 log = logging.getLogger(__name__)
 
 TEMP_POLL_INTERVAL_SECS = 1.0
@@ -297,6 +299,8 @@ class TempDeck(mod_abc.AbstractModule):
 
     async def attempt_reconnect(self) -> None:
         """Attempt to reestablish connections."""
+        if not IS_ROBOT:
+            return
         try:
             if not await self._driver.is_connected():
                 await self.cleanup()

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -9,6 +9,7 @@ from . import mod_abc, types, update
 from opentrons.drivers.asyncio.communication.errors import UnhandledGcode
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.thermocycler import (
+    DEFAULT_COMMAND_RETRIES,
     AbstractThermocyclerDriver,
     SimulatingDriver,
     ThermocyclerDriverFactory,
@@ -353,10 +354,9 @@ class Thermocycler(mod_abc.AbstractModule):
         await self._driver.set_plate_temperature(
             temp=temperature, hold_time=hold_time, volume=volume, ramp_rate=ramp_rate
         )
-
-        task = self._loop.create_task(self._wait_for_block_target())
-        self.make_cancellable(task)
-        await task
+        await self.run_task_fault_tolerant(
+            self._wait_for_block_target, DEFAULT_COMMAND_RETRIES
+        )
 
     async def wait_for_block_target(self) -> None:
         """
@@ -370,9 +370,7 @@ class Thermocycler(mod_abc.AbstractModule):
         Returns: None
         """
         await self.wait_for_is_running()
-        task = self._loop.create_task(self._wait_for_block_target())
-        self.make_cancellable(task)
-        await task
+        await self.run_task_fault_tolerant(self._wait_for_block_target, DEFAULT_COMMAND_RETRIES)
 
     async def cycle_temperatures(
         self,
@@ -435,18 +433,12 @@ class Thermocycler(mod_abc.AbstractModule):
         """Set the lid temperature in degrees Celsius"""
         await self.wait_for_is_running()
         await self._driver.set_lid_temperature(temp=temperature)
-
-        task = self._loop.create_task(self._wait_for_lid_target())
-        self.make_cancellable(task)
-        await task
+        await self.run_task_fault_tolerant(self._wait_for_lid_target, DEFAULT_COMMAND_RETRIES)
 
     async def wait_for_lid_target(self) -> None:
         """Set the lid temperature in degrees Celsius"""
         await self.wait_for_is_running()
-
-        task = self._loop.create_task(self._wait_for_lid_target())
-        self.make_cancellable(task)
-        await task
+        await self.run_task_fault_tolerant(self._wait_for_lid_target, DEFAULT_COMMAND_RETRIES)
 
     # TODO(mc, 2022-04-25): de-duplicate with `set_temperature`
     async def set_target_block_temperature(

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -370,7 +370,9 @@ class Thermocycler(mod_abc.AbstractModule):
         Returns: None
         """
         await self.wait_for_is_running()
-        await self.run_task_fault_tolerant(self._wait_for_block_target, DEFAULT_COMMAND_RETRIES)
+        await self.run_task_fault_tolerant(
+            self._wait_for_block_target, DEFAULT_COMMAND_RETRIES
+        )
 
     async def cycle_temperatures(
         self,
@@ -433,12 +435,16 @@ class Thermocycler(mod_abc.AbstractModule):
         """Set the lid temperature in degrees Celsius"""
         await self.wait_for_is_running()
         await self._driver.set_lid_temperature(temp=temperature)
-        await self.run_task_fault_tolerant(self._wait_for_lid_target, DEFAULT_COMMAND_RETRIES)
+        await self.run_task_fault_tolerant(
+            self._wait_for_lid_target, DEFAULT_COMMAND_RETRIES
+        )
 
     async def wait_for_lid_target(self) -> None:
         """Set the lid temperature in degrees Celsius"""
         await self.wait_for_is_running()
-        await self.run_task_fault_tolerant(self._wait_for_lid_target, DEFAULT_COMMAND_RETRIES)
+        await self.run_task_fault_tolerant(
+            self._wait_for_lid_target, DEFAULT_COMMAND_RETRIES
+        )
 
     # TODO(mc, 2022-04-25): de-duplicate with `set_temperature`
     async def set_target_block_temperature(

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -175,12 +175,16 @@ class Thermocycler(mod_abc.AbstractModule):
             self._enter_error_state
         )
 
-    @pyro_behavior(specialty_func=remove_pyro_synchronous_object, apply_local=True)
-    async def cleanup(self) -> None:
+    async def soft_cleanup(self) -> None:
         """Stop the poller task."""
         self._unsubscribe_reader()
         await self._poller.stop()
         await self._driver.disconnect()
+
+    @pyro_behavior(specialty_func=remove_pyro_synchronous_object, apply_local=True)
+    async def cleanup(self) -> None:
+        """Stop the poller task."""
+        await self.soft_cleanup()
 
     @classmethod
     def name(cls) -> str:

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -6,7 +6,6 @@ from typing import AsyncGenerator, List, Optional
 
 from opentrons_shared_data.errors.exceptions import ModuleCommunicationError
 
-from opentrons.config import IS_ROBOT
 from opentrons.drivers.asyncio.communication.errors import SerialException
 from opentrons.hardware_control.modules.errors import AbsorbanceReaderDisconnectedError
 
@@ -111,13 +110,9 @@ class Poller:
         try:
             async with self._use_read_lock():
                 await self._reader.read()
-        except asyncio.CancelledError as ce:
-            if not IS_ROBOT:
-                raise
-            log.error(f"canceled error: {ce}")
-            # cancelled error does not inherit from Exception so lets re-wrap it
-            new_exception = RuntimeError(str(ce)).with_traceback(ce.__traceback__)
-            self._error_callback(new_exception)
+        except asyncio.CancelledError:
+            log.exception("poller canceled.")
+            raise
         except AbsorbanceReaderDisconnectedError as e:
             self._error_callback(e)
             self._complete_all(e, previous_waiters)

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -6,6 +6,7 @@ from typing import AsyncGenerator, List, Optional
 
 from opentrons_shared_data.errors.exceptions import ModuleCommunicationError
 
+from opentrons.config import IS_ROBOT
 from opentrons.drivers.asyncio.communication.errors import SerialException
 from opentrons.hardware_control.modules.errors import AbsorbanceReaderDisconnectedError
 
@@ -111,6 +112,8 @@ class Poller:
             async with self._use_read_lock():
                 await self._reader.read()
         except asyncio.CancelledError as ce:
+            if not IS_ROBOT:
+                raise
             log.error(f"canceled error: {ce}")
             # cancelled error does not inherit from Exception so lets re-wrap it
             new_exception = RuntimeError(str(ce)).with_traceback(ce.__traceback__)

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -110,8 +110,11 @@ class Poller:
         try:
             async with self._use_read_lock():
                 await self._reader.read()
-        except asyncio.CancelledError:
-            raise
+        except asyncio.CancelledError as ce:
+            log.error(f"canceled error: {ce}")
+            # cancelled error does not inherit from Exception so lets re-wrap it
+            new_exception = RuntimeError(str(ce)).with_traceback(ce.__traceback__)
+            self._error_callback(new_exception)
         except AbsorbanceReaderDisconnectedError as e:
             self._error_callback(e)
             self._complete_all(e, previous_waiters)

--- a/api/src/opentrons/protocol_engine/execution/equipment.py
+++ b/api/src/opentrons/protocol_engine/execution/equipment.py
@@ -1,5 +1,6 @@
 """Equipment command side-effect logic."""
 
+import logging
 from dataclasses import dataclass
 from typing import List, Optional, overload
 
@@ -52,6 +53,8 @@ from opentrons.protocol_engine.state.module_substates import (
     VacuumModuleId,
 )
 from opentrons.types import MountType
+
+log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -774,9 +777,17 @@ class EquipmentHandler:
 
         attached_modules = self._hardware_api.attached_modules
         serial_number = self._state_store.modules.get_serial_number(module_id)
+        duplicates = []
         for mod in attached_modules:
             if mod.device_info["serial"] == serial_number:
-                return mod
+                duplicates.append(mod)
+
+        if len(duplicates):
+            if len(duplicates) > 1:
+                log.warn(f"found {len(duplicates)} modules with {serial_number}")
+            # Return the last one, because that should be the recently disconnected one
+            # the recently disconnected one will be the one that doesn't get deleted
+            return duplicates[-1]
 
         raise ModuleNotAttachedError(
             f'No module attached with serial number "{serial_number}"'

--- a/api/tests/opentrons/drivers/asyncio/communication/test_async_serial.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_async_serial.py
@@ -38,6 +38,8 @@ async def subject(mock_serial: MagicMock) -> AsyncSerial:
         executor=ThreadPoolExecutor(),
         loop=asyncio.get_running_loop(),
         reset_buffer_before_write=False,
+        baud_rate=115200,
+        timeout=10,
     )
 
 

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -1,10 +1,11 @@
 from typing import AsyncGenerator, Type, Union
+from unittest.mock import patch
 
 import mock
 import pytest
 from _pytest.fixtures import SubRequest
-from mock import AsyncMock, call, patch
-from unittest.mock import
+from mock import AsyncMock, call
+
 from opentrons.drivers.asyncio.communication.async_serial import AsyncSerial
 from opentrons.drivers.asyncio.communication.errors import (
     AlarmResponse,

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -3,8 +3,8 @@ from typing import AsyncGenerator, Type, Union
 import mock
 import pytest
 from _pytest.fixtures import SubRequest
-from mock import AsyncMock, call
-
+from mock import AsyncMock, call, patch
+from unittest.mock import
 from opentrons.drivers.asyncio.communication.async_serial import AsyncSerial
 from opentrons.drivers.asyncio.communication.errors import (
     AlarmResponse,
@@ -142,9 +142,11 @@ async def test_send_command_with_zero_retries(
     # the retries from the subject.send_data(data, retries=0) method call.
     async_subject._number_of_retries = 1
 
-    with pytest.raises(NoResponse):
-        # We want this to overwrite the internal `_number_of_retries`
-        await async_subject.send_data(data="send data", retries=0)
+    with patch("os.path.exists") as mock_exists:
+        mock_exists.return_value = True
+        with pytest.raises(NoResponse):
+            # We want this to overwrite the internal `_number_of_retries`
+            await async_subject.send_data(data="send data", retries=0)
 
     mock_serial_port.timeout_override.assert_called_once_with("timeout", None)
     mock_serial_port.write.assert_called_once_with(data=b"send data")
@@ -231,7 +233,9 @@ def test_get_error_codes_lowercase(
 
 async def test_on_retry(mock_serial_port: AsyncMock, subject: SerialKind) -> None:
     """It should try to re-open connection."""
-    await subject.on_retry()
+    with patch("os.path.exists") as mock_exists:
+        mock_exists.return_value = True
+        await subject.on_retry()
 
     mock_serial_port.close.assert_called_once()
     mock_serial_port.open.assert_called_once()

--- a/api/tests/opentrons/drivers/heater_shaker/test_driver.py
+++ b/api/tests/opentrons/drivers/heater_shaker/test_driver.py
@@ -29,7 +29,7 @@ async def test_open_lock(
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode(
         gcode="M242"
     )
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
 
 
 async def test_close_lock(
@@ -41,7 +41,7 @@ async def test_close_lock(
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode(
         gcode="M243"
     )
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
 
 
 async def test_get_lock_status(
@@ -56,7 +56,7 @@ async def test_get_lock_status(
         gcode="M241"
     )
 
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
     assert response == HeaterShakerLabwareLatchStatus.IDLE_UNKNOWN
 
 
@@ -71,7 +71,7 @@ async def test_set_temperature(
         .add_gcode(gcode="M104")
         .add_float(prefix="S", value=65.02, precision=2)
     )
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
 
 
 async def test_get_temperature(
@@ -82,7 +82,7 @@ async def test_get_temperature(
     connection.send_command.return_value = "M105 T:91.25 C:54.02 ok\n"
     response = await subject.get_temperature()
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode("M105")
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
     assert response == Temperature(current=54.02, target=91.25)
 
 
@@ -97,7 +97,7 @@ async def test_set_rpm(
         .add_gcode(gcode="M3")
         .add_int(prefix="S", value=2500)
     )
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
 
 
 async def test_get_rpm(
@@ -107,7 +107,7 @@ async def test_get_rpm(
     connection.send_command.return_value = "M123 T:2200 C:2100 ok\n"
     response = await subject.get_rpm()
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode("M123")
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
     assert response == RPM(current=2100, target=2200)
 
 
@@ -116,7 +116,7 @@ async def test_home(subject: driver.HeaterShakerDriver, connection: AsyncMock) -
     connection.send_command.return_value = "G28 ok\n"
     await subject.home()
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode("G28")
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
 
 
 async def test_deactivate_heater(
@@ -126,7 +126,7 @@ async def test_deactivate_heater(
     connection.send_command.return_value = "M106 ok\n"
     await subject.deactivate_heater()
     expected = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode("M106")
-    connection.send_command.assert_called_once_with(command=expected, retries=0)
+    connection.send_command.assert_called_once_with(command=expected, retries=4)
 
 
 async def test_get_device_info(
@@ -144,8 +144,8 @@ async def test_get_device_info(
     reset_reason = CommandBuilder(terminator=driver.HS_COMMAND_TERMINATOR).add_gcode(
         gcode="M114"
     )
-    connection.send_command.assert_any_call(command=device_info, retries=0)
-    connection.send_command.assert_called_with(command=reset_reason, retries=0)
+    connection.send_command.assert_any_call(command=device_info, retries=4)
+    connection.send_command.assert_called_with(command=reset_reason, retries=4)
 
 
 async def test_enter_bootloader(

--- a/api/tests/opentrons/hardware_control/modules/test_hc_flexstacker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_flexstacker.py
@@ -633,7 +633,7 @@ async def test_error_callback(
     # There are no asynchronous errors from the stacker (the door is handled
     # differently) so just inject a random exception.
     exc = Exception("Oh no!")
-    decoy.when(mock_driver.get_hopper_door_closed()).then_raise(exc)
+    decoy.when(await mock_driver.get_hopper_door_closed()).then_raise(exc)
     with pytest.raises(Exception, match="Oh no!"):
         await subject._poller.wait_next_poll()
     decoy.verify(

--- a/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_heatershaker.py
@@ -262,8 +262,9 @@ async def test_async_error_response(
     )
     await simulating_module_driver_patched._poller.wait_next_poll()
     decoy.when(await mock_driver.get_temperature()).then_raise(exc)
-    with pytest.raises(Exception):
-        await simulating_module_driver_patched._poller.wait_next_poll()
+    for i in range(5):
+        with pytest.raises(Exception):
+            await simulating_module_driver_patched._poller.wait_next_poll()
     decoy.verify(
         module_error_callback(
             exc, "heaterShakerModuleV1", "/dev/ot_module_sim_heatershaker0", None
@@ -313,8 +314,9 @@ async def test_reader_raises_error_from_get_error(
         "/dev/ot_module_sim_heatershaker0", "ERR:666:you know what it is", "M411"
     )
     decoy.when(await mock_driver.get_error_state()).then_raise(error_state_response)  # type: ignore[func-returns-value]
-    with pytest.raises(ErrorResponse):
-        await simulating_module_driver_patched._poller.wait_next_poll()
+    for i in range(5):
+        with pytest.raises(ErrorResponse):
+            await simulating_module_driver_patched._poller.wait_next_poll()
     decoy.verify(
         module_error_callback(
             error_state_response,

--- a/api/tests/opentrons/hardware_control/test_module_control.py
+++ b/api/tests/opentrons/hardware_control/test_module_control.py
@@ -1,5 +1,6 @@
 """Tests for opentrons.hardware_control.module_control."""
 
+import asyncio
 from typing import Awaitable, Callable, List, Union, cast
 
 import pytest
@@ -10,7 +11,7 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control import API as HardwareAPI
 from opentrons.hardware_control import types
 from opentrons.hardware_control.abstract_device import AbstractDevice
-from opentrons.hardware_control.module_control import AttachedModulesControl
+from opentrons.hardware_control.module_control import AttachedModulesControl, RECONNECT_ATTEMPTS
 from opentrons.hardware_control.modules import AbstractModule
 from opentrons.hardware_control.modules.types import (
     ModuleAtPort,
@@ -237,3 +238,93 @@ async def test_register_modules_sort(
     result = subject.available_modules
 
     assert result == [module_5, module_4, module_3, module_2, module_1]
+
+
+async def test_unregister_modules(
+    decoy: Decoy,
+    usb_bus: USBDriverInterface,
+    build_device: Callable[..., Awaitable[AbstractDevice]],
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """It should register attached modules."""
+    # Add a module
+    module_1 = decoy.mock(cls=AbstractModule)
+    decoy.when(module_1.usb_port).then_return(
+        USBPort(name="a", port_number=4, hub=True, hub_port=2)
+    )
+    decoy.when(module_1.serial_number).then_return("FakeSerial")
+    decoy.when(module_1.port).then_return("/dev/foo")
+
+    module_2 = decoy.mock(cls=AbstractModule)
+    decoy.when(module_2.usb_port).then_return(
+        USBPort(name="a", port_number=4, hub=True, hub_port=2)
+    )
+    decoy.when(module_2.serial_number).then_return("FakeSerial")
+    decoy.when(module_2.port).then_return("/dev/bar")
+
+    decoy.when(hardware_api.is_simulator).then_return(False)
+    #setup ports for mod 1
+    new_mods_at_ports = [ModuleAtPort(port="/dev/foo", name="bar")]
+    actual_ports = [
+        ModuleAtPort(port="/dev/foo", name="magdeck", usb_port=module_1.usb_port),
+    ]
+
+    decoy.when(usb_bus.match_virtual_ports(new_mods_at_ports)).then_return(actual_ports)
+
+    decoy.when(
+        await build_device(
+            usb_port=module_1.usb_port,
+            port="/dev/foo",
+            type=matchers.Anything(),
+            sim_serial_number=None,
+            sim_model=None,
+        )
+    ).then_return(module_1)
+    decoy.when(
+        await build_device(
+            usb_port=module_2.usb_port,
+            port="/dev/bar",
+            type=matchers.Anything(),
+            sim_serial_number=None,
+            sim_model=None,
+        )
+    ).then_return(module_2)
+
+    await subject.register_devices(new_devices_at_ports=new_mods_at_ports)
+    assert subject.available_modules == [module_1]
+    await subject.unregister_devices(devices_at_ports=new_mods_at_ports)
+    assert subject.available_modules == [module_1]
+    assert subject._available_modules == []
+    assert subject._recently_removed_modules == [module_1]
+    hardware_api.loop.create_task.called_once()
+
+
+    # Test a module gets removed after reconnect patch and it doesn't infinite recurse
+    async with asyncio.timeout(RECONNECT_ATTEMPTS + 1):
+        await subject._reconnect_patch(RECONNECT_ATTEMPTS)
+    assert subject._recently_removed_modules == []
+
+
+    # Test a module gets reconnected when it reappers on a new port
+    #connect and disconnect
+    await subject.register_devices(new_devices_at_ports=new_mods_at_ports)
+    await subject.unregister_devices(devices_at_ports=new_mods_at_ports)
+    # device comes back on another port
+    new_mods_at_ports = [ModuleAtPort(port="/dev/bar", name="bar")]
+    actual_ports = [
+        ModuleAtPort(port="/dev/bar", name="magdeck", usb_port=module_2.usb_port),
+    ]
+    decoy.when(usb_bus.match_virtual_ports(new_mods_at_ports)).then_return(actual_ports)
+    await subject.register_devices(new_devices_at_ports=new_mods_at_ports)
+    # reconnect gets called and module 1 gets reconnected
+    await subject._reconnect_patch(RECONNECT_ATTEMPTS)
+    assert subject.available_modules == [module_1]
+    assert subject._available_modules == [module_1]
+    assert subject._recently_removed_modules == []
+
+    module_1.move_port.assert_called_once_with(port="/dev/bar", usb_port=module_2.usb_port)
+
+
+
+

--- a/api/tests/opentrons/hardware_control/test_module_control.py
+++ b/api/tests/opentrons/hardware_control/test_module_control.py
@@ -11,7 +11,10 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control import API as HardwareAPI
 from opentrons.hardware_control import types
 from opentrons.hardware_control.abstract_device import AbstractDevice
-from opentrons.hardware_control.module_control import AttachedModulesControl, RECONNECT_ATTEMPTS
+from opentrons.hardware_control.module_control import (
+    RECONNECT_ATTEMPTS,
+    AttachedModulesControl,
+)
 from opentrons.hardware_control.modules import AbstractModule
 from opentrons.hardware_control.modules.types import (
     ModuleAtPort,
@@ -248,6 +251,8 @@ async def test_unregister_modules(
     subject: AttachedModulesControl,
 ) -> None:
     """It should register attached modules."""
+    loop = decoy.mock(cls=asyncio.AbstractEventLoop)
+    decoy.when(hardware_api.loop).then_return(loop)
     # Add a module
     module_1 = decoy.mock(cls=AbstractModule)
     decoy.when(module_1.usb_port).then_return(
@@ -264,7 +269,7 @@ async def test_unregister_modules(
     decoy.when(module_2.port).then_return("/dev/bar")
 
     decoy.when(hardware_api.is_simulator).then_return(False)
-    #setup ports for mod 1
+    # setup ports for mod 1
     new_mods_at_ports = [ModuleAtPort(port="/dev/foo", name="bar")]
     actual_ports = [
         ModuleAtPort(port="/dev/foo", name="magdeck", usb_port=module_1.usb_port),
@@ -297,17 +302,15 @@ async def test_unregister_modules(
     assert subject.available_modules == [module_1]
     assert subject._available_modules == []
     assert subject._recently_removed_modules == [module_1]
-    hardware_api.loop.create_task.called_once()
-
+    decoy.verify(loop.create_task(matchers.Anything()), times=1)
 
     # Test a module gets removed after reconnect patch and it doesn't infinite recurse
     async with asyncio.timeout(RECONNECT_ATTEMPTS + 1):
         await subject._reconnect_patch(RECONNECT_ATTEMPTS)
     assert subject._recently_removed_modules == []
 
-
     # Test a module gets reconnected when it reappers on a new port
-    #connect and disconnect
+    # connect and disconnect
     await subject.register_devices(new_devices_at_ports=new_mods_at_ports)
     await subject.unregister_devices(devices_at_ports=new_mods_at_ports)
     # device comes back on another port
@@ -322,9 +325,6 @@ async def test_unregister_modules(
     assert subject.available_modules == [module_1]
     assert subject._available_modules == [module_1]
     assert subject._recently_removed_modules == []
-
-    module_1.move_port.assert_called_once_with(port="/dev/bar", usb_port=module_2.usb_port)
-
-
-
-
+    decoy.verify(
+        await module_1.move_port(port="/dev/bar", usb_port=module_2.usb_port), times=1
+    )

--- a/api/tests/opentrons/hardware_control/test_module_control.py
+++ b/api/tests/opentrons/hardware_control/test_module_control.py
@@ -12,7 +12,6 @@ from opentrons.hardware_control import API as HardwareAPI
 from opentrons.hardware_control import types
 from opentrons.hardware_control.abstract_device import AbstractDevice
 from opentrons.hardware_control.module_control import (
-    RECONNECT_ATTEMPTS,
     AttachedModulesControl,
 )
 from opentrons.hardware_control.modules import AbstractModule
@@ -302,11 +301,9 @@ async def test_unregister_modules(
     assert subject.available_modules == [module_1]
     assert subject._available_modules == []
     assert subject._recently_removed_modules == [module_1]
-    decoy.verify(loop.create_task(matchers.Anything()), times=1)
-
-    # Test a module gets removed after reconnect patch and it doesn't infinite recurse
-    async with asyncio.timeout(RECONNECT_ATTEMPTS + 1):
-        await subject._reconnect_patch(RECONNECT_ATTEMPTS)
+    decoy.verify(loop.call_later(matchers.IsA(float), matchers.Anything()), times=1)
+    # loop is a mock so we need to call clear modules ourselves.
+    await subject._clear_old_modules()
     assert subject._recently_removed_modules == []
 
     # Test a module gets reconnected when it reappers on a new port
@@ -321,7 +318,6 @@ async def test_unregister_modules(
     decoy.when(usb_bus.match_virtual_ports(new_mods_at_ports)).then_return(actual_ports)
     await subject.register_devices(new_devices_at_ports=new_mods_at_ports)
     # reconnect gets called and module 1 gets reconnected
-    await subject._reconnect_patch(RECONNECT_ATTEMPTS)
     assert subject.available_modules == [module_1]
     assert subject._available_modules == [module_1]
     assert subject._recently_removed_modules == []

--- a/api/tests/opentrons/hardware_control/test_modules.py
+++ b/api/tests/opentrons/hardware_control/test_modules.py
@@ -96,6 +96,8 @@ async def test_module_caching() -> None:
             ModuleAtPort(port="/dev/ot_module_sim_tempdeck111", name="tempdeck")
         ]
     )
+    # give the remove module call time
+    await asyncio.sleep(0.2)
     only_magdeck = api.attached_modules.copy()
 
     assert only_magdeck[0] is with_magdeck[1]

--- a/api/tests/opentrons/hardware_control/test_thread_manager.py
+++ b/api/tests/opentrons/hardware_control/test_thread_manager.py
@@ -78,6 +78,8 @@ async def test_module_cache_remove_entry() -> None:
         loop,
     )
     future.result()
+    # give the cleanup task time
+    await asyncio.sleep(0.2)
     mods_after = thread_manager.attached_modules
     assert len(mods_after) == 1
 


### PR DESCRIPTION
# Overview
There are rare instances where modules briefly disconnect and reconnect. 
This adds a mechanism the module control layer to detect a disconnect, and wait up to 3 seconds to see if the module comes back. If it does, it reconnects the old instance so any client that was using that module reference does not notice the disappearance. 

It also adds a new mechanism in mod_abc that allows the "wait for" tasks to be tolerant of errors. so far we've only ever noticed this for sure in the heatershaker (and perhaps once in a temp deck) so this PR adds that tolerance to the heater-shaker and the tempdeck.