### PR TITLE
fix(api): volume float value comparison in liquid class transfers

### DIFF
--- a/api/src/opentrons/protocol_api/_liquid_properties.py
+++ b/api/src/opentrons/protocol_api/_liquid_properties.py
@@ -97,9 +97,7 @@ class LiquidHandlingPropertyByVolume:
             if -VOLUME_ROUNDING_ERROR_TOLERANCE < volume < 0:
                 validated_volume = 0
             else:
-                raise KeyError(
-                    f"Got invalid volume key {volume} for volume-dependent property. {e}"
-                ) from e
+                raise e
         if len(self._properties_by_volume) == 0:
             raise ValueError(
                 "No properties found for any volumes. Cannot interpolate for the given volume."

--- a/api/src/opentrons/protocol_api/_liquid_properties.py
+++ b/api/src/opentrons/protocol_api/_liquid_properties.py
@@ -61,8 +61,10 @@ from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     TransferProperties as SharedDataTransferProperties,
 )
 from opentrons_shared_data.liquid_classes.types import TipPositionDict
+from opentrons_shared_data.pipette.constants import VOLUME_ROUNDING_ERROR_TOLERANCE
 
 from . import validation
+from .validation import IsNegativeValueError
 
 
 class LiquidHandlingPropertyByVolume:
@@ -87,7 +89,17 @@ class LiquidHandlingPropertyByVolume:
 
     def get_for_volume(self, volume: float) -> float:
         """Get a value by volume for this property. Volumes not defined will be interpolated between set volumes."""
-        validated_volume = validation.ensure_positive_float(volume)
+        try:
+            validated_volume = validation.ensure_positive_float(volume)
+        except IsNegativeValueError as e:
+            # Due to rounding errors when handling volumes, we can sometimes get negative volumes close to zero.
+            # In such cases, we set the volume to zero.
+            if -VOLUME_ROUNDING_ERROR_TOLERANCE < volume < 0:
+                validated_volume = 0
+            else:
+                raise KeyError(
+                    f"Got invalid volume key {volume} for volume-dependent property. {e}"
+                ) from e
         if len(self._properties_by_volume) == 0:
             raise ValueError(
                 "No properties found for any volumes. Cannot interpolate for the given volume."

--- a/api/src/opentrons/protocol_api/validation.py
+++ b/api/src/opentrons/protocol_api/validation.py
@@ -103,6 +103,10 @@ class InvalidFixtureLocationError(ValueError):
     """An error raised when attempting to load a fixture in an invalid cutout."""
 
 
+class IsNegativeValueError(ValueError):
+    """An error raised when a negative number is encountered when expecting only positive ones."""
+
+
 def is_pipette_96_channel(pipette: Optional[PipetteNameType]) -> bool:
     """Return if this pipette type is a 96 channel."""
     if pipette is not None:
@@ -671,14 +675,14 @@ def validate_location(
 def ensure_boolean(value: bool) -> bool:
     """Ensure value is a boolean."""
     if not isinstance(value, bool):
-        raise ValueError("Value must be a boolean.")
+        raise ValueError(f"Value must be a boolean but it is {value}.")
     return value
 
 
 def ensure_float(value: Union[int, float]) -> float:
     """Ensure value is a float (or an integer) and return it as a float."""
     if not isinstance(value, (int, float)):
-        raise ValueError("Value must be a floating point number.")
+        raise ValueError(f"Value must be a floating point number but it is {value}.")
     return float(value)
 
 
@@ -688,7 +692,7 @@ def ensure_positive_float(value: Union[int, float]) -> float:
     if isnan(float_value) or isinf(float_value):
         raise ValueError("Value must be a defined, non-infinite number.")
     if float_value < 0:
-        raise ValueError("Value must be a positive float.")
+        raise IsNegativeValueError(f"Value must be a positive float but it is {value}.")
     return float_value
 
 
@@ -698,25 +702,31 @@ def ensure_greater_than_zero_float(value: Union[int, float]) -> float:
     if isnan(float_value) or isinf(float_value):
         raise ValueError("Value must be a defined, non-infinite number.")
     if float_value <= 0:
-        raise ValueError("Value must be a positive float greater than 0.")
+        raise ValueError(
+            f"Value must be a positive float greater than 0, but it is {value}."
+        )
     return float_value
 
 
 def ensure_positive_int(value: int) -> int:
     """Ensure value is a positive integer."""
     if not isinstance(value, int):
-        raise ValueError("Value must be an integer.")
+        raise ValueError(f"Value must be an integer but it is {value}.")
     if value < 0:
-        raise ValueError("Value must be a positive integer.")
+        raise ValueError(f"Value must be a positive integer but it is {value}.")
     return value
 
 
 def validate_coordinates(value: Sequence[float]) -> Tuple[float, float, float]:
     """Ensure value is a valid sequence of 3 floats and return a tuple of 3 floats."""
     if len(value) != 3:
-        raise ValueError("Coordinates must be a sequence of exactly three numbers")
+        raise ValueError(
+            f"Coordinates must be a sequence of exactly three numbers but received: {value}"
+        )
     if not all(isinstance(v, (float, int)) for v in value):
-        raise ValueError("All values in coordinates must be floats.")
+        raise ValueError(
+            f"All values in coordinates must be floats but they are: {value}."
+        )
     return float(value[0]), float(value[1]), float(value[2])
 
 

--- a/api/src/opentrons/protocol_engine/execution/pipetting.py
+++ b/api/src/opentrons/protocol_engine/execution/pipetting.py
@@ -5,6 +5,8 @@ from typing import Iterator, Optional, Tuple
 
 from typing_extensions import Protocol as TypingProtocol
 
+from opentrons_shared_data.pipette.constants import VOLUME_ROUNDING_ERROR_TOLERANCE
+
 from ..errors.exceptions import (
     InvalidAspirateVolumeError,
     InvalidDispenseVolumeError,
@@ -21,16 +23,6 @@ from opentrons.protocol_engine.types.liquid_level_detection import (
     SimulatedProbeResult,
 )
 from opentrons.types import Point
-
-# 1e-9 µL (1 femtoliter!) is a good value because:
-# * It's large relative to rounding errors that occur in practice in protocols. For
-#   example, https://opentrons.atlassian.net/browse/RESC-182 shows a rounding error
-#   on the order of 1e-15 µL.
-# * It's small relative to volumes that our users might actually care about and
-#   expect the robot to execute faithfully.
-# * It's the default absolute tolerance for math.isclose(), where it apparently works
-#   well in general.
-_VOLUME_ROUNDING_ERROR_TOLERANCE = 1e-9
 
 
 class PipettingHandler(TypingProtocol):
@@ -547,9 +539,7 @@ def _validate_aspirate_volume(
     # state_view.pipettes.get_available_volume()? Its whole `None` return vs. exception
     # raising thing is confusing me.
     available_volume = working_volume - current_volume
-    available_volume_with_tolerance = (
-        available_volume + _VOLUME_ROUNDING_ERROR_TOLERANCE
-    )
+    available_volume_with_tolerance = available_volume + VOLUME_ROUNDING_ERROR_TOLERANCE
 
     if aspirate_volume > available_volume_with_tolerance:
         raise InvalidAspirateVolumeError(
@@ -595,7 +585,7 @@ def _validate_dispense_volume(
         )
     else:
         remaining = aspirated_volume - dispense_volume
-        if remaining < -_VOLUME_ROUNDING_ERROR_TOLERANCE:
+        if remaining < -VOLUME_ROUNDING_ERROR_TOLERANCE:
             raise InvalidDispenseVolumeError(
                 f"Cannot dispense {dispense_volume} µL when only {aspirated_volume} µL has been aspirated."
             )

--- a/api/src/opentrons/protocol_engine/state/geometry.py
+++ b/api/src/opentrons/protocol_engine/state/geometry.py
@@ -22,7 +22,7 @@ from opentrons_shared_data.labware.labware_definition import (
     LabwareDefinition2,
     LabwareDefinition3,
 )
-from opentrons_shared_data.pipette import PIPETTE_X_SPAN
+from opentrons_shared_data.pipette.constants import PIPETTE_X_SPAN
 from opentrons_shared_data.pipette.types import ChannelCount, LabwareUri
 
 from .. import errors

--- a/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
+++ b/api/src/opentrons/protocols/advanced_control/transfers/transfer_liquid_utils.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, List, Literal, Optional, Sequence, Union
 from opentrons_shared_data.liquid_classes.liquid_class_definition import (
     PositionReference,
 )
+from opentrons_shared_data.pipette.constants import VOLUME_ROUNDING_ERROR_TOLERANCE
 
 from opentrons.protocol_api._liquid_properties import TipPosition
 from opentrons.protocol_api.disposal_locations import TrashBin, WasteChute
@@ -230,7 +231,8 @@ def check_current_volume_before_dispensing(
     dispense_volume: float,
 ) -> None:
     """Check if the current volume is valid for dispensing the dispense volume."""
-    if current_volume < dispense_volume:
+
+    if current_volume + VOLUME_ROUNDING_ERROR_TOLERANCE < dispense_volume:
         # Although this should never happen, we can get into an unexpected state
         # following error recovery and not have the expected amount of liquid in the tip.
         # If this happens, we want to raise a useful error so the user can understand

--- a/api/tests/opentrons/protocol_api/test_liquid_class_properties.py
+++ b/api/tests/opentrons/protocol_api/test_liquid_class_properties.py
@@ -479,6 +479,10 @@ def test_liquid_handling_property_by_volume() -> None:
     assert subject.get_for_volume(1) == 50.0
     assert subject.get_for_volume(1000) == 250.0
 
+    # Test that negative volumes close to zero are rounded to zero
+    subject.set_for_volume(0, 111)
+    assert subject.get_for_volume(-1e-10) == 111
+
     # Test fixed overrides
     subject.set_for_all_volumes(4321)
     for volume in (0, 1, 7, 100):

--- a/shared-data/python/opentrons_shared_data/pipette/__init__.py
+++ b/shared-data/python/opentrons_shared_data/pipette/__init__.py
@@ -22,18 +22,6 @@ if TYPE_CHECKING:
     )
 
 
-# TODO (spp, 2023-06-22: should probably move this to definition)
-"""
-The span of pipettes in X-direction based on number of channels.
-This is needed in order to determine safe tip drop location within a labware.
-"""
-PIPETTE_X_SPAN: Dict[ChannelCount, float] = {
-    1: 75,  # includes a margin
-    8: 75,  # includes a margin
-    96: 161,
-}
-
-
 def model_config() -> PipetteModelSpecs:
     """Load the per-pipette-model config file from within the wheel"""
     return copy.deepcopy(_model_config())

--- a/shared-data/python/opentrons_shared_data/pipette/__init__.py
+++ b/shared-data/python/opentrons_shared_data/pipette/__init__.py
@@ -7,13 +7,12 @@ from __future__ import annotations
 import copy
 import json
 from functools import lru_cache
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Optional
 
 from .. import load_shared_data
 
 if TYPE_CHECKING:
     from .types import (
-        ChannelCount,
         PipetteFusedSpec,
         PipetteModel,
         PipetteModelSpecs,

--- a/shared-data/python/opentrons_shared_data/pipette/constants.py
+++ b/shared-data/python/opentrons_shared_data/pipette/constants.py
@@ -1,0 +1,28 @@
+# This file contains constants defined for pipettes and liquid handling
+
+from typing import Dict
+from opentrons_shared_data.pipette.types import ChannelCount
+
+PIPETTE_X_SPAN: Dict[ChannelCount, float] = {
+    1: 75,  # includes a margin
+    8: 75,  # includes a margin
+    96: 161,
+}
+"""
+The span of pipettes in X-direction based on number of channels.
+This is needed in order to determine safe tip drop location within a labware.
+"""
+
+VOLUME_ROUNDING_ERROR_TOLERANCE = 1e-9
+"""
+# 1e-9 µL (1 femtoliter!) is a good value because:
+# * It's large relative to rounding errors that occur in practice in protocols. For
+#   example, https://opentrons.atlassian.net/browse/RESC-182 shows a rounding error
+#   on the order of 1e-15 µL.
+# * It's small relative to volumes that our users might actually care about and
+#   expect the robot to execute faithfully.
+# * It's the default absolute tolerance for math.isclose(), where it apparently works
+#   well in general.
+"""
+
+

--- a/shared-data/python/opentrons_shared_data/pipette/constants.py
+++ b/shared-data/python/opentrons_shared_data/pipette/constants.py
@@ -1,7 +1,9 @@
 # This file contains constants defined for pipettes and liquid handling
 
-from typing import Dict
-from opentrons_shared_data.pipette.types import ChannelCount
+from typing import TYPE_CHECKING, Dict
+
+if TYPE_CHECKING:
+    from opentrons_shared_data.pipette.types import ChannelCount
 
 PIPETTE_X_SPAN: Dict[ChannelCount, float] = {
     1: 75,  # includes a margin
@@ -27,5 +29,3 @@ VOLUME_ROUNDING_ERROR_TOLERANCE = 1e-9
 # * It's the default relative tolerance for math.isclose(), where it apparently works
 #   well in general.
 """
-
-

--- a/shared-data/python/opentrons_shared_data/pipette/constants.py
+++ b/shared-data/python/opentrons_shared_data/pipette/constants.py
@@ -15,13 +15,16 @@ This is needed in order to determine safe tip drop location within a labware.
 
 VOLUME_ROUNDING_ERROR_TOLERANCE = 1e-9
 """
+# Tolerance to use when determining whether two volumes are "close enough" to be considered
+# equal. This is required because floating point math in python has precision limitations.
+#
 # 1e-9 µL (1 femtoliter!) is a good value because:
 # * It's large relative to rounding errors that occur in practice in protocols. For
 #   example, https://opentrons.atlassian.net/browse/RESC-182 shows a rounding error
 #   on the order of 1e-15 µL.
 # * It's small relative to volumes that our users might actually care about and
 #   expect the robot to execute faithfully.
-# * It's the default absolute tolerance for math.isclose(), where it apparently works
+# * It's the default relative tolerance for math.isclose(), where it apparently works
 #   well in general.
 """
 

--- a/shared-data/python/opentrons_shared_data/pipette/constants.py
+++ b/shared-data/python/opentrons_shared_data/pipette/constants.py
@@ -1,9 +1,8 @@
 # This file contains constants defined for pipettes and liquid handling
 
-from typing import TYPE_CHECKING, Dict
+from typing import Dict
 
-if TYPE_CHECKING:
-    from opentrons_shared_data.pipette.types import ChannelCount
+from opentrons_shared_data.pipette.types import ChannelCount
 
 PIPETTE_X_SPAN: Dict[ChannelCount, float] = {
     1: 75,  # includes a margin


### PR DESCRIPTION
# Overview

Closes RQA-5611

This PR adds floating point rounding tolerance to volume comparisons in liquid class based transfers.
We already do this in protocol engine's pipette handling code. LC transfers need to mimic the same checks because we try to look ahead for errors before getting to the actual execution. So it makes sense to include the same tolerance in these checks.

## Test Plan and Hands on Testing

The protocol attached in the ticket now passes analysis.

## Changelog

- added the tolerance in dispense volume check
- updated the `get_for_volume()` function to use volume of `0uL` when the given volume is negative and close to zero
- updated the error messages in all LC validator functions to be more helpful

## Review requests

- Do you agree with the approach here?

## Risk assessment

- Small. Adds checks that already exist elsewhere in our codebase
