### PR TITLE
feat(step-generation): add missing atomic commandCreators for OAI

### DIFF
--- a/step-generation/src/commandCreators/atomic/__tests__/aspirateWhileTracking.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/aspirateWhileTracking.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_PIPETTE,
+  getInitialRobotStateStandard,
+  getSuccessResult,
+  makeContext,
+  SOURCE_LABWARE,
+} from '../../../fixtures'
+import { aspirateWhileTracking } from '../aspirateWhileTracking'
+
+import type { AspDispWhileTrackingParams } from '@opentrons/shared-data'
+import type { InvariantContext, RobotState } from '../../../types'
+
+const trackingParams: AspDispWhileTrackingParams = {
+  pipetteId: DEFAULT_PIPETTE,
+  labwareId: SOURCE_LABWARE,
+  wellName: 'A1',
+  volume: 50,
+  flowRate: 6,
+  trackFromLocation: {
+    origin: 'bottom',
+    offset: { z: 5 },
+  },
+  trackToLocation: {
+    origin: 'top',
+    offset: { z: 10 },
+  },
+}
+
+describe('aspirateWhileTracking', () => {
+  let invariantContext: InvariantContext
+  let robotState: RobotState
+
+  beforeEach(() => {
+    invariantContext = makeContext()
+    robotState = getInitialRobotStateStandard(invariantContext)
+  })
+
+  it('generates JSON and python', () => {
+    const result = aspirateWhileTracking(
+      trackingParams,
+      invariantContext,
+      robotState
+    )
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'aspirateWhileTracking',
+        key: expect.any(String),
+        params: trackingParams,
+      },
+    ])
+
+    expect(getSuccessResult(result).python).toBe(
+      `
+mock_pipette.aspirate(
+    volume=50,
+    location=mock_source_plate["A1"].bottom(z=5),
+    flow_rate=6,
+    end_location=mock_source_plate["A1"].top(z=10),
+)`.trimStart()
+    )
+  })
+})

--- a/step-generation/src/commandCreators/atomic/__tests__/dispenseWhileTracking.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/dispenseWhileTracking.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_PIPETTE,
+  getInitialRobotStateStandard,
+  getSuccessResult,
+  makeContext,
+  SOURCE_LABWARE,
+} from '../../../fixtures'
+import { dispenseWhileTracking } from '../dispenseWhileTracking'
+
+import type { AspDispWhileTrackingParams } from '@opentrons/shared-data'
+import type { InvariantContext, RobotState } from '../../../types'
+
+const trackingParams: AspDispWhileTrackingParams = {
+  pipetteId: DEFAULT_PIPETTE,
+  labwareId: SOURCE_LABWARE,
+  wellName: 'A1',
+  volume: 50,
+  flowRate: 6,
+  trackFromLocation: {
+    origin: 'bottom',
+    offset: { z: 5 },
+  },
+  trackToLocation: {
+    origin: 'top',
+    offset: { z: 10 },
+  },
+}
+
+describe('dispenseWhileTracking', () => {
+  let invariantContext: InvariantContext
+  let robotState: RobotState
+
+  beforeEach(() => {
+    invariantContext = makeContext()
+    robotState = getInitialRobotStateStandard(invariantContext)
+  })
+
+  it('generates JSON and python', () => {
+    const result = dispenseWhileTracking(
+      trackingParams,
+      invariantContext,
+      robotState
+    )
+    expect(getSuccessResult(result).commands).toEqual([
+      {
+        commandType: 'dispenseWhileTracking',
+        key: expect.any(String),
+        params: trackingParams,
+      },
+    ])
+
+    expect(getSuccessResult(result).python).toBe(
+      `
+mock_pipette.dispense(
+    volume=50,
+    location=mock_source_plate["A1"].bottom(z=5),
+    flow_rate=6,
+    end_location=mock_source_plate["A1"].top(z=10),
+)`.trimStart()
+    )
+  })
+})

--- a/step-generation/src/commandCreators/atomic/__tests__/home.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/home.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { getSuccessResult } from '../../../fixtures'
+import { home } from '../home'
+
+import type { InvariantContext, RobotState } from '../../../types'
+
+describe('home', () => {
+  it('generates JSON and python with no optional params', () => {
+    const result = home({}, {} as InvariantContext, {} as RobotState)
+    expect(getSuccessResult(result)).toEqual({
+      commands: [
+        {
+          commandType: 'home',
+          key: expect.any(String),
+          params: {},
+        },
+      ],
+      python: 'protocol.home()',
+    })
+  })
+
+  it('generates JSON and python with axes and skipIfMountPositionOk', () => {
+    const result = home(
+      { axes: ['x', 'y'], skipIfMountPositionOk: 'left' },
+      {} as InvariantContext,
+      {} as RobotState
+    )
+    expect(getSuccessResult(result)).toEqual({
+      commands: [
+        {
+          commandType: 'home',
+          key: expect.any(String),
+          params: {
+            axes: ['x', 'y'],
+            skipIfMountPositionOk: 'left',
+          },
+        },
+      ],
+      python:
+        'protocol.home(axes=["x", "y"],\n, skipIfMountPositionOk="left",\n)',
+    })
+  })
+})

--- a/step-generation/src/commandCreators/atomic/__tests__/moveRelative.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/moveRelative.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_PIPETTE,
+  getInitialRobotStateStandard,
+  getSuccessResult,
+  makeContext,
+} from '../../../fixtures'
+import { moveRelative } from '../moveRelative'
+
+import type { InvariantContext, RobotState } from '../../../types'
+
+describe('moveRelative', () => {
+  let invariantContext: InvariantContext
+  let robotState: RobotState
+
+  beforeEach(() => {
+    invariantContext = makeContext()
+    robotState = getInitialRobotStateStandard(invariantContext)
+  })
+
+  it('generates JSON and python for a relative move', () => {
+    const result = moveRelative(
+      { pipetteId: DEFAULT_PIPETTE, axis: 'z', distance: -2.5 },
+      invariantContext,
+      robotState
+    )
+    expect(getSuccessResult(result)).toEqual({
+      commands: [
+        {
+          commandType: 'moveRelative',
+          key: expect.any(String),
+          params: {
+            pipetteId: DEFAULT_PIPETTE,
+            axis: 'z',
+            distance: -2.5,
+          },
+        },
+      ],
+      python: 'mock_pipette.move_axes_relative(axis="z", distance=-2.5)',
+    })
+  })
+})

--- a/step-generation/src/commandCreators/atomic/__tests__/moveToCoordinate.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/moveToCoordinate.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_PIPETTE,
+  getInitialRobotStateStandard,
+  getSuccessResult,
+  makeContext,
+} from '../../../fixtures'
+import { moveToCoordinates } from '../moveToCoordinates'
+
+import type { InvariantContext, RobotState } from '../../../types'
+
+describe('moveToCoordinates', () => {
+  let invariantContext: InvariantContext
+  let robotState: RobotState
+
+  beforeEach(() => {
+    invariantContext = makeContext()
+    robotState = getInitialRobotStateStandard(invariantContext)
+  })
+
+  it('generates JSON and python with required params only', () => {
+    const result = moveToCoordinates(
+      {
+        pipetteId: DEFAULT_PIPETTE,
+        coordinates: { x: 100, y: 200, z: 50 },
+      },
+      invariantContext,
+      robotState
+    )
+    expect(getSuccessResult(result)).toEqual({
+      commands: [
+        {
+          commandType: 'moveToCoordinates',
+          key: expect.any(String),
+          params: {
+            pipetteId: DEFAULT_PIPETTE,
+            coordinates: { x: 100, y: 200, z: 50 },
+          },
+        },
+      ],
+      python: 'mock_pipette.move_axes_to(coordinates=(100, 200, 50))',
+    })
+  })
+
+  it('generates JSON and python with optional movement params', () => {
+    const result = moveToCoordinates(
+      {
+        pipetteId: DEFAULT_PIPETTE,
+        coordinates: { x: 1, y: 2, z: 3 },
+        forceDirect: true,
+        minimumZHeight: 42,
+      },
+      invariantContext,
+      robotState
+    )
+    expect(getSuccessResult(result)).toEqual({
+      commands: [
+        {
+          commandType: 'moveToCoordinates',
+          key: expect.any(String),
+          params: {
+            pipetteId: DEFAULT_PIPETTE,
+            coordinates: { x: 1, y: 2, z: 3 },
+            forceDirect: true,
+            minimumZHeight: 42,
+          },
+        },
+      ],
+      python:
+        'mock_pipette.move_axes_to(coordinates=(1, 2, 3), force_direct=True, minimum_z_height=42)',
+    })
+  })
+})

--- a/step-generation/src/commandCreators/atomic/__tests__/tryLiquidProbe.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/tryLiquidProbe.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_PIPETTE,
+  getInitialRobotStateStandard,
+  getSuccessResult,
+  makeContext,
+  SOURCE_LABWARE,
+} from '../../../fixtures'
+import { tryLiquidProbe } from '../tryLiquidProbe'
+
+import type { InvariantContext, RobotState } from '../../../types'
+
+describe('tryLiquidProbe', () => {
+  let invariantContext: InvariantContext
+  let robotState: RobotState
+
+  beforeEach(() => {
+    invariantContext = makeContext()
+    robotState = getInitialRobotStateStandard(invariantContext)
+  })
+
+  it('generates JSON and python', () => {
+    const params = {
+      pipetteId: DEFAULT_PIPETTE,
+      labwareId: SOURCE_LABWARE,
+      wellName: 'A1',
+      wellLocation: {
+        origin: 'top' as const,
+        offset: { z: 2 },
+      },
+    }
+    const result = tryLiquidProbe(params, invariantContext, robotState)
+    expect(getSuccessResult(result)).toEqual({
+      commands: [
+        {
+          commandType: 'tryLiquidProbe',
+          key: expect.any(String),
+          params,
+        },
+      ],
+      python: 'mock_pipette.detect_liquid_presence(mock_source_plate["A1"])',
+    })
+  })
+})

--- a/step-generation/src/commandCreators/atomic/aspirateWhileTracking.ts
+++ b/step-generation/src/commandCreators/atomic/aspirateWhileTracking.ts
@@ -1,0 +1,59 @@
+import {
+  formatPyStr,
+  formatPyWellLocation,
+  indentPyLines,
+  uuid,
+} from '../../utils'
+
+import type { AspirateWhileTrackingCreateCommand } from '@opentrons/shared-data'
+import type { CommandCreator } from '../../types'
+
+export const aspirateWhileTracking: CommandCreator<
+  AspirateWhileTrackingCreateCommand['params']
+> = (args, invariantContext, prevRobotState) => {
+  const {
+    pipetteId,
+    volume,
+    flowRate,
+    labwareId,
+    wellName,
+    trackFromLocation,
+    trackToLocation,
+  } = args
+
+  const commands = [
+    {
+      commandType: 'aspirateWhileTracking' as const,
+      key: uuid(),
+      params: {
+        pipetteId,
+        volume,
+        flowRate,
+        labwareId,
+        wellName,
+        trackFromLocation,
+        trackToLocation,
+      },
+    },
+  ]
+
+  const pipettePythonName =
+    invariantContext.pipetteEntities[pipetteId].pythonName
+  const labwarePythonName =
+    invariantContext.labwareEntities[labwareId].pythonName
+  const wellRef = `${labwarePythonName}[${formatPyStr(wellName)}]`
+  const pythonArgs = [
+    `volume=${volume}`,
+    `location=${wellRef}${formatPyWellLocation(trackFromLocation)}`,
+    `flow_rate=${flowRate}`,
+    `end_location=${wellRef}${formatPyWellLocation(trackToLocation)}`,
+  ]
+  const python = `${pipettePythonName}.aspirate(\n${indentPyLines(
+    pythonArgs.join(',\n')
+  )},\n)`
+
+  return {
+    commands,
+    python,
+  }
+}

--- a/step-generation/src/commandCreators/atomic/dispenseWhileTracking.ts
+++ b/step-generation/src/commandCreators/atomic/dispenseWhileTracking.ts
@@ -1,0 +1,59 @@
+import {
+  formatPyStr,
+  formatPyWellLocation,
+  indentPyLines,
+  uuid,
+} from '../../utils'
+
+import type { DispenseWhileTrackingParams } from '@opentrons/shared-data'
+import type { CommandCreator } from '../../types'
+
+export const dispenseWhileTracking: CommandCreator<
+  DispenseWhileTrackingParams
+> = (args, invariantContext, prevRobotState) => {
+  const {
+    pipetteId,
+    volume,
+    flowRate,
+    labwareId,
+    wellName,
+    trackFromLocation,
+    trackToLocation,
+  } = args
+
+  const commands = [
+    {
+      commandType: 'dispenseWhileTracking' as const,
+      key: uuid(),
+      params: {
+        pipetteId,
+        volume,
+        flowRate,
+        labwareId,
+        wellName,
+        trackFromLocation,
+        trackToLocation,
+      },
+    },
+  ]
+
+  const pipettePythonName =
+    invariantContext.pipetteEntities[pipetteId].pythonName
+  const labwarePythonName =
+    invariantContext.labwareEntities[labwareId].pythonName
+  const wellRef = `${labwarePythonName}[${formatPyStr(wellName)}]`
+  const pythonArgs = [
+    `volume=${volume}`,
+    `location=${wellRef}${formatPyWellLocation(trackFromLocation)}`,
+    `flow_rate=${flowRate}`,
+    `end_location=${wellRef}${formatPyWellLocation(trackToLocation)}`,
+  ]
+  const python = `${pipettePythonName}.dispense(\n${indentPyLines(
+    pythonArgs.join(',\n')
+  )},\n)`
+
+  return {
+    commands,
+    python,
+  }
+}

--- a/step-generation/src/commandCreators/atomic/home.ts
+++ b/step-generation/src/commandCreators/atomic/home.ts
@@ -1,0 +1,38 @@
+import {
+  formatPyList,
+  formatPyStr,
+  PROTOCOL_CONTEXT_NAME,
+  uuid,
+} from '../../utils'
+
+import type { HomeCreateCommand } from '@opentrons/shared-data'
+import type { CommandCreator } from '../../types'
+
+export const home: CommandCreator<HomeCreateCommand['params']> = (
+  args,
+  invariantContext,
+  prevRobotState
+) => {
+  const { axes, skipIfMountPositionOk } = args
+
+  const command: HomeCreateCommand = {
+    commandType: 'home',
+    key: uuid(),
+    params: {
+      axes,
+      skipIfMountPositionOk,
+    },
+  }
+  const pythonArgs = [
+    ...(axes != null ? [`axes=${formatPyList(axes)},\n`] : []),
+    ...(skipIfMountPositionOk != null
+      ? [`skipIfMountPositionOk=${formatPyStr(skipIfMountPositionOk)},\n`]
+      : []),
+  ]
+
+  const python = `${PROTOCOL_CONTEXT_NAME}.home(${pythonArgs.join(', ')})`
+  return {
+    commands: [command],
+    python: python,
+  }
+}

--- a/step-generation/src/commandCreators/atomic/moveRelative.ts
+++ b/step-generation/src/commandCreators/atomic/moveRelative.ts
@@ -1,0 +1,34 @@
+import { formatPyStr, uuid } from '../../utils'
+
+import type {
+  CreateCommand,
+  MoveRelativeCreateCommand,
+} from '@opentrons/shared-data'
+import type { CommandCreator } from '../../types'
+
+export const moveRelative: CommandCreator<
+  MoveRelativeCreateCommand['params']
+> = (args, invariantContext, prevRobotState) => {
+  const { pipetteId, axis, distance } = args
+
+  const { pipetteEntities } = invariantContext
+
+  const pipettePythonName = pipetteEntities[pipetteId].pythonName
+
+  const commands: CreateCommand[] = [
+    {
+      commandType: 'moveRelative',
+      key: uuid(),
+      params: {
+        pipetteId,
+        axis,
+        distance,
+      },
+    },
+  ]
+  const pythonArgs = [`axis=${formatPyStr(axis)}`, `distance=${distance}`]
+  return {
+    commands,
+    python: `${pipettePythonName}.move_axes_relative(${pythonArgs.join(', ')})`,
+  }
+}

--- a/step-generation/src/commandCreators/atomic/moveToCoordinates.ts
+++ b/step-generation/src/commandCreators/atomic/moveToCoordinates.ts
@@ -1,0 +1,41 @@
+import { formatPyTuple, uuid } from '../../utils'
+
+import type {
+  CreateCommand,
+  MoveToCoordinatesCreateCommand,
+} from '@opentrons/shared-data'
+import type { CommandCreator } from '../../types'
+
+export const moveToCoordinates: CommandCreator<
+  MoveToCoordinatesCreateCommand['params']
+> = (args, invariantContext, prevRobotState) => {
+  const { pipetteId, coordinates, minimumZHeight, forceDirect } = args
+
+  const { pipetteEntities } = invariantContext
+
+  const pipettePythonName = pipetteEntities[pipetteId].pythonName
+
+  const commands: CreateCommand[] = [
+    {
+      commandType: 'moveToCoordinates',
+      key: uuid(),
+      params: {
+        pipetteId,
+        coordinates,
+        minimumZHeight,
+        forceDirect,
+      },
+    },
+  ]
+
+  const pythonArgs = [
+    `coordinates=${formatPyTuple([coordinates.x, coordinates.y, coordinates.z])}`,
+    ...(forceDirect ? [`force_direct=True`] : []),
+    ...(minimumZHeight ? [`minimum_z_height=${minimumZHeight}`] : []),
+  ]
+
+  return {
+    commands,
+    python: `${pipettePythonName}.move_axes_to(${pythonArgs.join(', ')})`,
+  }
+}

--- a/step-generation/src/commandCreators/atomic/tryLiquidProbe.ts
+++ b/step-generation/src/commandCreators/atomic/tryLiquidProbe.ts
@@ -1,0 +1,38 @@
+import { formatPyStr, uuid } from '../../utils'
+
+import type {
+  CreateCommand,
+  TryLiquidProbeCreateCommand,
+} from '@opentrons/shared-data'
+import type { CommandCreator } from '../../types'
+
+export const tryLiquidProbe: CommandCreator<
+  TryLiquidProbeCreateCommand['params']
+> = (args, invariantContext, prevRobotState) => {
+  const { pipetteId, labwareId, wellName, wellLocation } = args
+
+  const { pipetteEntities } = invariantContext
+
+  const pipettePythonName = pipetteEntities[pipetteId].pythonName
+  const labwarePythonName =
+    invariantContext.labwareEntities[labwareId].pythonName
+
+  const commands: CreateCommand[] = [
+    {
+      commandType: 'tryLiquidProbe',
+      key: uuid(),
+      params: {
+        pipetteId,
+        labwareId,
+        wellName,
+        wellLocation,
+      },
+    },
+  ]
+  return {
+    commands,
+    python: `${pipettePythonName}.detect_liquid_presence(${labwarePythonName}[${formatPyStr(
+      wellName
+    )}])`,
+  }
+}


### PR DESCRIPTION
# Overview

closes AUTH-2960

this creates all the missing atomic command creators needed for OAI, they aren't wired up at all yet, but there are the command creators + the tests.

i still generated the JSON cuz why the heck not, idk lol

## Test Plan and Hands on Testing

Just review the command creators and the tests. nothing to smoke test yet.

## Changelog

create the command creators and tests for 

```
 'aspirateWhileTracking',
  'dispenseWhileTracking',
  'home',
  'moveRelative',
  'moveToCoordinates',
  'tryLiquidProbe',
```

## Risk assessment

low, just making atomic `commandCreators` but they're not wired in at all
