### PR TITLE
docs: Add software shut-down feature and update

### DIFF
--- a/docs/flex/docs/maintenance/cleaning.md
+++ b/docs/flex/docs/maintenance/cleaning.md
@@ -9,7 +9,7 @@ If you have any questions about cleaning your Flex and its related components, c
 
 ## Before you begin
 
-Flex is an electrically powered mechanical device. As a good practice, turn off the power before you start cleaning it and before reaching inside the enclosure. You may even want to unplug the robot as well. These are simple safety steps you can take to make the robot inoperable until you're finished.
+Flex is an electrically powered mechanical device. As a good practice, [turn off the power](../touchscreen/dashboard.md#dashboard-settings) before you start cleaning it and before reaching inside the enclosure. You may even want to unplug the robot as well. These are simple safety steps you can take to make the robot inoperable until you're finished.
 
 Along with turning the power off, remove any instruments, modules, and labware before cleaning the robot. Removing attached items gives you more room to work and provides better access to the deck, gantry, and other spaces.
 

--- a/docs/flex/docs/touchscreen/dashboard.md
+++ b/docs/flex/docs/touchscreen/dashboard.md
@@ -11,11 +11,15 @@ The *dashboard* is the main screen for the robot, accessible by tapping the robo
 
 The dashboard provides quick access to recently run protocols. It displays protocols as large cards in a horizontal carousel. Green cards show protocols that are ready to run. Orange cards show protocols that require hardware setup or have a deck configuration conflict. The dashboard can display up to eight previously run protocols.
 
+## Dashboard settings
+
 From the dashboard you can also perform actions that apply to the robot as a whole, rather than a particular protocol. Access these actions by tapping the three-dot (⋮) menu:
 
 - **Home gantry:** Move the gantry to its home position at the back right of the working area.
 
-- **Restart robot:** Perform a soft restart of the robot.
+- **Restart robot:** Tap the restart icon (↻) to perform a soft restart of the robot.
+
+- **Turn off robot:** Tap the power icon (⏻) to shut down the robot and then toggle the rear power switch off. This is the recommended way to turn off your Flex.
 
 - **[Deck configuration](deck-config.md):** Manage deck fixture locations.
 


### PR DESCRIPTION
# Overview

A new software shutdown icon has been added to the ODD touchscreen. Need to update Touchscreen > Dashboard with info about the button and how to properly turn off power to the Flex.

**Sandbox:** 

* [Dashboard](https://sandbox.docs.opentrons.com/flex-manual-power-off-instructions/flex/touchscreen/dashboard/#dashboard-settings)
* [Cleaning](https://sandbox.docs.opentrons.com/flex-manual-power-off-instructions/flex/maintenance/cleaning/#before-you-begin)

RTC-1013

## Test Plan and Hands on Testing

Had difficulty adding reference links. Thought that `attr_list` in the `.yml` file provided this functionality.

## Changelog

Added a section header to `dashboard.md` called "Dashboard settings." This is to allow linking from other sources.

Updated added link from Maintenance > Cleaning Flext to the new section in Dashboard. We tell people to turn off the power before cleaning the robot. Good to link to the new procedure.

## Review requests

- Reference links wonky

## Risk assessment

Low.
