### PR TITLE
docs(python-api): recommend max protocolName length (RTC-87)

### DIFF
--- a/docs/python-api/docs/protocol-structure.md
+++ b/docs/python-api/docs/protocol-structure.md
@@ -1,0 +1,71 @@
+---
+title: "Python API: Protocol Structure"
+description: "The metadata, requirements, and run() function in Python protocol files."
+---
+
+Every Python protocol file has three main parts:
+
+1. A `metadata` dictionary with information about the protocol.
+2. A `requirements` dictionary specifying the robot type and API version (required for Flex).
+3. A `run()` function containing all robot commands.
+
+The [tutorial](tutorial.md) walks through these sections step by step. This page summarizes key details about the metadata dictionary.
+
+## Metadata fields
+
+The fields `protocolName`, `description`, and `author` are displayed in the Opentrons App and on the Flex touchscreen. You can include them alongside `apiLevel` (or omit `apiLevel` from metadata if you specify it in `requirements`):
+
+```python
+metadata = {
+    "protocolName": "My Protocol",
+    "description": "What this protocol does",
+    "author": "Name <email@example.com>",
+}
+```
+
+<table>
+    <thead>
+        <tr>
+            <th style="width: 25%;">Field</th>
+            <th>Details</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>protocolName</code></td>
+            <td>
+                <ul>
+                    <li>The name of the protocol, shown in the Opentrons App and on the Flex touchscreen.</li>
+                    <li>Maximum 100 characters.</li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td><code>description</code></td>
+            <td>
+                <ul>
+                    <li>A brief summary of what the protocol does.</li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td><code>author</code></td>
+            <td>
+                <ul>
+                    <li>Contact information for the protocol author.</li>
+                </ul>
+            </td>
+        </tr>
+        <tr>
+            <td><code>apiLevel</code></td>
+            <td>
+                <ul>
+                    <li>The [API version](versioning.md) the protocol requires.</li>
+                    <li>For Flex protocols, specify <code>apiLevel</code> in <code>requirements</code> instead.</li>
+                </ul>
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+Keep `protocolName` short enough to read at a glance. The Opentrons App may truncate names longer than 100 characters in some views.

--- a/docs/python-api/mkdocs.yml
+++ b/docs/python-api/mkdocs.yml
@@ -4,6 +4,7 @@ site_name: python-api
 nav:
   - Python Protocol API: index.md
   - Tutorial: tutorial.md
+  - Protocol Structure: protocol-structure.md
   - Versioning: versioning.md
   - Labware: labware.md
   - Moving Labware: moving-labware.md


### PR DESCRIPTION
## Summary

- Adds a new **Protocol Structure** page to the Python API docs describing the `metadata`, `requirements`, and `run()` sections of a protocol file.
- Documents a recommended maximum length of **100 characters** for `protocolName`, matching how the Opentrons App truncates long names in some views.
- Adds the page to the Python API navigation after Tutorial.

Jira: https://opentrons.atlassian.net/browse/RTC-87

## Test plan

- [ ] Build or serve the Python API docs and confirm **Protocol Structure** appears in the nav after Tutorial
- [ ] Verify the page renders the metadata fields table and the 100-character `protocolName` recommendation
- [ ] Confirm no broken internal links on the new page


Made with [Cursor](https://cursor.com)