### PR TITLE
docs: use Opentrons blue for module compatibility checkmarks

### DIFF
--- a/docs/flex/docs/modules/index.md
+++ b/docs/flex/docs/modules/index.md
@@ -33,20 +33,20 @@ Opentrons Flex is compatible with with the following Opentrons modules:
 
 Certain module tasks, like heating from an ambient temperature to a high temperature or executing a Thermocycler profile, take more time than others. Starting with API version 2.27, you can use [concurrent commands](../../python-api/modules/concurrent.md) to continue pipetting and other steps in your Flex protocols. 
 
-Some modules originally designed for the OT-2 are compatible with Flex, as summarized in the table below. A checkmark :material-check-bold:{ .green } indicates compatibility, and an :octicons-x-12:{ .red } indicates incompatibility.
+Some modules originally designed for the OT-2 are compatible with Flex, as summarized in the table below. A checkmark :material-check-bold:{ .opentrons-blue } indicates compatibility, and an :octicons-x-12:{ .red } indicates incompatibility.
 
 
 | Device type and generation | OT-2 | Flex |
 |:---------------------------|:----:|:----:|
-| Absorbance Plate Reader    | :octicons-x-12:{ .red } | :material-check-bold:{ .green } |
-| Heater-Shaker Module GEN1  | :material-check-bold:{ .green } | :material-check-bold:{ .green } |
-| HEPA Module                | :material-check-bold:{ .green } | :octicons-x-12:{ .red } |
-| HEPA/UV Module             | :octicons-x-12:{ .red } | :material-check-bold:{ .green } |
-| Magnetic Block GEN1        | :octicons-x-12:{ .red } | :material-check-bold:{ .green } |
-| Magnetic Module GEN1       | :material-check-bold:{ .green } | :octicons-x-12:{ .red } |
-| Magnetic Module GEN2       | :material-check-bold:{ .green } | :octicons-x-12:{ .red } |
-| Stacker Module GEN1        | :octicons-x-12:{ .red } | :material-check-bold:{ .green } |
-| Temperature Module GEN1    | :material-check-bold:{ .green } | :octicons-x-12:{ .red } |
-| Temperature Module GEN2    | :material-check-bold:{ .green } | :material-check-bold:{ .green } |
-| Thermocycler Module GEN1   | :material-check-bold:{ .green } | :octicons-x-12:{ .red } |
-| Thermocycler Module GEN2   | :material-check-bold:{ .green } | :material-check-bold:{ .green } |
+| Absorbance Plate Reader    | :octicons-x-12:{ .red } | :material-check-bold:{ .opentrons-blue } |
+| Heater-Shaker Module GEN1  | :material-check-bold:{ .opentrons-blue } | :material-check-bold:{ .opentrons-blue } |
+| HEPA Module                | :material-check-bold:{ .opentrons-blue } | :octicons-x-12:{ .red } |
+| HEPA/UV Module             | :octicons-x-12:{ .red } | :material-check-bold:{ .opentrons-blue } |
+| Magnetic Block GEN1        | :octicons-x-12:{ .red } | :material-check-bold:{ .opentrons-blue } |
+| Magnetic Module GEN1       | :material-check-bold:{ .opentrons-blue } | :octicons-x-12:{ .red } |
+| Magnetic Module GEN2       | :material-check-bold:{ .opentrons-blue } | :octicons-x-12:{ .red } |
+| Stacker Module GEN1        | :octicons-x-12:{ .red } | :material-check-bold:{ .opentrons-blue } |
+| Temperature Module GEN1    | :material-check-bold:{ .opentrons-blue } | :octicons-x-12:{ .red } |
+| Temperature Module GEN2    | :material-check-bold:{ .opentrons-blue } | :material-check-bold:{ .opentrons-blue } |
+| Thermocycler Module GEN1   | :material-check-bold:{ .opentrons-blue } | :octicons-x-12:{ .red } |
+| Thermocycler Module GEN2   | :material-check-bold:{ .opentrons-blue } | :material-check-bold:{ .opentrons-blue } |

--- a/docs/flex/docs/modules/index.md
+++ b/docs/flex/docs/modules/index.md
@@ -15,7 +15,7 @@ This chapter summarizes the functions and physical specifications of modules tha
 
 ## Supported modules
 
-Opentrons Flex is compatible with with the following Opentrons modules:
+Opentrons Flex is compatible with the following Opentrons modules:
 
 - The [**Absorbance Plate Reader**](absorbance-plate-reader.md) is a fully automated spectrophotometer that uses light absorbance to determine sample concentrations. This module is optimized for a variety of applications, including protein quantification, sample normalization, cell viability assays, and monitoring bacterial growth.
 


### PR DESCRIPTION
# Overview

Updates the Flex modules compatibility table to use branded Opentrons blue checkmarks instead of generic green, matching the styling already used on the OT-2 modules page.

Fixes [RTC-927](https://opentrons.atlassian.net/browse/RTC-927).

## Test Plan and Hands on Testing

- [x] Built docs locally with `make build` from `docs/`
- [x] Verified `/flex/modules/` renders checkmarks with `opentrons-blue` class (`#006CFA`); red X marks unchanged
- [x] Confirmed visual consistency with OT-2 modules compatibility table

## Changelog

- Flex modules compatibility table checkmarks now use Opentrons blue instead of green

## Review requests

- Quick visual review of the compatibility table on the Flex modules page is sufficient

## Risk assessment

- **Low risk** — markdown-only CSS class swap in a single docs file; no functional or API changes
- No coupling to other systems; `.opentrons-blue` class already exists in shared theme CSS


Made with [Cursor](https://cursor.com)

[RTC-927]: https://opentrons.atlassian.net/browse/RTC-927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ