### PR TITLE
feat(components): update hardware sim vacuum module svg component

### DIFF
--- a/components/src/hardware-sim/Module/Vacuum.tsx
+++ b/components/src/hardware-sim/Module/Vacuum.tsx
@@ -1,104 +1,767 @@
 export function Vacuum(): JSX.Element {
   return (
     <svg
-      width="274"
-      height="90"
-      viewBox="0 0 274 90"
+      x="-11"
+      y="-5.5"
+      width="315"
+      height="97"
+      viewBox="0 0 247 80"
+      preserveAspectRatio="none"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <path
-        d="M198.836 87.4873V88.9718H270.363C272.21 88.9718 273.71 87.4725 273.71 85.6251V3.64166C273.71 1.79417 272.21 0.294922 270.363 0.294922H198.836V1.77941H189.433V0.294922H3.4942C1.64671 0.294922 0.147461 1.79417 0.147461 3.64166V85.628C0.147461 87.4755 1.64671 88.9747 3.4942 88.9747H189.433V87.4903H198.836V87.4873Z"
-        fill="#E9E9E9"
-      />
-      <path
-        d="M121.339 81.2449C122.072 81.2449 122.667 80.0086 122.667 78.4851V10.879C122.667 9.35547 122.072 8.11914 121.339 8.11914H115.59L114.41 8.70888H112.051L110.872 8.11914C110.872 8.11914 35.5781 8.11914 25.4486 8.11914C24.5537 8.11914 24.2457 8.70888 23.5897 8.70888C21.2307 8.70888 21.4773 8.11914 21.2307 8.11914C18.9855 8.11914 15.4814 8.11914 15.4814 8.11914C14.7486 8.11914 14.1539 9.35547 14.1539 10.879C14.1539 10.879 14.7435 15.7858 14.7435 16.9653C14.7435 18.1448 14.1551 18.8043 14.1538 19.914C14.1409 30.9175 14.1033 70.11 14.2718 70.632C14.4954 71.3251 14.7436 70.632 14.7436 72.4012C14.7437 74.1704 14.1539 74.1704 14.1539 74.1704V78.4875C14.1539 80.011 14.7436 80.6576 15.4814 81.2473H89.2371L121.339 81.2449Z"
-        fill="white"
-      />
-      <path
-        d="M258.607 1.7793H152.822C148.548 1.7793 145.084 5.24382 145.084 9.51753V79.7489C145.084 84.0227 148.548 87.4872 152.822 87.4872H258.607C262.881 87.4872 266.346 84.0227 266.346 79.7489V9.51753C266.346 5.24382 262.881 1.7793 258.607 1.7793Z"
-        stroke="#16212D"
-        strokeWidth="0.589744"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M258.608 3.45215H152.822C149.473 3.45215 146.757 6.16748 146.757 9.51701V79.7484C146.757 83.098 149.473 85.8133 152.822 85.8133H258.608C261.957 85.8133 264.672 83.098 264.672 79.7484V9.51701C264.672 6.16748 261.957 3.45215 258.608 3.45215Z"
-        stroke="#16212D"
-        strokeWidth="0.589744"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M59.9632 83.5354V87.4872H15.6823C11.4089 87.4872 7.94409 84.0224 7.94409 79.7489V9.51753C7.94409 5.24409 11.4089 1.7793 15.6823 1.7793H59.9603V5.734L57.4517 8.24258H25.817C25.2503 8.24258 24.6926 8.38719 24.1967 8.66166H22.1043C21.6085 8.38719 21.0507 8.24258 20.484 8.24258H16.0394C15.1157 8.24258 14.3661 8.99221 14.3661 9.91595V14.3606C14.3661 14.9272 14.5107 15.485 14.7851 15.9808V18.0733C14.5107 18.5691 14.3661 19.1269 14.3661 19.6935V69.5759C14.3661 70.1425 14.5107 70.7003 14.7851 71.1962V73.2886C14.5107 73.7844 14.3661 74.3422 14.3661 74.9089V79.3535C14.3661 80.2772 15.1157 81.0268 16.0394 81.0268H57.4487L59.9573 83.5354"
-        stroke="#16212D"
-        strokeWidth="0.589744"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M76.6943 87.4872H258.608C262.881 87.4872 266.346 84.0224 266.346 79.7489V9.51753C266.346 5.24409 262.881 1.7793 258.608 1.7793H76.6943V5.734L79.2029 8.24258H110.838C111.404 8.24258 111.962 8.38719 112.458 8.66166H114.55C115.046 8.38719 115.604 8.24258 116.171 8.24258H120.615C121.539 8.24258 122.289 8.99221 122.289 9.91595V79.3535C122.289 80.2772 121.539 81.0268 120.615 81.0268H79.2059L76.6973 83.5354V87.4872"
-        stroke="#16212D"
-        strokeWidth="0.589744"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M59.9641 83.5368H15.9813C13.6704 83.5368 11.7993 81.6657 11.7993 79.3578V9.91435C11.7993 7.60646 13.6734 5.73535 15.9813 5.73535H59.9641"
-        stroke="#16212D"
-        strokeWidth="0.589744"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M76.6943 83.5368H120.615C122.926 83.5368 124.797 81.6657 124.797 79.3578V9.91435C124.797 7.60646 122.923 5.73535 120.615 5.73535H76.6943"
-        stroke="#16212D"
-        strokeWidth="0.589744"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M203.021 48.4008C205.1 48.4008 206.787 46.7148 206.787 44.635C206.787 42.5552 205.1 40.8691 203.021 40.8691C200.941 40.8691 199.255 42.5552 199.255 44.635C199.255 46.7148 200.941 48.4008 203.021 48.4008Z"
-        stroke="#16212D"
-        strokeWidth="0.589744"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M203.02 46.6179C204.115 46.6179 205.003 45.7299 205.003 44.6346C205.003 43.5393 204.115 42.6514 203.02 42.6514C201.925 42.6514 201.037 43.5393 201.037 44.6346C201.037 45.7299 201.925 46.6179 203.02 46.6179Z"
-        stroke="#16212D"
-        strokeWidth="0.589744"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M189.433 1.77941V0.294922H3.4942C1.64671 0.294922 0.147461 1.79417 0.147461 3.64166V85.628C0.147461 87.4755 1.64671 88.9748 3.4942 88.9748H189.433V87.4903"
-        stroke="#16212D"
-        strokeWidth="0.589744"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M198.837 87.4873V88.9718H270.364C272.211 88.9718 273.711 87.4726 273.711 85.6251V3.64166C273.711 1.79417 272.211 0.294922 270.364 0.294922H198.837V1.77941"
-        stroke="#16212D"
-        strokeWidth="0.589744"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M0.147461 41.0371H4.35007C6.33628 41.0371 7.94767 42.6485 7.94767 44.6347C7.94767 46.6209 6.33628 48.2323 4.35007 48.2323H0.147461"
-        stroke="#16212D"
-        strokeWidth="0.589744"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <path
-        d="M4.32898 46.6208C5.42593 46.6208 6.31519 45.7316 6.31519 44.6346C6.31519 43.5377 5.42593 42.6484 4.32898 42.6484C3.23203 42.6484 2.34277 43.5377 2.34277 44.6346C2.34277 45.7316 3.23203 46.6208 4.32898 46.6208Z"
-        stroke="#16212D"
-        strokeWidth="0.589744"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
+      <g clipPath="url(#clip0_10791_36120)">
+        <rect
+          width="80"
+          height="247"
+          transform="matrix(0 1 -1 0 247 0)"
+          fill="#E9E9E9"
+        />
+        <path
+          d="M0.197266 44.8901L0.197266 35.1152"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M3.94771 41.791L4.63943 41.6586L5.22474 41.2612L5.59721 40.6784L5.75684 40.0162L5.59721 39.3274L5.22474 38.7446L4.63943 38.3473L3.94771 38.2148L3.28258 38.3473L2.69727 38.7446L2.2982 39.3274L2.16517 40.0162L2.2982 40.6784L2.69727 41.2612L3.28258 41.6586L3.94771 41.791Z"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M183.079 41.791L183.744 41.6586L184.329 41.2612L184.728 40.6784L184.861 40.0162L184.728 39.3274L184.329 38.7446L183.744 38.3473L183.079 38.2148L182.387 38.3473L181.802 38.7446L181.403 39.3274L181.27 40.0162L181.403 40.6784L181.802 41.2612L182.387 41.6586L183.079 41.791Z"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M56.6528 79.8047H57.7968H59.0472H60.3243H61.6545H62.9582H64.2618H65.4856H66.6562"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M56.6528 0.201172L57.7968 0.201172L59.0472 0.201172L60.3243 0.201172L61.6545 0.201172L62.9582 0.201172L64.2618 0.201172L65.4856 0.201172L66.6562 0.201172"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M143.092 1.71111V0.201172"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M143.092 78.2949V79.8049"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M17.7298 69.4719L18.2886 69.3659L18.794 69.0481L19.1133 68.5447L19.2197 67.9884L19.1133 67.4057L18.794 66.9024L18.2886 66.5845L17.7298 66.4785L17.1445 66.5845L16.6656 66.9024L16.3198 67.4057L16.2134 67.9884L16.3198 68.5447L16.6656 69.0481L17.1445 69.3659L17.7298 69.4719Z"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M105.579 13.5266L106.165 13.4206L106.643 13.1027L106.963 12.5994L107.096 12.0431L106.963 11.4604L106.643 10.9835L106.165 10.6392L105.579 10.5332L104.994 10.6392L104.515 10.9835L104.196 11.4604L104.063 12.0431L104.196 12.5994L104.515 13.1027L104.994 13.4206L105.579 13.5266Z"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M105.579 69.4719L106.165 69.3659L106.643 69.0481L106.963 68.5447L107.096 67.9884L106.963 67.4057L106.643 66.9024L106.165 66.5845L105.579 66.4785L104.994 66.5845L104.515 66.9024L104.196 67.4057L104.063 67.9884L104.196 68.5447L104.515 69.0481L104.994 69.3659L105.579 69.4719Z"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M17.7298 13.5266L18.2886 13.4206L18.794 13.1027L19.1133 12.5994L19.2197 12.0431L19.1133 11.4604L18.794 10.9835L18.2886 10.6392L17.7298 10.5332L17.1445 10.6392L16.6656 10.9835L16.3198 11.4604L16.2134 12.0431L16.3198 12.5994L16.6656 13.1027L17.1445 13.4206L17.7298 13.5266Z"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M143.092 0.201172L66.6559 0.201172"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M66.6562 2.7972V0.201172"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M66.6562 2.79688L56.6528 2.79688"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M56.6523 2.7972V0.201172"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M56.6523 0.201172L3.20309 0.201172"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M3.20312 0.201172L2.61781 0.254152L2.05912 0.439582L1.52702 0.704483L1.07473 1.10183L0.702257 1.55217L0.409609 2.05548L0.24997 2.63826L0.196773 3.22104"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M0.197266 3.2207L0.197266 35.1147"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M0.196655 35.1152L0.223253 35.4066L0.303065 35.698L0.436089 35.9629L0.622327 36.2013L0.861778 36.3868L1.12783 36.5192L1.39388 36.5987L1.68652 36.6252"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M3.94824 36.625H1.68682"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M3.94832 43.38L4.90609 43.2475L5.78407 42.8502L6.529 42.2144L7.03448 41.4197L7.32715 40.4926V39.5389L7.03448 38.6118L6.529 37.7906L5.78407 37.1548L4.90609 36.7575L3.94832 36.625"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M1.68682 43.3809H3.94824"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M1.68652 43.3809L1.39388 43.4074L1.12783 43.5133L0.861778 43.6458L0.622327 43.8312L0.436089 44.0431L0.303065 44.308L0.223253 44.5994L0.196655 44.8908"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M0.197266 44.8906L0.197266 76.8111"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M0.196773 76.8105L0.24997 77.3933L0.409609 77.9496L0.702257 78.4794L1.07473 78.9298L1.52702 79.3006L2.05912 79.5655L2.61781 79.7509L3.20312 79.8039"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M3.20309 79.8047H56.6523"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M56.6523 77.207V79.8031"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M66.6562 77.207H56.6528"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M66.6562 77.207V79.8031"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M66.6559 79.8047H143.092"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M150.647 0.201172V1.71111"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M150.647 79.8049V78.2949"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M243.765 0.201172L244.377 0.254152L244.936 0.439582L245.441 0.704483L245.92 1.10183L246.292 1.55217L246.558 2.05548L246.745 2.63826L246.798 3.22104"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M243.765 0.201172L150.647 0.201172"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M150.647 79.8047H243.765"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M246.798 76.8105L246.745 77.3933L246.558 77.9496L246.292 78.4794L245.92 78.9298L245.441 79.3006L244.936 79.5655L244.377 79.7509L243.765 79.8039"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M246.798 3.2207V76.8101"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M12.8076 9.79102L12.8076 70.2413"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M12.8073 70.2402L12.8605 70.7435L13.0201 71.2469L13.2596 71.6972L13.5788 72.0945L13.9779 72.4124L14.4568 72.6508L14.9357 72.8098L15.4678 72.8627"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M15.4678 7.16797L14.9357 7.19446L14.4568 7.3534L13.9779 7.59181L13.5788 7.93618L13.2596 8.33353L13.0201 8.78386L12.8605 9.26068L12.8073 9.79049"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M15.4682 72.8633H50.7197"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M50.7197 7.16797L15.4682 7.16797"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M53.7256 77.9766H51.4642"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M53.7256 75.8574V77.9766"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M50.7192 72.8633L51.3045 72.9163L51.8632 73.0752L52.3953 73.3666L52.8476 73.7375L53.2201 74.1878L53.5127 74.7176L53.6724 75.2739L53.7256 75.8567"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M51.4648 2.05469L14.1382 2.05469"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M14.1377 2.05469L12.8873 2.16065L11.69 2.53151L10.5726 3.11429L9.61486 3.90899L8.81671 4.88912L8.2048 5.97522L7.85894 7.19376L7.72592 8.43879"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M7.72656 8.43945L7.72656 71.5918"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M7.72592 71.5918L7.85894 72.8368L8.2048 74.0289L8.81671 75.115L9.61486 76.0951L10.5726 76.8898L11.69 77.4726L12.8873 77.8434L14.1377 77.9759"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M14.1382 77.9766H51.4648"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M51.4648 77.9766V75.8574"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M51.4648 75.857V75.7245L51.4116 75.5656L51.3318 75.4331L51.252 75.3272L51.1456 75.2477L51.0126 75.1682L50.8529 75.1152H50.7199"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M50.7197 75.1152H15.4682"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M15.4678 75.1144L14.51 75.0084L13.5788 74.7435L12.7275 74.2932L11.9825 73.6839L11.3706 72.9422L10.9183 72.0945L10.6523 71.1939L10.5459 70.2402"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M10.5459 70.2413L10.5459 9.79102"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M10.5459 9.79129L10.6523 8.83765L10.9183 7.91049L11.3706 7.06281L11.9825 6.32109L12.7275 5.73831L13.5788 5.26149L14.51 4.99659L15.4678 4.89062"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M15.4682 4.89063L50.7197 4.89062"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M51.4642 2.05469H53.7256"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M51.4648 4.1474V2.05469"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M53.7256 2.05469V4.1474"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M50.7199 4.89016H50.8529L51.0126 4.83718L51.1456 4.7842L51.252 4.67824L51.3318 4.57228L51.4116 4.43983L51.4648 4.30738V4.14844"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M53.7256 4.14844L53.6724 4.73122L53.5127 5.314L53.2201 5.81731L52.8476 6.26764L52.3953 6.6385L51.8632 6.92989L51.3045 7.08883L50.7192 7.1683"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M71.8174 77.9766H69.556"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M69.5557 77.9766V75.8574"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M69.5559 75.8567L69.6357 75.2739L69.7954 74.7176L70.088 74.1878L70.4605 73.7375L70.9128 73.3666L71.4182 73.0752L72.0036 72.9163L72.5889 72.8633"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M69.556 2.05469H71.8174"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M69.5557 4.1474V2.05469"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M72.5889 7.1683L72.0036 7.08883L71.4182 6.92989L70.9128 6.6385L70.4605 6.26764L70.088 5.81731L69.7954 5.314L69.6357 4.73122L69.5559 4.14844"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M72.5893 72.8633H107.841"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M107.841 7.16797L72.5893 7.16797"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M107.841 72.8627L108.346 72.8098L108.852 72.6508L109.304 72.4124L109.703 72.0945L110.022 71.6972L110.288 71.2469L110.421 70.7435L110.475 70.2402"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M110.475 70.2413V9.79102"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M110.475 9.79049L110.421 9.26068L110.288 8.78386L110.022 8.33353L109.703 7.93618L109.304 7.59181L108.852 7.3534L108.346 7.19446L107.841 7.16797"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M72.5889 75.1152H72.4292L72.2962 75.1682L72.1632 75.2477L72.0568 75.3272L71.9503 75.4331L71.8971 75.5656L71.8439 75.7245L71.8173 75.857"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M71.8174 75.8574V77.9766"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M71.8169 77.9766H133.514"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M133.514 77.9766H133.727H133.939L134.126 78.0031H134.339L134.525 78.0295L134.738 78.056L134.95 78.109L135.137 78.1355"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M135.137 1.87109L134.95 1.92407L134.738 1.95056L134.525 1.97705L134.339 2.00354L134.126 2.03003H133.939L133.727 2.05652H133.514"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M133.514 2.05469L71.8169 2.05469"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M71.8174 2.05469V4.1474"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M71.8173 4.14844L71.8439 4.30738L71.8971 4.43983L71.9503 4.57228L72.0568 4.67824L72.1632 4.7842L72.2962 4.83718L72.4292 4.89016H72.5889"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M72.5893 4.89063L107.841 4.89062"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M107.84 4.89062L108.798 4.99659L109.729 5.26149L110.554 5.73831L111.299 6.32109L111.911 7.06281L112.363 7.91049L112.656 8.83765L112.735 9.79129"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M112.735 9.79102V70.2413"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M112.735 70.2402L112.656 71.1939L112.363 72.0945L111.911 72.9422L111.299 73.6839L110.554 74.2932L109.729 74.7435L108.798 75.0084L107.84 75.1144"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M107.841 75.1152H72.5893"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M129.523 71.1947V8.81055"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M136.653 78.2946L135.27 78.1622L133.94 77.7648L132.689 77.1026L131.625 76.2284L130.72 75.1423L130.055 73.9238L129.656 72.5728L129.523 71.1953"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M129.523 8.81027L129.656 7.43279L130.055 6.10829L130.72 4.86326L131.625 3.80365L132.689 2.90299L133.94 2.24074L135.27 1.84339L136.653 1.71094"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M230.596 78.2949H136.654"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M136.654 1.71094L230.596 1.71094"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M237.752 71.1953L237.619 72.5728L237.193 73.9238L236.528 75.1423L235.65 76.2284L234.559 77.1026L233.336 77.7648L232.005 78.1622L230.595 78.2946"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M230.595 76.8112L231.713 76.7052L232.75 76.3874L233.734 75.8576L234.586 75.1688L235.278 74.3211L235.81 73.341L236.129 72.2814L236.235 71.1953"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M230.596 3.2207L136.654 3.2207"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M136.653 3.2207L135.563 3.32666L134.498 3.64454L133.541 4.14786L132.689 4.86309L131.971 5.71077L131.465 6.66441L131.146 7.72401L131.04 8.81011"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M131.04 8.81055V71.1947"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M131.04 71.1953L131.146 72.2814L131.465 73.341L131.971 74.3211L132.689 75.1688L133.541 75.8576L134.498 76.3874L135.563 76.7052L136.653 76.8112"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M136.654 76.8105H230.596"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M183.079 43.38L184.011 43.2475L184.915 42.8502L185.633 42.2144L186.166 41.4197L186.432 40.4926V39.5389L186.166 38.6118L185.633 37.7906L184.915 37.1548L184.011 36.7575L183.079 36.625L182.122 36.7575L181.244 37.1548L180.499 37.7906L179.993 38.6118L179.701 39.5389V40.4926L179.993 41.4197L180.499 42.2144L181.244 42.8502L182.122 43.2475L183.079 43.38Z"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M236.235 8.81011L236.129 7.72401L235.81 6.66441L235.278 5.71077L234.586 4.86309L233.734 4.14786L232.75 3.64454L231.713 3.32666L230.595 3.2207"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M230.595 1.71094L232.005 1.84339L233.336 2.24074L234.559 2.90299L235.65 3.80365L236.528 4.86326L237.193 6.10829L237.619 7.43279L237.752 8.81027"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M237.752 8.81055V71.1947"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M236.235 71.1947V8.81055"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M104.328 11.4323L104.195 11.9621L104.275 12.4919L104.541 12.9422L104.993 13.2866L105.499 13.419L106.031 13.3396L106.51 13.0482L106.829 12.6243L106.962 12.0945L106.882 11.5647L106.616 11.1144L106.164 10.7965L105.658 10.6641L105.126 10.7435L104.647 11.0084L104.328 11.4323Z"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M66.6613 79.798L143.097 79.798V78.288H150.653V79.798H243.765L244.377 79.745L244.936 79.5596L245.441 79.2947L245.92 78.9238L246.292 78.4735L246.558 77.9437L246.745 77.3874L246.798 76.8046V3.21518L246.745 2.6324L246.558 2.04962L246.292 1.54631L245.92 1.09597L245.441 0.698624L244.936 0.433723L244.377 0.248293L243.765 0.195313L150.648 0.195313V1.70525L143.092 1.70525V0.200611L66.656 0.200611M66.6613 0.200611L56.6579 0.200611L3.2086 0.200611L2.91595 0.227101L2.6233 0.253591L2.3466 0.343657L2.06459 0.439021L1.53249 0.703922L1.0802 1.10127L0.707745 1.5516L0.415081 2.05492L0.335269 2.34631L0.255458 2.6377L0.228859 2.92909L0.202245 3.22048V76.8099L0.228859 77.1013L0.255458 77.3927L0.415081 77.949L0.707745 78.4788L0.893982 78.7066L1.0802 78.9344L1.53249 79.3053L2.06459 79.5702L2.6233 79.7556L3.2086 79.8086H56.6579H66.6613M135.142 78.1185L135.137 78.1291H135.142V78.1185ZM135.142 78.1185L135.174 78.1291"
+          stroke="#16212D"
+          strokeWidth="0.5"
+          strokeMiterlimit="10"
+        />
+      </g>
+      <defs>
+        <clipPath id="clip0_10791_36120">
+          <rect
+            width="80"
+            height="247"
+            fill="white"
+            transform="matrix(0 1 -1 0 247 0)"
+          />
+        </clipPath>
+      </defs>
     </svg>
   )
 }


### PR DESCRIPTION
# Overview

Update SVG for vacuum module after receiving final rendering from Design. Due to the fact that the module definition does not capture the footprint of the module (only the main vacuum (left) portion of the module), we need to explicitly modify the SVG for accurate rendering on the deck.

## Test Plan and Hands on Testing

#### PD
- import or create a vacuum protocol
- navigate to starting deck view
- hover over and/or load labware on the 2 addressable areas of the vacuum module, and verify that the areas overlay correctly on the updated module SVG  

<img width="814" height="653" alt="Screenshot 2026-06-09 at 1 51 47 PM" src="https://github.com/user-attachments/assets/3720aeb7-8d08-445d-b1a7-469ea74902b9" />

#### App

- specifically in protocol run screen for a vacuum module protocol, verify that the module info in deck hardware map and labware in labware + liquids map aligns with updated module SVG  

<img width="665" height="520" alt="Screenshot 2026-06-09 at 1 43 13 PM" src="https://github.com/user-attachments/assets/d3853dd3-a69c-44e0-bc17-5dd366cc1a42" />
  
<img width="672" height="547" alt="Screenshot 2026-06-09 at 1 34 31 PM" src="https://github.com/user-attachments/assets/e7c3843f-b764-4249-a5da-8859f7578d0d" />

## Changelog

update vacuum module hardware sim svg component

## Review requests

see test plan

## Risk assessment

low