### PR TITLE
docs: add model number to Flex specs

### DIFF
--- a/docs/flex/docs/cover.tpl
+++ b/docs/flex/docs/cover.tpl
@@ -7,5 +7,5 @@
 
 <p><strong>Opentrons Labworks Inc.</strong></p>
 
-<p>April 2026</p>
+<p>June 2026</p>
 </div>

--- a/docs/flex/docs/index.md
+++ b/docs/flex/docs/index.md
@@ -18,5 +18,5 @@ div.cover {
 
 **Opentrons Labworks Inc.**
 
-April 2026
+June 2026
 </div>

--- a/docs/flex/docs/modules/stacker.md
+++ b/docs/flex/docs/modules/stacker.md
@@ -58,7 +58,7 @@ The Stacker accepts Opentrons Flex tip racks, selected items in our [Labware Lib
 
 ### Module compatibility
 
-Any Flex with a [serial number version](../system-description/specs.md#serial-number) that includes **A10** or **A20** _requires_ a Stacker retrofit kit. Robots with serial number version **A30** (or higher) are fully compatible with the Stacker; the retrofit kit is not required. The kit adds new firmware and hardware to your Flex which:
+Any Flex with a [serial number version](../system-description/specs.md#model-and-serial-numbers) that includes **A10** or **A20** _requires_ a Stacker retrofit kit. Robots with serial number version **A30** (or higher) are fully compatible with the Stacker; the retrofit kit is not required. The kit adds new firmware and hardware to your Flex which:
 
 - Allows early model robots to recognize and communicate with the Staker.
 - Prevents the HEPA/UV module from operating if the Stacker is improperly installed.

--- a/docs/flex/docs/system-description/specs.md
+++ b/docs/flex/docs/system-description/specs.md
@@ -45,12 +45,11 @@ For additional information on acceptable environmental conditions for use and tr
 
 A summary of certification information is printed on a sticker on the back of Flex, near the on/off switch. For detailed certification and compliance information, see the [Regulatory Compliance section][regulatory-compliance].
 
-## Serial number
+## Model and serial numbers
 
-Every Flex has a unique serial number. The format of the serial number
-provides additional information, including the robot's date of
-production. For example, the serial number `FLXA1020231007001` would
-indicate:
+The model number for all Flex robots is `FLEX12SUV`.
+
+Every Flex has a unique serial number. The format of the serial number provides additional information, including the robot's date of production. For example, the serial number `FLXA1020231007001` would indicate:
 
 | Characters  | Category | Meaning                                          |
 |-------------|----------|--------------------------------------------------|
@@ -64,7 +63,5 @@ indicate:
 You can find the serial number for your Flex:
 
 - On the certification sticker on the back of Flex, near the on/off switch.
-
 - On the reverse side of the touchscreen (towards the working area).
-
 - In the Opentrons App under **Devices** \> your Flex \> **Robot settings** \> **Advanced**.


### PR DESCRIPTION
# Overview

Adds the model number `FLEX12SUV` to the specifications page in the Flex manual. This identifier is printed on the certification sticker for each robot. Having it in the manual is useful for certain compliance requests.

## Test Plan and Hands on Testing

[Sandbox](https://sandbox.docs.opentrons.com/docs-flex-model-number/flex/system-description/specs/#model-and-serial-numbers)

checked that a search for "serial number" still returns this section as the top hit

## Changelog

- Add one line and change name of "Serial number" section
- Update link to section header
- Soft wrap text and remove unneeded newlines in this section

## Review requests

Ship it?

## Risk assessment

vv low