### PR TITLE
fix(api): fix the pipette upgrade race condition by checking completness in addition to presence

### DIFF
--- a/api/src/opentrons/hardware_control/backends/subsystem_manager.py
+++ b/api/src/opentrons/hardware_control/backends/subsystem_manager.py
@@ -337,11 +337,15 @@ class SubsystemManager:
     async def _probe_network_and_cache_fw_updates(
         self, targets: Set[FirmwareTarget], broadcast: bool = True
     ) -> None:
-        checked_targets = {
-            target
-            for target in targets
-            if target_to_subsystem(target) not in self._updates_ongoing
-        }
+        def _ok_to_check(target: FirmwareTarget) -> bool:
+            # the tool detection notification can happen before the updater removes it from ongoing, but it will be marked as done.
+            subsystem = target_to_subsystem(target)
+            return not (
+                subsystem in self._updates_ongoing
+                and self._updates_ongoing[subsystem].state != UpdateState.done
+            )
+
+        checked_targets = {target for target in targets if _ok_to_check(target)}
         if broadcast:
             await self._network_info.probe(checked_targets)
         else:


### PR DESCRIPTION
# Overview
So during a pipette firmware upgrade the system will process a tool notification AFTER the device update is marked as none but BEFORE it's deleted from the list of ongoing updates. this causes the pipette to never be added to the system. 

Had a bot that this happened 100% of the time on 9.1.0 and the team in china was getting alot of events of it happening since they swap pipettes so often.

