### PR TITLE
refactor(components, app): add a11y tags to odd modal

### DIFF
--- a/app/src/molecules/OddModal/OddModal.tsx
+++ b/app/src/molecules/OddModal/OddModal.tsx
@@ -67,6 +67,8 @@ export function OddModal(props: OddModalProps): JSX.Element {
         margin={SPACING.spacing32}
         flexDirection={DIRECTION_COLUMN}
         aria-label={`modal_${modalSize}`}
+        role="dialog"
+        aria-modal="true"
         onClick={(e: MouseEvent) => {
           e.stopPropagation()
         }}

--- a/components/src/modals/LegacyModal.tsx
+++ b/components/src/modals/LegacyModal.tsx
@@ -46,6 +46,8 @@ export function LegacyModal(props: LegacyModalProps): JSX.Element {
         className={cx(styles.modal, props.className, {
           [styles.alert_modal]: alertOverlay,
         })}
+        role="dialog"
+        aria-modal="true"
       >
         <Overlay onClick={onCloseClick} alertOverlay={alertOverlay} />
         <div

--- a/components/src/modals/ModalShell.tsx
+++ b/components/src/modals/ModalShell.tsx
@@ -79,6 +79,8 @@ export function ModalShell(props: ModalShellProps): JSX.Element {
       <ContentArea zIndex={zIndex} position={position} noPadding={noPadding}>
         <ModalArea
           aria-label="ModalShell_ModalArea"
+          role="dialog"
+          aria-modal="true"
           isFullPage={fullPage}
           onClick={(e: MouseEvent) => {
             e.stopPropagation()


### PR DESCRIPTION
# Overview
add `role="dialog"` and `aria-modal="true"` to modal components

<img width="1402" height="518" alt="Screenshot 2026-06-08 at 4 01 33 PM" src="https://github.com/user-attachments/assets/79c382b1-e6ed-4af6-a16b-c84a79db0bfa" />


closes AUTH-2995

## Test Plan and Hands on Testing
no visual change


## Changelog
- add `role` and `aria-modal`.

## Review requests


## Risk assessment
low
