### PR TITLE
fix(api): implement thermocycler reconnect in module disconnect tolerance

### DIFF
--- a/api/src/opentrons/drivers/thermocycler/abstract.py
+++ b/api/src/opentrons/drivers/thermocycler/abstract.py
@@ -102,3 +102,7 @@ class AbstractThermocyclerDriver(ABC):
     async def get_error_state(self) -> None:
         """Raise if the thermocycler is in an error state."""
         ...
+
+    async def move_port(self, new_port: str) -> None:
+        """Try to change the port of the underlying connection."""
+        pass

--- a/api/src/opentrons/drivers/thermocycler/driver.py
+++ b/api/src/opentrons/drivers/thermocycler/driver.py
@@ -340,6 +340,10 @@ class _BaseThermocyclerDriver(AbstractThermocyclerDriver, Generic[_ConnectionKin
         """For the gen1, do nothing."""
         pass
 
+    async def move_port(self, new_port: str) -> None:
+        """Try to change the port of the underlying connection."""
+        await self._connection.update_port(new_port)
+
 
 ThermocyclerDriver = _BaseThermocyclerDriver[SerialConnection]
 

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, List, Mapping, Optional, Union, cast
 
 from ..execution_manager import ExecutionManager
 from . import mod_abc, types, update
+from opentrons.config import IS_ROBOT
 from opentrons.drivers.asyncio.communication.errors import UnhandledGcode
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.thermocycler import (
@@ -185,6 +186,26 @@ class Thermocycler(mod_abc.AbstractModule):
     async def cleanup(self) -> None:
         """Stop the poller task."""
         await self.soft_cleanup()
+
+    async def move_port(self, port: str, usb_port: USBPort) -> None:
+        self._port = port
+        self._usb_port = usb_port
+        await self._driver.move_port(port)
+
+    async def attempt_reconnect(self) -> None:
+        """Attempt to reestablish connections."""
+        if not IS_ROBOT:
+            return
+        try:
+            if not await self._driver.is_connected():
+                self._driver = await ThermocyclerDriverFactory.create(
+                    port=self.port, loop=self.loop
+                )
+                self._reader._driver = self._driver
+            await self._poller.stop()
+            await self._poller.start()
+        except BaseException as e:
+            log.error(f"Got {e} when trying to reconnect.")
 
     @classmethod
     def name(cls) -> str:

--- a/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_thermocycler.py
@@ -610,3 +610,88 @@ async def test_reader_raises_error_from_get_error(
             serial=None,
         )
     )
+
+
+async def test_move_port_updates_port_and_calls_driver(
+    subject_mocked_driver: modules.Thermocycler,
+    mock_driver: mock.AsyncMock,
+) -> None:
+    """It should update the module's port and forward the new port to the driver."""
+    new_usb_port = USBPort(name="b", port_number=5, device_path="/dev/ot_module_tc_new")
+    await subject_mocked_driver.move_port(
+        port="/dev/ot_module_tc_new", usb_port=new_usb_port
+    )
+
+    assert subject_mocked_driver.port == "/dev/ot_module_tc_new"
+    mock_driver.move_port.assert_called_once_with("/dev/ot_module_tc_new")
+
+
+async def test_attempt_reconnect_skipped_off_robot(
+    subject_mocked_driver: modules.Thermocycler,
+    mock_driver: mock.AsyncMock,
+) -> None:
+    """It should no-op the reconnect attempt when not running on a robot."""
+    with mock.patch("opentrons.hardware_control.modules.thermocycler.IS_ROBOT", False):
+        await subject_mocked_driver.attempt_reconnect()
+
+    mock_driver.is_connected.assert_not_called()
+    mock_driver.disconnect.assert_not_called()
+
+
+async def test_attempt_reconnect_rebuilds_driver_when_disconnected(
+    subject_mocked_driver: modules.Thermocycler,
+    mock_driver: mock.AsyncMock,
+) -> None:
+    """It should rebuild the driver via the factory when the connection is down."""
+    mock_driver.is_connected.return_value = False
+    new_driver = mock.AsyncMock(spec=SimulatingDriver)
+    with (
+        mock.patch("opentrons.hardware_control.modules.thermocycler.IS_ROBOT", True),
+        mock.patch(
+            "opentrons.hardware_control.modules.thermocycler.ThermocyclerDriverFactory.create",
+            mock.AsyncMock(return_value=new_driver),
+        ) as create_mock,
+    ):
+        await subject_mocked_driver.attempt_reconnect()
+
+    mock_driver.is_connected.assert_called_once()
+    create_mock.assert_called_once_with(
+        port=subject_mocked_driver.port, loop=subject_mocked_driver.loop
+    )
+
+    assert subject_mocked_driver._reader._driver is new_driver
+
+
+async def test_attempt_reconnect_keeps_driver_when_still_connected(
+    subject_mocked_driver: modules.Thermocycler,
+    mock_driver: mock.AsyncMock,
+) -> None:
+    """It should not rebuild the driver if the existing connection is still up."""
+    mock_driver.is_connected.return_value = True
+    with (
+        mock.patch("opentrons.hardware_control.modules.thermocycler.IS_ROBOT", True),
+        mock.patch(
+            "opentrons.hardware_control.modules.thermocycler.ThermocyclerDriverFactory.create"
+        ) as create_mock,
+    ):
+        await subject_mocked_driver.attempt_reconnect()
+
+    create_mock.assert_not_called()
+
+    assert subject_mocked_driver._reader._driver is mock_driver
+
+
+async def test_attempt_reconnect_swallows_factory_failure(
+    subject_mocked_driver: modules.Thermocycler,
+    mock_driver: mock.AsyncMock,
+) -> None:
+    """It should not raise if reconnect cannot reestablish the connection."""
+    mock_driver.is_connected.return_value = False
+    with (
+        mock.patch("opentrons.hardware_control.modules.thermocycler.IS_ROBOT", True),
+        mock.patch(
+            "opentrons.hardware_control.modules.thermocycler.ThermocyclerDriverFactory.create",
+            mock.AsyncMock(side_effect=OSError("port gone")),
+        ),
+    ):
+        await subject_mocked_driver.attempt_reconnect()


### PR DESCRIPTION
Partially addresses [RQA-5635](https://opentrons.atlassian.net/browse/RQA-5635)

# Overview

PR #21627 added module disconnect tolerance: a mechanism where modules that briefly disconnect on USB are parked for up to 3 seconds and, if they re-enumerate, the old instance is swapped back into `_available_modules`
rather than being destroyed and rebuilt. The swap relies on each module implementing `move_port` and `attempt_reconnect` to actually rewire the old instance's driver to the new port.

We've only implemented these overrides for the Heater-Shaker and TempDeck. The Thermocycler inherited no-op stubs from `mod_abc.AbstractModule`, which simply `pass`. This PR implements TC-specific reconnection logic.


Relevant logs, available in the ticket, too:

```
Jun 16 17:47:29.777012 3444d2 opentrons-api[1107]: Device Removed: ModuleAtPort(port='/dev/ot_module_thermocycler3', name='thermocycler', ...)
Jun 16 17:47:30.625073 3444d2 opentrons-api[1107]: Polling exception
serial.serialutil.SerialException: write failed: [Errno 5] Input/output error
Jun 16 17:47:30.627702 3444d2 opentrons-api[1107]: Thermocycler has encountered an unrecoverable error: write failed: [Errno 5] Input/output error.
Jun 16 17:47:32.499698 3444d2 opentrons-api[1107]: Device Added: ModuleAtPort(port='/dev/ot_module_thermocycler0', name='thermocycler', ...)
Jun 16 17:47:32.631589 3444d2 opentrons-api[1107]: Attempting to find and reconect TC2PVT2023041003
Jun 16 17:47:32.631885 3444d2 opentrons-api[1107]: Found TC2PVT2023041003 was reconnected
Jun 16 17:47:32.632194 3444d2 opentrons-api[1107]: module moved from /dev/ot_module_thermocycler3 to /dev/ot_module_thermocycler0
...
Jun 16 18:28:51.561468 3444d2 opentrons-api[1107]: command.THERMOCYCLER_OPEN:
Jun 16 18:28:55.269225 3444d2 opentrons-api[1107]: ... serial.serialutil.PortNotOpenError: Attempting to use a port that is not open
```

## Changelog

- Thermocycler "attempting to use a port that is not open" errors are handled gracefully.

## Review requests

- This logic is heavily modeled after the existing temp deck reconnect logic. Does it look correct?

## Risk assessment

- seems low given existing patterns


[RQA-5635]: https://opentrons.atlassian.net/browse/RQA-5635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ