### PR TITLE
feat(step-generation): bump PAPI and PD versions

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -247,7 +247,7 @@ CUSTOM_LABWARE = json.loads("""{"fixture/fixture_trash/1":{"ordering":[["A1"]],"
             },
           },
         },
-        version: '8.11.0',
+        version: '9.0.0',
         name: 'opentrons/protocol-designer',
       },
       robot: { model: OT2_ROBOT_TYPE },

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -49,8 +49,8 @@ import type {
   WasteChuteEntities,
 } from '../types'
 
-export const PAPI_VERSION = '2.28' // oldest version that we need from api/src/opentrons/protocols/api_support/definitions.py, might not be the actual latest version
-export const PD_APPLICATION_VERSION = '8.11.0' // latest PD version to insert into DESIGNER_APPLICATION blob
+export const PAPI_VERSION = '2.29' // oldest version that we need from api/src/opentrons/protocols/api_support/definitions.py, might not be the actual latest version
+export const PD_APPLICATION_VERSION = '9.0.0' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {
   return ['import json', 'from opentrons import protocol_api, types'].join('\n')


### PR DESCRIPTION
# Overview

This PR updates the PAPI and PD versions in a created PD protocol file.

Closes EXEC-2717

## Test Plan and Hands on Testing

- export a PD protocol on the release branch
- verify that the metadata specifies API version 2.29 and PD version 9.0.0 

## Changelog

- update versions mentioned above

## Review requests

see test plan

## Risk assessment

⬇️ 