### PR TITLE
fix(app,protocol-visualization): fix selected command's jump

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -199,7 +199,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
   ])
 
   useEffect(() => {
-    if (currentCommandId == null) {
+    if (currentCommandId == null || !isGlobalPlaying) {
       return
     }
     if (filteredGroupedCommands != null && filteredGroupedCommands.length > 0) {

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -221,7 +221,12 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     if (scrollTargetId !== currentCommandId) {
       setScrollTargetId(currentCommandId)
     }
-  }, [filteredGroupedCommands, currentCommandId, scrollTargetId])
+  }, [
+    filteredGroupedCommands,
+    currentCommandId,
+    scrollTargetId,
+    isGlobalPlaying,
+  ])
 
   const { rows, rowIndexByCommandId } = useMemo(() => {
     const nextRows: AnnotatedStepsRow[] = []

--- a/app/src/organisms/Desktop/ProtocolVisualization/Controls/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/Controls/index.tsx
@@ -46,6 +46,7 @@ export function Controls(props: ControlsProps): JSX.Element {
     handlePlayPause,
     isPlaying,
     commands,
+    // groupedCommands,
     milliSecondsPerFrame,
     setMilliSecondsPerFrame,
   } = props

--- a/app/src/organisms/Desktop/ProtocolVisualization/Controls/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/Controls/index.tsx
@@ -14,11 +14,6 @@ import {
 import styles from './controls.module.css'
 import { PerStepOverflowMenu } from './PerStepOverflowMenu'
 
-// import {
-//   getNextGroupFirstCommandId,
-//   getPreviousGroupFirstCommandId,
-// } from './utils'
-
 import type { Dispatch, SetStateAction } from 'react'
 import type { RunTimeCommand } from '@opentrons/shared-data'
 import type { GroupedCommands } from '/app/redux/protocol-storage'
@@ -46,7 +41,6 @@ export function Controls(props: ControlsProps): JSX.Element {
     handlePlayPause,
     isPlaying,
     commands,
-    // groupedCommands,
     milliSecondsPerFrame,
     setMilliSecondsPerFrame,
   } = props

--- a/app/src/organisms/Desktop/ProtocolVisualization/Controls/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/Controls/index.tsx
@@ -14,6 +14,11 @@ import {
 import styles from './controls.module.css'
 import { PerStepOverflowMenu } from './PerStepOverflowMenu'
 
+// import {
+//   getNextGroupFirstCommandId,
+//   getPreviousGroupFirstCommandId,
+// } from './utils'
+
 import type { Dispatch, SetStateAction } from 'react'
 import type { RunTimeCommand } from '@opentrons/shared-data'
 import type { GroupedCommands } from '/app/redux/protocol-storage'

--- a/protocol-visualization/src/organisms/AnnotatedSteps/index.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/index.tsx
@@ -219,7 +219,12 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     if (scrollTargetId !== currentCommandId) {
       setScrollTargetId(currentCommandId)
     }
-  }, [filteredGroupedCommands, currentCommandId, scrollTargetId])
+  }, [
+    filteredGroupedCommands,
+    currentCommandId,
+    scrollTargetId,
+    isGlobalPlaying,
+  ])
 
   const { rows, rowIndexByCommandId } = useMemo(() => {
     const nextRows: AnnotatedStepsRow[] = []

--- a/protocol-visualization/src/organisms/AnnotatedSteps/index.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/index.tsx
@@ -197,7 +197,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
   ])
 
   useEffect(() => {
-    if (currentCommandId == null) {
+    if (currentCommandId == null || !isGlobalPlaying) {
       return
     }
     if (filteredGroupedCommands != null && filteredGroupedCommands.length > 0) {


### PR DESCRIPTION


# Overview
fix selected command's jump

the issue is that AnnotatedStep doesn't check the protocol's playing status and then when clicking a command and setSelectedCommand updates currentCommandIndex then calls auto-scroll (useEffect).


https://github.com/user-attachments/assets/d57ccb0c-5fb6-4a1b-8e2e-eec10d6fc50f



closes AUTH-3024

## Test Plan and Hands on Testing
- import the protocol that is attached to the ticket

## Changelog
- add a condition to check the protocol playing status

## Review requests


## Risk assessment
low
