### PR TITLE
fix(system-server,app,api-client): reenable USB registration

### DIFF
--- a/api-client/src/system/createAuthorization.ts
+++ b/api-client/src/system/createAuthorization.ts
@@ -1,4 +1,4 @@
-import { POST, request } from '../request'
+import { createAxiosConfig, DEFAULT_HEADERS, POST, request } from '../request'
 
 import type { ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
@@ -8,8 +8,18 @@ export function createAuthorization(
   config: HostConfig,
   registrationToken: RegistrationToken
 ): ResponsePromise<AuthorizationToken> {
-  return request<AuthorizationToken>(POST, '/system/authorize', null, {
-    ...config,
-    ...registrationToken,
-  })
+  return request<AuthorizationToken>(
+    POST,
+    '/system/authorize',
+    null,
+    {
+      ...config,
+    },
+    createAxiosConfig({
+      headers: {
+        authenticationBearer: registrationToken.token,
+        ...DEFAULT_HEADERS,
+      },
+    })
+  )
 }

--- a/app/src/pages/ODD/ConnectViaUSB/index.tsx
+++ b/app/src/pages/ODD/ConnectViaUSB/index.tsx
@@ -28,8 +28,9 @@ export function ConnectViaUSB(): JSX.Element {
   // TODO(bh, 2023-5-31): active connections from /system/connected isn't exactly the right way to monitor for a usb connection -
   // the system-server tracks active connections by authorization token, which is valid for 2 hours
   // another option is to report an active usb connection by monitoring usb port traffic (discovery-client polls health from the desktop app)
-  const activeConnections = useConnectionsQuery().data?.connections ?? []
-  const isConnected = activeConnections.some(
+
+  const connectionsQuery = useConnectionsQuery({ refetchInterval: 1000 })
+  const isConnected = (connectionsQuery.data?.connections ?? []).some(
     connection => connection.agent === 'com.opentrons.app.usb'
   )
 

--- a/system-server/system_server/service/check_jwt_headers.py
+++ b/system-server/system_server/service/check_jwt_headers.py
@@ -37,7 +37,10 @@ async def check_registration_token_header(
     request.state.authentication_bearer = authenticationBearer
 
 
-async def get_registration_token_header(request: Request) -> str:
+async def get_registration_token_header(
+    request: Request,
+    _check_token: Annotated[None, Depends(check_registration_token_header)],
+) -> str:
     """Gets the registration token from a request."""
     assert isinstance(request.state.authentication_bearer, str), (
         "No authentication_bearer in request state; is endpoint properly configured?"
@@ -70,7 +73,10 @@ async def check_authorization_token_header(
     request.state.authorization_authentication_bearer = authenticationBearer
 
 
-async def get_authorization_token_header(request: Request) -> str:
+async def get_authorization_token_header(
+    request: Request,
+    _check_token: Annotated[None, Depends(check_authorization_token_header)],
+) -> str:
     """Gets the authorization token from a request."""
     assert isinstance(request.state.authorization_authentication_bearer, str), (
         "No authorization_authentication_bearer in request state; is endpoint properly configured?"


### PR DESCRIPTION
# Overview

During the Flex first run experience, you can choose to connect to the Flex via USB rather than connecting the Flex to a network. If you do, you end up at a screen that won't let you pass until you connect to the Flex with a desktop app. This is executed by having the app use a legacy authorization system from before we actually added authn and authz that worked somewhat differently to the way the current authn and authz system works. If something in that process is broken, you can't get past the screen.

As in every good fable, three issues were preventing the Flex from noticing that an app was connected to it via USB in the welcome flow: one new, one middle-aged, and one old.

The new issue is that when we enabled real account mechanisms, they used OAuth2 and sent their auth token via the standard HTTP basic authorization `Authorization: Bearer {token}` header. The legacy "auth" system used a header called `authenticationBearer`, which to quote Hitchhiker's Guide to the Galaxy is something almost but not quite unlike tea. Specifying the legacy auth token through the `request()` function `token:` argument would put it in `Authorization: Bearer`, which the legacy `/system/authorize` endpoint wouldn't accept, so apps weren't registering themselves.

The middle-aged issue is that fastapi `Dependency`s do not have a guaranteed order of execution unless they mark each other as dependencies. The legacy auth system has a `check_{authorization,authentication}_token` `Dependency` that stuffs the token in the request state, and a `get_{authorization,authentication}_token` `Dependency` that gets the token from the request state, and if the token isn't there it 500s. So sometimes you'd happen to get the check dependency running before the get dependency, and everything would be fine; sometimes the check dependency wouldn't run first, and you'd 500. Marking the get dependency as dependent on the check dependency fixes this. Probably this problem became more serious after the system upgrades in 9.0.

The old issue is that the ODD page for waiting to connect an app via USB just, like, wasn't refetching? At all? ?????

## Test Plan and Hands on Testing

- Push the system server and the ODD to a robot
- `rm /data/ODD/config.json` to force ODD FRE
- go through the FRE to the connect via USB page
- Look at the robot from the desktop app while connected to the robot via USB
- You get a big green checkmark!

## Changelog

- Specify the old `authenticationBearer` header through axios config for the legacy auth routes
- Fix a dependency-ordering issue in system server in the legacy auth routes
- Add refetching to the `ConnectViaUSB` page

## Review requests

- Please submit your entry for the moral of this fable

## Risk assessment

Low, this wasn't working before at all and it doesn't change much.

Closes RQA-5462
