### PR TITLE
chore: add pnpm to engines to have some versions range

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "packageManager": "pnpm@10.32.1",
   "engines": {
-    "node": ">=22.22.0"
+    "node": ">=22.22.0",
+    "pnpm": ">=10.32.1"
   },
   "resolutions": {
     "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.cd77847.0"


### PR DESCRIPTION


# Overview
add pnpm to engine  to have some versions range

the latest version is v11.5.2

closes AUTH-3011

## Test Plan and Hands on Testing
no needed

## Changelog
- add pnpm to engine in package.json

## Review requests


## Risk assessment
low
