### PR TITLE
fix(app): fix codeblock width issue

### DIFF
--- a/app/src/atoms/CodeBlock/codeblock.module.css
+++ b/app/src/atoms/CodeBlock/codeblock.module.css
@@ -1,4 +1,5 @@
 .container {
+  width: 100%;
   padding: var(--spacing-6) var(--spacing-12);
   border-radius: var(--border-radius-4);
   background-color: var(--grey-20);


### PR DESCRIPTION


# Overview
fix codeblock width issue

[before]
<img width="498" height="183" alt="Screenshot 2026-06-04 at 7 15 18 PM" src="https://github.com/user-attachments/assets/775d3c31-31cf-40b2-b2b4-4dab91634435" />


[after]
<img width="504" height="188" alt="Screenshot 2026-06-04 at 7 16 27 PM" src="https://github.com/user-attachments/assets/b21e26cb-23d5-42bc-84de-7276ee2dccae" />

closes AUTH-2983


## Test Plan and Hands on Testing
- upload a protocol that has an analysis error

## Changelog
- update code block style

## Review requests


## Risk assessment
low