### PR TITLE
chore(hardware-testing): Add a selection of hardware testing src to the package.

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
@@ -32,6 +32,22 @@ from opentrons.types import Point, DeckSlotName, Location
 from opentrons.protocol_api._nozzle_layout import NozzleLayout
 from opentrons.protocols.advanced_control.transfers import common as tx_ctl_lib
 
+from hardware_testing.data import create_run_id, get_git_description
+from hardware_testing.data.ui import (  # noqa: F401
+    set_output_file,
+    print_info,
+    print_title,
+    print_header,
+    print_warning,
+    print_error,
+)
+
+from hardware_testing.drivers import asair_sensor as AsairDriver
+from hardware_testing.drivers import ImpactProtectionV2
+from hardware_testing.opentrons_api.helpers_ot3 import (
+    clear_pipette_ul_per_mm,
+)
+
 # ------ TODO remove and move necessary libraries into a standard release library. ----
 import importlib
 import os
@@ -83,15 +99,6 @@ if not IS_ROBOT or importlib.util.find_spec("hardware_testing") is None:
 from hardware_testing.scripts.data_center_client import (  # noqa: E402
     upload_data_to_google_drive,
 )
-from hardware_testing.data import create_run_id, get_git_description  # noqa: E402
-from hardware_testing.data.ui import (  # noqa: F401, E402
-    set_output_file,
-    print_info,
-    print_title,
-    print_header,
-    print_warning,
-    print_error,
-)
 from hardware_testing.gravimetric.measurement import (  # noqa: E402
     create_measurement_tag,
     record_measurement_data,
@@ -110,13 +117,8 @@ from hardware_testing.gravimetric.measurement.record import (  # noqa: E402
     GravimetricRecorder,
     GravimetricRecorderConfig,
 )
-from hardware_testing.drivers import asair_sensor as AsairDriver  # noqa: E402
-from hardware_testing.drivers import ImpactProtectionV2  # noqa: E402
 
 from hardware_testing.gravimetric import helpers, report, tips, config  # noqa: E402
-from hardware_testing.opentrons_api.helpers_ot3 import (  # noqa: E402
-    clear_pipette_ul_per_mm,
-)  # noqa: E402
 
 
 metadata = {"protocolName": "Gravimetric QC V3"}

--- a/hardware-testing/hardware_testing/production_qc_protocols/belt_calibration_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc_protocols/belt_calibration_ot3.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
 from opentrons.calibration_storage.types import AttitudeMatrix
-from opentrons.config import IS_ROBOT
 from opentrons.config.defaults_ot3 import DEFAULT_MACHINE_TRANSFORM
 from opentrons.hardware_control.ot3_calibration import (
     calibrate_belts,
@@ -29,61 +28,13 @@ from opentrons_shared_data.errors.exceptions import (
 )
 
 
-# ------ TODO remove and move necessary libraries into a standard release library. ----
-import importlib
-import os
-from opentrons.config import infer_config_base_dir
-from opentrons import version
-import sys
-
-
-def _download_and_extract(version_str: str, base_dir: str) -> None:
-    from urllib.request import urlretrieve
-    from zipfile import ZipFile
-
-    zipfile = f"https://github.com/Opentrons/opentrons/archive/refs/tags/v{release}.zip"
-    where_to_place = os.path.join(base_dir, "hardware_testing")
-    urlretrieve(zipfile, os.path.join(base_dir, "source.zip"))
-    zf = ZipFile(os.path.join(base_dir, "source.zip"), "r")
-    files = [f for f in zf.namelist() if "hardware_testing" in f and "tests" not in f]
-    files = [f for f in files if "py" in f]
-    start_path = f"opentrons-{version_str}/hardware-testing/hardware_testing/"
-    for f in files:
-        dest_name = f.replace(start_path, "")
-        dest_file = os.path.join(where_to_place, dest_name)
-        dat = zf.read(f)
-        os.makedirs(os.path.dirname(dest_file), exist_ok=True)
-        out = open(dest_file, "wb")
-        out.write(dat)
-        out.close()
-    with open(os.path.join(where_to_place, "VERSION.txt"), "w") as ver_file:
-        ver_file.write(version_str)
-
-
-if not IS_ROBOT or importlib.util.find_spec("hardware_testing") is None:
-    # we're simulating or there is not a vaild hardware-testing yet
-    base_dir = str(infer_config_base_dir())
-    release = f"{version.replace('a', '-alpha.').replace('b', '-beta.')}"
-    version_file_path = os.path.join(base_dir, "hardware_testing", "VERSION.txt")
-    if os.path.exists(version_file_path):
-        with open(version_file_path, "r") as version_file:
-            if version_file.readline() != release:
-                _download_and_extract(release, base_dir)
-    else:
-        _download_and_extract(release, base_dir)
-    sys.path.append(base_dir)
-
-
-# ----- END: TODO ------
-
-
-from hardware_testing.data.csv_report import (  # noqa: E402
+from hardware_testing.data.csv_report import (
     CSVReport,
     CSVSection,
     CSVResult,
     CSVLine,
 )
-from hardware_testing.opentrons_api import helpers_ot3  # noqa: E402
+from hardware_testing.opentrons_api import helpers_ot3
 
 metadata = {"protocolName": "Production qc Belt calibration"}
 

--- a/hardware-testing/hardware_testing/production_qc_protocols/gripper_assembly_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc_protocols/gripper_assembly_qc_ot3.py
@@ -7,7 +7,6 @@ from typing import Dict, Callable, List, Optional, Union, Tuple
 from opentrons.protocol_api import ParameterContext, ProtocolContext
 from opentrons.types import Point
 
-from opentrons.config import IS_ROBOT
 from opentrons.config.defaults_ot3 import (
     DEFAULT_MAX_SPEEDS,
     DEFAULT_RUN_CURRENT,
@@ -37,63 +36,16 @@ from opentrons_shared_data.errors.exceptions import (
     EdgeNotFoundError,
 )
 
-# ------ TODO remove and move necessary libraries into a standard release library. ----
-import importlib
-import os
-from opentrons.config import infer_config_base_dir
-from opentrons import version
-import sys
-
-
-def _download_and_extract(version_str: str, base_dir: str) -> None:
-    from urllib.request import urlretrieve
-    from zipfile import ZipFile
-
-    zipfile = f"https://github.com/Opentrons/opentrons/archive/refs/tags/v{release}.zip"
-    where_to_place = os.path.join(base_dir, "hardware_testing")
-    urlretrieve(zipfile, os.path.join(base_dir, "source.zip"))
-    zf = ZipFile(os.path.join(base_dir, "source.zip"), "r")
-    files = [f for f in zf.namelist() if "hardware_testing" in f and "tests" not in f]
-    files = [f for f in files if "py" in f]
-    start_path = f"opentrons-{version_str}/hardware-testing/hardware_testing/"
-    for f in files:
-        dest_name = f.replace(start_path, "")
-        dest_file = os.path.join(where_to_place, dest_name)
-        dat = zf.read(f)
-        os.makedirs(os.path.dirname(dest_file), exist_ok=True)
-        out = open(dest_file, "wb")
-        out.write(dat)
-        out.close()
-    with open(os.path.join(where_to_place, "VERSION.txt"), "w") as ver_file:
-        ver_file.write(version_str)
-
-
-if not IS_ROBOT or importlib.util.find_spec("hardware_testing") is None:
-    # we're simulating or there is not a vaild hardware-testing yet
-    base_dir = str(infer_config_base_dir())
-    release = f"{version.replace('a', '-alpha.').replace('b', '-beta.')}"
-    version_file_path = os.path.join(base_dir, "hardware_testing", "VERSION.txt")
-    if os.path.exists(version_file_path):
-        with open(version_file_path, "r") as version_file:
-            if version_file.readline() != release:
-                _download_and_extract(release, base_dir)
-    else:
-        _download_and_extract(release, base_dir)
-    sys.path.append(base_dir)
-
-
-# ----- END: TODO ------
-
-from hardware_testing.data.csv_report import (  # noqa: E402
+from hardware_testing.data.csv_report import (
     CSVLineRepeating,
     CSVReport,
     CSVSection,
     CSVResult,
     CSVLine,
 )
-from hardware_testing.opentrons_api import helpers_ot3  # noqa: E402
-from hardware_testing.drivers import find_port  # noqa: E402
-from hardware_testing.drivers.mark10 import Mark10, SimMark10  # noqa: E402
+from hardware_testing.opentrons_api import helpers_ot3
+from hardware_testing.drivers import find_port
+from hardware_testing.drivers.mark10 import Mark10, SimMark10
 
 metadata = {"protocolName": "Production qc Gripper assembly qc"}
 

--- a/hardware-testing/hardware_testing/production_qc_protocols/ninety_six_assembly_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc_protocols/ninety_six_assembly_qc_ot3.py
@@ -7,7 +7,6 @@ from typing import Dict, Callable, cast, List, Union, Tuple, Literal
 from opentrons.protocol_api import ParameterContext, ProtocolContext, OFF_DECK
 from opentrons.types import Point
 
-from opentrons.config import IS_ROBOT
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.backends.ot3controller import OT3Controller
 from opentrons.hardware_control.backends.ot3simulator import (
@@ -35,64 +34,18 @@ from opentrons.hardware_control.types import (
 from opentrons_shared_data.errors.exceptions import StallOrCollisionDetectedError
 from opentrons.hardware_control.motion_utilities import target_position_from_relative
 
-# ------ TODO remove and move necessary libraries into a standard release library. ----
-import importlib
-import os
-from opentrons.config import infer_config_base_dir
-from opentrons import version
-import sys
 
-
-def _download_and_extract(version_str: str, base_dir: str) -> None:
-    from urllib.request import urlretrieve
-    from zipfile import ZipFile
-
-    zipfile = f"https://github.com/Opentrons/opentrons/archive/refs/tags/v{release}.zip"
-    where_to_place = os.path.join(base_dir, "hardware_testing")
-    urlretrieve(zipfile, os.path.join(base_dir, "source.zip"))
-    zf = ZipFile(os.path.join(base_dir, "source.zip"), "r")
-    files = [f for f in zf.namelist() if "hardware_testing" in f and "tests" not in f]
-    files = [f for f in files if "py" in f]
-    start_path = f"opentrons-{version_str}/hardware-testing/hardware_testing/"
-    for f in files:
-        dest_name = f.replace(start_path, "")
-        dest_file = os.path.join(where_to_place, dest_name)
-        dat = zf.read(f)
-        os.makedirs(os.path.dirname(dest_file), exist_ok=True)
-        out = open(dest_file, "wb")
-        out.write(dat)
-        out.close()
-    with open(os.path.join(where_to_place, "VERSION.txt"), "w") as ver_file:
-        ver_file.write(version_str)
-
-
-if not IS_ROBOT or importlib.util.find_spec("hardware_testing") is None:
-    # we're simulating or there is not a vaild hardware-testing yet
-    base_dir = str(infer_config_base_dir())
-    release = f"{version.replace('a', '-alpha.').replace('b', '-beta.')}"
-    version_file_path = os.path.join(base_dir, "hardware_testing", "VERSION.txt")
-    if os.path.exists(version_file_path):
-        with open(version_file_path, "r") as version_file:
-            if version_file.readline() != release:
-                _download_and_extract(release, base_dir)
-    else:
-        _download_and_extract(release, base_dir)
-    sys.path.append(base_dir)
-
-
-# ----- END: TODO ------
-
-from hardware_testing.data.csv_report import (  # noqa: E402
+from hardware_testing.data.csv_report import (
     CSVReport,
     CSVSection,
     CSVResult,
     CSVLine,
     CSVLineRepeating,
 )
-from hardware_testing.drivers.sealed_pressure_fixture import (  # noqa: E402
+from hardware_testing.drivers.sealed_pressure_fixture import (
     SerialDriver as SealedPressureDriver,
 )
-from hardware_testing.opentrons_api import helpers_ot3  # noqa: E402
+from hardware_testing.opentrons_api import helpers_ot3
 
 
 # ----------- Monkey patches -----------

--- a/hardware-testing/hardware_testing/production_qc_protocols/pipette_assembly_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc_protocols/pipette_assembly_qc_ot3.py
@@ -18,7 +18,6 @@ from typing import (
 from opentrons.protocol_api import ParameterContext, ProtocolContext
 from opentrons.types import Point
 
-from opentrons.config import IS_ROBOT
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.backends.ot3controller import OT3Controller
 from opentrons.hardware_control.backends.ot3simulator import (
@@ -50,65 +49,19 @@ from opentrons.hardware_control.types import (
 
 from opentrons_shared_data.errors.exceptions import StallOrCollisionDetectedError
 
-# ------ TODO remove and move necessary libraries into a standard release library. ----
-import importlib
-import os
-from opentrons.config import infer_config_base_dir
-from opentrons import version
-import sys
 
-
-def _download_and_extract(version_str: str, base_dir: str) -> None:
-    from urllib.request import urlretrieve
-    from zipfile import ZipFile
-
-    zipfile = f"https://github.com/Opentrons/opentrons/archive/refs/tags/v{release}.zip"
-    where_to_place = os.path.join(base_dir, "hardware_testing")
-    urlretrieve(zipfile, os.path.join(base_dir, "source.zip"))
-    zf = ZipFile(os.path.join(base_dir, "source.zip"), "r")
-    files = [f for f in zf.namelist() if "hardware_testing" in f and "tests" not in f]
-    files = [f for f in files if "py" in f]
-    start_path = f"opentrons-{version_str}/hardware-testing/hardware_testing/"
-    for f in files:
-        dest_name = f.replace(start_path, "")
-        dest_file = os.path.join(where_to_place, dest_name)
-        dat = zf.read(f)
-        os.makedirs(os.path.dirname(dest_file), exist_ok=True)
-        out = open(dest_file, "wb")
-        out.write(dat)
-        out.close()
-    with open(os.path.join(where_to_place, "VERSION.txt"), "w") as ver_file:
-        ver_file.write(version_str)
-
-
-if not IS_ROBOT or importlib.util.find_spec("hardware_testing") is None:
-    # we're simulating or there is not a vaild hardware-testing yet
-    base_dir = str(infer_config_base_dir())
-    release = f"{version.replace('a', '-alpha.').replace('b', '-beta.')}"
-    version_file_path = os.path.join(base_dir, "hardware_testing", "VERSION.txt")
-    if os.path.exists(version_file_path):
-        with open(version_file_path, "r") as version_file:
-            if version_file.readline() != release:
-                _download_and_extract(release, base_dir)
-    else:
-        _download_and_extract(release, base_dir)
-    sys.path.append(base_dir)
-
-
-# ----- END: TODO ------
-
-from hardware_testing.data.csv_report import (  # noqa: E402
+from hardware_testing.data.csv_report import (
     CSVReport,
     CSVSection,
     CSVResult,
     CSVLine,
     CSVLineRepeating,
 )
-from hardware_testing.opentrons_api import helpers_ot3  # noqa: E402
+from hardware_testing.opentrons_api import helpers_ot3
 
-from hardware_testing.drivers import asair_sensor  # noqa: E402
+from hardware_testing.drivers import asair_sensor
 
-from hardware_testing.drivers.pressure_fixture import (  # noqa: E402
+from hardware_testing.drivers.pressure_fixture import (
     PressureFixtureBase,
     connect_to_fixture,
 )

--- a/hardware-testing/pyproject.toml
+++ b/hardware-testing/pyproject.toml
@@ -14,15 +14,11 @@ classifiers = [
     "Private :: Do Not Upload"  # Prevent uploading to PyPI.
 ]
 dependencies = [
-    "opentrons[flex-hardware]",
+    "opentrons==0.0.0",
     "opentrons-shared-data==0.0.0",
     "opentrons-hardware[FLEX]==0.0.0",
     "hardware-testing",
-    "abr-testing",
     "pyserial==3.5",
-    "types-pytz",
-    "paramiko",
-    "types-paramiko",
     "anyio==4.9.0",
 ]
 dynamic = ["version"]
@@ -52,6 +48,17 @@ local_scheme = 'no-local-version'
 [tool.hatch.build.targets.wheel]
 packages = ["hardware_testing"]
 exclude = [
+    "abr_tools",
+    "examples",
+    "gravimetric",
+    "labware",
+    "legacy_tests",
+    "modules",
+    "production_qc",
+    "production_qc_protocols",
+    "protocols",
+    "scripts",
+    "tools",
     "tests",
     "tests.*",
 ]
@@ -75,6 +82,7 @@ abr-testing = {path = "./../abr-testing", editable = true}
 
 [dependency-groups]
 dev = [
+    "abr-testing",
     "atomicwrites==1.4.1",
     "colorama==0.4.4",
     "pytest<9,>=8",
@@ -92,4 +100,7 @@ dev = [
     "build~=1.2.0",
     "matplotlib==3.10.0",
     "setuptools<82",
+    "paramiko",
+    "types-paramiko",
+    "types-pytz",
 ]

--- a/hardware-testing/uv.lock
+++ b/hardware-testing/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-11T14:25:00.393367Z"
+exclude-newer = "2026-06-04T17:30:16.725673759Z"
 exclude-newer-span = "P1W"
 
 [[package]]
@@ -764,19 +764,16 @@ wheels = [
 name = "hardware-testing"
 source = { editable = "." }
 dependencies = [
-    { name = "abr-testing" },
     { name = "anyio" },
     { name = "opentrons" },
     { name = "opentrons-hardware", extra = ["flex"] },
     { name = "opentrons-shared-data" },
-    { name = "paramiko" },
     { name = "pyserial" },
-    { name = "types-paramiko" },
-    { name = "types-pytz" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "abr-testing" },
     { name = "atomicwrites" },
     { name = "black" },
     { name = "build" },
@@ -787,31 +784,31 @@ dev = [
     { name = "flake8-noqa" },
     { name = "matplotlib" },
     { name = "mypy" },
+    { name = "paramiko" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pyusb" },
     { name = "requests" },
     { name = "setuptools" },
+    { name = "types-paramiko" },
+    { name = "types-pytz" },
     { name = "types-requests" },
     { name = "types-setuptools" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "abr-testing", editable = "../abr-testing" },
     { name = "anyio", specifier = "==4.9.0" },
     { name = "hardware-testing", editable = "." },
-    { name = "opentrons", extras = ["flex-hardware"], editable = "../api" },
+    { name = "opentrons", editable = "../api" },
     { name = "opentrons-hardware", extras = ["flex"], editable = "../hardware" },
     { name = "opentrons-shared-data", editable = "../shared-data" },
-    { name = "paramiko" },
     { name = "pyserial", specifier = "==3.5" },
-    { name = "types-paramiko" },
-    { name = "types-pytz" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "abr-testing", editable = "../abr-testing" },
     { name = "atomicwrites", specifier = "==1.4.1" },
     { name = "black", specifier = "==22.3.0" },
     { name = "build", specifier = "~=1.2.0" },
@@ -822,11 +819,14 @@ dev = [
     { name = "flake8-noqa", specifier = "~=1.4.0" },
     { name = "matplotlib", specifier = "==3.10.0" },
     { name = "mypy", specifier = "==1.11.0" },
+    { name = "paramiko" },
     { name = "pytest", specifier = ">=8,<9" },
     { name = "pytest-cov", specifier = "==4.1.0" },
     { name = "pyusb", specifier = "==1.2.1" },
     { name = "requests", specifier = "==2.27.1" },
     { name = "setuptools", specifier = "<82" },
+    { name = "types-paramiko" },
+    { name = "types-pytz" },
     { name = "types-requests", specifier = "==2.25.6" },
     { name = "types-setuptools", specifier = "==57.0.2" },
 ]

--- a/robot-server/pyproject.toml
+++ b/robot-server/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "uvicorn==0.27.0.post1",
     "wsproto==1.2.0",
     "opentrons-hardware[FLEX]==0.0.0",
+    "hardware-testing==0.0.0",
     "systemd-python==234; sys_platform == 'linux'",
     "sqlalchemy==1.4.51",
     "paho-mqtt==1.6.1",
@@ -37,6 +38,7 @@ dev = {requires-python = ">=3.11"}
 robot = [
     "opentrons==0.0.0",
     "opentrons-hardware[FLEX]==0.0.0",
+    "hardware-testing==0.0.0",
     "opentrons-shared-data==0.0.0",
     "server-utils==0.0.0",
     "anyio==4.9.0",
@@ -124,6 +126,7 @@ opentrons = { path = "../api", editable = true }
 opentrons-shared-data = { path = "../shared-data", editable = true }
 server-utils = { path = "../server-utils", editable = true }
 opentrons-hardware = { path = "../hardware", editable = true }
+hardware-testing = { path = "../hardware-testing", editable = true }
 
 [project.urls]
 "Source Code On Github" = "https://github.com/Opentrons/opentrons/tree/edge/robot-server"
@@ -138,7 +141,7 @@ build-backend = "hatchling.build"
 
 # --- hatch-dependency-coversion: exact co-versioning of specific deps ---
 [tool.hatch.metadata.hooks.dependency-coversion]
-override-versions-of = ["opentrons-shared-data", "opentrons", "server-utils"]
+override-versions-of = ["opentrons-shared-data", "opentrons", "server-utils", "hardware-testing"]
 
 # --- hatch-vcs-tunable: VCS-derived version with env-tunable settings ---
 [tool.hatch.build.hooks.vcs-tunable]

--- a/robot-server/uv.lock
+++ b/robot-server/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-11T14:55:56.577835Z"
+exclude-newer = "2026-06-04T17:31:24.135398002Z"
 exclude-newer-span = "P1W"
 
 [manifest]
@@ -568,6 +568,52 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hardware-testing"
+source = { editable = "../hardware-testing" }
+dependencies = [
+    { name = "anyio" },
+    { name = "opentrons" },
+    { name = "opentrons-hardware", extra = ["flex"] },
+    { name = "opentrons-shared-data" },
+    { name = "pyserial" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anyio", specifier = "==4.9.0" },
+    { name = "hardware-testing", editable = "../hardware-testing" },
+    { name = "opentrons", editable = "../api" },
+    { name = "opentrons-hardware", extras = ["flex"], editable = "../hardware" },
+    { name = "opentrons-shared-data", editable = "../shared-data" },
+    { name = "pyserial", specifier = "==3.5" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "abr-testing", editable = "../abr-testing" },
+    { name = "atomicwrites", specifier = "==1.4.1" },
+    { name = "black", specifier = "==22.3.0" },
+    { name = "build", specifier = "~=1.2.0" },
+    { name = "colorama", specifier = "==0.4.4" },
+    { name = "flake8", specifier = "~=7.0.0" },
+    { name = "flake8-annotations", specifier = "~=3.0.1" },
+    { name = "flake8-docstrings", specifier = "~=1.7.0" },
+    { name = "flake8-noqa", specifier = "~=1.4.0" },
+    { name = "matplotlib", specifier = "==3.10.0" },
+    { name = "mypy", specifier = "==1.11.0" },
+    { name = "paramiko" },
+    { name = "pytest", specifier = ">=8,<9" },
+    { name = "pytest-cov", specifier = "==4.1.0" },
+    { name = "pyusb", specifier = "==1.2.1" },
+    { name = "requests", specifier = "==2.27.1" },
+    { name = "setuptools", specifier = "<82" },
+    { name = "types-paramiko" },
+    { name = "types-pytz" },
+    { name = "types-requests", specifier = "==2.25.6" },
+    { name = "types-setuptools", specifier = "==57.0.2" },
 ]
 
 [[package]]
@@ -1810,6 +1856,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "anyio" },
     { name = "fastapi" },
+    { name = "hardware-testing" },
     { name = "opentrons" },
     { name = "opentrons-hardware", extra = ["flex"] },
     { name = "opentrons-shared-data" },
@@ -1860,6 +1907,7 @@ robot = [
     { name = "aiohttp" },
     { name = "anyio" },
     { name = "fastapi" },
+    { name = "hardware-testing" },
     { name = "opentrons" },
     { name = "opentrons-hardware", extra = ["flex"] },
     { name = "opentrons-shared-data" },
@@ -1881,6 +1929,7 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.12.14,<4" },
     { name = "anyio", specifier = "==4.9.0" },
     { name = "fastapi", specifier = "==0.100.0" },
+    { name = "hardware-testing", editable = "../hardware-testing" },
     { name = "opentrons", editable = "../api" },
     { name = "opentrons-hardware", extras = ["flex"], editable = "../hardware" },
     { name = "opentrons-shared-data", editable = "../shared-data" },
@@ -1931,6 +1980,7 @@ robot = [
     { name = "aiohttp", specifier = "==3.12.14" },
     { name = "anyio", specifier = "==4.9.0" },
     { name = "fastapi", specifier = "==0.100.0" },
+    { name = "hardware-testing", editable = "../hardware-testing" },
     { name = "opentrons", editable = "../api" },
     { name = "opentrons-hardware", extras = ["flex"], editable = "../hardware" },
     { name = "opentrons-shared-data", editable = "../shared-data" },


### PR DESCRIPTION
# Overview
With this, the data, drivers and the opentrons_api subdirectory will be included with standard package under opt/opentrons-robot-server.

With this we can create more protocols that use these tools in a shared code instead of duplicating them through many protocols.