### PR TITLE
fix(api): remove debugging variables from VacuumModule hardware controller class

### DIFF
--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -547,8 +547,6 @@ class VacuumModuleReader(Reader):
 
     def __init__(self, driver: AbstractVacuumModuleDriver) -> None:
         self.error: Optional[str] = None
-        self.pressure_calls = 0
-        self.power_calls = 0
         self.vacuum_state: VacuumState = VacuumState(
             target_gauge_pressure=0,
             current_gauge_pressure=0,
@@ -664,10 +662,10 @@ class VacuumModuleReader(Reader):
     async def update_pump_state(self) -> None:
         """Get latest pump state from driver and save updated values."""
         self.pump_state = await self._driver.get_pump_state()
+
         if self.target_power is not None:
             self._power_readings.insert(0, self.pump_state.current_pwm)
             self._power_readings.pop()
-        self.power_calls += 1
 
     def set_operation_mode(self, mode_type: VacuumModuleOperationMode) -> None:
         self.operation_mode = mode_type

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -530,14 +530,14 @@ class VacuumModule(mod_abc.AbstractModule):
             while not self._reader.power_target_reached():
                 await self._poller.wait_next_poll()
             # clear target after it's reached
-            self._reader.set_target_power(None)
+            self._reader.reset_power_target()
         elif self._reader.operation_mode == VacuumModuleOperationMode.PRESSURE:
             if not self._reader.vacuum_state.vacuum_enabled:
                 return
             while not self._reader.pressure_target_reached():
                 await self._poller.wait_next_poll()
             # clear target after it's reached
-            self._reader.set_target_pressure(None)
+            self._reader.reset_pressure_target()
         else:
             raise ValueError("Vacuum module target invalid.")
 
@@ -607,6 +607,14 @@ class VacuumModuleReader(Reader):
 
     def set_target_power(self, duty_cycle: Optional[float]) -> None:
         self.target_power = duty_cycle
+
+    def reset_pressure_target(self) -> None:
+        self.set_target_pressure(None)
+        self._pressure_readings = [None for p in self._pressure_readings]
+
+    def reset_power_target(self) -> None:
+        self.set_target_power(None)
+        self._power_readings = [None for p in self._power_readings]
 
     async def read(self) -> None:
         await self.update_vacuum_state()


### PR DESCRIPTION
## Overview
Accidentally merged a couple class member variables I didn’t mean to. It won’t break anything or change behavior, these just don’t serve any purpose outside of writing unit tests. My bad!

Also, clear the `pressure_readings` and `power_readings` buffers when their respective target value is reached.