### PR TITLE
fix(protocol-designer): consider correct wells when assigning liquid class

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks/useAssignLiquidClass.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks/useAssignLiquidClass.ts
@@ -2,16 +2,17 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
-import { ALL, COLUMN, getAllLiquidClassDefs } from '@opentrons/shared-data'
+import { getAllLiquidClassDefs } from '@opentrons/shared-data'
 
 import {
   getCurrentFormIsPresaved,
   getCurrentFormUnsavedChangedFields,
   getLabwareEntities,
   getLiquidEntities,
+  getPipetteEntities,
 } from '/protocol-designer/step-forms/selectors'
-import { getAllWellsFromPrimaryWells } from '/protocol-designer/steplist/formLevel/handleFormChange/utils'
 import { getAllWellContentsForActiveItem } from '/protocol-designer/top-selectors/well-contents'
+import { getEntireWellSelection } from '../../../PipetteFields/NozzleAndWellSelectionModal/utils'
 
 import { selectors as labwareIngredSelectors } from '../../../../../../../labware-ingred/selectors'
 import { getShouldUpdateForLiquidClass } from '../../../utils'
@@ -44,21 +45,26 @@ export function useAssignLiquidClass(
   const liquidsInLabware = useSelector(
     labwareIngredSelectors.getLiquidsByLabwareId
   )[formData[labwareField]]
+  const pipetteEntities = useSelector(getPipetteEntities)
+  const pipetteChannels = pipetteEntities[formData.pipette]?.spec.channels ?? 1
   const nozzlesConfigured = formData.nozzles
-  let channels = 1
-  if (nozzlesConfigured === COLUMN) {
-    channels = 8
-  } else if (nozzlesConfigured === ALL) {
-    channels = 96
-  }
-  const allWellsAdjustedForPipette =
-    channels !== 1
-      ? getAllWellsFromPrimaryWells(
-          formData[wellsField] as string[],
-          labwareEntities[formData[labwareField]]?.def,
-          channels as 8 | 96
-        )
-      : (formData[wellsField] as string[])
+  const primaryNozzle = formData.primaryNozzle
+  const labwareDef = labwareEntities[formData[labwareField]]?.def
+  const allWellsAdjustedForPipette = labwareDef != null
+    ? [
+        ...new Set(
+          (formData[wellsField] as string[]).flatMap(well =>
+            getEntireWellSelection(
+              well,
+              labwareDef.ordering,
+              nozzlesConfigured,
+              primaryNozzle,
+              pipetteChannels
+            )
+          )
+        ),
+      ]
+    : (formData[wellsField] as string[])
 
   const liquidClassesInSourceWellsSet = allWellsAdjustedForPipette.reduce<
     Set<string>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks/useAssignLiquidClass.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/MoveLiquidTools/hooks/useAssignLiquidClass.ts
@@ -12,11 +12,15 @@ import {
   getPipetteEntities,
 } from '/protocol-designer/step-forms/selectors'
 import { getAllWellContentsForActiveItem } from '/protocol-designer/top-selectors/well-contents'
-import { getEntireWellSelection } from '../../../PipetteFields/NozzleAndWellSelectionModal/utils'
 
 import { selectors as labwareIngredSelectors } from '../../../../../../../labware-ingred/selectors'
+import { getEntireWellSelection } from '../../../PipetteFields/NozzleAndWellSelectionModal/utils'
 import { getShouldUpdateForLiquidClass } from '../../../utils'
 
+import type {
+  NozzleConfigurationStyle,
+  PrimaryNozzleConfigurationStyle,
+} from '@opentrons/shared-data'
 import type { FormData } from '/protocol-designer/form-types'
 
 export interface LiquidClassOption {
@@ -47,24 +51,26 @@ export function useAssignLiquidClass(
   )[formData[labwareField]]
   const pipetteEntities = useSelector(getPipetteEntities)
   const pipetteChannels = pipetteEntities[formData.pipette]?.spec.channels ?? 1
-  const nozzlesConfigured = formData.nozzles
-  const primaryNozzle = formData.primaryNozzle
+  const nozzlesConfigured = formData.nozzles as NozzleConfigurationStyle
+  const primaryNozzle =
+    formData.primaryNozzle as PrimaryNozzleConfigurationStyle
   const labwareDef = labwareEntities[formData[labwareField]]?.def
-  const allWellsAdjustedForPipette = labwareDef != null
-    ? [
-        ...new Set(
-          (formData[wellsField] as string[]).flatMap(well =>
-            getEntireWellSelection(
-              well,
-              labwareDef.ordering,
-              nozzlesConfigured,
-              primaryNozzle,
-              pipetteChannels
+  const allWellsAdjustedForPipette =
+    labwareDef != null
+      ? [
+          ...new Set(
+            (formData[wellsField] as string[]).flatMap(well =>
+              getEntireWellSelection(
+                well,
+                labwareDef.ordering,
+                nozzlesConfigured,
+                primaryNozzle,
+                pipetteChannels
+              )
             )
-          )
-        ),
-      ]
-    : (formData[wellsField] as string[])
+          ),
+        ]
+      : (formData[wellsField] as string[])
 
   const liquidClassesInSourceWellsSet = allWellsAdjustedForPipette.reduce<
     Set<string>


### PR DESCRIPTION
# Overview

This PR fixes the logic by which we determine which source wells are selected when assigning a potential liquid class/

Closes RQA-5618

## Test Plan and Hands on Testing

- create a protocol with multiple liquids of different liquid classes and populate a well plate with them in neighboring wells
- set up a transfer or mix step such that a group of aspirate wells spans wells of multiple liquid classes. example: liquidClassA in well A1, liquidClassB in well B1, 96-channel column configuration, plate column 1 selected
- continue to page 2 of the form for liquid class selection, and confirm that the pre-selected value is "Don't use a liquid class", since the liquid class of all selected wells can't be resolved to a single liquid class

## Changelog

- fix logic in `useAssignLiquidClass` such that all affected wells 

## Review requests

see test plan

## Risk assessment

low. fixes existing bug