### PR TITLE
fix: fix StoryBook viewport option format

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -66,7 +66,11 @@ export const customViewports = {
 }
 
 export const parameters = {
-  viewport: { viewports: customViewports },
+  viewport: {
+    options: {
+      ...customViewports,
+    },
+  },
   options: {
     storySort: {
       method: 'alphabetical',


### PR DESCRIPTION


# Overview
fix StoryBook viewport option format

https://storybook.js.org/docs/essentials/viewport#add-new-devices

### before
<img width="1930" height="729" alt="Screenshot 2026-06-15 at 4 35 49 PM" src="https://github.com/user-attachments/assets/62facf44-4b42-4897-9ea6-41358508dcca" />


### after
<img width="1928" height="732" alt="Screenshot 2026-06-15 at 4 35 25 PM" src="https://github.com/user-attachments/assets/7d3d894c-b764-4e3a-a337-3f2474175bf6" />


closes AUTH-3025

## Test Plan and Hands on Testing

Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.

## Changelog
update viewport options in preview.tsx

## Review requests

## Risk assessment
low
