### PR TITLE
fix(api): handle numpy float64 pyro serialization for non builtin dict wrappers

### DIFF
--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -283,7 +283,7 @@ class OpentronsPyroSerializer:
             cls._enum_class_name_to_type,
             cls._typed_dict_class_name_to_type,
             # Sometimes the hardware API sends floats in the form of numpy float 64s. If they happen
-            # to be in a non-builtin dict wrapper, they won't get handled but the normal pyro serialization
+            # to be in a non-builtin dict wrapper, they won't get handled by the normal pyro serialization
             # so we need to handle it here by adding it to the list of registries.
             {"numpy.float64": numpy.float64},
         ]

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -8,6 +8,7 @@ from contextlib import contextmanager
 from types import ModuleType
 from typing import Any, Callable, Iterator
 
+import numpy
 import serpent
 from pydantic import BaseModel
 from Pyro5 import api as pyro
@@ -268,19 +269,23 @@ class OpentronsPyroSerializer:
         """Registers the specialty handler for dicts with non builtin keys using NonBuiltinKeyDictWrapper."""
         class_name = register_type_to_serpent(
             NonBuiltinKeyDictWrapper,
-            cls._unhashable_dict_wrapper_dict_to_class,
+            cls._non_builtin_key_dict_wrapper_dict_to_class,
             cls._pydantic_class_to_dict,
         )
         cls._pydantic_class_name_to_model[class_name] = NonBuiltinKeyDictWrapper
 
     @classmethod
-    def _unhashable_dict_wrapper_dict_to_class(  # noqa: C901
+    def _non_builtin_key_dict_wrapper_dict_to_class(  # noqa: C901
         cls, classname: str, d: dict[str, Any]
     ) -> dict[Any, Any]:
         registries: list[dict[str, Any]] = [
             cls._pydantic_class_name_to_model,
             cls._enum_class_name_to_type,
             cls._typed_dict_class_name_to_type,
+            # Sometimes the hardware API sends floats in the form of numpy float 64s. If they happen
+            # to be in a non-builtin dict wrapper, they won't get handled but the normal pyro serialization
+            # so we need to handle it here by adding it to the list of registries.
+            {"numpy.float64": numpy.float64},
         ]
         # Identify the types for the key and values, if available. Check for builtin types first.
         key_type = (


### PR DESCRIPTION
# Overview

Fixes RQA-5581

The 96-channel was experiencing issues with its attach/detach flow, erroring out on a serialization error. This was due to `move_axes` using a dictionary that has non-builtin keys (`Axis`) and the 96-channel having numpy float64s instead of builtin python floats. Because of the non-builtin keys dictionary wrapper (updated and explained in #21325) going through the non-standard pyro serialization, any non-builtin key or value had to be handled by us. Since we didn't run into or expect the numpy float64 here, and that isn't registered through the `OpentronsPyroSerializer`, we weren't handling it in this specific case.

The solution was to add the numpy type to the list of registries of types we expect in the `NonBuiltinKeyDictWrapper`. Then we can correctly serialize it and the 96-channel attach and detach flow work as expected.

## Test Plan and Hands on Testing

Tested on an actual hardware to assure attach flow works as expected.

## Changelog

- Handle `numpy.float64` when deserializing `NonBuiltinKeyDictWrapper`

## Review requests


## Risk assessment

Low, small surface area bug-fix.