### PR TITLE
fix(hardware-testing): add “shape” param to millipore vacuum collare defs

### DIFF
--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/slas_2026_demo/millipore_vacuum_manifold_collar_standard.json
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/slas_2026_demo/millipore_vacuum_manifold_collar_standard.json
@@ -69,6 +69,7 @@
   "gripForce": 17,
   "gripHeightFromLabwareBottom": 45,
   "containedSpace": {
+    "shape": "rectangular",
     "origin": { "x": 0, "y": 0, "z": 0 },
     "dimensions": {
       "xDimension": 134,

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/slas_2026_demo/millipore_vacuum_manifold_collar_tall.json
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/slas_2026_demo/millipore_vacuum_manifold_collar_tall.json
@@ -69,6 +69,7 @@
   "gripForce": 17,
   "gripHeightFromLabwareBottom": 66,
   "containedSpace": {
+    "shape": "rectangular",
     "origin": { "x": 0, "y": 0, "z": 0 },
     "dimensions": {
       "xDimension": 134,


### PR DESCRIPTION
## Overview
This fix allows you to import the millipore vacuum manifold collars as custom labware