### PR TITLE
fix(discovery-client,app): Delete `displayName` property; fix OT-2 vs. Flex LPC confusion

### DIFF
--- a/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotSlideout/index.tsx
@@ -221,15 +221,10 @@ export function ChooseRobotSlideout(
         return robots
       } else {
         return robots.filter(robot => {
-          const displayName = robot.displayName.toLowerCase()
           const name = robot.name.toLowerCase()
           const model = robot.robotModel.toLowerCase()
 
-          return (
-            displayName.includes(query) ||
-            name.includes(query) ||
-            model.includes(query)
-          )
+          return name.includes(query) || model.includes(query)
         })
       }
     },

--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -70,8 +70,7 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
     setSelectedRobot,
   } = props
   const navigate = useNavigate()
-  const isFlex =
-    useRobotType(selectedRobot?.displayName ?? '') === FLEX_ROBOT_TYPE
+  const isFlex = useRobotType(selectedRobot?.name ?? '') === FLEX_ROBOT_TYPE
   const [shouldApplyOffsets, setShouldApplyOffsets] = useState<boolean>(true)
   const { protocolKey, srcFileNames, srcFiles, mostRecentAnalysis } =
     storedProtocolData

--- a/app/src/pages/Desktop/Devices/DevicesLanding/index.tsx
+++ b/app/src/pages/Desktop/Devices/DevicesLanding/index.tsx
@@ -77,15 +77,10 @@ export function DevicesLanding(): JSX.Element {
         return robots
       } else {
         return robots.filter(robot => {
-          const displayName = robot.displayName.toLowerCase()
           const name = robot.name.toLowerCase()
           const model = robot.robotModel.toLowerCase()
 
-          return (
-            displayName.includes(query) ||
-            name.includes(query) ||
-            model.includes(query)
-          )
+          return name.includes(query) || model.includes(query)
         })
       }
     },

--- a/app/src/redux/discovery/__fixtures__/index.ts
+++ b/app/src/redux/discovery/__fixtures__/index.ts
@@ -60,10 +60,7 @@ export const mockDiscoveryClientRobotWithHealthSerial = {
 }
 
 export const mockBaseRobot: BaseRobot = {
-  // NOTE(mc, 2020-11-10): it's important that name and displayName are
-  // different in this fixture to ensure proper test coverage
   name: 'opentrons-robot-name',
-  displayName: 'robot-name',
   seen: false,
   local: null,
   health: null,

--- a/app/src/redux/discovery/__tests__/selectors.test.ts
+++ b/app/src/redux/discovery/__tests__/selectors.test.ts
@@ -134,7 +134,6 @@ const MOCK_STATE: State = {
 // flexConnectable is connectable because health is defined and healthStatus is "ok"
 const EXPECTED_FLEX_CONNECTABLE = {
   name: 'flexConnectable',
-  displayName: 'flexConnectable',
   status: CONNECTABLE,
   local: false,
   seen: true,
@@ -150,7 +149,6 @@ const EXPECTED_FLEX_CONNECTABLE = {
 // flexReachableError is reachable because healthStatus is "notOk" (responded with error)
 const EXPECTED_FLEX_REACHABLE_ERROR = {
   name: 'flexReachableError',
-  displayName: 'flexReachableError',
   status: REACHABLE,
   local: false,
   seen: true,
@@ -166,7 +164,6 @@ const EXPECTED_FLEX_REACHABLE_ERROR = {
 // flexReachableSeen is reachable because it was recently seen, even though IP is unreachable
 const EXPECTED_FLEX_REACHABLE_SEEN = {
   name: 'flexReachableSeen',
-  displayName: 'flexReachableSeen',
   status: REACHABLE,
   local: false,
   seen: true,
@@ -182,7 +179,6 @@ const EXPECTED_FLEX_REACHABLE_SEEN = {
 // flexUnreachable is unreachable because IP is unreachable and not seen recently
 const EXPECTED_FLEX_UNREACHABLE = {
   name: 'flexUnreachable',
-  displayName: 'flexUnreachable',
   status: UNREACHABLE,
   local: false,
   seen: false,
@@ -198,7 +194,6 @@ const EXPECTED_FLEX_UNREACHABLE = {
 // flexNoAddress is unreachable because we don't have any IP addresses for it
 const EXPECTED_FLEX_NO_ADDRESS = {
   name: 'flexNoAddress',
-  displayName: 'flexNoAddress',
   status: UNREACHABLE,
   local: null,
   seen: false,
@@ -287,9 +282,7 @@ describe('discovery selectors', () => {
         },
         robot: { connection: { connectedTo: '' } },
       },
-      expected: [
-        expect.objectContaining({ name: 'opentrons-foo', displayName: 'foo' }),
-      ],
+      expected: [expect.objectContaining({ name: 'opentrons-foo' })],
     },
     {
       name: 'handles legacy IPv6 robots by wrapping IP in [] and setting as local',

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -42,8 +42,6 @@ type GetAllRobots = (state: State) => DiscoveredRobot[]
 type GetViewableRobots = (state: State) => ViewableRobot[]
 type GetLocalRobot = (state: State) => DiscoveredRobot | null
 
-const makeDisplayName = (name: string): string => name.replace('opentrons-', '')
-
 const isLocal = (ip: string): boolean => {
   return (
     RE_HOSTNAME_IPV6_LL.test(ip) ||
@@ -109,7 +107,6 @@ export const getDiscoveredRobots: (state: State) => DiscoveredRobot[] =
         const serverHealthStatus = addr?.serverHealthStatus ?? null
         const baseRobot = {
           ...robotState,
-          displayName: makeDisplayName(robotName),
           local: ip !== null ? isLocal(ip) : null,
           seen: addr?.seen === true,
           robotModel: makeRobotModel(

--- a/app/src/redux/discovery/selectors.ts
+++ b/app/src/redux/discovery/selectors.ts
@@ -165,7 +165,7 @@ export const getConnectableRobots: GetConnectableRobots = createSelector(
   robots =>
     orderBy(
       robots.flatMap(r => (r.status === CONNECTABLE ? [r] : [])),
-      [robot => robot.displayName.toLowerCase()],
+      [robot => robot.name.toLowerCase()],
       ['asc']
     )
 )
@@ -175,7 +175,7 @@ export const getReachableRobots: GetReachableRobots = createSelector(
   robots =>
     orderBy(
       robots.flatMap(r => (r.status === REACHABLE ? [r] : [])),
-      [robot => robot.displayName.toLowerCase()],
+      [robot => robot.name.toLowerCase()],
       ['asc']
     )
 )
@@ -185,7 +185,7 @@ export const getUnreachableRobots: GetUnreachableRobots = createSelector(
   robots =>
     orderBy(
       robots.flatMap(r => (r.status === UNREACHABLE ? [r] : [])),
-      [robot => robot.displayName.toLowerCase()],
+      [robot => robot.name.toLowerCase()],
       ['asc']
     )
 )
@@ -197,7 +197,7 @@ export const getAllRobots: GetAllRobots = createSelector(
   (cr: DiscoveredRobot[], rr: DiscoveredRobot[], ur: DiscoveredRobot[]) =>
     orderBy(
       concat<DiscoveredRobot>(cr, rr, ur),
-      [robot => robot.displayName.toLowerCase()],
+      [robot => robot.name.toLowerCase()],
       ['asc']
     )
 )
@@ -208,7 +208,7 @@ export const getViewableRobots: GetViewableRobots = createSelector(
   (cr: ViewableRobot[], rr: ViewableRobot[]) =>
     orderBy(
       concat<ViewableRobot>(cr, rr),
-      [robot => robot.displayName.toLowerCase()],
+      [robot => robot.name.toLowerCase()],
       ['asc']
     )
 )

--- a/app/src/redux/discovery/types.ts
+++ b/app/src/redux/discovery/types.ts
@@ -30,7 +30,6 @@ export interface DiscoveryState {
 }
 
 export interface BaseRobot extends Omit<DiscoveryClientRobot, 'addresses'> {
-  displayName: string // todo(mm, 2026-04-27): What is the difference between this and DiscoveryClientRobot.name?
   local: boolean | null
   seen: boolean
   robotModel: RobotModel

--- a/discovery-client/src/store/types.ts
+++ b/discovery-client/src/store/types.ts
@@ -23,7 +23,7 @@ import type {
  * Health state of a given robot
  */
 export interface RobotState {
-  /** unique name of the robot */
+  /** The human-readable display name of the robot. */
   name: string
   /** latest /health response data from the robot */
   health: HealthResponse | null


### PR DESCRIPTION
## Overview

This makes a small simplification to the way that we deal with robot names in the frontend.

In the course of doing that, this fixes a bug where we would accidentally use OT-2 logic for Labware Position Check if a Flex robot happened to contain the string `opentrons-` in its name.

## Details

Our types for a robot contained two properties: `name` and `displayName`. *Both* of those properties carried what we would colloquially call the "robot display name." For example, if a user has named their robot `"Otie"`, the value of both of those properties would be `"Otie"`.

The sole difference between the two was that, if the name happened to contain the string `opentrons-`, that would be present in `name` but stripped from `displayName`. I haven't looked into the details of why we were doing that, but it was probably from ancient OT-2 history.

In practice, today, almost nothing was using the stripped `displayName`. We were almost always using the full `name`. The few exceptions were:

* Name sorting and filtering. This explains why the local dev server appears in a "random" place in the devices page: `opentrons-dev` was getting sorted as `dev`.
* A thing in Labware Position Check that looked up a robot by its name and then did different things depending on whether it's a Flex or OT-2. This had a bug where the lookup code was expecting `name`, but the calling code was providing `displayName`. The upshot is that robots with `opentrons-` in their name would be misidentified as OT-2s.

This PR deletes `displayName` and changes everything to use the full original `name` instead.

## Test Plan and Hands on Testing

* [x] Smoke-test the devices page.
* [x] Smoke-test the "choose a robot" slideout from the protocols page.

## Review requests

Does this make sense, conceptually?

## Risk assessment

Low. Thankfully, `displayName` wasn't used in very many places.