### PR TITLE
fix(protocol-designer, step-generation): fix vacuum Python emission

### DIFF
--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -592,7 +592,7 @@ export interface HydratedVacuumFormData extends AnnotationFields {
   stepType: 'vacuum'
   id: string
   moduleId: string
-  endingHoldVentCheckbox: boolean
+  endingHoldVentCheckbox: boolean | null
   modeType: typeof VACUUM_MODE_PRESSURE | typeof VACUUM_MODE_POWER | null
   vacuumOrderedProfileIds: string[]
   percentPower: number | null

--- a/protocol-designer/src/steplist/formLevel/stepFormToArgs/vacuumFormToArgs.ts
+++ b/protocol-designer/src/steplist/formLevel/stepFormToArgs/vacuumFormToArgs.ts
@@ -133,7 +133,7 @@ const getPumpEndSettings = (args: {
     return null
   }
   const duration = getTimeSecondsFromString(pumpDurationTime)
-  return { duration, ventAfter: endingHoldVentCheckbox }
+  return { duration, ventAfter: endingHoldVentCheckbox ?? false }
 }
 
 export const vacuumFormToArgs = (
@@ -211,7 +211,7 @@ export const vacuumFormToArgs = (
       return {
         commandCreatorFnName: 'vacuumCloseVentStartProfile',
         profile: profileElements.map(vacuumProfileItemToPeProfileElement),
-        ventAfter: endingHoldVentCheckbox,
+        ventAfter: endingHoldVentCheckbox ?? false,
         ...baseValues,
       }
     }

--- a/shared-data/command/types/module.ts
+++ b/shared-data/command/types/module.ts
@@ -403,7 +403,7 @@ export interface VacuumProfileCycle {
 export type VacuumProfile = Array<VacuumProfileCycle | AtomicVacuumProfileStep>
 export interface VacuumRunProfileParams {
   moduleId: string
-  profile: VacuumProfile
+  steps: VacuumProfile
   taskId?: string
   ventAfter?: boolean
 }

--- a/step-generation/src/commandCreators/atomic/__tests__/vacuumSetPumpPower.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/vacuumSetPumpPower.test.ts
@@ -106,11 +106,12 @@ mock_vacuum_module.start_set_vacuum_power(
         },
       ],
       python: `
-mock_vacuum_module_task_1 = mock_vacuum_module.start_set_vacuum_power(
+mock_vacuum_module.start_set_vacuum_power(
     percent_power=40,
-    duration=120,
+    duration_s=120,
     vent_after=False
-)`.trim(),
+)
+mock_vacuum_module_task_1 = protocol.create_timer(seconds=120)`.trim(),
     })
   })
 

--- a/step-generation/src/commandCreators/atomic/__tests__/vacuumSetPumpPressure.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/vacuumSetPumpPressure.test.ts
@@ -119,11 +119,13 @@ mock_vacuum_module.start_set_vacuum_pressure(
         },
       ],
       python: `
-mock_vacuum_module_task_3 = mock_vacuum_module.start_set_vacuum_pressure(
+mock_vacuum_module.start_set_vacuum_pressure(
     gauge_pressure_mbar=100,
-    duration=45,
+    duration_s=45,
     vent_after=True
-)`.trim(),
+)
+mock_vacuum_module_task_3 = protocol.create_timer(seconds=45)
+`.trim(),
     })
   })
 

--- a/step-generation/src/commandCreators/atomic/__tests__/vacuumStartRunProfile.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/vacuumStartRunProfile.test.ts
@@ -80,7 +80,7 @@ describe('vacuumStartRunProfile', () => {
           key: expect.any(String),
           params: {
             moduleId: vacuumModuleId,
-            profile: [{ ...args.profile[0], ventAfter: true }],
+            steps: [{ ...args.profile[0], ventAfter: true }],
             taskId: 'mock_vacuum_module_task_1',
             ventAfter: true,
           },
@@ -88,9 +88,10 @@ describe('vacuumStartRunProfile', () => {
       ],
       python: `
 mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
-    profile=[
+    steps=[
         {
             "gauge_pressure_mbar": 55,
+            "enable_pump": True,
             "hold_time_seconds": 12,
             "vent_after": False,
         }
@@ -128,7 +129,7 @@ mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
           key: expect.any(String),
           params: {
             moduleId: vacuumModuleId,
-            profile: [{ ...args.profile[0], ventAfter: false }],
+            steps: [{ ...args.profile[0], ventAfter: false }],
             taskId: 'mock_vacuum_module_task_1',
             ventAfter: false,
           },
@@ -136,9 +137,10 @@ mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
       ],
       python: `
 mock_vacuum_module_task_1 = mock_vacuum_module.start_execute_profile(
-    profile=[
+    steps=[
         {
             "percent_power": 30,
+            "enable_pump": True,
             "hold_time_seconds": 5,
             "vent_after": False,
         }

--- a/step-generation/src/commandCreators/atomic/vacuumSetPumpPower.ts
+++ b/step-generation/src/commandCreators/atomic/vacuumSetPumpPower.ts
@@ -4,6 +4,7 @@ import {
   formatPyValue,
   getModuleHasLiveTask,
   indentPyLines,
+  PROTOCOL_CONTEXT_NAME,
   uuid,
 } from '../../utils'
 import { getVacuumPumpHoldArgsPython } from '../../utils/vacuumPythonArgs/getVacuumPumpHoldArgsPython'
@@ -46,14 +47,19 @@ export const vacuumSetPumpPower: CommandCreator<VacuumPumpPowerArgs> = (
       }
     : null
 
-  const taskPython = taskId == null ? '' : `${taskId} = `
-
   const percentPowerArg = `percent_power=${formatPyValue(percentPower)}`
   const holdArgsPython = isTimedHold
     ? getVacuumPumpHoldArgsPython(duration, ventAfter)
     : []
   const allArgsPython = [percentPowerArg, ...holdArgsPython]
-  const python = `${taskPython}${module.pythonName}.start_set_vacuum_power(\n${indentPyLines(allArgsPython.join(',\n'))}\n)`
+  const basePython = `${module.pythonName}.start_set_vacuum_power(\n${indentPyLines(allArgsPython.join(',\n'))}\n)`
+  const taskCreatorPython = isTimedHold
+    ? `${taskId} = ${PROTOCOL_CONTEXT_NAME}.create_timer(seconds=${formatPyValue(duration)})`
+    : null
+  const python = [
+    basePython,
+    ...(taskCreatorPython != null ? [taskCreatorPython] : []),
+  ].join('\n')
   return {
     commands: [
       {

--- a/step-generation/src/commandCreators/atomic/vacuumSetPumpPressure.ts
+++ b/step-generation/src/commandCreators/atomic/vacuumSetPumpPressure.ts
@@ -4,6 +4,7 @@ import {
   formatPyValue,
   getModuleHasLiveTask,
   indentPyLines,
+  PROTOCOL_CONTEXT_NAME,
   uuid,
 } from '../../utils'
 import { getVacuumPumpHoldArgsPython } from '../../utils/vacuumPythonArgs/getVacuumPumpHoldArgsPython'
@@ -46,14 +47,19 @@ export const vacuumSetPumpPressure: CommandCreator<VacuumPumpPressureArgs> = (
       }
     : null
 
-  const taskPython = taskId == null ? '' : `${taskId} = `
-
   const gaugePressureArg = `gauge_pressure_mbar=${formatPyValue(gaugePressure)}`
   const holdArgsPython = isTimedHold
     ? getVacuumPumpHoldArgsPython(duration, ventAfter)
     : []
   const allArgsPython = [gaugePressureArg, ...holdArgsPython]
-  const python = `${taskPython}${module.pythonName}.start_set_vacuum_pressure(\n${indentPyLines(allArgsPython.join(',\n'))}\n)`
+  const basePython = `${module.pythonName}.start_set_vacuum_pressure(\n${indentPyLines(allArgsPython.join(',\n'))}\n)`
+  const taskCreatorPython = isTimedHold
+    ? `${taskId} = ${PROTOCOL_CONTEXT_NAME}.create_timer(seconds=${formatPyValue(duration)})`
+    : null
+  const python = [
+    basePython,
+    ...(taskCreatorPython != null ? [taskCreatorPython] : []),
+  ].join('\n')
 
   return {
     commands: [

--- a/step-generation/src/commandCreators/atomic/vacuumStartRunProfile.ts
+++ b/step-generation/src/commandCreators/atomic/vacuumStartRunProfile.ts
@@ -41,7 +41,7 @@ export const vacuumStartRunProfile: CommandCreator<
 
   // explicitly attach the ventAfter param to the final step of the profile in accordance with PE command shape
   // there is no direct ventAfter param at the startRunProfile command params top level
-  const profileWithVentOnFinal: VacuumModuleStartRunProfileCreateCommand['params']['profile'] =
+  const profileWithVentOnFinal: VacuumModuleStartRunProfileCreateCommand['params']['steps'] =
     profile.map((step, index) => {
       if (index === profile.length - 1) {
         return { ...step, ventAfter }
@@ -58,7 +58,7 @@ export const vacuumStartRunProfile: CommandCreator<
         key: uuid(),
         params: {
           moduleId,
-          profile: profileWithVentOnFinal,
+          steps: profileWithVentOnFinal,
           ventAfter,
           taskId,
         },

--- a/step-generation/src/getNextRobotStateAndWarnings/__tests__/vacuumUpdates.test.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/__tests__/vacuumUpdates.test.ts
@@ -631,7 +631,7 @@ describe('forVacuumStopPump', () => {
   })
 })
 
-const sampleVacuumProfile: VacuumModuleStartRunProfileCreateCommand['params']['profile'] =
+const sampleVacuumProfile: VacuumModuleStartRunProfileCreateCommand['params']['steps'] =
   [
     {
       enablePump: true,
@@ -653,7 +653,7 @@ describe('forVacuumStartRunProfile', () => {
     const result = forVacuumStartRunProfile(
       {
         moduleId: vacuumModuleId,
-        profile: sampleVacuumProfile,
+        steps: sampleVacuumProfile,
         taskId: vacuumTaskId,
       },
       invariantContext,
@@ -683,7 +683,7 @@ describe('forVacuumStartRunProfile', () => {
       forVacuumStartRunProfile(
         {
           moduleId: missingModuleId,
-          profile: sampleVacuumProfile,
+          steps: sampleVacuumProfile,
           taskId: vacuumTaskId,
         },
         invariantContext,

--- a/step-generation/src/getNextRobotStateAndWarnings/vacuumUpdates.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/vacuumUpdates.ts
@@ -134,7 +134,7 @@ export const forVacuumStartRunProfile = (
   invariantContext: InvariantContext,
   robotStateAndWarnings: RobotStateAndWarnings
 ): void => {
-  const { moduleId, profile, taskId, ventAfter = true } = params
+  const { moduleId, steps, taskId, ventAfter = true } = params
   const { robotState } = robotStateAndWarnings
   const moduleState = vacuumModuleStateGetter(robotState, moduleId)
   // taskId should not be null, but this is to satisfy type checks
@@ -143,7 +143,7 @@ export const forVacuumStartRunProfile = (
   }
   moduleState.currentPumpActivity = {
     type: 'profile',
-    profileElements: profile,
+    profileElements: steps,
     taskId,
     ventAfter,
   }

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -145,7 +145,7 @@ export interface ProfileBlockActivity {
 
 export interface VacuumPumpProfileActivity {
   type: 'profile'
-  profileElements: VacuumRunProfileParams['profile']
+  profileElements: VacuumRunProfileParams['steps']
   taskId: string
   ventAfter: boolean
 }
@@ -892,14 +892,14 @@ export type VacuumPumpArgs =
 export interface VacuumStartRunProfileArgs extends CommonArgs {
   moduleId: string
   commandCreatorFnName: 'vacuumStartRunProfile'
-  profile: VacuumRunProfileParams['profile']
+  profile: VacuumRunProfileParams['steps']
   ventAfter: boolean
 }
 
 export interface VacuumCloseVentStartProfileArgs extends CommonArgs {
   moduleId: string
   commandCreatorFnName: 'vacuumCloseVentStartProfile'
-  profile: VacuumRunProfileParams['profile']
+  profile: VacuumRunProfileParams['steps']
   ventAfter: boolean
 }
 

--- a/step-generation/src/utils/vacuumPythonArgs/__tests__/getVacuumProfileStepString.test.ts
+++ b/step-generation/src/utils/vacuumPythonArgs/__tests__/getVacuumProfileStepString.test.ts
@@ -15,9 +15,10 @@ describe('getVacuumProfileStepString', () => {
       },
     ]
     expect(getVacuumProfileStepString(profile)).toEqual([
-      `profile=[
+      `steps=[
     {
         "gauge_pressure_mbar": 55,
+        "enable_pump": True,
         "hold_time_seconds": 12,
         "vent_after": False,
     }
@@ -31,9 +32,10 @@ describe('getVacuumProfileStepString', () => {
       { enablePump: true, holdSeconds: 5, percentPower: 30, ventAfter: false },
     ]
     expect(getVacuumProfileStepString(profile)).toEqual([
-      `profile=[
+      `steps=[
     {
         "percent_power": 30,
+        "enable_pump": True,
         "hold_time_seconds": 5,
         "vent_after": False,
     }
@@ -57,9 +59,10 @@ describe('getVacuumProfileStepString', () => {
       },
     ]
     expect(getVacuumProfileStepString(profile)).toEqual([
-      `profile=[
+      `steps=[
     {
         "gauge_pressure_mbar": 30,
+        "enable_pump": True,
         "hold_time_seconds": 5,
         "vent_after": False,
     }
@@ -84,14 +87,16 @@ describe('getVacuumProfileStepString', () => {
       },
     ]
     expect(getVacuumProfileStepString(profile)).toEqual([
-      `profile=[
+      `steps=[
     {
         "gauge_pressure_mbar": 10,
+        "enable_pump": True,
         "hold_time_seconds": 1,
         "vent_after": False,
     },
     {
         "gauge_pressure_mbar": 20,
+        "enable_pump": True,
         "hold_time_seconds": 2,
         "vent_after": False,
     }
@@ -121,19 +126,22 @@ describe('getVacuumProfileStepString', () => {
       },
     ]
     expect(getVacuumProfileStepString(profile)).toEqual([
-      `profile=[
+      `steps=[
     {
         "gauge_pressure_mbar": 100,
+        "enable_pump": True,
         "hold_time_seconds": 1,
         "vent_after": False,
     },
     {
         "percent_power": 30,
+        "enable_pump": True,
         "hold_time_seconds": 5,
         "vent_after": False,
     },
     {
         "percent_power": 30,
+        "enable_pump": True,
         "hold_time_seconds": 5,
         "vent_after": False,
     }
@@ -163,14 +171,16 @@ describe('getVacuumProfileStepString', () => {
       },
     ]
     expect(getVacuumProfileStepString(profile)).toEqual([
-      `profile=[
+      `steps=[
     {
         "gauge_pressure_mbar": 1,
+        "enable_pump": True,
         "hold_time_seconds": 1,
         "vent_after": False,
     },
     {
         "percent_power": 50,
+        "enable_pump": True,
         "hold_time_seconds": 2,
         "vent_after": True,
     }

--- a/step-generation/src/utils/vacuumPythonArgs/__tests__/getVacuumPumpHoldArgsPython.test.ts
+++ b/step-generation/src/utils/vacuumPythonArgs/__tests__/getVacuumPumpHoldArgsPython.test.ts
@@ -4,24 +4,24 @@ import { getVacuumPumpHoldArgsPython } from '../getVacuumPumpHoldArgsPython'
 
 describe('getVacuumPumpHoldArgsPython', () => {
   it('emits duration only when ventAfter is omitted', () => {
-    expect(getVacuumPumpHoldArgsPython(30)).toEqual(['duration=30'])
+    expect(getVacuumPumpHoldArgsPython(30)).toEqual(['duration_s=30'])
   })
 
   it('emits duration and vent_after when ventAfter is true', () => {
     expect(getVacuumPumpHoldArgsPython(10, true)).toEqual([
-      'duration=10',
+      'duration_s=10',
       'vent_after=True',
     ])
   })
 
   it('emits duration and vent_after when ventAfter is false', () => {
     expect(getVacuumPumpHoldArgsPython(10, false)).toEqual([
-      'duration=10',
+      'duration_s=10',
       'vent_after=False',
     ])
   })
 
   it('formats non-integer duration like Python numbers', () => {
-    expect(getVacuumPumpHoldArgsPython(1.5)).toEqual(['duration=1.5'])
+    expect(getVacuumPumpHoldArgsPython(1.5)).toEqual(['duration_s=1.5'])
   })
 })

--- a/step-generation/src/utils/vacuumPythonArgs/getVacuumProfileStepString.ts
+++ b/step-generation/src/utils/vacuumPythonArgs/getVacuumProfileStepString.ts
@@ -33,6 +33,7 @@ const _getVacuumProfileAtomicStepString = (
 ): string => {
   const { holdSeconds, ventAfter } = step
   const baseDict = {
+    enable_pump: true,
     hold_time_seconds: holdSeconds,
     ...(ventAfter != null ? { vent_after: ventAfter } : {}),
   }
@@ -48,7 +49,6 @@ const _getVacuumProfileAtomicStepString = (
   return formatPyDict({
     percent_power: Number(percentPower),
     ...baseDict,
-    vent_after: ventAfter,
   })
 }
 
@@ -59,7 +59,7 @@ export const getVacuumProfileStepString = (
   let repetitionsArg: string
   if (profile.length === 1 && 'repetitions' in profile[0]) {
     const { steps, repetitions } = profile[0]
-    profileArg = `profile=[\n${indentPyLines(
+    profileArg = `steps=[\n${indentPyLines(
       steps
         .map((step, i) => {
           if (i === steps.length - 1) {
@@ -73,7 +73,7 @@ export const getVacuumProfileStepString = (
     return [profileArg, repetitionsArg]
   }
   const atomicProfileSteps = _getAtomicVacuumProfileSteps(profile)
-  profileArg = `profile=[\n${indentPyLines(
+  profileArg = `steps=[\n${indentPyLines(
     atomicProfileSteps
       .map((step, i) => {
         if (i === atomicProfileSteps.length - 1) {

--- a/step-generation/src/utils/vacuumPythonArgs/getVacuumPumpHoldArgsPython.ts
+++ b/step-generation/src/utils/vacuumPythonArgs/getVacuumPumpHoldArgsPython.ts
@@ -5,7 +5,7 @@ export const getVacuumPumpHoldArgsPython = (
   ventAfter?: boolean
 ): string[] => {
   return [
-    `duration=${formatPyValue(duration)}`,
+    `duration_s=${formatPyValue(duration)}`,
     ...(typeof ventAfter === 'boolean'
       ? [`vent_after=${formatPyValue(ventAfter)}`]
       : []),


### PR DESCRIPTION
# Overview

Fixes Python emission for vacuum profile commands. Namely, updates `profile` arg to correct `steps` arg and adds explicit `"enable_pump"` entry to all profile steps. Also, fixes a typing bug to convert `null` vent after values to `false`

## Test Plan and Hands on Testing

- create or import a vacuum protocol with a profile step and a timed pressure/power step
- export and inspect the emitted Python
- verify that 1) profile main argument is `steps`, not `profile`; 2) profile steps each contain an explicit `"enable_pump: True"` entry; 3) timed holds for pressure/power emit a separate timer task that is resolved, since `start_set_vacuum_power/pressure` does not return an awaitable task
- verify that the protocol passes analysis

## Changelog

- update shared types for params for vacuum profile commands (`profile` -> `steps`)
- update emitted Python from profile and hold vacuum command creators
- update all tests

## Review requests

see test plan

## Risk assessment

⬇️ fixes bugs for vacuum python emission