### PR TITLE
feat(server-utils): add key-server bindings

### DIFF
--- a/server-utils/server_utils/keys/__init__.py
+++ b/server-utils/server_utils/keys/__init__.py
@@ -1,0 +1,1 @@
+"""server_utils.keys: Shared code for talking to key-server."""

--- a/server-utils/server_utils/keys/fastapi.py
+++ b/server-utils/server_utils/keys/fastapi.py
@@ -1,0 +1,60 @@
+"""FastAPI-specific helpers for talking to key-server."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Annotated, AsyncGenerator
+
+import fastapi
+
+from .key_server import Client, LocalHTTPClient
+from server_utils.fastapi_utils.app_state import (
+    AppState,
+    AppStateAccessor,
+    get_app_state,
+)
+
+_key_client_accessor = AppStateAccessor[Client]("key_client")
+
+
+def install_key_client(app_state: AppState, client: Client) -> None:
+    """Store a singleton key-server `Client` in global server state for later retrieval.
+
+    This should be called once during server initialization.
+    """
+    _key_client_accessor.set_on(app_state, client)
+
+
+def get_key_client(
+    app_state: Annotated[AppState, fastapi.Depends(get_app_state)],
+) -> Client:
+    """A FastAPI dependency to retrieve the server's singleton key-server `Client`.
+
+    Endpoints can take this as a dependency to sign log messages.
+    """
+    client = _key_client_accessor.get_from(app_state)
+    assert client is not None, (
+        "Forgot to initialize key client as part of server startup?"
+    )
+    return client
+
+
+@asynccontextmanager
+async def build_key_client(
+    *,
+    key_server_uds: str | None = None,
+    key_server_url: str | None = None,
+) -> AsyncGenerator[Client, None]:
+    """Build a key-server `Client` appropriately configured for most servers.
+
+    `key_server_uds` (a path to a Unix domain socket) or `key_server_url` (a URL
+    like http://localhost:1234) describes how to connect to key-server. These should
+    typically be taken from CLI options or environment variables. Exactly one of
+    them must be specified; unlike the audit-server client there is no no-op
+    fallback, because callers that rely on signed log messages must fail loudly
+    rather than silently dropping signatures.
+    """
+    async with LocalHTTPClient(
+        key_server_uds=key_server_uds, key_server_url=key_server_url
+    ) as client:
+        yield client

--- a/server-utils/server_utils/keys/key_server.py
+++ b/server-utils/server_utils/keys/key_server.py
@@ -1,0 +1,129 @@
+"""Bindings to key-server's HTTP API.
+
+This is just the bare minimum required by dependent servers to sign log messages
+against key-server's signing key. Only the ``signMessage`` endpoint is exposed;
+the public-key endpoint and any other future endpoints are intentionally not
+proxied through this client.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import typing
+from abc import ABC, abstractmethod
+
+import aiohttp
+import pydantic
+
+SIGN_MESSAGE_ENDPOINT_PATH = "keys/internal/logSigning/signMessage"
+
+_log = logging.getLogger(__name__)
+
+
+class Client(ABC):
+    """An interface for a dependent server to sign log messages via key-server."""
+
+    @abstractmethod
+    async def sign_message(self, message: SignMessageData) -> SignedMessageData:
+        """Sign a single log message.
+
+        If the key-server cannot be contacted, or it returns a non-2xx response,
+        the implementation must raise an exception. Callers should never see a
+        silently-discarded signing request.
+        """
+        pass
+
+
+class LocalHTTPClient(Client):
+    """A client implementation that talks to key-server over a local HTTP connection."""
+
+    def __init__(
+        self,
+        *,
+        key_server_uds: str | None = None,
+        key_server_url: str | None = None,
+    ) -> None:
+        """Construct the client.
+
+        Params:
+            key_server_uds: e.g. `/path/to/socket`, to connect to key-server via
+                a Unix domain socket.
+            key_server_url: e.g. `http://localhost:1234`, to connect to key-server
+                via TCP.
+        """
+        if key_server_uds is not None and key_server_url is not None:
+            raise ValueError("Specify only one of key_server_uds or key_server_url.")
+
+        if key_server_uds is not None:
+            connector = aiohttp.UnixConnector(path=key_server_uds)
+            session = aiohttp.ClientSession(
+                connector=connector,
+                # We're connecting over a Unix socket, so this URL is nonsensical,
+                # but aiohttp seems to require it as a placeholder.
+                # https://github.com/aio-libs/aiohttp/issues/11324.
+                base_url="http://localhost",
+            )
+        elif key_server_url is not None:
+            session = aiohttp.ClientSession(base_url=key_server_url)
+        else:
+            raise ValueError("Specify key_server_uds or key_server_url.")
+
+        self._session = session
+        self._exit_stack = contextlib.AsyncExitStack()
+
+    async def __aenter__(self) -> typing.Self:
+        """When entered as a context manager, open the underlying connection."""
+        await self._exit_stack.enter_async_context(self._session)
+        return self
+
+    async def __aexit__(
+        self, exc_type: object, exc_value: object, traceback: object
+    ) -> None:
+        """When exited as a context manager, close the underlying connection."""
+        await self._exit_stack.aclose()
+
+    @typing.override
+    async def sign_message(self, message: SignMessageData) -> SignedMessageData:
+        request_body = SignMessageRequestBody(data=message)
+        async with self._session.post(
+            SIGN_MESSAGE_ENDPOINT_PATH,
+            data=request_body.model_dump_json(),
+            headers={"Content-Type": "application/json"},
+        ) as response:
+            response_bytes = await response.read()
+        response.raise_for_status()
+        parsed_response = SignMessageResponseBody.model_validate_json(response_bytes)
+        return parsed_response.data
+
+
+class _StrictBaseModel(pydantic.BaseModel):
+    model_config = {"strict": True}
+
+
+class SignMessageData(_StrictBaseModel):
+    """The payload portion of a sign-message request."""
+
+    message: str
+    previousHash: str | None
+
+
+class SignedMessageData(_StrictBaseModel):
+    """The payload portion of a sign-message success response."""
+
+    message: str
+    messageHash: str
+    messageSignature: str
+    signatureVersion: int
+
+
+class SignMessageRequestBody(_StrictBaseModel):
+    """Request envelope for sign-message."""
+
+    data: SignMessageData
+
+
+class SignMessageResponseBody(_StrictBaseModel):
+    """Response envelope for sign-message."""
+
+    data: SignedMessageData

--- a/server-utils/tests/keys/test_fastapi.py
+++ b/server-utils/tests/keys/test_fastapi.py
@@ -1,0 +1,103 @@
+"""Tests for the key-server FastAPI integration."""
+
+from __future__ import annotations
+
+import fastapi
+import pytest
+from starlette.testclient import TestClient
+
+from server_utils.keys.fastapi import (
+    build_key_client,
+    get_key_client,
+    install_key_client,
+)
+from server_utils.keys.key_server import (
+    Client,
+    LocalHTTPClient,
+    SignedMessageData,
+    SignMessageData,
+)
+
+
+async def test_build_key_client_with_uds_yields_local_http_client(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """With a UDS configured, `build_key_client` should yield a `LocalHTTPClient`."""
+    socket_path = tmp_path_factory.mktemp("keys") / "sock"
+    async with build_key_client(key_server_uds=str(socket_path)) as client:
+        assert isinstance(client, LocalHTTPClient)
+
+
+async def test_build_key_client_with_url_yields_local_http_client() -> None:
+    """With a URL configured, `build_key_client` should yield a `LocalHTTPClient`."""
+    async with build_key_client(key_server_url="http://localhost:1234") as client:
+        assert isinstance(client, LocalHTTPClient)
+
+
+async def test_build_key_client_rejects_both_uds_and_url(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Passing both UDS and URL to `build_key_client` should raise `ValueError`."""
+    socket_path = tmp_path_factory.mktemp("keys") / "sock"
+    with pytest.raises(ValueError):
+        async with build_key_client(
+            key_server_uds=str(socket_path),
+            key_server_url="http://localhost:1234",
+        ):
+            pass
+
+
+async def test_build_key_client_rejects_no_args() -> None:
+    """Passing neither UDS nor URL to `build_key_client` should raise `ValueError`.
+
+    Unlike the audit-server client there is no no-op fallback, so calling
+    ``build_key_client()`` with no transport configured must fail loudly.
+    """
+    with pytest.raises(ValueError):
+        async with build_key_client():
+            pass
+
+
+def test_install_and_get_key_client_via_dependency() -> None:
+    """`install_key_client` + `get_key_client` should round-trip through FastAPI."""
+
+    class StubClient(Client):
+        async def sign_message(
+            self, message: SignMessageData
+        ) -> SignedMessageData:  # pragma: no cover - not exercised here
+            raise NotImplementedError
+
+    stub_client = StubClient()
+
+    app = fastapi.FastAPI()
+    install_key_client(app.state, stub_client)
+
+    seen: dict[str, Client] = {}
+
+    @app.get("/check")
+    def check(
+        client: Client = fastapi.Depends(get_key_client),  # noqa: B008
+    ) -> dict[str, str]:
+        seen["client"] = client
+        return {"ok": "ok"}
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/check")
+        assert response.status_code == 200
+
+    assert seen["client"] is stub_client
+
+
+def test_get_key_client_without_install_raises() -> None:
+    """`get_key_client` should assert if no client has been installed."""
+    app = fastapi.FastAPI()
+
+    @app.get("/check")
+    def check(
+        client: Client = fastapi.Depends(get_key_client),  # noqa: B008
+    ) -> dict[str, str]:  # pragma: no cover - dependency assertion fires first
+        return {"ok": "ok"}
+
+    with TestClient(app, raise_server_exceptions=True) as test_client:
+        with pytest.raises(AssertionError):
+            test_client.get("/check")

--- a/server-utils/tests/keys/test_key_server.py
+++ b/server-utils/tests/keys/test_key_server.py
@@ -1,0 +1,256 @@
+"""Tests for our client of key-server's HTTP API."""
+
+from __future__ import annotations
+
+from contextlib import AsyncExitStack
+from pathlib import Path
+from typing import AsyncGenerator, Final
+
+import aiohttp
+import aiohttp.web
+import pytest
+
+from server_utils.keys.key_server import (
+    SIGN_MESSAGE_ENDPOINT_PATH,
+    LocalHTTPClient,
+    SignedMessageData,
+    SignMessageData,
+)
+
+
+class AppMock:
+    """A fake AIOHTTP app to test the client against.
+
+    This should mirror the HTTP API of our real key-server.
+    """
+
+    sign_message_response: object
+    """The JSON body the server should respond with to a sign-message request."""
+
+    sign_message_response_status: int
+    """The HTTP status code the server should respond with to a sign-message request."""
+
+    sign_message_requests: list[object]
+    """When the server receives a sign-message request, it records the request body here."""
+
+    sign_message_request_content_types: list[str | None]
+    """When the server receives a sign-message request, it records the Content-Type header here."""
+
+    app: Final[aiohttp.web.Application]
+
+    def __init__(self) -> None:
+        self.sign_message_response = {}
+        self.sign_message_response_status = 200
+        self.sign_message_requests = []
+        self.sign_message_request_content_types = []
+
+        app = aiohttp.web.Application()
+        app.router.add_post(f"/{SIGN_MESSAGE_ENDPOINT_PATH}", self._post_sign_message)
+        self.app = app
+
+    async def _post_sign_message(
+        self, request: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
+        self.sign_message_request_content_types.append(
+            request.headers.get("Content-Type")
+        )
+        body = await request.json()
+        self.sign_message_requests.append(body)
+        return aiohttp.web.json_response(
+            data=self.sign_message_response,
+            status=self.sign_message_response_status,
+        )
+
+
+@pytest.fixture(params=["unix_domain_socket", "tcp"])
+async def mock_server(
+    request: pytest.FixtureRequest,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> AsyncGenerator[tuple[AppMock, LocalHTTPClient], None]:
+    """Return a fake server, and a real client pointed at that fake server.
+
+    Parametrized over two connection types: Unix domain socket, and TCP.
+    """
+    async with AsyncExitStack() as exit_stack:
+        app_mock = AppMock()
+
+        runner = aiohttp.web.AppRunner(app_mock.app)
+
+        await runner.setup()
+        exit_stack.push_async_callback(runner.cleanup)
+
+        mock_server_type = request.param
+
+        if mock_server_type == "unix_domain_socket":
+            socket_path = tmp_path_factory.mktemp("mock") / "sock"
+
+            unix_site = aiohttp.web.UnixSite(runner, socket_path)
+            await unix_site.start()
+            exit_stack.push_async_callback(unix_site.stop)
+
+            client = await exit_stack.enter_async_context(
+                LocalHTTPClient(key_server_uds=str(socket_path))
+            )
+
+            yield (app_mock, client)
+
+        else:  # mock_server_type == "tcp"
+            tcp_site = aiohttp.web.TCPSite(runner, host="localhost", port=0)
+            await tcp_site.start()
+            exit_stack.push_async_callback(tcp_site.stop)
+
+            port = runner.addresses[0][1]
+            url = f"http://localhost:{port}"
+
+            client = await exit_stack.enter_async_context(
+                LocalHTTPClient(key_server_url=url)
+            )
+
+            yield (app_mock, client)
+
+
+async def test_sign_message(
+    mock_server: tuple[AppMock, LocalHTTPClient],
+) -> None:
+    """Test that the client can send a well-formed sign-message and parse the response."""
+    app_mock, client = mock_server
+
+    app_mock.sign_message_response = {
+        "data": {
+            "message": "Started run abc-123",
+            "messageHash": "sha256:aGFzaA==",
+            "messageSignature": "ed25519:c2ln",
+            "signatureVersion": 1,
+        }
+    }
+
+    message = SignMessageData(
+        message="Started run abc-123",
+        previousHash="sha256:cHJldg==",
+    )
+    result = await client.sign_message(message)
+
+    assert result == SignedMessageData(
+        message="Started run abc-123",
+        messageHash="sha256:aGFzaA==",
+        messageSignature="ed25519:c2ln",
+        signatureVersion=1,
+    )
+    assert app_mock.sign_message_requests == [
+        {
+            "data": {
+                "message": "Started run abc-123",
+                "previousHash": "sha256:cHJldg==",
+            }
+        }
+    ]
+
+
+async def test_sign_message_previous_hash_none(
+    mock_server: tuple[AppMock, LocalHTTPClient],
+) -> None:
+    """A `None` previousHash should serialize to JSON `null` in the request body."""
+    app_mock, client = mock_server
+
+    app_mock.sign_message_response = {
+        "data": {
+            "message": "first message",
+            "messageHash": "sha256:aGFzaA==",
+            "messageSignature": "ed25519:c2ln",
+            "signatureVersion": 1,
+        }
+    }
+
+    message = SignMessageData(
+        message="first message",
+        previousHash=None,
+    )
+    await client.sign_message(message)
+
+    assert len(app_mock.sign_message_requests) == 1
+    request_body = app_mock.sign_message_requests[0]
+    assert isinstance(request_body, dict)
+    # Verify "previousHash" was sent as null, not omitted.
+    assert "previousHash" in request_body["data"]
+    assert request_body["data"]["previousHash"] is None
+
+
+async def test_sign_message_http_error(
+    mock_server: tuple[AppMock, LocalHTTPClient],
+) -> None:
+    """A non-2xx response from key-server should be raised as an exception."""
+    app_mock, client = mock_server
+
+    app_mock.sign_message_response = {"errors": [{"detail": "boom"}]}
+    app_mock.sign_message_response_status = 500
+
+    message = SignMessageData(
+        message="anything",
+        previousHash=None,
+    )
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.sign_message(message)
+
+
+async def test_sign_message_sends_json_content_type(
+    mock_server: tuple[AppMock, LocalHTTPClient],
+) -> None:
+    """The client should send the request as application/json (not form-encoded)."""
+    app_mock, client = mock_server
+
+    app_mock.sign_message_response = {
+        "data": {
+            "message": "anything",
+            "messageHash": "sha256:aGFzaA==",
+            "messageSignature": "ed25519:c2ln",
+            "signatureVersion": 1,
+        }
+    }
+
+    message = SignMessageData(
+        message="anything",
+        previousHash=None,
+    )
+    await client.sign_message(message)
+
+    assert app_mock.sign_message_request_content_types == ["application/json"]
+
+
+async def test_sign_message_raises_when_uds_server_unreachable(
+    tmp_path: Path,
+) -> None:
+    """If the UDS server can't be contacted, the client must raise.
+
+    No socket file exists at the configured path, so aiohttp should raise a
+    connection-related error rather than returning a synthesized success.
+    """
+    socket_path = str(tmp_path / "does-not-exist.sock")
+
+    async with LocalHTTPClient(key_server_uds=socket_path) as client:
+        with pytest.raises(aiohttp.ClientConnectionError):
+            await client.sign_message(SignMessageData(message="hi", previousHash=None))
+
+
+async def test_sign_message_raises_when_tcp_server_unreachable() -> None:
+    """If the TCP server can't be contacted, the client must raise."""
+    # Port 1 is privileged and almost certainly not listening; the connection
+    # should be refused (or otherwise fail), surfacing as a connection error.
+    async with LocalHTTPClient(key_server_url="http://127.0.0.1:1") as client:
+        with pytest.raises(aiohttp.ClientConnectionError):
+            await client.sign_message(SignMessageData(message="hi", previousHash=None))
+
+
+def test_invalid_constructor_args_both_specified() -> None:
+    """Passing both `key_server_uds` and `key_server_url` should raise."""
+    with pytest.raises(ValueError):
+        LocalHTTPClient(
+            key_server_uds="/tmp/sock",
+            key_server_url="http://localhost:1234",
+        )
+
+
+def test_invalid_constructor_args_neither_specified() -> None:
+    """Passing neither `key_server_uds` nor `key_server_url` should raise."""
+    with pytest.raises(ValueError):
+        LocalHTTPClient()


### PR DESCRIPTION
The audit-server needs the key-server to sign messages for it to log.
