### PR TITLE
feat(app): Implement the desktop login modal

### DIFF
--- a/app/src/assets/localization/en/access_control.json
+++ b/app/src/assets/localization/en/access_control.json
@@ -1,8 +1,18 @@
 {
   "access_control_note": "Note for robot audit log by {{user}}",
+  "desktop_login_form_heading": "Log in",
+  "desktop_login_form_subheading": "Log in to access robot controls.",
+  "desktop_login_modal_header": "Compliance Ready Software Login",
   "documentation_required": "Documentation Required",
+  "forgot_password_heading": "Forgot password?",
+  "forgot_password_link": "Forgot password?",
+  "forgot_password_subheading": "Log in to an admin account to reset the password for your account.",
   "legal_name": "Legal Name",
+  "log_in_link": "Log in",
   "log_out": "Log out",
   "username": "Username",
+  "login_error_incorrect": "Incorrect username or password.",
+  "login_form_password_field": "Password",
+  "login_form_username_field": "Username",
   "view_actions": "View actions"
 }

--- a/app/src/organisms/Desktop/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
+++ b/app/src/organisms/Desktop/Breadcrumbs/__tests__/Breadcrumbs.test.tsx
@@ -1,12 +1,13 @@
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { fireEvent, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
 
 import { useAccessControlEnabledQuery } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { showLoginModal } from '/app/organisms/Desktop/LoginModal'
 import { useRobot } from '/app/redux-resources/robots'
 import { getIsOnDevice } from '/app/redux/config'
 import { mockConnectableRobot } from '/app/redux/discovery/__fixtures__'
@@ -14,7 +15,6 @@ import { getStoredProtocol } from '/app/redux/protocol-storage'
 import { storedProtocolData as storedProtocolDataFixture } from '/app/redux/protocol-storage/__fixtures__'
 import { useAccountIconInitial } from '/app/resources/access-control/useAccountIconInitial'
 import { useLogOut } from '/app/resources/access-control/useLogOut'
-import { useStoreLoginState } from '/app/resources/access-control/useStoreLoginState'
 import { useRunCreatedAtTimestamp } from '/app/resources/runs'
 import { getProtocolDisplayName } from '/app/transformations/protocols'
 
@@ -36,7 +36,7 @@ vi.mock('/app/redux/config')
 vi.mock('/app/redux/protocol-storage')
 vi.mock('/app/resources/access-control/useAccountIconInitial')
 vi.mock('/app/resources/access-control/useLogOut')
-vi.mock('/app/resources/access-control/useStoreLoginState')
+vi.mock('/app/organisms/Desktop/LoginModal')
 
 const ROBOT_NAME = 'otie'
 const RUN_ID = '95e67900-bc9f-4fbf-92c6-cc4d7226a51b'
@@ -96,7 +96,6 @@ describe('Breadcrumbs', () => {
     mockAccessControlEnabled(false)
     vi.mocked(useAccountIconInitial).mockReturnValue({ showIcon: false })
     vi.mocked(useLogOut).mockReturnValue(vi.fn())
-    vi.mocked(useStoreLoginState).mockReturnValue(vi.fn())
 
     when(useRobot).calledWith(ROBOT_NAME).thenReturn(mockConnectableRobot)
     when(useRunCreatedAtTimestamp).calledWith(RUN_ID).thenReturn(CREATED_AT)
@@ -114,6 +113,11 @@ describe('Breadcrumbs', () => {
       )
       .thenReturn(PROTOCOL_NAME)
   })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('renders an array of device breadcrumbs', () => {
     render(`/devices/${ROBOT_NAME}/protocol-runs/${RUN_ID}`)
     screen.getByText('Devices')
@@ -147,13 +151,16 @@ describe('Breadcrumbs', () => {
 
   describe('account section', () => {
     const BREADCRUMB_PATH = `/devices/${ROBOT_NAME}/protocol-runs/${RUN_ID}`
+    const ACCOUNT_ICON_INITIAL = 'T'
 
     it('does not render when access control is disabled', () => {
       mockAccessControlEnabled(false)
       render(BREADCRUMB_PATH)
 
       expect(screen.queryByRole('button', { name: 'Log in' })).toBeNull()
-      expect(screen.queryByText('😱')).toBeNull()
+      expect(
+        screen.queryByRole('button', { name: ACCOUNT_ICON_INITIAL })
+      ).toBeNull()
     })
 
     it('renders a log in link when access control is enabled and the user is logged out', () => {
@@ -162,36 +169,31 @@ describe('Breadcrumbs', () => {
       render(BREADCRUMB_PATH)
 
       screen.getByRole('button', { name: 'Log in' })
-      expect(screen.queryByText('😱')).toBeNull()
+      expect(
+        screen.queryByRole('button', { name: ACCOUNT_ICON_INITIAL })
+      ).toBeNull()
     })
 
     it('renders the account icon when access control is enabled and the user is logged in', () => {
       mockAccessControlEnabled(true)
       vi.mocked(useAccountIconInitial).mockReturnValue({
         showIcon: true,
-        iconContents: 'T',
+        iconContents: ACCOUNT_ICON_INITIAL,
       })
       render(BREADCRUMB_PATH)
 
-      // todo(mm, 2026-06-01): Update to the actual initial once login is implemented.
-      screen.getByRole('button', { name: '😱' })
+      screen.getByRole('button', { name: ACCOUNT_ICON_INITIAL })
       expect(screen.queryByRole('button', { name: 'Log in' })).toBeNull()
     })
 
-    it('calls storeLoginState when log in is clicked', () => {
-      const storeLoginState = vi.fn()
-      vi.mocked(useStoreLoginState).mockReturnValue(storeLoginState)
+    it('calls showLoginModal when log in is clicked', () => {
       mockAccessControlEnabled(true)
       vi.mocked(useAccountIconInitial).mockReturnValue({ showIcon: false })
       render(BREADCRUMB_PATH)
 
       fireEvent.click(screen.getByRole('button', { name: 'Log in' }))
 
-      expect(storeLoginState).toHaveBeenCalledWith('fake_username', {
-        access_token: 'fake_access_token',
-        token_type: 'Bearer',
-        expires_in: 180,
-      })
+      expect(showLoginModal).toHaveBeenCalledOnce()
     })
 
     it('opens the account menu and calls logOut when log out is clicked', () => {
@@ -200,11 +202,13 @@ describe('Breadcrumbs', () => {
       mockAccessControlEnabled(true)
       vi.mocked(useAccountIconInitial).mockReturnValue({
         showIcon: true,
-        iconContents: 'T',
+        iconContents: ACCOUNT_ICON_INITIAL,
       })
       render(BREADCRUMB_PATH)
 
-      fireEvent.click(screen.getByRole('button', { name: '😱' }))
+      fireEvent.click(
+        screen.getByRole('button', { name: ACCOUNT_ICON_INITIAL })
+      )
       screen.getByText('Account settings')
       fireEvent.click(screen.getByRole('button', { name: 'Log out' }))
 

--- a/app/src/organisms/Desktop/Breadcrumbs/index.tsx
+++ b/app/src/organisms/Desktop/Breadcrumbs/index.tsx
@@ -137,21 +137,18 @@ function AccountIconAndMenu(props: AccountIconAndMenuProps): JSX.Element {
 function LoginLink(): JSX.Element {
   const { t } = useTranslation('top_navigation')
   const host = useHost()
+  const handleClick = useCallback(() => {
+    if (host == null) {
+      console.error(
+        "Couldn't determine the host for a login modal. Is a provider missing?"
+      )
+    } else {
+      showLoginModal({ host })
+    }
+  }, [host])
 
   return (
-    <BasicButton
-      type="button"
-      onClick={() => {
-        if (host == null) {
-          console.error(
-            "Couldn't determine the host for a login modal. Is a provider missing?"
-          )
-        } else {
-          showLoginModal({ host })
-        }
-      }}
-      underLine
-    >
+    <BasicButton type="button" onClick={handleClick} underLine>
       {t('log_in')}
     </BasicButton>
   )

--- a/app/src/organisms/Desktop/Breadcrumbs/index.tsx
+++ b/app/src/organisms/Desktop/Breadcrumbs/index.tsx
@@ -15,9 +15,11 @@ import {
 import {
   ApiHostProvider,
   useAccessControlEnabledQuery,
+  useHost,
 } from '@opentrons/react-api-client'
 
 import { AccountIconButton } from '/app/atoms/buttons/AccountIconButton'
+import { showLoginModal } from '/app/organisms/Desktop/LoginModal'
 import { useRobot } from '/app/redux-resources/robots'
 import { getIsOnDevice } from '/app/redux/config'
 import { OPENTRONS_USB } from '/app/redux/discovery'
@@ -26,7 +28,6 @@ import { useAccessTokenForRobot } from '/app/redux/robot-auth'
 import { appShellUSBRequestor } from '/app/redux/shell/remote'
 import { useAccountIconInitial } from '/app/resources/access-control/useAccountIconInitial'
 import { useLogOut } from '/app/resources/access-control/useLogOut'
-import { useStoreLoginState } from '/app/resources/access-control/useStoreLoginState'
 import { useRunCreatedAtTimestamp } from '/app/resources/runs'
 import { getProtocolDisplayName } from '/app/transformations/protocols'
 
@@ -76,11 +77,7 @@ function AccountSection(): JSX.Element | null {
     if (accountIconInfo.showIcon) {
       return (
         <div className={styles.right_container}>
-          <AccountIconAndMenu
-            // todo(mm, 2026-05-28): Set initial=accountIconInfo.iconContents
-            // once we have a real login implementation and can get the user's real name.
-            initial="😱"
-          />
+          <AccountIconAndMenu initial={accountIconInfo.iconContents} />
         </div>
       )
     } else {
@@ -138,21 +135,23 @@ function AccountIconAndMenu(props: AccountIconAndMenuProps): JSX.Element {
 }
 
 function LoginLink(): JSX.Element {
-  const storeLoginState = useStoreLoginState()
-  // todo(mm, 2026-05-28): Replace this placeholder implementation with something
-  // that opens a login form, asks the user for their credentials, and sends the
-  // credentials to the robot.
-  const fakeHandleLogin = useCallback(() => {
-    storeLoginState('fake_username', {
-      access_token: 'fake_access_token',
-      token_type: 'Bearer',
-      expires_in: 180,
-    })
-  }, [storeLoginState])
   const { t } = useTranslation('top_navigation')
+  const host = useHost()
 
   return (
-    <BasicButton onClick={fakeHandleLogin} underLine>
+    <BasicButton
+      type="button"
+      onClick={() => {
+        if (host == null) {
+          console.error(
+            "Couldn't determine the host for a login modal. Is a provider missing?"
+          )
+        } else {
+          showLoginModal({ host })
+        }
+      }}
+      underLine
+    >
       {t('log_in')}
     </BasicButton>
   )

--- a/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
+++ b/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
@@ -1,0 +1,139 @@
+import NiceModal from '@ebay/nice-modal-react'
+import { fireEvent, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { renderWithProviders } from '/app/__testing-utils__'
+import { i18n } from '/app/i18n'
+import { useStoreLoginState } from '/app/resources/access-control/useStoreLoginState'
+import { useOAuth2PasswordLogin } from '/app/resources/auth'
+
+import { showLoginModal } from '..'
+
+import type { HostConfig, OAuth2TokenResponse } from '@opentrons/api-client'
+
+vi.mock('/app/resources/access-control/useStoreLoginState')
+vi.mock('/app/resources/auth')
+
+const MOCK_HOST: HostConfig = { hostname: 'otie.local' }
+
+const TOKEN_RESPONSE: OAuth2TokenResponse = {
+  access_token: 'new-access-token',
+  token_type: 'Bearer',
+  expires_in: 180,
+  refresh_token: 'new-refresh-token',
+}
+
+const renderAndOpenLoginModal = (): void => {
+  renderWithProviders(
+    <NiceModal.Provider>
+      <button
+        type="button"
+        onClick={() => {
+          showLoginModal({ host: MOCK_HOST })
+        }}
+      >
+        Open login modal
+      </button>
+    </NiceModal.Provider>,
+    { i18nInstance: i18n }
+  )
+  fireEvent.click(screen.getByRole('button', { name: 'Open login modal' }))
+}
+
+describe('LoginModal', () => {
+  beforeEach(() => {
+    vi.mocked(useStoreLoginState).mockReturnValue(vi.fn())
+    vi.mocked(useOAuth2PasswordLogin).mockReturnValue({
+      submitPassword: vi.fn(),
+      isAuthLoading: false,
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders the login form when opened', () => {
+    renderAndOpenLoginModal()
+
+    screen.getByText('Compliance Ready Software Login')
+    screen.getByLabelText('Username')
+    screen.getByLabelText('Password')
+    screen.getByRole('button', { name: 'Forgot password?' })
+  })
+
+  it('shows forgot password content and returns to login on back', () => {
+    renderAndOpenLoginModal()
+
+    fireEvent.change(screen.getByLabelText('Username'), {
+      target: { value: 'alice' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Forgot password?' }))
+
+    screen.getByText(
+      'Log in to an admin account to reset the password for your account.'
+    )
+    expect(screen.queryByLabelText('Username')).toBeNull()
+    screen.getByRole('button', { name: 'Back' })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+
+    expect(screen.getByLabelText('Username')).toHaveValue('alice')
+    screen.getByLabelText('Password')
+  })
+
+  it('submits credentials, stores login state, and closes on success', () => {
+    const storeLoginState = vi.fn()
+    const submitPassword = vi.fn()
+    vi.mocked(useStoreLoginState).mockReturnValue(storeLoginState)
+    vi.mocked(useOAuth2PasswordLogin).mockImplementation(
+      ({ onSuccess }) =>
+        ({
+          submitPassword: (username: string, password: string) => {
+            submitPassword(username, password)
+            onSuccess(username, TOKEN_RESPONSE)
+          },
+          isAuthLoading: false,
+        }) as ReturnType<typeof useOAuth2PasswordLogin>
+    )
+
+    renderAndOpenLoginModal()
+
+    fireEvent.change(screen.getByLabelText('Username'), {
+      target: { value: 'alice' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'secret-password' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Log in' }))
+
+    expect(submitPassword).toHaveBeenCalledWith('alice', 'secret-password')
+    expect(storeLoginState).toHaveBeenCalledWith('alice', TOKEN_RESPONSE)
+    expect(screen.queryByText('Compliance Ready Software Login')).toBeNull()
+  })
+
+  it('shows an error when authentication fails', () => {
+    vi.mocked(useOAuth2PasswordLogin).mockImplementation(
+      ({ onError }) =>
+        ({
+          submitPassword: () => {
+            onError('Invalid credentials')
+          },
+          isAuthLoading: false,
+        }) as ReturnType<typeof useOAuth2PasswordLogin>
+    )
+
+    renderAndOpenLoginModal()
+
+    fireEvent.change(screen.getByLabelText('Username'), {
+      target: { value: 'alice' },
+    })
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'wrong-password' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Log in' }))
+
+    screen.getByText('Incorrect username or password.')
+    screen.getByText('Compliance Ready Software Login')
+  })
+})

--- a/app/src/organisms/Desktop/LoginModal/index.tsx
+++ b/app/src/organisms/Desktop/LoginModal/index.tsx
@@ -1,0 +1,221 @@
+import { useId, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useTranslation } from 'react-i18next'
+import NiceModal, { useModal } from '@ebay/nice-modal-react'
+
+import {
+  BasicButton,
+  COLORS,
+  InputField,
+  Modal,
+  PrimaryButton,
+  SecondaryButton,
+  StyledText,
+} from '@opentrons/components'
+import { ApiHostProvider } from '@opentrons/react-api-client'
+
+import { getTopPortalEl } from '/app/App/portal'
+import { useStoreLoginState } from '/app/resources/access-control/useStoreLoginState'
+import { useOAuth2PasswordLogin } from '/app/resources/auth'
+
+import styles from './loginmodal.module.css'
+
+import type { ComponentProps } from 'react'
+import type { HostConfig } from '@opentrons/api-client'
+
+interface LoginModalProps {
+  host: HostConfig /** Which robot to log in to. */
+}
+
+/** Open the desktop login modal in the appropriate React portal. */
+export const showLoginModal = (props: LoginModalProps): void => {
+  void NiceModal.show(LoginModal, props)
+}
+
+const LoginModal = NiceModal.create((props: LoginModalProps) => {
+  const { host } = props
+  return (
+    <ApiHostProvider {...host}>
+      <LoginModalImpl />
+    </ApiHostProvider>
+  )
+})
+
+function LoginModalImpl(): JSX.Element {
+  const modal = useModal()
+  const { t } = useTranslation()
+  const [view, setView] = useState<'login' | 'forgotPassword'>('login')
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [loginError, setLoginError] = useState<string | null>(null)
+  const storeLoginState = useStoreLoginState()
+
+  const loginFormId = useId()
+
+  const handleClose = (): void => {
+    modal.remove()
+  }
+
+  const { submitPassword, isAuthLoading } = useOAuth2PasswordLogin({
+    onSuccess: (successfulUsername, response) => {
+      setLoginError(null)
+      storeLoginState(successfulUsername, response)
+      modal.remove()
+    },
+    onError: () => {
+      // todo(mm, 2026-06-02): This is copied from the ODD logic, but it needs to be
+      // reworked to show the actual error (e.g. a network error), and to show the
+      // number of attempts remaining before lockout.
+      setLoginError(t('access_control:login_error_incorrect') as string)
+    },
+  })
+
+  const isLoginDisabled = username === '' || password === '' || isAuthLoading
+
+  const handleSubmit: ComponentProps<'form'>['onSubmit'] = event => {
+    event.preventDefault()
+    submitPassword(username, password)
+  }
+
+  const handleUsernameChange = (value: string): void => {
+    setLoginError(null)
+    setUsername(value)
+  }
+
+  const handlePasswordChange = (value: string): void => {
+    setLoginError(null)
+    setPassword(value)
+  }
+
+  const footer = (
+    <div className={styles.modal_footer_container}>
+      {view === 'login' ? (
+        <PrimaryButton
+          type="submit"
+          form={loginFormId}
+          // todo(mm, 2026-06-02): Instead of outright disabling the submit button
+          // when any fields are missing, we should show errors on those fields.
+          disabled={isLoginDisabled}
+        >
+          {t('access_control:log_in_link')}
+        </PrimaryButton>
+      ) : (
+        <SecondaryButton
+          onClick={() => {
+            setView('login')
+          }}
+        >
+          {t('shared:back')}
+        </SecondaryButton>
+      )}
+    </div>
+  )
+
+  return createPortal(
+    <Modal
+      title={t('access_control:desktop_login_modal_header')}
+      onClose={handleClose}
+      footer={footer}
+    >
+      <div className={styles.content_container}>
+        {view === 'login' ? (
+          <LoginView
+            formId={loginFormId}
+            onSubmit={handleSubmit}
+            username={username}
+            password={password}
+            loginError={loginError}
+            onUsernameChange={handleUsernameChange}
+            onPasswordChange={handlePasswordChange}
+            onForgotPasswordClick={() => {
+              setView('forgotPassword')
+            }}
+          />
+        ) : (
+          <ForgotPasswordView />
+        )}
+      </div>
+    </Modal>,
+    getTopPortalEl()
+  )
+}
+
+interface LoginViewProps {
+  formId: string
+  onSubmit: ComponentProps<'form'>['onSubmit']
+  username: string
+  password: string
+  loginError: string | null
+  onUsernameChange: (value: string) => void
+  onPasswordChange: (value: string) => void
+  onForgotPasswordClick: () => void
+}
+
+function LoginView(props: LoginViewProps): JSX.Element {
+  const {
+    formId,
+    onSubmit,
+    username,
+    password,
+    loginError,
+    onUsernameChange,
+    onPasswordChange,
+    onForgotPasswordClick,
+  } = props
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <div className={styles.text_container}>
+        <StyledText desktopStyle="headingSmallBold">
+          {t('access_control:desktop_login_form_heading')}
+        </StyledText>
+        <StyledText color={COLORS.grey60} desktopStyle="bodyDefaultRegular">
+          {t('access_control:desktop_login_form_subheading')}
+        </StyledText>
+      </div>
+
+      <form id={formId} onSubmit={onSubmit} className={styles.fields_container}>
+        <InputField
+          name="username"
+          title={t('access_control:login_form_username_field')}
+          type="text"
+          value={username}
+          onChange={event => {
+            onUsernameChange(event.target.value)
+          }}
+        />
+        <InputField
+          name="password"
+          title={t('access_control:login_form_password_field')}
+          type="password"
+          value={password}
+          error={loginError ?? undefined}
+          onChange={event => {
+            onPasswordChange(event.target.value)
+          }}
+        />
+        <div>
+          <BasicButton type="button" underLine onClick={onForgotPasswordClick}>
+            {t('access_control:forgot_password_link')}
+          </BasicButton>
+        </div>
+      </form>
+    </>
+  )
+}
+
+function ForgotPasswordView(): JSX.Element {
+  const { t } = useTranslation()
+
+  return (
+    <div className={styles.text_container}>
+      <StyledText desktopStyle="headingSmallBold">
+        {t('access_control:forgot_password_heading')}
+      </StyledText>
+      <StyledText color={COLORS.grey60} desktopStyle="bodyDefaultRegular">
+        {t('access_control:forgot_password_subheading')}
+      </StyledText>
+    </div>
+  )
+}

--- a/app/src/organisms/Desktop/LoginModal/loginmodal.module.css
+++ b/app/src/organisms/Desktop/LoginModal/loginmodal.module.css
@@ -1,0 +1,26 @@
+.content_container {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: var(--spacing-24);
+}
+
+.text_container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.fields_container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-8);
+}
+
+.modal_footer_container {
+  display: flex;
+  width: 100%;
+  flex-direction: row;
+  justify-content: flex-end;
+  padding: var(--spacing-16) var(--spacing-24) var(--spacing-24);
+}

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginModal.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginModal.tsx
@@ -30,6 +30,8 @@ const LoginModalImpl = NiceModal.create((): JSX.Element => {
       modal.remove()
     },
     onError: () => {
+      // todo(mm, 2026-06-02): This needs to show the actual error (e.g. a network error),
+      // and show the number of attempts remaining before lockout.
       setLoginError(t('on_device_login_error_incorrect') as string)
     },
   })

--- a/components/src/atoms/buttons/BasicButton.tsx
+++ b/components/src/atoms/buttons/BasicButton.tsx
@@ -8,11 +8,12 @@ import { CURSOR_NOT_ALLOWED, CURSOR_POINTER } from '../../styles/cursor'
 import { SPACING, TYPOGRAPHY } from '../../ui-style-constants'
 import { StyledText } from '../StyledText/StyledText'
 
-import type { MouseEvent } from 'react'
+import type { ComponentProps, MouseEvent } from 'react'
 import type { IconName } from '../../icons'
 
 interface BasicButtonProps {
   children: string // Content of basic button
+  type?: ComponentProps<'button'>['type']
   onClick: (event: MouseEvent<HTMLButtonElement>) => void // Function to handle button click events
   isDisabled?: boolean // Optional prop to control button aria-disabled
   underLine?: boolean // Optional prop to control underline styling


### PR DESCRIPTION
## Overview

This closes EXEC-2680.

## Test Plan and Hands on Testing

https://github.com/user-attachments/assets/bf83f782-619c-4cac-89be-a1c1d42b35c6

## Changelog

Clicking "Log in" in the desktop app now opens a login modal. You can enter your username and password. If the login is successful, it will store an access token in Redux state.

## Known issues

* If the encryption key hasn't been set up yet, we're supposed to show the modal for doing that before we show the login modal. That's not implemented in this PR—we just show the login modal. EXEC-2707.
* The error handling is not right. All errors, even network errors, will currently show up as "invalid username or password." This is inherited from the ODD code. We'll have to fix both the desktop and ODD in a follow-up.
* Currently, when the user hasn't entered their username or password yet, the submit button is disabled. From speaking with the design team, it would be better if the button were enabled, but, when clicked, we showed a "username is required" / "password is required" error. This might involve rewriting the form in `react-hook-form`, I'm not sure.

## Review requests

Is this a sensible way to implement the form, with a native `<form>` tag and `onsubmit` handler? Aside from the known issues described above. 

## Risk assessment

Low.