### PR TITLE
fix(protocol-designer, step-generation): fix logic for getting tallest stack on shuttle

### DIFF
--- a/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
+++ b/protocol-designer/src/components/organisms/AssignLiquidsModal/LabwareToolbox.tsx
@@ -289,10 +289,11 @@ export function LabwareStackToolboxContainer({
     labwareId != null ? (labware[labwareId]?.stack ?? []) : []
   const slot = getSlotInLocationStack(labwareStack)
 
-  const largestStackInSlot = getLargestStackInSlot(
-    initialRobotState.labware,
-    slot
-  )
+  const largestStackInSlot = getLargestStackInSlot({
+    slot,
+    labwareState: initialRobotState.labware,
+    modulesState: initialRobotState.modules,
+  })
 
   const liquidLocations = useSelector(
     labwareIngredSelectors.getLiquidsByLabwareId

--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -370,10 +370,11 @@ export const moveLabware: CommandCreator<MoveLabwareParams> = (
 
   // check compatibility of stack to move to
   if (parentSlotForSlotCompatibility != null) {
-    const largestStackInSlot = getLargestStackInSlot(
-      prevRobotState.labware,
-      parentSlotForSlotCompatibility
-    )
+    const largestStackInSlot = getLargestStackInSlot({
+      slot: parentSlotForSlotCompatibility,
+      labwareState: prevRobotState.labware,
+      modulesState: prevRobotState.modules,
+    })
 
     const slot = getSlotInLocationStack(largestStackInSlot)
     const { isCompatible, isAboveStackLimit } = getIsLabwareCompatibleWithStack(

--- a/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/forMoveLabware.ts
@@ -123,7 +123,11 @@ export function forMoveLabware(
     const fullStack =
       movedStackUpToTarget.length > 0
         ? movedStackUpToTarget
-        : getLargestStackInSlot(labware, initialDeckSlot)
+        : getLargestStackInSlot({
+            slot: initialDeckSlot,
+            labwareState: labware,
+            modulesState: modules,
+          })
     const stackIndexOfTarget = fullStack.indexOf(labwareId)
     const moduleState = newStackerOnDeck.moduleState as FlexStackerModuleState
     if (stackIndexOfTarget !== -1) {
@@ -185,7 +189,11 @@ export function forMoveLabware(
       // For vacuum module: stack onto whatever is currently on the module's main slot
       // so that [collar, ...existingModuleLabware, moduleId, slot] is built correctly
       const moduleSlot = modules[newLocation.moduleId].slot
-      const existingStack = getLargestStackInSlot(labware, moduleSlot)
+      const existingStack = getLargestStackInSlot({
+        slot: moduleSlot,
+        labwareState: labware,
+        modulesState: modules,
+      })
       if (existingStack.length > 0) {
         newLocationStack.push(...existingStack)
       } else {
@@ -272,7 +280,11 @@ export function forMoveLabware(
   ) {
     // The collar stacks onto the topmost existing labware on the module, not the module itself
     const moduleSlot = modules[newLocation.moduleId].slot
-    const existingStack = getLargestStackInSlot(labware, moduleSlot)
+    const existingStack = getLargestStackInSlot({
+      slot: moduleSlot,
+      labwareState: labware,
+      modulesState: modules,
+    })
     const topLabwareIdOnModule =
       existingStack.length > 0 ? existingStack[0] : null
     if (

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -918,16 +918,34 @@ export const getTopLocationInStack = (stack?: string[]): string => {
 export const getNearestParentInStack = (stack: string[]): string | null =>
   stack.length >= 2 ? stack[1] : null
 
-export const getLargestStackInSlot = (
-  labwareState: RobotState['labware'],
+export const getLargestStackInSlot = (args: {
   slot: string
-): string[] =>
-  Object.values(labwareState).reduce<string[]>((acc, { stack }) => {
+  labwareState: RobotState['labware']
+  modulesState: RobotState['modules']
+}): string[] => {
+  const { slot, labwareState, modulesState } = args
+  const stackerEntry = Object.values(modulesState).find(
+    ({ slot: moduleSlot, moduleState }) =>
+      moduleSlot === slot && moduleState.type === FLEX_STACKER_MODULE_TYPE
+  )
+  if (stackerEntry != null) {
+    const shuttleGroup = (stackerEntry.moduleState as FlexStackerModuleState)
+      .labwareOnShuttle
+    if (shuttleGroup == null) return []
+    const shuttleIdsTopDown = [
+      shuttleGroup.lidLabwareId,
+      shuttleGroup.primaryLabwareId,
+      shuttleGroup.adapterLabwareId,
+    ].filter((id): id is string => id != null)
+    return shuttleIdsTopDown
+  }
+  return Object.values(labwareState).reduce<string[]>((acc, { stack }) => {
     if (stack[stack.length - 1] === slot && stack.length > acc.length) {
       acc = stack
     }
     return acc
   }, [])
+}
 
 /** Single-slot deck id (e.g. A3) for a staging-area slot (e.g. A4) on Flex. */
 export const getFlexStackerCutoutBaseDeckSlotId = (
@@ -1518,18 +1536,6 @@ export function createStagingAreaForInvariantContext(
     }
   }
   return {}
-}
-
-export const getLabwareIdOnHopper = (
-  labware: {
-    [labwareId: string]: LabwareTemporalProperties
-  },
-  moduleSlotLocation: string
-): string => {
-  const largestStackInSlot = getLargestStackInSlot(labware, moduleSlotLocation)
-  const indexOfHopper = largestStackInSlot.indexOf(HOPPER_STACKER_LOCATION)
-  const labwareIdOnModule = largestStackInSlot[indexOfHopper - 1]
-  return labwareIdOnModule
 }
 
 export const getIsSlotAHopper = (slot: string): boolean => {


### PR DESCRIPTION
# Overview

This PR ensures that the logic for determining the largest stack in a column 4 slot considers the presence of a Flex stacker loaded in that slot. If the stacker is present, we build the stack from the module's shuttle labware temporal property.

Closes RQA-5625

## Test Plan and Hands on Testing

- import the protocol attached to the ticke
- verify that no timeline error occurs when moving the labware to an empty shuttle (final step)

## Changelog

- consider potential stacker shuttle in `getLargestStackInSlot`
- update all instances of the above util to ingest module state

## Review requests

see test plan

## Risk assessment

low. fixes non-regression bug