### PR TITLE
test(robot-server): add tests to verify run removal when command annotations are present

### DIFF
--- a/robot-server/tests/integration/http_api/protocols/test_analyses_with_command_annotations.tavern.yaml
+++ b/robot-server/tests/integration/http_api/protocols/test_analyses_with_command_annotations.tavern.yaml
@@ -159,3 +159,22 @@ stages:
             liquids: []
             liquidClasses: []
             labwareOffsets: []
+
+  - name: Delete the protocol
+    request:
+      url: '{ot3_server_base_url}/protocols/{protocol_id}'
+      method: DELETE
+    response:
+      status_code: 200
+  - name: Get protocol with id to verify it is deleted
+    request:
+      url: '{ot3_server_base_url}/protocols/{protocol_id}'
+      method: GET
+    response:
+      strict:
+        - json:off
+      status_code: 404
+      json:
+        errors:
+          - id: ProtocolNotFound
+            title: Protocol Not Found

--- a/robot-server/tests/integration/http_api/runs/test_get_command_annotations_in_historical_run.tavern.yaml
+++ b/robot-server/tests/integration/http_api/runs/test_get_command_annotations_in_historical_run.tavern.yaml
@@ -235,3 +235,18 @@ stages:
           name: 'My step group 2'
           description: "Another comment!"
           params: {}
+
+  - name: Delete the run
+    request:
+      url: '{ot3_server_base_url}/runs/{run_id}'
+      method: DELETE
+    response:
+      status_code: 200
+      json: { }
+
+  - name: Try to get deleted run
+    request:
+      url: '{ot3_server_base_url}/runs/{run_id}'
+      method: GET
+    response:
+      status_code: 404

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -655,6 +655,8 @@ def test_get_all_runs(
 async def test_remove_run(
     subject: RunStore,
     mock_runs_publisher: mock.Mock,
+    state_summary: StateSummary,
+    command_annotations: List[pe_types.CommandAnnotation],
     data_files_store: DataFilesStore,
     run_time_parameters: List[pe_types.RunTimeParameter],
 ) -> None:
@@ -669,6 +671,14 @@ async def test_remove_run(
         run_id="run-id",
         protocol_id=None,
         created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+    )
+    # Add command annotations
+    subject.update_run_state(
+        run_id="run-id",
+        summary=state_summary,
+        commands=[],
+        command_annotations=command_annotations,
+        run_time_parameters=[],
     )
     subject.insert_action(run_id="run-id", action=action)
     await data_files_store.insert(


### PR DESCRIPTION
# Overview

While investigating [RABR-959](https://opentrons.atlassian.net/browse/RABR-959), I realized that there are no unit/ integration tests that check the removal of runs that have command annotations. So adding those.

## Changelog

- added tavern tests for removing a protocol & a run containing command annotations
- updated run removal unit test to include command annotations

## Review requests

- any case that's missing?

## Risk assessment

- None. Test only

[RABR-959]: https://opentrons.atlassian.net/browse/RABR-959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ