### PR TITLE
refactor(auth-server): reset password changes user scope

### DIFF
--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -437,4 +437,3 @@ def _get_scope_set_of_user(user: ORMUser) -> set[Scope]:
     if user.reset_password:
         return {Scope.USERS_READ_SELF, Scope.USERS_WRITE_SELF_PASSWORD}
     return set(ACCOUNT_TYPE_TO_SCOPES[AccountType(user.account_type)])
-

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -429,5 +429,12 @@ def _now() -> datetime:
 
 
 def _get_scope_set_of_user(user: ORMUser) -> set[Scope]:
-    """Return the scopes that a user is authorized for."""
+    """Return the scopes that a user is authorized for.
+
+    A user who must reset their password is restricted to reading and writing their
+    own account, so they can change their password but nothing else until they do.
+    """
+    if user.reset_password:
+        return {Scope.USERS_READ_SELF, Scope.USERS_WRITE_SELF_PASSWORD}
     return set(ACCOUNT_TYPE_TO_SCOPES[AccountType(user.account_type)])
+

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -15,9 +15,8 @@ from server_utils.auth.scopes import Scope, UnrecognizedScopeError, serialize_sc
 from auth_server.persistence.orm_models import User as ORMUser
 from auth_server.settings.store import SettingsStore
 from auth_server.users.is_account_locked import is_account_locked
-from auth_server.users.models import ACCOUNT_TYPE_TO_SCOPES, AccountType
 from auth_server.users.store import UserStore
-from auth_server.users.user_data_manager import password_hash
+from auth_server.users.user_data_manager import get_scope_set_of_user, password_hash
 
 _log = logging.getLogger(__name__)
 
@@ -131,7 +130,7 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
 
         requested_scopes = set(scopes)
         return requested_scopes.issubset(
-            s.api_name for s in _get_scope_set_of_user(user)
+            s.api_name for s in get_scope_set_of_user(user)
         )
 
     @override
@@ -142,7 +141,7 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         """Scopes that we'll authorize a client for, if it doesn't ask for any explicitly."""
         assert isinstance(request.user, ORMUser)
         user: ORMUser = request.user
-        return sorted(s.api_name for s in _get_scope_set_of_user(user))
+        return sorted(s.api_name for s in get_scope_set_of_user(user))
 
     @override
     @pydantic.validate_call(config=_validate_call_config)
@@ -426,14 +425,3 @@ def _is_list_of_type[ElementT](
 
 def _now() -> datetime:
     return datetime.now(tz=UTC)
-
-
-def _get_scope_set_of_user(user: ORMUser) -> set[Scope]:
-    """Return the scopes that a user is authorized for.
-
-    A user who must reset their password is restricted to reading and writing their
-    own account, so they can change their password but nothing else until they do.
-    """
-    if user.reset_password:
-        return {Scope.USERS_READ_SELF, Scope.USERS_WRITE_SELF_PASSWORD}
-    return set(ACCOUNT_TYPE_TO_SCOPES[AccountType(user.account_type)])

--- a/auth-server/auth_server/users/models.py
+++ b/auth-server/auth_server/users/models.py
@@ -40,6 +40,12 @@ ACCOUNT_TYPE_TO_SCOPES: dict[AccountType, set[Scope]] = {
     AccountType.AUDITOR: {Scope.USERS_READ_OTHERS},
 }
 
+# Scopes granted while resetPassword is true, before the user chooses a new password.
+RESET_PASSWORD_SCOPES: set[Scope] = {
+    Scope.USERS_READ_SELF,
+    Scope.USERS_WRITE_SELF_PASSWORD,
+}
+
 
 class UserCreate(BaseModel):
     """Request body for creating a user."""

--- a/auth-server/auth_server/users/models.py
+++ b/auth-server/auth_server/users/models.py
@@ -31,6 +31,7 @@ ACCOUNT_TYPE_TO_SCOPES: dict[AccountType, set[Scope]] = {
         # todo(mm, 2026-03-17): Protocol uploads should be togglable to admin-only by an auth setting.
         Scope.USERS_READ_SELF,
         Scope.USERS_WRITE_SELF,
+        Scope.USERS_WRITE_SELF_PASSWORD,
         Scope.PROTOCOLS_WRITE,
     },
     # Auditors should have read-only access to everything. Our read-only endpoints are

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -250,7 +250,9 @@ async def update_self(
     request_body: RequestModel[UpdateSelf],
     authorization_details: Annotated[
         RequireScopesResult,
-        fastapi.Depends(require_scopes(Scope.USERS_WRITE_SELF_PASSWORD)),
+        fastapi.Depends(
+            require_scopes(Scope.USERS_WRITE_SELF_PASSWORD, Scope.USERS_WRITE_SELF)
+        ),
     ],
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -250,9 +250,7 @@ async def update_self(
     request_body: RequestModel[UpdateSelf],
     authorization_details: Annotated[
         RequireScopesResult,
-        fastapi.Depends(
-            require_scopes(Scope.USERS_WRITE_SELF_PASSWORD, Scope.USERS_WRITE_SELF)
-        ),
+        fastapi.Depends(require_scopes(Scope.USERS_WRITE_SELF_PASSWORD)),
     ],
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -249,7 +249,8 @@ async def get_self(  # noqa: D103
 async def update_self(
     request_body: RequestModel[UpdateSelf],
     authorization_details: Annotated[
-        RequireScopesResult, fastapi.Depends(require_scopes(Scope.USERS_WRITE_SELF))
+        RequireScopesResult,
+        fastapi.Depends(require_scopes(Scope.USERS_WRITE_SELF_PASSWORD)),
     ],
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)

--- a/auth-server/auth_server/users/user_data_manager.py
+++ b/auth-server/auth_server/users/user_data_manager.py
@@ -5,6 +5,7 @@ import string
 from typing import Literal
 
 from pwdlib import PasswordHash
+
 from server_utils.auth.scopes import Scope
 
 from auth_server.persistence.orm_models import User

--- a/auth-server/auth_server/users/user_data_manager.py
+++ b/auth-server/auth_server/users/user_data_manager.py
@@ -5,6 +5,7 @@ import string
 from typing import Literal
 
 from pwdlib import PasswordHash
+from server_utils.auth.scopes import Scope
 
 from auth_server.persistence.orm_models import User
 from auth_server.settings.models import SettingsResponseData
@@ -95,14 +96,17 @@ class UserDataManager:
         )
 
         account_type = AccountType(user.account_type)
+        if user.reset_password:
+            scope_set = {Scope.USERS_READ_SELF, Scope.USERS_WRITE_SELF_PASSWORD}
+        else:
+            scope_set = ACCOUNT_TYPE_TO_SCOPES[account_type]
+        scopes = sorted(scope.api_name for scope in scope_set)
 
         return UserResponse(
             username=user.username,
             fullName=user.full_name,
             accountType=account_type,
-            scopes=sorted(
-                scope.api_name for scope in ACCOUNT_TYPE_TO_SCOPES[account_type]
-            ),
+            scopes=scopes,
             locked=is_currently_locked,
             resetPassword=user.reset_password,
         )

--- a/auth-server/auth_server/users/user_data_manager.py
+++ b/auth-server/auth_server/users/user_data_manager.py
@@ -14,6 +14,7 @@ from auth_server.settings.store import SettingsStore
 from auth_server.users.is_account_locked import is_account_locked
 from auth_server.users.models import (
     ACCOUNT_TYPE_TO_SCOPES,
+    RESET_PASSWORD_SCOPES,
     AccountType,
     ResetPasswordResponse,
     UserResponse,
@@ -90,7 +91,7 @@ def get_scope_set_of_user(user: User) -> set[Scope]:
     own account, so they can change their password but nothing else until they do.
     """
     if user.reset_password:
-        return {Scope.USERS_READ_SELF, Scope.USERS_WRITE_SELF_PASSWORD}
+        return set(RESET_PASSWORD_SCOPES)
     return set(ACCOUNT_TYPE_TO_SCOPES[AccountType(user.account_type)])
 
 

--- a/auth-server/auth_server/users/user_data_manager.py
+++ b/auth-server/auth_server/users/user_data_manager.py
@@ -83,6 +83,17 @@ def _validate_fields(
         raise InvalidInputError("Password must be at least 8 characters long")
 
 
+def get_scope_set_of_user(user: User) -> set[Scope]:
+    """Return the scopes that a user is authorized for.
+
+    A user who must reset their password is restricted to reading and writing their
+    own account, so they can change their password but nothing else until they do.
+    """
+    if user.reset_password:
+        return {Scope.USERS_READ_SELF, Scope.USERS_WRITE_SELF_PASSWORD}
+    return set(ACCOUNT_TYPE_TO_SCOPES[AccountType(user.account_type)])
+
+
 class UserDataManager:
     """Manages user data operations."""
 
@@ -97,11 +108,7 @@ class UserDataManager:
         )
 
         account_type = AccountType(user.account_type)
-        if user.reset_password:
-            scope_set = {Scope.USERS_READ_SELF, Scope.USERS_WRITE_SELF_PASSWORD}
-        else:
-            scope_set = ACCOUNT_TYPE_TO_SCOPES[account_type]
-        scopes = sorted(scope.api_name for scope in scope_set)
+        scopes = sorted(scope.api_name for scope in get_scope_set_of_user(user))
 
         return UserResponse(
             username=user.username,

--- a/auth-server/tests/conftest.py
+++ b/auth-server/tests/conftest.py
@@ -4,7 +4,7 @@ from typing import Generator
 import pytest
 import requests
 
-from server_utils.auth.scopes import serialize_scopes
+from server_utils.auth.scopes import Scope, serialize_scopes
 from tests.dev_server import DevServer
 
 from auth_server.users.models import ACCOUNT_TYPE_TO_SCOPES, AccountType
@@ -22,6 +22,21 @@ def admin_scopes_str() -> str:
 def user_scopes_str() -> str:
     """All the OAuth 2 scopes that a regular user should have, as a space-separated string."""
     return serialize_scopes(set(ACCOUNT_TYPE_TO_SCOPES[AccountType.USER]))
+
+
+@pytest.fixture
+def reset_password_scopes_str() -> str:
+    """The restricted OAuth 2 scopes a user gets while they must reset their password."""
+    return serialize_scopes({Scope.USERS_READ_SELF, Scope.USERS_WRITE_SELF_PASSWORD})
+
+
+@pytest.fixture
+def reset_password_scopes_list() -> list[str]:
+    """Scopes returned on a user record while they must reset their password."""
+    return sorted(
+        scope.api_name
+        for scope in {Scope.USERS_READ_SELF, Scope.USERS_WRITE_SELF_PASSWORD}
+    )
 
 
 @pytest.fixture

--- a/auth-server/tests/conftest.py
+++ b/auth-server/tests/conftest.py
@@ -7,7 +7,11 @@ import requests
 from server_utils.auth.scopes import Scope, serialize_scopes
 from tests.dev_server import DevServer
 
-from auth_server.users.models import ACCOUNT_TYPE_TO_SCOPES, AccountType
+from auth_server.users.models import (
+    ACCOUNT_TYPE_TO_SCOPES,
+    RESET_PASSWORD_SCOPES,
+    AccountType,
+)
 
 _INTEGRATION_SERVER_STARTUP_TIMEOUT_S = 30
 
@@ -27,10 +31,7 @@ def user_scopes_str() -> str:
 @pytest.fixture
 def reset_password_scopes_list() -> list[str]:
     """Scopes returned on a user record while they must reset their password."""
-    return sorted(
-        scope.api_name
-        for scope in {Scope.USERS_READ_SELF, Scope.USERS_WRITE_SELF_PASSWORD}
-    )
+    return sorted(scope.api_name for scope in RESET_PASSWORD_SCOPES)
 
 
 @pytest.fixture

--- a/auth-server/tests/conftest.py
+++ b/auth-server/tests/conftest.py
@@ -25,12 +25,6 @@ def user_scopes_str() -> str:
 
 
 @pytest.fixture
-def reset_password_scopes_str() -> str:
-    """The restricted OAuth 2 scopes a user gets while they must reset their password."""
-    return serialize_scopes({Scope.USERS_READ_SELF, Scope.USERS_WRITE_SELF_PASSWORD})
-
-
-@pytest.fixture
 def reset_password_scopes_list() -> list[str]:
     """Scopes returned on a user record while they must reset their password."""
     return sorted(

--- a/auth-server/tests/conftest.py
+++ b/auth-server/tests/conftest.py
@@ -4,7 +4,7 @@ from typing import Generator
 import pytest
 import requests
 
-from server_utils.auth.scopes import Scope, serialize_scopes
+from server_utils.auth.scopes import serialize_scopes
 from tests.dev_server import DevServer
 
 from auth_server.users.models import (

--- a/auth-server/tests/integration/test_reset_password_flow.tavern.yaml
+++ b/auth-server/tests/integration/test_reset_password_flow.tavern.yaml
@@ -5,8 +5,6 @@ marks:
       - run_server
       - admin_access_token
       - user_scopes_list
-      - user_scopes_str
-      - reset_password_scopes_str
       - reset_password_scopes_list
 
 stages:
@@ -70,7 +68,7 @@ stages:
         refresh_token: !anystr
         token_type: Bearer
         expires_in: !anyint
-        scope: '{reset_password_scopes_str}'
+        scope: users.read.self users.write.self.password
 
   - name: User cannot log in with the previous password
     request:
@@ -122,7 +120,6 @@ stages:
       status_code: 200
       json:
         access_token: !anystr
-        scope: '{user_scopes_str}'
       strict:
         - json:off
 
@@ -150,8 +147,6 @@ marks:
       - run_server
       - admin_access_token
       - user_scopes_list
-      - user_scopes_str
-      - reset_password_scopes_str
       - reset_password_scopes_list
 
 stages:
@@ -218,7 +213,7 @@ stages:
         refresh_token: !anystr
         token_type: Bearer
         expires_in: !anyint
-        scope: '{reset_password_scopes_str}'
+        scope: users.read.self users.write.self.password
 
   - name: User sets a new password via update self
     request:
@@ -255,7 +250,6 @@ stages:
         - json:off
       json:
         access_token: !anystr
-        scope: '{user_scopes_str}'
 
   - name: User cannot log in with the temporary password after update
     request:

--- a/auth-server/tests/integration/test_reset_password_flow.tavern.yaml
+++ b/auth-server/tests/integration/test_reset_password_flow.tavern.yaml
@@ -5,6 +5,9 @@ marks:
       - run_server
       - admin_access_token
       - user_scopes_list
+      - user_scopes_str
+      - reset_password_scopes_str
+      - reset_password_scopes_list
 
 stages:
   - name: Create a user for the reset-password flow
@@ -47,11 +50,11 @@ stages:
           fullName: Reset Password Flow User
           accountType: user
           locked: false
-          scopes: !force_original_structure '{user_scopes_list}'
+          scopes: !force_original_structure '{reset_password_scopes_list}'
           resetPassword: true
           temporaryPassword: !anystr
 
-  - name: User can log in with the temporary password
+  - name: User can log in with the temporary password but only gets self-write scopes
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/token'
@@ -67,7 +70,7 @@ stages:
         refresh_token: !anystr
         token_type: Bearer
         expires_in: !anyint
-        scope: !anystr
+        scope: '{reset_password_scopes_str}'
 
   - name: User cannot log in with the previous password
     request:
@@ -106,7 +109,7 @@ stages:
           scopes: !force_original_structure '{user_scopes_list}'
           resetPassword: false
 
-  - name: User can log in with the chosen password
+  - name: User can log in with the chosen password and gets full scopes back
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/token'
@@ -119,6 +122,7 @@ stages:
       status_code: 200
       json:
         access_token: !anystr
+        scope: '{user_scopes_str}'
       strict:
         - json:off
 
@@ -146,6 +150,9 @@ marks:
       - run_server
       - admin_access_token
       - user_scopes_list
+      - user_scopes_str
+      - reset_password_scopes_str
+      - reset_password_scopes_list
 
 stages:
   - name: Create a user for the self update reset-password flow
@@ -188,11 +195,11 @@ stages:
           fullName: Self Update Reset Password User
           accountType: user
           locked: false
-          scopes: !force_original_structure '{user_scopes_list}'
+          scopes: !force_original_structure '{reset_password_scopes_list}'
           resetPassword: true
           temporaryPassword: !anystr
 
-  - name: User logs in with the temporary password
+  - name: User logs in with the temporary password and only gets self-write scopes
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/token'
@@ -206,6 +213,12 @@ stages:
       save:
         json:
           user_access_token: access_token
+      json:
+        access_token: !anystr
+        refresh_token: !anystr
+        token_type: Bearer
+        expires_in: !anyint
+        scope: '{reset_password_scopes_str}'
 
   - name: User sets a new password via update self
     request:
@@ -227,7 +240,7 @@ stages:
           scopes: !force_original_structure '{user_scopes_list}'
           resetPassword: false
 
-  - name: User can log in with the new password
+  - name: User can log in with the new password and gets full scopes back
     request:
       method: POST
       url: '{run_server.base_url}/auth/oauth2/token'
@@ -242,6 +255,7 @@ stages:
         - json:off
       json:
         access_token: !anystr
+        scope: '{user_scopes_str}'
 
   - name: User cannot log in with the temporary password after update
     request:

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -6,6 +6,7 @@ marks:
       - admin_access_token
       - admin_scopes_list
       - user_scopes_list
+      - reset_password_scopes_list
 
 stages:
   - name: Create a new user
@@ -120,7 +121,7 @@ stages:
           fullName: Test New User Updated
           username: test_new_user_updated
           locked: false
-          scopes: !force_original_structure '{admin_scopes_list}'
+          scopes: !force_original_structure '{reset_password_scopes_list}'
           resetPassword: true
   - name: Get the user information
     request:
@@ -136,7 +137,7 @@ stages:
           fullName: Test New User Updated
           username: test_new_user_updated
           locked: false
-          scopes: !force_original_structure '{admin_scopes_list}'
+          scopes: !force_original_structure '{reset_password_scopes_list}'
           resetPassword: true
   - name: Reset the user's password to a temporary password
     request:
@@ -155,7 +156,7 @@ stages:
           fullName: Test New User Updated
           username: test_new_user_updated
           locked: false
-          scopes: !force_original_structure '{admin_scopes_list}'
+          scopes: !force_original_structure '{reset_password_scopes_list}'
           resetPassword: true
           temporaryPassword: !anystr
 

--- a/auth-server/tests/users/test_user_data_manager.py
+++ b/auth-server/tests/users/test_user_data_manager.py
@@ -3,12 +3,15 @@ import string
 import pytest
 from decoy import Decoy, matchers
 
-from server_utils.auth.scopes import Scope
-
 from auth_server.persistence.orm_models import User
 from auth_server.settings.models import SettingsResponseData
 from auth_server.settings.store import SettingsStore
-from auth_server.users.models import ACCOUNT_TYPE_TO_SCOPES, AccountType, UserResponse
+from auth_server.users.models import (
+    ACCOUNT_TYPE_TO_SCOPES,
+    RESET_PASSWORD_SCOPES,
+    AccountType,
+    UserResponse,
+)
 from auth_server.users.store import UserStore
 from auth_server.users.user_data_manager import (
     InvalidInputError,
@@ -398,10 +401,7 @@ def test_reset_user_password(
 
     assert result.username == "reset_me"
     assert result.resetPassword is True
-    assert result.scopes == sorted(
-        scope.api_name
-        for scope in {Scope.USERS_READ_SELF, Scope.USERS_WRITE_SELF_PASSWORD}
-    )
+    assert result.scopes == sorted(scope.api_name for scope in RESET_PASSWORD_SCOPES)
     assert len(result.temporaryPassword) == 8
     assert all(
         c in string.ascii_letters + string.digits for c in result.temporaryPassword

--- a/auth-server/tests/users/test_user_data_manager.py
+++ b/auth-server/tests/users/test_user_data_manager.py
@@ -3,11 +3,12 @@ import string
 import pytest
 from decoy import Decoy, matchers
 
+from server_utils.auth.scopes import Scope
+
 from auth_server.persistence.orm_models import User
 from auth_server.settings.models import SettingsResponseData
 from auth_server.settings.store import SettingsStore
 from auth_server.users.models import ACCOUNT_TYPE_TO_SCOPES, AccountType, UserResponse
-from server_utils.auth.scopes import Scope
 from auth_server.users.store import UserStore
 from auth_server.users.user_data_manager import (
     InvalidInputError,

--- a/auth-server/tests/users/test_user_data_manager.py
+++ b/auth-server/tests/users/test_user_data_manager.py
@@ -7,6 +7,7 @@ from auth_server.persistence.orm_models import User
 from auth_server.settings.models import SettingsResponseData
 from auth_server.settings.store import SettingsStore
 from auth_server.users.models import ACCOUNT_TYPE_TO_SCOPES, AccountType, UserResponse
+from server_utils.auth.scopes import Scope
 from auth_server.users.store import UserStore
 from auth_server.users.user_data_manager import (
     InvalidInputError,
@@ -396,6 +397,10 @@ def test_reset_user_password(
 
     assert result.username == "reset_me"
     assert result.resetPassword is True
+    assert result.scopes == sorted(
+        scope.api_name
+        for scope in {Scope.USERS_READ_SELF, Scope.USERS_WRITE_SELF_PASSWORD}
+    )
     assert len(result.temporaryPassword) == 8
     assert all(
         c in string.ascii_letters + string.digits for c in result.temporaryPassword

--- a/server-utils/server_utils/auth/scopes.py
+++ b/server-utils/server_utils/auth/scopes.py
@@ -89,6 +89,15 @@ class Scope(enum.Enum):
         "Update the currently authenticated user's own account (e.g. change password).",
     )
 
+    USERS_WRITE_SELF_PASSWORD = (
+        "users.write.self.password",
+        (
+            "Change the currently authenticated user's own password."
+            " This is the minimum scope granted to a user who must reset their"
+            " password before they can do anything else."
+        ),
+    )
+
     USERS_WRITE = (
         "users.write",
         "Create, update, and delete users.",


### PR DESCRIPTION
# Overview

more work towards reset password.
change user scopes to a scope that only allows to reset password. 

## Test Plan and Hands on Testing

tested with postman
added tavern tests

## Risk assessment

S. should restrict a user that needs to reset password
