### PR TITLE
chore: Fix recursive `make` invocations

### DIFF
--- a/api-client/Makefile
+++ b/api-client/Makefile
@@ -34,4 +34,4 @@ test:
 
 .PHONY: test-cov
 test-cov:
-	make -C .. test-js-api-client tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"
+	$(MAKE) -C .. test-js-api-client tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"

--- a/app/Makefile
+++ b/app/Makefile
@@ -100,8 +100,8 @@ dev-shell-odd:
 
 .PHONY: test
 test:
-	make -C .. test-js-app tests="$(tests)" test_opts="$(test_opts)"
+	$(MAKE) -C .. test-js-app tests="$(tests)" test_opts="$(test_opts)"
 
 .PHONY: test-cov
 test-cov:
-	make -C .. test-js-app tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"
+	$(MAKE) -C .. test-js-app tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"

--- a/js-package-testing/Makefile
+++ b/js-package-testing/Makefile
@@ -38,19 +38,19 @@ build-local-packages:
 	@echo "Creating pack directory..."
 	@mkdir -p $(PACK_DIR)
 	@echo "Building shared-data package..."
-	make -C ../shared-data pack
+	$(MAKE) -C ../shared-data pack
 	@echo "Moving shared-data package to pack directory..."
 	@mv ../shared-data/opentrons-shared-data-0.0.0-dev.tgz $(SHARED_DATA_PACK)
 	@echo "Building step-generation package..."
-	make -C ../step-generation pack
+	$(MAKE) -C ../step-generation pack
 	@echo "Moving step-generation package to pack directory..."
 	@mv ../step-generation/opentrons-step-generation-0.0.0-dev.tgz $(STEP_GENERATION_PACK)
 	@echo "Building components package..."
-	make -C ../components pack
+	$(MAKE) -C ../components pack
 	@echo "Moving components package to pack directory..."
 	@mv ../components/opentrons-components-0.0.0-dev.tgz $(COMPONENTS_PACK)
 	@echo "Building protocol-visualization package..."
-	make -C ../protocol-visualization pack
+	$(MAKE) -C ../protocol-visualization pack
 	@echo "Moving protocol-visualization package to pack directory..."
 	@mv ../protocol-visualization/opentrons-protocol-visualization-0.0.0-dev.tgz $(PROTOCOL_VISUALIZATION_PACK)
 	@echo "Extracting packages..."

--- a/labware-library/Makefile
+++ b/labware-library/Makefile
@@ -52,4 +52,4 @@ test:
 
 .PHONY: test-cov
 test-cov:
-	make -C .. test-js-labware-library tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"
+	$(MAKE) -C .. test-js-labware-library tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"

--- a/opentrons-ai-client/Makefile
+++ b/opentrons-ai-client/Makefile
@@ -71,7 +71,7 @@ test:
 
 .PHONY: test-cov
 test-cov:
-	make -C .. test-js-ai-client tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"
+	$(MAKE) -C .. test-js-ai-client tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"
 
 .PHONY: staging-deploy
 staging-deploy:

--- a/protocol-designer/Makefile
+++ b/protocol-designer/Makefile
@@ -57,7 +57,7 @@ test:
 
 .PHONY: test-cov
 test-cov:
-	make -C .. test-js-protocol-designer tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"
+	$(MAKE) -C .. test-js-protocol-designer tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"
 
 # analyze bundle
 .PHONY: bundle-analyzer

--- a/react-api-client/Makefile
+++ b/react-api-client/Makefile
@@ -33,4 +33,4 @@ test:
 
 .PHONY: test-cov
 test-cov:
-	make -C .. test-js-react-api-client tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"
+	$(MAKE) -C .. test-js-react-api-client tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"

--- a/step-generation/Makefile
+++ b/step-generation/Makefile
@@ -44,4 +44,4 @@ test:
 
 .PHONY: test-cov
 test-cov:
-	make -C .. test-js-step-generation tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"
+	$(MAKE) -C .. test-js-step-generation tests=$(tests) test_opts="$(test_opts)" cov_opts="$(cov_opts)"


### PR DESCRIPTION
## Overview

Per our old friend [the GNU Make manual](https://www.gnu.org/software/make/manual/html_node/MAKE-Variable.html), when a Makefile recipe wants to call `make` again, it should always do it through the `$(MAKE)` variable, never directly. This ensures options from the top-level invocation get propagated down correctly.

## Test Plan and Hands on Testing

Just CI.

## Review requests

None.

## Risk assessment

Low.