### PR TITLE
chore(protocol-designer): remove vacuum module feature flag

### DIFF
--- a/protocol-designer/src/components/organisms/FlexHardware/__tests__/FlexHardware.test.tsx
+++ b/protocol-designer/src/components/organisms/FlexHardware/__tests__/FlexHardware.test.tsx
@@ -10,7 +10,6 @@ import {
 import { renderWithProviders } from '/protocol-designer/__testing-utils__'
 import { i18n } from '/protocol-designer/assets/localization'
 import { useKitchen } from '/protocol-designer/components/organisms/Kitchen/useKitchen'
-import { getEnableVacuumModule } from '/protocol-designer/feature-flags/selectors'
 import {
   getAdditionalEquipmentEntities,
   getDeckConfiguration,
@@ -64,7 +63,6 @@ describe('FlexHardware', () => {
     vi.mocked(DeckConfigurator).mockReturnValue(
       <div>mock DeckConfigurator</div>
     )
-    vi.mocked(getEnableVacuumModule).mockReturnValue(true)
   })
 
   it('should render the deck configurator', () => {

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -39,7 +39,6 @@ import {
 } from '@opentrons/shared-data'
 import { getSlotInLocationStack, uuid } from '@opentrons/step-generation'
 
-import { getEnableVacuumModule } from '/protocol-designer/feature-flags/selectors'
 import { editDeckConfiguration } from '/protocol-designer/step-forms/actions'
 import { getInitialDeckSetup } from '/protocol-designer/step-forms/selectors'
 
@@ -134,7 +133,6 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
   const [allModuleOptions, setAllModuleOptions] = useState<CutoutConfigMap[][]>(
     []
   )
-  const enableVacuumModule = useSelector(getEnableVacuumModule)
   useEffect(
     () => {
       const options = [
@@ -148,13 +146,7 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
       ]
       setAllFixtureOptions(options)
       const moduleOptions = [
-        ...getModuleOptions(
-          cutoutId,
-          addressableAreaId,
-          deckDef,
-          fixtures,
-          enableVacuumModule
-        ),
+        ...getModuleOptions(cutoutId, addressableAreaId, deckDef, fixtures),
       ]
       setAllModuleOptions(moduleOptions)
     },
@@ -179,7 +171,6 @@ export function AddFixtureModal(props: AddFixtureModalProps): JSX.Element {
     deckDefinition: deckDef,
     addressableAreaId,
     fixtures,
-    enableVacuumModule,
   })
 
   let nextStageOptions = null

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/HardwareConfiguratorContainer.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/HardwareConfiguratorContainer.tsx
@@ -1,8 +1,4 @@
-import { useSelector } from 'react-redux'
-
 import { DeckConfigurator } from '@opentrons/components'
-
-import { getEnableVacuumModule } from '/protocol-designer/feature-flags/selectors'
 
 import { useDeckConfigurationEditing } from './utils'
 
@@ -35,14 +31,12 @@ export function HardwareConfiguratorContainer(
     updateInitialDeckState,
   } = props
 
-  const enableVacuumModule = useSelector(getEnableVacuumModule)
   const { addFixtureModal, addFixtureToCutout, removeFixtureFromCutout } =
     useDeckConfigurationEditing(
       deckConfig,
       modules,
       fixtures,
       hasGripper,
-      enableVacuumModule,
       setValue,
       updateInitialDeckState
     )

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/HardwareConfiguratorContainer.test.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/__tests__/HardwareConfiguratorContainer.test.tsx
@@ -5,7 +5,6 @@ import { DeckConfigurator } from '@opentrons/components'
 
 import { renderWithProviders } from '/protocol-designer/__testing-utils__'
 import { i18n } from '/protocol-designer/assets/localization'
-import { getEnableVacuumModule } from '/protocol-designer/feature-flags/selectors'
 
 import { HardwareConfiguratorContainer } from '../HardwareConfiguratorContainer'
 import { useDeckConfigurationEditing } from '../utils'
@@ -50,7 +49,6 @@ describe('HardwareConfiguratorContainer', () => {
       addFixtureToCutout: vi.fn(),
       removeFixtureFromCutout: vi.fn(),
     })
-    vi.mocked(getEnableVacuumModule).mockReturnValue(true)
   })
 
   it('should render the deck configurator and modal', () => {

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/utils.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/utils.tsx
@@ -22,7 +22,6 @@ import {
   THERMOCYCLER_V2_FRONT_FIXTURE,
   THERMOCYCLER_V2_REAR_FIXTURE,
   TRASH_BIN_ADAPTER_FIXTURE,
-  VACUUM_MODULE_V1,
   WASTE_CHUTE_ADDRESSABLE_AREAS,
 } from '@opentrons/shared-data'
 
@@ -66,7 +65,6 @@ export function useDeckConfigurationEditing(
   modules: FormModules | InitialDeckStateModules,
   fixtures: Fixtures,
   hasGripper: boolean,
-  enableVacuumModule: boolean,
   setValue?: UseFormSetValue<WizardFormState>,
   updateInitialDeckState?: (
     value: CutoutConfigMap[],
@@ -304,16 +302,13 @@ export const getModuleFixtures = (
   moduleModel: ModuleModel,
   addressableAreaId: AddressableAreaNamesWithFakes,
   deckDef: DeckDefinition,
-  fixtures: Fixtures,
-  enableVacuumModule: boolean
+  fixtures: Fixtures
 ): CutoutConfigMap[][] => {
   const addressableAreasById = getAAsToFixtureIdFromDeckDefWithFakes(
     cutoutId,
     deckDef
   )
-  const filteredModuleModels = getFilteredModules(moduleModel).filter(
-    model => model !== VACUUM_MODULE_V1 || enableVacuumModule
-  )
+  const filteredModuleModels = getFilteredModules(moduleModel)
   const isStagingAreaInSlot4 =
     fixtures != null &&
     Object.values(fixtures).some(
@@ -346,8 +341,7 @@ export const getModules = (
   cutoutId: CutoutId,
   addressableAreaId: AddressableAreaNamesWithFakes,
   deckDef: DeckDefinition,
-  fixtures: Fixtures,
-  enableVacuumModule: boolean
+  fixtures: Fixtures
 ): CutoutConfigMap[][] => {
   const availableOptions: CutoutConfigMap[][] = []
 
@@ -368,8 +362,7 @@ export const getModules = (
       MAGNETIC_BLOCK_V1,
       addressableAreaId,
       deckDef,
-      fixtures,
-      enableVacuumModule
+      fixtures
     )
   }
 
@@ -382,8 +375,7 @@ export const getModules = (
       model as ModuleModel,
       addressableAreaId,
       deckDef,
-      fixtures,
-      enableVacuumModule
+      fixtures
     )
     availableOptions.push(...moduleOptions)
   })
@@ -395,16 +387,9 @@ export const getModuleOptions = (
   cutoutId: CutoutId,
   addressableAreaId: AddressableAreaNamesWithFakes,
   deckDef: DeckDefinition,
-  fixtures: Fixtures,
-  enableVacuumModule: boolean
+  fixtures: Fixtures
 ): CutoutConfigMap[][] => {
-  return getModules(
-    cutoutId,
-    addressableAreaId,
-    deckDef,
-    fixtures,
-    enableVacuumModule
-  )
+  return getModules(cutoutId, addressableAreaId, deckDef, fixtures)
 }
 
 interface AvailableOptionsProps {
@@ -414,7 +399,6 @@ interface AvailableOptionsProps {
   addressableAreaId: AddressableAreaNamesWithFakes
   fixtures: Fixtures
   existingCutoutFixtureId?: CutoutFixtureIdsWithFakes
-  enableVacuumModule: boolean
 }
 export const getAvailableOptions = (
   props: AvailableOptionsProps
@@ -426,7 +410,6 @@ export const getAvailableOptions = (
     addressableAreaId,
     deckDefinition,
     fixtures,
-    enableVacuumModule,
   } = props
 
   let availableOptions: CutoutConfigMap[][] = []
@@ -443,8 +426,7 @@ export const getAvailableOptions = (
       cutoutId,
       addressableAreaId,
       deckDefinition,
-      fixtures,
-      enableVacuumModule
+      fixtures
     )
   }
   if (optionStage === 'wasteChuteOptions') {

--- a/protocol-designer/src/feature-flags/reducers.ts
+++ b/protocol-designer/src/feature-flags/reducers.ts
@@ -33,8 +33,6 @@ const initialFlags: Flags = {
     _FF_ENV_VARS_.OT_PD_ENABLE_CONCURRENT_MODULE_ACTIONS === '1' || false,
   OT_PD_ENABLE_BY_VOLUME_BUILDER:
     _FF_ENV_VARS_.OT_PD_ENABLE_BY_VOLUME_BUILDER === '1' || false,
-  OT_PD_ENABLE_VACUUM_MODULE:
-    _FF_ENV_VARS_.OT_PD_ENABLE_VACUUM_MODULE === '1' || false,
 }
 // @ts-expect-error(sa, 2021-6-10): cannot use string literals as action type
 // TODO IMMEDIATELY: refactor this to the old fashioned way if we cannot have type safety: https://github.com/redux-utilities/redux-actions/issues/282#issuecomment-595163081

--- a/protocol-designer/src/feature-flags/selectors.ts
+++ b/protocol-designer/src/feature-flags/selectors.ts
@@ -39,7 +39,3 @@ export const getEnableByVolumeBuilder: Selector<boolean> = createSelector(
   getFeatureFlagData,
   flags => flags.OT_PD_ENABLE_BY_VOLUME_BUILDER ?? false
 )
-export const getEnableVacuumModule: Selector<boolean> = createSelector(
-  getFeatureFlagData,
-  flags => flags.OT_PD_ENABLE_VACUUM_MODULE ?? false
-)

--- a/protocol-designer/src/feature-flags/types.ts
+++ b/protocol-designer/src/feature-flags/types.ts
@@ -41,6 +41,7 @@ export const DEPRECATED_FLAGS = [
   'OT_PD_ENABLE_REACT_SCAN',
   'OT_PD_ENABLE_FORK',
   'OT_PD_ENABLE_MULTIPLE_TEMPS_OT2',
+  'OT_PD_ENABLE_VACUUM_MODULE',
 ]
 // union of feature flag string constant IDs
 export type FlagTypes =
@@ -51,7 +52,6 @@ export type FlagTypes =
   | 'OT_PD_ENABLE_CONCURRENT_MODULE_ACTIONS'
   | 'OT_PD_ENABLE_BY_VOLUME_BUILDER'
   | 'OT_PD_ENABLE_CAMERA_SUPPORT'
-  | 'OT_PD_ENABLE_VACUUM_MODULE'
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = [
   'OT_PD_DISABLE_MODULE_RESTRICTIONS',

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/AddStepButton.tsx
@@ -45,10 +45,7 @@ import {
   getMainPagePortalEl,
 } from '/protocol-designer/components/organisms'
 import { OFFDECK } from '/protocol-designer/constants'
-import {
-  getEnableComment,
-  getEnableVacuumModule,
-} from '/protocol-designer/feature-flags/selectors'
+import { getEnableComment } from '/protocol-designer/feature-flags/selectors'
 import {
   getInitialRobotState,
   getRobotStateTimeline,
@@ -152,7 +149,6 @@ export function AddStepButton({
     'flexStacker',
     'vacuum',
   ]
-  const enableVacuumModule = useSelector(getEnableVacuumModule)
   const isStepTypeEnabled: Record<
     Exclude<StepType, 'manualIntervention'>,
     boolean
@@ -169,8 +165,7 @@ export function AddStepButton({
     heaterShaker: getIsModuleOnDeck(modules, HEATERSHAKER_MODULE_TYPE),
     absorbanceReader: getIsModuleOnDeck(modules, ABSORBANCE_READER_TYPE),
     flexStacker: getIsModuleOnDeck(modules, FLEX_STACKER_MODULE_TYPE),
-    vacuum:
-      enableVacuumModule && getIsModuleOnDeck(modules, VACUUM_MODULE_TYPE),
+    vacuum: getIsModuleOnDeck(modules, VACUUM_MODULE_TYPE),
   }
 
   const addStep = (stepType: StepType): ReturnType<any> =>

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/Timeline/__tests__/AddStepButton.test.tsx
@@ -18,10 +18,7 @@ import { makeContext, makeInitialRobotState } from '@opentrons/step-generation'
 import { renderWithProviders } from '/protocol-designer/__testing-utils__'
 import { i18n } from '/protocol-designer/assets/localization'
 import { OFFDECK } from '/protocol-designer/constants'
-import {
-  getEnableComment,
-  getEnableVacuumModule,
-} from '/protocol-designer/feature-flags/selectors'
+import { getEnableComment } from '/protocol-designer/feature-flags/selectors'
 import {
   getInitialRobotState,
   getRobotStateTimeline,
@@ -256,14 +253,12 @@ describe('AddStepButton', () => {
   })
 
   it('should not render vacuum step if vacuum module is not enabled', () => {
-    vi.mocked(getEnableVacuumModule).mockReturnValue(false)
     render(props)
     fireEvent.click(screen.getByText('Add Step'))
     expect(screen.queryByText('Vacuum')).not.toBeInTheDocument()
   })
 
   it('should render vacuum step if vacuum module is enabled', () => {
-    vi.mocked(getEnableVacuumModule).mockReturnValue(true)
     vi.mocked(getInitialDeckSetup).mockReturnValue({
       ...MOCK_INITIAL_DECK_SETUP,
       modules: {
@@ -284,7 +279,6 @@ describe('AddStepButton', () => {
   })
 
   it('should not render vacuum step if vacuum module is not on deck', () => {
-    vi.mocked(getEnableVacuumModule).mockReturnValue(true)
     vi.mocked(getInitialRobotState).mockReturnValue(MOCK_INITIAL_ROBOT_STATE)
     render(props)
     fireEvent.click(screen.getByText('Add Step'))


### PR DESCRIPTION
# Overview

Remove vacuum module feature flag across protocol designer, and deprecate its type.

Closes EXEC-2760

## Test Plan and Hands on Testing

Create a new protocol, and verify that you can add a vacuum module in slot A3, and create vacuum steps.

## Changelog

- remove `getEnableVacuumModule` feature flag from PD
- deprecate feature flag type

## Review requests

see test plan

## Risk assessment

low