### PR TITLE
feat(server-utils): add audit-server bindings

### DIFF
--- a/server-utils/server_utils/audit/__init__.py
+++ b/server-utils/server_utils/audit/__init__.py
@@ -1,0 +1,1 @@
+"""server_utils.audit: Shared code for sending audit log messages to audit-server."""

--- a/server-utils/server_utils/audit/audit_server.py
+++ b/server-utils/server_utils/audit/audit_server.py
@@ -1,0 +1,158 @@
+"""Bindings to audit-server's HTTP API.
+
+This is just the bare minimum required by dependent servers to submit
+audit log messages.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import typing
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+
+import aiohttp
+import pydantic
+
+LOG_MESSAGE_ENDPOINT_PATH = "audit/internal/logMessage"
+
+_log = logging.getLogger(__name__)
+
+
+class Client(ABC):
+    """An interface for a dependent server to submit audit log messages to audit-server."""
+
+    @abstractmethod
+    async def submit_log_message(
+        self, message: SubmitAuditLogMessageData
+    ) -> SubmitAuditLogSuccessData:
+        """Submit a single audit log message.
+
+        If there's an internal error (e.g. the audit server is unconnectable),
+        the implementation should raise it as an exception.
+        """
+        pass
+
+
+class LocalHTTPClient(Client):
+    """A client implementation that talks to audit-server over a local HTTP connection."""
+
+    def __init__(
+        self,
+        *,
+        audit_server_uds: str | None = None,
+        audit_server_url: str | None = None,
+    ) -> None:
+        """Construct the client.
+
+        Params:
+            audit_server_uds: e.g. `/path/to/socket`, to connect to audit-server via
+                a Unix domain socket.
+            audit_server_url: e.g. `http://localhost:1234`, to connect to audit-server
+                via TCP.
+        """
+        if audit_server_uds is not None and audit_server_url is not None:
+            raise ValueError(
+                "Specify only one of audit_server_uds or audit_server_url."
+            )
+
+        if audit_server_uds is not None:
+            connector = aiohttp.UnixConnector(path=audit_server_uds)
+            session = aiohttp.ClientSession(
+                connector=connector,
+                # We're connecting over a Unix socket, so this URL is nonsensical,
+                # but aiohttp seems to require it as a placeholder.
+                # https://github.com/aio-libs/aiohttp/issues/11324.
+                base_url="http://localhost",
+            )
+        elif audit_server_url is not None:
+            session = aiohttp.ClientSession(base_url=audit_server_url)
+        else:
+            raise ValueError("Specify audit_server_uds or audit_server_url.")
+
+        self._session = session
+        self._exit_stack = contextlib.AsyncExitStack()
+
+    async def __aenter__(self) -> typing.Self:
+        """When entered as a context manager, open the underlying connection."""
+        await self._exit_stack.enter_async_context(self._session)
+        return self
+
+    async def __aexit__(
+        self, exc_type: object, exc_value: object, traceback: object
+    ) -> None:
+        """When exited as a context manager, close the underlying connection."""
+        await self._exit_stack.aclose()
+
+    @typing.override
+    async def submit_log_message(
+        self, message: SubmitAuditLogMessageData
+    ) -> SubmitAuditLogSuccessData:
+        request_body = SubmitAuditLogMessageRequestBody(data=message)
+        async with self._session.post(
+            LOG_MESSAGE_ENDPOINT_PATH,
+            data=request_body.model_dump_json(),
+            headers={"Content-Type": "application/json"},
+        ) as response:
+            response_bytes = await response.read()
+        response.raise_for_status()
+        parsed_response = SubmitAuditLogMessageResponseBody.model_validate_json(
+            response_bytes
+        )
+        return parsed_response.data
+
+
+class NoOpClient(Client):
+    """A client implementation that doesn't actually contact audit-server.
+
+    Use this when audit-server isn't configured (e.g. CRS disabled).
+    It logs the message locally and returns a synthesized success response.
+    """
+
+    @typing.override
+    async def submit_log_message(
+        self, message: SubmitAuditLogMessageData
+    ) -> SubmitAuditLogSuccessData:
+        _log.info(
+            "Audit log message (audit-server not configured): "
+            "action=%s account_name=%s legal_name=%s reason=%s message=%s",
+            message.action,
+            message.accountName,
+            message.legalName,
+            message.reason,
+            message.message,
+        )
+        return SubmitAuditLogSuccessData(loggedAt=datetime.now(timezone.utc))
+
+
+class _StrictBaseModel(pydantic.BaseModel):
+    model_config = {"strict": True}
+
+
+class SubmitAuditLogMessageData(_StrictBaseModel):
+    """The payload portion of a log-message request."""
+
+    action: str
+    accountName: str
+    legalName: str
+    message: str
+    reason: str | None
+
+
+class SubmitAuditLogSuccessData(_StrictBaseModel):
+    """The payload of log-message success response."""
+
+    loggedAt: datetime
+
+
+class SubmitAuditLogMessageRequestBody(_StrictBaseModel):
+    """Request envelope for the log-message."""
+
+    data: SubmitAuditLogMessageData
+
+
+class SubmitAuditLogMessageResponseBody(_StrictBaseModel):
+    """Response envelope for log-message."""
+
+    data: SubmitAuditLogSuccessData

--- a/server-utils/server_utils/audit/fastapi.py
+++ b/server-utils/server_utils/audit/fastapi.py
@@ -1,0 +1,71 @@
+"""FastAPI-specific helpers for submitting audit log messages to audit-server."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from typing import Annotated, AsyncGenerator
+
+import fastapi
+
+from .audit_server import Client, LocalHTTPClient, NoOpClient
+from server_utils.fastapi_utils.app_state import (
+    AppState,
+    AppStateAccessor,
+    get_app_state,
+)
+
+_log = logging.getLogger(__name__)
+
+_audit_client_accessor = AppStateAccessor[Client]("audit_client")
+
+
+def install_audit_client(app_state: AppState, client: Client) -> None:
+    """Store a singleton audit `Client` in global server state for later retrieval.
+
+    This should be called once during server initialization.
+    """
+    _audit_client_accessor.set_on(app_state, client)
+
+
+def get_audit_client(
+    app_state: Annotated[AppState, fastapi.Depends(get_app_state)],
+) -> Client:
+    """A FastAPI dependency to retrieve the server's singleton audit `Client`.
+
+    Endpoints can take this as a dependency to submit audit log messages.
+    """
+    client = _audit_client_accessor.get_from(app_state)
+    assert client is not None, (
+        "Forgot to initialize audit client as part of server startup?"
+    )
+    return client
+
+
+@asynccontextmanager
+async def build_audit_client(
+    *,
+    audit_server_uds: str | None = None,
+    audit_server_url: str | None = None,
+) -> AsyncGenerator[Client, None]:
+    """Build an audit `Client` appropriately configured for most servers.
+
+    `audit_server_uds` (a path to a Unix domain socket) or `audit_server_url` (a URL
+    like http://localhost:1234) describes how to connect to audit-server. These should
+    typically be taken from CLI options or environment variables. If neither is
+    specified, a `NoOpClient` is returned that logs messages locally without
+    contacting any server.
+    """
+    if audit_server_uds is None and audit_server_url is None:
+        _log.info(
+            "Not configured to talk to audit-server."
+            " Audit log messages will only be logged locally."
+            " (This is normal when CRS is not enabled)."
+        )
+        yield NoOpClient()
+
+    else:
+        async with LocalHTTPClient(
+            audit_server_uds=audit_server_uds, audit_server_url=audit_server_url
+        ) as client:
+            yield client

--- a/server-utils/tests/audit/test_audit_server.py
+++ b/server-utils/tests/audit/test_audit_server.py
@@ -1,0 +1,245 @@
+"""Tests for our client of audit-server's HTTP API."""
+
+from __future__ import annotations
+
+from contextlib import AsyncExitStack
+from datetime import datetime, timezone
+from typing import AsyncGenerator, Final
+
+import aiohttp
+import aiohttp.web
+import pytest
+
+from server_utils.audit.audit_server import (
+    LOG_MESSAGE_ENDPOINT_PATH,
+    LocalHTTPClient,
+    NoOpClient,
+    SubmitAuditLogMessageData,
+    SubmitAuditLogSuccessData,
+)
+
+
+class AppMock:
+    """A fake AIOHTTP app to test the client against.
+
+    This should mirror the HTTP API of our real audit-server.
+    """
+
+    log_message_response: object
+    """The JSON body the server should respond with to a log-message request."""
+
+    log_message_response_status: int
+    """The HTTP status code the server should respond with to a log-message request."""
+
+    log_message_requests: list[object]
+    """When the server receives a log-message request, it records the request body here."""
+
+    log_message_request_content_types: list[str | None]
+    """When the server receives a log-message request, it records the Content-Type header here."""
+
+    app: Final[aiohttp.web.Application]
+
+    def __init__(self) -> None:
+        self.log_message_response = {}
+        self.log_message_response_status = 201
+        self.log_message_requests = []
+        self.log_message_request_content_types = []
+
+        app = aiohttp.web.Application()
+        app.router.add_post(f"/{LOG_MESSAGE_ENDPOINT_PATH}", self._post_log_message)
+        self.app = app
+
+    async def _post_log_message(
+        self, request: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
+        self.log_message_request_content_types.append(
+            request.headers.get("Content-Type")
+        )
+        body = await request.json()
+        self.log_message_requests.append(body)
+        return aiohttp.web.json_response(
+            data=self.log_message_response,
+            status=self.log_message_response_status,
+        )
+
+
+@pytest.fixture(params=["unix_domain_socket", "tcp"])
+async def mock_server(
+    request: pytest.FixtureRequest,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> AsyncGenerator[tuple[AppMock, LocalHTTPClient], None]:
+    """Return a fake server, and a real client pointed at that fake server.
+
+    Parametrized over two connection types: Unix domain socket, and TCP.
+    """
+    async with AsyncExitStack() as exit_stack:
+        app_mock = AppMock()
+
+        runner = aiohttp.web.AppRunner(app_mock.app)
+
+        await runner.setup()
+        exit_stack.push_async_callback(runner.cleanup)
+
+        mock_server_type = request.param
+
+        if mock_server_type == "unix_domain_socket":
+            socket_path = tmp_path_factory.mktemp("mock") / "sock"
+
+            unix_site = aiohttp.web.UnixSite(runner, socket_path)
+            await unix_site.start()
+            exit_stack.push_async_callback(unix_site.stop)
+
+            client = await exit_stack.enter_async_context(
+                LocalHTTPClient(audit_server_uds=str(socket_path))
+            )
+
+            yield (app_mock, client)
+
+        else:  # mock_server_type == "tcp"
+            tcp_site = aiohttp.web.TCPSite(runner, host="localhost", port=0)
+            await tcp_site.start()
+            exit_stack.push_async_callback(tcp_site.stop)
+
+            port = runner.addresses[0][1]
+            url = f"http://localhost:{port}"
+
+            client = await exit_stack.enter_async_context(
+                LocalHTTPClient(audit_server_url=url)
+            )
+
+            yield (app_mock, client)
+
+
+async def test_submit_log_message(
+    mock_server: tuple[AppMock, LocalHTTPClient],
+) -> None:
+    """Test that the client can send a well-formed log message and parse the response."""
+    app_mock, client = mock_server
+
+    logged_at = datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)
+    app_mock.log_message_response = {"data": {"loggedAt": logged_at.isoformat()}}
+
+    message = SubmitAuditLogMessageData(
+        action="run.start",
+        accountName="alice",
+        legalName="Alice Anderson",
+        message="Started run abc-123",
+        reason="Routine experiment",
+    )
+    result = await client.submit_log_message(message)
+
+    assert result == SubmitAuditLogSuccessData(loggedAt=logged_at)
+    assert app_mock.log_message_requests == [
+        {
+            "data": {
+                "action": "run.start",
+                "accountName": "alice",
+                "legalName": "Alice Anderson",
+                "message": "Started run abc-123",
+                "reason": "Routine experiment",
+            }
+        }
+    ]
+
+
+async def test_submit_log_message_reason_none(
+    mock_server: tuple[AppMock, LocalHTTPClient],
+) -> None:
+    """A `None` reason should serialize to JSON `null` in the request body."""
+    app_mock, client = mock_server
+
+    logged_at = datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)
+    app_mock.log_message_response = {"data": {"loggedAt": logged_at.isoformat()}}
+
+    message = SubmitAuditLogMessageData(
+        action="run.start",
+        accountName="alice",
+        legalName="Alice Anderson",
+        message="Started run abc-123",
+        reason=None,
+    )
+    result = await client.submit_log_message(message)
+
+    assert result == SubmitAuditLogSuccessData(loggedAt=logged_at)
+    assert len(app_mock.log_message_requests) == 1
+    request_body = app_mock.log_message_requests[0]
+    assert isinstance(request_body, dict)
+    # Verify "reason" was sent as null, not omitted.
+    assert "reason" in request_body["data"]
+    assert request_body["data"]["reason"] is None
+
+
+async def test_submit_log_message_http_error(
+    mock_server: tuple[AppMock, LocalHTTPClient],
+) -> None:
+    """A non-2xx response from audit-server should be raised as an exception."""
+    app_mock, client = mock_server
+
+    app_mock.log_message_response = {"errors": [{"detail": "boom"}]}
+    app_mock.log_message_response_status = 500
+
+    message = SubmitAuditLogMessageData(
+        action="run.start",
+        accountName="alice",
+        legalName="Alice Anderson",
+        message="Started run abc-123",
+        reason=None,
+    )
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.submit_log_message(message)
+
+
+def test_invalid_constructor_args_both_specified() -> None:
+    """Passing both `audit_server_uds` and `audit_server_url` should raise."""
+    with pytest.raises(ValueError):
+        LocalHTTPClient(
+            audit_server_uds="/tmp/sock",
+            audit_server_url="http://localhost:1234",
+        )
+
+
+def test_invalid_constructor_args_neither_specified() -> None:
+    """Passing neither `audit_server_uds` nor `audit_server_url` should raise."""
+    with pytest.raises(ValueError):
+        LocalHTTPClient()
+
+
+async def test_noop_client() -> None:
+    """`NoOpClient.submit_log_message` returns a success without contacting any server."""
+    client = NoOpClient()
+    message = SubmitAuditLogMessageData(
+        action="run.start",
+        accountName="alice",
+        legalName="Alice Anderson",
+        message="Started run abc-123",
+        reason=None,
+    )
+
+    before = datetime.now(timezone.utc)
+    result = await client.submit_log_message(message)
+    after = datetime.now(timezone.utc)
+
+    assert isinstance(result, SubmitAuditLogSuccessData)
+    assert before <= result.loggedAt <= after
+
+
+async def test_submit_log_message_sends_json_content_type(
+    mock_server: tuple[AppMock, LocalHTTPClient],
+) -> None:
+    """The client should send the request as application/json (not form-encoded)."""
+    app_mock, client = mock_server
+
+    logged_at = datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)
+    app_mock.log_message_response = {"data": {"loggedAt": logged_at.isoformat()}}
+
+    message = SubmitAuditLogMessageData(
+        action="run.start",
+        accountName="alice",
+        legalName="Alice Anderson",
+        message="Started run abc-123",
+        reason="why",
+    )
+    await client.submit_log_message(message)
+
+    assert app_mock.log_message_request_content_types == ["application/json"]

--- a/server-utils/tests/audit/test_fastapi.py
+++ b/server-utils/tests/audit/test_fastapi.py
@@ -1,0 +1,99 @@
+"""Tests for the audit-server FastAPI integration."""
+
+from __future__ import annotations
+
+import fastapi
+import pytest
+from starlette.testclient import TestClient
+
+from server_utils.audit.audit_server import (
+    Client,
+    LocalHTTPClient,
+    NoOpClient,
+    SubmitAuditLogMessageData,
+    SubmitAuditLogSuccessData,
+)
+from server_utils.audit.fastapi import (
+    build_audit_client,
+    get_audit_client,
+    install_audit_client,
+)
+
+
+async def test_build_audit_client_no_config_yields_noop() -> None:
+    """With no UDS or URL configured, `build_audit_client` should yield a `NoOpClient`."""
+    async with build_audit_client() as client:
+        assert isinstance(client, NoOpClient)
+
+
+async def test_build_audit_client_with_uds_yields_local_http_client(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """With a UDS configured, `build_audit_client` should yield a `LocalHTTPClient`."""
+    socket_path = tmp_path_factory.mktemp("audit") / "sock"
+    async with build_audit_client(audit_server_uds=str(socket_path)) as client:
+        assert isinstance(client, LocalHTTPClient)
+
+
+async def test_build_audit_client_with_url_yields_local_http_client() -> None:
+    """With a URL configured, `build_audit_client` should yield a `LocalHTTPClient`."""
+    async with build_audit_client(audit_server_url="http://localhost:1234") as client:
+        assert isinstance(client, LocalHTTPClient)
+
+
+async def test_build_audit_client_rejects_both_uds_and_url(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Passing both UDS and URL to `build_audit_client` should raise `ValueError`."""
+    socket_path = tmp_path_factory.mktemp("audit") / "sock"
+    with pytest.raises(ValueError):
+        async with build_audit_client(
+            audit_server_uds=str(socket_path),
+            audit_server_url="http://localhost:1234",
+        ):
+            pass
+
+
+def test_install_and_get_audit_client_via_dependency() -> None:
+    """`install_audit_client` + `get_audit_client` should round-trip through FastAPI."""
+
+    class StubClient(Client):
+        async def submit_log_message(
+            self, message: SubmitAuditLogMessageData
+        ) -> SubmitAuditLogSuccessData:  # pragma: no cover - not exercised here
+            raise NotImplementedError
+
+    stub_client = StubClient()
+
+    app = fastapi.FastAPI()
+    install_audit_client(app.state, stub_client)
+
+    seen: dict[str, Client] = {}
+
+    @app.get("/check")
+    def check(
+        client: Client = fastapi.Depends(get_audit_client),  # noqa: B008
+    ) -> dict[str, str]:
+        seen["client"] = client
+        return {"ok": "ok"}
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/check")
+        assert response.status_code == 200
+
+    assert seen["client"] is stub_client
+
+
+def test_get_audit_client_without_install_raises() -> None:
+    """`get_audit_client` should assert if no client has been installed."""
+    app = fastapi.FastAPI()
+
+    @app.get("/check")
+    def check(
+        client: Client = fastapi.Depends(get_audit_client),  # noqa: B008
+    ) -> dict[str, str]:  # pragma: no cover - dependency assertion fires first
+        return {"ok": "ok"}
+
+    with TestClient(app, raise_server_exceptions=True) as test_client:
+        with pytest.raises(AssertionError):
+            test_client.get("/check")


### PR DESCRIPTION
These work like the auth-server bindings and do the same things for the same reasons.

Most of this is just copies of the auth-server bindings with the names changed. The big question is the behavior when the auth-server is down or not installed. Here, we're raising (or, will when this is integrated - this PR doesn't actually _use_ the client anyway) if the audit message fails for any reason, which means robot-server for instance has to be responsible for knowing "don't try and submit an audit log if nobody's logged in". We could push that down to the audit-server, as we will eventually for reason format verification, but the robot-server (in this example) would still have to handle detecting and providing fallbacks for username and legal name, so I think this is appropriate.

Integrating this should be a matter of just following the pattern that the auth-server does - add a dependency loader and then bring in the client as a fastapi dependency - but we need some other changes first, like auth-server providing legal name in the `require_scopes()` dependency result, so I didn't do it here.