### PR TITLE
fix(step-generation): correctly grab single well from well sets in ROW configuration

### DIFF
--- a/step-generation/src/utils/safePipetteMovements.ts
+++ b/step-generation/src/utils/safePipetteMovements.ts
@@ -718,15 +718,8 @@ export const getTargetTipsFromWellSets = (args: {
   primaryNozzle: string
 }): string[] => {
   const { wellSets, nozzles, channels, primaryNozzle } = args
-  // 96-channel pipette with ROW nozzle configuration needs to transpose wellSets
   if (nozzles === ROW) {
-    const numCols = wellSets[0].length
-    const transposed: string[][] = Array.from(
-      { length: numCols },
-      (_, colIndex) => wellSets.map(row => row[colIndex])
-    )
-    // Pick the first well from each row
-    return transposed.map(row => row[0])
+    return wellSets.map(row => row[0])
   }
   return wellSets.map(wellSet => {
     // 96-channel pipette with ALL nozzle configuration or 8ch with PARTIAL


### PR DESCRIPTION
# Overview

This PR fixes a bug in the `getTargetTipsFromWellSets` utility through which nested lists of wells passed to liquid handling functions are reduced to a flat list of target wells.

Closes RQA-5623

## Test Plan and Hands on Testing

- import protocol attached to the ticket
- in step 8, navigate to final page of form (tip settings)
- select manual tip seletion, and select a valid set of tips
- save and verify no timeline error

## Changelog

No transposition is needed for ROW configuration well sets; rather, we should just grab the first well of each set to target (example: input rows `[[H1, H2, ..., H12], [G1, G2, ..., G12]]` should return `[H1, G1]`

## Review requests

see test plan

## Risk assessment

low. fixes a bug existing in prod