### PR TITLE
feat(app): Add a desktop component for the account icon button

### DIFF
--- a/app/src/atoms/buttons/AccountIconButton.tsx
+++ b/app/src/atoms/buttons/AccountIconButton.tsx
@@ -14,7 +14,7 @@ export function AccountIconButton(props: AccountIconButtonProps): JSX.Element {
   // todo(mm, 2026-05-27): Since the button only contains a single letter,
   // do we need some kind of aria label?
   return (
-    <button className={styles.button} onClick={onClick}>
+    <button className={styles.button} onClick={onClick} type="button">
       <StyledText desktopStyle="bodyLargeSemiBold">{initial}</StyledText>
     </button>
   )

--- a/app/src/atoms/buttons/AccountIconButton.tsx
+++ b/app/src/atoms/buttons/AccountIconButton.tsx
@@ -1,0 +1,21 @@
+import { StyledText } from '@opentrons/components'
+
+import styles from './accounticon.module.css'
+
+import type { ComponentProps } from 'react'
+
+interface AccountIconButtonProps {
+  initial: string /** A single character to show in the button. */
+  onClick?: ComponentProps<'button'>['onClick']
+}
+
+export function AccountIconButton(props: AccountIconButtonProps): JSX.Element {
+  const { initial, onClick } = props
+  // todo(mm, 2026-05-27): Since the button only contains a single letter,
+  // do we need some kind of aria label?
+  return (
+    <button className={styles.button} onClick={onClick}>
+      <StyledText desktopStyle="bodyLargeSemiBold">{initial}</StyledText>
+    </button>
+  )
+}

--- a/app/src/atoms/buttons/__tests__/AccountIconButton.test.tsx
+++ b/app/src/atoms/buttons/__tests__/AccountIconButton.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { renderWithProviders } from '/app/__testing-utils__'
+
+import '@testing-library/jest-dom/vitest'
+
+import { AccountIconButton } from '../AccountIconButton'
+
+import type { ComponentProps } from 'react'
+
+const render = (props: ComponentProps<typeof AccountIconButton>) => {
+  return renderWithProviders(<AccountIconButton {...props} />)[0]
+}
+
+describe('AccountIconButton', () => {
+  it('renders the account initial', () => {
+    render({ initial: 'T' })
+    screen.getByText('T')
+  })
+
+  it('calls onClick when the button is clicked', () => {
+    const onClick = vi.fn()
+    render({ initial: 'T', onClick })
+    fireEvent.click(screen.getByRole('button'))
+    expect(onClick).toHaveBeenCalled()
+  })
+})

--- a/app/src/atoms/buttons/accounticon.module.css
+++ b/app/src/atoms/buttons/accounticon.module.css
@@ -1,0 +1,21 @@
+.button {
+	display: flex;
+	width: 1.5rem;
+	height: 1.5rem;
+	align-items: center;
+	justify-content: center;
+	padding: var(--spacing-2);
+	border-radius: var(--border-radius-full);
+	background-color: var(--black-90);
+	color: var(--white);
+	cursor: pointer;
+}
+
+.button:hover {
+	background-color: var(--black-80);
+}
+
+.button:focus-visible {
+	outline: 2px solid var(--blue-50);
+	outline-offset: 2px;
+}

--- a/app/src/atoms/buttons/buttons.stories.tsx
+++ b/app/src/atoms/buttons/buttons.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { action } from 'storybook/actions'
 
 import {
   DIRECTION_COLUMN,
@@ -73,9 +74,7 @@ export const SubmitPrimary = SubmitPrimaryButtonTemplate.bind({})
 SubmitPrimary.args = {
   form: 'storybook-form',
   value: 'submit primary button',
-  onClick: () => {
-    console.log('submit primary button clicked')
-  },
+  onClick: action('submit primary button clicked'),
   disabled: false,
 }
 
@@ -95,9 +94,7 @@ TouchControl.args = {
   subText: 'touch control subtext',
   isActive: true,
   isOnDevice: false,
-  onClick: () => {
-    console.log('touch control button clicked')
-  },
+  onClick: action('touch control button clicked'),
 }
 
 const ToggleButtonTemplate: Story<
@@ -191,7 +188,5 @@ const AccountIconButtonTemplate: Story<
 export const AccountIcon = AccountIconButtonTemplate.bind({})
 AccountIcon.args = {
   initial: 'F',
-  onClick: () => {
-    console.log('account icon button clicked')
-  },
+  onClick: action('account icon button clicked'),
 }

--- a/app/src/atoms/buttons/buttons.stories.tsx
+++ b/app/src/atoms/buttons/buttons.stories.tsx
@@ -10,6 +10,7 @@ import {
   useLongPress,
 } from '@opentrons/components'
 
+import { AccountIconButton } from './AccountIconButton'
 import {
   QuaternaryButton,
   SubmitPrimaryButton,
@@ -176,3 +177,21 @@ const TextOnlyButtonTemplate: Story<
 }
 
 export const TextOnly = TextOnlyButtonTemplate.bind({})
+
+const AccountIconButtonTemplate: Story<
+  ComponentProps<typeof AccountIconButton>
+> = args => {
+  return (
+    <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing16}>
+      <AccountIconButton {...args} />
+    </Flex>
+  )
+}
+
+export const AccountIcon = AccountIconButtonTemplate.bind({})
+AccountIcon.args = {
+  initial: 'F',
+  onClick: () => {
+    console.log('account icon button clicked')
+  },
+}

--- a/app/src/atoms/buttons/buttons.stories.tsx
+++ b/app/src/atoms/buttons/buttons.stories.tsx
@@ -182,9 +182,9 @@ const AccountIconButtonTemplate: Story<
   ComponentProps<typeof AccountIconButton>
 > = args => {
   return (
-    <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing16}>
+    <div>
       <AccountIconButton {...args} />
-    </Flex>
+    </div>
   )
 }
 

--- a/app/src/atoms/buttons/buttons.stories.tsx
+++ b/app/src/atoms/buttons/buttons.stories.tsx
@@ -74,7 +74,9 @@ export const SubmitPrimary = SubmitPrimaryButtonTemplate.bind({})
 SubmitPrimary.args = {
   form: 'storybook-form',
   value: 'submit primary button',
-  onClick: action('submit primary button clicked'),
+  onClick: () => {
+    console.log('submit primary button clicked')
+  },
   disabled: false,
 }
 
@@ -94,7 +96,9 @@ TouchControl.args = {
   subText: 'touch control subtext',
   isActive: true,
   isOnDevice: false,
-  onClick: action('touch control button clicked'),
+  onClick: () => {
+    console.log('touch control button clicked')
+  },
 }
 
 const ToggleButtonTemplate: Story<


### PR DESCRIPTION
## Overview

This implements the desktop version of the account icon button. It's the same as the ODD version in `/app/src/organisms/ODD/Navigation`, except it's smaller, and it has a hover and focus-visible state.

This goes towards EXEC-2700. See that ticket for links to the designs.

## Test Plan and Hands on Testing

https://github.com/user-attachments/assets/0c10212d-0258-4a00-a86e-cf0d1df0d84b

## Review requests

Is the naming and placement of this file correct?

In Figma, it's treated like an icon button, so I put this next to `IconButton`. I didn't want to literally overload `IconButton` for this, because this *is* a bit different. The colors are different, the size might be different, it's a `string` instead of an SVG, etc.

## Risk assessment

No risk. This isn't used anywhere yet.