### PR TITLE
chore(api-client): Fix merge conflict in `home()`

### DIFF
--- a/api-client/src/robot/home.ts
+++ b/api-client/src/robot/home.ts
@@ -8,5 +8,7 @@ export function home(
   config: HostConfig,
   data: HomeData
 ): ResponsePromise<HomeResponse> {
-  return request<HomeResponse, HomeData>(POST, '/robot/home', data, config)
+  return request<HomeResponse, HomeData>(POST, '/robot/home', config, {
+    body: data,
+  })
 }


### PR DESCRIPTION
## Overview

This fixes a merge conflict between #21701 (added `home()` to api-client) and #21720 (refactored the conventions within api-client).

## Test Plan and Hands on Testing

* [x] Homing the robot works again.
* [x] Typechecking passes again.

## Review requests

None.

## Risk assessment

Low.