### PR TITLE
fix(protocol-designer, step-generation): fix available tiprack logic

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTiprack.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/SelectTiprack.tsx
@@ -61,6 +61,7 @@ export function SelectTiprack(props: TipSelectionBaseProps): JSX.Element {
           pipetteSpecs,
           nozzles,
           labwareEntities,
+          labwareRobotState: activeDeckSetup.labware,
         })
         if (selectedTiprackId === null && isTiprackSelectable) {
           setSelectedTiprackId(id)

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/__tests__/utils.test.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/__tests__/utils.test.ts
@@ -76,6 +76,7 @@ describe('getIsTiprackSelectable', () => {
         pipetteSpecs: { channels: 1 } as PipetteV2Specs,
         nozzles: ALL,
         labwareEntities: {},
+        labwareRobotState: mockRobotState.labware,
       })
     ).toBe(true)
   })
@@ -88,6 +89,7 @@ describe('getIsTiprackSelectable', () => {
         pipetteSpecs: { channels: 1 } as PipetteV2Specs,
         nozzles: ALL,
         labwareEntities: {},
+        labwareRobotState: mockRobotState.labware,
       })
     ).toBe(false)
   })
@@ -101,6 +103,7 @@ describe('getIsTiprackSelectable', () => {
         pipetteSpecs: { channels: 1 } as PipetteV2Specs,
         nozzles: ALL,
         labwareEntities: {},
+        labwareRobotState: mockRobotState.labware,
       })
     ).toBe(false)
   })
@@ -114,6 +117,7 @@ describe('getIsTiprackSelectable', () => {
         pipetteSpecs: { channels: 1 } as PipetteV2Specs,
         nozzles: ALL,
         labwareEntities: {},
+        labwareRobotState: mockRobotState.labware,
       })
     ).toBe(false)
   })
@@ -131,6 +135,7 @@ describe('getIsTiprackSelectable', () => {
         labwareEntities: {
           [MOCK_ADAPTER_ID]: { labwareDefURI: MOCK_ADAPTER_URI } as any,
         },
+        labwareRobotState: mockRobotState.labware,
       })
     ).toBe(true)
   })
@@ -148,6 +153,7 @@ describe('getIsTiprackSelectable', () => {
         labwareEntities: {
           [MOCK_ADAPTER_ID]: { labwareDefURI: MOCK_ADAPTER_URI } as any,
         },
+        labwareRobotState: mockRobotState.labware,
       })
     ).toBe(false)
   })
@@ -169,6 +175,7 @@ describe('getIsTiprackSelectable', () => {
             labwareEntities: {
               [MOCK_ADAPTER_ID]: { labwareDefURI: MOCK_ADAPTER_URI } as any,
             },
+            labwareRobotState: mockRobotState.labware,
           })
         ).toBe(false)
       })
@@ -186,6 +193,7 @@ describe('getIsTiprackSelectable', () => {
             labwareEntities: {
               [MOCK_ADAPTER_ID]: { labwareDefURI: MOCK_ADAPTER_URI } as any,
             },
+            labwareRobotState: mockRobotState.labware,
           })
         ).toBe(true)
       })
@@ -211,6 +219,7 @@ describe('getAreAnyMatchingTipracksSelectable', () => {
         nozzles: ALL,
         labwareEntities: {},
         validTiprackIds: [mockTiprackId],
+        labwareRobotState: mockRobotState.labware,
       })
     ).toBe(true)
   })
@@ -223,6 +232,7 @@ describe('getAreAnyMatchingTipracksSelectable', () => {
         nozzles: ALL,
         labwareEntities: {},
         validTiprackIds: [],
+        labwareRobotState: mockRobotState.labware,
       })
     ).toBe(false)
   })

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
@@ -115,6 +115,7 @@ export function TipSelectionWizard(
     nozzles,
     labwareEntities,
     validTiprackIds,
+    labwareRobotState: activeDeckSetup.labware,
   })
 
   const isSelectedTiprackValid =
@@ -126,6 +127,7 @@ export function TipSelectionWizard(
       nozzles,
       labwareEntities,
       validTiprackIds,
+      labwareRobotState: activeDeckSetup.labware,
     })
   const isAnySelectedWellTooManyPickups = selectedTips.some(group => {
     const primaryWell = group[0]

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/index.tsx
@@ -83,6 +83,7 @@ export function TipSelectionWizard(
       ? robotState?.tipState.tipracks[selectedTiprackId]
       : null
   const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
+  const { labware: activeDeckSetupLabware } = activeDeckSetup
   const { pipetteEntities, labwareEntities } = useSelector(getInvariantContext)
   const { spec: pipetteSpecs } = pipetteEntities[pipetteId]
   const robotType = useSelector(getRobotType)
@@ -109,25 +110,25 @@ export function TipSelectionWizard(
   }
 
   const areAnyMatchingTipracksSelectable = getAreAnyMatchingTipracksSelectable({
-    allLabware: Object.values(activeDeckSetup.labware),
+    allLabware: Object.values(activeDeckSetupLabware),
     formTiprackUri,
     pipetteSpecs,
     nozzles,
     labwareEntities,
     validTiprackIds,
-    labwareRobotState: activeDeckSetup.labware,
+    labwareRobotState: activeDeckSetupLabware,
   })
 
   const isSelectedTiprackValid =
     selectedTiprackId != null &&
     getIsTiprackSelectableAndValid({
-      labware: activeDeckSetup.labware[selectedTiprackId],
+      labware: activeDeckSetupLabware[selectedTiprackId],
       formTiprackUri,
       pipetteSpecs,
       nozzles,
       labwareEntities,
       validTiprackIds,
-      labwareRobotState: activeDeckSetup.labware,
+      labwareRobotState: activeDeckSetupLabware,
     })
   const isAnySelectedWellTooManyPickups = selectedTips.some(group => {
     const primaryWell = group[0]

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -5,7 +5,6 @@ import {
   getPositionFromSlotId,
 } from '@opentrons/shared-data'
 import {
-  COLUMN_4_SLOTS,
   getIsInPipettableLocation,
   getIsSafePickupWithinTiprack,
   getLabwareHasLid,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -52,6 +52,8 @@ const BASE_OFFSET_Y = 15
 // additional offset to account for irregular OT-2 8-channel pipette geometry (right "hump")
 const OFFSET_OT2_8_CHANNEL = 10
 
+type LabwareRobotState = RobotState['labware']
+
 export const getViewboxFromSelectedLabware = (
   selectedLabwareId: string,
   robotState: TimelineFrame | null,
@@ -194,7 +196,7 @@ export function getIsTiprackSelectable(args: {
   pipetteSpecs: PipetteV2Specs
   nozzles: NozzleConfigurationStyle
   labwareEntities: LabwareEntities
-  labwareRobotState: RobotState['labware']
+  labwareRobotState: LabwareRobotState
 }): boolean {
   // TODO: check if tiprack is on stacker. Will bottom of stack still be slot?
   const {
@@ -238,7 +240,7 @@ interface GetIsTiprackSelectableAndValidArgs {
   nozzles: NozzleConfigurationStyle
   labwareEntities: LabwareEntities
   validTiprackIds: string[]
-  labwareRobotState: RobotState['labware']
+  labwareRobotState: LabwareRobotState
 }
 
 export const getIsTiprackSelectableAndValid = (
@@ -271,7 +273,7 @@ export const getAreAnyMatchingTipracksSelectable = (args: {
   nozzles: NozzleConfigurationStyle
   labwareEntities: LabwareEntities
   validTiprackIds: string[]
-  labwareRobotState: RobotState['labware']
+  labwareRobotState: LabwareRobotState
 }): boolean => {
   const {
     allLabware,
@@ -282,12 +284,12 @@ export const getAreAnyMatchingTipracksSelectable = (args: {
     validTiprackIds,
     labwareRobotState,
   } = args
-  return allLabware.some(lw => {
-    if (!validTiprackIds.includes(lw.id)) {
+  return allLabware.some(labware => {
+    if (!validTiprackIds.includes(labware.id)) {
       return false
     }
     return getIsTiprackSelectable({
-      labware: lw,
+      labware,
       pipetteSpecs,
       formTiprackUri,
       nozzles,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -215,7 +215,6 @@ export function getIsTiprackSelectable(args: {
       nozzles,
       channels
     )
-  const slot = getSlotInLocationStack(stack)
   const hasLid = getLabwareHasLid({
     labwareId: id,
     labwareEntities,

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/utils.ts
@@ -6,7 +6,9 @@ import {
 } from '@opentrons/shared-data'
 import {
   COLUMN_4_SLOTS,
+  getIsInPipettableLocation,
   getIsSafePickupWithinTiprack,
+  getLabwareHasLid,
   getPipetteCenteringFullOffset,
   getPipetteMovementSafetyStatus,
   getSlotInLocationStack,
@@ -33,6 +35,7 @@ import type {
 import type {
   InvariantContext,
   LabwareEntities,
+  RobotState,
   TimelineFrame,
 } from '@opentrons/step-generation'
 import type {
@@ -192,12 +195,19 @@ export function getIsTiprackSelectable(args: {
   pipetteSpecs: PipetteV2Specs
   nozzles: NozzleConfigurationStyle
   labwareEntities: LabwareEntities
+  labwareRobotState: RobotState['labware']
 }): boolean {
   // TODO: check if tiprack is on stacker. Will bottom of stack still be slot?
-  const { labware, formTiprackUri, pipetteSpecs, nozzles, labwareEntities } =
-    args
+  const {
+    labware,
+    formTiprackUri,
+    pipetteSpecs,
+    nozzles,
+    labwareEntities,
+    labwareRobotState,
+  } = args
   const { channels } = pipetteSpecs
-  const { def, labwareDefURI, stack } = labware
+  const { id, def, labwareDefURI, stack } = labware
   const isPickupCompatibleWithPossibleAdapter =
     getIsPickupCompatibleWithPossibleAdapter(
       stack,
@@ -206,11 +216,20 @@ export function getIsTiprackSelectable(args: {
       channels
     )
   const slot = getSlotInLocationStack(stack)
+  const hasLid = getLabwareHasLid({
+    labwareId: id,
+    labwareEntities,
+    labwareRobotState,
+  })
+  const location = getSlotInLocationStack(stack)
+  const isInPipettableLocation = getIsInPipettableLocation(location)
+
   return (
     getIsTiprack(def) &&
     labwareDefURI === formTiprackUri &&
-    !COLUMN_4_SLOTS.includes(slot) &&
-    isPickupCompatibleWithPossibleAdapter
+    isPickupCompatibleWithPossibleAdapter &&
+    !hasLid &&
+    isInPipettableLocation
   )
 }
 
@@ -221,6 +240,7 @@ interface GetIsTiprackSelectableAndValidArgs {
   nozzles: NozzleConfigurationStyle
   labwareEntities: LabwareEntities
   validTiprackIds: string[]
+  labwareRobotState: RobotState['labware']
 }
 
 export const getIsTiprackSelectableAndValid = (
@@ -233,6 +253,7 @@ export const getIsTiprackSelectableAndValid = (
     nozzles,
     labwareEntities,
     validTiprackIds,
+    labwareRobotState,
   } = args
   const isSelectable = getIsTiprackSelectable({
     labware,
@@ -240,6 +261,7 @@ export const getIsTiprackSelectableAndValid = (
     pipetteSpecs,
     nozzles,
     labwareEntities,
+    labwareRobotState,
   })
   return isSelectable && validTiprackIds.includes(labware.id)
 }
@@ -251,6 +273,7 @@ export const getAreAnyMatchingTipracksSelectable = (args: {
   nozzles: NozzleConfigurationStyle
   labwareEntities: LabwareEntities
   validTiprackIds: string[]
+  labwareRobotState: RobotState['labware']
 }): boolean => {
   const {
     allLabware,
@@ -259,26 +282,20 @@ export const getAreAnyMatchingTipracksSelectable = (args: {
     nozzles,
     labwareEntities,
     validTiprackIds,
+    labwareRobotState,
   } = args
-  const { channels } = pipetteSpecs
-  return validTiprackIds.some(id => {
-    const labware = allLabware.find(l => l.id === id)
-    if (labware == null) {
+  return allLabware.some(lw => {
+    if (!validTiprackIds.includes(lw.id)) {
       return false
     }
-    const { def, labwareDefURI, stack } = labware
-    const isPickupCompatibleWithPossibleAdapter =
-      getIsPickupCompatibleWithPossibleAdapter(
-        stack,
-        labwareEntities,
-        nozzles,
-        channels
-      )
-    return (
-      getIsTiprack(def) &&
-      labwareDefURI === formTiprackUri &&
-      isPickupCompatibleWithPossibleAdapter
-    )
+    return getIsTiprackSelectable({
+      labware: lw,
+      pipetteSpecs,
+      formTiprackUri,
+      nozzles,
+      labwareEntities,
+      labwareRobotState,
+    })
   })
 }
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipTrackingField.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipTrackingField.tsx
@@ -25,11 +25,17 @@ import {
   getLabwareEntities,
   getPipetteEntities,
 } from '/protocol-designer/step-forms/selectors'
-import { getRobotStateAtActiveItem } from '/protocol-designer/top-selectors/labware-locations'
+import {
+  getDeckSetupForActiveItem,
+  getRobotStateAtActiveItem,
+} from '/protocol-designer/top-selectors/labware-locations'
 
 import { TipSelectionWizard } from './TipSelectionWizard'
 import { useMemoizedTipAccessibilityByTiprackIdByWellName } from './TipSelectionWizard/hooks'
-import { getValidTiprackIds } from './TipSelectionWizard/utils'
+import {
+  getAreAnyMatchingTipracksSelectable,
+  getValidTiprackIds,
+} from './TipSelectionWizard/utils'
 import styles from './tiptrackingfield.module.css'
 import { getNumPickups } from './utils'
 
@@ -63,6 +69,7 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
   const invariantContext = useSelector(getInvariantContext)
   const labwareEntities = useSelector(getLabwareEntities)
   const robotState = useSelector(getRobotStateAtActiveItem) ?? null
+  const activeDeckSetup = useSelector(getDeckSetupForActiveItem)
   const pipette = pipetteEntities[pipetteId]
   const { spec: pipetteSpecs } = pipette
   const { channels } = pipetteSpecs
@@ -151,7 +158,15 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
     robotState,
   })
 
-  const hasValidTiprackForPickup = validTiprackIds.length > 0
+  const areAnyMatchingTipracksSelectable = getAreAnyMatchingTipracksSelectable({
+    allLabware: Object.values(activeDeckSetup?.labware ?? {}),
+    formTiprackUri: formData.tipRack,
+    pipetteSpecs,
+    nozzles,
+    labwareEntities,
+    validTiprackIds,
+    labwareRobotState: robotState?.labware ?? {},
+  })
 
   return (
     <Flex className={styles.container}>
@@ -210,7 +225,7 @@ export function TipTrackingField(props: TipTrackingFieldProps): JSX.Element {
           </ListButton>
         </Flex>
       ) : null}
-      {!hasValidTiprackForPickup ? (
+      {!areAnyMatchingTipracksSelectable ? (
         <InlineNotification
           type="error"
           heading={t('tip_selection:no_valid_tips_available.title')}

--- a/step-generation/src/commandCreators/compound/__tests__/replaceTip.test.ts
+++ b/step-generation/src/commandCreators/compound/__tests__/replaceTip.test.ts
@@ -76,6 +76,7 @@ describe('replaceTip', () => {
           },
           [lidId]: {
             stack: [tiprackURI1, '1'],
+            stackedOnNode: { labwareId: tiprackURI1 },
           },
         },
       }

--- a/step-generation/src/robotStateSelectors.ts
+++ b/step-generation/src/robotStateSelectors.ts
@@ -232,7 +232,7 @@ export function getNextTiprack(
         getIsInPipettableLocation(slotInLocationStack)
 
       const hasLid = getLabwareHasLid({
-        labwareId: labwareId,
+        labwareId,
         labwareRobotState: robotState.labware,
         labwareEntities: invariantContext.labwareEntities,
       })

--- a/step-generation/src/robotStateSelectors.ts
+++ b/step-generation/src/robotStateSelectors.ts
@@ -8,7 +8,7 @@ import {
   ALL,
   COLUMN,
   FLEX_STACKER_MODULE_TYPE,
-  getIsLid,
+  getIsTiprack,
   getLabwareDefIsStandard,
   getLabwareDefURI,
   getTiprackVolume,
@@ -24,7 +24,9 @@ import {
 
 import { CLEAN, COLUMN_4_SLOTS } from './constants'
 import {
+  getIsInPipettableLocation,
   getIsSafePickupWithinTiprack,
+  getLabwareHasLid,
   getPipetteMovementSafetyStatus,
   getSlotInLocationStack,
 } from './utils'
@@ -215,26 +217,43 @@ export function getNextTiprack(
       `cannot getNextTiprack, no pipette entity for pipette "${pipetteId}"`
     )
   }
-  // filter out unmounted or non-compatible tiprack models
+  // filter out unmounted or non-compatible or lidded tiprack models
+  const excludedByLid: string[] = []
   const sortedTipracksIds = sortLabwareBySlot(robotState.labware).filter(
     labwareId => {
       console.assert(
         invariantContext.labwareEntities[labwareId]?.labwareDefURI != null,
         `cannot getNextTiprack, no labware entity for "${labwareId}"`
       )
-      const isOnDeck =
-        getSlotInLocationStack(robotState.labware[labwareId].stack) !==
-        'offDeck'
+      const slotInLocationStack = getSlotInLocationStack(
+        robotState.labware[labwareId].stack
+      )
+      const isInPipettableLocation =
+        getIsInPipettableLocation(slotInLocationStack)
+
+      const hasLid = getLabwareHasLid({
+        labwareId: labwareId,
+        labwareRobotState: robotState.labware,
+        labwareEntities: invariantContext.labwareEntities,
+      })
+      if (
+        isInPipettableLocation &&
+        hasLid &&
+        getIsTiprack(invariantContext.labwareEntities[labwareId].def)
+      ) {
+        excludedByLid.push(labwareId)
+        return false
+      }
+
       const labwareIdDefUri =
         invariantContext.labwareEntities[labwareId].labwareDefURI
-      return isOnDeck && labwareIdDefUri === tipRackUri
+      return isInPipettableLocation && labwareIdDefUri === tipRackUri
     }
   )
   let filteredSortedTiprackIds = sortedTipracksIds
   const is96Channel = pipetteEntity.spec.channels === 96
 
   const excludedBy96Channel: string[] = []
-  const excludedByLid: string[] = []
 
   if (is96Channel) {
     filteredSortedTiprackIds = filteredSortedTiprackIds.filter(tiprackId => {
@@ -254,17 +273,6 @@ export function getNextTiprack(
     })
   }
 
-  filteredSortedTiprackIds = filteredSortedTiprackIds.filter(tiprackId => {
-    const locationHasLid = Object.entries(robotState.labware).find(
-      ([id, temporalProperties]) =>
-        temporalProperties.stack.includes(tiprackId) &&
-        getIsLid(invariantContext.labwareEntities[id].def)
-    )
-    if (locationHasLid != null) {
-      excludedByLid.push(tiprackId)
-    }
-    return locationHasLid == null
-  })
   let firstAvailableTiprack: string | null = null
   let nextTip: string | null = null
 

--- a/step-generation/src/utils/misc.ts
+++ b/step-generation/src/utils/misc.ts
@@ -13,11 +13,13 @@ import {
   FLEX_STACKER_MODULE_V1,
   FLEX_STACKER_V1_FIXTURE,
   getDeckDefFromRobotType,
+  getIsLid,
   getIsTiprack,
   getLabwareDefURI,
   getMaxPoolCount,
   getMmFromBottom,
   getWellNamePerMultiTip,
+  GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
   linearInterpolate,
   NINETY_SIX_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
   ONE_CHANNEL_WASTE_CHUTE_ADDRESSABLE_AREA,
@@ -54,7 +56,7 @@ import {
   ZERO_OFFSET,
 } from '../constants'
 import { curryCommandCreator } from './curryCommandCreator'
-import { reduceCommandCreators, uuid } from './index'
+import { OFF_DECK, reduceCommandCreators, uuid } from './index'
 
 import type {
   ActiveNozzleNumber,
@@ -1605,4 +1607,27 @@ export const getIsSpaceInHopper = (
   const labwareStored = stackerState?.labwareInHopper
   const numberOfLabwareStored = labwareStored?.length ?? 0
   return maximumAllowedLabware > numberOfLabwareStored
+}
+
+export const getLabwareHasLid = (args: {
+  labwareId: string
+  labwareRobotState: RobotState['labware']
+  labwareEntities: LabwareEntities
+}): boolean => {
+  const { labwareId, labwareRobotState, labwareEntities } = args
+  return Object.entries(labwareRobotState).some(
+    ([id, { stackedOnNode }]) =>
+      typeof stackedOnNode === 'object' &&
+      'labwareId' in stackedOnNode &&
+      stackedOnNode.labwareId === labwareId &&
+      getIsLid(labwareEntities[id].def)
+  )
+}
+
+export const getIsInPipettableLocation = (location: string): boolean => {
+  return ![
+    OFF_DECK,
+    GRIPPER_WASTE_CHUTE_ADDRESSABLE_AREA,
+    ...COLUMN_4_SLOTS,
+  ].some(badLocation => location === badLocation)
 }


### PR DESCRIPTION
# Overview

Refines logic for tiprack availability for both manual and automatic tip selection. For automatic, I update logic for determining if a tiprack is lidded or in an inaccessible location. For manual tip trakcing, I correctly fork logic for valid tipracks (safe from collisions, safe pickup within tiprack) vs. selectable tipracks (compatible with possible adapter, unlidded, in accessible location)

Closes RQA-5628, Closes RQA-5629

## Test Plan and Hands on Testing

- upload the protocols attached to the tickets, and verify that the correct errors render, both in the timeline, and in the tip selection page of the transfer form and select tips modal

## Changelog

- refine logic for "valid" tipracks vs "selectable" tipracks, as specified above
- fix lidded tiprack logic in `robotStateSelectors`
- update unit tests 

## Review requests

see test plan

## Risk assessment

low