### PR TITLE
chore(js): Fix JS tests collecting files from the wrong project

### DIFF
--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -119,7 +119,7 @@ jobs:
       - name: check make version
         run: make --version
       - name: 'test native(er) packages'
-        run: make test-js-internal tests="${{matrix.shell}}/src"
+        run: make test-js-${{matrix.shell}}
 
   determine-build-type:
     runs-on: 'ubuntu-latest'

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,12 @@ $(SHARED_DATA_DIR)-py-test:
 	$(MAKE) -C $(SHARED_DATA_DIR) test-py
 
 .PHONY: test-js
-test-js: test-js-internal
+test-js:
+	pnpm vitest run $(tests) $(test_opts) $(cov_opts)
+
+.PHONY: test-js-%
+test-js-%:
+	pnpm vitest run --dir $* $(tests) $(test_opts) $(cov_opts)
 
 # lints and typechecks
 .PHONY: lint
@@ -320,15 +325,6 @@ circular-dependencies-js: $(JS_CIRCULAR_DEPENDENCIES_TARGETS)
 
 %-circular-dependencies-js:
 	pnpm madge $(and $(CI),--no-spinner --no-color) --circular $*
-
-.PHONY: test-js-internal
-test-js-internal:
-	pnpm vitest run $(tests) $(test_opts) $(cov_opts)
-
-
-.PHONY: test-js-%
-test-js-%:
-	$(MAKE) test-js-internal tests="$(if $(tests),$(foreach test,$(tests),$*/$(test)),$*)" test_opts="$(test_opts)" cov_opts="$(cov_opts)"
 
 # Convenience commands for running all of our servers in dev mode, together,
 # behind a reverse proxy listening on port 31950.

--- a/opentrons-ai-client/Makefile
+++ b/opentrons-ai-client/Makefile
@@ -67,11 +67,11 @@ serve: all
 
 .PHONY: test
 test:
-	$(MAKE) -C .. test-js-ai-client tests="$(tests)" test_opts="$(test_opts)"
+	$(MAKE) -C .. test-js-opentrons-ai-client tests="$(tests)" test_opts="$(test_opts)"
 
 .PHONY: test-cov
 test-cov:
-	make -C .. test-js-ai-client tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"
+	make -C .. test-js-opentrons-ai-client tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"
 
 .PHONY: staging-deploy
 staging-deploy:


### PR DESCRIPTION
## Overview

This closes AUTH-2907.

To do something like "run all the app tests," we were calling `vitest run app`. This accidentally collected test files that had the string `app` *anywhere* in their path. So, for example, it accidentally collected files in `app-shell` and `app-shell-odd`. To run only the tests within the `app` directory, we want `vitest run --dir app` instead.

## Test Plan and Hands on Testing

* [x] `make test-js` still works.
* [x] `make -C app test` now excludes tests from `app-shell`.
* [x] `make -C api-client test` now excludes tests from `react-api-client`.
* [x] Tests can still be filtered further via the `tests` variable, like `make test-js tests="some_pattern"` or `make -C app test tests="some_pattern"`.

## Review requests

None in particular.

## Risk assessment

Medium.
