### PR TITLE
fix(components): update requirements of components

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,9 @@ PYTHON_DIRS := $(API_DIR) $(AUTH_SERVER_DIR) $(DOCS_DIR) $(G_CODE_TESTING_DIR) $
 # documentation
 BUILD_NUMBER ?=
 
-# watch, coverage, update snapshot, and warning suppresion variables for tests and linting
+# watch, coverage, and warning suppresion variables for tests and linting
 watch ?= false
 cover ?= true
-updateSnapshot ?= false
 quiet ?= false
 
 FORMAT_FILE_GLOB = ".*.@(js|ts|tsx|yml|mjs|mts)" "**/*.@(ts|tsx|js|mts|mjs|json|md|yml)"

--- a/components/README.md
+++ b/components/README.md
@@ -18,7 +18,7 @@ export default function CowButton(props) {
 
 Usage requirements for dependent projects:
 
-- Node v22.12.0+ and pnpm v8+
+- Node v22.22.0+ and pnpm v10.32.1+
 - The following `dependencies` (peer dependencies of `@opentrons/components`)
   - `react`: `18.2.0`,
   - `react-router-dom`: `6.24.1`,
@@ -44,12 +44,12 @@ Unit tests live in a `__tests__` directory in the same directory as the module u
   - Make sure DOM attributes are mapped correctly
   - Make sure handlers fire correctly
 - Render tests
-  - Snapshot tests using [jest's snapshot functionality][jest-snapshots]
+  - Snapshot tests using [vitest's snapshot functionality][vitest-snapshots]
   - To regenerate snapshots after an intentional rendering change, run:
 
   ```shell
-  make test-js updateSnapshot=true
+  make test-js test_opts="-u"
   ```
 
-[jest-snapshots]: https://facebook.github.io/jest/docs/en/snapshot-testing.html
+[vitest-snapshots]: https://vitest.dev/guide/snapshot
 [contributing]: ../CONTRIBUTING.md


### PR DESCRIPTION



# Overview
update requirements of components (node version and pnpm version) and noticed that we haven't updated the snapshots since we switched from jest to vitest

https://vitest.dev/guide/snapshot.html#updating-snapshots

closes AUTH-2938

## Test Plan and Hands on Testing
- `make test-js test_opts="-u"`

## Changelog
- update readme
- update Makefile

## Review requests

## Risk assessment
low
