### PR TITLE
refactor(api-client): Refactor request inputs into an object with optional properties

### DIFF
--- a/api-client/src/auth/oauth2/getOAuth2Token.ts
+++ b/api-client/src/auth/oauth2/getOAuth2Token.ts
@@ -60,7 +60,7 @@ export function getOAuth2Token(
   return request<OAuth2TokenResponse, URLSearchParams>(
     POST,
     '/auth/oauth2/token',
-    encodedBody,
-    config
+    config,
+    { body: encodedBody }
   )
 }

--- a/api-client/src/auth/settings/getAccessControlEnabled.ts
+++ b/api-client/src/auth/settings/getAccessControlEnabled.ts
@@ -10,7 +10,6 @@ export function getAccessControlEnabled(
   return request<AccessControlEnabledSettingsResponse>(
     GET,
     '/auth/settings/accessControlEnabled',
-    null,
     config
   )
 }

--- a/api-client/src/auth/settings/getAuthSettings.ts
+++ b/api-client/src/auth/settings/getAuthSettings.ts
@@ -7,5 +7,5 @@ import type { AuthSettingsResponse } from './types'
 export function getAuthSettings(
   config: HostConfig
 ): ResponsePromise<AuthSettingsResponse> {
-  return request<AuthSettingsResponse>(GET, '/auth/settings', null, config)
+  return request<AuthSettingsResponse>(GET, '/auth/settings', config)
 }

--- a/api-client/src/auth/settings/patchAccessControlEnabled.ts
+++ b/api-client/src/auth/settings/patchAccessControlEnabled.ts
@@ -14,5 +14,5 @@ export function patchAccessControlEnabled(
   return request<
     AccessControlEnabledSettingsResponse,
     PatchAccessControlEnabledSettingsRequest
-  >(PATCH, '/auth/settings/accessControlEnabled', body, config)
+  >(PATCH, '/auth/settings/accessControlEnabled', config, { body })
 }

--- a/api-client/src/auth/users/getSelf.ts
+++ b/api-client/src/auth/users/getSelf.ts
@@ -5,5 +5,5 @@ import type { HostConfig } from '../../types'
 import type { AuthUserResponse } from './types'
 
 export function getSelf(config: HostConfig): ResponsePromise<AuthUserResponse> {
-  return request<AuthUserResponse>(GET, `/auth/users/self`, null, config)
+  return request<AuthUserResponse>(GET, `/auth/users/self`, config)
 }

--- a/api-client/src/auth/users/updateSelf.ts
+++ b/api-client/src/auth/users/updateSelf.ts
@@ -11,7 +11,7 @@ export function updateSelf(
   return request<AuthUserResponse, UpdateSelfRequest>(
     PATCH,
     '/auth/users/self',
-    body,
-    config
+    config,
+    { body }
   )
 }

--- a/api-client/src/calibration/deleteCalibration.ts
+++ b/api-client/src/calibration/deleteCalibration.ts
@@ -1,4 +1,4 @@
-import { createAxiosConfig, DELETE, request } from '../request'
+import { DELETE, request } from '../request'
 
 import type { ResponsePromise } from '../request'
 import type { EmptyResponse, HostConfig } from '../types'
@@ -11,11 +11,7 @@ export function deleteCalibration(
   const { calType, ...apiParams } = params
   const endpoint =
     params.calType === 'pipetteOffset' ? 'pipette_offset' : 'tip_length'
-  return request<EmptyResponse>(
-    DELETE,
-    `/calibration/${endpoint}`,
-    null,
-    config,
-    apiParams && createAxiosConfig({ params: apiParams })
-  )
+  return request<EmptyResponse>(DELETE, `/calibration/${endpoint}`, config, {
+    queryParams: apiParams,
+  })
 }

--- a/api-client/src/calibration/getCalibrationPipetteOffset.ts
+++ b/api-client/src/calibration/getCalibrationPipetteOffset.ts
@@ -10,7 +10,6 @@ export function getCalibrationPipetteOffset(
   return request<AllPipetteOffsetCalibrations>(
     GET,
     '/calibration/pipette_offset',
-    null,
     config
   )
 }

--- a/api-client/src/calibration/getCalibrationStatus.ts
+++ b/api-client/src/calibration/getCalibrationStatus.ts
@@ -7,5 +7,5 @@ import type { CalibrationStatus } from './types'
 export function getCalibrationStatus(
   config: HostConfig
 ): ResponsePromise<CalibrationStatus> {
-  return request<CalibrationStatus>(GET, '/calibration/status', null, config)
+  return request<CalibrationStatus>(GET, '/calibration/status', config)
 }

--- a/api-client/src/calibration/getCalibrationTipLength.ts
+++ b/api-client/src/calibration/getCalibrationTipLength.ts
@@ -10,7 +10,6 @@ export function getCalibrationTipLength(
   return request<AllTipLengthCalibrations>(
     GET,
     '/calibration/tip_length',
-    null,
     config
   )
 }

--- a/api-client/src/camera/createCamera.ts
+++ b/api-client/src/camera/createCamera.ts
@@ -11,7 +11,7 @@ export function createCamera(
   return request<CameraResponse, { data: CameraData }>(
     POST,
     `/camera`,
-    { data },
-    config
+    config,
+    { body: { data } }
   )
 }

--- a/api-client/src/camera/createCameraImageSettings.ts
+++ b/api-client/src/camera/createCameraImageSettings.ts
@@ -14,7 +14,7 @@ export function createCameraImageSettings(
   return request<CameraImageSettingsResponse, { data: CameraImageSettings }>(
     POST,
     `/camera/cameraSettings`,
-    { data },
-    config
+    config,
+    { body: { data } }
   )
 }

--- a/api-client/src/camera/createCapturePreviewImage.ts
+++ b/api-client/src/camera/createCapturePreviewImage.ts
@@ -1,10 +1,10 @@
-import { createAxiosConfig, POST, request } from '../request'
+import { POST, request } from '../request'
 
 import type {
   CameraImageSettings,
   DownloadedPreviewImageFileResponse,
 } from '../camera'
-import type { ResponsePromise } from '../request'
+import type { RequestConfig, ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
 
 export function createCapturePreviewImage(
@@ -14,11 +14,8 @@ export function createCapturePreviewImage(
   return request<
     DownloadedPreviewImageFileResponse,
     { data: CameraImageSettings }
-  >(
-    POST,
-    `/camera/capturePreviewImage`,
-    { data },
-    config,
-    createAxiosConfig({ responseType: 'blob' })
-  )
+  >(POST, `/camera/capturePreviewImage`, config, {
+    body: { data },
+    responseType: 'blob',
+  })
 }

--- a/api-client/src/camera/createCapturePreviewImage.ts
+++ b/api-client/src/camera/createCapturePreviewImage.ts
@@ -1,6 +1,5 @@
 import { createAxiosConfig, POST, request } from '../request'
 
-import type { AxiosRequestConfig } from 'axios'
 import type {
   CameraImageSettings,
   DownloadedPreviewImageFileResponse,
@@ -10,8 +9,7 @@ import type { HostConfig } from '../types'
 
 export function createCapturePreviewImage(
   config: HostConfig,
-  data: CameraImageSettings,
-  axiosConfig?: AxiosRequestConfig
+  data: CameraImageSettings
 ): ResponsePromise<DownloadedPreviewImageFileResponse> {
   return request<
     DownloadedPreviewImageFileResponse,
@@ -21,6 +19,6 @@ export function createCapturePreviewImage(
     `/camera/capturePreviewImage`,
     { data },
     config,
-    axiosConfig && createAxiosConfig(axiosConfig)
+    createAxiosConfig({ responseType: 'blob' })
   )
 }

--- a/api-client/src/camera/createCapturePreviewImage.ts
+++ b/api-client/src/camera/createCapturePreviewImage.ts
@@ -4,7 +4,7 @@ import type {
   CameraImageSettings,
   DownloadedPreviewImageFileResponse,
 } from '../camera'
-import type { RequestConfig, ResponsePromise } from '../request'
+import type { ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
 
 export function createCapturePreviewImage(

--- a/api-client/src/camera/getCamera.ts
+++ b/api-client/src/camera/getCamera.ts
@@ -5,5 +5,5 @@ import type { HostConfig } from '../types'
 import type { CameraResponse } from './types'
 
 export function getCamera(config: HostConfig): ResponsePromise<CameraResponse> {
-  return request<CameraResponse>(GET, `/camera`, null, config)
+  return request<CameraResponse>(GET, `/camera`, config)
 }

--- a/api-client/src/camera/getCameraImageSettings.ts
+++ b/api-client/src/camera/getCameraImageSettings.ts
@@ -12,7 +12,6 @@ export function getCameraImageSettings(
   return request<CameraImageSettingsResponse>(
     GET,
     `/camera/cameraSettings/${cameraId}`,
-    null,
     config
   )
 }

--- a/api-client/src/client_data/getClientData.ts
+++ b/api-client/src/client_data/getClientData.ts
@@ -8,5 +8,5 @@ export function getClientData<T = DefaultClientData>(
   config: HostConfig,
   key: string
 ): ResponsePromise<ClientDataResponse<T>> {
-  return request<ClientDataResponse<T>>(GET, `/clientData/${key}`, null, config)
+  return request<ClientDataResponse<T>>(GET, `/clientData/${key}`, config)
 }

--- a/api-client/src/client_data/updateClientData.ts
+++ b/api-client/src/client_data/updateClientData.ts
@@ -16,7 +16,7 @@ export function updateClientData<T = DefaultClientData>(
   return request<ClientDataResponse<T>, ClientDataRequest<T>>(
     PUT,
     `/clientData/${key}`,
-    { data: clientData },
-    config
+    config,
+    { body: { data: clientData } }
   )
 }

--- a/api-client/src/dataFiles/deleteRunImages.ts
+++ b/api-client/src/dataFiles/deleteRunImages.ts
@@ -7,10 +7,5 @@ export function deleteRunImages(
   config: HostConfig,
   runId: string
 ): ResponsePromise<EmptyResponse> {
-  return request<EmptyResponse>(
-    DELETE,
-    `/dataFiles/${runId}/images`,
-    null,
-    config
-  )
+  return request<EmptyResponse>(DELETE, `/dataFiles/${runId}/images`, config)
 }

--- a/api-client/src/dataFiles/getAllRunImages.ts
+++ b/api-client/src/dataFiles/getAllRunImages.ts
@@ -1,4 +1,4 @@
-import { createAxiosConfig, GET, request } from '../request'
+import { GET, request } from '../request'
 
 import type { ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
@@ -11,8 +11,7 @@ export function getAllRunImages(
   return request<DownloadedImageFileResponse>(
     GET,
     `/dataFiles/${runId}/images/download`,
-    null,
     config,
-    createAxiosConfig({ responseType: 'blob' })
+    { responseType: 'blob' }
   )
 }

--- a/api-client/src/dataFiles/getDataFile.ts
+++ b/api-client/src/dataFiles/getDataFile.ts
@@ -8,10 +8,5 @@ export function getDataFile(
   config: HostConfig,
   fileId: string
 ): ResponsePromise<DataFileDataResponse> {
-  return request<DataFileDataResponse>(
-    GET,
-    `/dataFiles/${fileId}`,
-    null,
-    config
-  )
+  return request<DataFileDataResponse>(GET, `/dataFiles/${fileId}`, config)
 }

--- a/api-client/src/dataFiles/getDataFileRaw.ts
+++ b/api-client/src/dataFiles/getDataFileRaw.ts
@@ -8,13 +8,13 @@ import type { DownloadedDataFileResponse } from './types'
 export function getDataFileRaw(
   config: HostConfig,
   fileId: string,
-  axiosConfig?: AxiosRequestConfig
+  responseType?: AxiosRequestConfig['responseType']
 ): ResponsePromise<DownloadedDataFileResponse> {
   return request<DownloadedDataFileResponse>(
     GET,
     `/dataFiles/${fileId}/download`,
     null,
     config,
-    axiosConfig && createAxiosConfig(axiosConfig)
+    createAxiosConfig({ responseType })
   )
 }

--- a/api-client/src/dataFiles/getDataFileRaw.ts
+++ b/api-client/src/dataFiles/getDataFileRaw.ts
@@ -1,20 +1,18 @@
-import { createAxiosConfig, GET, request } from '../request'
+import { GET, request } from '../request'
 
-import type { AxiosRequestConfig } from 'axios'
-import type { ResponsePromise } from '../request'
+import type { RequestConfig, ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
 import type { DownloadedDataFileResponse } from './types'
 
 export function getDataFileRaw(
   config: HostConfig,
   fileId: string,
-  responseType?: AxiosRequestConfig['responseType']
+  responseType?: RequestConfig<unknown>['responseType']
 ): ResponsePromise<DownloadedDataFileResponse> {
   return request<DownloadedDataFileResponse>(
     GET,
     `/dataFiles/${fileId}/download`,
-    null,
     config,
-    createAxiosConfig({ responseType })
+    { responseType }
   )
 }

--- a/api-client/src/dataFiles/getImageFiles.ts
+++ b/api-client/src/dataFiles/getImageFiles.ts
@@ -11,7 +11,6 @@ export function getImageFiles(
   return request<ImageFilesDataResponse>(
     GET,
     `/dataFiles/${runId}/images`,
-    null,
     config
   )
 }

--- a/api-client/src/dataFiles/getRunDataFileMetadata.ts
+++ b/api-client/src/dataFiles/getRunDataFileMetadata.ts
@@ -11,7 +11,6 @@ export function getRunDataFileMetadata(
   return request<RunDataFileMetadataResponse>(
     GET,
     `/dataFiles/${runId}/all`,
-    null,
     config
   )
 }

--- a/api-client/src/dataFiles/uploadCsvFile.ts
+++ b/api-client/src/dataFiles/uploadCsvFile.ts
@@ -18,7 +18,9 @@ export function uploadCsvFile(
   return request<UploadedCsvFileResponse, FormData>(
     POST,
     '/dataFiles',
-    formData,
-    config
+    config,
+    {
+      body: formData,
+    }
   )
 }

--- a/api-client/src/deck_configuration/getDeckConfiguration.ts
+++ b/api-client/src/deck_configuration/getDeckConfiguration.ts
@@ -7,10 +7,5 @@ import type { DeckConfigurationResponse } from './types'
 export function getDeckConfiguration(
   config: HostConfig
 ): ResponsePromise<DeckConfigurationResponse> {
-  return request<DeckConfigurationResponse>(
-    GET,
-    `/deck_configuration`,
-    null,
-    config
-  )
+  return request<DeckConfigurationResponse>(GET, `/deck_configuration`, config)
 }

--- a/api-client/src/deck_configuration/updateDeckConfiguration.ts
+++ b/api-client/src/deck_configuration/updateDeckConfiguration.ts
@@ -15,7 +15,7 @@ export function updateDeckConfiguration(
   return request<DeckConfigurationResponse, UpdateDeckConfigurationRequest>(
     PUT,
     '/deck_configuration',
-    { data: { cutoutFixtures: deckConfig } },
-    config
+    config,
+    { body: { data: { cutoutFixtures: deckConfig } } }
   )
 }

--- a/api-client/src/errorRecovery/settings/getErrorRecoverySettings.ts
+++ b/api-client/src/errorRecovery/settings/getErrorRecoverySettings.ts
@@ -10,7 +10,6 @@ export function getErrorRecoverySettings(
   return request<ErrorRecoverySettingsResponse>(
     GET,
     '/errorRecovery/settings',
-    null,
     config
   )
 }

--- a/api-client/src/errorRecovery/settings/updateErrorRecoverySettings.ts
+++ b/api-client/src/errorRecovery/settings/updateErrorRecoverySettings.ts
@@ -14,7 +14,7 @@ export function updateErrorRecoverySettings(
   return request<ErrorRecoverySettingsResponse, ErrorRecoverySettingsRequest>(
     PATCH,
     '/errorRecovery/settings',
-    settings,
-    config
+    config,
+    { body: settings }
   )
 }

--- a/api-client/src/health/getHealth.ts
+++ b/api-client/src/health/getHealth.ts
@@ -5,5 +5,5 @@ import type { HostConfig } from '../types'
 import type { Health } from './types'
 
 export function getHealth(config: HostConfig): ResponsePromise<Health> {
-  return request<Health>(GET, '/health', null, config)
+  return request<Health>(GET, '/health', config)
 }

--- a/api-client/src/instruments/getInstruments.ts
+++ b/api-client/src/instruments/getInstruments.ts
@@ -7,5 +7,5 @@ import type { Instruments } from './types'
 export function getInstruments(
   config: HostConfig
 ): ResponsePromise<Instruments> {
-  return request<Instruments>(GET, `/instruments`, null, config)
+  return request<Instruments>(GET, `/instruments`, config)
 }

--- a/api-client/src/keys/getCACertPassword.ts
+++ b/api-client/src/keys/getCACertPassword.ts
@@ -7,10 +7,5 @@ import type { CACertPassword } from './types'
 export function getCACertPassword(
   config: HostConfig
 ): ResponsePromise<CACertPassword> {
-  return request<CACertPassword>(
-    GET,
-    '/keys/internal/ca/password',
-    null,
-    config
-  )
+  return request<CACertPassword>(GET, '/keys/internal/ca/password', config)
 }

--- a/api-client/src/keys/getEncryptedCACertificates.ts
+++ b/api-client/src/keys/getEncryptedCACertificates.ts
@@ -10,7 +10,6 @@ export function getEncryptedCACertificates(
   return request<EncryptedCACertificates>(
     GET,
     '/keys/external/ca/encryptedCerts',
-    null,
     config
   )
 }

--- a/api-client/src/keys/getPlaintextCACertificates.ts
+++ b/api-client/src/keys/getPlaintextCACertificates.ts
@@ -10,7 +10,6 @@ export function getPlaintextCACertificates(
   return request<PlaintextCACertificates>(
     GET,
     '/keys/external/ca/plaintextCerts',
-    null,
     {
       ...config,
       secure: true,

--- a/api-client/src/labwareOffsets/createLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/createLabwareOffsets.ts
@@ -37,5 +37,5 @@ export function createLabwareOffsets(
   return request<
     CreateLabwareOffsetResponse,
     { data: CreateLabwareOffsetData }
-  >(POST, '/labwareOffsets', { data }, config)
+  >(POST, '/labwareOffsets', config, { body: { data } })
 }

--- a/api-client/src/labwareOffsets/deleteAllLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/deleteAllLabwareOffsets.ts
@@ -9,5 +9,5 @@ import type { HostConfig } from '../types'
 export function deleteAllLabwareOffsets(
   config: HostConfig
 ): ResponsePromise<{ data: null }> {
-  return request<{ data: null }>(DELETE, '/labwareOffsets', null, config)
+  return request<{ data: null }>(DELETE, '/labwareOffsets', config)
 }

--- a/api-client/src/labwareOffsets/deleteLabwareOffset.ts
+++ b/api-client/src/labwareOffsets/deleteLabwareOffset.ts
@@ -16,7 +16,6 @@ export function deleteLabwareOffset(
   return request<{ data: StoredLabwareOffset }>(
     DELETE,
     `/labwareOffsets/${id}`,
-    null,
     config
   )
 }

--- a/api-client/src/labwareOffsets/getLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/getLabwareOffsets.ts
@@ -1,4 +1,4 @@
-import { createAxiosConfig, GET, request } from '../request'
+import { GET, request } from '../request'
 
 import type { ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
@@ -24,11 +24,7 @@ export function getLabwareOffsets(
   config: HostConfig,
   params: LabwareOffsetsSearchParams = {}
 ): ResponsePromise<LabwareOffsetsResponse> {
-  return request<LabwareOffsetsResponse>(
-    GET,
-    '/labwareOffsets',
-    null,
-    config,
-    params && createAxiosConfig({ params })
-  )
+  return request<LabwareOffsetsResponse>(GET, '/labwareOffsets', config, {
+    queryParams: { ...params },
+  })
 }

--- a/api-client/src/labwareOffsets/searchLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/searchLabwareOffsets.ts
@@ -36,5 +36,5 @@ export function searchLabwareOffsets(
   return request<
     SearchLabwareOffsetsResponse,
     { data: SearchLabwareOffsetsRequest }
-  >(POST, '/labwareOffsets/searches', { data }, config)
+  >(POST, '/labwareOffsets/searches', config, { body: { data } })
 }

--- a/api-client/src/maintenance_runs/createMaintenanceCommand.ts
+++ b/api-client/src/maintenance_runs/createMaintenanceCommand.ts
@@ -1,4 +1,4 @@
-import { createAxiosConfig, POST, request } from '../request'
+import { POST, request } from '../request'
 
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { ResponsePromise } from '../request'
@@ -15,9 +15,7 @@ export function createMaintenanceCommand(
   return request<CommandData, { data: CreateCommand }>(
     POST,
     `/maintenance_runs/${maintenanceRunId}/commands`,
-    { data },
     config,
-    params && createAxiosConfig({ params }),
-    userNotes
+    { queryParams: { ...params }, body: { data }, userNotes }
   )
 }

--- a/api-client/src/maintenance_runs/createMaintenanceRun.ts
+++ b/api-client/src/maintenance_runs/createMaintenanceRun.ts
@@ -12,9 +12,7 @@ export function createMaintenanceRun(
   return request<MaintenanceRun, { data: CreateMaintenanceRunData }>(
     POST,
     '/maintenance_runs',
-    { data },
     config,
-    undefined,
-    userNotes
+    { body: { data }, userNotes }
   )
 }

--- a/api-client/src/maintenance_runs/createMaintenanceRunLabwareDefinition.ts
+++ b/api-client/src/maintenance_runs/createMaintenanceRunLabwareDefinition.ts
@@ -14,9 +14,7 @@ export function createMaintenanceRunLabwareDefinition(
   return request<LabwareDefinitionSummary, { data: LabwareDefinition }>(
     POST,
     `/maintenance_runs/${maintenanceRunId}/labware_definitions`,
-    { data },
     config,
-    undefined,
-    userNotes
+    { body: { data }, userNotes }
   )
 }

--- a/api-client/src/maintenance_runs/deleteMaintenanceRun.ts
+++ b/api-client/src/maintenance_runs/deleteMaintenanceRun.ts
@@ -11,9 +11,7 @@ export function deleteMaintenanceRun(
   return request<EmptyResponse>(
     DELETE,
     `/maintenance_runs/${maintenanceRunId}`,
-    null,
     config,
-    undefined,
-    userNotes
+    { userNotes }
   )
 }

--- a/api-client/src/maintenance_runs/getCurrentMaintenanceRun.ts
+++ b/api-client/src/maintenance_runs/getCurrentMaintenanceRun.ts
@@ -7,10 +7,5 @@ import type { MaintenanceRun } from './types'
 export function getCurrentMaintenanceRun(
   config: HostConfig
 ): ResponsePromise<MaintenanceRun> {
-  return request<MaintenanceRun>(
-    GET,
-    `/maintenance_runs/current_run`,
-    null,
-    config
-  )
+  return request<MaintenanceRun>(GET, `/maintenance_runs/current_run`, config)
 }

--- a/api-client/src/maintenance_runs/getMaintenanceRun.ts
+++ b/api-client/src/maintenance_runs/getMaintenanceRun.ts
@@ -11,7 +11,6 @@ export function getMaintenanceRun(
   return request<MaintenanceRun>(
     GET,
     `/maintenace_runs/${maintenanceRunId}`,
-    null,
     config
   )
 }

--- a/api-client/src/modules/getModules.ts
+++ b/api-client/src/modules/getModules.ts
@@ -5,5 +5,5 @@ import type { HostConfig } from '../types'
 import type { Modules } from './types'
 
 export function getModules(config: HostConfig): ResponsePromise<Modules> {
-  return request<Modules>(GET, `/modules`, null, config)
+  return request<Modules>(GET, `/modules`, config)
 }

--- a/api-client/src/networking/getWifiList.ts
+++ b/api-client/src/networking/getWifiList.ts
@@ -7,5 +7,5 @@ import type { WifiListResponse } from './types'
 export function getWifiList(
   config: HostConfig
 ): ResponsePromise<WifiListResponse> {
-  return request<WifiListResponse>(GET, '/wifi/list', null, config)
+  return request<WifiListResponse>(GET, '/wifi/list', config)
 }

--- a/api-client/src/pipettes/getPipetteSettings.ts
+++ b/api-client/src/pipettes/getPipetteSettings.ts
@@ -7,5 +7,5 @@ import type { PipetteSettings } from './types'
 export function getPipetteSettings(
   config: HostConfig
 ): ResponsePromise<PipetteSettings> {
-  return request<PipetteSettings>(GET, `/settings/pipettes`, null, config)
+  return request<PipetteSettings>(GET, `/settings/pipettes`, config)
 }

--- a/api-client/src/pipettes/getPipettes.ts
+++ b/api-client/src/pipettes/getPipettes.ts
@@ -1,4 +1,4 @@
-import { createAxiosConfig, GET, request } from '../request'
+import { GET, request } from '../request'
 
 import type { ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
@@ -8,11 +8,7 @@ export function getPipettes(
   config: HostConfig,
   params: GetPipettesParams
 ): ResponsePromise<Pipettes> {
-  return request<Pipettes>(
-    GET,
-    `/pipettes`,
-    null,
-    config,
-    params && createAxiosConfig({ params })
-  )
+  return request<Pipettes>(GET, `/pipettes`, config, {
+    queryParams: { ...params },
+  })
 }

--- a/api-client/src/pipettes/updatePipetteSettings.ts
+++ b/api-client/src/pipettes/updatePipetteSettings.ts
@@ -15,7 +15,7 @@ export function updatePipetteSettings(
   return request<IndividualPipetteSettings, UpdatePipetteSettingsData>(
     PATCH,
     `/settings/pipettes/${pipetteId}`,
-    data,
-    config
+    config,
+    { body: data }
   )
 }

--- a/api-client/src/protocols/createProtocol.ts
+++ b/api-client/src/protocols/createProtocol.ts
@@ -39,5 +39,7 @@ export function createProtocol(
     )
   }
 
-  return request<Protocol, FormData>(POST, '/protocols', formData, config)
+  return request<Protocol, FormData>(POST, '/protocols', config, {
+    body: formData,
+  })
 }

--- a/api-client/src/protocols/createProtocolAnalysis.ts
+++ b/api-client/src/protocols/createProtocolAnalysis.ts
@@ -33,6 +33,6 @@ export function createProtocolAnalysis(
   const response = request<
     ProtocolAnalysisSummaryResult,
     { data: CreateProtocolAnalysisData }
-  >(POST, `/protocols/${protocolKey}/analyses`, { data }, config)
+  >(POST, `/protocols/${protocolKey}/analyses`, config, { body: { data } })
   return response
 }

--- a/api-client/src/protocols/deleteProtocol.ts
+++ b/api-client/src/protocols/deleteProtocol.ts
@@ -7,10 +7,5 @@ export function deleteProtocol(
   config: HostConfig,
   protocolId: string
 ): ResponsePromise<EmptyResponse> {
-  return request<EmptyResponse>(
-    DELETE,
-    `/protocols/${protocolId}`,
-    null,
-    config
-  )
+  return request<EmptyResponse>(DELETE, `/protocols/${protocolId}`, config)
 }

--- a/api-client/src/protocols/getCsvFiles.ts
+++ b/api-client/src/protocols/getCsvFiles.ts
@@ -11,7 +11,6 @@ export function getCsvFiles(
   return request<UploadedCsvFilesResponse>(
     GET,
     `/protocols/${protocolId}/dataFiles`,
-    null,
     config
   )
 }

--- a/api-client/src/protocols/getProtocol.ts
+++ b/api-client/src/protocols/getProtocol.ts
@@ -8,5 +8,5 @@ export function getProtocol(
   config: HostConfig,
   protocolId: string
 ): ResponsePromise<Protocol> {
-  return request<Protocol>(GET, `/protocols/${protocolId}`, null, config)
+  return request<Protocol>(GET, `/protocols/${protocolId}`, config)
 }

--- a/api-client/src/protocols/getProtocolAnalyses.ts
+++ b/api-client/src/protocols/getProtocolAnalyses.ts
@@ -11,7 +11,6 @@ export function getProtocolAnalyses(
   return request<ProtocolAnalyses>(
     GET,
     `/protocols/${protocolId}/analyses`,
-    null,
     config
   )
 }

--- a/api-client/src/protocols/getProtocolAnalysisAsDocument.ts
+++ b/api-client/src/protocols/getProtocolAnalysisAsDocument.ts
@@ -12,7 +12,6 @@ export function getProtocolAnalysisAsDocument(
   return request<CompletedProtocolAnalysis>(
     GET,
     `/protocols/${protocolId}/analyses/${analysisId}/asDocument`,
-    null,
     config
   )
 }

--- a/api-client/src/protocols/getProtocolIds.ts
+++ b/api-client/src/protocols/getProtocolIds.ts
@@ -7,5 +7,5 @@ import type { ProtocolsIds } from './types'
 export function getProtocolIds(
   config: HostConfig
 ): ResponsePromise<ProtocolsIds> {
-  return request<ProtocolsIds>(GET, `/protocols/ids`, null, config)
+  return request<ProtocolsIds>(GET, `/protocols/ids`, config)
 }

--- a/api-client/src/protocols/getProtocols.ts
+++ b/api-client/src/protocols/getProtocols.ts
@@ -5,5 +5,5 @@ import type { HostConfig } from '../types'
 import type { Protocols } from './types'
 
 export function getProtocols(config: HostConfig): ResponsePromise<Protocols> {
-  return request<Protocols>(GET, `/protocols`, null, config)
+  return request<Protocols>(GET, `/protocols`, config)
 }

--- a/api-client/src/request.ts
+++ b/api-client/src/request.ts
@@ -25,23 +25,50 @@ export const PATCH = 'PATCH'
 export const DELETE = 'DELETE'
 export const PUT = 'PUT'
 
-export type BrandedAxiosConfig = AxiosRequestConfig & {
-  readonly __axiosConfigBrand: unique symbol
-}
-export function createAxiosConfig(
-  config: AxiosRequestConfig
-): BrandedAxiosConfig {
-  return config as BrandedAxiosConfig
+export interface RequestConfig<
+  RequestBodyT extends AxiosRequestConfig['data'],
+> {
+  /**
+   * The request body.
+   */
+  body?: RequestBodyT
+
+  /**
+   * Query parameters, e.g. {foo: "bar"} for ?foo=bar.
+   */
+  queryParams?: Record<string, string | number | boolean>
+
+  /**
+   * Request-specific headers.
+   *
+   * Common headers like Authorization, Opentrons-Version,
+   * and Opentrons-User-Notes don't need to be set here;
+   * they'll be added automatically.
+   */
+  headers?: Record<string, string>
+
+  /**
+   * The user-entered reason for this interaction with the robot.
+   * Generally required by the server for any mutation when
+   * Compliance Ready Software is enabled.
+   */
+  userNotes?: string
+
+  /**
+   * What kind of response body to expect and how Axios should parse it.
+   */
+  responseType?: AxiosRequestConfig['responseType']
 }
 
-export function request<ResData, ReqData = null>(
+export function request<
+  ResponseBodyT,
+  RequestBodyT extends AxiosRequestConfig['data'] = never,
+>(
   method: Method,
   url: string,
-  data: ReqData,
   hostConfig: HostConfig,
-  axiosConfig?: BrandedAxiosConfig,
-  userNotes?: string
-): ResponsePromise<ResData> {
+  requestConfig?: RequestConfig<RequestBodyT>
+): ResponsePromise<ResponseBodyT> {
   const {
     hostname,
     port,
@@ -50,14 +77,18 @@ export function request<ResData, ReqData = null>(
     secure,
   } = hostConfig
 
+  const params = requestConfig?.queryParams ?? {}
   const tokenHeader = token != null ? { Authorization: `Bearer ${token}` } : {}
   const userNotesHeader =
-    userNotes != null ? { 'Opentrons-User-Notes': userNotes } : {}
+    requestConfig?.userNotes != null
+      ? { 'Opentrons-User-Notes': requestConfig.userNotes }
+      : {}
+  const extraHeaders = requestConfig?.headers ?? {}
   const headers = {
     ...DEFAULT_HEADERS,
     ...tokenHeader,
     ...userNotesHeader,
-    ...axiosConfig?.headers,
+    ...extraHeaders,
   }
 
   const protocol = (secure ?? false) ? 'https' : 'http'
@@ -65,12 +96,13 @@ export function request<ResData, ReqData = null>(
 
   const baseURL = `${protocol}://${hostname}:${port ?? defaultPort}`
 
-  return requestor<ResData>({
+  return requestor<ResponseBodyT>({
     method,
     baseURL,
     url,
-    data,
-    ...axiosConfig,
+    params,
+    data: requestConfig?.body,
     headers,
+    responseType: requestConfig?.responseType,
   })
 }

--- a/api-client/src/robot/acknowledgeEstopDisengage.ts
+++ b/api-client/src/robot/acknowledgeEstopDisengage.ts
@@ -10,7 +10,6 @@ export function acknowledgeEstopDisengage(
   return request<EstopStatus>(
     PUT,
     '/robot/control/acknowledgeEstopDisengage',
-    null,
     config
   )
 }

--- a/api-client/src/robot/getDoorStatus.ts
+++ b/api-client/src/robot/getDoorStatus.ts
@@ -5,5 +5,5 @@ import type { HostConfig } from '../types'
 import type { DoorStatus } from './types'
 
 export function getDoorStatus(config: HostConfig): ResponsePromise<DoorStatus> {
-  return request<DoorStatus>(GET, '/robot/door/status', null, config)
+  return request<DoorStatus>(GET, '/robot/door/status', config)
 }

--- a/api-client/src/robot/getEstopStatus.ts
+++ b/api-client/src/robot/getEstopStatus.ts
@@ -7,5 +7,5 @@ import type { EstopStatus } from './types'
 export function getEstopStatus(
   config: HostConfig
 ): ResponsePromise<EstopStatus> {
-  return request<EstopStatus>(GET, '/robot/control/estopStatus', null, config)
+  return request<EstopStatus>(GET, '/robot/control/estopStatus', config)
 }

--- a/api-client/src/robot/getLights.ts
+++ b/api-client/src/robot/getLights.ts
@@ -5,5 +5,5 @@ import type { HostConfig } from '../types'
 import type { Lights } from './types'
 
 export function getLights(config: HostConfig): ResponsePromise<Lights> {
-  return request<Lights>(GET, '/robot/lights', null, config)
+  return request<Lights>(GET, '/robot/lights', config)
 }

--- a/api-client/src/robot/getRobotSettings.ts
+++ b/api-client/src/robot/getRobotSettings.ts
@@ -7,5 +7,5 @@ import type { RobotSettingsResponse } from './types'
 export function getRobotSettings(
   config: HostConfig
 ): ResponsePromise<RobotSettingsResponse> {
-  return request<RobotSettingsResponse>(GET, '/settings', null, config)
+  return request<RobotSettingsResponse>(GET, '/settings', config)
 }

--- a/api-client/src/robot/setLights.ts
+++ b/api-client/src/robot/setLights.ts
@@ -8,5 +8,7 @@ export function setLights(
   config: HostConfig,
   data: SetLightsData
 ): ResponsePromise<Lights> {
-  return request<Lights, SetLightsData>(POST, '/robot/lights', data, config)
+  return request<Lights, SetLightsData>(POST, '/robot/lights', config, {
+    body: data,
+  })
 }

--- a/api-client/src/robot/updateRobotSetting.ts
+++ b/api-client/src/robot/updateRobotSetting.ts
@@ -12,7 +12,7 @@ export function updateRobotSetting(
   return request<RobotSettingsResponse, UpdateRobotSettingRequest>(
     POST,
     '/settings',
-    { id, value },
-    config
+    config,
+    { body: { id, value } }
   )
 }

--- a/api-client/src/runs/addCameraImageSettingsToRun.ts
+++ b/api-client/src/runs/addCameraImageSettingsToRun.ts
@@ -15,7 +15,7 @@ export function addCameraImageSettingsToRun(
   return request<CameraImageSettingsResponse, { data: CameraImageSettings }>(
     POST,
     `/runs/${runId}/camera/cameraSettings`,
-    { data },
-    config
+    config,
+    { body: { data } }
   )
 }

--- a/api-client/src/runs/addCameraSettingsToRun.ts
+++ b/api-client/src/runs/addCameraSettingsToRun.ts
@@ -12,7 +12,7 @@ export function addCameraSettingsToRun(
   return request<CameraResponse, { data: CameraData }>(
     POST,
     `/runs/${runId}/camera/settings`,
-    { data },
-    config
+    config,
+    { body: { data } }
   )
 }

--- a/api-client/src/runs/addCapturePreviewImagetoRun.ts
+++ b/api-client/src/runs/addCapturePreviewImagetoRun.ts
@@ -1,6 +1,5 @@
 import { createAxiosConfig, POST, request } from '../request'
 
-import type { AxiosRequestConfig } from 'axios'
 import type {
   CameraImageSettings,
   DownloadedPreviewImageFileResponse,
@@ -11,8 +10,7 @@ import type { HostConfig } from '../types'
 export function addCapturePreviewImageToRun(
   config: HostConfig,
   runId: string,
-  data: CameraImageSettings,
-  axiosConfig?: AxiosRequestConfig
+  data: CameraImageSettings
 ): ResponsePromise<DownloadedPreviewImageFileResponse> {
   return request<
     DownloadedPreviewImageFileResponse,
@@ -22,6 +20,8 @@ export function addCapturePreviewImageToRun(
     `/runs/${runId}/camera/capturePreviewImage`,
     { data },
     config,
-    axiosConfig && createAxiosConfig(axiosConfig)
+    createAxiosConfig({
+      responseType: 'blob',
+    })
   )
 }

--- a/api-client/src/runs/addCapturePreviewImagetoRun.ts
+++ b/api-client/src/runs/addCapturePreviewImagetoRun.ts
@@ -1,10 +1,10 @@
-import { createAxiosConfig, POST, request } from '../request'
+import { POST, request } from '../request'
 
 import type {
   CameraImageSettings,
   DownloadedPreviewImageFileResponse,
 } from '../camera'
-import type { ResponsePromise } from '../request'
+import type { RequestConfig, ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
 
 export function addCapturePreviewImageToRun(
@@ -15,13 +15,8 @@ export function addCapturePreviewImageToRun(
   return request<
     DownloadedPreviewImageFileResponse,
     { data: CameraImageSettings }
-  >(
-    POST,
-    `/runs/${runId}/camera/capturePreviewImage`,
-    { data },
-    config,
-    createAxiosConfig({
-      responseType: 'blob',
-    })
-  )
+  >(POST, `/runs/${runId}/camera/capturePreviewImage`, config, {
+    body: { data },
+    responseType: 'blob',
+  })
 }

--- a/api-client/src/runs/addCapturePreviewImagetoRun.ts
+++ b/api-client/src/runs/addCapturePreviewImagetoRun.ts
@@ -4,7 +4,7 @@ import type {
   CameraImageSettings,
   DownloadedPreviewImageFileResponse,
 } from '../camera'
-import type { RequestConfig, ResponsePromise } from '../request'
+import type { ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
 
 export function addCapturePreviewImageToRun(

--- a/api-client/src/runs/addLabwareOffsetToRun.ts
+++ b/api-client/src/runs/addLabwareOffsetToRun.ts
@@ -36,5 +36,5 @@ export function addLabwareOffsetToRun(
         | LabwareOffsetCreateData
         | LabwareOffsetCreateData[]
     }
-  >(POST, `/runs/${runId}/labware_offsets`, { data }, config)
+  >(POST, `/runs/${runId}/labware_offsets`, config, { body: { data } })
 }

--- a/api-client/src/runs/commands/createCommand.ts
+++ b/api-client/src/runs/commands/createCommand.ts
@@ -1,4 +1,4 @@
-import { createAxiosConfig, POST, request } from '../../request'
+import { POST, request } from '../../request'
 
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { ResponsePromise } from '../../request'
@@ -15,8 +15,7 @@ export function createCommand(
   return request<CommandData, { data: CreateCommand }>(
     POST,
     `/runs/${runId}/commands`,
-    { data },
     config,
-    params && createAxiosConfig({ params })
+    { queryParams: { ...params }, body: { data } }
   )
 }

--- a/api-client/src/runs/commands/createLiveCommand.ts
+++ b/api-client/src/runs/commands/createLiveCommand.ts
@@ -1,4 +1,4 @@
-import { createAxiosConfig, POST, request } from '../../request'
+import { POST, request } from '../../request'
 
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { ResponsePromise } from '../../request'
@@ -14,8 +14,7 @@ export function createLiveCommand(
   return request<CommandData, { data: CreateCommand }>(
     POST,
     `/commands`,
-    { data },
     config,
-    params && createAxiosConfig({ params })
+    { queryParams: { ...params }, body: { data } }
   )
 }

--- a/api-client/src/runs/commands/getCommand.ts
+++ b/api-client/src/runs/commands/getCommand.ts
@@ -12,7 +12,6 @@ export function getCommand(
   return request<CommandDetail>(
     GET,
     `/runs/${runId}/commands/${commandId}`,
-    null,
     config
   )
 }

--- a/api-client/src/runs/commands/getCommands.ts
+++ b/api-client/src/runs/commands/getCommands.ts
@@ -1,4 +1,4 @@
-import { createAxiosConfig, GET, request } from '../../request'
+import { GET, request } from '../../request'
 
 import type { CommandsData } from '..'
 import type { ResponsePromise } from '../../request'
@@ -10,11 +10,7 @@ export function getCommands(
   runId: string,
   params: GetRunCommandsParamsRequest
 ): ResponsePromise<CommandsData> {
-  return request<CommandsData>(
-    GET,
-    `/runs/${runId}/commands`,
-    null,
-    config,
-    params && createAxiosConfig({ params })
-  )
+  return request<CommandsData>(GET, `/runs/${runId}/commands`, config, {
+    queryParams: { ...params },
+  })
 }

--- a/api-client/src/runs/commands/getCommandsAsPreSerializedList.ts
+++ b/api-client/src/runs/commands/getCommandsAsPreSerializedList.ts
@@ -1,4 +1,4 @@
-import { createAxiosConfig, GET, request } from '../../request'
+import { GET, request } from '../../request'
 
 import type { ResponsePromise } from '../../request'
 import type { HostConfig } from '../../types'
@@ -15,8 +15,7 @@ export function getCommandsAsPreSerializedList(
   return request<CommandsAsPreSerializedListData>(
     GET,
     `/runs/${runId}/commandsAsPreSerializedList`,
-    null,
     config,
-    params && createAxiosConfig({ params })
+    { queryParams: { ...params } }
   )
 }

--- a/api-client/src/runs/commands/getRunCommandErrors.ts
+++ b/api-client/src/runs/commands/getRunCommandErrors.ts
@@ -1,4 +1,4 @@
-import { createAxiosConfig, GET, request } from '../../request'
+import { GET, request } from '../../request'
 
 import type { ResponsePromise } from '../../request'
 import type { HostConfig } from '../../types'
@@ -12,8 +12,7 @@ export function getRunCommandErrors(
   return request<RunCommandErrors>(
     GET,
     `/runs/${runId}/commandErrors`,
-    null,
     config,
-    params && createAxiosConfig({ params })
+    { queryParams: { ...params } }
   )
 }

--- a/api-client/src/runs/createLabwareDefinition.ts
+++ b/api-client/src/runs/createLabwareDefinition.ts
@@ -16,5 +16,5 @@ export function createLabwareDefinition(
   return request<
     CreateLabwareDefinitionResponsePayload,
     { data: LabwareDefinition }
-  >(POST, `/runs/${runId}/labware_definitions`, { data }, config)
+  >(POST, `/runs/${runId}/labware_definitions`, config, { body: { data } })
 }

--- a/api-client/src/runs/createRun.ts
+++ b/api-client/src/runs/createRun.ts
@@ -21,5 +21,7 @@ export function createRun(
   config: HostConfig,
   data: CreateRunData = {}
 ): ResponsePromise<Run> {
-  return request<Run, { data: CreateRunData }>(POST, '/runs', { data }, config)
+  return request<Run, { data: CreateRunData }>(POST, '/runs', config, {
+    body: { data },
+  })
 }

--- a/api-client/src/runs/createRunAction.ts
+++ b/api-client/src/runs/createRunAction.ts
@@ -17,9 +17,7 @@ export function createRunAction(
   return request<RunAction, { data: CreateRunActionData }>(
     POST,
     `/runs/${runId}/actions`,
-    { data },
     config,
-    undefined,
-    userNotes
+    { body: { data }, userNotes }
   )
 }

--- a/api-client/src/runs/deleteRun.ts
+++ b/api-client/src/runs/deleteRun.ts
@@ -7,5 +7,5 @@ export function deleteRun(
   config: HostConfig,
   runId: string
 ): ResponsePromise<EmptyResponse> {
-  return request<EmptyResponse>(DELETE, `/runs/${runId}`, null, config)
+  return request<EmptyResponse>(DELETE, `/runs/${runId}`, config)
 }

--- a/api-client/src/runs/dismissCurrentRun.ts
+++ b/api-client/src/runs/dismissCurrentRun.ts
@@ -10,7 +10,7 @@ export function dismissCurrentRun(
   return request<EmptyResponse, { data: { current: false } }>(
     PATCH,
     `/runs/${runId}`,
-    { data: { current: false } },
-    config
+    config,
+    { body: { data: { current: false } } }
   )
 }

--- a/api-client/src/runs/getErrorRecoveryPolicy.ts
+++ b/api-client/src/runs/getErrorRecoveryPolicy.ts
@@ -11,7 +11,6 @@ export function getErrorRecoveryPolicy(
   return request<ErrorRecoveryPolicyResponse>(
     GET,
     `/runs/${runId}/errorRecoveryPolicy`,
-    null,
     config
   )
 }

--- a/api-client/src/runs/getRun.ts
+++ b/api-client/src/runs/getRun.ts
@@ -8,5 +8,5 @@ export function getRun(
   config: HostConfig,
   runId: string
 ): ResponsePromise<Run> {
-  return request<Run>(GET, `/runs/${runId}`, null, config)
+  return request<Run>(GET, `/runs/${runId}`, config)
 }

--- a/api-client/src/runs/getRunCurrentState.ts
+++ b/api-client/src/runs/getRunCurrentState.ts
@@ -8,10 +8,5 @@ export function getRunCurrentState(
   config: HostConfig,
   runId: string
 ): ResponsePromise<RunCurrentState> {
-  return request<RunCurrentState>(
-    GET,
-    `/runs/${runId}/currentState`,
-    null,
-    config
-  )
+  return request<RunCurrentState>(GET, `/runs/${runId}/currentState`, config)
 }

--- a/api-client/src/runs/getRunLoadedLabwareDefintions.ts
+++ b/api-client/src/runs/getRunLoadedLabwareDefintions.ts
@@ -11,7 +11,6 @@ export function getRunLoadedLabwareDefintions(
   return request<RunLoadedLabwareDefinitions>(
     GET,
     `runs/${runId}/loaded_labware_definitions`,
-    null,
     config
   )
 }

--- a/api-client/src/runs/getRuns.ts
+++ b/api-client/src/runs/getRuns.ts
@@ -1,4 +1,4 @@
-import { createAxiosConfig, GET, request } from '../request'
+import { GET, request } from '../request'
 
 import type { ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
@@ -8,11 +8,7 @@ export function getRuns(
   config: HostConfig,
   params: GetRunsParams
 ): ResponsePromise<Runs> {
-  return request<Runs>(
-    GET,
-    `/runs`,
-    null,
-    config,
-    params && createAxiosConfig({ params })
-  )
+  return request<Runs>(GET, `/runs`, config, {
+    queryParams: { ...params },
+  })
 }

--- a/api-client/src/runs/updateErrorRecoveryPolicy.ts
+++ b/api-client/src/runs/updateErrorRecoveryPolicy.ts
@@ -26,7 +26,9 @@ export function updateErrorRecoveryPolicy(
   return request<
     UpdateErrorRecoveryPolicyResponse,
     UpdateErrorRecoveryPolicyRequest
-  >(PUT, `/runs/${runId}/errorRecoveryPolicy`, { data: policy }, config)
+  >(PUT, `/runs/${runId}/errorRecoveryPolicy`, config, {
+    body: { data: policy },
+  })
 }
 
 function buildErrorRecoveryPolicyBody(

--- a/api-client/src/server/updateRobotName.ts
+++ b/api-client/src/server/updateRobotName.ts
@@ -11,7 +11,7 @@ export function updateRobotName(
   return request<UpdatedRobotName, { name: string }>(
     POST,
     '/server/name',
-    { name: newName },
-    config
+    config,
+    { body: { name: newName } }
   )
 }

--- a/api-client/src/sessions/createSession.ts
+++ b/api-client/src/sessions/createSession.ts
@@ -17,5 +17,5 @@ export function createSession(
   return request<
     Session,
     { data: { sessionType: SessionType; createParams?: unknown } | undefined }
-  >(POST, '/sessions', { data }, config)
+  >(POST, '/sessions', config, { body: { data } })
 }

--- a/api-client/src/sessions/deleteSession.ts
+++ b/api-client/src/sessions/deleteSession.ts
@@ -8,5 +8,5 @@ export function deleteSession(
   config: HostConfig,
   sessionId: string
 ): ResponsePromise<Session> {
-  return request<Session>(DELETE, `/sessions/${sessionId}`, null, config)
+  return request<Session>(DELETE, `/sessions/${sessionId}`, config)
 }

--- a/api-client/src/sessions/getSession.ts
+++ b/api-client/src/sessions/getSession.ts
@@ -8,5 +8,5 @@ export function getSession(
   config: HostConfig,
   sessionId: string
 ): ResponsePromise<Session> {
-  return request<Session>(GET, `/sessions/${sessionId}`, null, config)
+  return request<Session>(GET, `/sessions/${sessionId}`, config)
 }

--- a/api-client/src/sessions/getSessions.ts
+++ b/api-client/src/sessions/getSessions.ts
@@ -1,4 +1,4 @@
-import { createAxiosConfig, GET, request } from '../request'
+import { GET, request } from '../request'
 
 import type { ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
@@ -8,11 +8,7 @@ export function getSessions(
   config: HostConfig,
   params?: { session_type: SessionType }
 ): ResponsePromise<Sessions> {
-  return request<Sessions>(
-    GET,
-    `/sessions`,
-    null,
-    config,
-    params && createAxiosConfig({ params })
-  )
+  return request<Sessions>(GET, `/sessions`, config, {
+    queryParams: params,
+  })
 }

--- a/api-client/src/subsystems/getCurrentAllSubsystemUpdates.ts
+++ b/api-client/src/subsystems/getCurrentAllSubsystemUpdates.ts
@@ -15,7 +15,6 @@ export function getCurrentAllSubsystemUpdates(
   return request<CurrentSubsystemUpdates>(
     GET,
     '/subsystems/updates/current',
-    null,
     config
   )
 }

--- a/api-client/src/subsystems/getCurrentSubsystemUpdate.ts
+++ b/api-client/src/subsystems/getCurrentSubsystemUpdate.ts
@@ -17,7 +17,6 @@ export function getCurrentSubsystemUpdate(
   return request<SubsystemUpdateProgressData>(
     GET,
     `/subsystems/updates/current/${subsystem}`,
-    null,
     config
   )
 }

--- a/api-client/src/subsystems/getSubsystemUpdate.ts
+++ b/api-client/src/subsystems/getSubsystemUpdate.ts
@@ -11,7 +11,6 @@ export function getSubsystemUpdate(
   return request<SubsystemUpdateProgressData>(
     GET,
     `/subsystems/updates/all/${updateId}`,
-    null,
     config
   )
 }

--- a/api-client/src/subsystems/updateSubsystem.ts
+++ b/api-client/src/subsystems/updateSubsystem.ts
@@ -11,7 +11,6 @@ export function updateSubsystem(
   return request<SubsystemUpdateProgressData>(
     POST,
     `/subsystems/updates/${subsystem}`,
-    null,
     config
   )
 }

--- a/api-client/src/system/createAuthorization.ts
+++ b/api-client/src/system/createAuthorization.ts
@@ -8,7 +8,7 @@ export function createAuthorization(
   config: HostConfig,
   registrationToken: RegistrationToken
 ): ResponsePromise<AuthorizationToken> {
-  return request<AuthorizationToken>(POST, '/system/authorize', null, {
+  return request<AuthorizationToken>(POST, '/system/authorize', {
     ...config,
     ...registrationToken,
   })

--- a/api-client/src/system/createRegistration.ts
+++ b/api-client/src/system/createRegistration.ts
@@ -1,4 +1,4 @@
-import { createAxiosConfig, POST, request } from '../request'
+import { POST, request } from '../request'
 
 import type { ResponsePromise } from '../request'
 import type { HostConfig } from '../types'
@@ -8,11 +8,7 @@ export function createRegistration(
   config: HostConfig,
   params: CreateRegistrationParams
 ): ResponsePromise<RegistrationToken> {
-  return request<RegistrationToken>(
-    POST,
-    '/system/register',
-    null,
-    config,
-    params && createAxiosConfig({ params })
-  )
+  return request<RegistrationToken>(POST, '/system/register', config, {
+    queryParams: { ...params },
+  })
 }

--- a/api-client/src/system/createSplash.ts
+++ b/api-client/src/system/createSplash.ts
@@ -21,7 +21,7 @@ export function createSplash(
   return request<void, FormData>(
     POST,
     '/system/oem_mode/upload_splash',
-    formData,
-    config
+    config,
+    { body: formData }
   )
 }

--- a/api-client/src/system/getConnections.ts
+++ b/api-client/src/system/getConnections.ts
@@ -7,5 +7,5 @@ import type { ActiveConnections } from './types'
 export function getConnections(
   config: HostConfig
 ): ResponsePromise<ActiveConnections> {
-  return request<ActiveConnections>(GET, `/system/connected`, null, config)
+  return request<ActiveConnections>(GET, `/system/connected`, config)
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/Troubleshooting.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/Troubleshooting.tsx
@@ -64,7 +64,7 @@ export function Troubleshooting({
       Promise.all(
         robot.health.logs.map(log => {
           const logFileName: string = last(log.split('/')) ?? 'opentrons.log'
-          return request<string>(GET, log, null, host)
+          return request<string>(GET, log, host)
             .then(res => {
               zip.file(logFileName, res.data)
             })

--- a/app/src/resources/dataFiles/useImage.ts
+++ b/app/src/resources/dataFiles/useImage.ts
@@ -7,11 +7,7 @@ import { MIME_TYPES } from '/app/resources/dataFiles/constants'
 // Axios needs to know the `responseType` of the incoming data to parse it appropriately,
 //  so we wrap the network hook with an expected `blob` type for images.
 export function useImage(imageId: string): string | null {
-  const { data, dataUpdatedAt } = useDataFileRawQuery(
-    imageId,
-    {},
-    { responseType: 'blob' }
-  )
+  const { data, dataUpdatedAt } = useDataFileRawQuery(imageId, {}, 'blob')
 
   return useMemo(
     () => {

--- a/react-api-client/src/camera/useCapturePreviewImage.ts
+++ b/react-api-client/src/camera/useCapturePreviewImage.ts
@@ -36,7 +36,7 @@ export function useCapturePreviewImage(): UseAddCapturePreviewImageMutationResul
     AxiosError<ErrorResponse>,
     AddCapturePreviewImageParams
   >(({ settings }) =>
-    createCapturePreviewImage(host!, settings, { responseType: 'blob' })
+    createCapturePreviewImage(host!, settings)
       .then(response => {
         queryClient
           .invalidateQueries(getQueryKey(host, 'camera', 'capturePreviewImage'))

--- a/react-api-client/src/dataFiles/useDataFileRawQuery.ts
+++ b/react-api-client/src/dataFiles/useDataFileRawQuery.ts
@@ -4,9 +4,11 @@ import { getDataFileRaw } from '@opentrons/api-client'
 
 import { getQueryKey, useHost } from '../api'
 
-import type { AxiosRequestConfig } from 'axios'
 import type { UseQueryOptions, UseQueryResult } from 'react-query'
-import type { DownloadedDataFileResponse } from '@opentrons/api-client'
+import type {
+  DownloadedDataFileResponse,
+  RequestConfig,
+} from '@opentrons/api-client'
 
 // TODO(jh, 10-28-25): Split this into two hooks, perhaps in /app, that
 //  parses the return data via responseType based on known metadata about the
@@ -15,7 +17,7 @@ import type { DownloadedDataFileResponse } from '@opentrons/api-client'
 export function useDataFileRawQuery(
   fileId: string,
   options?: UseQueryOptions<DownloadedDataFileResponse>,
-  responseType?: AxiosRequestConfig['responseType']
+  responseType?: RequestConfig<unknown>['responseType']
 ): UseQueryResult<DownloadedDataFileResponse> {
   const host = useHost()
   const allOptions: UseQueryOptions<DownloadedDataFileResponse> = {

--- a/react-api-client/src/dataFiles/useDataFileRawQuery.ts
+++ b/react-api-client/src/dataFiles/useDataFileRawQuery.ts
@@ -9,13 +9,13 @@ import type { UseQueryOptions, UseQueryResult } from 'react-query'
 import type { DownloadedDataFileResponse } from '@opentrons/api-client'
 
 // TODO(jh, 10-28-25): Split this into two hooks, perhaps in /app, that
-//  parses the return data via axiosConfig based on known metadata about the
+//  parses the return data via responseType based on known metadata about the
 //  the data file id. The data file id metadata is always known through various
 //  /dataFile endpoints.
 export function useDataFileRawQuery(
   fileId: string,
   options?: UseQueryOptions<DownloadedDataFileResponse>,
-  axiosConfig?: AxiosRequestConfig
+  responseType?: AxiosRequestConfig['responseType']
 ): UseQueryResult<DownloadedDataFileResponse> {
   const host = useHost()
   const allOptions: UseQueryOptions<DownloadedDataFileResponse> = {
@@ -26,7 +26,7 @@ export function useDataFileRawQuery(
   const query = useQuery<DownloadedDataFileResponse>(
     getQueryKey(host, 'dataFiles', fileId, 'download'),
     () =>
-      getDataFileRaw(host!, fileId, axiosConfig).then(
+      getDataFileRaw(host!, fileId, responseType).then(
         response => response.data
       ),
     allOptions

--- a/react-api-client/src/runs/useAddCapturePreviewImageToRun.ts
+++ b/react-api-client/src/runs/useAddCapturePreviewImageToRun.ts
@@ -39,9 +39,7 @@ export function useCapturePreviewImageToRun(
     AxiosError<ErrorResponse>,
     AddCapturePreviewImageToRunParams
   >(({ settings }) =>
-    addCapturePreviewImageToRun(host!, runId, settings, {
-      responseType: 'blob',
-    })
+    addCapturePreviewImageToRun(host!, runId, settings)
       .then(response => {
         queryClient
           .invalidateQueries(


### PR DESCRIPTION
## Overview

These are some refactors in preparation for EXEC-2521.

Our bindings in api-client were all implemented atop a common function, with a growing number of positional parameters:

```typescript
request(
  method,
  url,
  body,
  hostConfig,
  axiosConfig,
  userNotes
)
```

That was growing cumbersome, so this PR refactors some of the positional parameters into optional properties:

```typescript
request(
  method,
  url,
  hostConfig,
  {
    body?,
    queryParams?,
    headers?,
    userNotes?,
    responseType?,
  }
)
```

This helps in a few ways:

* It makes it more ergonomic for functions in api-client to specify only the things that they actually need. For example, `GET` requests no longer need to explicitly specify a `null` body.
* It improves type safety, in some cases. For some reason, Axios types basically everything as `any`.
* It reduces the amount of code that directly interacts with Axios APIs, so we can eventually remove our Axios dependency.
* It helps with the `requiresSecureTransport: true` flag I'm adding in #21725.

## Changelog

ce0c38fe9f0b89dab8152a4719fcaf95e8736960 adjusts the way that a few functions were dealing with `responseType` in order to make our abstractions less leaky.

51d326d261006de5be341c578ab31e37bbeb7170 updates the `request()` API as described above.

Finally, 46e8f85af391bfed007c0fd1a0da1e894ce15cfc is the mass change.

## Test Plan and Hands on Testing

* [x] Smoke test a few requests in the app.

## Review requests

Does the new API (51d326d261006de5be341c578ab31e37bbeb7170) look good?

## Risk assessment

Low. This should be a behavior-preserving rearrangement. This is largely via LLM, but I've reviewed it line-by-line.