### PR TITLE
feat(api, app): generalize identifyModule live command for any module

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/identify_module.py
+++ b/api/src/opentrons/protocol_engine/commands/identify_module.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 from typing_extensions import Type
@@ -12,8 +12,9 @@ from ..types import ModuleModel
 from .command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 
 if TYPE_CHECKING:
+    from ..execution import EquipmentHandler
+    from ..state.module_substates import FlexStackerSubState, VacuumModuleSubState
     from ..state.state import StateView
-    from opentrons.protocol_engine.execution import EquipmentHandler
 
 IdentifyModuleCommandType = Literal["identifyModule"]
 
@@ -46,20 +47,23 @@ class IdentifyModuleImpl(
         self, params: IdentifyModuleParams
     ) -> SuccessData[IdentifyModuleResult]:
         """Execute the IdentifyModule command."""
+        module_substate: Union[FlexStackerSubState, VacuumModuleSubState]
         # ONLY flex stacker has support for identify module command...for now
         if params.model == ModuleModel.FLEX_STACKER_MODULE_V1:
             module_substate = self._state_view.modules.get_flex_stacker_substate(
                 module_id=params.moduleId
             )
-            module_hw = self._equipment.get_module_hardware_api(
-                module_substate.module_id
+        elif params.model == ModuleModel.VACUUM_MODULE_V1:
+            module_substate = self._state_view.modules.get_vacuum_module_substate(
+                module_id=params.moduleId
             )
-            if module_hw is not None:
-                await module_hw.identify(params.start, params.color)
         else:
             raise NotImplementedError(
                 f"IdentifyModule is not supported for {params.model}"
             )
+        module_hw = self._equipment.get_module_hardware_api(module_substate.module_id)
+        if module_hw is not None:
+            await module_hw.identify(params.start, params.color)
 
         return SuccessData(public=IdentifyModuleResult())
 

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -34,7 +34,7 @@ import {
   getModuleOptions,
   getOptions,
 } from '../DeviceDetailsDeckConfiguration/utils'
-import { useSendIdentifyStacker } from '../ModuleWizardFlows/hooks'
+import { useSendIdentifyModule } from '../ModuleWizardFlows/hooks'
 
 import type { TFunction } from 'i18next'
 import type { AttachedModule } from '@opentrons/api-client'
@@ -226,7 +226,7 @@ export function AddFixtureModal({
     )
   }
 
-  const sendIdentifyStacker = useSendIdentifyStacker()
+  const sendIdentifyModule = useSendIdentifyModule()
   const { parseModuleUSBPort } = useModuleUSBPort()
   const [identifyInUse, setIdentifyInUse] = useState<string | null>(null)
   const [identifyTimeout, setTimeoutID] = useState<NodeJS.Timeout | null>(null)
@@ -253,7 +253,7 @@ export function AddFixtureModal({
         unconfiguredMods?.find(m => m.serialNumber === fixtureSerialNumber) ??
         null
       if (module !== null) {
-        sendIdentifyStacker(module, false)
+        sendIdentifyModule(module, false)
         if (identifyTimeout !== null) {
           clearTimeout(identifyTimeout)
         }
@@ -265,11 +265,11 @@ export function AddFixtureModal({
 
   const stackerIdentifyHandler = (module: AttachedModule): void => {
     // Identify the stacker module
-    sendIdentifyStacker(module, true, 'blue')
+    sendIdentifyModule(module, true, 'blue')
     // Ensure that the module reverts after a set time
     setIdentifyInUse(module.serialNumber)
     const timeoutID = setTimeout(() => {
-      sendIdentifyStacker(module, false)
+      sendIdentifyModule(module, false)
       setIdentifyInUse(null)
     }, MODULE_IDENTIFY_TIME_MS)
     setTimeoutID(timeoutID)
@@ -287,7 +287,7 @@ export function AddFixtureModal({
       const previousModule =
         unconfiguredMods.find(m => m.serialNumber === identifyInUse) ?? null
       if (previousModule !== null && module !== null) {
-        sendIdentifyStacker(previousModule, false)
+        sendIdentifyModule(previousModule, false)
         if (identifyTimeout !== null) {
           clearTimeout(identifyTimeout)
         }

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/AddFixtureModal.test.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/AddFixtureModal.test.tsx
@@ -14,7 +14,7 @@ import {
 import { renderWithProviders } from '/app/__testing-utils__'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 
-import { useSendIdentifyStacker } from '../../ModuleWizardFlows/hooks'
+import { useSendIdentifyModule } from '../../ModuleWizardFlows/hooks'
 import { AddFixtureModal } from '../AddFixtureModal'
 
 import type { Mock } from 'vitest'
@@ -60,7 +60,7 @@ const render = (props: ComponentProps<typeof AddFixtureModal>) => {
 
 describe('Touchscreen AddFixtureModal', () => {
   let props: ComponentProps<typeof AddFixtureModal>
-  let sendIdentifyStacker: (
+  let sendIdentifyModule: (
     module: AttachedModule,
     start: boolean,
     color?: IdentifyColor
@@ -71,7 +71,7 @@ describe('Touchscreen AddFixtureModal', () => {
     t = vi.fn(key => key)
     vi.mocked(useTranslation).mockReturnValue({ t } as any)
 
-    sendIdentifyStacker = vi.fn()
+    sendIdentifyModule = vi.fn()
     props = {
       cutoutId: 'cutoutD3',
       addressableAreaId: 'D3',
@@ -87,7 +87,7 @@ describe('Touchscreen AddFixtureModal', () => {
     vi.mocked(useModulesQuery).mockReturnValue({
       data: { data: [] },
     } as unknown as UseQueryResult<Modules>)
-    vi.mocked(useSendIdentifyStacker).mockReturnValue(sendIdentifyStacker)
+    vi.mocked(useSendIdentifyModule).mockReturnValue(sendIdentifyModule)
   })
 
   it('should render text and buttons', () => {

--- a/app/src/organisms/LocationConflictModal/ChooseModuleToConfigureModal.tsx
+++ b/app/src/organisms/LocationConflictModal/ChooseModuleToConfigureModal.tsx
@@ -35,7 +35,7 @@ import { OddModal } from '/app/molecules/OddModal'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 import { useCloseCurrentRun } from '/app/resources/runs'
 
-import { useSendIdentifyStacker } from '../ModuleWizardFlows/hooks'
+import { useSendIdentifyModule } from '../ModuleWizardFlows/hooks'
 
 import type { TFunction } from 'i18next'
 import type { AttachedModule } from '@opentrons/api-client'
@@ -96,15 +96,15 @@ export const ChooseModuleToConfigureModal = (
       [[], []]
     ) ?? []
 
-  const sendIdentifyStacker = useSendIdentifyStacker()
+  const sendIdentifyModule = useSendIdentifyModule()
   const [identifyInUse, setIdentifyInUse] = useState<string | null>(null)
   const [identifyTimeout, setTimeoutID] = useState<NodeJS.Timeout | null>(null)
 
   const stackerIdentifyHandler = (module: AttachedModule): void => {
-    sendIdentifyStacker(module, true, 'blue')
+    sendIdentifyModule(module, true, 'blue')
     setIdentifyInUse(module.serialNumber)
     const timeoutID = setTimeout(() => {
-      sendIdentifyStacker(module, false)
+      sendIdentifyModule(module, false)
       setIdentifyInUse(null)
     }, MODULE_IDENTIFY_TIME_MS)
     setTimeoutID(timeoutID)
@@ -127,7 +127,7 @@ export const ChooseModuleToConfigureModal = (
         unconfiguredModuleMatches.find(m => m.serialNumber === identifyInUse) ??
         null
       if (previousModule !== null && module !== null) {
-        sendIdentifyStacker(previousModule, false)
+        sendIdentifyModule(previousModule, false)
         if (identifyTimeout !== null) {
           clearTimeout(identifyTimeout)
         }
@@ -138,7 +138,7 @@ export const ChooseModuleToConfigureModal = (
   const handleStackerClearAndConfigureModule = (
     module: AttachedModule
   ): void => {
-    sendIdentifyStacker(module, false)
+    sendIdentifyModule(module, false)
     if (identifyTimeout !== null) {
       clearTimeout(identifyTimeout)
     }

--- a/app/src/organisms/LocationConflictModal/__tests__/LocationConflictModal.test.tsx
+++ b/app/src/organisms/LocationConflictModal/__tests__/LocationConflictModal.test.tsx
@@ -25,7 +25,7 @@ import {
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 import { useCloseCurrentRun } from '/app/resources/runs'
 
-import { useSendIdentifyStacker } from '../../ModuleWizardFlows/hooks'
+import { useSendIdentifyModule } from '../../ModuleWizardFlows/hooks'
 import { LocationConflictModal } from '../LocationConflictModal'
 
 import type { ComponentProps } from 'react'
@@ -57,7 +57,7 @@ const render = (props: ComponentProps<typeof LocationConflictModal>) => {
 
 describe('LocationConflictModal', () => {
   let props: ComponentProps<typeof LocationConflictModal>
-  let sendIdentifyStacker: (
+  let sendIdentifyModule: (
     module: AttachedModule,
     start: boolean,
     color?: IdentifyColor
@@ -71,7 +71,7 @@ describe('LocationConflictModal', () => {
       deckDef: ot3StandardDeckV5 as any,
       robotName: 'otie',
     }
-    sendIdentifyStacker = vi.fn()
+    sendIdentifyModule = vi.fn()
     vi.mocked(useCloseCurrentRun).mockReturnValue({
       closeCurrentRun: vi.fn(),
     } as any)
@@ -82,7 +82,7 @@ describe('LocationConflictModal', () => {
     vi.mocked(useUpdateDeckConfigurationMutation).mockReturnValue({
       updateDeckConfiguration: mockUpdate,
     } as any)
-    vi.mocked(useSendIdentifyStacker).mockReturnValue(sendIdentifyStacker)
+    vi.mocked(useSendIdentifyModule).mockReturnValue(sendIdentifyModule)
   })
   afterEach(() => {
     vi.resetAllMocks()

--- a/app/src/organisms/ModuleWizardFlows/CheckStackerInstall.tsx
+++ b/app/src/organisms/ModuleWizardFlows/CheckStackerInstall.tsx
@@ -7,7 +7,7 @@ import { FLEX_STACKER_MODULE_TYPE } from '@opentrons/shared-data'
 import { SmallButton } from '/app/atoms/buttons'
 import { SimpleWizardBody } from '/app/molecules/SimpleWizardBody'
 
-import { useSendIdentifyStacker } from './hooks'
+import { useSendIdentifyModule } from './hooks'
 
 import type { AttachedModule } from '@opentrons/api-client'
 import type { DeckConfiguration } from '@opentrons/shared-data'
@@ -49,17 +49,17 @@ export function CheckStackerInstall(
     } else {
       if (attachedStacker != null) {
         // Transition back to standard identify for stacker
-        sendIdentifyStacker(attachedStacker, true, 'blue')
+        sendIdentifyModule(attachedStacker, true, 'blue')
       }
       proceed()
     }
   }
 
-  const sendIdentifyStacker = useSendIdentifyStacker()
+  const sendIdentifyModule = useSendIdentifyModule()
   const handleTryAgain = (): void => {
     if (attachedStacker != null) {
       // Set the stacker to red
-      sendIdentifyStacker(attachedStacker, true, 'red')
+      sendIdentifyModule(attachedStacker, true, 'red')
     }
     setStackerNotInstalled(false)
   }

--- a/app/src/organisms/ModuleWizardFlows/SelectLocation.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectLocation.tsx
@@ -34,6 +34,7 @@ import {
   SINGLE_RIGHT_CUTOUTS,
   SINGLE_RIGHT_SLOT_FIXTURE,
   SINGLE_SLOT_FIXTURES,
+  VACUUM_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
 import { useModuleUSBPort } from '/app/local-resources/modules'
@@ -87,6 +88,7 @@ export function SelectLocation(props: SelectLocationProps): JSX.Element {
   const { parseModuleUSBPort } = useModuleUSBPort()
 
   const isFlexStacker = attachedModule.moduleType === FLEX_STACKER_MODULE_TYPE
+  const isVacuumModule = attachedModule.moduleType === VACUUM_MODULE_TYPE
 
   const handleOnClick = (): void => {
     if (maintenanceRunId == null) {
@@ -282,7 +284,7 @@ export function SelectLocation(props: SelectLocationProps): JSX.Element {
             })}
             {isFlexStacker ? null : ` ${t('location_must_be_correct')}`}
           </StyledText>
-          {isFlexStacker ? (
+          {isFlexStacker || isVacuumModule ? (
             <InlineNotification
               type="neutral"
               message={t('look_for_pulsing_lights')}

--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -28,7 +28,7 @@ import {
   SimpleWizardBodyContainer,
 } from '/app/molecules/SimpleWizardBody'
 
-import { useSendIdentifyStacker } from './hooks'
+import { useSendIdentifyModule } from './hooks'
 
 import type { AttachedModule } from '@opentrons/api-client'
 
@@ -75,7 +75,7 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
   const isSingleModule = newModules.length === 1 && !hasUnsetupabbleModules
   // Unless, of course, we're being invoked by a caller giving us a specific module
   const shortCircuitFlow = attachedModuleOnLaunch != null || isSingleModule
-  const sendIdentifyStacker = useSendIdentifyStacker()
+  const sendIdentifyModule = useSendIdentifyModule()
 
   const getModuleNameAndPort = (module: AttachedModule): ModuleNameAndPort => {
     const name = getModuleDisplayName(module.moduleModel)
@@ -88,7 +88,7 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
     () => {
       if (shortCircuitFlow) {
         setSelectedModule(newModules[0])
-        sendIdentifyStacker(newModules[0], true)
+        sendIdentifyModule(newModules[0], true)
       }
     },
     // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
@@ -100,12 +100,12 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
   const handleModuleSelected = (serialNumber: string): void => {
     // stop blinking previous module
     if (selectedModule != null) {
-      sendIdentifyStacker(selectedModule, false)
+      sendIdentifyModule(selectedModule, false)
     }
     // set module
     for (const mod of newModules) {
       if (mod.serialNumber === serialNumber) {
-        sendIdentifyStacker(mod, true)
+        sendIdentifyModule(mod, true)
         setSelectedModule(mod)
         break
       }

--- a/app/src/organisms/ModuleWizardFlows/Success.tsx
+++ b/app/src/organisms/ModuleWizardFlows/Success.tsx
@@ -18,7 +18,7 @@ import { useGetModulesNeedingSetupThatCanCurrentlyBeSetUp } from '/app/App/hooks
 import { SmallButton } from '/app/atoms/buttons'
 import { SimpleWizardBody } from '/app/molecules/SimpleWizardBody'
 
-import { useSendIdentifyStacker } from './hooks'
+import { useSendIdentifyModule } from './hooks'
 
 import type { AttachedModule } from '@opentrons/api-client'
 import type { ModuleSetupWizardMaybePipetteStepProps } from './types'
@@ -48,14 +48,14 @@ export function Success(props: SuccessProps): JSX.Element {
     setSelectedModule,
   } = props
   const { t } = useTranslation('module_wizard_flows')
-  const sendIdentifyStacker = useSendIdentifyStacker()
+  const sendIdentifyModule = useSendIdentifyModule()
   const moduleDisplayName = getModuleDisplayName(attachedModule.moduleModel)
   const newModules = useGetModulesNeedingSetupThatCanCurrentlyBeSetUp()
 
   const handleOnClick = (restart: boolean): void => {
     if (restart) {
       setSelectedModule(null)
-      sendIdentifyStacker(attachedModule, false)
+      sendIdentifyModule(attachedModule, false)
       restartSetup()
       return
     }

--- a/app/src/organisms/ModuleWizardFlows/UpdateFirmware.tsx
+++ b/app/src/organisms/ModuleWizardFlows/UpdateFirmware.tsx
@@ -20,7 +20,7 @@ import {
   SUCCESS,
 } from '/app/redux/robot-api'
 
-import { useSendIdentifyStacker } from './hooks'
+import { useSendIdentifyModule } from './hooks'
 
 import type { AttachedModule } from '@opentrons/api-client'
 import type { Dispatch, State } from '/app/redux/types'
@@ -48,7 +48,7 @@ export function UpdateFirmware(props: UpdateFirmwareProps): JSX.Element {
   const { t } = useTranslation('module_wizard_flows')
 
   const dispatch = useDispatch<Dispatch>()
-  const sendIdentifyStacker = useSendIdentifyStacker()
+  const sendIdentifyModule = useSendIdentifyModule()
   const [getLatestRequestId, handleModuleApiRequests] = useModuleApiRequests()
   const moduleSerialNumber = props.attachedModule.serialNumber
   const [moduleRequestTimeoutId, setModuleRequestTimeoutId] =
@@ -92,7 +92,7 @@ export function UpdateFirmware(props: UpdateFirmwareProps): JSX.Element {
         setShouldProceed(true)
         setIsModuleUpdating(false)
         setInProgress(false)
-        sendIdentifyStacker(matchingModule, true, 'blue')
+        sendIdentifyModule(matchingModule, true, 'blue')
         patchModuleAfterUpdate(matchingModule)
         setTimeout(() => {
           proceed()

--- a/app/src/organisms/ModuleWizardFlows/__tests__/UpdateFirmware.test.tsx
+++ b/app/src/organisms/ModuleWizardFlows/__tests__/UpdateFirmware.test.tsx
@@ -18,7 +18,7 @@ import {
   useDispatchApiRequest,
 } from '/app/redux/robot-api'
 
-import { useSendIdentifyStacker } from '../hooks'
+import { useSendIdentifyModule } from '../hooks'
 import { UpdateFirmware } from '../UpdateFirmware'
 
 import type { ComponentProps } from 'react'
@@ -45,7 +45,7 @@ const render = (props: ComponentProps<typeof UpdateFirmware>) => {
 describe('UpdateFirmware', () => {
   let dispatchApiRequest: DispatchApiRequestType
   let handleModuleApiRequests: (robotName: string, serial: string) => void
-  let sendIdentifyStacker: (
+  let sendIdentifyModule: (
     module: AttachedModule,
     start: boolean,
     color?: IdentifyColor
@@ -55,7 +55,7 @@ describe('UpdateFirmware', () => {
     vi.useFakeTimers()
     dispatchApiRequest = vi.fn()
     handleModuleApiRequests = vi.fn()
-    sendIdentifyStacker = vi.fn()
+    sendIdentifyModule = vi.fn()
     props = {
       proceed: vi.fn(),
       goBack: vi.fn(),
@@ -84,7 +84,7 @@ describe('UpdateFirmware', () => {
       dispatchApiRequest,
       [LAST_ID],
     ])
-    vi.mocked(useSendIdentifyStacker).mockReturnValue(sendIdentifyStacker)
+    vi.mocked(useSendIdentifyModule).mockReturnValue(sendIdentifyModule)
   })
 
   afterEach(() => {

--- a/app/src/organisms/ModuleWizardFlows/hooks.tsx
+++ b/app/src/organisms/ModuleWizardFlows/hooks.tsx
@@ -11,38 +11,30 @@ type sendIdentifyModuleType = (
   color?: IdentifyColor
 ) => void
 
-export function useSendIdentifyStacker(): sendIdentifyModuleType {
+export function useSendIdentifyModule(): sendIdentifyModuleType {
   const { createLiveCommand } = useCreateLiveCommandMutation()
 
-  const sendIdentifyStacker = useCallback(
+  const sendIdentifyModule = useCallback(
     (
       module: AttachedModule,
       start: boolean,
       color: IdentifyColor | null = null
     ) => {
-      // Only send identify command for flex stacker modules,
-      // other module types are not currently supported
-      if (module.moduleType === 'flexStackerModuleType') {
-        createLiveCommand({
-          command: {
-            commandType: 'identifyModule',
-            params: {
-              model: module.moduleModel,
-              moduleId: module.id,
-              start,
-              ...(color != null ? { color } : {}),
-            },
+      createLiveCommand({
+        command: {
+          commandType: 'identifyModule',
+          params: {
+            model: module.moduleModel,
+            moduleId: module.id,
+            start,
+            ...(color != null ? { color } : {}),
           },
-        }).catch(error => {
-          console.log(error.message)
-        })
-      } else {
-        console.warn(
-          `Module type ${module.moduleType} does not support identify command`
-        )
-      }
+        },
+      }).catch(error => {
+        console.log(error.message)
+      })
     },
     [createLiveCommand]
   )
-  return sendIdentifyStacker
+  return sendIdentifyModule
 }

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -20,7 +20,7 @@ import { CheckStackerInstall } from './CheckStackerInstall'
 import { CloseDoor } from './CloseStackerDoor'
 import { SECTIONS } from './constants'
 import { DetachProbe } from './DetachProbe'
-import { useSendIdentifyStacker } from './hooks'
+import { useSendIdentifyModule } from './hooks'
 import { InstallShuttle } from './InstallShuttle'
 import { ModuleWizardScreen } from './ModuleWizardScreen'
 import { PlaceAdapter } from './PlaceAdapter'
@@ -67,7 +67,7 @@ export function ModuleWizardFlows(
     deckConfig,
   } = useModuleSetupWizard({ closeFlow, attachedModuleOnLaunch, onComplete })
 
-  const sendIdentifyStacker = useSendIdentifyStacker()
+  const sendIdentifyModule = useSendIdentifyModule()
   const [selectedModule, setSelectedModule] = useState<AttachedModule | null>(
     null
   )
@@ -118,7 +118,7 @@ export function ModuleWizardFlows(
         isModuleUpdating={wizardFlowBaseProps.isModuleUpdating}
         handleCleanUpAndClose={() => {
           if (selectedModule != null) {
-            sendIdentifyStacker(selectedModule, false)
+            sendIdentifyModule(selectedModule, false)
           }
           handleCleanUpAndClose()
         }}

--- a/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
+++ b/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
@@ -14,7 +14,7 @@ import {
 import { useCreateTargetedMaintenanceRunMutation } from '/app/resources/runs'
 
 import { ACTIONS } from './constants'
-import { useSendIdentifyStacker } from './hooks'
+import { useSendIdentifyModule } from './hooks'
 import { moduleSetupWizardReducer } from './moduleSetupWizardReducer'
 
 import type { SetStateAction } from 'react'
@@ -68,7 +68,7 @@ export function useModuleSetupWizard(
 ): UseModuleSetupWizardResult {
   const { closeFlow, attachedModuleOnLaunch, onComplete } = params
   const isOnDevice = useSelector(getIsOnDevice)
-  const sendIdentifyStacker = useSendIdentifyStacker()
+  const sendIdentifyModule = useSendIdentifyModule()
   const [state, dispatch] = useReducer(moduleSetupWizardReducer, {
     currentStepIndex: 0,
     currentStep: null,
@@ -142,7 +142,7 @@ export function useModuleSetupWizard(
 
   const handleCleanUpAndClose = (): void => {
     setIsExiting(true)
-    if (attachedModule != null) sendIdentifyStacker(attachedModule, false)
+    if (attachedModule != null) sendIdentifyModule(attachedModule, false)
     if (maintenanceRunId == null) {
       console.log(
         'closing module setup wizard: no maintenance run, not deleting'


### PR DESCRIPTION
# Overview

On the frontend, we should not gate sending the `identifyModule` live command (wrapped in the then `useSendIdentifyStacker`, now `useSendIdentifyModule` hook) by module type. The backend shold accept this command for any module. Also, here I render the pulsing lights notification in the `SelectLocation` module wizard flow screen if the module is a vacuum.

## Test Plan and Hands on Testing

#### Inline notification for vacuum module
- plug in a vacuum module and walk through setup flow
- verify that in module location selection screen, the pulsing lights inline notification renders, and the vacuum blinks accordingly  
<img width="771" height="478" alt="Screenshot 2026-06-08 at 2 28 35 PM" src="https://github.com/user-attachments/assets/d27c8c1f-6a69-41f3-803a-2fa496b18a0b" />

- on a robot with API pushed from this branch, test that in vacuum module setup flow, the LED on the top of the module pulses

## Changelog

- allow sending the `identifyModule` live command for arbitrary module types; rename the hook and implementations accordingly
- add switching logic in `identify_module.py` to identify a vacuum in addition to a stacker; this is extensible to other module types in the future

## Review requests

see test plan

## Risk assessment

low