### PR TITLE
feat(app): Show detailed error messages when a login fails

### DIFF
--- a/app/src/assets/localization/en/access_control.json
+++ b/app/src/assets/localization/en/access_control.json
@@ -10,9 +10,13 @@
   "legal_name": "Legal Name",
   "log_in_link": "Log in",
   "log_out": "Log out",
-  "username": "Username",
   "login_error_incorrect": "Incorrect username or password.",
+  "login_error_incorrect_with_attempts_remaining": "Incorrect username or password ({{attemptsRemaining}} attempts remaining before lockout).",
+  "login_error_locked": "Account locked. Please contact an administrator to unlock your account.",
+  "login_error_unknown": "An unknown error occurred while trying to log in.",
+  "login_error_unknown_with_message": "An unknown error occurred while trying to log in: {{message}}",
   "login_form_password_field": "Password",
   "login_form_username_field": "Username",
+  "username": "Username",
   "view_actions": "View actions"
 }

--- a/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
+++ b/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
@@ -117,7 +117,7 @@ describe('LoginModal', () => {
       ({ onError }) =>
         ({
           submitPassword: () => {
-            onError('Invalid credentials')
+            onError('Test error message')
           },
           isAuthLoading: false,
         }) as ReturnType<typeof useOAuth2PasswordLogin>
@@ -133,7 +133,7 @@ describe('LoginModal', () => {
     })
     fireEvent.click(screen.getByRole('button', { name: 'Log in' }))
 
-    screen.getByText('Incorrect username or password.')
+    screen.getByText('Test error message')
     screen.getByText('Compliance Ready Software Login')
   })
 })

--- a/app/src/organisms/Desktop/LoginModal/index.tsx
+++ b/app/src/organisms/Desktop/LoginModal/index.tsx
@@ -62,11 +62,8 @@ function LoginModalImpl(): JSX.Element {
       storeLoginState(successfulUsername, response)
       modal.remove()
     },
-    onError: () => {
-      // todo(mm, 2026-06-02): This is copied from the ODD logic, but it needs to be
-      // reworked to show the actual error (e.g. a network error), and to show the
-      // number of attempts remaining before lockout.
-      setLoginError(t('access_control:login_error_incorrect') as string)
+    onError: message => {
+      setLoginError(message)
     },
   })
 

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginModal.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginModal.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { useTranslation } from 'react-i18next'
 import NiceModal, { useModal } from '@ebay/nice-modal-react'
 
 import { useStoreLoginState } from '/app/resources/access-control/useStoreLoginState'
@@ -16,7 +15,6 @@ export interface LoginModalResult {
 
 const LoginModalImpl = NiceModal.create((): JSX.Element => {
   const modal = useModal()
-  const { t } = useTranslation('device_settings')
   const [step, setStep] = useState<LoginStep>('username')
   const [loginError, setLoginError] = useState<string | null>(null)
   const storeLoginState = useStoreLoginState()
@@ -29,10 +27,8 @@ const LoginModalImpl = NiceModal.create((): JSX.Element => {
       modal.resolve(result)
       modal.remove()
     },
-    onError: () => {
-      // todo(mm, 2026-06-02): This needs to show the actual error (e.g. a network error),
-      // and show the number of attempts remaining before lockout.
-      setLoginError(t('on_device_login_error_incorrect') as string)
+    onError: message => {
+      setLoginError(message)
     },
   })
 

--- a/app/src/resources/auth/hooks/useOAuth2PasswordLogin.ts
+++ b/app/src/resources/auth/hooks/useOAuth2PasswordLogin.ts
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import axios from 'axios'
 
 import { OAUTH2_CLIENT_ID } from '@opentrons/api-client'
@@ -17,26 +18,13 @@ interface OAuth2TokenErrorResponse {
   opentrons_login_attempts_remaining?: number
 }
 
-function getOAuth2PasswordLoginErrorMessage(error: unknown): string {
-  if (axios.isAxiosError(error)) {
-    const data = error.response?.data as OAuth2TokenErrorResponse | undefined
-    const description = data?.error_description
-    if (description != null && description !== '') return description
-    const code = data?.error
-    if (code != null && code !== '') return code
-  }
-  return error instanceof Error ? error.message : 'Login failed'
-}
-
 export interface UseOAuth2PasswordLoginOptions {
   /**
-   * Called when the token endpoint succeeds (e.g. navigate away).
-   * Use `useNavigate` from the caller for desktop vs ODD routing.
+   * Called when the login request succeeds.
    */
   onSuccess: (username: string, response: OAuth2TokenResponse) => void
   /**
    * Called with a user-facing message when the token request fails.
-   * Wire to `makeSnackbar` / toast in the page or organism, not in this hook.
    */
   onError: (message: string) => void
 }
@@ -55,6 +43,32 @@ export function useOAuth2PasswordLogin(
   options: UseOAuth2PasswordLoginOptions
 ): UseOAuth2PasswordLoginResult {
   const { onSuccess, onError } = options
+  const { t } = useTranslation('access_control')
+
+  const getErrorMessage = (error: unknown): string => {
+    if (axios.isAxiosError(error)) {
+      const data = error.response?.data as OAuth2TokenErrorResponse | undefined
+      const oauth2ErrorCode = data?.error
+      const attemptsRemaining = data?.opentrons_login_attempts_remaining
+      if (oauth2ErrorCode === 'invalid_grant') {
+        if (typeof attemptsRemaining === 'number') {
+          if (attemptsRemaining === 0) {
+            return t('login_error_locked')
+          } else {
+            return t('login_error_incorrect_with_attempts_remaining', {
+              attemptsRemaining,
+            })
+          }
+        } else {
+          return t('login_error_incorrect')
+        }
+      } else {
+        return t('login_error_unknown_with_message', { message: error.message })
+      }
+    } else {
+      return t('login_error_unknown')
+    }
+  }
 
   const { getOAuth2Token, isLoading } = useGetOAuth2TokenMutation({
     onSuccess: (responseData, requestVariables) => {
@@ -69,7 +83,7 @@ export function useOAuth2PasswordLogin(
       }
     },
     onError: (error: unknown) => {
-      onError(getOAuth2PasswordLoginErrorMessage(error))
+      onError(getErrorMessage(error))
     },
   })
 


### PR DESCRIPTION
## Overview

This closes EXEC-2713.

## Changelog

Formerly, the desktop and ODD login forms would show an "incorrect username or password" message for *any* error. Now, they show a different error message depending on what went wrong:

* Incorrect username or password
* Incorrect username or password, with *n* attempts remaining before lockout
* Locked out; the user needs to contact an admin to unlock their account
* Unknown error (possibly a network error)

## Test Plan and Hands on Testing

Tested mostly on the desktop, e.g.:

https://github.com/user-attachments/assets/37b8ff70-0591-4d1f-a10f-5763251be426

The ODD shares the same code, so I expect it to work there too.

## Review requests

None.

## Risk assessment

Low.