### PR TITLE
feat(protocol-designer, step-generation): disallow moving labware to/from an active vacuum

### DIFF
--- a/protocol-designer/src/assets/localization/en/alert.json
+++ b/protocol-designer/src/assets/localization/en/alert.json
@@ -372,6 +372,10 @@
       },
       "TALL_LABWARE_EAST_WEST_OF_HEATER_SHAKER": {
         "body": "The Heater-Shaker labware latch will collide with labware over 53 mm. Move labware to a different slot."
+      },
+      "VACUUM_UNDER_PRESSURE": {
+        "body": "Deactivate the pump to move labware to or from it.",
+        "title": "The vacuum module is under pressure."
       }
     },
     "warning": {

--- a/step-generation/src/commandCreators/atomic/__tests__/moveLabware.test.ts
+++ b/step-generation/src/commandCreators/atomic/__tests__/moveLabware.test.ts
@@ -4,6 +4,8 @@ import {
   fixture12Trough,
   fixtureTiprackAdapter,
   HEATERSHAKER_MODULE_TYPE,
+  VACUUM_MODULE_TYPE,
+  VACUUM_MODULE_V1,
   WASTE_CHUTE_CUTOUT,
 } from '@opentrons/shared-data'
 
@@ -1181,6 +1183,108 @@ describe('moveLabware', () => {
     expect(errors).toHaveLength(1)
     expect(errors[0]).toMatchObject({
       type: 'TIPRACK_LID_NOT_ALLOWED_ON_DECK',
+    })
+  })
+  it('should return an error when trying to move labware to a vacuum module while active', () => {
+    const VACUUM_MODULE_ID = 'vacuumModuleId'
+    const VACUUM_MODULE_SLOT = 'B1'
+
+    invariantContext = {
+      ...invariantContext,
+      moduleEntities: {
+        [VACUUM_MODULE_ID]: {
+          id: VACUUM_MODULE_ID,
+          type: VACUUM_MODULE_TYPE,
+          model: VACUUM_MODULE_V1,
+          pythonName: 'mock_vacuum_module',
+        },
+      },
+    }
+
+    robotState = {
+      ...robotState,
+      modules: {
+        ...robotState.modules,
+        [VACUUM_MODULE_ID]: {
+          slot: VACUUM_MODULE_SLOT,
+          moduleState: {
+            type: VACUUM_MODULE_TYPE,
+            ventStatus: null,
+            numPumpActivitiesStarted: 1,
+            currentPumpActivity: {
+              type: 'indefiniteHold',
+              mode: 'pressure',
+              targetPressure: 10,
+            },
+          },
+        } as any,
+      },
+    }
+
+    const params = {
+      labwareId: SOURCE_LABWARE,
+      strategy: 'usingGripper',
+      newLocation: { moduleId: VACUUM_MODULE_ID },
+    } as MoveLabwareParams
+
+    const result = moveLabware(params, invariantContext, robotState)
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'VACUUM_UNDER_PRESSURE',
+    })
+  })
+  it('should return an error when trying to move labware from a vacuum module while active', () => {
+    const VACUUM_MODULE_ID = 'vacuumModuleId'
+    const VACUUM_MODULE_SLOT = 'B1'
+
+    invariantContext = {
+      ...invariantContext,
+      moduleEntities: {
+        [VACUUM_MODULE_ID]: {
+          id: VACUUM_MODULE_ID,
+          type: VACUUM_MODULE_TYPE,
+          model: VACUUM_MODULE_V1,
+          pythonName: 'mock_vacuum_module',
+        },
+      },
+    }
+
+    robotState = {
+      ...robotState,
+      labware: {
+        ...robotState.labware,
+        [SOURCE_LABWARE]: {
+          stack: [SOURCE_LABWARE, VACUUM_MODULE_ID, VACUUM_MODULE_SLOT],
+        },
+      },
+      modules: {
+        ...robotState.modules,
+        [VACUUM_MODULE_ID]: {
+          slot: VACUUM_MODULE_SLOT,
+          moduleState: {
+            type: VACUUM_MODULE_TYPE,
+            ventStatus: null,
+            numPumpActivitiesStarted: 1,
+            currentPumpActivity: {
+              type: 'indefiniteHold',
+              mode: 'pressure',
+              targetPressure: 10,
+            },
+          },
+        } as any,
+      },
+    }
+
+    const params = {
+      labwareId: SOURCE_LABWARE,
+      strategy: 'usingGripper',
+      newLocation: { slotName: 'A1' },
+    } as MoveLabwareParams
+
+    const result = moveLabware(params, invariantContext, robotState)
+    expect(getErrorResult(result).errors).toHaveLength(1)
+    expect(getErrorResult(result).errors[0]).toMatchObject({
+      type: 'VACUUM_UNDER_PRESSURE',
     })
   })
 })

--- a/step-generation/src/commandCreators/atomic/moveLabware.ts
+++ b/step-generation/src/commandCreators/atomic/moveLabware.ts
@@ -189,6 +189,11 @@ export const moveLabware: CommandCreator<MoveLabwareParams> = (
       initialModuleState.lidOpen !== true
     ) {
       errors.push(errorCreators.absorbanceReaderLidClosed())
+    } else if (
+      initialModuleState.type === VACUUM_MODULE_TYPE &&
+      initialModuleState.currentPumpActivity.type !== 'pumpDeactivated'
+    ) {
+      errors.push(errorCreators.vacuumUnderPressure())
     }
   }
   const destModuleId =
@@ -237,6 +242,11 @@ export const moveLabware: CommandCreator<MoveLabwareParams> = (
       if (destModuleState.lidOpen !== true) {
         errors.push(errorCreators.absorbanceReaderLidClosed())
       }
+    } else if (
+      destModuleState.type === VACUUM_MODULE_TYPE &&
+      destModuleState.currentPumpActivity.type !== 'pumpDeactivated'
+    ) {
+      errors.push(errorCreators.vacuumUnderPressure())
     }
   }
   const isLabwareIdATiprackLid =

--- a/step-generation/src/errorCreators.ts
+++ b/step-generation/src/errorCreators.ts
@@ -527,3 +527,11 @@ export const liveTaskError = (): CommandCreatorError => {
       'This module is currently running a live task. Please wait for it to complete before performing this action.',
   }
 }
+
+export const vacuumUnderPressure = (): CommandCreatorError => {
+  return {
+    type: 'VACUUM_UNDER_PRESSURE',
+    message:
+      'The vacuum module is under pressure. Deactivate the pump to move labware to or from it.',
+  }
+}

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -1089,6 +1089,7 @@ export type ErrorType =
   | 'TIP_VOLUME_EXCEEDED'
   | 'TIPRACK_LID_NOT_ALLOWED_ON_DECK'
   | 'TOO_MANY_TIPS'
+  | 'VACUUM_UNDER_PRESSURE'
 
 export interface CommandCreatorError {
   message: string


### PR DESCRIPTION
# Overview

Add error creator and wire up in moveLabware command creator such that moving a labware to or from an active vacuum module throws a timeline error.

## Test Plan and Hands on Testing
[untitled (54).py](https://github.com/user-attachments/files/29065145/untitled.54.py)

- create or import a protocol that attempts to move a labware to or from a vacuum with pump activity running
- verify that the correct timeline error is thrown
<img width="759" height="73" alt="Screenshot 2026-06-17 at 4 10 12 PM" src="https://github.com/user-attachments/assets/2ee3cfa4-fe3a-4c73-acaf-294ba93280ad" />

## Changelog

- create new `'VACUUM_UNDER_PRESSURE'` error creator
- wire up in `moveLabware` command creator
- add unit tests

## Review requests

see test plan

## Risk assessment

low. adds necessary protection