### PR TITLE
chore(protocol-designer): update PD `REQUIRED_APP_VERSION`

### DIFF
--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -16,7 +16,7 @@ import { cssModuleSideEffect } from './cssModuleSideEffect'
 
 import type { UserConfig } from 'vite'
 
-const REQUIRED_APP_VERSION = '9.0.0' // PD requires this robot stack version or higher
+const REQUIRED_APP_VERSION = '10.0.0-beta' // PD requires this robot stack version or higher
 const { getVersion, generateBuildInfoHtml } = createGitVersionToolkit({
   project: 'protocol-designer',
 })


### PR DESCRIPTION
# Overview

Update `REQUIRED_APP_VERSION` const  to corretly get most recent labware definitions in PD build.

Closes EXEC-2745

## Test Plan and Hands on Testing

- launch PD dev server
- create a protocol with a vacuum module
- in starting deck state, click to add some labware to the module, and verify that new labware is shown (collars, spacers, filter plates)

## Changelog

- update `REQUIRED_APP_VERSION` in PD vite config

## Review requests

see test plan

## Risk assessment

low