### PR TITLE
refactor(app): refactor button stories to switch from console.log to action

### DIFF
--- a/app/src/atoms/buttons/buttons.stories.tsx
+++ b/app/src/atoms/buttons/buttons.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-
 import { action } from 'storybook/actions'
 
 import {

--- a/app/src/atoms/buttons/buttons.stories.tsx
+++ b/app/src/atoms/buttons/buttons.stories.tsx
@@ -1,12 +1,13 @@
 import * as React from 'react'
 
+import { action } from 'storybook/actions'
+
 import {
   DIRECTION_COLUMN,
-  DIRECTION_ROW,
-  Flex,
-  LegacyStyledText,
+  DISPLAY_FLEX,
   PrimaryButton,
   SPACING,
+  StyledText,
   useLongPress,
 } from '@opentrons/components'
 
@@ -29,42 +30,48 @@ export default {
 const TertiaryButtonTemplate: Story<
   ComponentProps<typeof TertiaryButton>
 > = args => {
-  const { children } = args
+  const { children, onClick } = args
   return (
-    <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing16}>
-      <TertiaryButton>{children}</TertiaryButton>
-    </Flex>
+    <div style={{ padding: SPACING.spacing16 }}>
+      <TertiaryButton onClick={onClick}>{children}</TertiaryButton>
+    </div>
   )
 }
 
 export const Tertiary = TertiaryButtonTemplate.bind({})
 Tertiary.args = {
   children: 'tertiary button',
+  onClick: () => {
+    action('tertiary button clicked')()
+  },
 }
 
 const QuaternaryButtonTemplate: Story<
   ComponentProps<typeof QuaternaryButton>
 > = args => {
-  const { children } = args
+  const { children, onClick } = args
   return (
-    <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing16}>
-      <QuaternaryButton>{children}</QuaternaryButton>
-    </Flex>
+    <div style={{ padding: SPACING.spacing16 }}>
+      <QuaternaryButton onClick={onClick}>{children}</QuaternaryButton>
+    </div>
   )
 }
 
 export const Quaternary = QuaternaryButtonTemplate.bind({})
 Quaternary.args = {
   children: 'quaternary button',
+  onClick: () => {
+    action('quaternary button clicked')()
+  },
 }
 
 const SubmitPrimaryButtonTemplate: Story<
   ComponentProps<typeof SubmitPrimaryButton>
 > = args => {
   return (
-    <Flex flexDirection={DIRECTION_ROW} width="15rem">
+    <div style={{ padding: SPACING.spacing16, width: '15rem' }}>
       <SubmitPrimaryButton {...args} />
-    </Flex>
+    </div>
   )
 }
 
@@ -73,7 +80,7 @@ SubmitPrimary.args = {
   form: 'storybook-form',
   value: 'submit primary button',
   onClick: () => {
-    console.log('submit primary button clicked')
+    action('submit primary button clicked')()
   },
   disabled: false,
 }
@@ -82,9 +89,9 @@ const TouchControlButtonTemplate: Story<
   ComponentProps<typeof TouchControlButton>
 > = args => {
   return (
-    <Flex>
+    <div style={{ padding: SPACING.spacing16 }}>
       <TouchControlButton {...args} />
-    </Flex>
+    </div>
   )
 }
 
@@ -95,7 +102,7 @@ TouchControl.args = {
   isActive: true,
   isOnDevice: false,
   onClick: () => {
-    console.log('touch control button clicked')
+    action('touch control button clicked')()
   },
 }
 
@@ -108,9 +115,9 @@ const ToggleButtonTemplate: Story<
     setIsToggled(currentIsToggled => !currentIsToggled)
   }
   return (
-    <Flex>
+    <div style={{ padding: SPACING.spacing16 }}>
       <ToggleButton {...rest} toggledOn={isToggled} onClick={handleClick} />
-    </Flex>
+    </div>
   )
 }
 
@@ -143,16 +150,19 @@ const LongPressButtonTemplate: Story<
   }, [longPress, longPress.isLongPressed])
 
   return (
-    <Flex flexDirection={DIRECTION_COLUMN} gap={SPACING.spacing16}>
+    <div
+      style={{
+        display: DISPLAY_FLEX,
+        flexDirection: DIRECTION_COLUMN,
+        padding: SPACING.spacing16,
+        gap: SPACING.spacing16,
+      }}
+    >
       <PrimaryButton ref={longPress.ref} width="16rem" onClick={handlePress}>
         {children}
       </PrimaryButton>
-      {
-        <LegacyStyledText
-          marginTop={SPACING.spacing16}
-        >{`You tapped ${tapCount} times`}</LegacyStyledText>
-      }
-    </Flex>
+      <StyledText>{`You tapped ${tapCount} times`}</StyledText>
+    </div>
   )
 }
 


### PR DESCRIPTION

# Overview

refactor button stories to switch from console.log to action and remove `Flex`

<img width="1465" height="774" alt="Screenshot 2026-05-29 at 6 11 48 PM" src="https://github.com/user-attachments/assets/69eebb70-5b20-48e8-94bd-abd8915aac5d" />


close AUTH-2933


## Test Plan and Hands on Testing
- make -C components dev
when clicking a button, text is displayed under `Actions`

## Changelog
- switch from console.log to action
- remove `Flex`

## Review requests


## Risk assessment
low
