### PR TITLE
fix(protocol-designer): sentry set commits during build

### DIFF
--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -136,6 +136,9 @@ export default defineConfig(async (): Promise<UserConfig> => {
             ? 'local-dev'
             : (sentryReleaseEnv ?? OT_PD_VERSION),
           inject: false,
+          // set-commits --auto can hang on large monorepos (see sentry-cli set-commits).
+          // CI associates commits in getsentry/action-release after the build.
+          setCommits: false,
         },
         ...(enableSentrySourcemapUpload
           ? {


### PR DESCRIPTION
## Overview

Build with Sentry only happens on tags, that is why this just surfaced.  I reproduced locally and then changed the set commits and then could not reproduce anymore.

Staging Protocol Designer tag builds were hanging after `@sentry/vite-plugin` finished uploading source maps. The process stayed at high CPU on `sentry-cli releases set-commits … --auto --ignore-missing` and never exited, which led to cancelled `build PD` jobs (e.g. [actions run 26843517929](https://github.com/Opentrons/opentrons/actions/runs/26843517929)).

This PR sets `setCommits: false` on the Vite plugin release config so the plugin does not run `set-commits --auto` during the build. Commit association for tagged releases is unchanged: CI still runs `getsentry/action-release` with `set_commits: auto` and `fetch-depth: 0` after the build (see `.github/workflows/pd-test-build-deploy.yaml`).

**Related context**

- [sentry-javascript-bundler-plugins#746](https://github.com/getsentry/sentry-javascript-bundler-plugins/issues/746) (hang after successful source map upload)
- [sentry-cli#2026](https://github.com/getsentry/sentry-cli/issues/2026) (`get_commits_from_git` / large commit sets)
- [sentry-cli releases docs](https://docs.sentry.io/cli/releases/)

## Changelog

- **fix(protocol-designer):** Disable automatic commit association in `@sentry/vite-plugin` during build to avoid `set-commits --auto` hangs on this monorepo; commits continue to be set in CI via `getsentry/action-release`.