### PR TITLE
fix(protocol-designer): render error nozzle/well selector button

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/ExtendedPartialTipField.tsx
@@ -31,7 +31,7 @@ import type { FieldProps, FieldPropsByName } from '../../types'
 interface ExtendedPartialTipFieldProps extends FieldProps {
   pipetteSpecs: PipetteV2Specs
   propsForFields: FieldPropsByName
-  stepType: string
+  stepType: 'mix' | 'transfer'
 }
 export function ExtendedPartialTipField(
   props: ExtendedPartialTipFieldProps
@@ -235,6 +235,18 @@ export function ExtendedPartialTipField(
     })
   }
 
+  const fieldsForWellSelection = [
+    'primaryNozzle',
+    'nozzles',
+    ...(stepType === 'transfer'
+      ? ['aspirate_wells', 'dispense_wells']
+      : ['wells']),
+  ]
+  const shouldShowErrorForNozzleAndWellModalButton =
+    fieldsForWellSelection.some(
+      field => propsForFields[field].errorToShow != null
+    )
+
   return (
     <>
       <div className={styles.nozzle_selection_text}>
@@ -242,7 +254,9 @@ export function ExtendedPartialTipField(
           {t('pipette_nozzles_and_wells')}
         </StyledText>
         <ListButton
-          type="noActive"
+          type={
+            shouldShowErrorForNozzleAndWellModalButton ? 'error' : 'noActive'
+          }
           onClick={handleOpen}
           testId="nozzle_and_well_modal"
         >


### PR DESCRIPTION
# Overview

This PR ensures clicking continue in a mix or transfer step form in which the user has not selected nozzles and wells in the modal correctly renders an error on the list button that produces the modal.

Closes RQA-5621

## Test Plan and Hands on Testing
[test_example.py](https://github.com/user-attachments/files/28959408/Bulk_proteomic.2.py)

- import or create a PD protocol with a pipettable labware
- create a transfer step
- populate the pipette, tiprack, and labware fields, but leave the "Pipette nozzles and wells" field empty
- click "continue" on the step form footer, and verify that the list button renders error state
- repeat with mix step

## Changelog

- check errors for field handled by `NozzleAndWellSelectionModal`

## Review requests

see test plan

## Risk assessment

low