### PR TITLE
feat(api, robot-server): Module implementation updates for pyro compatibility

### DIFF
--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -167,7 +167,6 @@ def identify_hardware_process() -> HardwareControlAPI:
     """
     robot_conf = robot_configs.load()
     logging_config.log_init(robot_conf.log_level)
-    pyro.config.COMMTIMEOUT = 100
     try:
         # Find the OT3API on the nameserver
         # todo(chb, 03-31-2026): for now this is using the same methodology as the DirectedRunProcess work, consolidate

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -663,6 +663,26 @@ def _bundled_fw_dict_to_class(  # type: ignore
     )
 
 
+# ABSMeasurementConfig registry
+def _ABSMeasurementConfig_class_to_dict(obj) -> Dict:  # type: ignore
+    return {
+        "__class__": "opentrons.drivers.types.ABSMeasurementConfig",
+        "measure_mode": obj.measure_mode.value,
+        "sample_wavelengths": obj.sample_wavelengths,
+        "reference_wavelength": obj.reference_wavelength,
+    }
+
+
+def _ABSMeasurementConfig_dict_to_class(  # type: ignore
+    classname, d
+) -> opentrons.drivers.types.ABSMeasurementConfig:
+    return opentrons.drivers.types.ABSMeasurementConfig(
+        measure_mode=opentrons.drivers.types.ABSMeasurementMode(d["measure_mode"]),
+        sample_wavelengths=d["sample_wavelengths"],
+        reference_wavelength=d["reference_wavelength"],
+    )
+
+
 # Handy function to map all registries for the Hardware controller
 def register_hardware_types() -> None:
     """Registers serialize and deserialize behavior for Opentrons Hardware types and classes.
@@ -824,6 +844,13 @@ def register_hardware_types() -> None:
         class_type=opentrons.hardware_control.modules.module_calibration.ModuleCalibrationOffset,
         dict_to_class=_ModuleCalibrationOffset_dict_to_class,
         class_to_dict=_ModuleCalibrationOffset_class_to_dict,
+    )
+
+    # ABSMeasurementConfig registration
+    register_type_to_serpent(
+        class_type=opentrons.drivers.types.ABSMeasurementConfig,
+        dict_to_class=_ABSMeasurementConfig_dict_to_class,
+        class_to_dict=_ABSMeasurementConfig_class_to_dict,
     )
 
     # handle Typed Dicts for the hardware controller

--- a/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
+++ b/api/src/opentrons/protocol_engine/commands/absorbance_reader/read.py
@@ -103,8 +103,8 @@ class ReadAbsorbanceImpl(
             start_time = datetime.now()
             results = await abs_reader.start_measure()
             finish_time = datetime.now()
-            if abs_reader._measurement_config is not None:
-                sample_wavelengths = abs_reader._measurement_config.sample_wavelengths
+            if abs_reader.measurement_config is not None:
+                sample_wavelengths = abs_reader.measurement_config.sample_wavelengths
                 for wavelength, result in zip(sample_wavelengths, results):
                     converted_values = (
                         self._state_view.modules.convert_absorbance_reader_data_points(

--- a/api/src/opentrons/protocol_engine/execution/heater_shaker_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/heater_shaker_movement_flagger.py
@@ -20,6 +20,7 @@ from ..types import (
     HeaterShakerMovementRestrictors,
     LabwareLocation,
     ModuleLocation,
+    ModuleModel,
 )
 from opentrons.motion_planning.adjacent_slots_getters import (
     get_east_west_slots,
@@ -139,10 +140,10 @@ class HeaterShakerMovementFlagger:
             # Different module types have different keys under .device_info.
             # Heater-Shaker should always have .device_info["serial"].
             if (
-                isinstance(module, HardwareHeaterShaker)
+                module.model() == ModuleModel.HEATER_SHAKER_MODULE_V1
                 and module.device_info["serial"] == serial_number
             ):
-                return module
+                return module  # type: ignore[return-value]
         return None
 
     def raise_if_movement_restricted(

--- a/api/src/opentrons/protocol_engine/execution/thermocycler_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/thermocycler_movement_flagger.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from ..errors import ThermocyclerNotOpenError, WrongModuleTypeError
 from ..state.state import StateStore
-from ..types import LabwareLocation, ModuleLocation
+from ..types import LabwareLocation, ModuleLocation, ModuleModel
 from .equipment import EquipmentHandler
 from opentrons.drivers.types import ThermocyclerLidStatus
 from opentrons.hardware_control import HardwareControlAPI
@@ -176,10 +176,10 @@ class ThermocyclerMovementFlagger:
             # Different module types have different keys under .device_info.
             # Thermocyclers should always have .device_info["serial"].
             if (
-                isinstance(module, HardwareThermocycler)
-                and module.device_info["serial"] == serial_number
-            ):
-                return module
+                module.model() == ModuleModel.THERMOCYCLER_MODULE_V1
+                or module.model() == ModuleModel.THERMOCYCLER_MODULE_V2
+            ) and module.device_info["serial"] == serial_number:
+                return module  # type: ignore[return-value]
         return None
 
     class _HardwareThermocyclerMissingError(Exception):

--- a/api/src/opentrons/util/pyro/pyro_daemon_utility.py
+++ b/api/src/opentrons/util/pyro/pyro_daemon_utility.py
@@ -4,6 +4,7 @@ import logging
 import socket
 from typing import Any, Callable
 
+import Pyro5
 from Pyro5 import api as pyro
 from Pyro5 import errors
 
@@ -25,6 +26,7 @@ def create_pyro_daemon(pyroname: str, resource: Any, registry: Callable) -> None
     registry()
 
     # Handle Pyro registration and publication of our synchronized object
+    Pyro5.config.THREADPOOL_SIZE = 100  # type: ignore
     with pyro.Daemon() as daemon:  # type: ignore
         utility = DaemonUtility(daemon)
         # Create a guaranteed synchronous adapted alias to the resource

--- a/api/src/opentrons/util/pyro/pyro_daemon_utility.py
+++ b/api/src/opentrons/util/pyro/pyro_daemon_utility.py
@@ -14,8 +14,6 @@ from opentrons.util.pyro.pyro_synchronous_adapter import (
 
 log = logging.getLogger(__name__)
 
-PYRO_TIMEOUT = 100
-
 
 def create_pyro_daemon(pyroname: str, resource: Any, registry: Callable) -> None:  # type: ignore
     """Function to create a Pyro Daemon request loop servicing a given resource.
@@ -27,7 +25,6 @@ def create_pyro_daemon(pyroname: str, resource: Any, registry: Callable) -> None
     registry()
 
     # Handle Pyro registration and publication of our synchronized object
-    pyro.config.COMMTIMEOUT = PYRO_TIMEOUT
     with pyro.Daemon() as daemon:  # type: ignore
         utility = DaemonUtility(daemon)
         # Create a guaranteed synchronous adapted alias to the resource
@@ -47,9 +44,7 @@ def create_pyro_daemon(pyroname: str, resource: Any, registry: Callable) -> None
                 finally:
                     ns.remove(name=pyroname)
         except (errors.NamingError, errors.CommunicationError, socket.timeout):
-            raise errors.CommunicationError(
-                f"Opentrons Pyro5 Nameserver not found within {PYRO_TIMEOUT} seconds."
-            )
+            raise errors.CommunicationError("Opentrons Pyro5 Nameserver not found.")
         finally:
             utility.remove_PSO(pyro_object)
             daemon.close()

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -618,7 +618,11 @@ def convert_result_to_proxy(  # noqa: C901
         try:
             proxy_list = []
             for r in result:
-                # CASEY NOTE: these need to optionally inherit their parents execution rule?
+                if hasattr(r, "__weakref__"):
+                    # If the resulting object contains a weakref then utilize the inner instance
+                    # Example - CallBridger wrapping an AbstractModule
+                    r = r.__weakref__()
+
                 pyro_synchronous_obj = utility.find_PSO(r)
                 if pyro_synchronous_obj is None:
                     if not hasattr(r, "_loop"):

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
@@ -66,13 +66,15 @@ from opentrons.util.pyro.pyro_client_async_adapter import (
     AsyncClientPyroObject,
     ClientPyroFunctionWrapper,
 )
-from opentrons.util.pyro.pyro_daemon_utility import PYRO_TIMEOUT, create_pyro_daemon
+from opentrons.util.pyro.pyro_daemon_utility import create_pyro_daemon
 from opentrons.util.pyro.pyro_synchronous_adapter import (
     DaemonUtility,
     PyroSynchronousObject,
     convert_result_to_proxy,
     pyro_behavior,
 )
+
+TEST_PYRO_TIMEOUT = 5
 
 OT3_PIP_CAL = ot3_calibration.PipetteOffsetByPipetteMount(
     offset=Point(0, 0, 0),
@@ -282,7 +284,7 @@ async def test_pyro_behavior_ot3api_dicts_with_non_builtin_keys(
 
     def _pyro_daemon() -> None:
         # Wait for the nameserver to be ready so locate_ns can succeed.
-        name_server_ready.wait(timeout=PYRO_TIMEOUT)
+        name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
         create_pyro_daemon("OT3API", managed_obj, register_hardware_types)
 
     ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
@@ -293,7 +295,7 @@ async def test_pyro_behavior_ot3api_dicts_with_non_builtin_keys(
 
     # Client-side requests below
     register_hardware_types()
-    name_server_ready.wait(timeout=PYRO_TIMEOUT)
+    name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
     ns = pyro.locate_ns()
 
     retries_counter = 0
@@ -421,7 +423,7 @@ async def test_pyro_module_properties(
 
     def _pyro_daemon() -> None:
         # Wait for the nameserver to be ready so locate_ns can succeed.
-        name_server_ready.wait(timeout=PYRO_TIMEOUT)
+        name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
         create_pyro_daemon("OT3API", ot3_hardware, register_hardware_types)
 
     ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
@@ -432,7 +434,7 @@ async def test_pyro_module_properties(
 
     # Client-side requests below
     register_hardware_types()
-    name_server_ready.wait(timeout=PYRO_TIMEOUT)
+    name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
     ns = pyro.locate_ns()
 
     retries_counter = 0
@@ -503,7 +505,7 @@ async def test_pyro_async_wrapped_calls(  # noqa: C901
 
     def _pyro_daemon() -> None:
         # Wait for the nameserver to be ready so locate_ns can succeed.
-        name_server_ready.wait(timeout=PYRO_TIMEOUT)
+        name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
         create_pyro_daemon("OT3API", ot3_hardware, register_hardware_types)
 
     class cool_door_class:
@@ -532,7 +534,7 @@ async def test_pyro_async_wrapped_calls(  # noqa: C901
 
         cool_door_instance = cool_door_class(new_loop)
         # Wait for the nameserver to be ready so locate_ns can succeed.
-        name_server_ready.wait(timeout=PYRO_TIMEOUT)
+        name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
         try:
             create_pyro_daemon("cool_door", cool_door_instance, register_hardware_types)
         finally:
@@ -549,7 +551,7 @@ async def test_pyro_async_wrapped_calls(  # noqa: C901
 
     # Client-side requests below
     register_hardware_types()
-    name_server_ready.wait(timeout=PYRO_TIMEOUT)
+    name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
     ns = pyro.locate_ns()
 
     retries_counter = 0
@@ -632,7 +634,7 @@ async def test_pipette_proxy_dictionary(
 
     def _pyro_daemon() -> None:
         # Wait for the nameserver to be ready so locate_ns can succeed.
-        name_server_ready.wait(timeout=PYRO_TIMEOUT)
+        name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
         create_pyro_daemon("OT3API", managed, register_hardware_types)
 
     ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
@@ -643,7 +645,7 @@ async def test_pipette_proxy_dictionary(
 
     # Client-side requests below
     register_hardware_types()
-    name_server_ready.wait(timeout=PYRO_TIMEOUT)
+    name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
     ns = pyro.locate_ns()
 
     retries_counter = 0

--- a/api/tests/opentrons/protocol_engine/commands/absorbance_reader/test_read.py
+++ b/api/tests/opentrons/protocol_engine/commands/absorbance_reader/test_read.py
@@ -74,7 +74,7 @@ async def test_absorbance_reader_implementation(
     )
 
     decoy.when(await absorbance_module_hw.start_measure()).then_return([[1.2, 1.3]])
-    decoy.when(absorbance_module_hw._measurement_config).then_return(
+    decoy.when(absorbance_module_hw.measurement_config).then_return(
         ABSMeasurementConfig(
             measure_mode=ABSMeasurementMode.SINGLE,
             sample_wavelengths=[1, 2],

--- a/api/tests/opentrons/protocol_engine/execution/test_heater_shaker_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_heater_shaker_movement_flagger.py
@@ -32,6 +32,7 @@ from opentrons.protocol_engine.types import (
     HeaterShakerLatchStatus,
     HeaterShakerMovementRestrictors,
     ModuleLocation,
+    ModuleModel,
 )
 from opentrons.types import DeckSlotName
 
@@ -398,6 +399,7 @@ async def test_raises_depending_on_heater_shaker_latch_status(
 
     heater_shaker = decoy.mock(cls=HardwareHeaterShaker)
     decoy.when(hardware_api.attached_modules).then_return([heater_shaker])
+    decoy.when(heater_shaker.model()).then_return(ModuleModel.HEATER_SHAKER_MODULE_V1)
     decoy.when(heater_shaker.device_info).then_return({"serial": "module-serial"})
     decoy.when(heater_shaker.labware_latch_status).then_return(latch_status)
 

--- a/api/tests/opentrons/protocol_engine/execution/test_thermocycler_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_thermocycler_movement_flagger.py
@@ -25,6 +25,7 @@ from opentrons.protocol_engine.state.state import StateStore
 from opentrons.protocol_engine.types import (
     DeckSlotLocation,
     ModuleLocation,
+    ModuleModel,
 )
 from opentrons.types import DeckSlotName
 
@@ -142,6 +143,7 @@ async def test_raises_depending_on_thermocycler_hardware_lid_status(
     ).then_return("module-serial")
 
     thermocycler = decoy.mock(cls=HardwareThermocycler)
+    decoy.when(thermocycler.model()).then_return(ModuleModel.THERMOCYCLER_MODULE_V2)
     decoy.when(thermocycler.device_info).then_return({"serial": "module-serial"})
     decoy.when(thermocycler.lid_status).then_return(lid_status)
     decoy.when(hardware_api.attached_modules).then_return([thermocycler])

--- a/api/tests/opentrons/util/test_pyro_async_client_adapter.py
+++ b/api/tests/opentrons/util/test_pyro_async_client_adapter.py
@@ -19,7 +19,9 @@ from opentrons.hardware_control.pyro_utils.serpent_type_registry import (
 )
 from opentrons.util.pyro import pyro_client_async_adapter as _get_thread_proxy_module
 from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
-from opentrons.util.pyro.pyro_daemon_utility import PYRO_TIMEOUT, create_pyro_daemon
+from opentrons.util.pyro.pyro_daemon_utility import create_pyro_daemon
+
+TEST_PYRO_TIMEOUT = 5
 
 
 @pytest.fixture
@@ -51,7 +53,7 @@ async def test_client_async_on_ot3api(decoy: Decoy, managed_obj: OT3API) -> None
 
     def _pyro_daemon() -> None:
         # Wait for the nameserver to be ready so locate_ns can succeed.
-        name_server_ready.wait(timeout=PYRO_TIMEOUT)
+        name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
         create_pyro_daemon("OT3API", managed_obj, register_hardware_types)
 
     ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
@@ -62,7 +64,7 @@ async def test_client_async_on_ot3api(decoy: Decoy, managed_obj: OT3API) -> None
 
     # Client-side requests below
     register_hardware_types()
-    name_server_ready.wait(timeout=PYRO_TIMEOUT)
+    name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
     ns = pyro.locate_ns()
 
     retries_counter = 0
@@ -125,7 +127,7 @@ async def test_thread_local_proxy_reuses_connections(
         ns_daemon.requestLoop()
 
     def _pyro_daemon() -> None:
-        name_server_ready.wait(timeout=PYRO_TIMEOUT)
+        name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
         create_pyro_daemon("OT3API", managed_obj, register_hardware_types)
 
     ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
@@ -135,7 +137,7 @@ async def test_thread_local_proxy_reuses_connections(
     server_thread.start()
 
     register_hardware_types()
-    name_server_ready.wait(timeout=PYRO_TIMEOUT)
+    name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
     ns = pyro.locate_ns()
 
     retries_counter = 0

--- a/api/tests/opentrons/util/test_pyro_synchronous_adapter.py
+++ b/api/tests/opentrons/util/test_pyro_synchronous_adapter.py
@@ -17,11 +17,13 @@ from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.pyro_utils.serpent_type_registry import (
     register_hardware_types,
 )
-from opentrons.util.pyro.pyro_daemon_utility import PYRO_TIMEOUT, create_pyro_daemon
+from opentrons.util.pyro.pyro_daemon_utility import create_pyro_daemon
 from opentrons.util.pyro.pyro_synchronous_adapter import (
     DaemonUtility,
     PyroSynchronousObject,
 )
+
+TEST_PYRO_TIMEOUT = 5
 
 
 @pytest.fixture
@@ -78,7 +80,7 @@ async def test_pyro_client_server_ot3api(managed_obj: OT3API) -> None:
 
     def _pyro_daemon() -> None:
         # Wait for the nameserver to be ready so locate_ns can succeed.
-        name_server_ready.wait(timeout=PYRO_TIMEOUT)
+        name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
         create_pyro_daemon("OT3API", managed_obj, register_hardware_types)
 
     ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
@@ -89,7 +91,7 @@ async def test_pyro_client_server_ot3api(managed_obj: OT3API) -> None:
 
     # Client-side requests below
     register_hardware_types()
-    name_server_ready.wait(timeout=PYRO_TIMEOUT)
+    name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
     ns = pyro.locate_ns()
 
     retries_counter = 0

--- a/robot-server/tests/runs/test_run_process.py
+++ b/robot-server/tests/runs/test_run_process.py
@@ -23,7 +23,7 @@ from opentrons.protocol_engine.resources.camera_provider import (
 )
 from opentrons.protocol_engine.resources.file_provider import FileProvider
 from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
-from opentrons.util.pyro.pyro_daemon_utility import PYRO_TIMEOUT, create_pyro_daemon
+from opentrons.util.pyro.pyro_daemon_utility import create_pyro_daemon
 from opentrons_shared_data.robot.types import RobotTypeEnum
 from server_utils.fastapi_utils.app_state import AppState
 
@@ -39,6 +39,8 @@ from robot_server.runs.run_process import (
 from robot_server.runs.run_process_entry_point import initialize_run_process
 from robot_server.runs.run_process_pyro_provider import RunProcessPyroProvider
 from robot_server.service.pyro_utils import pyro_resource, resource_utilities
+
+TEST_PYRO_TIMEOUT = 5
 
 
 @pytest.fixture
@@ -125,7 +127,7 @@ async def _host_pyro_nameserver_and_ot3api(
 
     def _ot3api_pyro_daemon() -> None:
         # Wait for the nameserver to be ready so locate_ns can succeed.
-        name_server_ready.wait(timeout=PYRO_TIMEOUT)
+        name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
         create_pyro_daemon("OT3API", hw_api, register_hardware_types)
 
     ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
@@ -136,7 +138,7 @@ async def _host_pyro_nameserver_and_ot3api(
 
     # Client-side requests below
     register_hardware_types()
-    name_server_ready.wait(timeout=PYRO_TIMEOUT)
+    name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
     # Initialize the RobotServerPyroResource
     pyro_resource.start_initializing_pyro_resource(app_state)
     ns = pyro.locate_ns()
@@ -241,7 +243,7 @@ async def test_run_process_create(
 
     ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
     ns_thread.start()
-    name_server_ready.wait(timeout=PYRO_TIMEOUT)
+    name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
     ot3_async, rs_async = await _host_pyro_nameserver_and_ot3api(
         ot3_hardware_api, mock_app_state
     )

--- a/robot-server/tests/service/pyro_utils/test_pyro_resource.py
+++ b/robot-server/tests/service/pyro_utils/test_pyro_resource.py
@@ -29,7 +29,7 @@ from opentrons.util.pyro.pyro_client_async_adapter import (
     AsyncClientPyroObject,
     ClientPyroFunctionWrapper,
 )
-from opentrons.util.pyro.pyro_daemon_utility import PYRO_TIMEOUT, create_pyro_daemon
+from opentrons.util.pyro.pyro_daemon_utility import create_pyro_daemon
 from opentrons_shared_data.data_files import DataFileInfo, MimeType
 from opentrons_shared_data.robot.types import RobotTypeEnum
 from server_utils.fastapi_utils.app_state import AppState
@@ -46,6 +46,8 @@ from robot_server.service.pyro_utils import (
     pyro_resource,
     resource_utilities,
 )
+
+TEST_PYRO_TIMEOUT = 5
 
 
 @pytest.fixture
@@ -115,7 +117,7 @@ async def _host_pyro_nameserver_and_ot3api(
 
     def _ot3api_pyro_daemon() -> None:
         # Wait for the nameserver to be ready so locate_ns can succeed.
-        name_server_ready.wait(timeout=PYRO_TIMEOUT)
+        name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
         create_pyro_daemon("OT3API", hw_api, register_hardware_types)
 
     ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
@@ -129,7 +131,7 @@ async def _host_pyro_nameserver_and_ot3api(
 
     # Client-side requests below
     register_hardware_types()
-    name_server_ready.wait(timeout=PYRO_TIMEOUT)
+    name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
     ns = pyro.locate_ns()
 
     retries_counter = 0


### PR DESCRIPTION
# Overview

While testing module compatibility with running in subprocess/pyro mode, a handful of small issues were discovered:
- Attempts to validate module type by checking the object type of a module no longer worked, because the a module hardware object in the protocol engine is now always an AsyncClientPyroObject wrapping a proxy.
- The Pyro COMMTIMEOUT that has been in use causes timeout errors on any mesaurably long action, such as a Thermocycler profile execution.
- The absorbance reader was using a private member variable reference, which is unsupportable in subprocess mode. 

Small fixes for each of these have been implemented to allow a protocol using a large variety of modules to execute without issue.


## Test Plan and Hands on Testing

- [x] Update unit tests to reflect changes
- [x] Run a protocol using **All** modules on a Flex, ensure it completes successfully

## Changelog

- Serial number validation for heater shaker and thermocycler now use ModuleModel to confirm module type, rather than `isinstance` check
- Pyro COMMTIMEOUT is now reverted to the default infinite value so communication requests do not have a time limit
- Absorbance reader read command no longer uses private attribute reference

## Review requests
The COMMTIMEOUT change is important to be able to do any of our long tasks, but is there a concern with not having one? It was previously in place from an early stage of testing implementation when subprocess mode was incomplete. With it gone, we fall back to standard error catching at each layer, which may be the more appropriate approach regardless.

## Risk assessment
Low - unblocks module use during subprocess mode