### PR TITLE
fix(hardware-testing): Fix csv tagging.

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
@@ -1092,7 +1092,9 @@ def retract_and_wait(
                 return_val.grams_average += volume * 0.001
         return return_val
 
-    m_tag = create_measurement_tag(mode, None if blank else volume, channel, trial)
+    m_tag = create_measurement_tag(
+        mode.value, None if blank else volume, channel, trial
+    )
     fixture_settings.pipette._retract()
     if fixture_settings.recorder and not blank and fixture_settings.ctx.is_simulating():
         if mode == MeasurementType.ASPIRATE:

--- a/hardware-testing/hardware_testing/gravimetric/report.py
+++ b/hardware-testing/hardware_testing/gravimetric/report.py
@@ -200,7 +200,7 @@ def create_csv_test_report(
                 title="MEASUREMENTS",
                 lines=[
                     CSVLine(
-                        create_measurement_tag(measurement, volume, channel, trial)
+                        create_measurement_tag(measurement.value, volume, channel, trial)
                         + f"-{i}",
                         [float],
                     )

--- a/hardware-testing/hardware_testing/gravimetric/report.py
+++ b/hardware-testing/hardware_testing/gravimetric/report.py
@@ -200,7 +200,9 @@ def create_csv_test_report(
                 title="MEASUREMENTS",
                 lines=[
                     CSVLine(
-                        create_measurement_tag(measurement.value, volume, channel, trial)
+                        create_measurement_tag(
+                            measurement.value, volume, channel, trial
+                        )
                         + f"-{i}",
                         [float],
                     )


### PR DESCRIPTION
# Overview
We were storing the MeasurementType's enum name not value and it was ,essing up all the auto importing and  graphing.

just tack in '.value' in the places it matters.