### PR TITLE
fix(api): correct column bound for H1-fronted reservoir well coverage

### DIFF
--- a/api/src/opentrons/protocol_engine/state/_well_math.py
+++ b/api/src/opentrons/protocol_engine/state/_well_math.py
@@ -193,8 +193,7 @@ def wells_covered_sparse(  # noqa: C901
                     ]
             elif starting_nozzle == "H1":
                 if (
-                    target_column_index + nozzle_column
-                    < len(target_wells_by_column[target_column_index])
+                    target_column_index + nozzle_column < len(target_wells_by_column)
                 ) and (target_row_index - nozzle_row >= 0):
                     yield target_wells_by_column[target_column_index + nozzle_column][
                         target_row_index - nozzle_row

--- a/api/tests/opentrons/protocol_engine/state/test_well_math.py
+++ b/api/tests/opentrons/protocol_engine/state/test_well_math.py
@@ -110,6 +110,17 @@ _96_RECTANGLE_MAP = NozzleMap.build(
         }
     ),
 )
+_96_ROW_H_MAP = NozzleMap.build(
+    physical_nozzles=pipette_fixtures.NINETY_SIX_MAP,
+    physical_rows=pipette_fixtures.NINETY_SIX_ROWS,
+    physical_columns=pipette_fixtures.NINETY_SIX_COLS,
+    starting_nozzle="H1",
+    back_left_nozzle="H1",
+    front_right_nozzle="H12",
+    valid_nozzle_maps=ValidNozzleMaps(
+        maps={"RowH": pipette_fixtures.NINETY_SIX_ROWS["H"]}
+    ),
+)
 _8_FULL_MAP = NozzleMap.build(
     physical_nozzles=pipette_fixtures.EIGHT_CHANNEL_MAP,
     physical_rows=pipette_fixtures.EIGHT_CHANNEL_ROWS,
@@ -395,6 +406,34 @@ def test_wells_covered_sparse_1(
             _1_reservoir,
         )
     ) == ["A1"]
+
+
+@pytest.mark.parametrize(
+    "target_well,result",
+    [
+        ("A1", ["A1", "A2", "A3"]),
+        ("A2", ["A2", "A3"]),
+        ("A3", ["A3"]),
+    ],
+)
+def test_wells_covered_sparse_h1_taller_than_wide(
+    target_well: str, result: list[str]
+) -> None:
+    """It should not over-index columns for an H1-fronted row config on a taller-than-wide reservoir."""
+    # A sparse reservoir with more rows than columns (3 columns x 6 rows), column-major ordering.
+    grid = [[f"{chr(65 + r)}{c + 1}" for r in range(6)] for c in range(3)]
+    assert (
+        list(
+            wells_covered_sparse(
+                _96_ROW_H_MAP.columns,
+                _96_ROW_H_MAP.rows,
+                _96_ROW_H_MAP.starting_nozzle,
+                target_well,
+                grid,
+            )
+        )
+        == result
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What's broken

`wells_covered_sparse` raises `IndexError` in its `starting_nozzle == "H1"` branch when a 96-channel pipette runs in a row configuration (row H) into a sparse reservoir that has more rows than columns. The branch bounds-checks the column index against the number of rows in the current column instead of the number of columns, then indexes past the end of the grid.

```
wells_covered_sparse(rowH.columns, rowH.rows, "H1", "A2", grid_3cols_x_6rows)
-> IndexError: list index out of range
```

## Why it happens

The guard used `len(target_wells_by_column[target_column_index])` (rows in that column) instead of `len(target_wells_by_column)` (number of columns). The sibling branches — the `A1` sparse branch and the `H1` branch of `wells_covered_dense` — both correctly bound on `len(target_wells_by_column)`; this was a copy-paste slip unique to sparse-H1.

## Fix

Bound the column index on `len(target_wells_by_column)`, matching the sibling branches.

## Test

`test_wells_covered_sparse_h1_taller_than_wide` builds a real row-H 96 nozzle map over a 3-col × 6-row grid; targets A2/A3 raise `IndexError` before and return the correct wells after.
