### PR TITLE
feat(api): prevent moving labware to/from the vacuum module when its running.

### DIFF
--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -254,6 +254,15 @@ class VacuumModule(mod_abc.AbstractModule):
         )
 
     @property
+    def under_vacuum(self) -> bool:
+        state = self.vacuum_state
+        atm_pressure = state.pressure_atm
+        avg_pressure = (state.pressure_abs_a + state.pressure_abs_b) / 2
+        return math.isclose(
+            state.pressure_abs_a, state.pressure_abs_b, abs_tol=PRESSURE_TOL
+        ) and not math.isclose(avg_pressure, atm_pressure, abs_tol=PRESSURE_TOL)
+
+    @property
     def total_cycle_count(self) -> Optional[int]:
         return self._total_cycle_count
 

--- a/api/src/opentrons/protocol_engine/commands/command_unions.py
+++ b/api/src/opentrons/protocol_engine/commands/command_unions.py
@@ -255,6 +255,7 @@ from .move_labware import (
     MoveLabwareCreate,
     MoveLabwareParams,
     MoveLabwareResult,
+    VacuumModuleUnderVacuumMovementError,
 )
 from .move_relative import (
     MoveRelative,
@@ -1008,6 +1009,7 @@ CommandDefinedErrorData = Union[
     DefinedErrorData[OverpressureError],
     DefinedErrorData[LiquidNotFoundError],
     DefinedErrorData[GripperMovementError],
+    DefinedErrorData[VacuumModuleUnderVacuumMovementError],
     DefinedErrorData[StallOrCollisionError],
     DefinedErrorData[FlexStackerStallOrCollisionError],
     DefinedErrorData[FlexStackerShuttleError],

--- a/api/src/opentrons/protocol_engine/commands/move_labware.py
+++ b/api/src/opentrons/protocol_engine/commands/move_labware.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 from pydantic.json_schema import SkipJsonSchema
 from typing_extensions import (
     Literal,
+    NotRequired,
     TypedDict,
     assert_type,
 )  # note: need this instead of typing for py<3.12
@@ -28,6 +29,7 @@ from ..errors import (
     LabwareMovementNotAllowedError,
     LabwareOffsetDoesNotExistError,
     NotSupportedOnRobotType,
+    VacuumModuleStillUnderVacuumError,
 )
 from ..errors.error_occurrence import ErrorOccurrence
 from ..resources import fixture_validation, labware_validation
@@ -142,6 +144,27 @@ class ErrorDetails(TypedDict):
     eventualDestinationLocationSequence: LabwareLocationSequence
 
 
+class VacuumModuleUnderVacuumMovementErrorInfo(TypedDict):
+    """Details for a failed moveLabware due to residual vacuum."""
+
+    moduleId: str
+    currentGaugePressureMbar: NotRequired[float]
+
+
+class VacuumModuleUnderVacuumMovementError(ErrorOccurrence):
+    """Returned when trying to move labware while a Vacuum Module is still under vacuum.
+
+    The pump is not engaged, but the chamber has not yet returned to atmospheric
+    pressure. This error is recoverable by waiting and retrying the move.
+    """
+
+    isDefined: bool = True
+
+    errorType: Literal["vacuumModuleUnderVacuum"] = "vacuumModuleUnderVacuum"
+
+    errorInfo: VacuumModuleUnderVacuumMovementErrorInfo
+
+
 class GripperMovementError(ErrorOccurrence):
     """Returned when something physically goes wrong when the gripper moves labware.
 
@@ -155,7 +178,11 @@ class GripperMovementError(ErrorOccurrence):
     errorInfo: ErrorDetails
 
 
-_ExecuteReturn = SuccessData[MoveLabwareResult] | DefinedErrorData[GripperMovementError]
+_ExecuteReturn = (
+    SuccessData[MoveLabwareResult]
+    | DefinedErrorData[GripperMovementError]
+    | DefinedErrorData[VacuumModuleUnderVacuumMovementError]
+)
 
 
 class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteReturn]):
@@ -337,9 +364,23 @@ class MoveLabwareImplementation(AbstractCommandImpl[MoveLabwareParams, _ExecuteR
             labware_definition_uri=definition_uri,
             labware_location=available_new_location,
         )
-        await self._labware_movement.ensure_movement_not_obstructed_by_module(
-            labware_id=params.labwareId, new_location=available_new_location
-        )
+        try:
+            await self._labware_movement.ensure_movement_not_obstructed_by_module(
+                labware_id=params.labwareId, new_location=available_new_location
+            )
+        except VacuumModuleStillUnderVacuumError as error:
+            return DefinedErrorData(
+                public=VacuumModuleUnderVacuumMovementError(
+                    id=self._model_utils.generate_id(),
+                    createdAt=self._model_utils.get_timestamp(),
+                    detail=error.message,
+                    errorInfo={
+                        "moduleId": error.module_id,
+                        "currentGaugePressureMbar": error.current_gauge_pressure_mbar,
+                    },
+                ),
+                state_update=state_update,
+            )
 
         if params.strategy == LabwareMovementStrategy.USING_GRIPPER:
             if self._state_view.config.robot_type == "OT-2 Standard":
@@ -541,7 +582,7 @@ class MoveLabware(
     BaseCommand[
         MoveLabwareParams,
         MoveLabwareResult,
-        GripperMovementError,
+        GripperMovementError | VacuumModuleUnderVacuumMovementError,
     ]
 ):
     """A ``moveLabware`` command."""

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/start_run_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/start_run_profile.py
@@ -9,6 +9,7 @@ from pydantic.json_schema import SkipJsonSchema
 from typing_extensions import Literal, Type
 
 from ...errors.error_occurrence import ErrorOccurrence
+from ...state import update_types
 from ..command import AbstractCommandImpl, BaseCommand, BaseCommandCreate, SuccessData
 from opentrons.hardware_control.modules.types import (
     VacuumModuleCycle,
@@ -142,11 +143,17 @@ class StartRunProfileImpl(
         self, params: StartRunProfileParams
     ) -> SuccessData[StartRunProfileResult]:
         """Run a vacuum module profile."""
+        state_update = update_types.StateUpdate()
         vm_state = self._state_view.modules.get_vacuum_module_substate(params.moduleId)
         vm_hardware = self._equipment.get_module_hardware_api(vm_state.module_id)
         profile: List[hc_profile_step] = []
+        pump_engaged = False
         for step in params.profile:
             profile.append(step.convert_element())
+            if not isinstance(step, VacuumModuleProfileCycle):
+                pump_engaged = step.enablePump
+
+        state_update.update_vacuum_module_pump_engaged(params.moduleId, pump_engaged)
 
         async def start_run_profile(task_handler: TaskHandler) -> None:
             if vm_hardware is not None:
@@ -155,12 +162,16 @@ class StartRunProfileImpl(
                         profile=profile, vent_after=params.ventAfter
                     )
 
+                    state_update.update_vacuum_module_pump_engaged(
+                        params.moduleId, vm_hardware.pump_running
+                    )
+
         task = await self._task_handler.create_task(
             task_function=start_run_profile, id=params.taskId
         )
 
         return SuccessData(
-            public=StartRunProfileResult(taskId=task.id),
+            public=StartRunProfileResult(taskId=task.id), state_update=state_update
         )
 
 

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_power.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_power.py
@@ -81,6 +81,9 @@ class StartSetVacuumPowerImpl(
         """Start the vacuum pump."""
         state_update = update_types.StateUpdate()
         vm_state = self._state_view.modules.get_vacuum_module_substate(params.moduleId)
+        state_update.update_vacuum_module_pump_engaged(
+            params.moduleId, params.duration is None
+        )
         if params.percentPower < 0 or params.percentPower > 100:
             raise ValueError(
                 f"pump power {params.percentPower} invalid must be between 1 and 100%"
@@ -104,6 +107,10 @@ class StartSetVacuumPowerImpl(
                         await vm_hardware.wait_for_command_duration()
                     else:
                         await vm_hardware.wait_for_target()
+
+                    state_update.update_vacuum_module_pump_engaged(
+                        params.moduleId, vm_hardware.pump_running
+                    )
 
         task = await self._task_handler.create_task(
             task_function=start_set_vacuum_power, id=params.taskId

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_pressure.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_pressure.py
@@ -82,6 +82,10 @@ class StartSetVacuumPressureImpl(
         """Start the vacuum pump."""
         state_update = update_types.StateUpdate()
         vm_state = self._state_view.modules.get_vacuum_module_substate(params.moduleId)
+        state_update.update_vacuum_module_pump_engaged(
+            params.moduleId, params.duration is None
+        )
+
         if (
             params.gaugePressure < MAX_GAUGE_PRESSURE_MBAR
             or params.gaugePressure > MIN_GAUGE_PRESSURE_MBAR
@@ -108,6 +112,10 @@ class StartSetVacuumPressureImpl(
                         await vm_hardware.wait_for_command_duration()
                     else:
                         await vm_hardware.wait_for_target()
+
+                    state_update.update_vacuum_module_pump_engaged(
+                        params.moduleId, vm_hardware.pump_running
+                    )
 
         task = await self._task_handler.create_task(
             task_function=start_set_vacuum_pressure, id=params.taskId

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/stop_vacuum.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/stop_vacuum.py
@@ -53,6 +53,7 @@ class StopVacuumImpl(
         if vm_hardware is not None:
             await vm_hardware.set_vacuum_state(enable_vacuum=False)
 
+        state_update.update_vacuum_module_pump_engaged(params.moduleId, False)
         return SuccessData(public=StopVacuumResult(), state_update=state_update)
 
 

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -100,6 +100,7 @@ from .exceptions import (
     TouchTipIncompatibleArgumentsError,
     UnexpectedProtocolError,
     UnsupportedLabwareForActionError,
+    VacuumModuleStillUnderVacuumError,
     VacuumModuleUnderVacuumError,
     VolumeModeDoesNotExistError,
     WellDoesNotExistError,
@@ -214,5 +215,6 @@ __all__ = [
     "CameraCaptureError",
     "CameraDisabledError",
     "CameraSettingsInvalidError",
+    "VacuumModuleStillUnderVacuumError",
     "VacuumModuleUnderVacuumError",
 ]

--- a/api/src/opentrons/protocol_engine/errors/__init__.py
+++ b/api/src/opentrons/protocol_engine/errors/__init__.py
@@ -100,6 +100,7 @@ from .exceptions import (
     TouchTipIncompatibleArgumentsError,
     UnexpectedProtocolError,
     UnsupportedLabwareForActionError,
+    VacuumModuleUnderVacuumError,
     VolumeModeDoesNotExistError,
     WellDoesNotExistError,
     WrongModuleTypeError,
@@ -213,4 +214,5 @@ __all__ = [
     "CameraCaptureError",
     "CameraDisabledError",
     "CameraSettingsInvalidError",
+    "VacuumModuleUnderVacuumError",
 ]

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -863,7 +863,7 @@ class HeaterShakerLabwareLatchStatusUnknown(ProtocolEngineError):
 
 
 class VacuumModuleUnderVacuumError(ProtocolEngineError):
-    """Raised when trying to move to a labware that's in a Vacuum Module thats under vacuum."""
+    """Raised when trying to move labware while a Vacuum Module pump is engaged."""
 
     def __init__(
         self,
@@ -873,6 +873,38 @@ class VacuumModuleUnderVacuumError(ProtocolEngineError):
     ) -> None:
         """Build a VacuumModuleUnderVacuumError."""
         super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
+
+class VacuumModuleStillUnderVacuumError(ProtocolEngineError):
+    """Raised when trying to move labware while a Vacuum Module is still under vacuum.
+
+    Unlike VacuumModuleUnderVacuumError, this is raised when the pump is not engaged
+    but the chamber has not yet returned to atmospheric pressure. This condition is
+    recoverable at runtime by waiting for pressure to equalize.
+    """
+
+    def __init__(
+        self,
+        module_id: str,
+        current_gauge_pressure_mbar: float,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a VacuumModuleStillUnderVacuumError."""
+        self.module_id = module_id
+        self.current_gauge_pressure_mbar = current_gauge_pressure_mbar
+        super().__init__(
+            ErrorCodes.GENERAL_ERROR,
+            message
+            or (
+                f"Vacuum Module {module_id} is still under vacuum at "
+                f"{current_gauge_pressure_mbar} mbar. Wait for pressure to equalize "
+                "before moving labware to or from it."
+            ),
+            details,
+            wrapping,
+        )
 
 
 class EngageHeightOutOfRangeError(ProtocolEngineError):

--- a/api/src/opentrons/protocol_engine/errors/exceptions.py
+++ b/api/src/opentrons/protocol_engine/errors/exceptions.py
@@ -862,6 +862,19 @@ class HeaterShakerLabwareLatchStatusUnknown(ProtocolEngineError):
         super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
 
 
+class VacuumModuleUnderVacuumError(ProtocolEngineError):
+    """Raised when trying to move to a labware that's in a Vacuum Module thats under vacuum."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a VacuumModuleUnderVacuumError."""
+        super().__init__(ErrorCodes.GENERAL_ERROR, message, details, wrapping)
+
+
 class EngageHeightOutOfRangeError(ProtocolEngineError):
     """Raised when a Magnetic Module engage height is out of bounds."""
 

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -26,7 +26,10 @@ from .thermocycler_plate_lifter import ThermocyclerPlateLifter
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import Axis, OT3Mount
 from opentrons.motion_planning import get_gripper_labware_movement_waypoints
-from opentrons.protocol_engine.errors.exceptions import VacuumModuleUnderVacuumError
+from opentrons.protocol_engine.errors.exceptions import (
+    VacuumModuleStillUnderVacuumError,
+    VacuumModuleUnderVacuumError,
+)
 from opentrons.protocol_engine.execution.vacuum_module_movement_flagger import (
     VacuumModuleMovementFlagger,
 )
@@ -309,3 +312,5 @@ class LabwareMovementHandler:
                     "Cannot move labware to or from a Vacuum Module"
                     " when the pump is running."
                 )
+            except VacuumModuleStillUnderVacuumError:
+                raise

--- a/api/src/opentrons/protocol_engine/execution/labware_movement.py
+++ b/api/src/opentrons/protocol_engine/execution/labware_movement.py
@@ -26,6 +26,10 @@ from .thermocycler_plate_lifter import ThermocyclerPlateLifter
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.types import Axis, OT3Mount
 from opentrons.motion_planning import get_gripper_labware_movement_waypoints
+from opentrons.protocol_engine.errors.exceptions import VacuumModuleUnderVacuumError
+from opentrons.protocol_engine.execution.vacuum_module_movement_flagger import (
+    VacuumModuleMovementFlagger,
+)
 from opentrons.protocol_engine.resources.ot3_validation import ensure_ot3_hardware
 from opentrons.protocol_engine.state.state import StateStore
 from opentrons.types import Point
@@ -53,6 +57,7 @@ class LabwareMovementHandler:
         thermocycler_plate_lifter: Optional[ThermocyclerPlateLifter] = None,
         thermocycler_movement_flagger: Optional[ThermocyclerMovementFlagger] = None,
         heater_shaker_movement_flagger: Optional[HeaterShakerMovementFlagger] = None,
+        vacuum_module_movement_flagger: Optional[VacuumModuleMovementFlagger] = None,
     ) -> None:
         """Initialize a LabwareMovementHandler instance."""
         self._hardware_api = hardware_api
@@ -82,6 +87,14 @@ class LabwareMovementHandler:
             heater_shaker_movement_flagger
             or HeaterShakerMovementFlagger(
                 state_store=self._state_store, hardware_api=self._hardware_api
+            )
+        )
+        self._vm_movement_flagger = (
+            vacuum_module_movement_flagger
+            or VacuumModuleMovementFlagger(
+                state_store=self._state_store,
+                hardware_api=self._hardware_api,
+                equipment=self._equipment,
             )
         )
 
@@ -273,6 +286,9 @@ class LabwareMovementHandler:
                 await self._tc_movement_flagger.ensure_labware_in_open_thermocycler(
                     labware_parent=parent
                 )
+                await self._vm_movement_flagger.ensure_vacuum_module_is_idle(
+                    labware_parent=parent
+                )
                 if not self._state_store.labware.is_lid(labware_id):
                     # Lid placement is actually improved by holding the labware latched on the H/S
                     # So, we skip this check for lids.
@@ -287,4 +303,9 @@ class LabwareMovementHandler:
                 raise LabwareMovementNotAllowedError(
                     "Cannot move labware to or from a Heater-Shaker"
                     " with its labware latch closed."
+                )
+            except VacuumModuleUnderVacuumError:
+                raise LabwareMovementNotAllowedError(
+                    "Cannot move labware to or from a Vacuum Module"
+                    " when the pump is running."
                 )

--- a/api/src/opentrons/protocol_engine/execution/vacuum_module_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/vacuum_module_movement_flagger.py
@@ -8,7 +8,10 @@ from ..types import LabwareLocation, ModuleLocation, ModuleModel
 from .equipment import EquipmentHandler
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons.hardware_control.modules.vacuum_module import VacuumModule
-from opentrons.protocol_engine.errors.exceptions import VacuumModuleUnderVacuumError
+from opentrons.protocol_engine.errors.exceptions import (
+    VacuumModuleStillUnderVacuumError,
+    VacuumModuleUnderVacuumError,
+)
 
 
 class VacuumModuleMovementFlagger:
@@ -43,10 +46,13 @@ class VacuumModuleMovementFlagger:
     ) -> None:
         """Flag unsafe movements to a VacuumModule.
 
-        If the given labware is in a VacuumModule, and that VacuumModule's is
-        currently running according the engine's vacuum_module state as well as
-        the hardware API (for non-virtual modules), raises VacuumModuleRunningError.
-        If it is a virtual module, checks only for vacuum_module state in engine.
+        If the given labware is in a VacuumModule, and that VacuumModule's pump is
+        currently engaged according to the engine's vacuum module state, raises
+        VacuumModuleUnderVacuumError.
+
+        If the pump is not engaged but the hardware reports the module is still under
+        vacuum, raises VacuumModuleStillUnderVacuumError. That error is recoverable at
+        runtime by waiting for pressure to equalize.
 
         Otherwise, no-ops.
         """
@@ -61,28 +67,32 @@ class VacuumModuleMovementFlagger:
         except WrongModuleTypeError:
             return  # Labware on a module, but not a VacuumModule.
 
-        if (
-            vm_substate.pump_engaged
-            or not self._state_store.config.use_virtual_modules
-            and await self._vacuum_module_is_under_vacuum(module_id)
-        ):
+        if vm_substate.pump_engaged:
             raise VacuumModuleUnderVacuumError(
-                f"Vacuum Module {vm_substate.module_id} must not be under active vacuum when moving labware to or from it."
+                f"Vacuum Module {vm_substate.module_id} must not have its pump engaged "
+                "when moving labware to or from it."
             )
 
-    async def _vacuum_module_is_under_vacuum(
+        if not self._state_store.config.use_virtual_modules:
+            vacuum_module = await self._get_hardware_vacuum_module(module_id=module_id)
+            if vacuum_module.under_vacuum:
+                raise VacuumModuleStillUnderVacuumError(
+                    module_id=vm_substate.module_id,
+                    current_gauge_pressure_mbar=(
+                        vacuum_module.vacuum_state.current_gauge_pressure
+                    ),
+                )
+
+    async def _get_hardware_vacuum_module(
         self,
         module_id: str,
-    ) -> bool:
-        """Get vacuum state of the hardware VacuumModule corresponding with the module ID.
+    ) -> VacuumModule:
+        """Get the hardware VacuumModule corresponding with the module ID.
 
         Raises:
             _HardwareVacuumModuleMissingError: If we can't find that VacuumModule in
                 the hardware API.
         """
-        if self._state_store.config.use_virtual_modules:
-            return False
-
         vacuum_module_serial = self._state_store.modules.get_serial_number(
             module_id=module_id
         )
@@ -94,7 +104,7 @@ class VacuumModuleMovementFlagger:
                 f'No VacuumModule found with serial number "{vacuum_module_serial}".'
             )
 
-        return vacuum_module.under_vacuum
+        return vacuum_module
 
     async def _find_vacuum_module_by_serial(
         self, serial_number: str
@@ -102,9 +112,9 @@ class VacuumModuleMovementFlagger:
         """Find the hardware VacuumModule with the given serial number."""
         for module in self._hardware_api.attached_modules:
             if (
-                module.model() == ModuleModel.THERMOCYCLER_MODULE_V1
-                or module.model() == ModuleModel.THERMOCYCLER_MODULE_V2
-            ) and module.device_info["serial"] == serial_number:
+                module.model() == ModuleModel.VACUUM_MODULE_V1
+                and module.device_info["serial"] == serial_number
+            ):
                 return module  # type: ignore[return-value]
         return None
 

--- a/api/src/opentrons/protocol_engine/execution/vacuum_module_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/vacuum_module_movement_flagger.py
@@ -1,0 +1,112 @@
+"""Helpers for flagging unsafe movements to a Vacuum Module."""
+
+from typing import Optional
+
+from ..errors import WrongModuleTypeError
+from ..state.state import StateStore
+from ..types import LabwareLocation, ModuleLocation, ModuleModel
+from .equipment import EquipmentHandler
+from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.modules.vacuum_module import VacuumModule
+from opentrons.protocol_engine.errors.exceptions import VacuumModuleUnderVacuumError
+
+
+class VacuumModuleMovementFlagger:
+    """A helper for flagging unsafe movements to a VacuumModule Module.
+
+    This is only intended for use by movement handlers.
+    It's a separate class for independent testability.
+    """
+
+    def __init__(
+        self,
+        state_store: StateStore,
+        hardware_api: HardwareControlAPI,
+        equipment: EquipmentHandler,
+    ) -> None:
+        """Initialize the VacuumModuleMovementFlagger.
+
+        Args:
+            state_store: The Protocol Engine state store interface. Used to figure out
+                         which VacuumModule a labware is in, if any.
+            hardware_api: The underlying hardware interface. Used to query
+                          VacuumModules' current vacuum states.
+            equipment: The protocol engine interface to move a present vacuum_module to an
+                            operable state if need be.
+        """
+        self._state_store = state_store
+        self._hardware_api = hardware_api
+        self._equipment = equipment
+
+    async def ensure_vacuum_module_is_idle(
+        self, labware_parent: LabwareLocation
+    ) -> None:
+        """Flag unsafe movements to a VacuumModule.
+
+        If the given labware is in a VacuumModule, and that VacuumModule's is
+        currently running according the engine's vacuum_module state as well as
+        the hardware API (for non-virtual modules), raises VacuumModuleRunningError.
+        If it is a virtual module, checks only for vacuum_module state in engine.
+
+        Otherwise, no-ops.
+        """
+        if isinstance(labware_parent, ModuleLocation):
+            module_id = labware_parent.moduleId
+        else:
+            return  # Labware not on a module.
+        try:
+            vm_substate = self._state_store.modules.get_vacuum_module_substate(
+                module_id=module_id
+            )
+        except WrongModuleTypeError:
+            return  # Labware on a module, but not a VacuumModule.
+
+        if (
+            vm_substate.pump_engaged
+            or not self._state_store.config.use_virtual_modules
+            and await self._vacuum_module_is_under_vacuum(module_id)
+        ):
+            raise VacuumModuleUnderVacuumError(
+                f"Vacuum Module {vm_substate.module_id} must not be under active vacuum when moving labware to or from it."
+            )
+
+    async def _vacuum_module_is_under_vacuum(
+        self,
+        module_id: str,
+    ) -> bool:
+        """Get vacuum state of the hardware VacuumModule corresponding with the module ID.
+
+        Raises:
+            _HardwareVacuumModuleMissingError: If we can't find that VacuumModule in
+                the hardware API.
+        """
+        if self._state_store.config.use_virtual_modules:
+            return False
+
+        vacuum_module_serial = self._state_store.modules.get_serial_number(
+            module_id=module_id
+        )
+        vacuum_module = await self._find_vacuum_module_by_serial(
+            serial_number=vacuum_module_serial
+        )
+        if vacuum_module is None:
+            raise self._HardwareVacuumModuleMissingError(
+                f'No VacuumModule found with serial number "{vacuum_module_serial}".'
+            )
+
+        return vacuum_module.under_vacuum
+
+    async def _find_vacuum_module_by_serial(
+        self, serial_number: str
+    ) -> Optional[VacuumModule]:
+        """Find the hardware VacuumModule with the given serial number."""
+        for module in self._hardware_api.attached_modules:
+            if (
+                module.model() == ModuleModel.THERMOCYCLER_MODULE_V1
+                or module.model() == ModuleModel.THERMOCYCLER_MODULE_V2
+            ) and module.device_info["serial"] == serial_number:
+                return module  # type: ignore[return-value]
+        return None
+
+    class _HardwareVacuumModuleMissingError(Exception):
+        pass

--- a/api/src/opentrons/protocol_engine/state/module_substates/vacuum_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/vacuum_module_substate.py
@@ -27,7 +27,7 @@ class VacuumModuleSubState:
         """Return a new state with the given update applied."""
         new_pump_engaged = self.pump_engaged
         if isinstance(update.pump_engaged, bool):
-            new_pump_engaged = self.pump_engaged
+            new_pump_engaged = update.pump_engaged
         return VacuumModuleSubState(
             module_id=self.module_id, pump_engaged=new_pump_engaged
         )

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -312,6 +312,9 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
         if state_update.flex_stacker_state_update != update_types.NO_CHANGE:
             self._handle_flex_stacker_commands(state_update.flex_stacker_state_update)
 
+        if state_update.vacuum_module_state_update != update_types.NO_CHANGE:
+            self._handle_vacuum_module_commands(state_update.vacuum_module_state_update)
+
     def _module_model_map(
         self, module_id: str, actual_model: Any, module_live_data: Any
     ) -> Any:

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -979,6 +979,18 @@ class StateUpdate:
         )
         return self
 
+    def update_vacuum_module_pump_engaged(
+        self, module_id: str, pump_engaged: bool
+    ) -> Self:
+        """Set the pump engaged state."""
+        self.vacuum_module_state_update = dataclasses.replace(
+            VacuumModuleStateUpdate.create_or_override(
+                self.vacuum_module_state_update, module_id
+            ),
+            pump_engaged=pump_engaged,
+        )
+        return self
+
     def set_pipette_ready_to_aspirate(
         self, pipette_id: str, ready_to_aspirate: bool
     ) -> Self:

--- a/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
+++ b/api/tests/opentrons/protocol_engine/commands/test_move_labware.py
@@ -28,6 +28,7 @@ from opentrons.protocol_engine.commands.move_labware import (
     MoveLabwareImplementation,
     MoveLabwareParams,
     MoveLabwareResult,
+    VacuumModuleUnderVacuumMovementError,
 )
 from opentrons.protocol_engine.execution import (
     EquipmentHandler,
@@ -1204,4 +1205,162 @@ async def test_vacuum_module_dock_incompatibility_raises(
     )
 
     with pytest.raises(errors.LabwareIsNotAllowedInLocationError):
+        await subject.execute(data)
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        LabwareMovementStrategy.MANUAL_MOVE_WITHOUT_PAUSE,
+        LabwareMovementStrategy.USING_GRIPPER,
+    ],
+)
+async def test_move_labware_raises_when_vacuum_module_still_under_vacuum(
+    decoy: Decoy,
+    subject: MoveLabwareImplementation,
+    equipment: EquipmentHandler,
+    labware_movement: LabwareMovementHandler,
+    state_view: StateView,
+    model_utils: ModelUtils,
+    strategy: LabwareMovementStrategy,
+) -> None:
+    """It should raise a defined error when the vacuum chamber is still evacuated."""
+    labware_id = "manifold-collar-id"
+    module_id = "vacuum-module-id"
+    current_gauge_pressure_mbar = -275.0
+    error_id = "vacuum-error-id"
+    error_created_at = datetime.now()
+    origin_location = ModuleLocation(moduleId=module_id)
+    new_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_4)
+    available_new_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_5)
+
+    data = MoveLabwareParams(
+        labwareId=labware_id,
+        newLocation=new_location,
+        strategy=strategy,
+    )
+    lw_def = LabwareDefinition2.model_construct(
+        namespace="opentrons-test",
+        parameters=Parameters2.model_construct(),  # type: ignore[call-arg]
+    )
+
+    decoy.when(state_view.labware.get(labware_id=labware_id)).then_return(
+        LoadedLabware(
+            id=labware_id,
+            loadName="load-name",
+            definitionUri="opentrons-test/load-name/1",
+            location=origin_location,
+            offsetId=None,
+        )
+    )
+    decoy.when(state_view.labware.get_definition(labware_id=labware_id)).then_return(
+        lw_def
+    )
+    decoy.when(
+        state_view.geometry.ensure_location_not_occupied(new_location, None, lw_def)
+    ).then_return(available_new_location)
+    decoy.when(
+        equipment.find_applicable_labware_offset_id(
+            labware_definition_uri="opentrons-test/load-name/1",
+            labware_location=available_new_location,
+        )
+    ).then_return("wowzers-a-new-offset-id")
+    decoy.when(
+        await labware_movement.ensure_movement_not_obstructed_by_module(  # type: ignore[func-returns-value]
+            labware_id=labware_id,
+            new_location=available_new_location,
+        )
+    ).then_raise(
+        errors.VacuumModuleStillUnderVacuumError(
+            module_id=module_id,
+            current_gauge_pressure_mbar=current_gauge_pressure_mbar,
+        )
+    )
+    decoy.when(model_utils.get_timestamp()).then_return(error_created_at)
+    decoy.when(model_utils.generate_id()).then_return(error_id)
+
+    result = await subject.execute(data)
+
+    assert result == DefinedErrorData(
+        public=VacuumModuleUnderVacuumMovementError.model_construct(
+            id=error_id,
+            createdAt=error_created_at,
+            detail=(
+                f"Vacuum Module {module_id} is still under vacuum at "
+                f"{current_gauge_pressure_mbar} mbar. Wait for pressure to equalize "
+                "before moving labware to or from it."
+            ),
+            errorInfo={
+                "moduleId": module_id,
+                "currentGaugePressureMbar": current_gauge_pressure_mbar,
+            },
+        ),
+        state_update=update_types.StateUpdate(
+            addressable_area_used=update_types.AddressableAreaUsedUpdate(
+                addressable_area_name=new_location.slotName.id
+            ),
+        ),
+    )
+
+
+async def test_move_labware_raises_when_vacuum_module_pump_engaged(
+    decoy: Decoy,
+    subject: MoveLabwareImplementation,
+    equipment: EquipmentHandler,
+    labware_movement: LabwareMovementHandler,
+    state_view: StateView,
+) -> None:
+    """It should raise when the vacuum module pump is still engaged."""
+    labware_id = "manifold-collar-id"
+    module_id = "vacuum-module-id"
+    origin_location = ModuleLocation(moduleId=module_id)
+    new_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_4)
+    available_new_location = DeckSlotLocation(slotName=DeckSlotName.SLOT_5)
+
+    data = MoveLabwareParams(
+        labwareId=labware_id,
+        newLocation=new_location,
+        strategy=LabwareMovementStrategy.MANUAL_MOVE_WITHOUT_PAUSE,
+    )
+    lw_def = LabwareDefinition2.model_construct(
+        namespace="opentrons-test",
+        parameters=Parameters2.model_construct(),  # type: ignore[call-arg]
+    )
+
+    decoy.when(state_view.labware.get(labware_id=labware_id)).then_return(
+        LoadedLabware(
+            id=labware_id,
+            loadName="load-name",
+            definitionUri="opentrons-test/load-name/1",
+            location=origin_location,
+            offsetId=None,
+        )
+    )
+    decoy.when(state_view.labware.get_definition(labware_id=labware_id)).then_return(
+        lw_def
+    )
+    decoy.when(
+        state_view.geometry.ensure_location_not_occupied(new_location, None, lw_def)
+    ).then_return(available_new_location)
+    decoy.when(
+        equipment.find_applicable_labware_offset_id(
+            labware_definition_uri="opentrons-test/load-name/1",
+            labware_location=available_new_location,
+        )
+    ).then_return("wowzers-a-new-offset-id")
+    decoy.when(
+        await labware_movement.ensure_movement_not_obstructed_by_module(  # type: ignore[func-returns-value]
+            labware_id=labware_id,
+            new_location=available_new_location,
+        )
+    ).then_raise(
+        errors.LabwareMovementNotAllowedError(
+            "Cannot move labware to or from a Vacuum Module when the pump is running."
+        )
+    )
+
+    with pytest.raises(
+        errors.LabwareMovementNotAllowedError,
+        match="when the pump is running",
+    ):
         await subject.execute(data)

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_run_profile.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_run_profile.py
@@ -24,6 +24,7 @@ from opentrons.protocol_engine.commands.vacuum_module.start_run_profile import (
 )
 from opentrons.protocol_engine.execution import EquipmentHandler, TaskHandler
 from opentrons.protocol_engine.resources import ModelUtils
+from opentrons.protocol_engine.state import update_types
 from opentrons.protocol_engine.state.module_substates import (
     VacuumModuleId,
     VacuumModuleSubState,
@@ -162,6 +163,7 @@ async def test_start_run_profile(
     decoy.when(
         equipment.get_module_hardware_api(VacuumModuleId("vacuum-module-id"))
     ).then_return(vm_hardware)
+    decoy.when(vm_hardware.pump_running).then_return(False)
 
     task: Task | None = None
 
@@ -183,4 +185,12 @@ async def test_start_run_profile(
     decoy.verify(
         await vm_hardware.execute_profile(profile=expected_hc_steps, vent_after=True)
     )
-    assert result == SuccessData(public=expected_result)
+    expected_state_update = update_types.StateUpdate()
+    expected_state_update.update_vacuum_module_pump_engaged(
+        "input-vacuum_module-id", False
+    )
+
+    assert result == SuccessData(
+        public=expected_result,
+        state_update=expected_state_update,
+    )

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_power.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_power.py
@@ -61,6 +61,7 @@ async def test_start_set_vacuum_power(
     decoy.when(equipment.get_module_hardware_api(expected_module_id)).then_return(
         vm_hardware
     )
+    decoy.when(vm_hardware.pump_running).then_return(True)
 
     task: Task | None = None
 
@@ -87,7 +88,10 @@ async def test_start_set_vacuum_power(
             vent_after=True,
         )
     )
+    expected_state_update = update_types.StateUpdate()
+    expected_state_update.update_vacuum_module_pump_engaged("input-vacuum-id", True)
+
     assert result == SuccessData(
         public=expected_result,
-        state_update=update_types.StateUpdate(),
+        state_update=expected_state_update,
     )

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_pressure.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_pressure.py
@@ -69,6 +69,7 @@ async def test_start_set_vacuum_presure(
     decoy.when(equipment.get_module_hardware_api(expected_module_id)).then_return(
         vm_hardware
     )
+    decoy.when(vm_hardware.pump_running).then_return(False)
 
     task: Task | None = None
 
@@ -96,7 +97,10 @@ async def test_start_set_vacuum_presure(
         )
     )
 
+    expected_state_update = update_types.StateUpdate()
+    expected_state_update.update_vacuum_module_pump_engaged("input-vacuum-id", False)
+
     assert result == SuccessData(
         public=expected_result,
-        state_update=update_types.StateUpdate(),
+        state_update=expected_state_update,
     )

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_stop_vacuum.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_stop_vacuum.py
@@ -48,7 +48,11 @@ async def test_stop_vacuum(
     result = await subject.execute(data)
 
     decoy.verify(await vm_hardware.set_vacuum_state(enable_vacuum=False))
+
+    expected_state_update = update_types.StateUpdate()
+    expected_state_update.update_vacuum_module_pump_engaged("input-vacuum-id", False)
+
     assert result == SuccessData(
         public=expected_result,
-        state_update=update_types.StateUpdate(),
+        state_update=expected_state_update,
     )

--- a/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_labware_movement_handler.py
@@ -32,6 +32,9 @@ from opentrons.protocol_engine.execution.thermocycler_movement_flagger import (
 from opentrons.protocol_engine.execution.thermocycler_plate_lifter import (
     ThermocyclerPlateLifter,
 )
+from opentrons.protocol_engine.execution.vacuum_module_movement_flagger import (
+    VacuumModuleMovementFlagger,
+)
 from opentrons.protocol_engine.state.state import StateStore
 from opentrons.protocol_engine.types import (
     DeckSlotLocation,
@@ -89,6 +92,12 @@ def heater_shaker_movement_flagger(decoy: Decoy) -> HeaterShakerMovementFlagger:
 
 
 @pytest.fixture
+def vacuum_module_movement_flagger(decoy: Decoy) -> VacuumModuleMovementFlagger:
+    """Get a mocked out VacuumModuleMovementFlagger instance."""
+    return decoy.mock(cls=VacuumModuleMovementFlagger)
+
+
+@pytest.fixture
 def labware_def(decoy: Decoy) -> LabwareDefinition2:
     """Get a mocked out LabwareDefinition2 instance."""
     return decoy.mock(cls=LabwareDefinition2)
@@ -143,6 +152,7 @@ def subject(
     thermocycler_plate_lifter: ThermocyclerPlateLifter,
     thermocycler_movement_flagger: ThermocyclerMovementFlagger,
     heater_shaker_movement_flagger: HeaterShakerMovementFlagger,
+    vacuum_module_movement_flagger: VacuumModuleMovementFlagger,
 ) -> LabwareMovementHandler:
     """Get LabwareMovementHandler for OT3, with its dependencies mocked out."""
     return LabwareMovementHandler(
@@ -153,6 +163,7 @@ def subject(
         thermocycler_plate_lifter=thermocycler_plate_lifter,
         thermocycler_movement_flagger=thermocycler_movement_flagger,
         heater_shaker_movement_flagger=heater_shaker_movement_flagger,
+        vacuum_module_movement_flagger=vacuum_module_movement_flagger,
     )
 
 

--- a/api/tests/opentrons/protocol_engine/execution/test_vacuum_module_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_vacuum_module_movement_flagger.py
@@ -1,0 +1,201 @@
+"""Tests for vacuum_module_movement_flagger."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from decoy import Decoy
+
+from opentrons.hardware_control import API as HardwareAPI
+from opentrons.hardware_control.modules.vacuum_module import VacuumModule
+from opentrons.protocol_engine.errors import (
+    VacuumModuleStillUnderVacuumError,
+    VacuumModuleUnderVacuumError,
+    WrongModuleTypeError,
+)
+from opentrons.protocol_engine.execution.equipment import EquipmentHandler
+from opentrons.protocol_engine.execution.vacuum_module_movement_flagger import (
+    VacuumModuleMovementFlagger,
+)
+from opentrons.protocol_engine.state.config import Config
+from opentrons.protocol_engine.state.module_substates.vacuum_module_substate import (
+    VacuumModuleId,
+    VacuumModuleSubState,
+)
+from opentrons.protocol_engine.state.state import StateStore
+from opentrons.protocol_engine.types import (
+    DeckSlotLocation,
+    DeckType,
+    ModuleLocation,
+    ModuleModel,
+)
+from opentrons.types import DeckSlotName
+
+
+@pytest.fixture
+def hardware_api(decoy: Decoy) -> HardwareAPI:
+    """Get a mock in the shape of a HardwareAPI."""
+    return decoy.mock(cls=HardwareAPI)
+
+
+@pytest.fixture
+def equipment(decoy: Decoy) -> EquipmentHandler:
+    """Get a mock in the shape of an EquipmentHandler."""
+    return decoy.mock(cls=EquipmentHandler)
+
+
+@pytest.fixture
+def state_store(decoy: Decoy) -> StateStore:
+    """Get a mock in the shape of a StateStore."""
+    return decoy.mock(cls=StateStore)
+
+
+@pytest.fixture
+def subject(
+    state_store: StateStore,
+    hardware_api: HardwareAPI,
+    equipment: EquipmentHandler,
+) -> VacuumModuleMovementFlagger:
+    """Return a vacuum module movement flagger initialized with mocked dependencies."""
+    return VacuumModuleMovementFlagger(
+        state_store=state_store,
+        hardware_api=hardware_api,
+        equipment=equipment,
+    )
+
+
+async def test_ensure_vacuum_module_is_idle_noops_for_non_module_location(
+    subject: VacuumModuleMovementFlagger,
+) -> None:
+    """It should no-op when labware is not on a module."""
+    await subject.ensure_vacuum_module_is_idle(
+        labware_parent=DeckSlotLocation(slotName=DeckSlotName.SLOT_1)
+    )
+
+
+async def test_ensure_vacuum_module_is_idle_noops_for_non_vacuum_module(
+    decoy: Decoy,
+    subject: VacuumModuleMovementFlagger,
+    state_store: StateStore,
+) -> None:
+    """It should no-op when labware is on a non-vacuum module."""
+    decoy.when(
+        state_store.modules.get_vacuum_module_substate(module_id="module-id")
+    ).then_raise(WrongModuleTypeError("not a vacuum module"))
+
+    await subject.ensure_vacuum_module_is_idle(
+        labware_parent=ModuleLocation(moduleId="module-id")
+    )
+
+
+async def test_ensure_vacuum_module_is_idle_raises_when_pump_engaged(
+    decoy: Decoy,
+    subject: VacuumModuleMovementFlagger,
+    state_store: StateStore,
+) -> None:
+    """It should raise when the vacuum module pump is engaged."""
+    decoy.when(
+        state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
+    ).then_return(
+        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=True)
+    )
+
+    with pytest.raises(VacuumModuleUnderVacuumError, match="pump engaged"):
+        await subject.ensure_vacuum_module_is_idle(
+            labware_parent=ModuleLocation(moduleId="vacuum-id")
+        )
+
+
+async def test_ensure_vacuum_module_is_idle_raises_when_hardware_still_under_vacuum(
+    decoy: Decoy,
+    subject: VacuumModuleMovementFlagger,
+    state_store: StateStore,
+    hardware_api: HardwareAPI,
+) -> None:
+    """It should raise with gauge pressure when the chamber is still under vacuum."""
+    decoy.when(state_store.config).then_return(
+        Config(
+            robot_type="OT-3 Standard",
+            deck_type=DeckType.OT3_STANDARD,
+            use_virtual_modules=False,
+        )
+    )
+    decoy.when(
+        state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
+    ).then_return(
+        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=False)
+    )
+    decoy.when(
+        state_store.modules.get_serial_number(module_id="vacuum-id")
+    ).then_return("vacuum-serial")
+
+    hardware_vacuum_module = MagicMock(spec=VacuumModule)
+    hardware_vacuum_module.model.return_value = ModuleModel.VACUUM_MODULE_V1
+    hardware_vacuum_module.device_info = {"serial": "vacuum-serial"}
+    hardware_vacuum_module.vacuum_state.current_gauge_pressure = -250.0
+    type(hardware_vacuum_module).under_vacuum = property(lambda self: True)  # noqa: ARG005
+    decoy.when(hardware_api.attached_modules).then_return([hardware_vacuum_module])
+
+    with pytest.raises(VacuumModuleStillUnderVacuumError, match="-250") as exc_info:
+        await subject.ensure_vacuum_module_is_idle(
+            labware_parent=ModuleLocation(moduleId="vacuum-id")
+        )
+
+    assert exc_info.value.current_gauge_pressure_mbar == -250.0
+
+
+async def test_ensure_vacuum_module_is_idle_noops_when_hardware_not_under_vacuum(
+    decoy: Decoy,
+    subject: VacuumModuleMovementFlagger,
+    state_store: StateStore,
+    hardware_api: HardwareAPI,
+) -> None:
+    """It should no-op when the pump is off and the chamber is at atmospheric pressure."""
+    decoy.when(state_store.config).then_return(
+        Config(
+            robot_type="OT-3 Standard",
+            deck_type=DeckType.OT3_STANDARD,
+            use_virtual_modules=False,
+        )
+    )
+    decoy.when(
+        state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
+    ).then_return(
+        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=False)
+    )
+    decoy.when(
+        state_store.modules.get_serial_number(module_id="vacuum-id")
+    ).then_return("vacuum-serial")
+
+    hardware_vacuum_module = MagicMock(spec=VacuumModule)
+    hardware_vacuum_module.model.return_value = ModuleModel.VACUUM_MODULE_V1
+    hardware_vacuum_module.device_info = {"serial": "vacuum-serial"}
+    type(hardware_vacuum_module).under_vacuum = property(lambda self: False)  # noqa: ARG005
+    decoy.when(hardware_api.attached_modules).then_return([hardware_vacuum_module])
+
+    await subject.ensure_vacuum_module_is_idle(
+        labware_parent=ModuleLocation(moduleId="vacuum-id")
+    )
+
+
+async def test_ensure_vacuum_module_is_idle_skips_hardware_check_for_virtual_modules(
+    decoy: Decoy,
+    subject: VacuumModuleMovementFlagger,
+    state_store: StateStore,
+) -> None:
+    """It should not query hardware when using virtual modules."""
+    decoy.when(state_store.config).then_return(
+        Config(
+            robot_type="OT-3 Standard",
+            deck_type=DeckType.OT3_STANDARD,
+            use_virtual_modules=True,
+        )
+    )
+    decoy.when(
+        state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
+    ).then_return(
+        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=False)
+    )
+
+    await subject.ensure_vacuum_module_is_idle(
+        labware_parent=ModuleLocation(moduleId="vacuum-id")
+    )

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/protocol_api_demo/vacuum_module_api_demo.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/protocol_api_demo/vacuum_module_api_demo.py
@@ -331,7 +331,7 @@ def run(ctx: ProtocolContext) -> None:
                 },
                 {
                     "enable_pump": True,
-                    "gauge_pressure_mbar": -9800,
+                    "gauge_pressure_mbar": -800,
                     "hold_time_seconds": 10,
                     "vent_after": True,
                 },

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/slas_2026_demo/millipore_vacuum_manifold_collar_short.json
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/slas_2026_demo/millipore_vacuum_manifold_collar_short.json
@@ -55,7 +55,7 @@
     "vacuumModuleV1": {
       "x": 0,
       "y": 0,
-      "z": -8.0
+      "z": 0
     }
   },
   "stackingOffsetWithLabware": {
@@ -67,7 +67,7 @@
   },
   "stackLimit": 1,
   "gripForce": 17,
-  "gripHeightFromLabwareBottom": 45,
+  "gripHeightFromLabwareBottom": 53,
   "containedSpace": {
     "shape": "rectangular",
     "origin": { "x": 0, "y": 0, "z": 0 },

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/slas_2026_demo/millipore_vacuum_manifold_collar_tall.json
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/slas_2026_demo/millipore_vacuum_manifold_collar_tall.json
@@ -24,7 +24,7 @@
   "version": 1,
   "metadata": {
     "tags": [],
-    "displayName": "Millipore Vacuum Manifold Collar (Tall)",
+    "displayName": "Millipore Vacuum Manifold Collar Tall",
     "displayCategory": "adapter",
     "displayVolumeUnits": "µL"
   },
@@ -63,11 +63,11 @@
     "vacuumModuleV1": {
       "x": 0,
       "y": 0,
-      "z": -8.0
+      "z": 0
     }
   },
   "gripForce": 17,
-  "gripHeightFromLabwareBottom": 66,
+  "gripHeightFromLabwareBottom": 74,
   "containedSpace": {
     "shape": "rectangular",
     "origin": { "x": 0, "y": 0, "z": 0 },

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_qc_protocol.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_qc_protocol.py
@@ -206,7 +206,7 @@ def run(ctx: ProtocolContext) -> None:
                     },
                 ],
                 repetitions=1,
-                vent_after=False
+                vent_after=False,
             )
             ctx.wait_for_tasks([task3])
 

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_qc_protocol.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_qc_protocol.py
@@ -206,6 +206,7 @@ def run(ctx: ProtocolContext) -> None:
                     },
                 ],
                 repetitions=1,
+                vent_after=False
             )
             ctx.wait_for_tasks([task3])
 

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_still_under_vacuum_test.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_still_under_vacuum_test.py
@@ -1,0 +1,131 @@
+"""Runtime test for VacuumModuleStillUnderVacuumError on moveLabware.
+
+Evacuates the vacuum module chamber, waits for the pump to stop, then attempts to
+move labware off the module while pressure is still below atmospheric. On real
+hardware this should return a recoverable ``vacuumModuleUnderVacuum`` defined error
+on ``moveLabware``. Protocol analysis and simulation will pass the move because the
+under-vacuum hardware check is not performed with virtual modules.
+
+Expected runtime flow:
+1. Protocol evacuates the chamber and stops the pump (vent stays closed).
+2. The gripper move to the dock fails with ``vacuumModuleUnderVacuum``.
+3. Open the vent (or call ``stop_vacuum_pump()``) and wait for pressure to equalize.
+4. Resume the run; the retried move should succeed.
+"""
+from typing import cast
+
+from opentrons.protocol_api import (
+    ParameterContext,
+    ProtocolContext,
+    VacuumModuleContext,
+)
+
+metadata = {
+    "protocolName": "Vacuum Module Still Under Vacuum Error Test",
+    "author": "Opentrons <protocols@opentrons.com>",
+    "description": (
+        "Triggers the recoverable vacuumModuleUnderVacuum defined error on "
+        "moveLabware when the pump is off but the chamber is still evacuating."
+    ),
+}
+requirements = {
+    "robotType": "Flex",
+    "apiLevel": "2.30",
+}
+
+
+def add_parameters(parameters: ParameterContext) -> None:
+    """Runtime parameters."""
+    parameters.add_str(
+        variable_name="collar",
+        display_name="Vacuum Collar",
+        description="Collar loaded on the vacuum module dock.",
+        default="opentrons_vacuum_manifold_collar_short",
+        choices=[
+            {
+                "display_name": "Opentrons: Short",
+                "value": "opentrons_vacuum_manifold_collar_short",
+            },
+            {
+                "display_name": "Opentrons: Tall",
+                "value": "opentrons_vacuum_manifold_collar_tall",
+            },
+            {
+                "display_name": "Millipore: Short",
+                "value": "millipore_vacuum_manifold_collar_short",
+            },
+            {
+                "display_name": "Millipore: Tall",
+                "value": "millipore_vacuum_manifold_collar_tall",
+            },
+        ],
+    )
+    parameters.add_int(
+        display_name="Target Pressure (mbar)",
+        variable_name="target_pressure_mbar",
+        description="Gauge pressure setpoint. More negative = stronger vacuum.",
+        default=-300,
+        minimum=-800,
+        maximum=-50,
+    )
+    parameters.add_int(
+        display_name="Vacuum Hold (seconds)",
+        variable_name="vacuum_hold_seconds",
+        description="Timed pump run. Vent stays closed after the pump stops.",
+        default=10,
+        minimum=5,
+        maximum=120,
+    )
+
+
+def run(ctx: ProtocolContext) -> None:
+    """Evacuate the module, then attempt a labware move while still under vacuum."""
+    vm_mod = cast(
+        VacuumModuleContext,
+        ctx.load_module(module_name="vacuumModuleV1", location="A3"),
+    )
+    ctx.load_trash_bin("A1")
+
+    collar = vm_mod.load_adapter_to_dock(ctx.params.collar)  # type: ignore[attr-defined]
+    target_pressure = ctx.params.target_pressure_mbar  # type: ignore[attr-defined]
+    hold_seconds = ctx.params.vacuum_hold_seconds  # type: ignore[attr-defined]
+
+    ctx.home()
+
+    ctx.comment("Move collar from dock onto vacuum module.")
+    ctx.move_labware(collar, vm_mod, use_gripper=True)
+
+    ctx.comment(
+        f"Evacuate to {target_pressure} mbar for {hold_seconds}s with vent closed. "
+        "Pump will stop when the timer expires; chamber stays under vacuum."
+    )
+    vm_mod.close_vent()
+    vacuum_task = vm_mod.start_set_vacuum_pressure(
+        target_pressure,
+        hold_seconds,
+        vent_after=False,
+    )
+    ctx.wait_for_tasks([vacuum_task])
+
+    ctx.comment(
+        "Pump is off but chamber should still be under vacuum. "
+        "NEXT MOVE SHOULD FAIL on real hardware with recoverable error "
+        "vacuumModuleUnderVacuum (VacuumModuleStillUnderVacuumError). "
+        "Analysis/simulation will not raise this error."
+    )
+    ctx.pause(
+        "Ready to attempt move while chamber is still under vacuum. "
+        "On hardware, expect vacuumModuleUnderVacuum. "
+        "After the error, open the vent and resume to retry the move."
+    )
+
+    ctx.move_labware(collar, vm_mod.manifold_dock, use_gripper=True)  # type: ignore[attr-defined]
+
+    ctx.comment(
+        "Move succeeded. If this followed a recoverable error, venting and "
+        "resuming worked as expected."
+    )
+
+    ctx.comment("Cleanup: vent chamber and return collar to module.")
+    vm_mod.stop_vacuum_pump()
+    ctx.move_labware(collar, vm_mod, use_gripper=True)


### PR DESCRIPTION
# Overview

Prevent moving labware to/from a vacuum module when it is running and is under vacuum at analysis and runtime. Raise a new `VacuumModuleStillUnderVacuumError` error at run time if we try to move labware while the vacuum module is still under vacuum.

## Test Plan and Hands on Testing

- [x] Make sure you get an analysis error `VacuumModuleUnderVacuumError` when attempting to move a labware with the gripper to/from the vacuum module after calling `start_set_vacuum_pressure` or `start_set_vacuum_power` when running indefinitely (duration=None)
```python
        vm_mod.close_vent()
        task1 = vm_mod.start_set_vacuum_pressure(-300, vent_after=True)

        # This should fail ❌ analysis, because the last state of the pump is running
        ctx.move_labware(manifold_collar, vm_mod.manifold_dock, use_gripper=True)
        ctx.wait_for_tasks([task1])

        # Using stop_vacuum_pump sets the pump state back to not running
        task1 = vm_mod.start_set_vacuum_pressure(-300, vent_after=True)
        ctx.wait_for_tasks([task1])
        vm_mod.stop_vacuum_pump()

        # This should ✅ PASS analysis, because the last state of the pump is NOT running
        ctx.move_labware(manifold_collar, vm_mod.manifold_dock, use_gripper=True)
```
- [x] Make sure you get an analysis error when attempting to move labware with the gripper to/from the vacuum module after calling `start_run_profile` if the last step has no `duration` or `pump_enable` is True.
```python
            vm_mod.close_vent()
            task3 = vm_mod.start_execute_profile(
                steps=[
                    {
                        "enable_pump": True,
                        "gauge_pressure_mbar": -200,
                        "hold_time_seconds": 10,
                        "vent_after": False,
                    },
                    {
                        "enable_pump": True,
                        "hold_time_seconds": 20,
                        "vent_after": False,
                    },
                ],
                repetitions=1,
                vent_after=False
            )
             # This should ❌ fail analysis, because the last state of enable_pump is True
            ctx.move_labware(manifold_collar, vm_mod, use_gripper=True)
            ctx.wait_for_tasks([task3])
```
- [x] Make sure we send `VacuumModuleStillUnderVacuumError` in error recovery when attempting to move labware to/from vacuum module under vacuum.

## Changelog

- Added VacuumModuleMovementFlagger to prevent moving labware to/from the vacuum module when engaged
- Added `VacuumModuleStillUnderVacuumError` error recovery case when attempting to move labware to/from vacuum module under vacuum.
- hardware testing fixes for custom millipore manifold defs

## Review requests
## Risk assessment
Low