### PR TITLE
fix(app): add mutation callbacks in ODD `ConfirmCancelRunModal`

### DIFF
--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/__tests__/ConfirmCancelRunModal.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/__tests__/ConfirmCancelRunModal.test.tsx
@@ -148,48 +148,116 @@ describe('ConfirmCancelRunModal', () => {
     expect(mockStopRun).toHaveBeenCalled()
   })
 
-  it('when run is stopped, the run is dismissed and the modal closes if the run is not yet active', () => {
-    props = {
-      ...props,
-      isActiveRun: false,
-    }
-
-    vi.mocked(useNotifyRunQuery).mockReturnValue({
-      data: {
-        data: {
-          status: RUN_STATUS_STOPPED,
-        },
-      },
-    } as any)
+  it('when tapping cancel run with error, should remain in canceling state', () => {
+    mockStopRun.mockImplementation((_id: string, options: any) => {
+      options.onSettled()
+    })
 
     render(props)
+    const button = screen.getByText('Cancel run')
+    fireEvent.click(button)
 
-    expect(mockDismissCurrentRun).toHaveBeenCalled()
-    expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
+    screen.getByText('mock CancelingRunModal')
   })
 
-  it('when quick transfer run is stopped, the run is dismissed and navigates to quick transfer', () => {
+  it('when stop run succeeds and run is not active, run is dismissed and navigates to /protocols', () => {
     props = {
       ...props,
       isActiveRun: false,
     }
 
-    vi.mocked(useNotifyRunQuery).mockReturnValue({
-      data: {
-        data: {
-          status: RUN_STATUS_STOPPED,
-        },
-      },
-    } as any)
+    mockStopRun.mockImplementation((_id: string, options: any) => {
+      options.onSuccess()
+      options.onSettled()
+    })
 
     render(props)
+    const button = screen.getByText('Cancel run')
+    fireEvent.click(button)
 
-    expect(mockDismissCurrentRun).toHaveBeenCalled()
-    expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
+    expect(mockTrackProtocolRunEvent).toHaveBeenCalledWith({
+      name: 'runCancel',
+    })
+    expect(mockDismissCurrentRun).toHaveBeenCalledWith(RUN_ID)
     expect(mockNavigate).toHaveBeenCalledWith('/protocols')
   })
 
-  it('when quick transfer run with protocolId is stopped, it navigates to protocol-specific quick transfer', () => {
+  it('when stop run succeeds with protocolId, navigates to protocol-specific page', () => {
+    props = {
+      ...props,
+      isActiveRun: false,
+      protocolId: 'test-protocol-id',
+    }
+
+    mockStopRun.mockImplementation((_id: string, options: any) => {
+      options.onSuccess()
+      options.onSettled()
+    })
+
+    render(props)
+    const button = screen.getByText('Cancel run')
+    fireEvent.click(button)
+
+    expect(mockDismissCurrentRun).toHaveBeenCalledWith(RUN_ID)
+    expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith('/protocols/test-protocol-id')
+  })
+
+  it('when run is active, stop run does not dismiss or navigate', () => {
+    mockStopRun.mockImplementation((_id: string, options: any) => {
+      options.onSuccess()
+      options.onSettled()
+    })
+
+    render(props)
+    const button = screen.getByText('Cancel run')
+    fireEvent.click(button)
+
+    expect(mockDismissCurrentRun).not.toHaveBeenCalled()
+    expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it('when stop run errors and run is not active, still dismisses and navigates', () => {
+    props = {
+      ...props,
+      isActiveRun: false,
+    }
+
+    mockStopRun.mockImplementation((_id: string, options: any) => {
+      options.onSettled()
+    })
+
+    render(props)
+    const button = screen.getByText('Cancel run')
+    fireEvent.click(button)
+
+    expect(mockDismissCurrentRun).toHaveBeenCalledWith(RUN_ID)
+    expect(mockNavigate).toHaveBeenCalledWith('/protocols')
+    expect(mockTrackProtocolRunEvent).not.toHaveBeenCalled()
+  })
+
+  it('when run status becomes stopped via polling, run is dismissed and navigates to /protocols', () => {
+    props = {
+      ...props,
+      isActiveRun: false,
+    }
+
+    vi.mocked(useNotifyRunQuery).mockReturnValue({
+      data: {
+        data: {
+          status: RUN_STATUS_STOPPED,
+        },
+      },
+    } as any)
+
+    render(props)
+
+    expect(mockDismissCurrentRun).toHaveBeenCalled()
+    expect(mockNavigate).toHaveBeenCalledWith('/protocols')
+  })
+
+  it('when run status becomes stopped via polling with protocolId, navigates to protocol-specific page', () => {
     props = {
       ...props,
       isActiveRun: false,
@@ -207,33 +275,10 @@ describe('ConfirmCancelRunModal', () => {
     render(props)
 
     expect(mockDismissCurrentRun).toHaveBeenCalled()
-    expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
     expect(mockNavigate).toHaveBeenCalledWith('/protocols/test-protocol-id')
   })
 
-  it('when run with protocolId is stopped, it navigates to protocol page', () => {
-    props = {
-      ...props,
-      isActiveRun: false,
-      protocolId: 'test-protocol-id',
-    }
-
-    vi.mocked(useNotifyRunQuery).mockReturnValue({
-      data: {
-        data: {
-          status: RUN_STATUS_STOPPED,
-        },
-      },
-    } as any)
-
-    render(props)
-
-    expect(mockDismissCurrentRun).toHaveBeenCalled()
-    expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
-    expect(mockNavigate).toHaveBeenCalledWith('/protocols/test-protocol-id')
-  })
-
-  it('when run is stopped, the run is not dismissed if the run is active', () => {
+  it('when run status becomes stopped via polling and run is active, run is not dismissed', () => {
     vi.mocked(useNotifyRunQuery).mockReturnValue({
       data: {
         data: {
@@ -245,19 +290,5 @@ describe('ConfirmCancelRunModal', () => {
     render(props)
 
     expect(mockDismissCurrentRun).not.toHaveBeenCalled()
-    expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
-  })
-
-  it('when tapping cancel run with error, should reset isCanceling', () => {
-    mockStopRun.mockImplementation((id, options) => {
-      options.onError()
-    })
-
-    render(props)
-    const button = screen.getByText('Cancel run')
-    fireEvent.click(button)
-
-    const cancelButton = screen.getByText('Cancel run')
-    expect(cancelButton).toBeInTheDocument()
   })
 })

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
@@ -41,7 +41,7 @@ export function ConfirmCancelRunModal({
     useDismissCurrentRunMutation()
   const localRobot = useSelector(getLocalRobot)
   const { data, isError: isRunFetchError } = useNotifyRunQuery(runId)
-  const runStatus = data?.data.status
+  const { status: runStatus, current: isRunCurrent } = data?.data ?? {}
   const robotName = localRobot?.name ?? ''
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const navigate = useNavigate()
@@ -54,33 +54,38 @@ export function ConfirmCancelRunModal({
     iconColor: COLORS.yellow50,
   }
 
+  const dismissAndNavigate = useCallback((): void => {
+    if (!isActiveRun) {
+      dismissCurrentRun(runId)
+      if (protocolId != null) {
+        navigate(`/protocols/${protocolId}`)
+      } else {
+        navigate('/protocols')
+      }
+    }
+  }, [isActiveRun, dismissCurrentRun, runId, protocolId, navigate])
+
   const handleCancelRun = (): void => {
     setIsCanceling(true)
     stopRun(runId, {
-      onError: () => {
-        setIsCanceling(false)
+      onSuccess: () => {
+        trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_ACTION.CANCEL })
+      },
+      onSettled: () => {
+        dismissAndNavigate()
       },
     })
   }
 
-  useEffect(
-    () => {
-      if (runStatus === RUN_STATUS_STOPPED || isRunFetchError) {
-        trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_ACTION.CANCEL })
-        if (!isActiveRun) {
-          dismissCurrentRun(runId)
-          if (protocolId != null) {
-            navigate(`/protocols/${protocolId}`)
-          } else {
-            navigate('/protocols')
-          }
-        }
-      }
-    },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [runStatus]
-  )
+  useEffect(() => {
+    if (
+      runStatus === RUN_STATUS_STOPPED ||
+      isRunFetchError ||
+      isRunCurrent === false
+    ) {
+      dismissAndNavigate()
+    }
+  }, [runStatus, isRunCurrent, isRunFetchError, dismissAndNavigate])
 
   return isCanceling || isDismissing ? (
     <CancelingRunModal />


### PR DESCRIPTION
Closes [RABR-946](https://opentrons.atlassian.net/browse/RABR-946) and [RABR-947](https://opentrons.atlassian.net/browse/RABR-947)

# Overview

The ODD `ConfirmCancelRunModal` checks the run status before performing a redirect to a new view, however, it's possible the run is not in a `STOPPED` condition before the `runStatus` is updated within the modal, which causes the redirect logic to no-op. 

To fix, we can add a mechanism for handling redirects that are directly tied to the CTA: if the request succeeds, report the analytic event and redirect. If the request fails, just do the redirect. 

We need to keep the `useEffect` in case the stop is initiated on the desktop app, however, we add need to add the case in which the run is un-currented as a reason to redirect, too. We remove the analytic from the `useEffect` entirely - this means the user cancelled the run on the desktop app, which has its own analytic event. If we were to keep the analytic in the `useEffect`, we'd be over-reporting the event.

<img width="590" height="350" alt="Screenshot 2026-06-02 at 11 04 32 AM" src="https://github.com/user-attachments/assets/46e7d595-3b96-4978-8a86-c590e8ec86b5" />

## Test Plan and Hands on Testing

- I cannot reproduce this exact case readily without manual HTTP intervention, but I validated that redirection logic works appropriately on the ODD.

## Changelog

- Fixed a bug in which the ODD's "Confirm Cancel Run" modal hangs indefinitely.  

## Risk assessment

- low, just additive behavior, easy to audit

[RABR-946]: https://opentrons.atlassian.net/browse/RABR-946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RABR-947]: https://opentrons.atlassian.net/browse/RABR-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ