### PR TITLE
fix(protocol-visualization, app): no longer glitching when scrolling

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedGroup.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedGroup.tsx
@@ -1,9 +1,14 @@
+import clsx from 'clsx'
 import { useLayoutEffect, useState } from 'react'
 
 import { COLORS, Icon, StepGroup } from '@opentrons/components'
 
 import styles from './annotatedsteps.module.css'
 import { IndividualCommand } from './IndividualCommand'
+import {
+  getExpandedGroupBodyMaxHeightPx,
+  shouldCapExpandedGroupBodyHeight,
+} from './utils'
 
 import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import type {
@@ -12,11 +17,6 @@ import type {
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
 import type { LeafNode } from '/app/redux/protocol-storage'
-
-/** Reserve space for StepGroup header (title row, optional subtitle, padding). */
-const STEP_GROUP_HEADER_RESERVE_PX = 80
-const MIN_EXPANDED_BODY_PX = 160
-const LIST_VIEWPORT_BOTTOM_BUFFER_PX = 8
 
 interface AnnotatedGroupProps {
   scrollTargetId: string | null
@@ -70,15 +70,14 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
     command => command.isHighlighted
   )
 
-  const expandedMaxHeightPx =
-    listViewportHeight > 0
-      ? Math.max(
-          MIN_EXPANDED_BODY_PX,
-          listViewportHeight -
-            STEP_GROUP_HEADER_RESERVE_PX -
-            LIST_VIEWPORT_BOTTOM_BUFFER_PX
-        )
-      : null
+  const shouldCapExpandedBody = shouldCapExpandedGroupBodyHeight({
+    subCommandCount: subCommands.length,
+    listViewportHeight,
+    hasTrailingErrors,
+  })
+  const expandedMaxHeightPx = shouldCapExpandedBody
+    ? getExpandedGroupBodyMaxHeightPx(listViewportHeight)
+    : null
 
   return (
     <div className={styles.annotated_group_container}>
@@ -102,11 +101,14 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
       >
         {isExpanded ? (
           <div
-            className={styles.annotated_group_expanded}
+            className={clsx(styles.annotated_group_expanded, {
+              [styles.annotated_group_expanded_natural_height]:
+                !shouldCapExpandedBody,
+            })}
             style={
               expandedMaxHeightPx != null
                 ? { maxHeight: expandedMaxHeightPx }
-                : {}
+                : undefined
             }
           >
             {subCommands.map((subCommand, index) => (

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedGroup.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/AnnotatedGroup.tsx
@@ -1,5 +1,5 @@
-import clsx from 'clsx'
 import { useLayoutEffect, useState } from 'react'
+import clsx from 'clsx'
 
 import { COLORS, Icon, StepGroup } from '@opentrons/components'
 
@@ -105,11 +105,11 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
               [styles.annotated_group_expanded_natural_height]:
                 !shouldCapExpandedBody,
             })}
-            style={
-              expandedMaxHeightPx != null
-                ? { maxHeight: expandedMaxHeightPx }
-                : undefined
-            }
+            style={{
+              ...(expandedMaxHeightPx != null && {
+                maxHeight: expandedMaxHeightPx,
+              }),
+            }}
           >
             {subCommands.map((subCommand, index) => (
               <IndividualCommand

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/IndividualCommand.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/IndividualCommand.tsx
@@ -73,9 +73,7 @@ export function IndividualCommand({
         ? commandEl.closest<HTMLElement>(`.${styles.annotated_group_expanded}`)
         : null
     const outerListEl =
-      listElement ??
-      commandEl.closest<HTMLElement>('[role="list"]') ??
-      null
+      listElement ?? commandEl.closest<HTMLElement>('[role="list"]') ?? null
 
     let scrollContainer: HTMLElement | null = outerListEl
 

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/IndividualCommand.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/IndividualCommand.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import clsx from 'clsx'
 
 import { COLORS, CommandText } from '@opentrons/components'
@@ -27,6 +27,28 @@ interface IndividualCommandProps {
   commandNumber: number
   setSelectedCommand?: Dispatch<SetStateAction<string | null>>
 }
+
+function scrollContainerToShowTarget(
+  container: HTMLElement,
+  target: HTMLElement
+): boolean {
+  const containerRect = container.getBoundingClientRect()
+  const targetRect = target.getBoundingClientRect()
+  const isBelow = targetRect.bottom >= containerRect.bottom - 8
+  const isAbove = targetRect.top <= containerRect.top + 1
+
+  if (!isBelow && !isAbove) {
+    return false
+  }
+
+  const nextTop = container.scrollTop + (targetRect.top - containerRect.top)
+  container.scrollTo({
+    behavior: 'auto',
+    top: Math.max(0, nextTop),
+  })
+  return true
+}
+
 export function IndividualCommand({
   command,
   analysis,
@@ -41,50 +63,38 @@ export function IndividualCommand({
   const commandRef = useRef<HTMLDivElement | null>(null)
   const iconColor = isHighlighted ? COLORS.purple50 : COLORS.grey50
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isHighlighted || commandRef.current == null) return
     if (command.id !== scrollTargetId) return
 
-    requestAnimationFrame(() => {
-      const commandEl = commandRef.current
-      if (commandEl == null) return
+    const commandEl = commandRef.current
+    const groupExpandedEl =
+      fromGroup === true
+        ? commandEl.closest<HTMLElement>(`.${styles.annotated_group_expanded}`)
+        : null
+    const outerListEl =
+      listElement ??
+      commandEl.closest<HTMLElement>('[role="list"]') ??
+      null
 
-      const groupExpandedEl =
-        fromGroup === true
-          ? commandEl.closest<HTMLElement>(
-              `.${styles.annotated_group_expanded}`
-            )
-          : null
+    let scrollContainer: HTMLElement | null = outerListEl
 
-      const container: HTMLElement | null =
-        groupExpandedEl instanceof HTMLElement
-          ? groupExpandedEl
-          : (listElement ??
-            commandEl.closest<HTMLElement>('[role="list"]') ??
-            null)
+    if (groupExpandedEl instanceof HTMLElement) {
+      const hasInnerScroll =
+        groupExpandedEl.scrollHeight > groupExpandedEl.clientHeight + 1
+      scrollContainer = hasInnerScroll ? groupExpandedEl : outerListEl
+    }
 
-      if (container == null) {
-        commandEl.scrollIntoView({
-          behavior: 'smooth',
-          block: 'nearest',
-          inline: 'nearest',
-        })
-        return
-      }
-
-      const containerRect = container.getBoundingClientRect()
-      const commandRect = commandEl.getBoundingClientRect()
-      const isBelow = commandRect.bottom >= containerRect.bottom - 8
-      const isAbove = commandRect.top <= containerRect.top + 1
-      if (!isBelow && !isAbove) return
-
-      const nextTop =
-        container.scrollTop + (commandRect.top - containerRect.top)
-      container.scrollTo({
-        behavior: 'smooth',
-        top: Math.max(0, nextTop),
+    if (scrollContainer == null) {
+      commandEl.scrollIntoView({
+        behavior: 'auto',
+        block: 'nearest',
+        inline: 'nearest',
       })
-    })
+      return
+    }
+
+    scrollContainerToShowTarget(scrollContainer, commandEl)
   }, [isHighlighted, scrollTargetId, command.id, listElement, fromGroup])
 
   const commandWrapStyle = clsx(styles.individual_command_wrap, {

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
@@ -40,6 +40,11 @@
   overflow-y: auto;
 }
 
+.annotated_group_expanded_natural_height {
+  max-height: none;
+  overflow-y: visible;
+}
+
 .annotated_group_expanded::-webkit-scrollbar {
   display: none;
 }

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -319,7 +319,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
   const [listViewportHeight, setListViewportHeight] = useState(0)
   const dynamicRowHeight = useDynamicRowHeight({
     defaultRowHeight: DEFAULT_ROW_HEIGHT_PX,
-    key: `${listWidth}-${listViewportHeight}-${rows.length}`,
+    key: `${listWidth}-${rows.length}`,
   })
 
   useEffect(() => {
@@ -342,8 +342,11 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     if (scrollTargetId == null) return
     const rowIndex = rowIndexByCommandId.get(scrollTargetId)
     if (rowIndex == null) return
-    listRef?.scrollToRow({ index: rowIndex, align: 'auto' })
-  }, [scrollTargetId, rowIndexByCommandId, listRef])
+    listRef?.scrollToRow({
+      index: rowIndex,
+      align: rowIndex >= rows.length - 1 ? 'end' : 'auto',
+    })
+  }, [scrollTargetId, rowIndexByCommandId, listRef, rows.length])
 
   useEffect(() => {
     setListElement(listRef?.element ?? null)

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/utils.ts
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/utils.ts
@@ -49,9 +49,7 @@ export function shouldCapExpandedGroupBodyHeight(params: {
     return false
   }
 
-  return (
-    getEstimatedExpandedGroupContentHeightPx(params) > bodyMaxHeightPx
-  )
+  return getEstimatedExpandedGroupContentHeightPx(params) > bodyMaxHeightPx
 }
 
 export const getIsVisibleProtocolStep = (command: RunTimeCommand): boolean => {

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/utils.ts
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/utils.ts
@@ -1,5 +1,59 @@
 import type { RunTimeCommand } from '@opentrons/shared-data'
 
+/** Reserve space for StepGroup header (title row, optional subtitle, padding). */
+export const STEP_GROUP_HEADER_RESERVE_PX = 80
+export const MIN_EXPANDED_BODY_PX = 160
+export const LIST_VIEWPORT_BOTTOM_BUFFER_PX = 8
+/** Matches AnnotatedSteps DEFAULT_ROW_HEIGHT_PX. */
+export const ESTIMATED_COMMAND_HEIGHT_PX = 64
+export const TRAILING_ERRORS_FOOTER_ESTIMATE_PX = 100
+
+export function getExpandedGroupBodyMaxHeightPx(
+  listViewportHeight: number
+): number | null {
+  if (listViewportHeight <= 0) {
+    return null
+  }
+
+  return Math.max(
+    MIN_EXPANDED_BODY_PX,
+    listViewportHeight -
+      STEP_GROUP_HEADER_RESERVE_PX -
+      LIST_VIEWPORT_BOTTOM_BUFFER_PX
+  )
+}
+
+export function getEstimatedExpandedGroupContentHeightPx(params: {
+  subCommandCount: number
+  hasTrailingErrors?: boolean
+}): number {
+  const { subCommandCount, hasTrailingErrors = false } = params
+
+  return (
+    subCommandCount * ESTIMATED_COMMAND_HEIGHT_PX +
+    (hasTrailingErrors ? TRAILING_ERRORS_FOOTER_ESTIMATE_PX : 0)
+  )
+}
+
+/** Only cap expanded step-group height when content would exceed the list viewport. */
+export function shouldCapExpandedGroupBodyHeight(params: {
+  subCommandCount: number
+  listViewportHeight: number
+  hasTrailingErrors?: boolean
+}): boolean {
+  const bodyMaxHeightPx = getExpandedGroupBodyMaxHeightPx(
+    params.listViewportHeight
+  )
+
+  if (bodyMaxHeightPx == null) {
+    return false
+  }
+
+  return (
+    getEstimatedExpandedGroupContentHeightPx(params) > bodyMaxHeightPx
+  )
+}
+
 export const getIsVisibleProtocolStep = (command: RunTimeCommand): boolean => {
   return !command.commandType.includes('load') && command.commandType !== 'home'
 }

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/utils.ts
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/utils.ts
@@ -1,10 +1,10 @@
 import type { RunTimeCommand } from '@opentrons/shared-data'
 
-/** Reserve space for StepGroup header (title row, optional subtitle, padding). */
+// space for StepGroup header (title row, optional subtitle, padding)
 export const STEP_GROUP_HEADER_RESERVE_PX = 80
 export const MIN_EXPANDED_BODY_PX = 160
 export const LIST_VIEWPORT_BOTTOM_BUFFER_PX = 8
-/** Matches AnnotatedSteps DEFAULT_ROW_HEIGHT_PX. */
+// matches AnnotatedSteps DEFAULT_ROW_HEIGHT_PX.
 export const ESTIMATED_COMMAND_HEIGHT_PX = 64
 export const TRAILING_ERRORS_FOOTER_ESTIMATE_PX = 100
 
@@ -35,7 +35,7 @@ export function getEstimatedExpandedGroupContentHeightPx(params: {
   )
 }
 
-/** Only cap expanded step-group height when content would exceed the list viewport. */
+// only cap expanded stepGroup height when content would exceed the list viewport
 export function shouldCapExpandedGroupBodyHeight(params: {
   subCommandCount: number
   listViewportHeight: number

--- a/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedGroup.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedGroup.tsx
@@ -1,5 +1,5 @@
-import clsx from 'clsx'
 import { useLayoutEffect, useState } from 'react'
+import clsx from 'clsx'
 
 import { COLORS, Icon, StepGroup } from '@opentrons/components'
 

--- a/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedGroup.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedGroup.tsx
@@ -105,11 +105,11 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
               [styles.annotated_group_expanded_natural_height]:
                 !shouldCapExpandedBody,
             })}
-            style={
-              expandedMaxHeightPx != null
-                ? { maxHeight: expandedMaxHeightPx }
-                : undefined
-            }
+            style={{
+              ...(expandedMaxHeightPx != null && {
+                maxHeight: expandedMaxHeightPx,
+              }),
+            }}
           >
             {subCommands.map((subCommand, index) => (
               <IndividualCommand

--- a/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedGroup.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedGroup.tsx
@@ -1,9 +1,14 @@
+import clsx from 'clsx'
 import { useLayoutEffect, useState } from 'react'
 
 import { COLORS, Icon, StepGroup } from '@opentrons/components'
 
 import styles from './annotatedsteps.module.css'
 import { IndividualCommand } from './IndividualCommand'
+import {
+  getExpandedGroupBodyMaxHeightPx,
+  shouldCapExpandedGroupBodyHeight,
+} from './utils'
 
 import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import type {
@@ -12,11 +17,6 @@ import type {
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
 import type { LeafNode } from '../../types'
-
-/** Reserve space for StepGroup header (title row, optional subtitle, padding). */
-const STEP_GROUP_HEADER_RESERVE_PX = 80
-const MIN_EXPANDED_BODY_PX = 160
-const LIST_VIEWPORT_BOTTOM_BUFFER_PX = 8
 
 interface AnnotatedGroupProps {
   scrollTargetId: string | null
@@ -70,15 +70,14 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
     command => command.isHighlighted
   )
 
-  const expandedMaxHeightPx =
-    listViewportHeight > 0
-      ? Math.max(
-          MIN_EXPANDED_BODY_PX,
-          listViewportHeight -
-            STEP_GROUP_HEADER_RESERVE_PX -
-            LIST_VIEWPORT_BOTTOM_BUFFER_PX
-        )
-      : null
+  const shouldCapExpandedBody = shouldCapExpandedGroupBodyHeight({
+    subCommandCount: subCommands.length,
+    listViewportHeight,
+    hasTrailingErrors,
+  })
+  const expandedMaxHeightPx = shouldCapExpandedBody
+    ? getExpandedGroupBodyMaxHeightPx(listViewportHeight)
+    : null
 
   return (
     <div className={styles.annotated_group_container}>
@@ -102,11 +101,14 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
       >
         {isExpanded ? (
           <div
-            className={styles.annotated_group_expanded}
+            className={clsx(styles.annotated_group_expanded, {
+              [styles.annotated_group_expanded_natural_height]:
+                !shouldCapExpandedBody,
+            })}
             style={
               expandedMaxHeightPx != null
                 ? { maxHeight: expandedMaxHeightPx }
-                : {}
+                : undefined
             }
           >
             {subCommands.map((subCommand, index) => (

--- a/protocol-visualization/src/organisms/AnnotatedSteps/IndividualCommand.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/IndividualCommand.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useLayoutEffect, useRef } from 'react'
 import clsx from 'clsx'
 
 import { COLORS, CommandText } from '@opentrons/components'
@@ -26,6 +26,28 @@ interface IndividualCommandProps {
   commandNumber: number
   setSelectedCommand?: Dispatch<SetStateAction<string | null>> // remove redux dependency
 }
+
+function scrollContainerToShowTarget(
+  container: HTMLElement,
+  target: HTMLElement
+): boolean {
+  const containerRect = container.getBoundingClientRect()
+  const targetRect = target.getBoundingClientRect()
+  const isBelow = targetRect.bottom >= containerRect.bottom - 8
+  const isAbove = targetRect.top <= containerRect.top + 1
+
+  if (!isBelow && !isAbove) {
+    return false
+  }
+
+  const nextTop = container.scrollTop + (targetRect.top - containerRect.top)
+  container.scrollTo({
+    behavior: 'auto',
+    top: Math.max(0, nextTop),
+  })
+  return true
+}
+
 export function IndividualCommand({
   command,
   analysis,
@@ -40,50 +62,38 @@ export function IndividualCommand({
   const commandRef = useRef<HTMLDivElement | null>(null)
   const iconColor = isHighlighted ? COLORS.purple50 : COLORS.grey50
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!isHighlighted || commandRef.current == null) return
     if (command.id !== scrollTargetId) return
 
-    requestAnimationFrame(() => {
-      const commandEl = commandRef.current
-      if (commandEl == null) return
+    const commandEl = commandRef.current
+    const groupExpandedEl =
+      fromGroup === true
+        ? commandEl.closest<HTMLElement>(`.${styles.annotated_group_expanded}`)
+        : null
+    const outerListEl =
+      listElement ??
+      commandEl.closest<HTMLElement>('[role="list"]') ??
+      null
 
-      const groupExpandedEl =
-        fromGroup === true
-          ? commandEl.closest<HTMLElement>(
-              `.${styles.annotated_group_expanded}`
-            )
-          : null
+    let scrollContainer: HTMLElement | null = outerListEl
 
-      const container: HTMLElement | null =
-        groupExpandedEl instanceof HTMLElement
-          ? groupExpandedEl
-          : (listElement ??
-            commandEl.closest<HTMLElement>('[role="list"]') ??
-            null)
+    if (groupExpandedEl instanceof HTMLElement) {
+      const hasInnerScroll =
+        groupExpandedEl.scrollHeight > groupExpandedEl.clientHeight + 1
+      scrollContainer = hasInnerScroll ? groupExpandedEl : outerListEl
+    }
 
-      if (container == null) {
-        commandEl.scrollIntoView({
-          behavior: 'smooth',
-          block: 'nearest',
-          inline: 'nearest',
-        })
-        return
-      }
-
-      const containerRect = container.getBoundingClientRect()
-      const commandRect = commandEl.getBoundingClientRect()
-      const isBelow = commandRect.bottom >= containerRect.bottom - 8
-      const isAbove = commandRect.top <= containerRect.top + 1
-      if (!isBelow && !isAbove) return
-
-      const nextTop =
-        container.scrollTop + (commandRect.top - containerRect.top)
-      container.scrollTo({
-        behavior: 'smooth',
-        top: Math.max(0, nextTop),
+    if (scrollContainer == null) {
+      commandEl.scrollIntoView({
+        behavior: 'auto',
+        block: 'nearest',
+        inline: 'nearest',
       })
-    })
+      return
+    }
+
+    scrollContainerToShowTarget(scrollContainer, commandEl)
   }, [isHighlighted, scrollTargetId, command.id, listElement, fromGroup])
 
   const commandWrapStyle = clsx(styles.individual_command_wrap, {

--- a/protocol-visualization/src/organisms/AnnotatedSteps/IndividualCommand.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/IndividualCommand.tsx
@@ -72,9 +72,7 @@ export function IndividualCommand({
         ? commandEl.closest<HTMLElement>(`.${styles.annotated_group_expanded}`)
         : null
     const outerListEl =
-      listElement ??
-      commandEl.closest<HTMLElement>('[role="list"]') ??
-      null
+      listElement ?? commandEl.closest<HTMLElement>('[role="list"]') ?? null
 
     let scrollContainer: HTMLElement | null = outerListEl
 

--- a/protocol-visualization/src/organisms/AnnotatedSteps/annotatedsteps.module.css
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/annotatedsteps.module.css
@@ -40,6 +40,11 @@
   overflow-y: auto;
 }
 
+.annotated_group_expanded_natural_height {
+  max-height: none;
+  overflow-y: visible;
+}
+
 .annotated_group_expanded::-webkit-scrollbar {
   display: none;
 }

--- a/protocol-visualization/src/organisms/AnnotatedSteps/index.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/index.tsx
@@ -317,7 +317,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
   const [listViewportHeight, setListViewportHeight] = useState(0)
   const dynamicRowHeight = useDynamicRowHeight({
     defaultRowHeight: DEFAULT_ROW_HEIGHT_PX,
-    key: `${listWidth}-${listViewportHeight}-${rows.length}`,
+    key: `${listWidth}-${rows.length}`,
   })
 
   useEffect(() => {
@@ -340,8 +340,11 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     if (scrollTargetId == null) return
     const rowIndex = rowIndexByCommandId.get(scrollTargetId)
     if (rowIndex == null) return
-    listRef?.scrollToRow({ index: rowIndex, align: 'auto' })
-  }, [scrollTargetId, rowIndexByCommandId, listRef])
+    listRef?.scrollToRow({
+      index: rowIndex,
+      align: rowIndex >= rows.length - 1 ? 'end' : 'auto',
+    })
+  }, [scrollTargetId, rowIndexByCommandId, listRef, rows.length])
 
   useEffect(() => {
     setListElement(listRef?.element ?? null)

--- a/protocol-visualization/src/organisms/AnnotatedSteps/utils.ts
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/utils.ts
@@ -49,9 +49,7 @@ export function shouldCapExpandedGroupBodyHeight(params: {
     return false
   }
 
-  return (
-    getEstimatedExpandedGroupContentHeightPx(params) > bodyMaxHeightPx
-  )
+  return getEstimatedExpandedGroupContentHeightPx(params) > bodyMaxHeightPx
 }
 
 export const getIsVisibleProtocolStep = (command: RunTimeCommand): boolean => {

--- a/protocol-visualization/src/organisms/AnnotatedSteps/utils.ts
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/utils.ts
@@ -1,5 +1,59 @@
 import type { RunTimeCommand } from '@opentrons/shared-data'
 
+/** Reserve space for StepGroup header (title row, optional subtitle, padding). */
+export const STEP_GROUP_HEADER_RESERVE_PX = 80
+export const MIN_EXPANDED_BODY_PX = 160
+export const LIST_VIEWPORT_BOTTOM_BUFFER_PX = 8
+/** Matches AnnotatedSteps DEFAULT_ROW_HEIGHT_PX. */
+export const ESTIMATED_COMMAND_HEIGHT_PX = 64
+export const TRAILING_ERRORS_FOOTER_ESTIMATE_PX = 100
+
+export function getExpandedGroupBodyMaxHeightPx(
+  listViewportHeight: number
+): number | null {
+  if (listViewportHeight <= 0) {
+    return null
+  }
+
+  return Math.max(
+    MIN_EXPANDED_BODY_PX,
+    listViewportHeight -
+      STEP_GROUP_HEADER_RESERVE_PX -
+      LIST_VIEWPORT_BOTTOM_BUFFER_PX
+  )
+}
+
+export function getEstimatedExpandedGroupContentHeightPx(params: {
+  subCommandCount: number
+  hasTrailingErrors?: boolean
+}): number {
+  const { subCommandCount, hasTrailingErrors = false } = params
+
+  return (
+    subCommandCount * ESTIMATED_COMMAND_HEIGHT_PX +
+    (hasTrailingErrors ? TRAILING_ERRORS_FOOTER_ESTIMATE_PX : 0)
+  )
+}
+
+/** Only cap expanded step-group height when content would exceed the list viewport. */
+export function shouldCapExpandedGroupBodyHeight(params: {
+  subCommandCount: number
+  listViewportHeight: number
+  hasTrailingErrors?: boolean
+}): boolean {
+  const bodyMaxHeightPx = getExpandedGroupBodyMaxHeightPx(
+    params.listViewportHeight
+  )
+
+  if (bodyMaxHeightPx == null) {
+    return false
+  }
+
+  return (
+    getEstimatedExpandedGroupContentHeightPx(params) > bodyMaxHeightPx
+  )
+}
+
 export const getIsVisibleProtocolStep = (command: RunTimeCommand): boolean => {
   return !command.commandType.includes('load') && command.commandType !== 'home'
 }

--- a/protocol-visualization/src/organisms/AnnotatedSteps/utils.ts
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/utils.ts
@@ -1,10 +1,10 @@
 import type { RunTimeCommand } from '@opentrons/shared-data'
 
-/** Reserve space for StepGroup header (title row, optional subtitle, padding). */
+// space for StepGroup header (title row, optional subtitle, padding)
 export const STEP_GROUP_HEADER_RESERVE_PX = 80
 export const MIN_EXPANDED_BODY_PX = 160
 export const LIST_VIEWPORT_BOTTOM_BUFFER_PX = 8
-/** Matches AnnotatedSteps DEFAULT_ROW_HEIGHT_PX. */
+// matches AnnotatedSteps DEFAULT_ROW_HEIGHT_PX.
 export const ESTIMATED_COMMAND_HEIGHT_PX = 64
 export const TRAILING_ERRORS_FOOTER_ESTIMATE_PX = 100
 
@@ -35,7 +35,7 @@ export function getEstimatedExpandedGroupContentHeightPx(params: {
   )
 }
 
-/** Only cap expanded step-group height when content would exceed the list viewport. */
+// only cap expanded stepGroup height when content would exceed the list viewport
 export function shouldCapExpandedGroupBodyHeight(params: {
   subCommandCount: number
   listViewportHeight: number


### PR DESCRIPTION
# Overview

closes RQA-5498

Fixes the scrolling issue where it glitches when you get to the last step. Had to fix the issue in the 2 sources of truth, so in the `app` directory and `protocol-visualization` directory

## Test Plan and Hands on Testing

Smoke test that the attached protocol in the ticket (pyro protocol) doesn't glitch when you scroll to the bottom (step 10). smoke test with some longer protocols too and protocols with step groups

should work as expected

## Changelog

- only cap height when content actually overflows: `shouldCapExpandedGroupBodyHeight()` compares estimated content height vs viewport. Small groups use natural height with `overflow-y: visible` (no inner scroll).
- `IndividualCommand` had changes: scrolls the inner container only if it actually has overflow; otherwise scrolls the outer list.
- `scrollToRow`: now uses align: 'end' for the last row so the final step group anchors to the bottom cleanly.
- also removed `listViewportHeight` from the dynamic row height cache key, this prevents unnecessary remeasurement when the viewport is first measured.
- large groups still get the `viewport-filling` max height and inner scroll when they need it. 
- applied these changes to both app and PV directories (2 sources of truth for PV right now)

## Risk assessment

medium, affects protocol vis so should smoke test with a lot of protocols