### PR TITLE
feat(hardware-testing): Integrate the barcode scanner into the qc stubs 

### DIFF
--- a/api/src/opentrons/drivers/barcode_scanner/rtscanner_driver.py
+++ b/api/src/opentrons/drivers/barcode_scanner/rtscanner_driver.py
@@ -132,7 +132,7 @@ class RTScanner(AbstractBarcodeScannerDriver):
 
     async def set_scan_timeout(self, timeout_ms: int) -> None:
         """Tell the scanner how long to keep decoding before failing."""
-        assert timeout_ms <= 3000
+        assert timeout_ms <= 3600000
         self._timeout_ms = timeout_ms
         await self.set_menu_option(decode_timeout + int_conv(timeout_ms))
         await self._conn.set_timeout("timeout", timeout_ms / 1000.0)

--- a/api/src/opentrons/drivers/barcode_scanner/simulator.py
+++ b/api/src/opentrons/drivers/barcode_scanner/simulator.py
@@ -12,6 +12,7 @@ class BarcodeSimulatorDriver(AbstractBarcodeScannerDriver):
         self.scan_timeout = 1000
         self.serial_number = "fake-serial"
         self.sound_profile = SoundProfile.FULL_SOUND
+        self.connected = True
 
     async def connect(self) -> None:
         """Connect to the barcode scanner."""

--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -391,6 +391,7 @@ def set_csv_report_meta_data_ot3(
     robot_serial = get_robot_serial_ot3(api)
     dut_str = _get_serial_for_dut(api, dut)
     print(f"device under test: {dut_str}")
+    barcode = dut_str
     if dut != DeviceUnderTest.OTHER:
         # always confirm barcode for robot/pipette/gripper
         if isinstance(api, SynchronousAdapter):
@@ -400,8 +401,6 @@ def set_csv_report_meta_data_ot3(
             barcode = get_device_barcode(ctx, api, dut)
         elif not api.is_simulator:
             barcode = input("SCAN device barcode: ").strip()
-        else:
-            barcode = dut_str
     print(f"barcode: {barcode}")
 
     # default the CSV tag to be the DUT

--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -391,18 +391,17 @@ def set_csv_report_meta_data_ot3(
     robot_serial = get_robot_serial_ot3(api)
     dut_str = _get_serial_for_dut(api, dut)
     print(f"device under test: {dut_str}")
-    if isinstance(api, SynchronousAdapter):
-        # if we're running with one of protocol engine's adapters we're running in a protocol and
-        # need to use the ctx to grab the barcode scanner instead of users typing input.
-        assert ctx
-    if not api.is_simulator and dut != DeviceUnderTest.OTHER:
+    if dut != DeviceUnderTest.OTHER:
         # always confirm barcode for robot/pipette/gripper
-        if ctx:
-            barcode = get_device_barcode(ctx, api, dut)  # type: ignore[arg-type]
-        else:
+        if isinstance(api, SynchronousAdapter):
+            # if we're running with one of protocol engine's adapters we're running in a protocol and
+            # need to use the ctx to grab the barcode scanner instead of users typing input.
+            assert ctx
+            barcode = get_device_barcode(ctx, api, dut)
+        elif not api.is_simulator:
             barcode = input("SCAN device barcode: ").strip()
-    else:
-        barcode = dut_str
+        else:
+            barcode = dut_str
     print(f"barcode: {barcode}")
 
     # default the CSV tag to be the DUT

--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -51,7 +51,7 @@ from opentrons.hardware_control.backends.ot3utils import (
 from opentrons.hardware_control.instruments.ot2.pipette import Pipette as PipetteOT2
 from opentrons.hardware_control.instruments.ot3.pipette import Pipette as PipetteOT3
 from opentrons.hardware_control.ot3api import OT3API
-from opentrons.hardware_control import SyncHardwareAPI
+from opentrons.hardware_control import SyncHardwareAPI, SynchronousAdapter
 from opentrons.hardware_control.types import HardwareFeatureFlags
 
 from ..data import get_git_description, csv_report
@@ -352,12 +352,35 @@ def _get_serial_for_dut(
         return input("enter ID for test: ")
 
 
+async def _scan_barcode(self) -> Optional[str]:  # noqa: ANN001
+    scanner = self.attached_peripherals[0]
+    return await scanner.scan_barcode()
+
+
+def get_device_barcode(
+    ctx: ProtocolContext,
+    api: SyncHardwareAPI,
+    dut: DeviceUnderTest = DeviceUnderTest.ROBOT,
+) -> str:
+    """Have the user scan a devices barcode."""
+    OT3API._scan_barcode = _scan_barcode  # type: ignore[attr-defined]
+    for i in range(3):
+        ctx.pause(f"Point scanner at {dut.value} barcode")
+        result = api._scan_barcode()
+        if result:
+            return result
+        ctx.pause("Failed to scan, try again.")
+
+    raise RuntimeError("Error scanning barcode.")
+
+
 def set_csv_report_meta_data_ot3(
     api: Union[OT3API, SyncHardwareAPI],
     report: csv_report.CSVReport,
     operator: str,
     dut: DeviceUnderTest = DeviceUnderTest.ROBOT,
     tag: str = "",
+    ctx: Optional[ProtocolContext] = None,
 ) -> None:
     """Set CSVReport meta-data given an OT3."""
     # operator should be entered first
@@ -368,9 +391,16 @@ def set_csv_report_meta_data_ot3(
     robot_serial = get_robot_serial_ot3(api)
     dut_str = _get_serial_for_dut(api, dut)
     print(f"device under test: {dut_str}")
+    if isinstance(api, SynchronousAdapter):
+        # if we're running with one of protocol engine's adapters we're running in a protocol and
+        # need to use the ctx to grab the barcode scanner instead of users typing input.
+        assert ctx
     if not api.is_simulator and dut != DeviceUnderTest.OTHER:
         # always confirm barcode for robot/pipette/gripper
-        barcode = input("SCAN device barcode: ").strip()
+        if ctx:
+            barcode = get_device_barcode(ctx, api, dut)  # type: ignore[arg-type]
+        else:
+            barcode = input("SCAN device barcode: ").strip()
     else:
         barcode = dut_str
     print(f"barcode: {barcode}")
@@ -1557,15 +1587,48 @@ def direct_eeprom_data(data: EEPROMData) -> DirectEEPROMData:
     )
 
 
-# TODO Barcode scanner?
-def get_user_answer(api: SyncHardwareAPI, prompt: str) -> bool:
+def get_user_answer(ctx: ProtocolContext, api: SyncHardwareAPI, prompt: str) -> bool:
     """Have the user answer a yes/no question."""
-    return True
+    OT3API._scan_barcode = _scan_barcode  # type: ignore[attr-defined]
+    for i in range(3):
+        ctx.pause(f"Point Scanner at Yes or No: {prompt}")
+        result = api._scan_barcode()
+        if result:
+            return "yes" in result.lower()
+        ctx.pause("Failed to scan, try again.")
+
+    raise RuntimeError("Error scanning barcode.")
 
 
 def get_input_number(
     ctx: ProtocolContext, api: SyncHardwareAPI, prompt: str, default: Union[int, float]
 ) -> Union[int, float]:
     """Have the user input a value."""
-    ctx.pause(f"Use Scanner: {prompt}")
+    OT3API._scan_barcode = _scan_barcode  # type: ignore[attr-defined]
+
+    def _is_float(s: str) -> bool:
+        try:
+            float(s)
+            return True
+        except ValueError:
+            return False
+
+    def _is_int(s: str) -> bool:
+        try:
+            int(s)
+            return True
+        except ValueError:
+            return False
+
+    for i in range(3):
+        ctx.pause(f"Point Scanner at Yes or No: {prompt}")
+        result = api._scan_barcode()
+        if result:
+            if _is_int(result):
+                return int(result)
+            elif _is_float(result):
+                return float(result)
+            ctx.pause(f"{result} is not a number, try again.")
+        else:
+            ctx.pause("Failed to scan, try again.")
     return default

--- a/hardware-testing/hardware_testing/production_qc_protocols/belt_calibration_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc_protocols/belt_calibration_ot3.py
@@ -115,7 +115,7 @@ def _generate_report(
 ) -> None:
     report = _create_csv_report()
     helpers_ot3.set_csv_report_meta_data_ot3(
-        ctx._core.get_hardware(), report, operator=ctx.params.operator  # type: ignore[attr-defined]
+        ctx._core.get_hardware(), report, operator=ctx.params.operator, ctx=ctx  # type: ignore[attr-defined]
     )  # STORE ATTITUDE
     if attitude:
         report("ATTITUDE", "attitude-x", attitude[0])

--- a/hardware-testing/hardware_testing/production_qc_protocols/belt_calibration_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc_protocols/belt_calibration_ot3.py
@@ -26,6 +26,7 @@ from opentrons_shared_data.errors.exceptions import (
     EdgeNotFoundError,
     MisalignedGantryError,
 )
+from opentrons.hardware_control.peripherals import BarcodeScannerModel
 
 
 from hardware_testing.data.csv_report import (
@@ -356,6 +357,9 @@ def run(ctx: ProtocolContext) -> None:
                 results.append(dist_after)
             passing = max(results) <= MAX_ERROR_DISTANCE_MM
     else:
+        ctx._core.get_hardware().create_simulating_peripheral(
+            BarcodeScannerModel.BARCODE_SCANNER_V1
+        )
         nom_front_left = helpers_ot3.get_slot_calibration_square_position_ot3(
             SLOT_FRONT_LEFT
         )

--- a/hardware-testing/hardware_testing/production_qc_protocols/gripper_assembly_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc_protocols/gripper_assembly_qc_ot3.py
@@ -11,6 +11,7 @@ from opentrons.config.defaults_ot3 import (
     DEFAULT_MAX_SPEEDS,
     DEFAULT_RUN_CURRENT,
 )
+from opentrons.hardware_control.peripherals import BarcodeScannerModel
 from opentrons.hardware_control.ot3_calibration import (
     calibrate_gripper,
     calibrate_gripper_jaw,
@@ -818,6 +819,7 @@ def run(ctx: ProtocolContext) -> None:
             )
             for m in OT3Mount
         }
+        api.create_simulating_peripheral(BarcodeScannerModel.BARCODE_SCANNER_V1)
         api.reset()
 
     # Apply monkey patches

--- a/hardware-testing/hardware_testing/production_qc_protocols/gripper_assembly_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc_protocols/gripper_assembly_qc_ot3.py
@@ -827,7 +827,7 @@ def run(ctx: ProtocolContext) -> None:
 
     report = build_report(test_name)
     dut = helpers_ot3.DeviceUnderTest.GRIPPER
-    helpers_ot3.set_csv_report_meta_data_ot3(api, report, operator=ctx.params.operator, dut=dut)  # type: ignore[attr-defined]
+    helpers_ot3.set_csv_report_meta_data_ot3(api, report, operator=ctx.params.operator, dut=dut, ctx=ctx)  # type: ignore[attr-defined]
     args = ctx.params.get_all()
     t_sections = {s: f for s, f in TESTS if not args[f"skip_{s.value.lower()}"]}
     if args["increment"]:

--- a/hardware-testing/hardware_testing/production_qc_protocols/ninety_six_assembly_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc_protocols/ninety_six_assembly_qc_ot3.py
@@ -7,6 +7,7 @@ from typing import Dict, Callable, cast, List, Union, Tuple, Literal
 from opentrons.protocol_api import ParameterContext, ProtocolContext, OFF_DECK
 from opentrons.types import Point
 
+from opentrons.hardware_control.peripherals import BarcodeScannerModel
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.backends.ot3controller import OT3Controller
 from opentrons.hardware_control.backends.ot3simulator import (
@@ -1415,6 +1416,7 @@ def run(ctx: ProtocolContext) -> None:
             )
             for m in OT3Mount
         }
+        api.create_simulating_peripheral(BarcodeScannerModel.BARCODE_SCANNER_V1)
         api.reset()
 
     test_name = "ninety-six-assembly-qc-ot3"

--- a/hardware-testing/hardware_testing/production_qc_protocols/ninety_six_assembly_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc_protocols/ninety_six_assembly_qc_ot3.py
@@ -294,22 +294,28 @@ def build_jaws_csv_lines() -> List[Union[CSVLine, CSVLineRepeating]]:
     return lines
 
 
-def _check_if_jaw_is_aligned_with_endstop(api: SyncHardwareAPI) -> bool:
+def _check_if_jaw_is_aligned_with_endstop(
+    ctx: ProtocolContext, api: SyncHardwareAPI
+) -> bool:
     if not api.is_simulator:
-        pass_no_hit = helpers_ot3.get_user_answer(api, "are both endstop Lights OFF?")
+        pass_no_hit = helpers_ot3.get_user_answer(
+            ctx, api, "are both endstop Lights OFF?"
+        )
     else:
         pass_no_hit = True
 
     return pass_no_hit
 
 
-def jaw_precheck(api: SyncHardwareAPI, ax: Axis, speed: float) -> Tuple[bool, bool]:
+def jaw_precheck(
+    ctx: ProtocolContext, api: SyncHardwareAPI, ax: Axis, speed: float
+) -> Tuple[bool, bool]:
     """Check the LEDs work and jaws are aligned."""
     # HOME
     helpers_ot3.home_tip_motors_sync(api, False)  # Home with no backoff
     # Check LEDs can turn on when homed
     if not api.is_simulator:
-        led_check = helpers_ot3.get_user_answer(api, "are both endstop Lights ON?")
+        led_check = helpers_ot3.get_user_answer(ctx, api, "are both endstop Lights ON?")
     else:
         led_check = True
     if not led_check:
@@ -318,7 +324,9 @@ def jaw_precheck(api: SyncHardwareAPI, ax: Axis, speed: float) -> Tuple[bool, bo
     helpers_ot3.move_tip_motor_relative_ot3_sync(api, RETRACT_MM, speed=speed)
     # Check Jaws are aligned
     if not api.is_simulator:
-        jaws_aligned = helpers_ot3.get_user_answer(api, "are both endstop Lights OFF?")
+        jaws_aligned = helpers_ot3.get_user_answer(
+            ctx, api, "are both endstop Lights OFF?"
+        )
     else:
         jaws_aligned = True
 
@@ -340,7 +348,7 @@ def test_jaws(
 
     async def _save_result(tag: str, led_check: bool, jaws_aligned: bool) -> bool:
         if led_check and jaws_aligned:
-            no_hit = _check_if_jaw_is_aligned_with_endstop(api)
+            no_hit = _check_if_jaw_is_aligned_with_endstop(ctx, api)
         else:
             no_hit = False
         result = CSVResult.from_bool(led_check and jaws_aligned and no_hit)
@@ -358,7 +366,7 @@ def test_jaws(
         speeds = CURRENTS_SPEEDS_JAWS[current]
         for speed in sorted(speeds, reverse=False):
 
-            led_check, jaws_aligned = jaw_precheck(api, ax, speed)
+            led_check, jaws_aligned = jaw_precheck(ctx, api, ax, speed)
 
             if led_check and jaws_aligned:
                 helpers_ot3.set_gantry_load_per_axis_motion_settings_ot3_sync(
@@ -1085,7 +1093,11 @@ def get_trash_nominal() -> Point:
 
 
 def aspirate_and_wait(
-    api: SyncHardwareAPI, reservoir: Point, volume: int, seconds: int = 30
+    ctx: ProtocolContext,
+    api: SyncHardwareAPI,
+    reservoir: Point,
+    volume: int,
+    seconds: int = 30,
 ) -> Tuple[bool, float]:
     """Aspirate and wait."""
     helpers_ot3.move_to_arched_ot3_sync(api, OT3Mount.LEFT, reservoir)
@@ -1102,7 +1114,7 @@ def aspirate_and_wait(
     api.set_lights(True, True)
 
     if not api.is_simulator:
-        result = helpers_ot3.get_user_answer(api, "look good")
+        result = helpers_ot3.get_user_answer(ctx, api, "look good")
     else:
         result = True
     duration_seconds = monotonic() - start_time
@@ -1152,6 +1164,7 @@ def test_droplets(
         api.home_z(OT3Mount.LEFT)
 
         result, duration = aspirate_and_wait(
+            ctx,
             api,
             reservoir["A1"].top().move(OFFSET_FOR_1_WELL_LABWARE).point,
             test_volume,
@@ -1407,7 +1420,7 @@ def run(ctx: ProtocolContext) -> None:
     test_name = "ninety-six-assembly-qc-ot3"
     report = build_report(test_name)
     dut = helpers_ot3.DeviceUnderTest.PIPETTE_LEFT
-    helpers_ot3.set_csv_report_meta_data_ot3(api, report, operator=ctx.params.operator, dut=dut)  # type: ignore[attr-defined]
+    helpers_ot3.set_csv_report_meta_data_ot3(api, report, operator=ctx.params.operator, dut=dut, ctx=ctx)  # type: ignore[attr-defined]
     args = ctx.params.get_all()
     t_sections = {
         s: f for s, f in TESTS if not args[f"skip_{s.value.lower().replace('-', '_')}"]

--- a/hardware-testing/hardware_testing/production_qc_protocols/pipette_assembly_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc_protocols/pipette_assembly_qc_ot3.py
@@ -670,7 +670,7 @@ def _read_pressure_and_check_results(
 
 
 def _aspirate_and_look_for_droplets(
-    api: SyncHardwareAPI, mount: OT3Mount, wait_time: int
+    ctx: ProtocolContext, api: SyncHardwareAPI, mount: OT3Mount, wait_time: int
 ) -> bool:
     pip = api.hardware_pipettes[mount.to_mount()]
     assert pip
@@ -685,7 +685,9 @@ def _aspirate_and_look_for_droplets(
     if api.is_simulator:
         leak_test_passed = True
     else:
-        leak_test_passed = helpers_ot3.get_user_answer(api, "did it pass? no leaking?")
+        leak_test_passed = helpers_ot3.get_user_answer(
+            ctx, api, "did it pass? no leaking?"
+        )
 
     api.move_rel(mount, Point(z=-LEAK_HOVER_ABOVE_LIQUID_MM))
     api.dispense(mount, pipette_volume, is_full_dispense=True)
@@ -784,6 +786,7 @@ def _fixture_check_pressure(
 
 
 def _test_for_leak(
+    ctx: ProtocolContext,
     api: SyncHardwareAPI,
     cfg: TestConfig,
     tip_volume: int,
@@ -814,7 +817,7 @@ def _test_for_leak(
         assert CALIBRATED_LABWARE_LOCATIONS.reservoir
         _move_safe(api, cfg.mount, CALIBRATED_LABWARE_LOCATIONS.reservoir)
         test_passed = _aspirate_and_look_for_droplets(
-            api, cfg.mount, droplet_wait_seconds
+            ctx, api, cfg.mount, droplet_wait_seconds
         )
         _drop_tip_in_trash(api, cfg)
     return test_passed
@@ -833,6 +836,7 @@ def test_fixture(
         side=cfg.fixture_side,
     )
     _test_for_leak(
+        ctx,
         api,
         cfg,
         PRESSURE_FIXTURE_TIP_VOLUME,
@@ -864,6 +868,7 @@ def test_liquid(
     for i in range(cfg.num_trials):
         droplet_wait_seconds = cfg.droplet_wait_seconds * (i + 1)
         test_passed = _test_for_leak(
+            ctx,
             api,
             cfg,
             cfg.pipette_volume,
@@ -1313,7 +1318,7 @@ def _test_plunger_positions(
     if api.is_simulator:
         blow_out_passed = True
     else:
-        blow_out_passed = helpers_ot3.get_user_answer(api, "is BLOW-OUT correct?")
+        blow_out_passed = helpers_ot3.get_user_answer(ctx, api, "is BLOW-OUT correct?")
         if not blow_out_passed:
             printval = f"02-01-BLOW-OUT:移液器BLOW-OUT {blow_out_passed}"
             FINAL_TEST_FAIL_INFOR.append(printval)
@@ -1322,7 +1327,7 @@ def _test_plunger_positions(
     if api.is_simulator:
         drop_tip_passed = True
     else:
-        drop_tip_passed = helpers_ot3.get_user_answer(api, "is DROP-TIP correct?")
+        drop_tip_passed = helpers_ot3.get_user_answer(ctx, api, "is DROP-TIP correct?")
         if not drop_tip_passed:
             printval = f"02-02-DROP-TIP:移液器DROP-TIP {drop_tip_passed}"
             FINAL_TEST_FAIL_INFOR.append(printval)
@@ -1767,7 +1772,7 @@ def test_liquid_probe_new(
                     # bad named method here since it's going to the liquid
                     _move_to_above_plate_liquid(api, cfg.mount, probe, end_z - top_z)
                     helpers_ot3.get_user_answer(
-                        api, "Is the tip just touching the liquid?"
+                        ctx, api, "Is the tip just touching the liquid?"
                     )
                     good_height = end_z
                 _drop_tip_in_trash(api, cfg)
@@ -2411,7 +2416,7 @@ def run(ctx: ProtocolContext) -> None:
 
         report = build_report(test_name, config)
         dut = helpers_ot3.DeviceUnderTest.PIPETTE_LEFT
-        helpers_ot3.set_csv_report_meta_data_ot3(api, report, operator=ctx.params.operator, dut=dut)  # type: ignore[attr-defined]
+        helpers_ot3.set_csv_report_meta_data_ot3(api, report, operator=ctx.params.operator, dut=dut, ctx=ctx)  # type: ignore[attr-defined]
 
         store_config(report, ctx, config.pipette_channels, config.pipette_volume)
 

--- a/hardware-testing/hardware_testing/production_qc_protocols/pipette_assembly_qc_ot3.py
+++ b/hardware-testing/hardware_testing/production_qc_protocols/pipette_assembly_qc_ot3.py
@@ -28,6 +28,7 @@ from opentrons.hardware_control.ot3_calibration import (
     EdgeNotFoundError,
     CalibrationStructureNotFoundError,
 )
+from opentrons.hardware_control.peripherals import BarcodeScannerModel
 from opentrons.hardware_control.types import (
     TipStateType,
     FailedTipStateCheck,
@@ -2373,6 +2374,7 @@ def run(ctx: ProtocolContext) -> None:
             )
             for m in OT3Mount
         }
+        api.create_simulating_peripheral(BarcodeScannerModel.BARCODE_SCANNER_V1)
         api.reset()
 
     args = ctx.params.get_all()


### PR DESCRIPTION
# Overview
The factory QC scripts require input at certain points, the barcode scanner offers the best system for easy, repeatable input.