### PR TITLE
fix(app): Undo debugging (?) changes to useAccessControlEnabledQuery()

### DIFF
--- a/react-api-client/src/auth/settings/useAccessControlEnabledQuery.ts
+++ b/react-api-client/src/auth/settings/useAccessControlEnabledQuery.ts
@@ -23,15 +23,7 @@ export function useAccessControlEnabledQuery(
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
   const query = useQuery<AccessControlEnabledSettingsResponse, AxiosError>(
     getQueryKey(host, 'auth', 'settings', 'accessControlEnabled'),
-    () =>
-      getAccessControlEnabled(host!)
-        .then(() => ({ data: { accessControlEnabled: true } }))
-        .catch((error: AxiosError) => {
-          if (error.response?.status === 404) {
-            return { data: { accessControlEnabled: false } }
-          }
-          throw error
-        }),
+    () => getAccessControlEnabled(host!).then(response => response.data),
     { enabled: host !== null, ...options }
   )
 


### PR DESCRIPTION
## Overview

This closes RQA-5642.

The frontend asks the backend whether access control is enabled. Commit 232441cc4e10368cfc4d947a43c4fd6826c76415 / PR #21764 changed the frontend's interpretation of the response, to something that wasn't correct. The change was unrelated to what the rest of that PR was doing—maybe it was supposed to be temporary for debugging?

This PR simply reverts that change, leaving the other changes of the original PR in-place.

## Test Plan and Hands on Testing

* In one terminal, `make dev-backend-flex`
* In a second terminal, `make -C app dev-odd`
* [x] The ODD no longer shows a lock icon

## Review requests

* @ncdiehl11 Am I missing something and we _did_ need this change? Or was it just left over from debugging or something?
* Am I merging this into the correct branch? I just picked the same branch that the original PR went into.

## Risk assessment

Low.