### PR TITLE
fix(app): handle loading the auth settings query before sending documented mutations

### DIFF
--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -35,7 +35,8 @@ import { OPENTRONS_USB } from '/app/redux/discovery'
 import { useAccessTokenForRobot } from '/app/redux/robot-auth'
 import { appShellUSBRequestor } from '/app/redux/shell/remote'
 
-import { DocumentationRequiredModalContext } from '../local-resources/access-control/DocumentationRequiredModalContext'
+import { DocumentationRequiredContextProvider } from '../local-resources/access-control/DocumentationRequiredModalContext'
+import { InProgressModal } from '../molecules/InProgressModal'
 import { ProtocolVisualization } from '../pages/Desktop/Protocols/ProtocolVisualization'
 import { DesktopAppFallback } from './DesktopAppFallback'
 import { useRefreshAccessTokenOnActivity } from './hooks/useRefreshAccessTokenOnActivity'
@@ -128,8 +129,9 @@ export const DesktopApp = (): JSX.Element => {
                 setIsEmergencyStopModalDismissed,
               }}
             >
-              <DocumentationRequiredModalContext.Provider
-                value={{ showDocumentationRequiredModal }}
+              <DocumentationRequiredContextProvider
+                showDocumentationRequiredModal={showDocumentationRequiredModal}
+                loadingModal={<InProgressModal description="Loading..." />}
               >
                 <Box width="100%" height="100vh">
                   <Alerts>
@@ -173,7 +175,7 @@ export const DesktopApp = (): JSX.Element => {
                     <RobotControlTakeover />
                   </Alerts>
                 </Box>
-              </DocumentationRequiredModalContext.Provider>
+              </DocumentationRequiredContextProvider>
             </EmergencyStopContext.Provider>
           </ToasterOven>
         </ErrorBoundary>

--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -35,8 +35,7 @@ import { OPENTRONS_USB } from '/app/redux/discovery'
 import { useAccessTokenForRobot } from '/app/redux/robot-auth'
 import { appShellUSBRequestor } from '/app/redux/shell/remote'
 
-import { DocumentationRequiredContextProvider } from '../local-resources/access-control/DocumentationRequiredModalContext'
-import { InProgressModal } from '../molecules/InProgressModal'
+import { DocumentationRequiredModalContext } from '../local-resources/access-control/DocumentationRequiredModalContext'
 import { ProtocolVisualization } from '../pages/Desktop/Protocols/ProtocolVisualization'
 import { DesktopAppFallback } from './DesktopAppFallback'
 import { useRefreshAccessTokenOnActivity } from './hooks/useRefreshAccessTokenOnActivity'
@@ -129,9 +128,11 @@ export const DesktopApp = (): JSX.Element => {
                 setIsEmergencyStopModalDismissed,
               }}
             >
-              <DocumentationRequiredContextProvider
-                showDocumentationRequiredModal={showDocumentationRequiredModal}
-                loadingModal={<InProgressModal description="Loading..." />}
+              <DocumentationRequiredModalContext.Provider
+                value={{
+                  showDocumentationRequiredModal:
+                    showDocumentationRequiredModal,
+                }}
               >
                 <Box width="100%" height="100vh">
                   <Alerts>
@@ -175,7 +176,7 @@ export const DesktopApp = (): JSX.Element => {
                     <RobotControlTakeover />
                   </Alerts>
                 </Box>
-              </DocumentationRequiredContextProvider>
+              </DocumentationRequiredModalContext.Provider>
             </EmergencyStopContext.Provider>
           </ToasterOven>
         </ErrorBoundary>

--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -129,10 +129,7 @@ export const DesktopApp = (): JSX.Element => {
               }}
             >
               <DocumentationRequiredModalContext.Provider
-                value={{
-                  showDocumentationRequiredModal:
-                    showDocumentationRequiredModal,
-                }}
+                value={{ showDocumentationRequiredModal }}
               >
                 <Box width="100%" height="100vh">
                   <Alerts>

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -59,8 +59,9 @@ import {
 import { getLocalRobot } from '/app/redux/discovery'
 import { getIsShellReady, updateBrightness } from '/app/redux/shell'
 
-import { DocumentationRequiredModalContext } from '../local-resources/access-control/DocumentationRequiredModalContext'
+import { DocumentationRequiredContextProvider } from '../local-resources/access-control/DocumentationRequiredModalContext'
 import { LocalizationProvider } from '../LocalizationProvider'
+import { InProgressModal } from '../molecules/InProgressModal'
 import { requireDocumentation } from '../organisms/ODD/DocumentationRequired/requireDocumentation'
 import { getLocalRobotAccessToken } from '../redux/robot-auth'
 import { hackWindowNavigatorOnLine } from './hacks'
@@ -258,10 +259,11 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
                         robotName={localRobot.name}
                       />
                     ) : null}
-                    <DocumentationRequiredModalContext.Provider
-                      value={{
-                        showDocumentationRequiredModal: requireDocumentation,
-                      }}
+                    <DocumentationRequiredContextProvider
+                      showDocumentationRequiredModal={requireDocumentation}
+                      loadingModal={
+                        <InProgressModal description="Loading..." />
+                      }
                     >
                       <NiceModal.Provider>
                         <RobotEncryptionKeyTakeover>
@@ -282,7 +284,7 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
                           </ToasterOven>
                         </RobotEncryptionKeyTakeover>
                       </NiceModal.Provider>
-                    </DocumentationRequiredModalContext.Provider>
+                    </DocumentationRequiredContextProvider>
                   </MaintenanceRunTakeover>
                 </>
               )}

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -59,9 +59,8 @@ import {
 import { getLocalRobot } from '/app/redux/discovery'
 import { getIsShellReady, updateBrightness } from '/app/redux/shell'
 
-import { DocumentationRequiredContextProvider } from '../local-resources/access-control/DocumentationRequiredModalContext'
+import { DocumentationRequiredModalContext } from '../local-resources/access-control/DocumentationRequiredModalContext'
 import { LocalizationProvider } from '../LocalizationProvider'
-import { InProgressModal } from '../molecules/InProgressModal'
 import { requireDocumentation } from '../organisms/ODD/DocumentationRequired/requireDocumentation'
 import { getLocalRobotAccessToken } from '../redux/robot-auth'
 import { hackWindowNavigatorOnLine } from './hacks'
@@ -247,9 +246,10 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
               ) : (
                 <>
                   <IncompatibleModuleTakeover isOnDevice={true} />
-                  <DocumentationRequiredContextProvider
-                    showDocumentationRequiredModal={requireDocumentation}
-                    loadingModal={<InProgressModal description="Loading..." />}
+                  <DocumentationRequiredModalContext.Provider
+                    value={{
+                      showDocumentationRequiredModal: requireDocumentation,
+                    }}
                   >
                     <MaintenanceRunTakeover>
                       <EstopTakeover />
@@ -284,7 +284,7 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
                         </RobotEncryptionKeyTakeover>
                       </NiceModal.Provider>
                     </MaintenanceRunTakeover>
-                  </DocumentationRequiredContextProvider>
+                  </DocumentationRequiredModalContext.Provider>
                 </>
               )}
             </Box>

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -247,24 +247,23 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
               ) : (
                 <>
                   <IncompatibleModuleTakeover isOnDevice={true} />
-                  <MaintenanceRunTakeover>
-                    <EstopTakeover />
-                    <FirmwareUpdateTakeover />
-                    {showModuleSetupModal && localRobot?.name != null ? (
-                      <ModuleWizardFlows
-                        showSetupLauncher={true}
-                        closeFlow={() => {
-                          setShowModuleSetupModal(false)
-                        }}
-                        robotName={localRobot.name}
-                      />
-                    ) : null}
-                    <DocumentationRequiredContextProvider
-                      showDocumentationRequiredModal={requireDocumentation}
-                      loadingModal={
-                        <InProgressModal description="Loading..." />
-                      }
-                    >
+                  <DocumentationRequiredContextProvider
+                    showDocumentationRequiredModal={requireDocumentation}
+                    loadingModal={<InProgressModal description="Loading..." />}
+                  >
+                    <MaintenanceRunTakeover>
+                      <EstopTakeover />
+                      <FirmwareUpdateTakeover />
+                      {showModuleSetupModal && localRobot?.name != null ? (
+                        <ModuleWizardFlows
+                          showSetupLauncher={true}
+                          closeFlow={() => {
+                            setShowModuleSetupModal(false)
+                          }}
+                          robotName={localRobot.name}
+                        />
+                      ) : null}
+
                       <NiceModal.Provider>
                         <RobotEncryptionKeyTakeover>
                           <ToasterOven>
@@ -284,8 +283,8 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
                           </ToasterOven>
                         </RobotEncryptionKeyTakeover>
                       </NiceModal.Provider>
-                    </DocumentationRequiredContextProvider>
-                  </MaintenanceRunTakeover>
+                    </MaintenanceRunTakeover>
+                  </DocumentationRequiredContextProvider>
                 </>
               )}
             </Box>

--- a/app/src/local-resources/access-control/DocumentationRequiredModalContext.tsx
+++ b/app/src/local-resources/access-control/DocumentationRequiredModalContext.tsx
@@ -1,5 +1,6 @@
-import { createContext } from 'react'
+import { createContext, useState } from 'react'
 
+import type { ReactNode } from 'react'
 import type {
   DocumentationReport,
   DocumentedAction,
@@ -10,6 +11,7 @@ export interface DocumentationRequiredModalContextType {
     username: string,
     actionsToDocument: DocumentedAction[]
   ) => Promise<DocumentationReport>
+  setIsLoading: (isLoading: boolean) => void
 }
 
 /**
@@ -23,4 +25,31 @@ export const DocumentationRequiredModalContext =
     ) => {
       return Promise.resolve('' as DocumentationReport)
     },
+    setIsLoading: () => {},
   })
+
+// TODO(jj): Right now, the ODD and desktop use <InProgressModal> for the loading screen.
+// this should be replaced with a designed loading modal.
+export const DocumentationRequiredContextProvider = ({
+  children,
+  showDocumentationRequiredModal,
+  loadingModal,
+}: {
+  children: ReactNode
+  showDocumentationRequiredModal: (
+    username: string,
+    actionsToDocument: DocumentedAction[]
+  ) => Promise<DocumentationReport>
+  loadingModal: ReactNode
+}): JSX.Element => {
+  const [isLoading, setIsLoading] = useState(false)
+
+  return (
+    <DocumentationRequiredModalContext.Provider
+      value={{ showDocumentationRequiredModal, setIsLoading }}
+    >
+      {isLoading && loadingModal}
+      {children}
+    </DocumentationRequiredModalContext.Provider>
+  )
+}

--- a/app/src/local-resources/access-control/DocumentationRequiredModalContext.tsx
+++ b/app/src/local-resources/access-control/DocumentationRequiredModalContext.tsx
@@ -1,6 +1,5 @@
-import { createContext, useState } from 'react'
+import { createContext } from 'react'
 
-import type { ReactNode } from 'react'
 import type {
   DocumentationReport,
   DocumentedAction,
@@ -11,7 +10,6 @@ export interface DocumentationRequiredModalContextType {
     username: string,
     actionsToDocument: DocumentedAction[]
   ) => Promise<DocumentationReport>
-  setIsLoading: (isLoading: boolean) => void
 }
 
 /**
@@ -25,31 +23,4 @@ export const DocumentationRequiredModalContext =
     ) => {
       return Promise.resolve('' as DocumentationReport)
     },
-    setIsLoading: () => {},
   })
-
-// TODO(jj): Right now, the ODD and desktop use <InProgressModal> for the loading screen.
-// this should be replaced with a designed loading modal.
-export const DocumentationRequiredContextProvider = ({
-  children,
-  showDocumentationRequiredModal,
-  loadingModal,
-}: {
-  children: ReactNode
-  showDocumentationRequiredModal: (
-    username: string,
-    actionsToDocument: DocumentedAction[]
-  ) => Promise<DocumentationReport>
-  loadingModal: ReactNode
-}): JSX.Element => {
-  const [isLoading, setIsLoading] = useState(false)
-
-  return (
-    <DocumentationRequiredModalContext.Provider
-      value={{ showDocumentationRequiredModal, setIsLoading }}
-    >
-      {isLoading && loadingModal}
-      {children}
-    </DocumentationRequiredModalContext.Provider>
-  )
-}

--- a/app/src/local-resources/access-control/__tests__/documentationRequiredModalTestUtils.tsx
+++ b/app/src/local-resources/access-control/__tests__/documentationRequiredModalTestUtils.tsx
@@ -16,6 +16,7 @@ export const DocumentationRequiredModalTestProvider: FunctionComponent<{
   <DocumentationRequiredModalContext.Provider
     value={{
       showDocumentationRequiredModal: mockShowDocumentationRequiredModal,
+      setIsLoading: vi.fn(),
     }}
   >
     {children}

--- a/app/src/local-resources/access-control/__tests__/documentationRequiredModalTestUtils.tsx
+++ b/app/src/local-resources/access-control/__tests__/documentationRequiredModalTestUtils.tsx
@@ -16,7 +16,6 @@ export const DocumentationRequiredModalTestProvider: FunctionComponent<{
   <DocumentationRequiredModalContext.Provider
     value={{
       showDocumentationRequiredModal: mockShowDocumentationRequiredModal,
-      setIsLoading: vi.fn(),
     }}
   >
     {children}

--- a/app/src/local-resources/access-control/__tests__/maintenanceRunDocumentation.test.tsx
+++ b/app/src/local-resources/access-control/__tests__/maintenanceRunDocumentation.test.tsx
@@ -191,24 +191,30 @@ describe('maintenance run documentation flow', () => {
     })
     await waitFor(() => {
       expect(
-        result.current.commandDocState.reasonForInteractionRequired &&
+        !result.current.commandDocState.isLoading &&
+          result.current.commandDocState.reasonForInteractionRequired &&
           result.current.commandDocState.docreport
       ).toEqual(MOCK_DOCREPORT)
     })
 
+    const { deletionDocState } = result.current
+
     // The deletion gate is in place but has NOT prompted yet — it is set up
     // to prompt only when the deletion mutation actually runs.
-    expect(result.current.deletionDocState.reasonForInteractionRequired).toBe(
-      true
-    )
     expect(
-      result.current.deletionDocState.reasonForInteractionRequired &&
-        result.current.deletionDocState.docreport
+      !deletionDocState.isLoading &&
+        deletionDocState.reasonForInteractionRequired
+    ).toBe(true)
+    expect(
+      !deletionDocState.isLoading &&
+        deletionDocState.reasonForInteractionRequired &&
+        deletionDocState.docreport
     ).toBeNull()
     expect(
-      result.current.deletionDocState.reasonForInteractionRequired &&
-        result.current.deletionDocState.docreport == null &&
-        result.current.deletionDocState.askForDocumentation
+      !deletionDocState.isLoading &&
+        deletionDocState.reasonForInteractionRequired &&
+        deletionDocState.docreport == null &&
+        deletionDocState.askForDocumentation
     ).toBeDefined()
 
     // 2) Every step of the maintenance run executes against the same
@@ -236,7 +242,8 @@ describe('maintenance run documentation flow', () => {
     // commandDocState's report rather than asking the user again.
     expect(mockShowDocumentationRequiredModal).toHaveBeenCalledTimes(1)
     expect(
-      result.current.commandDocState.reasonForInteractionRequired &&
+      !result.current.commandDocState.isLoading &&
+        result.current.commandDocState.reasonForInteractionRequired &&
         result.current.commandDocState.docreport
     ).toEqual(MOCK_DOCREPORT)
 

--- a/app/src/local-resources/access-control/__tests__/useGuardedAction.test.ts
+++ b/app/src/local-resources/access-control/__tests__/useGuardedAction.test.ts
@@ -82,7 +82,9 @@ describe('useGuardedAction', () => {
     const { result } = renderHook(() => useGuardedAction(), { wrapper })
 
     const currentResult = await act(
-      () => !result.current.reasonForInteractionRequired
+      () =>
+        !result.current.isLoading &&
+        !result.current.reasonForInteractionRequired
     )
     expect(currentResult).toBe(true)
     expect(mockShowDocumentationRequiredModal).not.toHaveBeenCalled()
@@ -107,7 +109,9 @@ describe('useGuardedAction', () => {
     const { result } = renderHook(() => useGuardedAction(), { wrapper })
 
     const currentResult = await act(
-      () => !result.current.reasonForInteractionRequired
+      () =>
+        !result.current.isLoading &&
+        !result.current.reasonForInteractionRequired
     )
     expect(currentResult).toBe(true)
     expect(mockShowDocumentationRequiredModal).not.toHaveBeenCalled()
@@ -120,21 +124,30 @@ describe('useGuardedAction', () => {
       wrapper,
     })
 
-    expect(result.current.reasonForInteractionRequired).toBe(true)
     expect(
-      result.current.reasonForInteractionRequired && result.current.docreport
+      !result.current.isLoading && result.current.reasonForInteractionRequired
+    ).toBe(true)
+    expect(
+      !result.current.isLoading &&
+        result.current.reasonForInteractionRequired &&
+        result.current.docreport
     ).toBe(docreport)
   })
 
   it('returns callback to open modal when documentation is not provided', async () => {
     const { result } = renderHook(() => useGuardedAction(), { wrapper })
 
-    expect(result.current.reasonForInteractionRequired).toBe(true)
     expect(
-      result.current.reasonForInteractionRequired && result.current.docreport
+      !result.current.isLoading && result.current.reasonForInteractionRequired
+    ).toBe(true)
+    expect(
+      !result.current.isLoading &&
+        result.current.reasonForInteractionRequired &&
+        result.current.docreport
     ).toBeNull()
     expect(
-      result.current.reasonForInteractionRequired &&
+      !result.current.isLoading &&
+        result.current.reasonForInteractionRequired &&
         result.current.docreport == null &&
         result.current.askForDocumentation
     ).toBeDefined()

--- a/app/src/local-resources/access-control/__tests__/useMaintenanceRunDocumentation.test.ts
+++ b/app/src/local-resources/access-control/__tests__/useMaintenanceRunDocumentation.test.ts
@@ -46,7 +46,10 @@ const wrapper = wrapWithDocumentationRequiredModal()
 
 describe('isDocumentationProvided', () => {
   it('returns true when access control is disabled', () => {
-    const state: DocumentationState = { reasonForInteractionRequired: false }
+    const state: DocumentationState = {
+      reasonForInteractionRequired: false,
+      isLoading: false,
+    }
 
     expect(isDocumentationProvided(state)).toBe(true)
   })
@@ -55,6 +58,7 @@ describe('isDocumentationProvided', () => {
     const state: DocumentationState = {
       reasonForInteractionRequired: true,
       docreport: mockDocreport,
+      isLoading: false,
     }
 
     expect(isDocumentationProvided(state)).toBe(true)
@@ -65,6 +69,7 @@ describe('isDocumentationProvided', () => {
       reasonForInteractionRequired: true,
       docreport: null,
       askForDocumentation: vi.fn(),
+      isLoading: false,
     }
 
     expect(isDocumentationProvided(state)).toBe(false)
@@ -111,20 +116,24 @@ describe('useMaintenanceRunDocumentation', () => {
 
     await waitFor(() => {
       expect(
-        result.current.commandDocState.reasonForInteractionRequired &&
+        !result.current.commandDocState.isLoading &&
+          result.current.commandDocState.reasonForInteractionRequired &&
           result.current.commandDocState.docreport
       ).toEqual(mockDocreport)
     })
 
-    expect(result.current.deletionDocState.reasonForInteractionRequired).toBe(
-      true
-    )
     expect(
-      result.current.deletionDocState.reasonForInteractionRequired &&
+      !result.current.deletionDocState.isLoading &&
+        result.current.deletionDocState.reasonForInteractionRequired
+    ).toBe(true)
+    expect(
+      !result.current.deletionDocState.isLoading &&
+        result.current.deletionDocState.reasonForInteractionRequired &&
         result.current.deletionDocState.docreport
     ).toBeNull()
     expect(
-      result.current.deletionDocState.reasonForInteractionRequired &&
+      !result.current.deletionDocState.isLoading &&
+        result.current.deletionDocState.reasonForInteractionRequired &&
         result.current.deletionDocState.docreport == null &&
         result.current.deletionDocState.askForDocumentation
     ).toBeDefined()
@@ -144,6 +153,7 @@ describe('useMaintenanceRunDocumentation', () => {
 
     await act(async () => {
       if (
+        !result.current.deletionDocState.isLoading &&
         result.current.deletionDocState.reasonForInteractionRequired &&
         result.current.deletionDocState.docreport == null
       ) {

--- a/app/src/local-resources/access-control/__tests__/usePromptForInteractionReason.test.ts
+++ b/app/src/local-resources/access-control/__tests__/usePromptForInteractionReason.test.ts
@@ -90,7 +90,9 @@ describe('usePromptForInteractionReason', () => {
       }
     )
 
-    expect(result.current.reasonForInteractionRequired).toBe(false)
+    expect(
+      !result.current.isLoading && result.current.reasonForInteractionRequired
+    ).toBe(false)
     expect(mockShowDocumentationRequiredModal).not.toHaveBeenCalled()
   })
 
@@ -116,7 +118,9 @@ describe('usePromptForInteractionReason', () => {
         wrapper,
       }
     )
-    expect(result.current.reasonForInteractionRequired).toBe(false)
+    expect(
+      !result.current.isLoading && result.current.reasonForInteractionRequired
+    ).toBe(false)
     expect(mockShowDocumentationRequiredModal).not.toHaveBeenCalled()
   })
   it('prompts for documentation when access control is enabled', async () => {
@@ -132,9 +136,13 @@ describe('usePromptForInteractionReason', () => {
     })
 
     await waitFor(() => {
-      expect(result.current.reasonForInteractionRequired).toBe(true)
       expect(
-        result.current.reasonForInteractionRequired && result.current.docreport
+        !result.current.isLoading && result.current.reasonForInteractionRequired
+      ).toBe(true)
+      expect(
+        !result.current.isLoading &&
+          result.current.reasonForInteractionRequired &&
+          result.current.docreport
       ).toEqual(mockDocreport)
     })
   })

--- a/app/src/local-resources/access-control/useGuardedAction.ts
+++ b/app/src/local-resources/access-control/useGuardedAction.ts
@@ -72,6 +72,9 @@ export function useGuardedAction(
   }, [reasonForInteractionLoading, setIsLoading])
 
   const docState: DocumentationState = useMemo(() => {
+    if (reasonForInteractionLoading) {
+      return { isLoading: true }
+    }
     if (!reasonForInteractionRequired) {
       return { reasonForInteractionRequired: false, isLoading: false }
     }
@@ -80,17 +83,19 @@ export function useGuardedAction(
       docreport != null &&
       isDocumentationReportValid(docreport, minLengthOfReasonForInteraction)
     ) {
-      return { reasonForInteractionRequired: true, docreport }
+      return { reasonForInteractionRequired: true, docreport, isLoading: false }
     }
 
     return {
       reasonForInteractionRequired: true,
       docreport: null,
       askForDocumentation: showDocumentationModal,
+      isLoading: false,
     }
   }, [
     docreport,
     minLengthOfReasonForInteraction,
+    reasonForInteractionLoading,
     reasonForInteractionRequired,
     showDocumentationModal,
   ])

--- a/app/src/local-resources/access-control/useGuardedAction.ts
+++ b/app/src/local-resources/access-control/useGuardedAction.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useMemo } from 'react'
+import { useCallback, useContext, useEffect, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 
 import {
@@ -43,14 +43,18 @@ export function useGuardedAction(
   const minLengthOfReasonForInteraction =
     authSettingsQuery?.data?.data?.minLengthOfReasonForInteraction ?? 0
 
+  const reasonForInteractionLoading = useMemo(
+    () => authSettingsQuery?.isLoading || accessControlEnabledQuery?.isLoading,
+    [accessControlEnabledQuery?.isLoading, authSettingsQuery?.isLoading]
+  )
+
   const reasonForInteractionRequired = useMemo(
     () => accessControlEnabled && requireReasonForInteraction,
     [accessControlEnabled, requireReasonForInteraction]
   )
 
-  const { showDocumentationRequiredModal: requireDocumentation } = useContext(
-    DocumentationRequiredModalContext
-  )
+  const { showDocumentationRequiredModal: requireDocumentation, setIsLoading } =
+    useContext(DocumentationRequiredModalContext)
 
   const showDocumentationModal = useCallback(
     async (actionsToDocument: DocumentedAction[]) => {
@@ -63,9 +67,13 @@ export function useGuardedAction(
     [currentUsername, requireDocumentation]
   )
 
+  useEffect(() => {
+    setIsLoading(reasonForInteractionLoading)
+  }, [reasonForInteractionLoading, setIsLoading])
+
   const docState: DocumentationState = useMemo(() => {
     if (!reasonForInteractionRequired) {
-      return { reasonForInteractionRequired: false }
+      return { reasonForInteractionRequired: false, isLoading: false }
     }
 
     if (

--- a/app/src/local-resources/access-control/useGuardedAction.ts
+++ b/app/src/local-resources/access-control/useGuardedAction.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo } from 'react'
+import { useCallback, useContext, useMemo } from 'react'
 import { useSelector } from 'react-redux'
 
 import {
@@ -53,8 +53,9 @@ export function useGuardedAction(
     [accessControlEnabled, requireReasonForInteraction]
   )
 
-  const { showDocumentationRequiredModal: requireDocumentation, setIsLoading } =
-    useContext(DocumentationRequiredModalContext)
+  const { showDocumentationRequiredModal: requireDocumentation } = useContext(
+    DocumentationRequiredModalContext
+  )
 
   const showDocumentationModal = useCallback(
     async (actionsToDocument: DocumentedAction[]) => {
@@ -66,10 +67,6 @@ export function useGuardedAction(
     },
     [currentUsername, requireDocumentation]
   )
-
-  useEffect(() => {
-    setIsLoading(reasonForInteractionLoading)
-  }, [reasonForInteractionLoading, setIsLoading])
 
   const docState: DocumentationState = useMemo(() => {
     if (reasonForInteractionLoading) {

--- a/app/src/local-resources/access-control/useMaintenanceRunDocumentation.ts
+++ b/app/src/local-resources/access-control/useMaintenanceRunDocumentation.ts
@@ -29,6 +29,7 @@ export const useMaintenanceRunDocumentation = (
   deletionDocState: DocumentationState
   actionsToDocument: DocumentedAction[]
   addActionToDocument: (action: DocumentedAction) => void
+  isLoading: boolean
 } => {
   const [actionsToDocument, setActionsToDocument] = useState<
     DocumentedAction[]
@@ -44,6 +45,7 @@ export const useMaintenanceRunDocumentation = (
   }, [])
 
   return {
+    isLoading: commandDocState.isLoading || deletionDocState.isLoading,
     commandDocState,
     deletionDocState,
     actionsToDocument,

--- a/app/src/local-resources/access-control/usePromptForInteractionReason.ts
+++ b/app/src/local-resources/access-control/usePromptForInteractionReason.ts
@@ -24,15 +24,16 @@ export const usePromptForInteractionReason = (
   initialDocstate?: DocumentationState
 ): DocumentationState => {
   const [docReport, setDocReport] = useState<DocumentationReport>()
-  const docStateToUse = initialDocstate?.reasonForInteractionRequired
-    ? initialDocstate.docreport
-    : docReport
+  const docStateToUse =
+    !initialDocstate?.isLoading && initialDocstate?.reasonForInteractionRequired
+      ? initialDocstate.docreport
+      : docReport
   const docState = useGuardedAction(docStateToUse ?? undefined)
   const promptInFlight = useRef(false)
 
   useEffect(() => {
     const promptForDocumentation = async (): Promise<void> => {
-      if (docState.reasonForInteractionRequired) {
+      if (!docState.isLoading && docState.reasonForInteractionRequired) {
         if (docState.docreport == null && !promptInFlight.current) {
           promptInFlight.current = true
           await docState
@@ -44,7 +45,9 @@ export const usePromptForInteractionReason = (
         }
       }
     }
-    void promptForDocumentation()
+    if (!docState.isLoading) {
+      void promptForDocumentation()
+    }
   }, [actionsToDocument, docReport, docState])
 
   return docState

--- a/app/src/local-resources/access-control/utils.ts
+++ b/app/src/local-resources/access-control/utils.ts
@@ -13,6 +13,9 @@ export function isDocumentationReportValid(
 }
 
 export function isDocumentationProvided(state: DocumentationState): boolean {
+  if (state.isLoading) {
+    return false
+  }
   if (!state.reasonForInteractionRequired) {
     return true
   }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ConfirmCancelModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ConfirmCancelModal.tsx
@@ -55,6 +55,7 @@ export function ConfirmCancelModal(
   // TODO(jj): add doc state to desktop app
   const { stopRun } = useStopRunMutation({
     reasonForInteractionRequired: false,
+    isLoading: false,
   })
   const isFlex = useIsFlex(robotName)
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipMaintenanceRun.tsx
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipMaintenanceRun.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
+import { isDocumentationProvided } from '/app/local-resources/access-control/utils'
 import {
   useChainMaintenanceCommands,
   useNotifyCurrentMaintenanceRun,
@@ -126,28 +127,39 @@ function useCreateDropTipMaintenanceRun({
       }
     )
 
-  useEffect(
-    () => {
-      if (
-        issuedCommandsType === 'setup' &&
-        mount != null &&
-        instrumentModelName != null
-      ) {
-        createTargetedMaintenanceRun({}).catch((e: Error) => {
-          setErrorDetails({
-            message: `Error creating maintenance run: ${e.message}`,
-          })
+  const hasSentCreateMaintenanceRun = useRef(false)
+
+  useEffect(() => {
+    if (
+      issuedCommandsType === 'setup' &&
+      mount != null &&
+      instrumentModelName != null &&
+      isDocumentationProvided(commandDocState) &&
+      !hasSentCreateMaintenanceRun.current
+    ) {
+      hasSentCreateMaintenanceRun.current = true
+      createTargetedMaintenanceRun({}).catch((e: Error) => {
+        hasSentCreateMaintenanceRun.current = false
+        setErrorDetails({
+          message: `Error creating maintenance run: ${e.message}`,
         })
-      } else {
-        console.warn(
-          'Could not create maintenance run due to missing pipette data.'
-        )
-      }
-    },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [mount, instrumentModelName]
-  )
+      })
+    } else if (
+      issuedCommandsType === 'setup' &&
+      (mount == null || instrumentModelName == null)
+    ) {
+      console.warn(
+        'Could not create maintenance run due to missing pipette data.'
+      )
+    }
+  }, [
+    commandDocState,
+    createTargetedMaintenanceRun,
+    instrumentModelName,
+    issuedCommandsType,
+    mount,
+    setErrorDetails,
+  ])
 }
 
 interface UseMonitorMaintenanceRunForDeletionParams {

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryActionMutation.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryActionMutation.test.ts
@@ -36,7 +36,7 @@ describe('useRecoveryActionMutation', () => {
         {
           proceedToRouteAndStep: mockProceedToRouteAndStep,
         } as any,
-        { reasonForInteractionRequired: false }
+        { reasonForInteractionRequired: false, isLoading: false }
       )
     )
 
@@ -52,7 +52,7 @@ describe('useRecoveryActionMutation', () => {
         {
           proceedToRouteAndStep: mockProceedToRouteAndStep,
         } as any,
-        { reasonForInteractionRequired: false }
+        { reasonForInteractionRequired: false, isLoading: false }
       )
     )
 
@@ -76,7 +76,7 @@ describe('useRecoveryActionMutation', () => {
         {
           proceedToRouteAndStep: mockProceedToRouteAndStep,
         } as any,
-        { reasonForInteractionRequired: false }
+        { reasonForInteractionRequired: false, isLoading: false }
       )
     )
 
@@ -94,7 +94,7 @@ describe('useRecoveryActionMutation', () => {
         {
           proceedToRouteAndStep: mockProceedToRouteAndStep,
         } as any,
-        { reasonForInteractionRequired: false }
+        { reasonForInteractionRequired: false, isLoading: false }
       )
     )
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -189,7 +189,7 @@ export function useERUtils({
   const recoveryActionMutationUtils = useRecoveryActionMutation(
     runId,
     routeUpdateActions,
-    { reasonForInteractionRequired: false }
+    { reasonForInteractionRequired: false, isLoading: false }
   )
 
   // TODO(jh, 06-14-24): Ensure other string build utilities that are internal to ErrorRecoveryFlows are exported under

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -125,6 +125,7 @@ export function useRecoveryCommands({
   // TODO(jj): add doc state to desktop app
   const { stopRun } = useStopRunMutation({
     reasonForInteractionRequired: false,
+    isLoading: false,
   })
   const updateErrorRecoveryPolicy = useUpdateRecoveryPolicyWithStrategy(runId)
   const currentRecoveryPolicy = useErrorRecoveryPolicy(runId)?.data?.data

--- a/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
+++ b/app/src/organisms/GripperWizardFlows/BeforeBeginning.tsx
@@ -1,9 +1,10 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 import { COLORS, LegacyStyledText } from '@opentrons/components'
 import { EXTENSION } from '@opentrons/shared-data'
 
+import { isDocumentationProvided } from '/app/local-resources/access-control/utils'
 import { GenericWizardTile } from '/app/molecules/GenericWizardTile'
 import {
   SimpleWizardBody,
@@ -26,6 +27,7 @@ import type {
   CreateMaintenanceRunData,
   MaintenanceRun,
 } from '@opentrons/api-client'
+import type { DocumentationState } from '@opentrons/react-api-client'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { GripperWizardFlowType, GripperWizardStepProps } from './types'
 
@@ -63,6 +65,7 @@ interface BeforeBeginningProps extends GripperWizardStepProps {
   >
   isCreateLoading: boolean
   createdMaintenanceRunId: string | null
+  documentationState: DocumentationState
 }
 
 export const BeforeBeginning = (
@@ -79,18 +82,27 @@ export const BeforeBeginning = (
     maintenanceRunId,
     setErrorMessage,
     createdMaintenanceRunId,
+    documentationState,
   } = props
   const { t } = useTranslation(['gripper_wizard_flows', 'shared', 'branded'])
-  useEffect(
-    () => {
-      if (createdMaintenanceRunId == null) {
-        createMaintenanceRun({})
-      }
-    },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  )
+  const hasSentCreateMaintenanceRun = useRef(false)
+  useEffect(() => {
+    if (
+      createdMaintenanceRunId != null ||
+      isCreateLoading ||
+      hasSentCreateMaintenanceRun.current ||
+      !isDocumentationProvided(documentationState)
+    ) {
+      return
+    }
+    hasSentCreateMaintenanceRun.current = true
+    createMaintenanceRun({})
+  }, [
+    createMaintenanceRun,
+    createdMaintenanceRunId,
+    documentationState,
+    isCreateLoading,
+  ])
 
   const commandsOnProceed: CreateCommand[] = [
     { commandType: 'home' as const, params: {} },

--- a/app/src/organisms/GripperWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -34,6 +34,10 @@ describe('BeforeBeginning', () => {
       setErrorMessage: vi.fn(),
       errorMessage: null,
       createdMaintenanceRunId: null,
+      documentationState: {
+        reasonForInteractionRequired: false,
+        isLoading: false,
+      },
     }
     vi.mocked(InProgressModal).mockReturnValue(<div>mock in progress</div>)
   })

--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -49,6 +49,7 @@ import type {
   MaintenanceRun,
   RunStatus,
 } from '@opentrons/api-client'
+import type { DocumentationState } from '@opentrons/react-api-client'
 import type { CreateCommand, Vector3D } from '@opentrons/shared-data'
 import type { GripperWizardFlowType } from './types'
 
@@ -194,6 +195,7 @@ export function GripperWizardFlows(
       attachedGripper={attachedGripper}
       createMaintenanceRun={createTargetedMaintenanceRun}
       isCreateLoading={isCreateLoading}
+      commandDocState={commandDocState}
       isRobotMoving={
         isChainCommandMutationLoading ||
         isCommandLoading ||
@@ -224,6 +226,7 @@ interface GripperWizardProps {
     unknown
   >
   isCreateLoading: boolean
+  commandDocState: DocumentationState
   isRobotMoving: boolean
   isExiting: boolean
   setErrorMessage: (message: string | null) => void
@@ -251,6 +254,7 @@ export const GripperWizard = (
     chainRunCommands,
     attachedGripper,
     isCreateLoading,
+    commandDocState,
     isRobotMoving,
     createRunCommand,
     setErrorMessage,
@@ -347,6 +351,7 @@ export const GripperWizard = (
         {...sharedProps}
         createMaintenanceRun={createMaintenanceRun}
         createdMaintenanceRunId={createdMaintenanceRunId}
+        documentationState={commandDocState}
       />
     )
   } else if (currentStep.section === SECTIONS.MOVE_PIN) {

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
@@ -77,6 +77,9 @@ export function useLPCFlows({
   const [maintenanceRunId, setMaintenanceRunId] = useState<string | null>(null)
   const [isLaunching, setIsLaunching] = useState(false)
   const [hasCreatedLPCRun, setHasCreatedLPCRun] = useState(false)
+
+  // if launchLPC is called while other queries are still loading, we will return a constructed promise and store any provided callbacks in this ref
+  // once unblocked, the useEffect will launch LPC and resolve the constructed promise with the results
   const pendingLaunchRef = useRef<PendingLaunch | null>(null)
 
   const {

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 import { getLabwareDefinitionsFromCommands } from '@opentrons/components'
 import {
@@ -34,6 +34,11 @@ import type {
 } from '/app/organisms/LabwarePositionCheck/LPCFlows/LPCFlows'
 
 const RUN_RECORD_INTERVAL_MS = 1000 * 5
+
+interface PendingLaunch {
+  resolve: () => void
+  reject: (reason?: unknown) => void
+}
 
 interface UseLPCFlowsBase {
   showLPC: boolean
@@ -72,12 +77,14 @@ export function useLPCFlows({
   const [maintenanceRunId, setMaintenanceRunId] = useState<string | null>(null)
   const [isLaunching, setIsLaunching] = useState(false)
   const [hasCreatedLPCRun, setHasCreatedLPCRun] = useState(false)
+  const pendingLaunchRef = useRef<PendingLaunch | null>(null)
 
   const {
     commandDocState,
     deletionDocState,
     actionsToDocument,
     addActionToDocument,
+    isLoading: isDocumentationLoading,
   } = useMaintenanceRunDocumentation('lpc_flow')
 
   const isFlex = robotType === FLEX_ROBOT_TYPE
@@ -173,25 +180,53 @@ export function useLPCFlows({
     [maintenanceRunId]
   )
 
+  const isFlexLPCInitializing = flexOffsets == null
+  const isLaunchBlocked =
+    isDocumentationLoading || (isFlex && isFlexLPCInitializing)
+
+  const createLPCMaintenanceRun = useCallback((): Promise<void> => {
+    // Inject OT-2 offsets into the maintenance run upon creation.
+    // The Flex injects offsets directly in LPC commands and therefore should not load them into the maintenance run.
+    const injectedOffsets =
+      robotType === OT2_ROBOT_TYPE ? { labwareOffsets: ot2Offsets } : {}
+
+    return createTargetedMaintenanceRun(injectedOffsets).then(
+      maintenanceRun => {
+        setMaintenanceRunId(maintenanceRun.data.id)
+      }
+    )
+  }, [createTargetedMaintenanceRun, ot2Offsets, robotType])
+
+  // If documentation or Flex offset queries are still loading, queue the launch
+  // and run it once prerequisites are ready.
+  useEffect(() => {
+    if (isLaunchBlocked || pendingLaunchRef.current == null) {
+      return
+    }
+
+    const { resolve, reject } = pendingLaunchRef.current
+    pendingLaunchRef.current = null
+
+    void createLPCMaintenanceRun().then(resolve).catch(reject)
+  }, [createLPCMaintenanceRun, isLaunchBlocked])
+
   const launchLPC = (): Promise<void> => {
     // Avoid accidentally creating several maintenance runs if a request is ongoing.
-    if (!isLaunching) {
-      analytics.reportLaunchLpcWizard()
-      setIsLaunching(true)
-      // Inject OT-2 offsets into the maintenance run upon creation.
-      // The Flex injects offsets directly in LPC commands and therefore should not load them into the maintenance run.
-      const injectedOffsets =
-        robotType === OT2_ROBOT_TYPE ? { labwareOffsets: ot2Offsets } : {}
-
-      return createTargetedMaintenanceRun(injectedOffsets).then(
-        maintenanceRun => {
-          setMaintenanceRunId(maintenanceRun.data.id)
-        }
-      )
-    } else {
+    if (isLaunching) {
       console.warn('Attempted to launch LPC while already launching.')
       return Promise.resolve()
     }
+
+    analytics.reportLaunchLpcWizard()
+    setIsLaunching(true)
+
+    if (isLaunchBlocked) {
+      return new Promise((resolve, reject) => {
+        pendingLaunchRef.current = { resolve, reject }
+      })
+    }
+
+    return createLPCMaintenanceRun()
   }
 
   const handleCloseLPC = (): void => {
@@ -204,8 +239,6 @@ export function useLPCFlows({
       })
     }
   }
-
-  const isFlexLPCInitializing = flexOffsets == null
 
   const showLPC =
     runId != null &&
@@ -241,7 +274,7 @@ export function useLPCFlows({
       }
     : {
         launchLPC,
-        isLaunchingLPC: isLaunching,
+        isLaunchingLPC: isLaunching || isDocumentationLoading,
         isFlexLPCInitializing,
         lpcProps: null,
         showLPC,

--- a/app/src/organisms/LegacyLabwarePositionCheck/LegacyLabwarePositionCheckComponent.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/LegacyLabwarePositionCheckComponent.tsx
@@ -273,13 +273,13 @@ export const LegacyLabwarePositionCheckComponent = (
   const [isExiting, setIsExiting] = useState(false)
   const { createMaintenanceCommand: createSilentCommand } =
     useCreateMaintenanceCommandMutation(
-      { reasonForInteractionRequired: false },
+      { reasonForInteractionRequired: false, isLoading: false },
       [],
       () => {}
     ) // No ACM on the OT-2
   const { chainRunCommands, isCommandMutationLoading: isCommandChainLoading } =
     useChainMaintenanceCommands(
-      { reasonForInteractionRequired: false },
+      { reasonForInteractionRequired: false, isLoading: false },
       [],
       () => {}
     ) // No ACM on the OT-2

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/__tests__/RunFailedModal.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/__tests__/RunFailedModal.test.tsx
@@ -17,7 +17,10 @@ import type { NavigateFunction } from 'react-router-dom'
 vi.mock('@opentrons/react-api-client')
 vi.mock('../ErrorContent')
 vi.mock('/app/local-resources/access-control/useGuardedAction', () => ({
-  useGuardedAction: () => ({ reasonForInteractionRequired: false }),
+  useGuardedAction: () => ({
+    reasonForInteractionRequired: false,
+    isLoading: false,
+  }),
 }))
 
 const RUN_ID = 'mock_runID'

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -65,7 +65,10 @@ describe('BeforeBeginning', () => {
       requiredPipette: undefined,
       createdMaintenanceRunId: null,
       deckConfig: mockDeckConfig,
-      documentationState: { reasonForInteractionRequired: false },
+      documentationState: {
+        reasonForInteractionRequired: false,
+        isLoading: false,
+      },
     }
     // mockNeedHelpLink.mockReturnValue(<div>mock need help link</div>)
     vi.mocked(InProgressModal).mockReturnValue(<div>mock in progress</div>)

--- a/app/src/organisms/RunTimeControl/__tests__/hooks.test.tsx
+++ b/app/src/organisms/RunTimeControl/__tests__/hooks.test.tsx
@@ -45,7 +45,10 @@ describe('useRunControls hook', () => {
     const mockResumeRunFromRecoveryAssumingFalsePositive = vi.fn()
 
     when(useRunActionMutations)
-      .calledWith(mockPausedRun.id, { reasonForInteractionRequired: false })
+      .calledWith(mockPausedRun.id, {
+        reasonForInteractionRequired: false,
+        isLoading: false,
+      })
       .thenReturn({
         playRun: mockPlayRun,
         pauseRun: mockPauseRun,

--- a/app/src/organisms/RunTimeControl/hooks.ts
+++ b/app/src/organisms/RunTimeControl/hooks.ts
@@ -40,7 +40,10 @@ export function useRunControls(
     isPauseRunActionLoading,
     isStopRunActionLoading,
     isResumeRunFromRecoveryActionLoading,
-  } = useRunActionMutations(runId!, { reasonForInteractionRequired: false })
+  } = useRunActionMutations(runId!, {
+    reasonForInteractionRequired: false,
+    isLoading: false,
+  })
 
   const {
     cloneRun,

--- a/app/src/organisms/TakeoverModal/__tests__/MaintenanceRunTakeover.test.tsx
+++ b/app/src/organisms/TakeoverModal/__tests__/MaintenanceRunTakeover.test.tsx
@@ -16,7 +16,10 @@ import type { MaintenanceRunStatus } from '../MaintenanceRunStatusProvider'
 vi.mock('../useMaintenanceRunTakeover')
 vi.mock('/app/resources/maintenance_runs')
 vi.mock('/app/local-resources/access-control/useGuardedAction', () => ({
-  useGuardedAction: () => ({ reasonForInteractionRequired: false }),
+  useGuardedAction: () => ({
+    reasonForInteractionRequired: false,
+    isLoading: false,
+  }),
 }))
 
 const MOCK_MAINTENANCE_RUN: MaintenanceRunStatus = {

--- a/app/src/pages/ODD/RunningProtocol/__tests__/RunningProtocol.test.tsx
+++ b/app/src/pages/ODD/RunningProtocol/__tests__/RunningProtocol.test.tsx
@@ -143,7 +143,10 @@ describe('RunningProtocol', () => {
       completedAt: '2022-05-04T18:24:41.833862+00:00',
     })
     when(vi.mocked(useRunActionMutations))
-      .calledWith(RUN_ID, { reasonForInteractionRequired: false })
+      .calledWith(RUN_ID, {
+        reasonForInteractionRequired: false,
+        isLoading: false,
+      })
       .thenReturn({
         playRun: mockPlayRun,
         pauseRun: mockPauseRun,

--- a/app/src/resources/maintenance_runs/hooks/useRobotControlCommands.ts
+++ b/app/src/resources/maintenance_runs/hooks/useRobotControlCommands.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { useDeleteMaintenanceRunMutation } from '@opentrons/react-api-client'
 
@@ -10,6 +10,11 @@ import { useChainMaintenanceCommands } from './useChainMaintenanceCommands'
 import type { MaintenanceRun, Mount } from '@opentrons/api-client'
 import type { DocumentedAction } from '@opentrons/react-api-client'
 import type { CreateCommand } from '@opentrons/shared-data'
+
+interface PendingExecution {
+  resolve: (value: MaintenanceRun) => void
+  reject: (reason?: unknown) => void
+}
 
 export interface PipetteDetails {
   mount: Mount
@@ -48,12 +53,14 @@ export function useRobotControlCommands({
   runEndedAction,
 }: UseRobotControlCommandsProps): UseRobotControlCommandsResult {
   const [isExecuting, setIsExecuting] = useState(false)
+  const pendingExecutionRef = useRef<PendingExecution | null>(null)
 
   const {
     commandDocState,
     deletionDocState,
     actionsToDocument,
     addActionToDocument,
+    isLoading: isDocumentationLoading,
   } = useMaintenanceRunDocumentation(runStartedAction)
 
   const { chainRunCommands } = useChainMaintenanceCommands(
@@ -114,8 +121,28 @@ export function useRobotControlCommands({
       }
     )
 
+  // If documentation state is loading, we queue the execution, and run it in the useEffect when the documentation is ready.
+  // If documentation state is not loading, we can execute the commands immediately.
+  useEffect(() => {
+    if (isDocumentationLoading || pendingExecutionRef.current == null) {
+      return
+    }
+
+    const { resolve, reject } = pendingExecutionRef.current
+    pendingExecutionRef.current = null
+
+    void createTargetedMaintenanceRun({}).then(resolve).catch(reject)
+  }, [createTargetedMaintenanceRun, isDocumentationLoading])
+
   const executeCommands = (): Promise<MaintenanceRun> => {
     setIsExecuting(true)
+
+    if (isDocumentationLoading) {
+      return new Promise((resolve, reject) => {
+        pendingExecutionRef.current = { resolve, reject }
+      })
+    }
+
     return createTargetedMaintenanceRun({})
   }
 

--- a/react-api-client/src/access_control/__tests__/useDocumentedMutation.test.tsx
+++ b/react-api-client/src/access_control/__tests__/useDocumentedMutation.test.tsx
@@ -31,7 +31,7 @@ describe('useDocumentedMutation', () => {
     const { result } = renderHook(
       () =>
         useDocumentedMutation<number, AxiosError, number>(
-          { reasonForInteractionRequired: false },
+          { reasonForInteractionRequired: false, isLoading: false },
           ['play_run'],
           testMutationKey,
           ({ variables: n }) => mutationFn(n),
@@ -59,6 +59,7 @@ describe('useDocumentedMutation', () => {
           {
             reasonForInteractionRequired: true,
             docreport: MOCK_REPORT,
+            isLoading: false,
           },
           ['play_run'],
           testMutationKey,
@@ -89,6 +90,7 @@ describe('useDocumentedMutation', () => {
             reasonForInteractionRequired: true,
             docreport: null,
             askForDocumentation,
+            isLoading: false,
           },
           ['play_run'],
           testMutationKey,
@@ -118,6 +120,7 @@ describe('useDocumentedMutation', () => {
             reasonForInteractionRequired: true,
             docreport: null,
             askForDocumentation,
+            isLoading: false,
           },
           ['play_run'],
           testMutationKey,

--- a/react-api-client/src/access_control/types.ts
+++ b/react-api-client/src/access_control/types.ts
@@ -18,14 +18,20 @@ export type DocumentationReport = string & {
  * @param askForDocumentation - a function that opens the documentation modal and returns the documentation report
  */
 export type DocumentationState =
-  | { reasonForInteractionRequired: false }
-  | { reasonForInteractionRequired: true; docreport: DocumentationReport }
+  | { isLoading: true }
+  | { reasonForInteractionRequired: false; isLoading: false }
+  | {
+      reasonForInteractionRequired: true
+      docreport: DocumentationReport
+      isLoading: false
+    }
   | {
       reasonForInteractionRequired: true
       docreport: null
       askForDocumentation: (
         actionsToDocument: DocumentedAction[]
       ) => Promise<DocumentationReport>
+      isLoading: false
     }
 
 export interface DocumentedMutationParameters<TVariables = void> {

--- a/react-api-client/src/access_control/useDocumentedMutation.ts
+++ b/react-api-client/src/access_control/useDocumentedMutation.ts
@@ -60,7 +60,10 @@ const checkDocumentationReport = async (
   documentationState: DocumentationState,
   actionsToDocument: DocumentedAction[]
 ): Promise<DocumentationReport | null> => {
-  if (!documentationState.reasonForInteractionRequired) {
+  if (
+    documentationState.isLoading ||
+    !documentationState.reasonForInteractionRequired
+  ) {
     return null
   }
   if (documentationState.docreport != null) {
@@ -82,6 +85,9 @@ function useWrappedMutationFn<TData, TVariables>(
       )
       if (docreport == null) {
         console.error('No documentation report provided')
+      }
+      if (documentationState.isLoading) {
+        throw new Error('Access control queries are still loading')
       }
       return await mutationFn({ variables, userNotes: docreport ?? '' })
     },

--- a/react-api-client/src/maintenance_runs/__tests__/useCreateMaintenanceCommandMutation.test.tsx
+++ b/react-api-client/src/maintenance_runs/__tests__/useCreateMaintenanceCommandMutation.test.tsx
@@ -38,7 +38,7 @@ describe('useCreateMaintenanceCommandMutation hook', () => {
     const { result } = renderHook(
       () =>
         useCreateMaintenanceCommandMutation(
-          { reasonForInteractionRequired: false },
+          { reasonForInteractionRequired: false, isLoading: false },
           ['lpc_flow'],
           () => {}
         ),
@@ -69,7 +69,7 @@ describe('useCreateMaintenanceCommandMutation hook', () => {
     const { result } = renderHook(
       () =>
         useCreateMaintenanceCommandMutation(
-          { reasonForInteractionRequired: false },
+          { reasonForInteractionRequired: false, isLoading: false },
           ['lpc_flow'],
           () => {}
         ),

--- a/react-api-client/src/maintenance_runs/__tests__/useCreateMaintenanceRunMutation.test.tsx
+++ b/react-api-client/src/maintenance_runs/__tests__/useCreateMaintenanceRunMutation.test.tsx
@@ -41,7 +41,7 @@ describe('useCreateMaintenanceRunMutation hook', () => {
     const { result } = renderHook(
       () =>
         useCreateMaintenanceRunMutation(
-          { reasonForInteractionRequired: false },
+          { reasonForInteractionRequired: false, isLoading: false },
           ['lpc_flow']
         ),
       {
@@ -71,7 +71,7 @@ describe('useCreateMaintenanceRunMutation hook', () => {
     const { result } = renderHook(
       () =>
         useCreateMaintenanceRunMutation(
-          { reasonForInteractionRequired: false },
+          { reasonForInteractionRequired: false, isLoading: false },
           ['lpc_flow']
         ),
       {

--- a/react-api-client/src/maintenance_runs/__tests__/useDeleteMaintenanceRunMutation.test.tsx
+++ b/react-api-client/src/maintenance_runs/__tests__/useDeleteMaintenanceRunMutation.test.tsx
@@ -37,7 +37,7 @@ describe('useDeleteMaintenanceRunMutation hook', () => {
     const { result } = renderHook(
       () =>
         useDeleteMaintenanceRunMutation(
-          { reasonForInteractionRequired: false },
+          { reasonForInteractionRequired: false, isLoading: false },
           []
         ),
       {
@@ -61,7 +61,7 @@ describe('useDeleteMaintenanceRunMutation hook', () => {
     const { result } = renderHook(
       () =>
         useDeleteMaintenanceRunMutation(
-          { reasonForInteractionRequired: false },
+          { reasonForInteractionRequired: false, isLoading: false },
           []
         ),
       {

--- a/react-api-client/src/runs/__tests__/usePlayRunMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/usePlayRunMutation.test.tsx
@@ -37,7 +37,11 @@ describe('usePlayRunMutation hook', () => {
     vi.mocked(createRunAction).mockRejectedValue('oh no')
 
     const { result } = renderHook(
-      () => usePlayRunMutation({ reasonForInteractionRequired: false }),
+      () =>
+        usePlayRunMutation({
+          reasonForInteractionRequired: false,
+          isLoading: false,
+        }),
       { wrapper }
     )
 
@@ -55,7 +59,11 @@ describe('usePlayRunMutation hook', () => {
     } as Response<RunAction>)
 
     const { result } = renderHook(
-      () => usePlayRunMutation({ reasonForInteractionRequired: false }),
+      () =>
+        usePlayRunMutation({
+          reasonForInteractionRequired: false,
+          isLoading: false,
+        }),
       {
         wrapper,
       }

--- a/react-api-client/src/runs/__tests__/useRunActionMutations.test.tsx
+++ b/react-api-client/src/runs/__tests__/useRunActionMutations.test.tsx
@@ -77,6 +77,7 @@ describe('useRunActionMutations hook', () => {
       () =>
         useRunActionMutations(RUN_ID_1, {
           reasonForInteractionRequired: false,
+          isLoading: false,
         }),
       {
         wrapper,

--- a/react-api-client/src/runs/__tests__/useStopRunMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/useStopRunMutation.test.tsx
@@ -34,7 +34,11 @@ describe('useStopRunMutation hook', () => {
     vi.mocked(createRunAction).mockRejectedValue('oops')
 
     const { result } = renderHook(
-      () => useStopRunMutation({ reasonForInteractionRequired: false }),
+      () =>
+        useStopRunMutation({
+          reasonForInteractionRequired: false,
+          isLoading: false,
+        }),
       {
         wrapper,
       }
@@ -54,7 +58,11 @@ describe('useStopRunMutation hook', () => {
     } as Response<RunAction>)
 
     const { result } = renderHook(
-      () => useStopRunMutation({ reasonForInteractionRequired: false }),
+      () =>
+        useStopRunMutation({
+          reasonForInteractionRequired: false,
+          isLoading: false,
+        }),
       {
         wrapper,
       }


### PR DESCRIPTION
# Overview

Adds checks to ensure that the auth settings query has finished loading before using `isReasonForInteractionRequired` from documentation states. This should prevent mutations from going forward without prompting for documentation if it is needed. 

Some places are missing UI for these loading states but I will be handling that in a follow up PR so I can develop a more generalized solution. 

## Test Plan and Hands on Testing

Right now documentation flows are used on playing and stopping runs, homing pipettes, dropping tips, and on launching and ending maintenance runs. These actions should work normally in ACM, popping up Documentation Required modals, and without their network requests generating 422 errors.

## Review requests

In useLPCFlows I created a handler that basically queues the maintenance run creation, waits until the auth settings query is done, and then launches the mutation. I did my best to ensure this wouldn't create any race conditions or unfortunate side effects, but would love more eyes on that sections in particular. 


## Risk assessment

Medium - due to breadth
