### PR TITLE
fix(app): Fix Wi-Fi modal layout

### DIFF
--- a/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/ConnectModal/FormModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/ConnectModal/FormModal.tsx
@@ -2,11 +2,7 @@ import { Controller } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import styled, { css } from 'styled-components'
 
-import {
-  BUTTON_TYPE_SUBMIT,
-  Flex,
-  FONT_SIZE_BODY_1,
-} from '@opentrons/components'
+import { BUTTON_TYPE_SUBMIT, FONT_SIZE_BODY_1 } from '@opentrons/components'
 
 import { ScrollableAlertModal } from '/app/molecules/modals'
 import { SECURITY_WPA_EAP, SECURITY_WPA_PSK } from '/app/redux/networking'

--- a/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/ConnectModal/FormModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/ConnectModal/FormModal.tsx
@@ -26,7 +26,7 @@ const StyledCopy = styled.p`
   margin: 0 1rem 1rem;
 `
 
-const StyledFlex = styled(Flex)`
+const StyledFieldContainer = styled.div`
   font-size: ${FONT_SIZE_BODY_1};
   display: table;
   width: 80%;
@@ -91,7 +91,7 @@ export const FormModal = (props: FormModalProps): JSX.Element => {
       ]}
     >
       <StyledCopy>{bodyText}</StyledCopy>
-      <StyledFlex id={id}>
+      <StyledFieldContainer id={id}>
         {fields.map(fieldProps => {
           const { name } = fieldProps
           const fieldId = `${id}__${name}`
@@ -154,7 +154,7 @@ export const FormModal = (props: FormModalProps): JSX.Element => {
             />
           )
         })}
-      </StyledFlex>
+      </StyledFieldContainer>
     </ScrollableAlertModal>
   )
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/ConnectModal/SecurityField.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/ConnectModal/SecurityField.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { SelectField } from '@opentrons/components'
@@ -24,11 +25,6 @@ export interface SecurityFieldProps {
   fieldState: ControllerFieldState
   className?: string
 }
-
-const ALL_SECURITY_OPTIONS = [
-  { options: [{ value: SECURITY_NONE, label: 'shared:none' }] },
-  { options: [{ value: SECURITY_WPA_PSK, label: 'wpa2_personal' }] },
-]
 
 const makeEapOptionsGroup = (
   eapOptions: EapOption[]
@@ -58,8 +54,18 @@ export const SecurityField = (props: SecurityFieldProps): JSX.Element => {
     fieldState
   )
 
+  const noneText = t('shared:none')
+  const wpa2PersonalText = t('wpa2_personal')
+  const allSecurityOptions = useMemo(
+    () => [
+      { options: [{ value: SECURITY_NONE, label: noneText }] },
+      { options: [{ value: SECURITY_WPA_PSK, label: wpa2PersonalText }] },
+    ],
+    [noneText, wpa2PersonalText]
+  )
+
   const options = [
-    ...(showAllOptions ? ALL_SECURITY_OPTIONS : []),
+    ...(showAllOptions ? allSecurityOptions : []),
     makeEapOptionsGroup(eapOptions),
   ]
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/ConnectModal/SecurityField.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/ConnectModal/SecurityField.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { SelectField } from '@opentrons/components'
@@ -54,15 +53,10 @@ export const SecurityField = (props: SecurityFieldProps): JSX.Element => {
     fieldState
   )
 
-  const noneText = t('shared:none')
-  const wpa2PersonalText = t('wpa2_personal')
-  const allSecurityOptions = useMemo(
-    () => [
-      { options: [{ value: SECURITY_NONE, label: noneText }] },
-      { options: [{ value: SECURITY_WPA_PSK, label: wpa2PersonalText }] },
-    ],
-    [noneText, wpa2PersonalText]
-  )
+  const allSecurityOptions = [
+    { options: [{ value: SECURITY_NONE, label: t('shared:none') }] },
+    { options: [{ value: SECURITY_WPA_PSK, label: t('wpa2_personal') }] },
+  ]
 
   const options = [
     ...(showAllOptions ? allSecurityOptions : []),


### PR DESCRIPTION
## Overview

This fixes RQA-5632.

## Test Plan and Hands on Testing

* [x] Fields are laid out vertically now.
* [x] No more missing i18n strings, as far as I can tell.

Before:

<img width="512" height="400" alt="Screenshot 2026-06-15 at 4 52 28 PM" src="https://github.com/user-attachments/assets/bb9ec962-a803-4129-8d14-f4aaf934c332" />

After:

<img width="512" height="400" alt="Screenshot 2026-06-15 at 4 50 21 PM" src="https://github.com/user-attachments/assets/819db17a-9d84-4d14-9637-34a0201ff759" />

## Review requests

Does this make sense, as a surgical fix?

## Risk assessment

Low, I hope? I think what we see is what we get.