### PR TITLE
feat(audit-server): sign audit messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ dev-backend:
 dev-backend-flex:
 	$(python) scripts/run_concurrently.py \
 		$(MAKE) -C auth-server dev ';' \
-		$(MAKE) -C audit-server dev ';' \
+		$(MAKE) -C audit-server dev OT_AUDIT_SERVER_key_server_url=http://localhost:33960 ';' \
 		$(MAKE) -C robot-server dev-flex OT_ROBOT_SERVER_auth_server_url=http://localhost:31950 BEHIND_DEV_PROXY=1 ';' \
 		$(MAKE) -C system-server dev OT_SYSTEM_SERVER_auth_server_url=http://localhost:31950 ';' \
 		$(MAKE) -C key-server dev-mitmproxy ';' \

--- a/audit-server/audit_server/app.py
+++ b/audit-server/audit_server/app.py
@@ -1,5 +1,6 @@
 """The server's ASGI app object."""
 
+import logging
 from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator, Optional
@@ -7,6 +8,7 @@ from typing import AsyncGenerator, Optional
 from fastapi import FastAPI
 
 from server_utils import systemd_utils
+from server_utils.keys.fastapi import build_key_client, install_key_client
 
 from audit_server.log_ingest.router import router as ingest_router
 from audit_server.persistence.database import sql_engine_ctx
@@ -20,6 +22,8 @@ from audit_server.persistence.persistence_directory import (
     prepare_root,
 )
 from audit_server.server_settings import AuditServerSettings, get_settings
+
+_log = logging.getLogger(__name__)
 
 
 def _get_persistence_directory_root(settings: AuditServerSettings) -> Optional[Path]:
@@ -42,6 +46,22 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     async with AsyncExitStack() as exit_stack:
         engine = exit_stack.enter_context(sql_engine_ctx(db_path))
         set_sql_engine(app.state, engine)
+
+        if settings.key_server_uds is not None or settings.key_server_url is not None:
+            key_client = await exit_stack.enter_async_context(
+                build_key_client(
+                    key_server_uds=settings.key_server_uds,
+                    key_server_url=settings.key_server_url,
+                )
+            )
+            install_key_client(app.state, key_client)
+        else:
+            _log.warning(
+                "key-server is not configured."
+                " Log ingest will will fail."
+                " Set OT_AUDIT_SERVER_key_server_uds or OT_AUDIT_SERVER_key_server_url"
+                " to enable logging."
+            )
 
         systemd_utils.notify_up()
         yield

--- a/audit-server/audit_server/log_ingest/models.py
+++ b/audit-server/audit_server/log_ingest/models.py
@@ -17,6 +17,12 @@ class SubmitAuditLogMessageData(_StrictBaseModel):
     reason: str | None
 
 
+class AuditLogMessage(SubmitAuditLogMessageData):
+    """An audit log message together with the time the audit server received it."""
+
+    loggedAt: datetime.datetime
+
+
 class SubmitAuditLogSuccessData(_StrictBaseModel):
     """The response to a successful audit log submission."""
 

--- a/audit-server/audit_server/log_ingest/router.py
+++ b/audit-server/audit_server/log_ingest/router.py
@@ -13,7 +13,8 @@ from server_utils.fastapi_utils.models.json_api import (
     SimpleBody,
 )
 from server_utils.keys.fastapi import get_key_client
-from server_utils.keys.key_server import Client as KeyClient, SignMessageData
+from server_utils.keys.key_server import Client as KeyClient
+from server_utils.keys.key_server import SignMessageData
 
 from .models import (
     AuditLogMessage,

--- a/audit-server/audit_server/log_ingest/router.py
+++ b/audit-server/audit_server/log_ingest/router.py
@@ -4,6 +4,7 @@ import datetime
 from logging import getLogger
 from typing import Annotated
 
+import aiohttp
 import fastapi
 
 from server_utils.fastapi_utils.models.json_api import (
@@ -12,9 +13,13 @@ from server_utils.fastapi_utils.models.json_api import (
     SimpleBody,
 )
 from server_utils.keys.fastapi import get_key_client
-from server_utils.keys.key_server import Client as KeyClient
+from server_utils.keys.key_server import Client as KeyClient, SignMessageData
 
-from .models import SubmitAuditLogMessageData, SubmitAuditLogSuccessData
+from .models import (
+    AuditLogMessage,
+    SubmitAuditLogMessageData,
+    SubmitAuditLogSuccessData,
+)
 
 LOG = getLogger(__name__)
 
@@ -28,7 +33,13 @@ router = fastapi.APIRouter()
     responses={
         fastapi.status.HTTP_201_CREATED: {
             "model": SimpleBody[SubmitAuditLogSuccessData]
-        }
+        },
+        fastapi.status.HTTP_503_SERVICE_UNAVAILABLE: {
+            "description": (
+                "Key-server could not be reached, so the audit log message"
+                " could not be signed."
+            ),
+        },
     },
 )
 async def post_log_message(
@@ -36,12 +47,35 @@ async def post_log_message(
     key_client: Annotated[KeyClient, fastapi.Depends(get_key_client)],
 ) -> PydanticResponse[SimpleBody[SubmitAuditLogSuccessData]]:
     """Log an audit message."""
+    ingest_time = datetime.datetime.now(datetime.timezone.utc)
+    message = AuditLogMessage(
+        action=request_body.data.action,
+        accountName=request_body.data.accountName,
+        legalName=request_body.data.legalName,
+        message=request_body.data.message,
+        reason=request_body.data.reason,
+        loggedAt=ingest_time,
+    )
+    message_str = message.model_dump_json(indent=None)
+    try:
+        signed_message = await key_client.sign_message(
+            SignMessageData(message=message_str, previousHash=None)
+        )
+    except aiohttp.ClientConnectionError as exc:
+        # The key-server is unreachable. We refuse to ingest the message rather
+        # than persisting it without a signature, so callers can retry once the
+        # key-server is back up.
+        LOG.warning("Key-server is unreachable: %s", exc)
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "Audit log message could not be signed: key-server is unavailable."
+            ),
+        ) from exc
     LOG.info(
-        f"Logging action {request_body.data.action}: {request_body.data.message} from {request_body.data.accountName} for reason {request_body.data.reason}"
+        f"Logged message={signed_message.message} hash={signed_message.messageHash} sig={signed_message.messageSignature} ver={signed_message.signatureVersion}"
     )
     return await PydanticResponse.create(
         status_code=fastapi.status.HTTP_201_CREATED,
-        content=SimpleBody(
-            data=SubmitAuditLogSuccessData(loggedAt=datetime.datetime.utcnow())
-        ),
+        content=SimpleBody(data=SubmitAuditLogSuccessData(loggedAt=ingest_time)),
     )

--- a/audit-server/audit_server/log_ingest/router.py
+++ b/audit-server/audit_server/log_ingest/router.py
@@ -2,6 +2,7 @@
 
 import datetime
 from logging import getLogger
+from typing import Annotated
 
 import fastapi
 
@@ -10,6 +11,8 @@ from server_utils.fastapi_utils.models.json_api import (
     RequestModel,
     SimpleBody,
 )
+from server_utils.keys.fastapi import get_key_client
+from server_utils.keys.key_server import Client as KeyClient
 
 from .models import SubmitAuditLogMessageData, SubmitAuditLogSuccessData
 
@@ -30,6 +33,7 @@ router = fastapi.APIRouter()
 )
 async def post_log_message(
     request_body: RequestModel[SubmitAuditLogMessageData],
+    key_client: Annotated[KeyClient, fastapi.Depends(get_key_client)],
 ) -> PydanticResponse[SimpleBody[SubmitAuditLogSuccessData]]:
     """Log an audit message."""
     LOG.info(

--- a/audit-server/audit_server/server_settings.py
+++ b/audit-server/audit_server/server_settings.py
@@ -45,3 +45,21 @@ class AuditServerSettings(BaseSettings):
         description="Path to Alembic config file.",
         validation_alias="ALEMBIC_CONFIG",  # read ALEMBIC_CONFIG from env (no OT_ prefix)
     )
+    key_server_uds: str | None = Field(
+        default=None,
+        description=(
+            "The path to the Unix domain socket where key-server is listening."
+            " This is mutually exclusive with key_server_url."
+            " If both are unset, audit log messages cannot be signed and any"
+            " request that requires the key-server client will fail."
+        ),
+    )
+    key_server_url: str | None = Field(
+        default=None,
+        description=(
+            "The base URL (e.g. `http://localhost:33960`) where key-server is listening."
+            " This is mutually exclusive with key_server_uds."
+            " If both are unset, audit log messages cannot be signed and any"
+            " request that requires the key-server client will fail."
+        ),
+    )

--- a/audit-server/tests/conftest.py
+++ b/audit-server/tests/conftest.py
@@ -1,6 +1,9 @@
+import asyncio
+import threading
 import time
-from typing import Generator
+from typing import Callable, Generator
 
+import aiohttp.web
 import pytest
 import requests
 
@@ -10,9 +13,69 @@ _INTEGRATION_SERVER_STARTUP_TIMEOUT_S = 30
 
 
 @pytest.fixture
-def run_server(unused_tcp_port: int) -> Generator[DevServer, None, None]:
-    """Run a dev server as a fixture scoped to the test."""
-    with DevServer(port=unused_tcp_port) as dev_server:
+def fake_key_server(
+    unused_tcp_port_factory: Callable[[], int],
+) -> Generator[str, None, None]:
+    """Run a minimal in-process stand-in for key-server on a TCP port.
+
+    Yields the base URL (e.g. ``http://localhost:12345``) that audit-server
+    can use to reach this fake. The fake responds to
+    ``POST /keys/internal/logSigning/signMessage`` with a canned signature
+    so tests don't have to depend on a real key-server being running.
+    """
+    port = unused_tcp_port_factory()
+
+    async def sign_message(request: aiohttp.web.Request) -> aiohttp.web.Response:
+        body = await request.json()
+        message = body["data"]["message"]
+        return aiohttp.web.json_response(
+            data={
+                "data": {
+                    "message": message,
+                    "messageHash": "sha256:ZmFrZQ==",
+                    "messageSignature": "ed25519:ZmFrZQ==",
+                    "signatureVersion": 1,
+                }
+            }
+        )
+
+    app = aiohttp.web.Application()
+    app.router.add_post("/keys/internal/logSigning/signMessage", sign_message)
+
+    loop = asyncio.new_event_loop()
+    runner = aiohttp.web.AppRunner(app)
+
+    def serve() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(runner.setup())
+        site = aiohttp.web.TCPSite(runner, host="127.0.0.1", port=port)
+        loop.run_until_complete(site.start())
+        loop.run_forever()
+
+    thread = threading.Thread(target=serve, name="fake-key-server", daemon=True)
+    thread.start()
+
+    base_url = f"http://127.0.0.1:{port}"
+    _wait_for_tcp(base_url)
+    try:
+        yield base_url
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        asyncio.run(runner.cleanup())
+
+
+@pytest.fixture
+def run_server(
+    unused_tcp_port: int, fake_key_server: str
+) -> Generator[DevServer, None, None]:
+    """Run a dev server as a fixture scoped to the test.
+
+    The dev server is configured to talk to the in-process ``fake_key_server``
+    so that routes that depend on the key-server client resolve cleanly.
+    """
+    extra_env = {"OT_AUDIT_SERVER_key_server_url": fake_key_server}
+    with DevServer(port=unused_tcp_port, extra_env=extra_env) as dev_server:
         dev_server.start()
         base_url = f"http://localhost:{dev_server.port}"
         _wait_until_ready(base_url)
@@ -35,3 +98,17 @@ def _wait_until_ready(base_url: str) -> None:
                 return
 
             time.sleep(0.1)
+
+
+def _wait_for_tcp(base_url: str) -> None:
+    with requests.Session() as requests_session:
+        started = time.monotonic()
+        while True:
+            if time.monotonic() - started > _INTEGRATION_SERVER_STARTUP_TIMEOUT_S:
+                raise RuntimeError(f"fake key-server at {base_url} did not come up")
+            try:
+                requests_session.get(base_url)
+            except requests.ConnectionError:
+                time.sleep(0.05)
+            else:
+                return

--- a/audit-server/tests/dev_server.py
+++ b/audit-server/tests/dev_server.py
@@ -5,15 +5,25 @@ import signal
 import subprocess
 import sys
 from types import TracebackType
-from typing import Optional
+from typing import Mapping, Optional
 
 
 class DevServer:
     """An instance of the server, running as a background process."""
 
-    def __init__(self, port: int) -> None:
-        """Initialize a dev server."""
+    def __init__(
+        self,
+        port: int,
+        extra_env: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        """Initialize a dev server.
+
+        ``extra_env`` is layered on top of the parent process's environment
+        when spawning the subprocess, so tests can inject configuration like
+        ``OT_AUDIT_SERVER_key_server_url`` without polluting ``os.environ``.
+        """
         self.port: int = port
+        self._extra_env: Mapping[str, str] = extra_env or {}
 
     def __enter__(self) -> DevServer:
         return self
@@ -29,6 +39,7 @@ class DevServer:
     def start(self) -> None:
         """Run the audit server in a background process."""
         env = {k: v for k, v in os.environ.items()}
+        env.update(self._extra_env)
         # In order to collect coverage we run using `coverage`.
         # `-a` is to append to existing `.coverage` file.
         # `--source` is the source code folder to collect coverage stats on.

--- a/audit-server/tests/log_ingest/test_router.py
+++ b/audit-server/tests/log_ingest/test_router.py
@@ -80,15 +80,15 @@ def _assert_loggedat_is_recent_utc_iso(value: object) -> datetime.datetime:
     assert isinstance(value, str)
     parsed = datetime.datetime.fromisoformat(value)
     assert parsed.tzinfo is not None, f"loggedAt {value!r} must include tz info"
-    assert parsed.utcoffset() == datetime.timedelta(
-        0
-    ), f"loggedAt {value!r} must be UTC"
+    assert parsed.utcoffset() == datetime.timedelta(0), (
+        f"loggedAt {value!r} must be UTC"
+    )
     # The route stamps loggedAt at request handling time; allow a generous skew so
     # the test isn't flaky on slow CI.
     now = datetime.datetime.now(datetime.timezone.utc)
-    assert (
-        abs((now - parsed).total_seconds()) < 60
-    ), f"loggedAt {value!r} is too far from now {now.isoformat()}"
+    assert abs((now - parsed).total_seconds()) < 60, (
+        f"loggedAt {value!r} is too far from now {now.isoformat()}"
+    )
     return parsed
 
 

--- a/audit-server/tests/log_ingest/test_router.py
+++ b/audit-server/tests/log_ingest/test_router.py
@@ -1,0 +1,222 @@
+"""Unit tests for the `/audit/internal/logMessage` route."""
+
+from __future__ import annotations
+
+import datetime
+import json
+from typing import Generator
+
+import aiohttp
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from server_utils.keys.fastapi import install_key_client
+from server_utils.keys.key_server import (
+    Client as KeyClient,
+)
+from server_utils.keys.key_server import (
+    SignedMessageData,
+    SignMessageData,
+)
+
+from audit_server.log_ingest.router import router as ingest_router
+
+_ENDPOINT_PATH = "/audit/internal/logMessage"
+
+_CANNED_SIGNED_MESSAGE = SignedMessageData(
+    message="<placeholder>",
+    messageHash="sha256:ZmFrZQ==",
+    messageSignature="ed25519:ZmFrZQ==",
+    signatureVersion=1,
+)
+
+
+class StubKeyClient(KeyClient):
+    """A hand-rolled mock of the key-server `Client`.
+
+    Captures every call to `sign_message` in `calls` and, by default, returns
+    `_CANNED_SIGNED_MESSAGE`. Setting `raise_on_sign` to an exception makes
+    the next call raise that exception instead, simulating a key-server that's
+    unreachable or otherwise broken.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[SignMessageData] = []
+        self.response: SignedMessageData = _CANNED_SIGNED_MESSAGE
+        self.raise_on_sign: Exception | None = None
+
+    async def sign_message(self, message: SignMessageData) -> SignedMessageData:
+        self.calls.append(message)
+        if self.raise_on_sign is not None:
+            raise self.raise_on_sign
+        return self.response
+
+
+@pytest.fixture
+def stub_key_client() -> StubKeyClient:
+    """A fresh `StubKeyClient` for each test."""
+    return StubKeyClient()
+
+
+@pytest.fixture
+def app(stub_key_client: StubKeyClient) -> FastAPI:
+    """A minimal FastAPI app wired up with the log-ingest router and a stub key client."""
+    app = FastAPI()
+    install_key_client(app.state, stub_key_client)
+    app.include_router(ingest_router)
+    return app
+
+
+@pytest.fixture
+def client(app: FastAPI) -> Generator[TestClient, None, None]:
+    """A starlette `TestClient` for the FastAPI app."""
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def _assert_loggedat_is_recent_utc_iso(value: object) -> datetime.datetime:
+    """Assert ``value`` is an ISO-8601 UTC datetime near the current wall clock."""
+    assert isinstance(value, str)
+    parsed = datetime.datetime.fromisoformat(value)
+    assert parsed.tzinfo is not None, f"loggedAt {value!r} must include tz info"
+    assert parsed.utcoffset() == datetime.timedelta(
+        0
+    ), f"loggedAt {value!r} must be UTC"
+    # The route stamps loggedAt at request handling time; allow a generous skew so
+    # the test isn't flaky on slow CI.
+    now = datetime.datetime.now(datetime.timezone.utc)
+    assert (
+        abs((now - parsed).total_seconds()) < 60
+    ), f"loggedAt {value!r} is too far from now {now.isoformat()}"
+    return parsed
+
+
+def test_full_request_body_forwarded_to_key_server(
+    client: TestClient,
+    stub_key_client: StubKeyClient,
+) -> None:
+    """The full request body must be serialized to JSON and forwarded to
+    ``key_client.sign_message`` (along with the server-stamped ``loggedAt``)."""
+    request_body = {
+        "data": {
+            "action": "run.start",
+            "accountName": "alice",
+            "legalName": "Alice Anderson",
+            "message": "Started run abc-123",
+            "reason": "Routine experiment",
+        },
+    }
+    response = client.post(_ENDPOINT_PATH, json=request_body)
+
+    assert response.status_code == 201, response.text
+
+    assert len(stub_key_client.calls) == 1
+    forwarded_arg = stub_key_client.calls[0]
+    assert forwarded_arg.previousHash is None
+
+    forwarded_payload = json.loads(forwarded_arg.message)
+    # Every field from the request body must round-trip into what we ask the
+    # key-server to sign.
+    for key, value in request_body["data"].items():
+        assert forwarded_payload[key] == value
+    # The server also adds an ingest timestamp; verify it's a sensible value.
+    _assert_loggedat_is_recent_utc_iso(forwarded_payload["loggedAt"])
+    # Make sure nothing extra got smuggled in.
+    assert set(forwarded_payload) == set(request_body["data"]) | {"loggedAt"}
+
+
+def test_full_request_body_forwarded_with_null_reason(
+    client: TestClient,
+    stub_key_client: StubKeyClient,
+) -> None:
+    """A `reason: null` request body must round-trip through to the key-server
+    payload as JSON `null` (not omitted)."""
+    request_body = {
+        "data": {
+            "action": "run.start",
+            "accountName": "alice",
+            "legalName": "Alice Anderson",
+            "message": "Started run abc-123",
+            "reason": None,
+        },
+    }
+    response = client.post(_ENDPOINT_PATH, json=request_body)
+
+    assert response.status_code == 201, response.text
+
+    assert len(stub_key_client.calls) == 1
+    forwarded_payload = json.loads(stub_key_client.calls[0].message)
+    assert "reason" in forwarded_payload
+    assert forwarded_payload["reason"] is None
+
+
+def test_non_ascii_utf8_message_forwarded_verbatim(
+    client: TestClient,
+    stub_key_client: StubKeyClient,
+) -> None:
+    """Non-ASCII characters that round-trip cleanly through UTF-8 must reach
+    the key-server with their code points intact."""
+    # Includes Latin diacritics, CJK ideographs, a zero-width joiner emoji
+    # sequence, and a high-plane emoji to cover BMP + supplementary planes.
+    non_ascii_message = "Démarrage du protocole №1: 实验开始 — 🧬👩‍🔬🚀 (β=½)"
+    request_body = {
+        "data": {
+            "action": "run.start",
+            "accountName": "élise",
+            "legalName": "Élise Müller-中野",
+            "message": non_ascii_message,
+            "reason": "experimentación",
+        },
+    }
+    response = client.post(_ENDPOINT_PATH, json=request_body)
+
+    assert response.status_code == 201, response.text
+
+    assert len(stub_key_client.calls) == 1
+    forwarded_arg = stub_key_client.calls[0]
+    forwarded_payload = json.loads(forwarded_arg.message)
+    assert forwarded_payload["message"] == non_ascii_message
+    assert forwarded_payload["accountName"] == "élise"
+    assert forwarded_payload["legalName"] == "Élise Müller-中野"
+    assert forwarded_payload["reason"] == "experimentación"
+    # The serialized JSON we pass to the key-server must itself round-trip
+    # losslessly through UTF-8, since the key-server hashes UTF-8 bytes.
+    assert (
+        forwarded_arg.message.encode("utf-8").decode("utf-8") == forwarded_arg.message
+    )
+    assert non_ascii_message in forwarded_arg.message
+
+
+def test_returns_503_when_key_server_unavailable(
+    client: TestClient,
+    stub_key_client: StubKeyClient,
+) -> None:
+    """If the key-server cannot be contacted, the endpoint must return a
+    well-formed HTTP 503 instead of crashing with a 500."""
+    stub_key_client.raise_on_sign = aiohttp.ClientConnectionError("connection refused")
+
+    request_body = {
+        "data": {
+            "action": "run.start",
+            "accountName": "alice",
+            "legalName": "Alice Anderson",
+            "message": "Started run abc-123",
+            "reason": None,
+        },
+    }
+    response = client.post(_ENDPOINT_PATH, json=request_body)
+
+    assert response.status_code == 503
+    assert response.headers["content-type"].startswith("application/json")
+    body = response.json()
+    assert isinstance(body, dict)
+    # FastAPI's standard error envelope: {"detail": "..."}.
+    assert "detail" in body
+    assert isinstance(body["detail"], str) and body["detail"]
+    # The error message should clearly identify key-server as the cause so
+    # the operator knows what to fix.
+    assert "key-server" in body["detail"].lower()
+    # And the stub really was called — proving we did try to reach the key
+    # server before returning 503.
+    assert len(stub_key_client.calls) == 1


### PR DESCRIPTION
The audit log needs to save signed messages, which we have to do via the key-server, so use the client we created to get access to the key server and sign messages. The messages that we sign are the full json dump of the audit log ingest request body.

Closes EXEC-2723