### PR TITLE
fix(protocol-designer, step-generation): fix logic for pipette centering

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteShadow.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/PipetteShadows/PipetteShadow.tsx
@@ -118,6 +118,7 @@ export function PipetteShadow(props: {
     wellName: hoveredWell,
     pipetteSpec,
     primaryNozzle,
+    nozzleConfiguration: nozzles,
   })
 
   const { channels, pipetteBoundingBoxOffsets } = pipetteSpec

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -7,6 +7,7 @@ import {
 import {
   COLUMN_4_SLOTS,
   getIsSafePickupWithinTiprack,
+  getPipetteCenteringFullOffset,
   getPipetteMovementSafetyStatus,
   getSlotInLocationStack,
 } from '@opentrons/step-generation'
@@ -101,6 +102,7 @@ export const getHoveredOffsetFromWell = (args: {
   wellName: string | null
   pipetteSpec: PipetteV2Specs
   primaryNozzle: PrimaryNozzleConfigurationStyle
+  nozzleConfiguration: NozzleConfigurationStyle
 }): { x: number; y: number } => {
   const {
     selectedLabwareId,
@@ -108,6 +110,7 @@ export const getHoveredOffsetFromWell = (args: {
     wellName,
     pipetteSpec,
     primaryNozzle,
+    nozzleConfiguration,
   } = args
   const { nozzleMap, pipetteBoundingBoxOffsets } = pipetteSpec
   const { backLeftCorner, frontRightCorner } = pipetteBoundingBoxOffsets
@@ -126,13 +129,17 @@ export const getHoveredOffsetFromWell = (args: {
     }
   }
   const well = labware.def.wells[wellName]
-  const wellIsRectangular = well.shape === 'rectangular'
 
-  const labwareHasOneRowAndIsRectangular =
-    labware.def.ordering[0].length === 1 && wellIsRectangular
-  const wellHeight = labwareHasOneRowAndIsRectangular ? well.yDimension : well.y
-  const wellX = well.x + xOffset
-  const wellY = wellHeight + yOffset
+  const centeringOffset = getPipetteCenteringFullOffset({
+    wellTargetName: wellName,
+    primaryNozzle,
+    nozzleConfiguration,
+    specs: pipetteSpec,
+    labwareDef: labware.def,
+  })
+
+  const wellX = well.x + centeringOffset.x + xOffset
+  const wellY = well.y + centeringOffset.y + yOffset
   const isSingleChannelPipette = pipetteSpec.channels === 1
 
   return {

--- a/protocol-designer/src/steplist/generateSubstepItem.ts
+++ b/protocol-designer/src/steplist/generateSubstepItem.ts
@@ -319,7 +319,7 @@ export function generateSubstepItem(
   labwareNamesByModuleId: LabwareNamesByModuleId
 ): SubstepItemData | null | undefined {
   if (!robotState) {
-    console.info(
+    console.warn(
       `No robot state, could not generate substeps for step ${stepId}.` +
         `There was probably an upstream error.`
     )

--- a/step-generation/src/utils/__tests__/getPipetteCriticalPoint.test.ts
+++ b/step-generation/src/utils/__tests__/getPipetteCriticalPoint.test.ts
@@ -38,7 +38,7 @@ describe('getPipetteCriticalPoint', () => {
     channels: 8,
   } as unknown as PipetteEntity
 
-  it('returns center point for COLUMN configuration when labware has one row', () => {
+  it('returns primary nozzle position for COLUMN configuration (centering handled by getPipetteCenteringYOffset)', () => {
     const result = getPipetteCriticalPoint(
       COLUMN as NozzleConfigurationStyle,
       mock96chPipetteEntity,
@@ -46,8 +46,8 @@ describe('getPipetteCriticalPoint', () => {
       fixture12Trough as LabwareDefinition
     )
 
-    // midpoint between A1 [0,0,0] and H1 [70,0,0] → [35,0,0]
-    expect(result).toEqual({ x: 35, y: 0, z: 0 })
+    // COLUMN centering is handled by getPipetteCenteringYOffset, not here
+    expect(result).toEqual({ x: 0, y: 0, z: 0 })
   })
 
   it('returns center point for ROW configuration when labware has one row', () => {
@@ -62,7 +62,7 @@ describe('getPipetteCriticalPoint', () => {
     expect(result).toEqual({ x: 0, y: 55, z: 0 })
   })
 
-  it('uses primary nozzle as backLeftPoint correctly for different nozzle', () => {
+  it('returns primary nozzle position for COLUMN configuration with A12 primary nozzle', () => {
     const result = getPipetteCriticalPoint(
       COLUMN as NozzleConfigurationStyle,
       mock96chPipetteEntity,
@@ -70,8 +70,8 @@ describe('getPipetteCriticalPoint', () => {
       fixture12Trough as LabwareDefinition
     )
 
-    // midpoint between A12 [0,110,0] and H12 [70,110,0] → [35,110,0]
-    expect(result).toEqual({ x: 35, y: 110, z: 0 })
+    // COLUMN centering is handled by getPipetteCenteringYOffset, not here
+    expect(result).toEqual({ x: 0, y: 110, z: 0 })
   })
 
   it('returns default position when labware has more than one column', () => {

--- a/step-generation/src/utils/getPipetteCriticalPoint.ts
+++ b/step-generation/src/utils/getPipetteCriticalPoint.ts
@@ -19,7 +19,7 @@ export const getPipetteCriticalPoint = (
     nozzleConfiguration === COLUMN ||
     (nozzleConfiguration === ALL && spec.channels === 8)
   const labwareHasOneRow = labwareDefinition.ordering[0].length === 1
-  if ((isColumn || isRow) && labwareHasOneRow) {
+  if (isRow && labwareHasOneRow) {
     // return the XY CENTER
     const frontPoint = isColumn
       ? `H${primaryNozzle.slice(1)}`

--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -69,6 +69,8 @@ const FLEX_TC_LID_FRONT_RIGHT_PT = {
   z: FLEX_TC_LID_COLLISION_ZONE.front_right.z,
 }
 
+const FULL_96_PIPETTE_NOZZLE_OFFSET_X_MM = 49.5 // designates half of full width of pipette nozzle plane for 96-ch pipettes
+
 interface SlotInfo {
   addressableArea: AddressableArea | null
   position: CoordinateTuple | null
@@ -845,9 +847,14 @@ const getIsMovementWithinDeckExtents = (args: {
 
 // gets arbitrary span between two pipette nozzles, assuming constant grid spacing
 const getNozzleGapFromPipetteSpecs = (specs: PipetteV2Specs): number => {
-  const [nozzleX1, nozzleX2] = [0, 1].map(
-    index => Object.values(specs.nozzleMap)[index][0]
-  )
+  const { channels, nozzleMap } = specs
+  if (channels === 1) {
+    return 0
+  }
+
+  // for 96- and 8-channel pipettes, the gap between nozzles A1 and B1
+  // is consistent for all nozzles
+  const [nozzleX1, nozzleX2] = ['A1', 'B1'].map(key => nozzleMap[key][1])
   const nozzleGap = Math.abs(nozzleX1 - nozzleX2)
   return nozzleGap
 }
@@ -860,7 +867,9 @@ interface PipetteCenteringArgs {
   labwareDef: LabwareDefinition
 }
 
-const getPipetteCenteringFullOffset = (args: PipetteCenteringArgs): Point => {
+export const getPipetteCenteringFullOffset = (
+  args: PipetteCenteringArgs
+): Point => {
   const centeringXOffset = getPipetteCenteringXOffset(args)
   const centeringYOffset = getPipetteCenteringYOffset(args)
   return {
@@ -872,12 +881,16 @@ const getPipetteCenteringFullOffset = (args: PipetteCenteringArgs): Point => {
 const getPipetteCenteringXOffset = (args: PipetteCenteringArgs): number => {
   const { primaryNozzle, nozzleConfiguration, specs, labwareDef } = args
   const { channels } = specs
+  if (channels !== 96) {
+    return 0
+  }
   const { ordering } = labwareDef
   const shouldCenterInX = ordering.length === 1 // labware is comprised of 1 column (row-format, as an 8-ch reservoir)
   if (!shouldCenterInX) {
     return 0
   }
   let numNozzleColumns: number
+  const directionForXOffset = getTipColumnName(primaryNozzle) === '12' ? 1 : -1
   if (
     (nozzleConfiguration === ALL && channels === 96) ||
     nozzleConfiguration === ROW
@@ -886,9 +899,8 @@ const getPipetteCenteringXOffset = (args: PipetteCenteringArgs): number => {
   } else if (nozzleConfiguration === QUADRANT) {
     numNozzleColumns = 6
   } else {
-    numNozzleColumns = 1
+    return directionForXOffset * FULL_96_PIPETTE_NOZZLE_OFFSET_X_MM
   }
-  const directionForXOffset = getTipColumnName(primaryNozzle) === '12' ? 1 : -1
   const nozzleGap = getNozzleGapFromPipetteSpecs(specs)
   return shouldCenterInX
     ? (((numNozzleColumns - 1) * nozzleGap) / 2) * directionForXOffset
@@ -904,30 +916,36 @@ const getPipetteCenteringYOffset = (args: PipetteCenteringArgs): number => {
     labwareDef,
   } = args
   const { channels } = specs
+  if (channels === 1) {
+    return 0
+  }
+  const nozzleGap = getNozzleGapFromPipetteSpecs(specs)
   const { ordering } = labwareDef
   const wellTargetColumnIndex = ordering.findIndex(column =>
     column.includes(wellTargetName)
   )
   const wellTargetColumn = ordering[wellTargetColumnIndex]
-  const shouldCenterInY = wellTargetColumn.length === 1
-  if (!shouldCenterInY) {
+  if (wellTargetColumn.length !== 1) {
     return 0
   }
-  let numNozzleRows: number
-  if (
-    nozzleConfiguration === COLUMN ||
-    (nozzleConfiguration === ALL && channels === 96) ||
-    channels === 8
-  ) {
-    numNozzleRows = 8
-  } else if (nozzleConfiguration === PARTIAL_COLUMN) {
-    numNozzleRows = PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
-  } else if (nozzleConfiguration === QUADRANT) {
-    numNozzleRows = 4
-  } else {
-    numNozzleRows = 1
+  if (nozzleConfiguration === PARTIAL_COLUMN) {
+    // determine number of nozzle gaps between nozzle A and primary
+    const spanFromAToPrimary =
+      8 - PARTIAL_NOZZLE_MAP[primaryNozzle as PartialPrimaryNozzles]
+
+    // shift forward such that nozzle A targets the well center
+    const offsetToNozzleA = -1 * spanFromAToPrimary * nozzleGap
+
+    // since there are 7 "gaps" between front and back nozzles
+    const offsetFromNozzleAToBack = (7 * nozzleGap) / 2
+
+    // "push" pipette back to center the pipette
+    return offsetToNozzleA + offsetFromNozzleAToBack
   }
-  const nozzleGap = getNozzleGapFromPipetteSpecs(specs)
+
+  // all other 96- and 8-channel nozzle configs
   const directionForYOffset = getTipRowName(primaryNozzle) === 'H' ? -1 : 1
-  return (((numNozzleRows - 1) * nozzleGap) / 2) * directionForYOffset
+
+  // 7 here again since there are 7 "gaps" between front and back nozzles
+  return ((7 * nozzleGap) / 2) * directionForYOffset
 }


### PR DESCRIPTION
# Overview

This PR refines the logic for centering multi-channel pipettes in reservoir wells. It also unifies the pipette positioning for both safety checks and pipette shadow renders.

Closes RQA-5529

## Test Plan and Hands on Testing

- import the protocols attached to the tickets and verify that there are no errors for well selection for reservoirs
- open a reservoir transfer step and change the nozzle configurations, verifying that hovering the reservoirs centers the pipette so that the reservoir wells are accessible
- smoke tested each combination of 8/96-ch pipette, each nozzle configuration, each primary nozzle for that configuration, and 1- and 12-channel reservoirs

## Changelog

- unify logic for pipette centering in both UI (`PipetteShadow`) and movement safety checks for one source of truth
- fix tests

## Review requests

See test plan. Generally, smoke test combinations of 8- and 96-channel pipette nozzle configurations and primary nozzles with reservoirs specifically.

## Risk assessment

lowish. should only serve to more accurately position pipette based on expected physical exectuion