### PR TITLE
docs: prefer `tip_rack` as a variable name (RTC-336)

### DIFF
--- a/docs/flex/docs/protocols/ot-2.md
+++ b/docs/flex/docs/protocols/ot-2.md
@@ -48,18 +48,18 @@ For example, you could convert an OT-2 protocol that uses a P300 Single-Channel 
 ```python
 # Original OT-2 code
 def run(protocol: protocol_api.ProtocolContext):
-    tips = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
+    tip_rack = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
     left_pipette = protocol.load_instrument(
-        "p300_single_gen2", "left", tip_racks=[tips]
+        "p300_single_gen2", "left", tip_racks=[tip_rack]
     )
 ```
 
 ```python
 # Modified Flex code
 def run(protocol: protocol_api.ProtocolContext):
-    tips = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "D1")
+    tip_rack = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "D1")
     left_pipette = protocol.load_instrument(
-        "flex_1channel_1000", "left", tip_racks[tips]
+        "flex_1channel_1000", "left", tip_racks=[tip_rack]
     )
 ```
 

--- a/docs/python-api/docs/adapting-ot2-flex.md
+++ b/docs/python-api/docs/adapting-ot2-flex.md
@@ -46,25 +46,25 @@ You also need to specify `"robotType": "Flex"`. If you omit `robotType` in the `
 Flex uses different types of pipettes and tip racks than OT-2, which have their own load names in the API. If possible, load Flex pipettes of the same capacity or larger than the OT-2 pipettes. See the [list of pipette API load names](pipettes/loading.md#api-load-names) for the valid values of `instrument_name` in Flex protocols. And check [Labware Library](https://labware.opentrons.com) or the Opentrons App for the load names of Flex tip racks.
 
 !!! note
-    If you use smaller capacity tips than in the OT-2 protocol, you may need to make further adjustments to avoid running out of tips. Also, the protocol may have more steps and take longer to execute.
+    If you use smaller capacity tips than in the OT-2 protocol, you may need to make further adjustments to avoid running out of tip_rack. Also, the protocol may have more steps and take longer to execute.
 
-This example converts OT-2 code that uses a P300 Single-Channel GEN2 pipette and 300 µL tips to Flex code that uses a Flex 1-Channel 1000 µL pipette and 1000 µL tips.
+This example converts OT-2 code that uses a P300 Single-Channel GEN2 pipette and 300 µL tips to Flex code that uses a Flex 1-Channel 1000 µL pipette and 1000 µL tip_rack.
 
 === "Original OT-2 code"
     ```python
     def run(protocol: protocol_api.ProtocolContext):
-        tips = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
+        tip_rack = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
         left_pipette = protocol.load_instrument(
-            "p300_single_gen2", "left", tip_racks=[tips]
+            "p300_single_gen2", "left", tip_racks=[tip_rack]
         )
     ```
 
 === "Updated Flex code"
     ```python
     def run(protocol: protocol_api.ProtocolContext):
-        tips = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "D1")
+        tip_rack = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "D1")
         left_pipette = protocol.load_instrument(
-            "flex_1channel_1000", "left", tip_racks=[tips]
+            "flex_1channel_1000", "left", tip_racks=[tip_rack]
         )
     ```
 

--- a/docs/python-api/docs/advanced-control/jupyter.md
+++ b/docs/python-api/docs/advanced-control/jupyter.md
@@ -78,10 +78,10 @@ For example, the following dummy protocol will use a P300 Single-Channel GEN2 pi
 ```python
 metadata = {"apiLevel": "2.13"}
 def run(protocol):
-    tiprack = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
+    tip_rack = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
     reservoir = protocol.load_labware("nest_12_reservoir_15ml", 2)
     plate = protocol.load_labware("nest_96_wellplate_200ul_flat", 3)
-    p300 = protocol.load_instrument("p300_single_gen2", "left", tip_racks=[tiprack])
+    p300 = protocol.load_instrument("p300_single_gen2", "left", tip_racks=[tip_rack])
     p300.pick_up_tip()
     p300.return_tip()
 ```
@@ -121,20 +121,20 @@ How the API applies labware offsets varies depending on the API level of your pr
 In the latest API version, labware offsets can apply to the same labware when used in different on-deck locations on the Flex. For example, if you use `set_offset()` on a tip rack, use all the tips, and replace the rack with a fresh one of the same type in any deck location on the Flex, the offsets will apply to the fresh tip rack:
 
 ```python
-tiprack = protocol.load_labware(
+tip_rack = protocol.load_labware(
     load_name="opentrons_flex_96_tiprack_1000ul", location="D3"
 )
-tiprack2 = protocol.load_labware(
+tip_rack_2 = protocol.load_labware(
     load_name="opentrons_flex_96_tiprack_1000ul",
     location=protocol_api.OFF_DECK,
 )
-tiprack.set_offset(x=0.1, y=0.1, z=0.1)
+tip_rack.set_offset(x=0.1, y=0.1, z=0.1)
 protocol.move_labware(
-    labware=tiprack, new_location=protocol_api.OFF_DECK
-)  # tiprack has no offset while off-deck
+    labware=tip_rack, new_location=protocol_api.OFF_DECK
+)  # tip_rack has no offset while off-deck
 protocol.move_labware(
-    labware=tiprack2, new_location="B3"
-)  # tiprack2 now has offset 0.1, 0.1, 0.1
+    labware=tip_rack_2, new_location="B3"
+)  # tip_rack_2 now has offset 0.1, 0.1, 0.1
 ```
 
 In OT-2 protocols, only reuse labware offsets with the same labware type-location combination. If you want an offset to apply to a piece of labware as it moves around the OT-2 deck, call `set_offset()` again after each movement:

--- a/docs/python-api/docs/advanced-control/robot-motors.md
+++ b/docs/python-api/docs/advanced-control/robot-motors.md
@@ -37,7 +37,7 @@ requirements = {
 
 def run(protocol: protocol_api.ProtocolContext): 
     pipette = protocol.load_instrument("flex_96channel_1000")
-    tips = protocol.load_labware("opentrons_flex_96_filtertiprack_1000ul", "D2")
+    tip_rack = protocol.load_labware("opentrons_flex_96_filtertiprack_1000ul", "D2")
 
     def drop_tips():
         plunger_distance = -30
@@ -51,7 +51,7 @@ def run(protocol: protocol_api.ProtocolContext):
             speed=5.5
         )
     pipette.home()
-    pipette.move_to(tips['A1'].top(z=130))
+    pipette.move_to(tip_rack['A1'].top(z=130))
     drop_tips()
     pipette.home()
 ```

--- a/docs/python-api/docs/building-block-commands/pipette-tips.md
+++ b/docs/python-api/docs/building-block-commands/pipette-tips.md
@@ -15,7 +15,7 @@ To pick up a tip, call the [`pick_up_tip()`][opentrons.protocol_api.InstrumentCo
 pipette.pick_up_tip()
 ```
 
-When added to the protocol template, this simple statement works because the API knows which tip rack is associated with `pipette`, as indicated by `tip_racks=[tiprack_1]` in the [`load_instrument()`][opentrons.protocol_api.ProtocolContext.load_instrument] call. And it knows the on-deck location of the tip rack (slot D3 on Flex, slot 3 on OT-2) from the `location` argument of [`load_labware()`][opentrons.protocol_api.ProtocolContext.load_labware]. Given this information, the robot moves to the tip rack and picks up a tip from position A1 in the rack. On subsequent calls to `pick_up_tip()`, the robot will use the next available tip. For example:
+When added to the protocol template, this simple statement works because the API knows which tip rack is associated with `pipette`, as indicated by `tip_racks=[tip_rack]` in the [`load_instrument()`][opentrons.protocol_api.ProtocolContext.load_instrument] call. And it knows the on-deck location of the tip rack (slot D3 on Flex, slot 3 on OT-2) from the `location` argument of [`load_labware()`][opentrons.protocol_api.ProtocolContext.load_labware]. Given this information, the robot moves to the tip rack and picks up a tip from position A1 in the rack. On subsequent calls to `pick_up_tip()`, the robot will use the next available tip. For example:
 
 ```python
 pipette.pick_up_tip()  # picks up tip from rack location A1
@@ -27,9 +27,9 @@ pipette.drop_tip()     # drops tip in trash bin
 If you omit the `tip_rack` argument from the `pipette` variable, the API will raise an error. In that case, you must pass the tip rack's location to `pick_up_tip` like this:
 
 ```python
-pipette.pick_up_tip(tiprack_1["A1"])
+pipette.pick_up_tip(tip_rack["A1"])
 pipette.drop_tip()
-pipette.pick_up_tip(tiprack_1["B1"])
+pipette.pick_up_tip(tip_rack["B1"])
 ```
 
 In most cases, it's best to associate tip racks with a pipette and let the API automatically track pickup location for you. This also makes it easy to pick up tips when iterating over a loop, as shown in the next section.
@@ -52,7 +52,7 @@ If your protocol requires a lot of tips, add a second tip rack to the protocol. 
 First, add another tip rack to the sample protocol:
 
 ```python
-tiprack_2 = protocol.load_labware(
+tip_rack_2 = protocol.load_labware(
     load_name="opentrons_flex_96_tiprack_1000ul",
     location="C3"
 )
@@ -64,7 +64,7 @@ Next, change the pipette's `tip_rack` property to include the additional rack:
 pipette = protocol.load_instrument(
     instrument_name="flex_1channel_1000",
     mount="left",
-    tip_racks=[tiprack_1, tiprack_2],
+    tip_racks=[tip_rack, tip_rack_2],
 )
 ```
 
@@ -93,7 +93,7 @@ You can specify where to drop the tip by passing in a location. For example, thi
 pipette.pick_up_tip()            # picks up tip from rack location A1
 pipette.drop_tip()               # drops tip in default trash container
 pipette.pick_up_tip()            # picks up tip from rack location B1
-pipette.drop_tip(tiprack["A1"])  # drops tip in rack location A1
+pipette.drop_tip(tip_rack["A1"])  # drops tip in rack location A1
 ```
 
 *New in version 2.0*
@@ -151,19 +151,19 @@ To avoid these tip use conflicts, you can use [`set_empty()`][opentrons.protocol
 Start by specifying and placing an empty tip rack on the deck:
 
 ```python
-# set tiprack_1 as empty
-tiprack_1.set_empty()
+# set tip_rack_1 as empty
+tip_rack_1.set_empty()
 
 # pick up a tip from the pipette's assigned tip rack
 pipette.pick_up_tip()
 
-# return attached tips to the empty tiprack_1
-pipette.drop_tip(tiprack_1["A1"])
+# return attached tips to the empty tip_rack_1
+pipette.drop_tip(tip_rack_1["A1"])
 ```
 
 *New in version 2.28*
 
-In the example above, the pipette uses automatic tip tracking to pick up the next available tip in its assigned tip rack. Then, it drops the attached tip in well A1 of the empty `tiprack_1`.
+In the example above, the pipette uses automatic tip tracking to pick up the next available tip in its assigned tip rack. Then, it drops the attached tip in well A1 of the empty `tip_rack_1`.
 
 ----->
 ## Working with used tips
@@ -175,7 +175,7 @@ pipette.pick_up_tip()                # picks up tip from rack location A1
 pipette.return_tip()                 # drops tip in rack location A1
 pipette.pick_up_tip()                # picks up tip from rack location B1
 pipette.drop_tip()                   # drops tip in trash bin
-pipette.pick_up_tip(tiprack_1["A1"]) # picks up tip from rack location A1
+pipette.pick_up_tip(tip_rack["A1"]) # picks up tip from rack location A1
 ```
 
 Early API versions treated returned tips as unused items. They could be picked up again without an explicit argument. For example:

--- a/docs/python-api/docs/examples.md
+++ b/docs/python-api/docs/examples.md
@@ -11,16 +11,16 @@ These sample protocols are designed for anyone using an Opentrons Flex or OT-2 l
 
 ```python
 # This code uses named arguments
-tiprack_1 = protocol.load_labware(
+tip_rack = protocol.load_labware(
     load_name="opentrons_flex_96_tiprack_200ul",
     location="D2"
 )
 
 # This code uses positional arguments
-tiprack_1 = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "D2")
+tip_rack = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "D2")
 ```
 
-Both examples instantiate the variable `tiprack_1` with a Flex tip rack, but the former is more explicit. It shows the parameter name and its value together (e.g. `location="D2"`), which may be helpful when you're unsure about what's going on in a protocol code sample.
+Both examples instantiate the variable `tip_rack` with a Flex tip rack, but the former is more explicit. It shows the parameter name and its value together (e.g. `location="D2"`), which may be helpful when you're unsure about what's going on in a protocol code sample.
 
 Python developers with more experience should feel free to ignore the code styling used here and work with these examples as you like.
 
@@ -54,14 +54,14 @@ This code only loads the instruments and labware listed above, and performs no o
     
     def run(protocol: protocol_api.ProtocolContext):
         # load tip rack in deck slot D3
-        tiprack = protocol.load_labware(
+        tip_rack = protocol.load_labware(
             load_name="opentrons_flex_96_tiprack_1000ul", location="D3"
         )
         # attach pipette to left mount
         pipette = protocol.load_instrument(
             instrument_name="flex_1channel_1000",
             mount="left",
-            tip_racks=[tiprack]
+            tip_racks=[tip_rack]
         )
         # load well plate in deck slot D2
         plate = protocol.load_labware(
@@ -84,14 +84,14 @@ This code only loads the instruments and labware listed above, and performs no o
     
     def run(protocol: protocol_api.ProtocolContext):
         # load tip rack in deck slot 3
-        tiprack = protocol.load_labware(
+        tip_rack = protocol.load_labware(
             load_name="opentrons_96_tiprack_300ul", location=3
         )
         # attach pipette to left mount
         pipette = protocol.load_instrument(
             instrument_name="p300_single_gen2",
             mount="left",
-            tip_racks=[tiprack]
+            tip_racks=[tip_rack]
         )  
         # load well plate in deck slot 2
         plate = protocol.load_labware(
@@ -123,7 +123,7 @@ This protocol uses some [building block commands](building-block-commands/index.
             load_name="corning_96_wellplate_360ul_flat",
             location="D1"
         )
-        tiprack_1 = protocol.load_labware(
+        tip_rack_1 = protocol.load_labware(
             load_name="opentrons_flex_96_tiprack_200ul",
             location="D2"
         )
@@ -131,7 +131,7 @@ This protocol uses some [building block commands](building-block-commands/index.
         pipette = protocol.load_instrument(
             instrument_name="flex_1channel_1000",
             mount="left",
-            tip_racks=[tiprack_1]
+            tip_racks=[tip_rack_1]
         )
     
         pipette.pick_up_tip()
@@ -151,14 +151,14 @@ This protocol uses some [building block commands](building-block-commands/index.
             load_name="corning_96_wellplate_360ul_flat",
             location=1
         )
-        tiprack_1 = protocol.load_labware(
+        tip_rack_1 = protocol.load_labware(
             load_name="opentrons_96_tiprack_300ul",
             location=2
         )
         pipette = protocol.load_instrument(
             instrument_name="p300_single",
             mount="left",
-            tip_racks=[tiprack_1]
+            tip_racks=[tip_rack_1]
         )
     
         pipette.pick_up_tip()
@@ -182,7 +182,7 @@ These protocols accomplish the same thing as the previous example, but a little 
             load_name="corning_96_wellplate_360ul_flat",
             location="D1"
         )
-        tiprack_1 = protocol.load_labware(
+        tip_rack_1 = protocol.load_labware(
             load_name="opentrons_flex_96_tiprack_200ul",
             location="D2"
         )
@@ -190,7 +190,7 @@ These protocols accomplish the same thing as the previous example, but a little 
         pipette = protocol.load_instrument(
             instrument_name="flex_1channel_1000",
             mount="left",
-            tip_racks=[tiprack_1]
+            tip_racks=[tip_rack_1]
         )
         # transfer 100 µL from well A1 to well B1
         pipette.transfer(
@@ -211,14 +211,14 @@ These protocols accomplish the same thing as the previous example, but a little 
             load_name="corning_96_wellplate_360ul_flat",
             location=1
         )
-        tiprack_1 = protocol.load_labware(
+        tip_rack_1 = protocol.load_labware(
             load_name="opentrons_96_tiprack_300ul",
             location=2
         )
         pipette = protocol.load_instrument(
             instrument_name="p300_single",
             mount="left",
-            tip_racks=[tiprack_1]
+            tip_racks=[tip_rack_1]
         )
         # transfer 100 µL from well A1 to well B1
         pipette.transfer(
@@ -243,14 +243,14 @@ Opentrons-verified liquid class definitions are based on Flex pipette and tip co
             load_name="corning_96_wellplate_360ul_flat",
             location="D1"
         )
-        tiprack_1 = protocol.load_labware(
+        tip_rack_1 = protocol.load_labware(
             load_name="opentrons_flex_96_tiprack_200ul",
             location="C1"
         )
         pipette = protocol.load_instrument(
             instrument_name="flex_1channel_1000",
             mount="left",
-            tip_racks=[tiprack_1]
+            tip_racks=[tip_rack_1]
         )
         liquid_1 = protocol.get_liquid_class("glycerol_50")
         trash = protocol.load_trash_bin("A3")
@@ -280,7 +280,7 @@ When used in a protocol, loops automate repetitive steps such as aspirating and 
             load_name="corning_96_wellplate_360ul_flat",
             location="D1"
         )
-        tiprack_1 = protocol.load_labware(
+        tip_rack_1 = protocol.load_labware(
             load_name="opentrons_flex_96_tiprack_200ul",
             location="D2"
         )
@@ -292,7 +292,7 @@ When used in a protocol, loops automate repetitive steps such as aspirating and 
         pipette = protocol.load_instrument(
             instrument_name="flex_1channel_1000",
             mount="left",
-            tip_racks=[tiprack_1]
+            tip_racks=[tip_rack_1]
         )
         # distribute 20 µL from reservoir:A1 -> plate:row:1
         # distribute 20 µL from reservoir:A2 -> plate:row:2
@@ -317,7 +317,7 @@ When used in a protocol, loops automate repetitive steps such as aspirating and 
             load_name="corning_96_wellplate_360ul_flat",
             location=1
         )
-        tiprack_1 = protocol.load_labware(
+        tip_rack_1 = protocol.load_labware(
             load_name="opentrons_96_tiprack_300ul",
             location=2
         )
@@ -328,7 +328,7 @@ When used in a protocol, loops automate repetitive steps such as aspirating and 
         pipette = protocol.load_instrument(
             instrument_name="p300_single",
             mount="left",
-            tip_racks=[tiprack_1]
+            tip_racks=[tip_rack_1]
         )
         # distribute 20 µL from reservoir:A1 -> plate:row:1
         # distribute 20 µL from reservoir:A2 -> plate:row:2
@@ -359,7 +359,7 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
             load_name="corning_96_wellplate_360ul_flat",
             location="D1"
         )
-        tiprack_1 = protocol.load_labware(
+        tip_rack_1 = protocol.load_labware(
             load_name="opentrons_flex_96_tiprack_1000ul",
             location="D2"
         )
@@ -371,7 +371,7 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
         pipette = protocol.load_instrument(
             instrument_name="flex_1channel_1000", 
             mount="left",
-            tip_racks=[tiprack_1]
+            tip_racks=[tip_rack_1]
         )
     
         pipette.pick_up_tip()
@@ -397,7 +397,7 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
             load_name="corning_96_wellplate_360ul_flat",
             location=1
         )
-        tiprack_1 = protocol.load_labware(
+        tip_rack_1 = protocol.load_labware(
             load_name="opentrons_96_tiprack_300ul",
             location=2
         )
@@ -408,7 +408,7 @@ Opentrons electronic pipettes can do some things that a human cannot do with a p
         pipette = protocol.load_instrument(
             instrument_name="p300_single", 
             mount="left",
-            tip_racks=[tiprack_1])
+            tip_racks=[tip_rack_1])
     
         pipette.pick_up_tip()
     
@@ -439,11 +439,11 @@ This protocol dispenses diluent to all wells of a Corning 96-well plate. Next, i
             load_name="corning_96_wellplate_360ul_flat",
             location="D1"
         )
-        tiprack_1 = protocol.load_labware(
+        tip_rack_1 = protocol.load_labware(
             load_name="opentrons_flex_96_tiprack_200ul",
             location="D2"
         )
-        tiprack_2 = protocol.load_labware(
+        tip_rack_2 = protocol.load_labware(
             load_name="opentrons_flex_96_tiprack_200ul",
             location="D3"
         )
@@ -455,7 +455,7 @@ This protocol dispenses diluent to all wells of a Corning 96-well plate. Next, i
         pipette = protocol.load_instrument(
             instrument_name="flex_1channel_1000",
             mount="left",
-            tip_racks=[tiprack_1, tiprack_2]
+            tip_racks=[tip_rack_1, tip_rack_2]
         )
         # Dispense diluent
         pipette.distribute(
@@ -498,11 +498,11 @@ This protocol dispenses diluent to all wells of a Corning 96-well plate. Next, i
             load_name="corning_96_wellplate_360ul_flat",
             location=1
         )
-        tiprack_1 = protocol.load_labware(
+        tip_rack_1 = protocol.load_labware(
             load_name="opentrons_96_tiprack_300ul",
             location=2
         )
-        tiprack_2 = protocol.load_labware(
+        tip_rack_2 = protocol.load_labware(
             load_name="opentrons_96_tiprack_300ul",
             location=3
         )
@@ -513,7 +513,7 @@ This protocol dispenses diluent to all wells of a Corning 96-well plate. Next, i
         pipette = protocol.load_instrument(
             instrument_name="p300_single",
             mount="left",
-            tip_racks=[tiprack_1, tiprack_2]
+            tip_racks=[tip_rack_1, tip_rack_2]
         )
         # Dispense diluent
         pipette.distribute(
@@ -562,11 +562,11 @@ This protocol dispenses different volumes of liquids to a well plate and automat
             load_name="corning_96_wellplate_360ul_flat",
             location="D1"
         )
-        tiprack_1 = protocol.load_labware(
+        tip_rack_1 = protocol.load_labware(
             load_name="opentrons_flex_96_tiprack_200ul",
             location="D2"
         )
-        tiprack_2 = protocol.load_labware(
+        tip_rack_2 = protocol.load_labware(
             load_name="opentrons_flex_96_tiprack_200ul",
             location="D3"
         )
@@ -578,7 +578,7 @@ This protocol dispenses different volumes of liquids to a well plate and automat
         pipette = protocol.load_instrument(
             instrument_name="flex_1channel_1000",
             mount="right",
-            tip_racks=[tiprack_1, tiprack_2]
+            tip_racks=[tip_rack_1, tip_rack_2]
         )
     
         # Volume amounts are for demonstration purposes only
@@ -615,11 +615,11 @@ This protocol dispenses different volumes of liquids to a well plate and automat
             load_name="corning_96_wellplate_360ul_flat",
             location=1
         )
-        tiprack_1 = protocol.load_labware(
+        tip_rack_1 = protocol.load_labware(
             load_name="opentrons_96_tiprack_300ul",
             location=2
         )
-        tiprack_2 = protocol.load_labware(
+        tip_rack_2 = protocol.load_labware(
             load_name="opentrons_96_tiprack_300ul",
             location=3
         )
@@ -630,7 +630,7 @@ This protocol dispenses different volumes of liquids to a well plate and automat
         pipette = protocol.load_instrument(
             instrument_name="p300_single", 
             mount="right",
-            tip_racks=[tiprack_1, tiprack_2]
+            tip_racks=[tip_rack_1, tip_rack_2]
         )
     
         # Volume amounts are for demonstration purposes only

--- a/docs/python-api/docs/index.md
+++ b/docs/python-api/docs/index.md
@@ -48,14 +48,14 @@ For example, if we wanted to transfer liquid from well A1 to well B1 on a plate,
         plate = protocol.load_labware(
             "corning_96_wellplate_360ul_flat", location="D1"
         )
-        tiprack = protocol.load_labware(
+        tip_rack = protocol.load_labware(
             "opentrons_flex_96_tiprack_200ul", location="D2"
         )
         trash = protocol.load_trash_bin(location="A3")
 
         # pipettes
         left_pipette = protocol.load_instrument(
-            "flex_1channel_1000", mount="left", tip_racks=[tiprack]
+            "flex_1channel_1000", mount="left", tip_racks=[tip_rack]
         )
 
         # commands
@@ -100,13 +100,13 @@ For example, if we wanted to transfer liquid from well A1 to well B1 on a plate,
         plate = protocol.load_labware(
             "corning_96_wellplate_360ul_flat", location="1"
         )
-        tiprack = protocol.load_labware(
+        tip_rack = protocol.load_labware(
             "opentrons_96_tiprack_300ul", location="2"
         )
 
         # pipettes
         left_pipette = protocol.load_instrument(
-            "p300_single", mount="left", tip_racks=[tiprack]
+            "p300_single", mount="left", tip_racks=[tip_rack]
         )
 
         # commands

--- a/docs/python-api/docs/labware.md
+++ b/docs/python-api/docs/labware.md
@@ -37,13 +37,13 @@ Similar to the code sample in [How the API Works][how-the-api-works], here's how
 
 ```python
 # Flex
-tiprack = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "D1")
+tip_rack = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "D1")
 plate = protocol.load_labware("opentrons_96_wellplate_200ul_pcr_full_skirt", "D2")
 ```
 
 ```python
 # OT-2
-tiprack = protocol.load_labware("opentrons_96_tiprack_300ul", "1")
+tip_rack = protocol.load_labware("opentrons_96_tiprack_300ul", "1")
 plate = protocol.load_labware("opentrons_96_wellplate_200ul_pcr_full_skirt", "2")
 ```
 *New in version 2.0*
@@ -53,7 +53,7 @@ When the `load_labware()` method loads labware into your protocol, it returns a 
 !!! tip
     The `load_labware()` method includes an optional `label` argument. You can use it to identify labware with a descriptive name. If used, the label value is displayed in the Opentrons App. For example:
     ```python
-    tiprack = protocol.load_labware(
+    tip_rack = protocol.load_labware(
         load_name="opentrons_flex_96_tiprack_200ul",
         location="D1",
         label="any-name-you-want"
@@ -75,7 +75,7 @@ plate = protocol.load_labware(
 And this example loads an Opentrons Flex Tip Rack Lid onto a rack of 200 µL tips:
 
 ```python
-tiprack = protocol.load_labware(
+tip_rack = protocol.load_labware(
     load_name="opentrons_flex_96_tiprack_200ul",
     location="D1",
     lid="opentrons_flex_tiprack_lid"

--- a/docs/python-api/docs/liquid-classes.md
+++ b/docs/python-api/docs/liquid-classes.md
@@ -170,14 +170,14 @@ requirements = {"robotType": "Flex", "apiLevel": "{{ apiLevel }}"}
 
 # define tips, trash, and pipette
 def run(protocol: protocol_api.ProtocolContext):
-    tiprack = protocol.load_labware(
+    tip_rack = protocol.load_labware(
         load_name="opentrons_flex_96_tiprack_50ul", location="D3"
     )
     trash = protocol.load_trash_bin(location="A3")
     pipette = protocol.load_instrument(
         instrument_name="flex_1channel_50",
         mount="left",
-        tip_racks=[tiprack],
+        tip_racks=[tip_rack],
     )
 
     # load source and destination labware
@@ -248,7 +248,7 @@ To customize an Opentrons-verified liquid class, first add your pipettes, tips, 
 
 ```python
 custom_water = protocol.get_liquid_class(name="water", version=1)
-custom_water_properties = custom_water.get_for(pipette, tiprack)
+custom_water_properties = custom_water.get_for(pipette, tip_rack)
 ```
 
 Here, you can also use the optional `version` parameter to specify which version of the liquid class definition you’d like to customize. If unspecified, the API loads the latest version.

--- a/docs/python-api/docs/moving-labware.md
+++ b/docs/python-api/docs/moving-labware.md
@@ -224,22 +224,22 @@ metadata = {"apiLevel": "{{ apiLevel }}", "protocolName": "Tip rack replacement"
 requirements = {"robotType": "OT-2"}
 
 def run(protocol: protocol_api.ProtocolContext):
-    tips1 = protocol.load_labware("opentrons_96_tiprack_1000ul", 1)
+    tip_rack_1 = protocol.load_labware("opentrons_96_tiprack_1000ul", 1)
     # load another tip rack but don't put it in a slot yet
-    tips2 = protocol.load_labware(
+    tip_rack_2 = protocol.load_labware(
         "opentrons_96_tiprack_1000ul", protocol_api.OFF_DECK
     )
     pipette = protocol.load_instrument(
-        "p1000_single_gen2", "left", tip_racks=[tips1, tips2]
+        "p1000_single_gen2", "left", tip_racks=[tip_rack_1, tip_rack_2]
     )
     # use all the on-deck tips
     for i in range(96):
         pipette.pick_up_tip()
         pipette.drop_tip()
     # pause to move the spent tip rack off-deck
-    protocol.move_labware(labware=tips1, new_location=protocol_api.OFF_DECK)
+    protocol.move_labware(labware=tip_rack_1, new_location=protocol_api.OFF_DECK)
     # pause to move the fresh tip rack on-deck
-    protocol.move_labware(labware=tips2, new_location=1)
+    protocol.move_labware(labware=tip_rack_2, new_location=1)
     pipette.pick_up_tip()
 ```
 

--- a/docs/python-api/docs/pipettes/characteristics.md
+++ b/docs/python-api/docs/pipettes/characteristics.md
@@ -42,8 +42,8 @@ from opentrons import protocol_api
 requirements = {"robotType": "Flex", "apiLevel":"{{ apiLevel }}"}
 
 def run(protocol: protocol_api.ProtocolContext):
-    # Load a tiprack for 1000 µL tips
-    tiprack1 = protocol.load_labware(
+    # Load a tip_rack for 1000 µL tips
+    tip_rack_1 = protocol.load_labware(
         load_name="opentrons_flex_96_tiprack_1000ul", location="D1")
     # Load a 96-well plate
     plate = protocol.load_labware(
@@ -52,10 +52,10 @@ def run(protocol: protocol_api.ProtocolContext):
     right = protocol.load_instrument(
         instrument_name="flex_8channel_1000",
         mount="right",
-        tip_racks=[tiprack1])
+        tip_racks=[tip_rack_1])
 ```
 
-After loading our instruments and labware, let’s tell the robot to pick up a pipette tip from location A1 in `tiprack1`:
+After loading our instruments and labware, let’s tell the robot to pick up a pipette tip from location A1 in `tip_rack_1`:
 
 ```python
 right.pick_up_tip()
@@ -88,7 +88,7 @@ To demonstrate these concepts, let’s write a protocol that uses a Flex 8-Chann
 ```python
 def run(protocol: protocol_api.ProtocolContext):
     # Load a tip rack for 200 µL tips
-    tiprack1 = protocol.load_labware(
+    tip_rack_1 = protocol.load_labware(
         load_name="opentrons_flex_96_tiprack_200ul", location="D1")
     # Load a well plate
     plate = protocol.load_labware(
@@ -97,10 +97,10 @@ def run(protocol: protocol_api.ProtocolContext):
     right = protocol.load_instrument(
         instrument_name="flex_8channel_1000",
         mount="right",
-        tip_racks=[tiprack1])
+        tip_racks=[tip_rack_1])
 ```
 
-After loading our instruments and labware, let’s tell the robot to pick up a pipette tip from location A1 in tiprack1:
+After loading our instruments and labware, let’s tell the robot to pick up a pipette tip from location A1 in `tip_rack_1`:
 
 ```python
 right.pick_up_tip()
@@ -135,12 +135,12 @@ These flow rate properties operate independently. This means you can specify dif
 
 ```python
 def run(protocol: protocol_api.ProtocolContext):
-    tiprack1 = protocol.load_labware(
+    tip_rack_1 = protocol.load_labware(
         load_name="opentrons_flex_96_tiprack_1000ul", location="D1")
     pipette = protocol.load_instrument(
         instrument_name="flex_1channel_1000",
         mount="left",
-        tip_racks=[tiprack1])
+        tip_racks=[tip_rack_1])
     plate = protocol.load_labware(
         load_name="corning_96_wellplate_360ul_flat", location="D3")
     pipette.pick_up_tip()

--- a/docs/python-api/docs/pipettes/loading.md
+++ b/docs/python-api/docs/pipettes/loading.md
@@ -100,18 +100,18 @@ from opentrons import protocol_api
 requirements = {"robotType": "Flex", "apiLevel":"{{ apiLevel }}"}
 
 def run(protocol: protocol_api.ProtocolContext):
-    tiprack1 = protocol.load_labware(
+    tip_rack_1 = protocol.load_labware(
         load_name="opentrons_flex_96_tiprack_1000ul", location="D1")
-    tiprack2 = protocol.load_labware(
+    tip_rack_2 = protocol.load_labware(
         load_name="opentrons_flex_96_tiprack_1000ul", location="C1")
     left = protocol.load_instrument(
         instrument_name="flex_1channel_1000",
         mount="left",
-        tip_racks=[tiprack1])
+        tip_racks=[tip_rack_1])
     right = protocol.load_instrument(
         instrument_name="flex_8channel_1000",
         mount="right",
-        tip_racks=[tiprack2])
+        tip_racks=[tip_rack_2])
 ```
 
 If you're writing a protocol that uses the Flex Gripper, you might think that this would be the place in your protocol to declare that. However, the gripper doesn't require `load_instrument()`! Whether your gripper requires a protocol is determined by the presence of [`ProtocolContext.move_labware()`][opentrons.protocol_api.ProtocolContext.move_labware] commands. See [Moving Labware](../moving-labware.md) for more details.
@@ -142,18 +142,18 @@ from opentrons import protocol_api
 metadata = {"apiLevel": "{{ apiLevel }}"}
 
 def run(protocol: protocol_api.ProtocolContext):
-    tiprack1 = protocol.load_labware(
+    tip_rack_1 = protocol.load_labware(
         load_name="opentrons_96_tiprack_1000ul", location=1)
-    tiprack2 = protocol.load_labware(
+    tip_rack_2 = protocol.load_labware(
         load_name="opentrons_96_tiprack_1000ul", location=2)
     left = protocol.load_instrument(
         instrument_name="p1000_single_gen2",
         mount="left",
-        tip_racks=[tiprack1])
+        tip_racks=[tip_rack_1])
     right = protocol.load_instrument(
         instrument_name="p300_multi_gen2",
         mount="right",
-        tip_racks=[tiprack1])
+        tip_racks=[tip_rack_1])
 ```
 
 *New in version 2.0*
@@ -169,35 +169,35 @@ The advantage of using `tip_racks` is twofold. First, associating tip racks with
 
 ```python
 def run(protocol: protocol_api.ProtocolContext):
-    tiprack_left = protocol.load_labware(
+    tip_rack_left = protocol.load_labware(
         load_name="opentrons_flex_96_tiprack_200ul", location="D1")
-    tiprack_right = protocol.load_labware(
+    tip_rack_right = protocol.load_labware(
         load_name="opentrons_flex_96_tiprack_200ul", location="D2")
     left_pipette = protocol.load_instrument(
         instrument_name="flex_8channel_1000", mount="left")
     right_pipette = protocol.load_instrument(
         instrument_name="flex_8channel_1000",
         mount="right",
-        tip_racks=[tiprack_right])
+        tip_racks=[tip_rack_right])
 ```
 
 Let's pick up a tip with the left pipette. We need to specify the location as an argument of `pick_up_tip()`, since we loaded the left pipette without a `tip_racks` argument.
 
 ```python
-left_pipette.pick_up_tip(tiprack_left["A1"])
+left_pipette.pick_up_tip(tip_rack_left["A1"])
 left_pipette.drop_tip()
 ```
 
-But now you have to specify `tiprack_left` every time you call `pick_up_tip`, which means you're doing all your own tip tracking:
+But now you have to specify `tip_rack_left` every time you call `pick_up_tip`, which means you're doing all your own tip tracking:
 
 ```python
-left_pipette.pick_up_tip(tiprack_left["A2"])
+left_pipette.pick_up_tip(tip_rack_left["A2"])
 left_pipette.drop_tip()
-left_pipette.pick_up_tip(tiprack_left["A3"])
+left_pipette.pick_up_tip(tip_rack_left["A3"])
 left_pipette.drop_tip()
 ```
 
-However, because you specified a tip rack location for the right pipette, the robot will automatically pick up from location A1 of its associated tiprack:
+However, because you specified a tip rack location for the right pipette, the robot will automatically pick up from location A1 of its associated tip rack:
 
 ```python
 right_pipette.pick_up_tip()
@@ -288,7 +288,7 @@ To automatically use liquid presence detection, add the optional Boolean argumen
 right = protocol.load_instrument(
     instrument_name="flex_8channel_1000",
     mount="right",
-    tip_racks=[tiprack2],
+    tip_racks=[tip_rack_2],
     liquid_presence_detection=True
 )
 ```

--- a/docs/python-api/docs/pipettes/partial-tip-pickup.md
+++ b/docs/python-api/docs/pipettes/partial-tip-pickup.md
@@ -294,22 +294,22 @@ On the other hand, you must use the tip rack adapter for full rack pickup. If th
 When switching between full and partial pickup, you may want to organize your tip racks into lists, depending on whether they're loaded on adapters or not.
 
 ```python
-tips_1 = protocol.load_labware(
+tip_rack_1 = protocol.load_labware(
     "opentrons_flex_96_tiprack_1000ul", "C1"
 )
-tips_2 = protocol.load_labware(
+tip_rack_2 = protocol.load_labware(
     "opentrons_flex_96_tiprack_1000ul", "D1"
 )
-tips_3 = protocol.load_labware(
+tip_rack_3 = protocol.load_labware(
     "opentrons_flex_96_tiprack_1000ul", "C3",
     adapter="opentrons_flex_96_tiprack_adapter"
 )
-tips_4 = protocol.load_labware(
+tip_rack_4 = protocol.load_labware(
     "opentrons_flex_96_tiprack_1000ul", "D3",
     adapter="opentrons_flex_96_tiprack_adapter"
 )
-partial_tip_racks = [tips_1, tips_2]
-full_tip_racks = [tips_3, tips_4]
+partial_tip_racks = [tip_rack_1, tip_rack_2]
+full_tip_racks = [tip_rack_3, tip_rack_4]
 ```
 
 !!! tip
@@ -387,12 +387,12 @@ pipette.configure_nozzle_layout(
 When using column 12, the pipette overhangs space to the left of wherever it is picking up tips or pipetting. For this reason, it's a good idea to organize tip racks front to back on the deck. If you place them side by side, the rack to the right will be inaccessible. For example, let's load three tip racks in the front left corner of the deck:
 
 ```python
-tips_C1 = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "C1")
-tips_D1 = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "D1")
-tips_D2 = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "D2")
+tip_rack_C1 = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "C1")
+tip_rack_D1 = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "D1")
+tip_rack_D2 = protocol.load_labware("opentrons_flex_96_tiprack_1000ul", "D2")
 ```
 
-Now the pipette will be able to access the racks in column 1 only. `pick_up_tip(tips_D2["A1"])` will raise an error due to the tip rack immediately to its left, in slot D1. There a couple of ways to avoid this error:
+Now the pipette will be able to access the racks in column 1 only. `pick_up_tip(tip_rack_D2["A1"])` will raise an error due to the tip rack immediately to its left, in slot D1. There a couple of ways to avoid this error:
 
 - Load the tip rack in a different slot, with no tall labware to its left.
 - Use all the tips in slot D1 first, and then use [`move_labware()`][opentrons.protocol_api.ProtocolContext.move_labware] to make space for the pipette before picking up tips from D2.

--- a/docs/python-api/docs/runtime-parameters/use-case-cherrypicking.md
+++ b/docs/python-api/docs/runtime-parameters/use-case-cherrypicking.md
@@ -110,14 +110,14 @@ def run(protocol: protocol_api.ProtocolContext):
     unique_source_slots = list(set(source_slots))
 
     # load tip rack in deck slot C1
-    tiprack = protocol.load_labware(
+    tip_rack = protocol.load_labware(
         load_name="opentrons_flex_96_tiprack_1000ul", location="C1"
     )
     # attach pipette to left mount
     pipette = protocol.load_instrument(
         instrument_name="flex_1channel_1000",
         mount="left",
-        tip_racks=[tiprack]
+        tip_racks=[tip_rack]
     )
     # load trash bin
     trash = protocol.load_trash_bin("A3")

--- a/docs/python-api/docs/runtime-parameters/use-case-dry-run.md
+++ b/docs/python-api/docs/runtime-parameters/use-case-dry-run.md
@@ -122,10 +122,10 @@ if protocol.params.dry_run is True:
     pipette.reset_tipracks()
 else:
     protocol.move_labware(
-        labware=tips_1, new_location=chute, use_gripper=True
+        labware=tip_rack_1, new_location=chute, use_gripper=True
     )
     protocol.move_labware(
-        labware=tips_2, new_location="C3", use_gripper=True
+        labware=tip_rack_2, new_location="C3", use_gripper=True
     )
 ```
 You can modify this code for similar cases. You may be moving tip racks by hand, rather than with the gripper. Or you could even mix the two, moving the used (but full) rack off-deck by hand — instead of dropping it down the chute, spilling all the tips — and have the gripper move a new rack into place. Ultimately, it's up to you to fine-tune your dry run behavior, and communicate it to your protocol's users with your parameter descriptions.

--- a/docs/python-api/docs/tutorial.md
+++ b/docs/python-api/docs/tutorial.md
@@ -104,7 +104,7 @@ For serial dilution, you need to load a tip rack, reservoir, and 96-well plate o
 
     ```python
     def run(protocol: protocol_api.ProtocolContext):
-        tips = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "D1")
+        tip_rack = protocol.load_labware("opentrons_flex_96_tiprack_200ul", "D1")
         reservoir = protocol.load_labware("nest_12_reservoir_15ml", "D2")
         plate = protocol.load_labware("nest_96_wellplate_200ul_flat", "D3")
     ```
@@ -120,7 +120,7 @@ For serial dilution, you need to load a tip rack, reservoir, and 96-well plate o
     
     ```python
     def run(protocol: protocol_api.ProtocolContext):
-        tips = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
+        tip_rack = protocol.load_labware("opentrons_96_tiprack_300ul", 1)
         reservoir = protocol.load_labware("nest_12_reservoir_15ml", 2)
         plate = protocol.load_labware("nest_96_wellplate_200ul_flat", 3)
     ```
@@ -134,7 +134,7 @@ For serial dilution, you need to load a tip rack, reservoir, and 96-well plate o
 You may notice that these deck maps don't show where the liquids will be at the start of the protocol. Liquid definitions aren’t required in Python protocols, unlike protocols made in [Protocol Designer](https://designer.opentrons.com/). If you want to identify liquids, see [Labeling Liquids in Labware][labeling-liquids-in-labware]. (Sneak peek: you’ll put the diluent in column 1 of the reservoir and the solution in column 2 of the reservoir.)
 
 ### Trash bin
-Flex and OT-2 both come with a trash bin for disposing used tips.
+Flex and OT-2 both come with a trash bin for disposing used tip_rack.
 
 The OT-2 trash bin is fixed in slot 12. Since it can't go anywhere else on the deck, you don't need to write any code to tell the API where it is.
 
@@ -149,15 +149,15 @@ Next you’ll specify what pipette to use in the protocol. Loading a pipette is 
 
 #### Flex
 ```python
-left_pipette = protocol.load_instrument("flex_1channel_1000", "left", tip_racks=[tips])
+left_pipette = protocol.load_instrument("flex_1channel_1000", "left", tip_racks=[tip_rack])
 ```
 #### OT-2
 ```python
-left_pipette = protocol.load_instrument("p300_single_gen2", "left", tip_racks=[tips])
+left_pipette = protocol.load_instrument("p300_single_gen2", "left", tip_racks=[tip_rack])
 ```
 
 !!! note
-    You may notice that the value of `tip_racks` is in brackets, indicating that it’s a list. This serial dilution protocol only uses one tip rack, but some protocols require more tips, so you can assign them to a pipette all at once, like `tip_racks=[tips1, tips2]`.
+    You may notice that the value of `tip_racks` is in brackets, indicating that it’s a list. This serial dilution protocol only uses one tip rack, but some protocols require more tips, so you can assign them to a pipette all at once, like `tip_racks=[tip_rack_1, tip_rack_2]`.
 
 ## Commands
 Finally, all of your labware and hardware is in place, so it’s time to give the robot pipetting commands. The required steps of the serial dilution process break down into three main phases:


### PR DESCRIPTION
## Summary

- Updates Python API and Flex documentation code samples to prefer `tip_rack` as the variable name for tip rack labware objects, per [RTC-336](https://opentrons.atlassian.net/browse/RTC-336).
- Renames related variants consistently (`tip_rack_1`, `tip_rack_2`, `tip_rack_left`, etc.) while leaving API load names (e.g. `opentrons_96_tiprack_300ul`) unchanged.
- Fixes a pre-existing typo in the Flex OT-2 conversion example (`tip_racks[tips]` → `tip_racks=[tip_rack]`).

## Test plan

- [ ] Spot-check updated code samples in the Python API tutorial, examples, and pipette tips pages
- [ ] Confirm API load names in strings were not altered
- [ ] Build docs locally if needed: `make -C docs build` or equivalent


Made with [Cursor](https://cursor.com)

[RTC-336]: https://opentrons.atlassian.net/browse/RTC-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ