### PR TITLE
fix(app-shell-odd): fix some race conditions and memory usage

### DIFF
--- a/app-shell-odd/src/system-update/__tests__/handler.test.ts
+++ b/app-shell-odd/src/system-update/__tests__/handler.test.ts
@@ -96,7 +96,19 @@ describe('update driver manager', () => {
     when(getConfig)
       .calledWith('update')
       .thenReturn({ channel: 'alpha' } as any as Cfg.Config['update'])
+    const webDriverPayload = {
+      manifestUrl: FLEX_MANIFEST_URL,
+      channel: 'alpha',
+      updateCacheDirectory: testDir,
+      currentVersion: CURRENT_SYSTEM_VERSION,
+    } as WebUpdateSource
+    when(getWebProvider)
+      .calledWith(webDriverPayload)
+      .thenReturn({
+        source: () => webDriverPayload,
+      } as UpdateProvider<WebUpdateSource>)
     const driver = manageDriver(dispatch)
+    let wrappedDriver: null | UpdateDriver = null
     expect(driver.getUpdateDriver()).toBeNull()
     expect(getConfig).not.toHaveBeenCalled()
     return driver
@@ -104,14 +116,18 @@ describe('update driver manager', () => {
         type: CONFIG_INITIALIZED,
       } as ConfigInitializedAction)
       .then(() => {
-        expect(driver.getUpdateDriver()).not.toBeNull()
+        wrappedDriver = driver.getUpdateDriver()
+        expect(wrappedDriver).not.toBeNull()
         expect(getConfig).toHaveBeenCalledOnce()
-        expect(getWebProvider).toHaveBeenCalledWith({
-          manifestUrl: FLEX_MANIFEST_URL,
-          channel: 'alpha',
-          updateCacheDirectory: testDir,
-          currentVersion: CURRENT_SYSTEM_VERSION,
-        })
+        expect(getWebProvider).toHaveBeenCalledWith(webDriverPayload)
+      })
+      .then(() =>
+        driver.handleAction({
+          type: CONFIG_INITIALIZED,
+        } as ConfigInitializedAction)
+      )
+      .then(() => {
+        expect(wrappedDriver).toBe(driver.getUpdateDriver())
       })
   })
 

--- a/app-shell-odd/src/system-update/from-web/__tests__/release-files.test.ts
+++ b/app-shell-odd/src/system-update/from-web/__tests__/release-files.test.ts
@@ -221,6 +221,7 @@ describe('downloadReleaseFiles', () => {
   it('should try and fetch both system zip and release notes', () =>
     directoryWithCleanup(directory => {
       let tempSystemPath = ''
+      let tempReleaseNotesPath = ''
       when(fetchToFile)
         .calledWith(
           'http://opentrons.com/ot3-system.zip',
@@ -240,6 +241,7 @@ describe('downloadReleaseFiles', () => {
           expect.any(Object)
         )
         .thenDo((_url, dest) => {
+          tempReleaseNotesPath = dest
           return fs
             .writeFile(dest, 'this is the contents of the release notes')
             .then(() => dest)
@@ -272,7 +274,8 @@ describe('downloadReleaseFiles', () => {
                 'this is the contents of the release notes'
               )
             ),
-          expect(fs.stat(path.dirname(tempSystemPath))).rejects.toThrow(),
+          expect(fs.stat(tempSystemPath)).rejects.toThrow(),
+          expect(fs.stat(tempReleaseNotesPath)).rejects.toThrow(),
         ])
       })
     }))
@@ -354,7 +357,7 @@ describe('downloadReleaseFiles', () => {
     }))
   it('should fail if it cannot fetch system zip', () =>
     directoryWithCleanup(directory => {
-      let tempSystemPath = ''
+      let tempReleaseNotesPath = ''
       when(fetchToFile)
         .calledWith(
           'http://opentrons.com/ot3-system.zip',
@@ -369,7 +372,7 @@ describe('downloadReleaseFiles', () => {
           expect.any(Object)
         )
         .thenDo((_url, dest) => {
-          tempSystemPath = dest
+          tempReleaseNotesPath = dest
           return fs
             .writeFile(dest, 'this is the contents of the release notes')
             .then(() => dest)
@@ -387,9 +390,7 @@ describe('downloadReleaseFiles', () => {
         )
       )
         .rejects.toThrow()
-        .then(() =>
-          expect(fs.stat(path.dirname(tempSystemPath))).rejects.toThrow()
-        )
+        .then(() => expect(fs.stat(tempReleaseNotesPath)).rejects.toThrow())
     }))
   it('should allow the http requests to be aborted', () =>
     directoryWithCleanup(directory => {

--- a/app-shell-odd/src/system-update/from-web/release-files.ts
+++ b/app-shell-odd/src/system-update/from-web/release-files.ts
@@ -145,7 +145,7 @@ export function getReleaseFiles(
 
 // downloads the entire release set to a temporary directory, and once they're
 // all successfully downloaded, renames the directory to `directory`
-export async function downloadReleaseFiles(
+export function downloadReleaseFiles(
   urls: ReleaseSetUrls,
   directory: string,
   // `onProgress` will be called with download progress as the files are read
@@ -207,7 +207,9 @@ export async function downloadReleaseFiles(
         rm(dlPath(directory, urls.system), { force: true }),
         urls.releaseNotes
           ? rm(dlPath(directory, urls.releaseNotes), { force: true })
-          : new Promise<void>(resolve => resolve()),
+          : new Promise<void>(resolve => {
+              resolve()
+            }),
       ]).then(() => {
         log.error(`throwing error ${error}`)
         throw error

--- a/app-shell-odd/src/system-update/from-web/release-files.ts
+++ b/app-shell-odd/src/system-update/from-web/release-files.ts
@@ -2,7 +2,6 @@
 
 import path from 'path'
 import { mkdirp, move, readdir, readFile, rm } from 'fs-extra'
-import tempy from 'tempy'
 
 import { fetchToFile } from '../../http'
 import { createLogger } from '../../log'
@@ -12,8 +11,16 @@ import type { DownloadProgress } from '../../http'
 import type { ReleaseSetFilepaths, ReleaseSetUrls } from '../types'
 
 const log = createLogger('systemUpdate/from-web/release-files')
+
+const DOWNLOAD_ARTIFACT_SUFFIX = '.odd-download'
 const outPath = (dir: string, url: string): string => {
   return path.join(dir, path.basename(url))
+}
+const dlPath = (dir: string, url: string): string => {
+  return path.join(dir, path.basename(url)) + '.odd-download'
+}
+const outPathFromDlPath = (dlPath: string): string => {
+  return dlPath.slice(0, -DOWNLOAD_ARTIFACT_SUFFIX.length)
 }
 
 const RELEASE_DIRECTORY_PREFIX = 'cached-release-'
@@ -138,21 +145,18 @@ export function getReleaseFiles(
 
 // downloads the entire release set to a temporary directory, and once they're
 // all successfully downloaded, renames the directory to `directory`
-export function downloadReleaseFiles(
+export async function downloadReleaseFiles(
   urls: ReleaseSetUrls,
   directory: string,
   // `onProgress` will be called with download progress as the files are read
   onProgress: (progress: DownloadProgress) => void,
   canceller: AbortController
 ): Promise<ReleaseSetData> {
-  const tempDir: string = tempy.directory()
-  const tempSystemPath = outPath(tempDir, urls.system)
-  const tempNotesPath = outPath(tempDir, urls.releaseNotes ?? '')
   // downloads are streamed directly to the filesystem to avoid loading them
   // all into memory simultaneously
   const notesReq =
     urls.releaseNotes != null
-      ? fetchToFile(urls.releaseNotes, tempNotesPath, {
+      ? fetchToFile(urls.releaseNotes, dlPath(directory, urls.releaseNotes), {
           signal: canceller.signal,
         }).catch(err => {
           log.warn(
@@ -162,26 +166,32 @@ export function downloadReleaseFiles(
         })
       : Promise.resolve(null)
   if (urls.releaseNotes != null) {
-    log.info(`Downloading ${urls.releaseNotes} to ${tempNotesPath}`)
+    log.info(
+      `Downloading ${urls.releaseNotes} to ${dlPath(directory, urls.releaseNotes)}`
+    )
   } else {
     log.info('No release notes available, not downloading')
   }
-  log.info(`Downloading ${urls.system} to ${tempSystemPath}`)
-  const systemReq = fetchToFile(urls.system, tempSystemPath, {
+  log.info(`Downloading ${urls.system} to ${dlPath(directory, urls.system)}`)
+  const systemReq = fetchToFile(urls.system, dlPath(directory, urls.system), {
     onProgress,
     signal: canceller.signal,
   })
   return Promise.all([systemReq, notesReq])
     .then(results => {
       const [systemTemp, releaseNotesTemp] = results
-      const systemPath = outPath(directory, systemTemp)
-      const notesPath = releaseNotesTemp
-        ? outPath(directory, releaseNotesTemp)
-        : null
-
-      log.info(`Download complete, ${tempDir}=>${directory}`)
-
-      return move(tempDir, directory, { overwrite: true }).then(() => {
+      const systemMove = move(systemTemp, outPathFromDlPath(systemTemp), {
+        overwrite: true,
+      }).then(() => outPathFromDlPath(systemTemp))
+      const notesMove = releaseNotesTemp
+        ? move(releaseNotesTemp, outPathFromDlPath(releaseNotesTemp), {
+            overwrite: true,
+          }).then(() => outPathFromDlPath(releaseNotesTemp))
+        : new Promise<null>(resolve => {
+            resolve(null)
+          })
+      return Promise.all([systemMove, notesMove]).then(results => {
+        const [systemPath, notesPath] = results
         log.info(`Move complete`)
         return augmentWithReleaseNotesContent({
           system: systemPath,
@@ -193,7 +203,13 @@ export function downloadReleaseFiles(
       log.error(
         `Failed to download release files: ${error.name}: ${error.message}`
       )
-      return rm(tempDir, { force: true, recursive: true }).then(() => {
+      return Promise.all([
+        rm(dlPath(directory, urls.system), { force: true }),
+        urls.releaseNotes
+          ? rm(dlPath(directory, urls.releaseNotes), { force: true })
+          : new Promise<void>(resolve => resolve()),
+      ]).then(() => {
+        log.error(`throwing error ${error}`)
         throw error
       })
     })

--- a/app-shell-odd/src/system-update/handler.ts
+++ b/app-shell-odd/src/system-update/handler.ts
@@ -333,25 +333,31 @@ export function manageDriver(dispatch: Dispatch): UpdatableDriver {
   let updateDriver: UpdateDriver | null = null
   return {
     handleAction: action => {
-      if (action.type === CONFIG_INITIALIZED) {
-        log.info('Initializing update driver')
-        return new Promise(resolve => {
-          updateDriver = createUpdateDriver(dispatch)
-          resolve()
-        })
-      } else if (updateDriver != null) {
-        if (action.type === VALUE_UPDATED && updateDriver.shouldReload()) {
+      if (updateDriver == null) {
+        if (action.type === CONFIG_INITIALIZED) {
+          log.info('Initializing update driver')
+          return new Promise(resolve => {
+            updateDriver = createUpdateDriver(dispatch)
+            resolve()
+          })
+        } else {
+          return new Promise(resolve => {
+            log.warn(
+              `update driver manager received action ${action.type} before initialization`
+            )
+            resolve()
+          })
+        }
+      } else {
+        if (
+          (action.type === CONFIG_INITIALIZED ||
+            action.type === VALUE_UPDATED) &&
+          updateDriver.shouldReload()
+        ) {
           return updateDriver.reload()
         } else {
           return updateDriver.handleAction(action)
         }
-      } else {
-        return new Promise(resolve => {
-          log.warn(
-            `update driver manager received action ${action.type} before initialization`
-          )
-          resolve()
-        })
       }
     },
     getUpdateDriver: () => updateDriver,


### PR DESCRIPTION
# Overview

Fix up some little issues with ODD update downloading:
- we had the possibility of creating multiple download handlers if we got multiple config-init actions, which I could see in at least some logs; now we only have one
- stop using temp directories in /tmp for storing downloads, because these downloads are tremendously large and eat all our ram

## Test Plan and Hands on Testing

- [ ] Install on a machine and check that you only get logs from _one_ update manager starting
- [ ] Install on a machine and force an update download (i.e. by `rm -rf /data/ODD/__ot_system_update__` and then waiting a minute)

## Changelog

- Use next-to-the-target-with-suffix style temporary download files instead of a tmpdir
- switch up when we mark an update manager as ready

## Review requests

- Normal stuff

## Risk assessment

- Medium; we do run the risk if this is wrong of stacking up downloaded files.