### PR TITLE
fix(app): fix scroll bar flickering issue

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
@@ -32,7 +32,7 @@
 
 .annotated_group_expanded {
   display: flex;
-  max-height: min(75dvh, calc(100dvh - 10rem));
+  /*max-height: min(75dvh, calc(100dvh - 10rem));*/
   flex-direction: column;
   padding: var(--spacing-8);
   border-bottom: 1px solid var(--grey-30);
@@ -133,6 +133,7 @@
 .annotated_steps_list {
   width: 100%;
   height: 100%;
+  scrollbar-gutter: stable;
 }
 
 .annotated_steps_row {

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/annotatedsteps.module.css
@@ -32,7 +32,6 @@
 
 .annotated_group_expanded {
   display: flex;
-  /*max-height: min(75dvh, calc(100dvh - 10rem));*/
   flex-direction: column;
   padding: var(--spacing-8);
   border-bottom: 1px solid var(--grey-30);

--- a/protocol-visualization/src/organisms/AnnotatedSteps/annotatedsteps.module.css
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/annotatedsteps.module.css
@@ -32,7 +32,6 @@
 
 .annotated_group_expanded {
   display: flex;
-  max-height: min(75dvh, calc(100dvh - 10rem));
   flex-direction: column;
   padding: var(--spacing-8);
   border-bottom: 1px solid var(--grey-30);
@@ -133,6 +132,7 @@
 .annotated_steps_list {
   width: 100%;
   height: 100%;
+  scrollbar-gutter: stable;
 }
 
 .annotated_steps_row {


### PR DESCRIPTION


# Overview
fix scroll bar flickering issue

the issue is CSS does height calc since protocol visualization uses react-window for virtualization of the step command which means js part does calc for height and width. Windows display scale 150% causes an infinity loop between CSS calc and js calc then causes the flickering issue.

closes RQA-5610

## Test Plan and Hands on Testing
- run this branch 
- test the protocol that is attached to the ticket

## Changelog
- remove height calc from CSS

## Review requests


## Risk assessment
should be low
