### PR TITLE
fix(odd): add support for backing out of a 'Documentation Required' modal

### DIFF
--- a/app/src/local-resources/access-control/DocumentationRequiredModalContext.tsx
+++ b/app/src/local-resources/access-control/DocumentationRequiredModalContext.tsx
@@ -8,7 +8,8 @@ import type {
 export interface DocumentationRequiredModalContextType {
   showDocumentationRequiredModal: (
     username: string,
-    actionsToDocument: DocumentedAction[]
+    actionsToDocument: DocumentedAction[],
+    onCancel?: () => void
   ) => Promise<DocumentationReport>
 }
 
@@ -19,7 +20,8 @@ export const DocumentationRequiredModalContext =
   createContext<DocumentationRequiredModalContextType>({
     showDocumentationRequiredModal: (
       username: string,
-      actionsToDocument: DocumentedAction[]
+      actionsToDocument: DocumentedAction[],
+      onCancel?: () => void
     ) => {
       return Promise.resolve('' as DocumentationReport)
     },

--- a/app/src/local-resources/access-control/useGuardedAction.ts
+++ b/app/src/local-resources/access-control/useGuardedAction.ts
@@ -28,6 +28,7 @@ import type {
  *
  *  This documentation state is designed to be passed along to the useDocumentedMutation hook.
  *
+ * @param docreport - optional pre-provided documentation report
  */
 export function useGuardedAction(
   docreport?: DocumentationReport
@@ -58,15 +59,18 @@ export function useGuardedAction(
   )
 
   const showDocumentationModal = useCallback(
-    async (actionsToDocument: DocumentedAction[], onCancel?: () => void) => {
+    async (
+      actionsToDocument: DocumentedAction[],
+      handleCancel?: () => void
+    ) => {
       const docResult = await requireDocumentation(
         currentUsername ?? '',
         actionsToDocument,
-        onCancel
+        handleCancel
       )
       return docResult
     },
-    [currentUsername, requireDocumentation]
+    [requireDocumentation, currentUsername]
   )
 
   const docState: DocumentationState = useMemo(() => {

--- a/app/src/local-resources/access-control/useGuardedAction.ts
+++ b/app/src/local-resources/access-control/useGuardedAction.ts
@@ -58,10 +58,11 @@ export function useGuardedAction(
   )
 
   const showDocumentationModal = useCallback(
-    async (actionsToDocument: DocumentedAction[]) => {
+    async (actionsToDocument: DocumentedAction[], onCancel?: () => void) => {
       const docResult = await requireDocumentation(
         currentUsername ?? '',
-        actionsToDocument
+        actionsToDocument,
+        onCancel
       )
       return docResult
     },

--- a/app/src/local-resources/access-control/useMaintenanceRunDocumentation.ts
+++ b/app/src/local-resources/access-control/useMaintenanceRunDocumentation.ts
@@ -14,6 +14,7 @@ import type {
  * Generates docstate to prompt for documentation when deleting the maintenance run.
  *
  * @param maintenanceRunName: The name of the maintenance run, to be displayed in the initial documentation modal.
+ * @param onCancelStart: Optional callback when the user backs out of the initial documentation modal.
  * @param initialDocstate: An optional documentation state - to be used in flows like attaching where prompting needs to occur before the first mutation.
  *
  * @returns commandDocState: DocumentationState to be passed to the creation hook and the maintenance run commands.
@@ -23,7 +24,7 @@ import type {
  */
 export const useMaintenanceRunDocumentation = (
   maintenanceRunName: DocumentedAction,
-  onCancel?: () => void,
+  onCancelStart?: () => void,
   initialDocstate?: DocumentationState
 ): {
   commandDocState: DocumentationState
@@ -37,7 +38,7 @@ export const useMaintenanceRunDocumentation = (
   >([maintenanceRunName])
   const commandDocState = usePromptForInteractionReason(
     [maintenanceRunName],
-    onCancel,
+    onCancelStart,
     initialDocstate
   )
   const deletionDocState = useGuardedAction()

--- a/app/src/local-resources/access-control/useMaintenanceRunDocumentation.ts
+++ b/app/src/local-resources/access-control/useMaintenanceRunDocumentation.ts
@@ -23,6 +23,7 @@ import type {
  */
 export const useMaintenanceRunDocumentation = (
   maintenanceRunName: DocumentedAction,
+  onCancel?: () => void,
   initialDocstate?: DocumentationState
 ): {
   commandDocState: DocumentationState
@@ -36,6 +37,7 @@ export const useMaintenanceRunDocumentation = (
   >([maintenanceRunName])
   const commandDocState = usePromptForInteractionReason(
     [maintenanceRunName],
+    onCancel,
     initialDocstate
   )
   const deletionDocState = useGuardedAction()

--- a/app/src/local-resources/access-control/usePromptForInteractionReason.ts
+++ b/app/src/local-resources/access-control/usePromptForInteractionReason.ts
@@ -21,6 +21,7 @@ import type {
  */
 export const usePromptForInteractionReason = (
   actionsToDocument: DocumentedAction[],
+  onCancel?: () => void,
   initialDocstate?: DocumentationState
 ): DocumentationState => {
   const [docReport, setDocReport] = useState<DocumentationReport>()
@@ -37,7 +38,7 @@ export const usePromptForInteractionReason = (
         if (docState.docreport == null && !promptInFlight.current) {
           promptInFlight.current = true
           await docState
-            .askForDocumentation(actionsToDocument)
+            .askForDocumentation(actionsToDocument, onCancel)
             .then(setDocReport)
             .finally(() => {
               promptInFlight.current = false
@@ -48,7 +49,7 @@ export const usePromptForInteractionReason = (
     if (!docState.isLoading) {
       void promptForDocumentation()
     }
-  }, [actionsToDocument, docReport, docState])
+  }, [actionsToDocument, docReport, docState, onCancel])
 
   return docState
 }

--- a/app/src/local-resources/instruments/hooks/useHomePipettes.ts
+++ b/app/src/local-resources/instruments/hooks/useHomePipettes.ts
@@ -13,7 +13,7 @@ export interface UseHomePipettesResult {
 
 export type UseHomePipettesProps = Pick<
   UseRobotControlCommandsProps,
-  'pipetteInfo' | 'onSettled'
+  'pipetteInfo' | 'onSuccess'
 >
 
 // Home pipettes except for plungers.

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ProtocolDropTipModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ProtocolDropTipModal.tsx
@@ -54,7 +54,7 @@ export function useProtocolDropTipModal({
 
   const { homePipettes, isHoming } = useHomePipettes({
     pipetteInfo,
-    onSettled: () => {
+    onSuccess: () => {
       onSkipAndHome()
     },
   })

--- a/app/src/organisms/DropTipWizardFlows/TipsAttachedModal.tsx
+++ b/app/src/organisms/DropTipWizardFlows/TipsAttachedModal.tsx
@@ -23,7 +23,7 @@ import type { OddModalHeaderBaseProps } from '/app/molecules/OddModal/types'
 import type { PipetteWithTip } from '/app/resources/instruments'
 import type { PipetteDetails } from '/app/resources/maintenance_runs'
 
-type TipsAttachedModalProps = Pick<UseHomePipettesProps, 'onSettled'> & {
+type TipsAttachedModalProps = Pick<UseHomePipettesProps, 'onSuccess'> & {
   aPipetteWithTip: PipetteWithTip
   host: HostConfig | null
   setTipStatusResolved: (onEmpty?: () => void) => Promise<void>
@@ -51,7 +51,7 @@ const TipsAttachedModal = NiceModal.create(
     const { homePipettes, isHoming } = useHomePipettes({
       ...homePipetteProps,
       pipetteInfo: buildPipetteDetails(aPipetteWithTip),
-      onSettled: () => {
+      onSuccess: () => {
         modal.remove()
         void setTipStatusResolved()
       },

--- a/app/src/organisms/DropTipWizardFlows/__tests__/TipsAttachedModal.test.tsx
+++ b/app/src/organisms/DropTipWizardFlows/__tests__/TipsAttachedModal.test.tsx
@@ -54,7 +54,7 @@ const render = (aPipetteWithTip: PipetteWithTip) => {
             host: MOCK_HOST,
             aPipetteWithTip,
             setTipStatusResolved: mockSetTipStatusResolved,
-            onSettled: vi.fn(),
+            onSuccess: vi.fn(),
           })
         }
         data-testid="testButton"

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCommands.ts
@@ -86,7 +86,13 @@ export function useDropTipCommands({
 
   const { deleteMaintenanceRun } = useDeleteMaintenanceRunMutation(
     deletionDocState,
-    [...actionsToDocument, 'end_drop_tips']
+    [...actionsToDocument, 'end_drop_tips'],
+    {
+      onError: () => {
+        setHasSeenClose(false)
+        toggleIsExiting()
+      },
+    }
   )
   const deckConfig = useNotifyDeckConfigurationQuery().data ?? []
 
@@ -111,7 +117,7 @@ export function useDropTipCommands({
               })
               .finally(() => {
                 deleteMaintenanceRun(activeMaintenanceRunId, {
-                  onSettled: () => {
+                  onSuccess: () => {
                     closeFlow()
                   },
                 })

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipWithType.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipWithType.ts
@@ -34,7 +34,7 @@ export interface UseDropTipWithTypeResult {
 export function useDropTipWithType(
   params: UseDTWithTypeParams
 ): UseDropTipWithTypeResult {
-  const { issuedCommandsType, fixitCommandTypeUtils } = params
+  const { issuedCommandsType, fixitCommandTypeUtils, closeFlow } = params
 
   const { isExiting, toggleIsExiting } = useIsExitingDT(issuedCommandsType)
   const { errorDetails, setErrorDetails } = useErrorDetails()
@@ -43,7 +43,7 @@ export function useDropTipWithType(
     deletionDocState,
     actionsToDocument,
     addActionToDocument,
-  } = useMaintenanceRunDocumentation('drop_tips')
+  } = useMaintenanceRunDocumentation('drop_tips', closeFlow)
   const activeMaintenanceRunId = useDropTipMaintenanceRun({
     ...params,
     setErrorDetails,

--- a/app/src/organisms/EmergencyStop/EstopPressedModal.tsx
+++ b/app/src/organisms/EmergencyStop/EstopPressedModal.tsx
@@ -87,7 +87,7 @@ function TouchscreenModal({
 
   const { handlePlaceReaderLid, isValidPlateReaderMove } =
     usePlacePlateReaderLid({
-      onSettled: closeModal,
+      onSuccess: closeModal,
     })
   const modalHeader: OddModalHeaderBaseProps = {
     title: t('estop_pressed'),
@@ -165,7 +165,7 @@ function DesktopModal({
   const { acknowledgeEstopDisengage } = useAcknowledgeEstopDisengageMutation()
   const { handlePlaceReaderLid, isValidPlateReaderMove } =
     usePlacePlateReaderLid({
-      onSettled: closeModal,
+      onSuccess: closeModal,
     })
 
   const modalProps: ModalProps = {

--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -147,8 +147,9 @@ export function GripperWizardFlows(
     }
     if (maintenanceRunData != null) {
       deleteMaintenanceRun(maintenanceRunData?.data.id)
+    } else {
+      closeFlow()
     }
-    closeFlow()
   }
 
   const { deleteMaintenanceRun, isLoading: isDeleteLoading } =
@@ -160,7 +161,7 @@ export function GripperWizardFlows(
           closeFlow()
         },
         onError: () => {
-          closeFlow()
+          setIsExiting(false)
         },
       }
     )

--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -73,7 +73,7 @@ export function GripperWizardFlows(
     deletionDocState,
     actionsToDocument,
     addActionToDocument,
-  } = useMaintenanceRunDocumentation(flowName)
+  } = useMaintenanceRunDocumentation(flowName, closeFlow)
   const {
     chainRunCommands,
     isCommandMutationLoading: isChainCommandMutationLoading,

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
@@ -82,13 +82,22 @@ export function useLPCFlows({
   // once unblocked, the useEffect will launch LPC and resolve the constructed promise with the results
   const pendingLaunchRef = useRef<PendingLaunch | null>(null)
 
+  const handleDocumentationCancel = useCallback((): void => {
+    if (pendingLaunchRef.current != null) {
+      const { reject } = pendingLaunchRef.current
+      pendingLaunchRef.current = null
+      reject(new Error('Documentation cancelled'))
+    }
+    setIsLaunching(false)
+  }, [])
+
   const {
     commandDocState,
     deletionDocState,
     actionsToDocument,
     addActionToDocument,
     isLoading: isDocumentationLoading,
-  } = useMaintenanceRunDocumentation('lpc_flow')
+  } = useMaintenanceRunDocumentation('lpc_flow', handleDocumentationCancel)
 
   const isFlex = robotType === FLEX_ROBOT_TYPE
   const deckConfig = useNotifyDeckConfigurationQuery().data

--- a/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
+++ b/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
@@ -147,9 +147,10 @@ export function useModuleSetupWizard(
     {
       onSuccess: () => {
         setMaintenanceRunId(null)
+        handleClose()
       },
       onError: () => {
-        setMaintenanceRunId(null)
+        setIsExiting(false)
       },
     }
   )
@@ -176,7 +177,6 @@ export function useModuleSetupWizard(
             'closing module setup wizard: homed, clearing maintenance run'
           )
           deleteMaintenanceRun(maintenanceRunId)
-          handleClose()
         })
         .catch(error => {
           console.error(error.message)

--- a/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
+++ b/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
@@ -98,7 +98,7 @@ export function useModuleSetupWizard(
     deletionDocState,
     actionsToDocument,
     addActionToDocument,
-  } = useMaintenanceRunDocumentation('add_module')
+  } = useMaintenanceRunDocumentation('add_module', closeFlow)
 
   const { chainRunCommands, isCommandMutationLoading } =
     useChainMaintenanceCommands(

--- a/app/src/organisms/ODD/DocumentationRequired/DocumentationRequiredModal.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/DocumentationRequiredModal.tsx
@@ -12,9 +12,11 @@ const DocumentationRequiredModalImpl = NiceModal.create(
   ({
     username,
     actionsToDocument,
+    onCancel,
   }: {
     username: string
     actionsToDocument: DocumentedAction[]
+    onCancel?: () => void
   }): JSX.Element => {
     const modal = useModal()
 
@@ -25,6 +27,7 @@ const DocumentationRequiredModalImpl = NiceModal.create(
     }
 
     const handleBack = (): void => {
+      onCancel?.()
       modal.resolve('' as DocumentationReport)
       modal.remove()
     }
@@ -44,9 +47,11 @@ const DocumentationRequiredModalImpl = NiceModal.create(
 
 export const showDocumentationRequiredModal = (
   username: string,
-  actionsToDocument: DocumentedAction[]
+  actionsToDocument: DocumentedAction[],
+  onCancel?: () => void
 ): Promise<DocumentationReport> =>
   NiceModal.show(DocumentationRequiredModalImpl, {
     username,
     actionsToDocument,
+    onCancel,
   })

--- a/app/src/organisms/ODD/DocumentationRequired/__tests__/requireDocumentation.test.ts
+++ b/app/src/organisms/ODD/DocumentationRequired/__tests__/requireDocumentation.test.ts
@@ -22,6 +22,10 @@ describe('requireDocumentation', () => {
     const result = await requireDocumentation('alice', [])
 
     expect(result).toEqual('starting calibration' as DocumentationReport)
-    expect(showDocumentationRequiredModal).toHaveBeenCalledWith('alice', [])
+    expect(showDocumentationRequiredModal).toHaveBeenCalledWith(
+      'alice',
+      [],
+      undefined
+    )
   })
 })

--- a/app/src/organisms/ODD/DocumentationRequired/requireDocumentation.ts
+++ b/app/src/organisms/ODD/DocumentationRequired/requireDocumentation.ts
@@ -16,11 +16,13 @@ import type {
  */
 export async function requireDocumentation(
   username: string,
-  actionsToDocument: DocumentedAction[]
+  actionsToDocument: DocumentedAction[],
+  onCancel?: () => void
 ): Promise<DocumentationReport> {
   const modalResult = await showDocumentationRequiredModal(
     username,
-    actionsToDocument
+    actionsToDocument,
+    onCancel
   )
 
   return modalResult

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/__tests__/ConfirmCancelRunModal.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/__tests__/ConfirmCancelRunModal.test.tsx
@@ -150,7 +150,7 @@ describe('ConfirmCancelRunModal', () => {
 
   it('when tapping cancel run with error, should remain in canceling state', () => {
     mockStopRun.mockImplementation((_id: string, options: any) => {
-      options.onSettled()
+      options.onError()
     })
 
     render(props)
@@ -168,7 +168,6 @@ describe('ConfirmCancelRunModal', () => {
 
     mockStopRun.mockImplementation((_id: string, options: any) => {
       options.onSuccess()
-      options.onSettled()
     })
 
     render(props)
@@ -191,7 +190,6 @@ describe('ConfirmCancelRunModal', () => {
 
     mockStopRun.mockImplementation((_id: string, options: any) => {
       options.onSuccess()
-      options.onSettled()
     })
 
     render(props)
@@ -206,7 +204,6 @@ describe('ConfirmCancelRunModal', () => {
   it('when run is active, stop run does not dismiss or navigate', () => {
     mockStopRun.mockImplementation((_id: string, options: any) => {
       options.onSuccess()
-      options.onSettled()
     })
 
     render(props)
@@ -225,7 +222,7 @@ describe('ConfirmCancelRunModal', () => {
     }
 
     mockStopRun.mockImplementation((_id: string, options: any) => {
-      options.onSettled()
+      options.onError()
     })
 
     render(props)

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
@@ -72,9 +72,10 @@ export function ConfirmCancelRunModal({
     stopRun(runId, {
       onSuccess: () => {
         trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_ACTION.CANCEL })
-      },
-      onSettled: () => {
         dismissAndNavigate()
+      },
+      onError: () => {
+        setIsCanceling(false)
       },
     })
   }

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from 'react-router-dom'
 import { RUN_STATUS_STOPPED } from '@opentrons/api-client'
 import { COLORS, LegacyStyledText } from '@opentrons/components'
 import {
+  isDocumentedMutationError,
   useDismissCurrentRunMutation,
   useStopRunMutation,
 } from '@opentrons/react-api-client'
@@ -73,9 +74,14 @@ export function ConfirmCancelRunModal({
     stopRun(runId, {
       onSuccess: () => {
         trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_ACTION.CANCEL })
-      },
-      onSettled: () => {
         dismissAndNavigate()
+      },
+      onError: (error: unknown) => {
+        if (isDocumentedMutationError(error)) {
+          setIsCanceling(false)
+        } else {
+          dismissAndNavigate()
+        }
       },
     })
   }

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
@@ -68,7 +68,6 @@ export function ConfirmCancelRunModal({
     }
   }, [isActiveRun, dismissCurrentRun, runId, protocolId, navigate])
 
-  // TODO(jj): add error handling for docreport error
   const handleCancelRun = (): void => {
     setIsCanceling(true)
     stopRun(runId, {

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
@@ -67,15 +67,15 @@ export function ConfirmCancelRunModal({
     }
   }, [isActiveRun, dismissCurrentRun, runId, protocolId, navigate])
 
+  // TODO(jj): add error handling for docreport error
   const handleCancelRun = (): void => {
     setIsCanceling(true)
     stopRun(runId, {
       onSuccess: () => {
         trackProtocolRunEvent({ name: ANALYTICS_PROTOCOL_RUN_ACTION.CANCEL })
-        dismissAndNavigate()
       },
-      onError: () => {
-        setIsCanceling(false)
+      onSettled: () => {
+        dismissAndNavigate()
       },
     })
   }

--- a/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
@@ -130,7 +130,7 @@ export const ChoosePipette = (props: ChoosePipetteProps): JSX.Element => {
 
   const initialAction =
     mount === LEFT ? 'attach_pipette_left' : 'attach_pipette_right'
-  const initialDocstate = usePromptForInteractionReason([initialAction])
+  const initialDocstate = usePromptForInteractionReason([initialAction], exit)
   const isWaitingForDocumentation = !isDocumentationProvided(initialDocstate)
 
   const bothMounts = getIsGantryEmpty(attachedPipettesByMount)

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -214,7 +214,11 @@ export const PipetteWizardFlows = (
     deletionDocState,
     actionsToDocument,
     addActionToDocument,
-  } = useMaintenanceRunDocumentation(maintenanceRunAction, initialDocstate)
+  } = useMaintenanceRunDocumentation(
+    maintenanceRunAction,
+    closeFlow,
+    initialDocstate
+  )
 
   const { chainRunCommands, isCommandMutationLoading } =
     useChainMaintenanceCommands(

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -298,6 +298,7 @@ export const PipetteWizardFlows = (
     )
 
   const handleCleanUpAndClose = (): void => {
+    setIsExiting(true)
     if (maintenanceRunData?.data.id == null) handleClose()
     else {
       chainRunCommands(

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -279,9 +279,7 @@ export const PipetteWizardFlows = (
       onComplete()
     }
     if (maintenanceRunData != null) {
-      deleteMaintenanceRun(maintenanceRunData?.data.id, {
-        onSettled: closeFlow,
-      })
+      deleteMaintenanceRun(maintenanceRunData?.data.id)
     } else {
       closeFlow()
     }
@@ -292,11 +290,9 @@ export const PipetteWizardFlows = (
       deletionDocState,
       [...actionsToDocument, deleteRunAction],
       {
-        onSuccess: () => {
-          closeFlow()
-        },
+        onSuccess: closeFlow,
         onError: () => {
-          closeFlow()
+          setIsExiting(false)
         },
       }
     )

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -275,12 +275,10 @@ export const PipetteWizardFlows = (
     }
   }
   const handleClose = (): void => {
-    if (onComplete != null) {
-      onComplete()
-    }
     if (maintenanceRunData != null) {
       deleteMaintenanceRun(maintenanceRunData?.data.id)
     } else {
+      onComplete?.()
       closeFlow()
     }
   }
@@ -290,7 +288,10 @@ export const PipetteWizardFlows = (
       deletionDocState,
       [...actionsToDocument, deleteRunAction],
       {
-        onSuccess: closeFlow,
+        onSuccess: () => {
+          onComplete?.()
+          closeFlow()
+        },
         onError: () => {
           setIsExiting(false)
         },

--- a/app/src/organisms/TakeoverModal/MaintenanceRunTakeover.tsx
+++ b/app/src/organisms/TakeoverModal/MaintenanceRunTakeover.tsx
@@ -48,7 +48,12 @@ export function MaintenanceRunTakeoverModal(
 
   const { deleteMaintenanceRun, reset } = useDeleteMaintenanceRunMutation(
     docState,
-    ['end_calibration']
+    ['end_calibration'],
+    {
+      onError: () => {
+        setIsLoading(false)
+      },
+    }
   )
 
   const handleCloseAndTerminate = (): void => {

--- a/app/src/pages/ODD/RunSummary/index.tsx
+++ b/app/src/pages/ODD/RunSummary/index.tsx
@@ -291,7 +291,7 @@ export function RunSummary(): JSX.Element {
         setTipStatusResolved: setTipStatusResolvedAndRoute(handleReturnToDash),
         host,
         aPipetteWithTip,
-        onSettled: () => {
+        onSuccess: () => {
           closeCurrentRunIfValid(() => {
             navigate('/dashboard')
           })
@@ -310,7 +310,7 @@ export function RunSummary(): JSX.Element {
         setTipStatusResolved: setTipStatusResolvedAndRoute(handleRunAgain),
         host,
         aPipetteWithTip,
-        onSettled: () => {
+        onSuccess: () => {
           runAgain()
         },
       })

--- a/app/src/resources/maintenance_runs/hooks/useRobotControlCommands.ts
+++ b/app/src/resources/maintenance_runs/hooks/useRobotControlCommands.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useDeleteMaintenanceRunMutation } from '@opentrons/react-api-client'
 
@@ -55,13 +55,25 @@ export function useRobotControlCommands({
   const [isExecuting, setIsExecuting] = useState(false)
   const pendingExecutionRef = useRef<PendingExecution | null>(null)
 
+  const handleDocumentationCancel = useCallback((): void => {
+    if (pendingExecutionRef.current != null) {
+      const { reject } = pendingExecutionRef.current
+      pendingExecutionRef.current = null
+      reject(new Error('Documentation cancelled'))
+    }
+    setIsExecuting(false)
+  }, [])
+
   const {
     commandDocState,
     deletionDocState,
     actionsToDocument,
     addActionToDocument,
     isLoading: isDocumentationLoading,
-  } = useMaintenanceRunDocumentation(runStartedAction)
+  } = useMaintenanceRunDocumentation(
+    runStartedAction,
+    handleDocumentationCancel
+  )
 
   const { chainRunCommands } = useChainMaintenanceCommands(
     commandDocState,

--- a/app/src/resources/maintenance_runs/hooks/useRobotControlCommands.ts
+++ b/app/src/resources/maintenance_runs/hooks/useRobotControlCommands.ts
@@ -36,8 +36,8 @@ export interface UseRobotControlCommandsProps {
   pipetteInfo: PipetteDetails | null
   commands: CreateCommand[]
   continuePastCommandFailure: boolean
-  /* An onSettled callback executed after the deletion of the maintenance run. */
-  onSettled?: () => void
+  /* An onSuccess callback executed after the deletion of the maintenance run. */
+  onSuccess?: () => void
   runStartedAction: DocumentedAction
   runEndedAction: DocumentedAction
 }
@@ -48,7 +48,7 @@ export function useRobotControlCommands({
   pipetteInfo,
   commands,
   continuePastCommandFailure,
-  onSettled,
+  onSuccess,
   runStartedAction,
   runEndedAction,
 }: UseRobotControlCommandsProps): UseRobotControlCommandsResult {
@@ -114,17 +114,13 @@ export function useRobotControlCommands({
               console.error(error.message)
             })
             .finally(() =>
-              deleteMaintenanceRun(runId).catch((error: Error) => {
-                console.error(
-                  'Failed to delete maintenance run:',
-                  error.message
-                )
+              deleteMaintenanceRun(runId, {
+                onSuccess: () => {
+                  onSuccess?.()
+                  setIsExecuting(false)
+                },
               })
             )
-            .finally(() => {
-              onSettled?.()
-              setIsExecuting(false)
-            })
         },
         onError: (error: Error) => {
           console.error(error.message)

--- a/app/src/resources/modules/hooks/usePlacePlateReaderLid.ts
+++ b/app/src/resources/modules/hooks/usePlacePlateReaderLid.ts
@@ -19,7 +19,7 @@ interface UsePlacePlateReaderLidResult {
 
 type UsePlacePlateReaderLidProps = Pick<
   UseRobotControlCommandsProps,
-  'onSettled'
+  'onSuccess'
 >
 
 export function usePlacePlateReaderLid(

--- a/react-api-client/src/access_control/__tests__/useDocumentedMutation.test.tsx
+++ b/react-api-client/src/access_control/__tests__/useDocumentedMutation.test.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { DocumentedMutationError } from '../types'
 import { useDocumentedMutation } from '../useDocumentedMutation'
 
 import type { AxiosError } from 'axios'
@@ -137,5 +138,69 @@ describe('useDocumentedMutation', () => {
       expect(result.current.data).toBe('run-ok')
     })
     expect(mutationFn).toHaveBeenCalledWith('run')
+  })
+
+  it('throws DocumentedMutationError when access control queries are still loading', async () => {
+    const mutationFn = vi.fn(async (n: number) => n + 1)
+
+    const { result } = renderHook(
+      () =>
+        useDocumentedMutation<number, DocumentedMutationError, number>(
+          { isLoading: true },
+          ['play_run'],
+          testMutationKey,
+          ({ variables: n }) => mutationFn(n),
+          {}
+        ),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.mutate(5)
+    })
+
+    await waitFor(() => {
+      expect(result.current.error).toBeInstanceOf(DocumentedMutationError)
+    })
+    expect(result.current.error).toMatchObject({
+      type: 'access_control_loading',
+    })
+    expect(mutationFn).not.toHaveBeenCalled()
+  })
+
+  it('throws DocumentedMutationError when documentation is required but not provided', async () => {
+    const askForDocumentation = vi
+      .fn()
+      .mockResolvedValue('' as DocumentationReport)
+    const mutationFn = vi.fn(async (n: number) => n + 1)
+
+    const { result } = renderHook(
+      () =>
+        useDocumentedMutation<number, DocumentedMutationError, number>(
+          {
+            reasonForInteractionRequired: true,
+            docreport: null,
+            askForDocumentation,
+            isLoading: false,
+          },
+          ['play_run'],
+          testMutationKey,
+          ({ variables: n }) => mutationFn(n),
+          {}
+        ),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.mutate(5)
+    })
+
+    await waitFor(() => {
+      expect(result.current.error).toBeInstanceOf(DocumentedMutationError)
+    })
+    expect(result.current.error).toMatchObject({
+      type: 'no_documentation_report',
+    })
+    expect(mutationFn).not.toHaveBeenCalled()
   })
 })

--- a/react-api-client/src/access_control/index.ts
+++ b/react-api-client/src/access_control/index.ts
@@ -2,5 +2,7 @@ export type {
   DocumentationReport,
   DocumentationState,
   DocumentedAction,
+  DocumentedMutationErrorType,
 } from './types'
+export { DocumentedMutationError, isDocumentedMutationError } from './types'
 export { useDocumentedMutation } from './useDocumentedMutation'

--- a/react-api-client/src/access_control/types.ts
+++ b/react-api-client/src/access_control/types.ts
@@ -29,7 +29,8 @@ export type DocumentationState =
       reasonForInteractionRequired: true
       docreport: null
       askForDocumentation: (
-        actionsToDocument: DocumentedAction[]
+        actionsToDocument: DocumentedAction[],
+        onCancel?: () => void
       ) => Promise<DocumentationReport>
       isLoading: false
     }

--- a/react-api-client/src/access_control/types.ts
+++ b/react-api-client/src/access_control/types.ts
@@ -10,6 +10,35 @@ export type DocumentationReport = string & {
   readonly _brand: 'DocumentationReport'
 }
 
+export type DocumentedMutationErrorType =
+  | 'no_documentation_report'
+  | 'access_control_loading'
+
+const DOCUMENTED_MUTATION_ERROR_MESSAGES: Record<
+  DocumentedMutationErrorType,
+  string
+> = {
+  no_documentation_report: 'No documentation report provided',
+  access_control_loading: 'Access control queries are still loading',
+}
+
+export class DocumentedMutationError extends Error {
+  declare readonly name: 'DocumentedMutationError'
+  declare readonly type: DocumentedMutationErrorType
+
+  constructor(type: DocumentedMutationErrorType) {
+    super(DOCUMENTED_MUTATION_ERROR_MESSAGES[type])
+    this.name = 'DocumentedMutationError'
+    this.type = type
+  }
+}
+
+export function isDocumentedMutationError(
+  error: unknown
+): error is DocumentedMutationError {
+  return error instanceof DocumentedMutationError
+}
+
 /**
  * Documentation state to be passed to the useDocumentedMutation hook.
  *

--- a/react-api-client/src/access_control/useDocumentedMutation.ts
+++ b/react-api-client/src/access_control/useDocumentedMutation.ts
@@ -1,6 +1,8 @@
 import { useCallback } from 'react'
 import { useMutation } from 'react-query'
 
+import { DocumentedMutationError } from './types'
+
 import type {
   MutationFunction,
   MutationKey,
@@ -83,11 +85,11 @@ function useWrappedMutationFn<TData, TVariables>(
         documentationState,
         actionsToDocument
       )
-      if (!isDocumentationProvided(documentationState, docreport)) {
-        throw new Error('No documentation report provided')
-      }
       if (documentationState.isLoading) {
-        throw new Error('Access control queries are still loading')
+        throw new DocumentedMutationError('access_control_loading')
+      }
+      if (!isDocumentationProvided(documentationState, docreport)) {
+        throw new DocumentedMutationError('no_documentation_report')
       }
       return await mutationFn({ variables, userNotes: docreport ?? '' })
     },

--- a/react-api-client/src/access_control/useDocumentedMutation.ts
+++ b/react-api-client/src/access_control/useDocumentedMutation.ts
@@ -83,8 +83,8 @@ function useWrappedMutationFn<TData, TVariables>(
         documentationState,
         actionsToDocument
       )
-      if (docreport == null) {
-        console.error('No documentation report provided')
+      if (docreport == null || docreport.length === 0) {
+        throw new Error('No documentation report provided')
       }
       if (documentationState.isLoading) {
         throw new Error('Access control queries are still loading')

--- a/react-api-client/src/access_control/useDocumentedMutation.ts
+++ b/react-api-client/src/access_control/useDocumentedMutation.ts
@@ -83,7 +83,7 @@ function useWrappedMutationFn<TData, TVariables>(
         documentationState,
         actionsToDocument
       )
-      if (docreport == null || docreport.length === 0) {
+      if (!isDocumentationProvided(documentationState, docreport)) {
         throw new Error('No documentation report provided')
       }
       if (documentationState.isLoading) {
@@ -94,4 +94,17 @@ function useWrappedMutationFn<TData, TVariables>(
     [actionsToDocument, documentationState, mutationFn]
   )
   return wrappedMutationFn
+}
+
+const isDocumentationProvided = (
+  state: DocumentationState,
+  docreport: DocumentationReport | null
+): boolean => {
+  if (state.isLoading) {
+    return false
+  }
+  if (!state.reasonForInteractionRequired) {
+    return true
+  }
+  return docreport != null && docreport.length > 0
 }

--- a/robot-server/simulators/test-flex.json
+++ b/robot-server/simulators/test-flex.json
@@ -6,10 +6,6 @@
       "model": "p1000_single_3.4",
       "id": "321_flex"
     },
-    "left": {
-      "model": "p50_single_3.4",
-      "id": "123_flex"
-    },
     "gripper": {
       "model": "gripper_1.3",
       "id": "1234_flex_gripper"

--- a/robot-server/simulators/test-flex.json
+++ b/robot-server/simulators/test-flex.json
@@ -6,6 +6,10 @@
       "model": "p1000_single_3.4",
       "id": "321_flex"
     },
+    "left": {
+      "model": "p50_single_3.4",
+      "id": "123_flex"
+    },
     "gripper": {
       "model": "gripper_1.3",
       "id": "1234_flex_gripper"


### PR DESCRIPTION
# Overview

Backing out of a documentation required modal now aborts the mutation that was meant to occur and returns the user to whatever state they were in before launching the mutation. For documentation required modals that pop up at the end of maintenance runs, this means returning to the results screen.

https://github.com/user-attachments/assets/92d48e04-93c8-4c50-b869-e4ae9aedf256

https://github.com/user-attachments/assets/9a32651c-740a-4bfa-84b3-668e8ce58b89

## Test Plan and Hands on Testing

For all maintenance runs and actions that require documentation, pressing the exit button the Documentation Required modal should return users to the screen they were on before the modal popped up, without any visible errors or side effects. 

## Risk assessment

Low