### PR TITLE
fix(step-generation): target correct wells/tips in partial column mode

### DIFF
--- a/step-generation/src/commandCreators/atomic/__tests__/configureNozzleLayout.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/configureNozzleLayout.test.ts
@@ -122,7 +122,7 @@ mock_pipette.configure_nozzle_layout(
       `
 mock_pipette.configure_nozzle_layout(
     protocol_api.PARTIAL_COLUMN,
-    start="D1", end="H1",
+    start="H1", end="D1",
 )`.trimStart()
     )
   })

--- a/step-generation/src/commandCreators/atomic/configureNozzleLayout.ts
+++ b/step-generation/src/commandCreators/atomic/configureNozzleLayout.ts
@@ -26,7 +26,7 @@ export const configureNozzleLayout: CommandCreator<
     pythonArgs = [
       `protocol_api.${style}`,
       ...(primaryNozzle != null
-        ? [`start=${formatPyStr(primaryNozzle)}, end=${formatPyStr(H1_NOZZLE)}`]
+        ? [`start=${formatPyStr(H1_NOZZLE)}, end=${formatPyStr(primaryNozzle)}`]
         : []),
     ]
   } else {

--- a/step-generation/src/commandCreators/compound/consolidate.ts
+++ b/step-generation/src/commandCreators/compound/consolidate.ts
@@ -12,6 +12,7 @@ import {
   isFlexPipette,
   LOW_VOLUME_PIPETTES,
   NONE_LIQUID_CLASS_NAME,
+  PARTIAL_COLUMN,
   POSITION_REFERENCE_MAPPED_TO_WELL_ORIGIN,
   SAFE_MOVE_TO_WELL_LOCATION,
   WATER_LIQUID_CLASS_NAME,
@@ -37,6 +38,7 @@ import {
   reduceCommandCreators,
   SOURCE_WELL_BLOWOUT_DESTINATION,
 } from '../../utils'
+import { getTransformedWellsForPartialColumn } from '../../utils/getTransformedWellsForPartialColumn'
 import {
   getCustomLiquidClassProperties,
   getLiquidClassName,
@@ -58,7 +60,10 @@ import {
 import { mixInPlaceUtil } from './mix'
 import { replaceTip } from './replaceTip'
 
-import type { WellLocation } from '@opentrons/shared-data'
+import type {
+  PartialPrimaryNozzles,
+  WellLocation,
+} from '@opentrons/shared-data'
 import type {
   CommandCreator,
   CommandCreatorError,
@@ -410,12 +415,33 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
         wasteChuteEntities[blowoutLocation]?.pythonName)
   const sourceLabwarePythonName = labwareEntities[sourceLabware].pythonName
   const destLabwarePythonName = labwareEntities[destLabware]?.pythonName
-  const pythonSourceWells = sourceWells
+
+  const transformedSourceWells =
+    nozzles === PARTIAL_COLUMN
+      ? getTransformedWellsForPartialColumn({
+          labwareDef: labwareEntities[sourceLabware].def,
+          wells: sourceWells,
+          primaryNozzle: primaryNozzle as PartialPrimaryNozzles,
+        })
+      : sourceWells
+  const transformedDestWell = (
+    nozzles === PARTIAL_COLUMN &&
+    destWell != null &&
+    labwareEntities[destLabware] != null
+      ? getTransformedWellsForPartialColumn({
+          labwareDef: labwareEntities[destLabware].def,
+          wells: [destWell],
+          primaryNozzle: primaryNozzle as PartialPrimaryNozzles,
+        })
+      : [destWell]
+  )[0]
+
+  const pythonSourceWells = transformedSourceWells
     .map(well => `${sourceLabwarePythonName}[${formatPyStr(well)}]`)
     .join(', ')
   const pythonDestWells =
-    args.destWell != null && destLabwarePythonName != null
-      ? `${destLabwarePythonName}[${formatPyStr(args.destWell)}]`
+    transformedDestWell != null && destLabwarePythonName != null
+      ? `${destLabwarePythonName}[${formatPyStr(transformedDestWell)}]`
       : null
 
   const pythonLiquidClassArgs = [
@@ -450,11 +476,20 @@ export const consolidate: CommandCreator<ConsolidateArgs> = (
       })
     : null
 
+  const transformedTargetTips =
+    targetTips != null && tiprackEntity != null && nozzles === PARTIAL_COLUMN
+      ? getTransformedWellsForPartialColumn({
+          labwareDef: tiprackEntity?.def,
+          wells: targetTips,
+          primaryNozzle: primaryNozzle as PartialPrimaryNozzles,
+        })
+      : targetTips
+
   const tiprackName =
     tiprackSelected != null
       ? labwareEntities[tiprackSelected]?.pythonName
       : null
-  const fullTipWellsToPickupString = targetTips
+  const fullTipWellsToPickupString = transformedTargetTips
     ?.map(targetTip => `${tiprackName}[${formatPyStr(targetTip)}]`)
     .join(', ')
 

--- a/step-generation/src/commandCreators/compound/distribute.ts
+++ b/step-generation/src/commandCreators/compound/distribute.ts
@@ -12,6 +12,7 @@ import {
   isFlexPipette,
   LOW_VOLUME_PIPETTES,
   NONE_LIQUID_CLASS_NAME,
+  PARTIAL_COLUMN,
   POSITION_REFERENCE_MAPPED_TO_WELL_ORIGIN,
   SAFE_MOVE_TO_WELL_LOCATION,
   WATER_LIQUID_CLASS_NAME,
@@ -40,6 +41,7 @@ import {
   reduceCommandCreators,
   SOURCE_WELL_BLOWOUT_DESTINATION,
 } from '../../utils'
+import { getTransformedWellsForPartialColumn } from '../../utils/getTransformedWellsForPartialColumn'
 import {
   getCustomLiquidClassProperties,
   getLiquidClassName,
@@ -61,7 +63,10 @@ import {
 import { mixInPlaceUtil } from './mix'
 import { replaceTip } from './replaceTip'
 
-import type { WellLocation } from '@opentrons/shared-data'
+import type {
+  PartialPrimaryNozzles,
+  WellLocation,
+} from '@opentrons/shared-data'
 import type {
   CommandCreator,
   CommandCreatorError,
@@ -457,10 +462,31 @@ export const distribute: CommandCreator<DistributeArgs> = (
         wasteChuteEntities[blowoutLocation]?.pythonName)
   const sourceLabwarePythonName = labwareEntities[sourceLabware].pythonName
   const destLabwarePythonName = labwareEntities[destLabware]?.pythonName
+
+  const transformedSourceWell = (
+    nozzles === PARTIAL_COLUMN
+      ? getTransformedWellsForPartialColumn({
+          labwareDef: labwareEntities[sourceLabware].def,
+          wells: [sourceWell],
+          primaryNozzle: primaryNozzle as PartialPrimaryNozzles,
+        })
+      : [sourceWell]
+  )[0]
+  const transformedDestWells =
+    nozzles === PARTIAL_COLUMN &&
+    destWells != null &&
+    labwareEntities[destLabware] != null
+      ? getTransformedWellsForPartialColumn({
+          labwareDef: labwareEntities[destLabware].def,
+          wells: destWells,
+          primaryNozzle: primaryNozzle as PartialPrimaryNozzles,
+        })
+      : destWells
+
   const pythonSourceWells = `${sourceLabwarePythonName}[${formatPyStr(
-    args.sourceWell
+    transformedSourceWell
   )}]`
-  const pythonDestWells = args.destWells
+  const pythonDestWells = transformedDestWells
     .map(well => `${destLabwarePythonName}[${formatPyStr(well)}]`)
     .join(', ')
 
@@ -500,7 +526,15 @@ export const distribute: CommandCreator<DistributeArgs> = (
     tiprackSelected != null
       ? labwareEntities[tiprackSelected]?.pythonName
       : null
-  const fullTipWellsToPickupString = targetTips
+  const transformedTargetTips =
+    targetTips != null && tiprackEntity != null && nozzles === PARTIAL_COLUMN
+      ? getTransformedWellsForPartialColumn({
+          labwareDef: tiprackEntity?.def,
+          wells: targetTips,
+          primaryNozzle: primaryNozzle as PartialPrimaryNozzles,
+        })
+      : targetTips
+  const fullTipWellsToPickupString = transformedTargetTips
     ?.map(targetTip => `${tiprackName}[${formatPyStr(targetTip)}]`)
     .join(', ')
 

--- a/step-generation/src/commandCreators/compound/transfer.ts
+++ b/step-generation/src/commandCreators/compound/transfer.ts
@@ -10,6 +10,7 @@ import {
   isFlexPipette,
   LOW_VOLUME_PIPETTES,
   NONE_LIQUID_CLASS_NAME,
+  PARTIAL_COLUMN,
   POSITION_REFERENCE_MAPPED_TO_WELL_ORIGIN,
   SAFE_MOVE_TO_WELL_LOCATION,
   WATER_LIQUID_CLASS_NAME,
@@ -37,6 +38,7 @@ import {
   reduceCommandCreators,
   SOURCE_WELL_BLOWOUT_DESTINATION,
 } from '../../utils'
+import { getTransformedWellsForPartialColumn } from '../../utils/getTransformedWellsForPartialColumn'
 import {
   getCustomLiquidClassProperties,
   getLiquidClassName,
@@ -60,7 +62,10 @@ import { blowOutInWasteChute } from './blowOutInWasteChute'
 import { mixInPlaceUtil } from './mix'
 import { replaceTip } from './replaceTip'
 
-import type { WellLocation } from '@opentrons/shared-data'
+import type {
+  PartialPrimaryNozzles,
+  WellLocation,
+} from '@opentrons/shared-data'
 import type {
   CommandCreator,
   CommandCreatorError,
@@ -451,12 +456,32 @@ export const transfer: CommandCreator<TransferArgs> = (
         wasteChuteEntities[blowoutLocation]?.pythonName)
   const sourceLabwarePythonName = labwareEntities[sourceLabware].pythonName
   const destLabwarePythonName = labwareEntities[destLabware]?.pythonName
-  const pythonSourceWells = sourceWells
+
+  const transformedSourceWells =
+    nozzles === PARTIAL_COLUMN
+      ? getTransformedWellsForPartialColumn({
+          labwareDef: labwareEntities[sourceLabware].def,
+          wells: sourceWells,
+          primaryNozzle: primaryNozzle as PartialPrimaryNozzles,
+        })
+      : sourceWells
+  const transformedDestWells =
+    nozzles === PARTIAL_COLUMN &&
+    destWells != null &&
+    labwareEntities[destLabware] != null
+      ? getTransformedWellsForPartialColumn({
+          labwareDef: labwareEntities[destLabware].def,
+          wells: destWells,
+          primaryNozzle: primaryNozzle as PartialPrimaryNozzles,
+        })
+      : destWells
+
+  const pythonSourceWells = transformedSourceWells
     .map(well => `${sourceLabwarePythonName}[${formatPyStr(well)}]`)
     .join(', ')
   const pythonDestWells =
-    destWells != null && destLabwarePythonName != null
-      ? destWells
+    transformedDestWells != null && destLabwarePythonName != null
+      ? transformedDestWells
           .map(well => `${destLabwarePythonName}[${formatPyStr(well)}]`)
           .join(', ')
       : null
@@ -492,12 +517,20 @@ export const transfer: CommandCreator<TransferArgs> = (
         primaryNozzle,
       })
     : null
+  const transformedTargetTips =
+    targetTips != null && tiprackEntity != null && nozzles === PARTIAL_COLUMN
+      ? getTransformedWellsForPartialColumn({
+          labwareDef: tiprackEntity?.def,
+          wells: targetTips,
+          primaryNozzle: primaryNozzle as PartialPrimaryNozzles,
+        })
+      : targetTips
 
   const tiprackName =
     tiprackSelected != null
       ? labwareEntities[tiprackSelected]?.pythonName
       : null
-  const fullTipWellsToPickupString = targetTips
+  const fullTipWellsToPickupString = transformedTargetTips
     ?.map(targetTip => `${tiprackName}[${formatPyStr(targetTip)}]`)
     .join(', ')
 

--- a/step-generation/src/utils/getTransformedWellsForPartialColumn.ts
+++ b/step-generation/src/utils/getTransformedWellsForPartialColumn.ts
@@ -1,0 +1,39 @@
+import { PARTIAL_NOZZLE_MAP } from '@opentrons/shared-data'
+
+import type {
+  LabwareDefinition2,
+  PartialPrimaryNozzles,
+} from '@opentrons/shared-data'
+
+export const getTransformedWellsForPartialColumn = (args: {
+  labwareDef: LabwareDefinition2
+  wells: string[]
+  primaryNozzle: PartialPrimaryNozzles
+}): string[] => {
+  const { labwareDef, wells, primaryNozzle } = args
+
+  // transform partial nozzle to H1 nozzle
+  const nozzleOffsetCount = PARTIAL_NOZZLE_MAP[primaryNozzle] - 1
+  const { ordering, parameters } = labwareDef
+
+  return wells.map(well => {
+    const column = ordering.find(col => col.includes(well))
+    if (column == null) {
+      console.warn(
+        `Could not find column for ${well} in ${parameters.loadName}`
+      )
+      return well
+    }
+
+    // single-well column (like a reservoir): no transformation needed
+    if (column.length === 1) {
+      return well
+    }
+    const foundWellIndex = column.indexOf(well)
+    if (foundWellIndex === -1) {
+      console.warn(`Could not find column index of ${well}`)
+      return well
+    }
+    return column[foundWellIndex + nozzleOffsetCount]
+  })
+}


### PR DESCRIPTION
# Overview

This PR ensures the emitted Python for partial column nozzle configuration targets the correct wells/tips (assuming H1 primary nozzle).

Closes RQA-5372

## Test Plan and Hands on Testing

- create a protocol with partial column configuration in a moveLiquid step, export, and verify that the correct tips and wells are targeted in the transfer step (aligned with primary nozzle H1)

## Changelog

- introduce utility to transform wells targeted by a partial primary nozzle (B1-G1, as used throughout the user interface) to H1 (as prescribed by the API) 

## Review requests

- see test plan

## Risk assessment

low. only touches emitted Python, and corrects a bad bug in prod