### PR TITLE
feat(step-generation): directly assign tasks to vacuum pump state command creators

### DIFF
--- a/step-generation/src/commandCreators/atomic/__tests__/vacuumSetPumpPower.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/vacuumSetPumpPower.test.ts
@@ -106,12 +106,11 @@ mock_vacuum_module.start_set_vacuum_power(
         },
       ],
       python: `
-mock_vacuum_module.start_set_vacuum_power(
+mock_vacuum_module_task_1 = mock_vacuum_module.start_set_vacuum_power(
     percent_power=40,
     duration_s=120,
     vent_after=False
-)
-mock_vacuum_module_task_1 = protocol.create_timer(seconds=120)`.trim(),
+)`.trim(),
     })
   })
 

--- a/step-generation/src/commandCreators/atomic/__tests__/vacuumSetPumpPressure.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/vacuumSetPumpPressure.test.ts
@@ -119,12 +119,11 @@ mock_vacuum_module.start_set_vacuum_pressure(
         },
       ],
       python: `
-mock_vacuum_module.start_set_vacuum_pressure(
+mock_vacuum_module_task_3 = mock_vacuum_module.start_set_vacuum_pressure(
     gauge_pressure_mbar=100,
     duration_s=45,
     vent_after=True
 )
-mock_vacuum_module_task_3 = protocol.create_timer(seconds=45)
 `.trim(),
     })
   })

--- a/step-generation/src/commandCreators/atomic/vacuumSetPumpPower.ts
+++ b/step-generation/src/commandCreators/atomic/vacuumSetPumpPower.ts
@@ -4,7 +4,6 @@ import {
   formatPyValue,
   getModuleHasLiveTask,
   indentPyLines,
-  PROTOCOL_CONTEXT_NAME,
   uuid,
 } from '../../utils'
 import { getVacuumPumpHoldArgsPython } from '../../utils/vacuumPythonArgs/getVacuumPumpHoldArgsPython'
@@ -52,14 +51,8 @@ export const vacuumSetPumpPower: CommandCreator<VacuumPumpPowerArgs> = (
     ? getVacuumPumpHoldArgsPython(duration, ventAfter)
     : []
   const allArgsPython = [percentPowerArg, ...holdArgsPython]
-  const basePython = `${module.pythonName}.start_set_vacuum_power(\n${indentPyLines(allArgsPython.join(',\n'))}\n)`
-  const taskCreatorPython = isTimedHold
-    ? `${taskId} = ${PROTOCOL_CONTEXT_NAME}.create_timer(seconds=${formatPyValue(duration)})`
-    : null
-  const python = [
-    basePython,
-    ...(taskCreatorPython != null ? [taskCreatorPython] : []),
-  ].join('\n')
+  const taskPython = isTimedHold ? `${taskId} = ` : ''
+  const python = `${taskPython}${module.pythonName}.start_set_vacuum_power(\n${indentPyLines(allArgsPython.join(',\n'))}\n)`
   return {
     commands: [
       {

--- a/step-generation/src/commandCreators/atomic/vacuumSetPumpPressure.ts
+++ b/step-generation/src/commandCreators/atomic/vacuumSetPumpPressure.ts
@@ -4,7 +4,6 @@ import {
   formatPyValue,
   getModuleHasLiveTask,
   indentPyLines,
-  PROTOCOL_CONTEXT_NAME,
   uuid,
 } from '../../utils'
 import { getVacuumPumpHoldArgsPython } from '../../utils/vacuumPythonArgs/getVacuumPumpHoldArgsPython'
@@ -52,15 +51,8 @@ export const vacuumSetPumpPressure: CommandCreator<VacuumPumpPressureArgs> = (
     ? getVacuumPumpHoldArgsPython(duration, ventAfter)
     : []
   const allArgsPython = [gaugePressureArg, ...holdArgsPython]
-  const basePython = `${module.pythonName}.start_set_vacuum_pressure(\n${indentPyLines(allArgsPython.join(',\n'))}\n)`
-  const taskCreatorPython = isTimedHold
-    ? `${taskId} = ${PROTOCOL_CONTEXT_NAME}.create_timer(seconds=${formatPyValue(duration)})`
-    : null
-  const python = [
-    basePython,
-    ...(taskCreatorPython != null ? [taskCreatorPython] : []),
-  ].join('\n')
-
+  const taskPython = isTimedHold ? `${taskId} = ` : ''
+  const python = `${taskPython}${module.pythonName}.start_set_vacuum_pressure(\n${indentPyLines(allArgsPython.join(',\n'))}\n)`
   return {
     commands: [
       {


### PR DESCRIPTION
# Overview

According to #21772, VacuumModule.start_set_vacuum_pressure/pwoer now returns an awaitable task, so we no longer need to set an explicit timer to await alongside the vacuum pump hold. This PR updates the relevant command creators' Python accordingly.

## Test Plan and Hands on Testing

- in PD create a timed vacuum pump power or pressure hold step
- verify that the emitted Python for the step has the following shape:
```python
    vacuum_module_1_task_2 = vacuum_module_1.start_set_vacuum_power(
        percent_power=22,
        duration_s=611,
        vent_after=True
    )

    # Step 7: pause
    protocol.wait_for_tasks([vacuum_module_1_task_2])
```

## Changelog

- fix emitted Python from `vacuumSetPumpPower` and `vacuumSetPumpPressure` command creators according to API
- update tests

## Review requests

see test plan

## Risk assessment

low