### PR TITLE
feat(app): Enforce HTTPS when necessary

### DIFF
--- a/api-client/src/auth/oauth2/getOAuth2Token.ts
+++ b/api-client/src/auth/oauth2/getOAuth2Token.ts
@@ -61,6 +61,6 @@ export function getOAuth2Token(
     POST,
     '/auth/oauth2/token',
     config,
-    { body: encodedBody }
+    { body: encodedBody, requiresSecureTransport: true }
   )
 }

--- a/api-client/src/auth/users/updateSelf.ts
+++ b/api-client/src/auth/users/updateSelf.ts
@@ -14,7 +14,7 @@ export function updateSelf(
     config,
     {
       body,
-      requiresSecureTransport: true // Might be sending a new password.
+      requiresSecureTransport: true, // Might be sending a new password.
     }
   )
 }

--- a/api-client/src/auth/users/updateSelf.ts
+++ b/api-client/src/auth/users/updateSelf.ts
@@ -12,6 +12,9 @@ export function updateSelf(
     PATCH,
     '/auth/users/self',
     config,
-    { body }
+    {
+      body,
+      requiresSecureTransport: true // Might be sending a new password.
+    }
   )
 }

--- a/api-client/src/keys/getPlaintextCACertificates.ts
+++ b/api-client/src/keys/getPlaintextCACertificates.ts
@@ -10,9 +10,9 @@ export function getPlaintextCACertificates(
   return request<PlaintextCACertificates>(
     GET,
     '/keys/external/ca/plaintextCerts',
+    config,
     {
-      ...config,
-      secure: true,
+      requiresSecureTransport: true,
     }
   )
 }

--- a/api-client/src/request.ts
+++ b/api-client/src/request.ts
@@ -58,6 +58,19 @@ export interface RequestConfig<
    * What kind of response body to expect and how Axios should parse it.
    */
   responseType?: AxiosRequestConfig['responseType']
+
+  /**
+   * If true, this request will always use HTTPS, never HTTP.
+   * (Unless it's to localhost, in which case it may still use HTTP.)
+   *
+   * This must be set to true whenever a request carries secrets. For example, if
+   * the request is to change a user's password, this needs to be true to avoid
+   * exposing the new password over the network.
+   *
+   * This should otherwise be set to false because HTTPS requires some onerous manual
+   * setup, and so not every robot will support it.
+   */
+  requiresSecureTransport?: boolean
 }
 
 export function request<
@@ -91,8 +104,15 @@ export function request<
     ...extraHeaders,
   }
 
-  const protocol = (secure ?? false) ? 'https' : 'http'
-  const defaultPort = (secure ?? false) ? DEFAULT_HTTPS_PORT : DEFAULT_PORT
+  const requiresSecureTransport =
+    'Authorization' in headers ||
+    (requestConfig?.requiresSecureTransport ?? false)
+
+  const protocol =
+    (secure ?? false) || (requiresSecureTransport && !isLocalhost(hostConfig))
+      ? 'https'
+      : 'http'
+  const defaultPort = protocol === 'https' ? DEFAULT_HTTPS_PORT : DEFAULT_PORT
 
   const baseURL = `${protocol}://${hostname}:${port ?? defaultPort}`
 
@@ -105,4 +125,12 @@ export function request<
     headers,
     responseType: requestConfig?.responseType,
   })
+}
+
+function isLocalhost(hostConfig: HostConfig): boolean {
+  return (
+    hostConfig.hostname === 'localhost' ||
+    hostConfig.hostname === '127.0.0.1' ||
+    hostConfig.hostname === '::1'
+  )
 }


### PR DESCRIPTION
## Overview

This closes EXEC-2521.

## Changelog

* Any request with an `Authorization` header will automatically use HTTPS. This is important so the client doesn't leak its OAuth 2 access tokens.
* If a request carries some other secret (e.g. if the user is setting a new password, and that password is present in the request body), it can individually declare that it needs HTTPS, irrespective of whether an `Authorization` header is present.
* Localhost requests are always considered "secure"; they'll go over HTTP even if a request otherwise would have required HTTPS. This is helpful for the on-device display, avoiding a Whole Lot of Stuff to get it to trust the robot's self-signed certificates.

## Test Plan and Hands on Testing

* [x] Make sure the desktop app protects its secrets with HTTPS now.
  * Enable Compliance Ready Software on a robot.
  * Import the certs into the desktop app.
  * Log in to the desktop app.
    * Make sure the `/auth/oauth2` requests, carrying your password, go over HTTPS.
  * Issue some requests from the desktop app, e.g. toggle the lights.
    * Make sure the request carries an `Authorization` header and make sure it's over HTTPS.
* [x] Make sure the "reset password" flow still works on the on-device display. (This tests the localhost exemption.)
* [x] Make sure requests from the desktop app still use HTTP (not HTTPS) when the robot doesn't have Compliance Ready Software turned on.

## Review requests

Agreed with *not* using HTTPS for localhost? 

## Risk assessment

Medium. This affects basically every request.