### PR TITLE
feat(api): couple of vm profile behavior tweaks

### DIFF
--- a/api/src/opentrons/drivers/vacuum_module/types.py
+++ b/api/src/opentrons/drivers/vacuum_module/types.py
@@ -154,3 +154,7 @@ class PumpState:
     current_pwm: float
     pump_running: bool
     manual_control: bool
+
+
+PRESSURE_COMPARISON_WINDOW_SIZE = 10
+POWER_COMPARISON_WINDOW_SIZE = 10

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -463,12 +463,13 @@ class VacuumModule(mod_abc.AbstractModule):
                     for step in this_cycle["steps"]:
                         self._current_step_index += 1
                         await self._execute_cycle_step(step)
-                        await self.wait_for_target()
                         if (
                             step["hold_time_minutes"] is not None
                             or step["hold_time_seconds"] is not None
                         ):
                             await self.wait_for_command_duration()
+                        else:  # profile will wait for either
+                            await self.wait_for_target()
                 if this_cycle["vent_after"] is not None:
                     await self.set_vent_state(
                         vent_state=VentState(this_cycle["vent_after"])

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -468,7 +468,7 @@ class VacuumModule(mod_abc.AbstractModule):
                             or step["hold_time_seconds"] is not None
                         ):
                             await self.wait_for_command_duration()
-                        else:  # profile will wait for either
+                        else:
                             await self.wait_for_target()
                 if this_cycle["vent_after"] is not None:
                     await self.set_vent_state(

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -13,6 +13,8 @@ from opentrons.drivers.vacuum_module.driver import (
 )
 from opentrons.drivers.vacuum_module.simulator import SimulatingDriver
 from opentrons.drivers.vacuum_module.types import (
+    POWER_COMPARISON_WINDOW_SIZE,
+    PRESSURE_COMPARISON_WINDOW_SIZE,
     LEDColor,
     LEDPattern,
     PumpState,
@@ -372,6 +374,7 @@ class VacuumModule(mod_abc.AbstractModule):
     ) -> None:
         """Handler for internal pressure controls."""
         self._reader.set_operation_mode(VacuumModuleOperationMode.PRESSURE)
+        self._reader.set_target_pressure(gauge_pressure_mbar)
         await self._driver.set_vacuum_state(
             enable_vacuum=enable_vacuum,
             gauge_pressure_mbar=gauge_pressure_mbar,
@@ -393,6 +396,7 @@ class VacuumModule(mod_abc.AbstractModule):
     ) -> None:
         """Control the pump agnostically to the internal pressure"""
         self._reader.set_operation_mode(VacuumModuleOperationMode.POWER)
+        self._reader.set_target_power(duty_cycle)
 
         await self._driver.set_vacuum_state(enable_vacuum=False)
         await self._driver.set_pump_state(
@@ -514,31 +518,25 @@ class VacuumModule(mod_abc.AbstractModule):
 
     async def wait_for_target(self) -> None:
         await self.wait_for_is_running()
-
         task = self._loop.create_task(self._wait_for_target())
         self.make_cancellable(task)
         await task
 
     async def _wait_for_target(self) -> None:
         if self._reader.operation_mode == VacuumModuleOperationMode.POWER:
-            await self._reader.update_pump_state()
             if not self._reader.pump_state.pump_running:
                 return
-            # should there be a tolerance here?
-            while (
-                self._reader.pump_state.current_pwm
-                != self._reader.pump_state.target_pwm
-            ):
+            while not self._reader.power_target_reached():
                 await self._poller.wait_next_poll()
+            # clear target after it's reached
+            self._reader.set_target_power(None)
         elif self._reader.operation_mode == VacuumModuleOperationMode.PRESSURE:
-            await self._reader.update_vacuum_state()
             if not self._reader.vacuum_state.vacuum_enabled:
                 return
-            while (
-                self._reader.vacuum_state.current_gauge_pressure
-                != self._reader.vacuum_state.target_gauge_pressure
-            ):
+            while not self._reader.pressure_target_reached():
                 await self._poller.wait_next_poll()
+            # clear target after it's reached
+            self._reader.set_target_pressure(None)
         else:
             raise ValueError("Vacuum module target invalid.")
 
@@ -548,6 +546,8 @@ class VacuumModuleReader(Reader):
 
     def __init__(self, driver: AbstractVacuumModuleDriver) -> None:
         self.error: Optional[str] = None
+        self.pressure_calls = 0
+        self.power_calls = 0
         self.vacuum_state: VacuumState = VacuumState(
             target_gauge_pressure=0,
             current_gauge_pressure=0,
@@ -574,6 +574,14 @@ class VacuumModuleReader(Reader):
         self._refresh_state = False
         self._initialized_callback: Optional[Callable[[], Awaitable[None]]] = None
         self._error_callback: Optional[Callable[[Exception], None]] = None
+        self.target_pressure: Optional[float] = None
+        self.target_power: Optional[float] = None
+        self._pressure_readings: List[Optional[float]] = [
+            None
+        ] * PRESSURE_COMPARISON_WINDOW_SIZE
+        self._power_readings: List[Optional[float]] = [
+            None
+        ] * POWER_COMPARISON_WINDOW_SIZE
 
     def set_initialized_callback(
         self, callback: Callable[[], Awaitable[None]]
@@ -595,6 +603,12 @@ class VacuumModuleReader(Reader):
     def _remove_error_callback(self) -> None:
         self._error_callback = None
 
+    def set_target_pressure(self, gauge_pressure_mbar: Optional[float]) -> None:
+        self.target_pressure = gauge_pressure_mbar
+
+    def set_target_power(self, duty_cycle: Optional[float]) -> None:
+        self.target_power = duty_cycle
+
     async def read(self) -> None:
         await self.update_vacuum_state()
         await self.update_pump_state()
@@ -608,6 +622,16 @@ class VacuumModuleReader(Reader):
                     await self._initialized_callback()
 
         self._set_error(None)
+
+    def power_target_reached(self) -> bool:
+        if not all([p is not None for p in self._power_readings]):
+            return False
+        return all([p == self.target_power for p in self._power_readings])
+
+    def pressure_target_reached(self) -> bool:
+        if not all([p is not None for p in self._pressure_readings]):
+            return False
+        return all([p == self.target_pressure for p in self._pressure_readings])
 
     def set_refresh_state(self) -> None:
         """Tell the reader to refresh all states, even ones that arent polled."""
@@ -632,9 +656,17 @@ class VacuumModuleReader(Reader):
         """Get latest vacuum state from driver and save updated values."""
         self.vacuum_state = await self._driver.get_vacuum_state()
 
+        if self.target_pressure is not None:
+            self._pressure_readings.insert(0, self.vacuum_state.current_gauge_pressure)
+            self._pressure_readings.pop()
+
     async def update_pump_state(self) -> None:
         """Get latest pump state from driver and save updated values."""
         self.pump_state = await self._driver.get_pump_state()
+        if self.target_power is not None:
+            self._power_readings.insert(0, self.pump_state.current_pwm)
+            self._power_readings.pop()
+        self.power_calls += 1
 
     def set_operation_mode(self, mode_type: VacuumModuleOperationMode) -> None:
         self.operation_mode = mode_type

--- a/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
@@ -7,6 +7,8 @@ from decoy import Decoy
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.vacuum_module.simulator import SimulatingDriver
 from opentrons.drivers.vacuum_module.types import (
+    POWER_COMPARISON_WINDOW_SIZE,
+    PRESSURE_COMPARISON_WINDOW_SIZE,
     HardwareRevision,
     LEDColor,
     LEDPattern,
@@ -44,6 +46,74 @@ def usb_port() -> USBPort:
 def mock_driver(decoy: Decoy) -> SimulatingDriver:
     """Mocked simulating driver."""
     return decoy.mock(cls=SimulatingDriver)
+
+
+@pytest.fixture
+async def test_wait_for_target_subject(
+    usb_port: USBPort,
+    mock_driver: SimulatingDriver,
+    mock_execution_manager: ExecutionManager,
+    module_error_callback: ModuleErrorCallback,
+    module_disconnected_callback: ModuleDisconnectedCallback,
+    decoy: Decoy,
+) -> AsyncGenerator[modules.VacuumModule, None]:
+    """Test subject with mocked vm state updates."""
+    reader = VacuumModuleReader(driver=mock_driver)
+    poller = Poller(reader=reader, interval=SIMULATING_POLL_PERIOD)
+    vacuum = modules.VacuumModule(
+        port="/dev/ot_module_sim_vacuummodule0",
+        usb_port=usb_port,
+        driver=mock_driver,
+        reader=reader,
+        poller=poller,
+        device_info={
+            "serial": "dummySerialFS",
+            "model": "nff",
+            "version": "vacuum-fw",
+            "reset_reason": "0",
+        },
+        hw_control_loop=asyncio.get_running_loop(),
+        execution_manager=mock_execution_manager,
+        error_callback=module_error_callback,
+        disconnected_callback=module_disconnected_callback,
+    )
+    decoy.when(await mock_driver.get_device_info()).then_return(
+        {
+            "serial": "vacuum-fw",
+            "model": HardwareRevision.NFF.value,
+            "version": "dummySerialFS",
+            "reset_reason": "0",
+        }
+    )
+
+    decoy.when(await mock_driver.get_vacuum_state()).then_return(
+        VacuumState(
+            target_gauge_pressure=0,
+            current_gauge_pressure=0,
+            pressure_abs_a=0,
+            pressure_abs_b=0,
+            pressure_atm=0,
+            vacuum_enabled=True,
+            vacuum_duration=0,
+            vent_state=VentState.CLOSED,
+        )
+    )
+    decoy.when(await mock_driver.get_pump_state()).then_return(
+        PumpState(
+            target_rpm=0,
+            current_rpm=0,
+            target_pwm=0,
+            current_pwm=0,
+            pump_running=True,
+            manual_control=True,
+        )
+    )
+
+    await poller.start()
+    try:
+        yield vacuum
+    finally:
+        await vacuum.cleanup()
 
 
 @pytest.fixture
@@ -343,16 +413,28 @@ async def test_update_vacuum_state(
     assert subject._reader.vacuum_state == vacuum_state
 
 
+@pytest.mark.parametrize(
+    ("pressure_readings", "power_readings"),
+    [
+        (
+            [0, 0, -100, -200, -199, -201, -250, -300, -299, -300, -275, -300],
+            [0, 0, 30, 50, 30, 35, 40, 65, 66, 67, 68, 75],
+        )
+    ],
+)
 async def test_wait_for_target(
-    subject: modules.VacuumModule,
+    test_wait_for_target_subject: modules.VacuumModule,
     mock_driver: SimulatingDriver,
     decoy: Decoy,
+    pressure_readings: List[float],
+    power_readings: List[int],
 ) -> None:
     """Ensure that the hc function reads the correct state and returns."""
-    current_pressures = [0, -100, -200, -300]
-    current_powers = [0, 30, 50, 75]
-    target_gauge_pressure = current_pressures[-1]
-    target_pwm = current_powers[-1]
+    subject = test_wait_for_target_subject
+
+    target_pwm = power_readings[-1]
+    target_gauge_pressure = pressure_readings[-1]
+
     vacuum_states = [
         VacuumState(
             target_gauge_pressure=target_gauge_pressure,
@@ -360,11 +442,11 @@ async def test_wait_for_target(
             pressure_abs_a=0,
             pressure_abs_b=0,
             pressure_atm=0,
-            vacuum_enabled=False,
+            vacuum_enabled=True,
             vacuum_duration=0,
             vent_state=VentState.CLOSED,
         )
-        for _pressure in current_pressures
+        for _pressure in pressure_readings
     ]
     pump_states = [
         PumpState(
@@ -372,25 +454,58 @@ async def test_wait_for_target(
             current_rpm=80,
             target_pwm=target_pwm,
             current_pwm=_pwm,
-            pump_running=False,
+            pump_running=True,
             manual_control=True,
         )
-        for _pwm in current_powers
+        for _pwm in power_readings
     ]
-    decoy.when(await mock_driver.get_vacuum_state()).then_return(
-        vacuum_states[0], vacuum_states[1], vacuum_states[2], vacuum_states[3]
-    )
-    decoy.when(await mock_driver.get_pump_state()).then_return(
-        pump_states[0], pump_states[1], pump_states[2], pump_states[3]
-    )
 
+    pressure_read_calls = 0
+
+    async def _pressure_reading_side_effect() -> VacuumState:
+        nonlocal pressure_read_calls
+        pressure_read_calls += 1
+        if pressure_read_calls < len(pressure_readings):
+            return vacuum_states[pressure_read_calls - 1]
+        else:
+            return vacuum_states[-1]
+
+    power_read_calls = 0
+
+    async def _power_reading_side_effect() -> PumpState:
+        nonlocal power_read_calls
+        power_read_calls += 1
+        if power_read_calls < len(power_readings):
+            return pump_states[power_read_calls - 1]
+        else:
+            return pump_states[-1]
+
+    decoy.when(await mock_driver.get_vacuum_state()).then_do(
+        _pressure_reading_side_effect
+    )
+    decoy.when(await mock_driver.get_pump_state()).then_do(_power_reading_side_effect)
+
+    power_read_calls = 0
     await subject.set_pump_state(start_pump=True, duty_cycle=target_pwm)
     await subject.wait_for_target()
+    power_reads_while_waiting = power_read_calls
 
+    pressure_read_calls = 0
     await subject.set_vacuum_state(
         enable_vacuum=True, gauge_pressure_mbar=target_gauge_pressure
     )
     await subject.wait_for_target()
+    pressure_reads_while_waiting = pressure_read_calls
+
+    assert len(pressure_readings) == len(power_readings)
+
+    expected_pressure_reads = (
+        len(pressure_readings) + PRESSURE_COMPARISON_WINDOW_SIZE - 1
+    )
+    expected_power_reads = len(power_readings) + POWER_COMPARISON_WINDOW_SIZE - 1
+
+    assert pressure_reads_while_waiting == expected_pressure_reads
+    assert power_reads_while_waiting == expected_power_reads
 
 
 async def test_execute_profile(


### PR DESCRIPTION
## Overview
Just a couple small fixes for vm profile behavior

## Changelog
- have vm profiles wait for a duration if specified in a given profile step, otherwise wait for the target power/pressure to be reached - not both, this way the time needed to ramp is included in the duration
- allow pressure/power readings to stabilize for 10 readings before deciding that the target has been reached