### PR TITLE
refactor(components): move argType from root to secondary button

### DIFF
--- a/components/src/atoms/buttons/buttons.stories.tsx
+++ b/components/src/atoms/buttons/buttons.stories.tsx
@@ -1,6 +1,5 @@
 import { ICON_DATA_BY_NAME } from '../../icons/icon-data'
-import { Flex, STYLE_PROPS } from '../../primitives'
-import { DIRECTION_ROW } from '../../styles'
+import { STYLE_PROPS } from '../../primitives'
 import { SPACING } from '../../ui-style-constants'
 import { AlertPrimaryButton as AlertPrimaryButtonComponent } from './AlertPrimaryButton'
 import { AltPrimaryButton as AltPrimaryButtonComponent } from './AltPrimaryButton'
@@ -9,6 +8,7 @@ import { PrimaryButton as PrimaryButtonComponent } from './PrimaryButton'
 import { SecondaryButton as SecondaryButtonComponent } from './SecondaryButton'
 
 import type { Meta, StoryObj } from '@storybook/react'
+import type { CSSProperties } from 'react'
 
 const meta: Meta = {
   title: 'Helix/Atoms/Buttons',
@@ -29,35 +29,44 @@ const meta: Meta = {
         type: 'boolean',
       },
     },
-    isDangerous: {
-      control: {
-        type: 'boolean',
-      },
-    },
   },
 }
 
 export default meta
+
+const BUTTON_CONTAINER_STYLE: CSSProperties = {
+  padding: SPACING.spacing16,
+}
 
 export const PrimaryButton: StoryObj<typeof PrimaryButtonComponent> = {
   args: {
     children: 'primary button',
   },
   render: args => (
-    <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing16}>
+    <div style={BUTTON_CONTAINER_STYLE}>
       <PrimaryButtonComponent {...args} />
-    </Flex>
+    </div>
   ),
 }
 
 export const SecondaryButton: StoryObj<typeof SecondaryButtonComponent> = {
   args: {
     children: 'secondary button',
+    isDangerous: false,
+  },
+  argTypes: {
+    isDangerous: {
+      control: {
+        type: 'boolean',
+      },
+      description:
+        'Styles the button as a dangerous action with non-reversible side effects.',
+    },
   },
   render: args => (
-    <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing16}>
+    <div style={BUTTON_CONTAINER_STYLE}>
       <SecondaryButtonComponent {...args} />
-    </Flex>
+    </div>
   ),
 }
 
@@ -67,9 +76,9 @@ export const AlertPrimaryButton: StoryObj<typeof AlertPrimaryButtonComponent> =
       children: 'alert tertiary button',
     },
     render: args => (
-      <Flex>
+      <div style={BUTTON_CONTAINER_STYLE}>
         <AlertPrimaryButtonComponent {...args} />
-      </Flex>
+      </div>
     ),
   }
 
@@ -78,9 +87,9 @@ export const AltPrimaryButton: StoryObj<typeof AltPrimaryButtonComponent> = {
     children: 'alt primary button',
   },
   render: args => (
-    <Flex>
+    <div style={BUTTON_CONTAINER_STYLE}>
       <AltPrimaryButtonComponent {...args} />
-    </Flex>
+    </div>
   ),
 }
 
@@ -106,8 +115,8 @@ export const BasicButton: StoryObj<typeof BasicButtonComponent> = {
     },
   },
   render: args => (
-    <Flex flexDirection={DIRECTION_ROW} gridGap={SPACING.spacing16}>
+    <div style={BUTTON_CONTAINER_STYLE}>
       <BasicButtonComponent {...args} />
-    </Flex>
+    </div>
   ),
 }


### PR DESCRIPTION


# Overview
`isDangerous` is for secondary button and others don't need that.

closes AUTH-3012


## Test Plan and Hands on Testing
- make -C components dev
isDangerous is rendered for secondary button


## Changelog
- remove argType from the root and move it to secondary button

## Review requests


## Risk assessment
low
