### PR TITLE
fix(api): tempdeck debounce logic was inverted

### DIFF
--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -342,7 +342,7 @@ class TempDeckReader(Reader):
     def on_error(self, exception: Exception) -> None:
         self._debounce_count -= 1
         if self._error_callback:
-            if self._debounce_count == 0:
+            if self._debounce_count != 0:
                 log.error(
                     f"Reader encountered error {exception} but has {self._debounce_count} tries left"
                 )

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import AsyncGenerator
 
-from decoy import Decoy
+from decoy import Decoy, matchers
 import pytest
 
 from opentrons.hardware_control.modules.types import (
@@ -109,6 +109,31 @@ async def test_error_callback(
     exc = Exception("oh no!")
     decoy.when(await mock_get_temp()).then_raise(exc)
     monkeypatch.setattr(subject._driver, "get_temperature", mock_get_temp)
+    # TODO(sf,rh): this is EXEC-2757. wait_next_poll() doesn't handle disconnects
+    # well and will raise before any HC-module-level error handling happens, aka
+    # reconnect logic (driver-level error handling is fine, though)
+    with pytest.raises(Exception, match="oh no!"):
+        await subject._poller.wait_next_poll()
+    decoy.verify(
+        module_error_callback(
+            matchers.Anything(),
+            "temperatureModuleV1",
+            "/dev/ot_module_sim_tempdeck0",
+            "dummySerialTD",
+        ),
+        times=0,
+    )
+    with pytest.raises(Exception, match="oh no!"):
+        await subject._poller.wait_next_poll()
+    decoy.verify(
+        module_error_callback(
+            matchers.Anything(),
+            "temperatureModuleV1",
+            "/dev/ot_module_sim_tempdeck0",
+            "dummySerialTD",
+        ),
+        times=0,
+    )
     with pytest.raises(Exception, match="oh no!"):
         await subject._poller.wait_next_poll()
     decoy.verify(


### PR DESCRIPTION
The debounce count should not error while there are retries remaining and should error when there isn't, not the other way around. As far as I can tell this also fixes an issue where on reconnect, the device info would often fail to parse.

Tested this by forcing a disconnect during a tempdeck command and while the tempdeck is idle; in both cases, we parse device info fine and allow 3 retries before destroying the module.

Closes EXEC-2755
Closes EXEC-2756
