### PR TITLE
fix(api): make SynchronousAdapter play nice with async pyro proxy calls

### DIFF
--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -99,6 +99,8 @@ def create_protocol_context(
     if isinstance(hardware_api, ThreadManager):
         sync_hardware = hardware_api.sync
     elif hasattr(hardware_api, "_proxy"):
+        # If this is an Async Client Pyro version of the hardware API, we reconstruct it to
+        # force all the calls to be synchronous, allowing it to be easily used in the SynchronousAdapter
         with Proxy(hardware_api._proxy._pyroUri) as new_proxy:  # type: ignore[no-untyped-call]
             sync_acpo = AsyncClientPyroObject(new_proxy, force_synchronous=True)
             sync_hardware = SynchronousAdapter(sync_acpo)  # type: ignore[arg-type]

--- a/api/src/opentrons/protocol_api/create_protocol_context.py
+++ b/api/src/opentrons/protocol_api/create_protocol_context.py
@@ -3,6 +3,8 @@
 import asyncio
 from typing import Any, Dict, Optional, Union, cast
 
+from Pyro5.api import Proxy
+
 from opentrons_shared_data.labware.types import LabwareDefinition
 
 from .core.common import ProtocolCore as AbstractProtocolCore
@@ -32,6 +34,7 @@ from opentrons.protocols.api_support.deck_type import (
 from opentrons.protocols.api_support.definitions import MAX_SUPPORTED_VERSION
 from opentrons.protocols.api_support.types import APIVersion
 from opentrons.util.broker import Broker
+from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
 
 
 class ProtocolEngineCoreRequiredError(Exception):
@@ -95,6 +98,10 @@ def create_protocol_context(
 
     if isinstance(hardware_api, ThreadManager):
         sync_hardware = hardware_api.sync
+    elif hasattr(hardware_api, "_proxy"):
+        with Proxy(hardware_api._proxy._pyroUri) as new_proxy:  # type: ignore[no-untyped-call]
+            sync_acpo = AsyncClientPyroObject(new_proxy, force_synchronous=True)
+            sync_hardware = SynchronousAdapter(sync_acpo)  # type: ignore[arg-type]
     else:
         sync_hardware = SynchronousAdapter(hardware_api)
 

--- a/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
@@ -58,6 +58,10 @@ def AsyncClientPyroObject(
     by the PyroSynchronousObject constructor will be wrapped to be awaitable again. Standard method calls and
     property attributes will be forwarded as usual.
 
+    If `force_synchronous` is set to `True`, we instead keep the async methods `synchronized`. This is useful if
+    the proxy is being used in a situation where async calls need to be made synchronous to begin with. This way
+    we do not need to ping pong back and forth between async and non-async wrapping.
+
     Proxy wrapping Example:
     -------
     An example of this would be with a remote call to an `OT3API` instance which has been wrapped and hosted.

--- a/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
@@ -48,7 +48,9 @@ class _ACPO:
     pass
 
 
-def AsyncClientPyroObject(pyro_synchronous_object: Pyro5.api.Proxy) -> _ACPO:
+def AsyncClientPyroObject(
+    pyro_synchronous_object: Pyro5.api.Proxy, force_synchronous: bool = False
+) -> _ACPO:
     """A Wrapper Class constructor to take a PyroSynchronousObject Proxy and make calls awaitable.
 
     The purpose of this class re-constructor is to create an object with all the attributes of a Proxy object
@@ -71,13 +73,14 @@ def AsyncClientPyroObject(pyro_synchronous_object: Pyro5.api.Proxy) -> _ACPO:
     AsyncCls = type(
         f"AsyncClientPyroObject_{pyro_synchronous_object.__class__.__name__}_{id(pyro_synchronous_object)}",
         (_ACPO,),
-        dict(_build_classdict(pyro_synchronous_object)),
+        dict(_build_classdict(pyro_synchronous_object, force_synchronous)),
     )
     return AsyncCls()  # type: ignore
 
 
 def _build_classdict(
     pso: Pyro5.api.Proxy,
+    force_synchronous: bool,
 ) -> Iterator[tuple[str, Any]]:
     # ensures metadata is available
     pso._pyroBind()  # type: ignore
@@ -85,14 +88,14 @@ def _build_classdict(
     async_method_names = [method["__name__"] for method in async_methods.values()]
     # Attach PSO exposed methods to the AsyncClientPyroObject
     for method in pso._pyroMethods:
-        if method in async_method_names:
+        if method in async_method_names and not force_synchronous:
             # For methods that are awaitable wrap them as an async reference that forwards the call to the PSO Proxy.
             method_metadata: dict[str, Any] = async_methods[method]
             async_method = wrap_as_async(method_metadata)
-            yield (method, async_method)
+            yield method, async_method
         else:
             # For standard method calls forward the direct call to the method on the PSO Proxy.
-            yield (method, wrap_parameter_validation(pso, method))
+            yield method, wrap_parameter_validation(pso, method)
     # Attach PSO exposed attributes to the AsyncClientPyroObject
     for attr in pso._pyroAttrs:
         # For property attributes we use to attach a wrapped `getattr` call for that attribute.
@@ -101,7 +104,7 @@ def _build_classdict(
             attr,
             property(wrap_property(pso, attr)),
         )
-    yield ("_proxy", pso)
+    yield "_proxy", pso
 
 
 ### Helpers ###

--- a/api/tests/opentrons/protocol_api_old/test_module_context.py
+++ b/api/tests/opentrons/protocol_api_old/test_module_context.py
@@ -29,7 +29,9 @@ from opentrons.types import Location, Point
 
 @pytest.fixture
 def mock_hardware() -> mock.MagicMock:
-    return mock.MagicMock()
+    mock_hardware = mock.MagicMock()
+    del mock_hardware._proxy
+    return mock_hardware
 
 
 @pytest.fixture


### PR DESCRIPTION
# Overview

Fixes RQA-5593.

A bug was found where calls using the protocol context `SynchronousAdapter` would fail while using Pyro, with an error that looked like `'AsyncClientPyroObject_Proxy_547823319472' object has no attribute '_loop'`. Looking into this, it was happening because the object being wrapped in the `SynchronousAdapter` was the `AsyncClientPyroObject` (or ACPO) which did not contain a `_loop` attribute as the error says. While the bug was found on a call using a private method, this could be recreated with official methods and properties of the API.

The solution went about for this involved adding a `force_synchronous` argument to the ACPO constructor and reconstructing the ACPO passed into the protocol context to use this flag. This in effect does not "re-async" that already synchronized calls, and therefore gets us the same result as the `SynchronousAdapter` was doing when handling async calls. And since non of these calls are async now, we do not hit that code block trying to access `_loop`, and the protocols that were failing before now work.

## Test Plan and Hands on Testing

Tested the following two protocols to ensure that they now pass.

```python
requirements = {"robotType": "Flex", "apiLevel": "2.29"}

def run(context):
    if context.door_closed:
        context.pause()
    else:
        context.delay(10)

    if context.rail_lights_on:
        context.pause()
    else:
        context.delay(10)
```

```python
requirements = {"robotType": "Flex", "apiLevel": "2.29"}

def run(context):
    api = context._core.get_hardware()
    api.cache_instruments()
    api.home()
```

## Changelog

- Add a `force_synchronous` argument to the `AsyncClientPyroObject`
- Use the forced synchronous version of the ACPO when wrapped in a `SynchronousAdapter`

## Review requests

## Risk assessment

Low, only effects code in Pyro mode and fixes code that was not working before.