### PR TITLE
refactor(app,protocol-designer, opentrons-ai-client): remove marginLeft from Modal

### DIFF
--- a/app/src/App/DesktopAppFallback.tsx
+++ b/app/src/App/DesktopAppFallback.tsx
@@ -32,7 +32,7 @@ export function DesktopAppFallback({ error }: FallbackProps): JSX.Element {
   useSentryReport(error)
 
   return (
-    <Modal type="warning" title={t('error_boundary_title')} marginLeft="0">
+    <Modal type="warning" title={t('error_boundary_title')}>
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing32}>
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
           <LegacyStyledText forwardedAs="p">

--- a/app/src/organisms/Desktop/CalibrationTaskList/index.tsx
+++ b/app/src/organisms/Desktop/CalibrationTaskList/index.tsx
@@ -115,7 +115,6 @@ export function CalibrationTaskList({
         width: 50rem;
         height: 47.5rem;
       `}
-      marginLeft="0"
     >
       {showCompletionScreen ? (
         <Flex

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SlotDetailModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/SlotDetailModal.tsx
@@ -184,7 +184,6 @@ export function SlotDetailModal(
       closeOnOutsideClick
       childrenPadding={0}
       width={isVariedStack || selectedLiquidId != null ? '47rem' : '31.25rem'}
-      marginLeft="0"
       overflowY="hidden"
     >
       <Box

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/RobotUpdateProgressModal.tsx
@@ -120,7 +120,6 @@ export function RobotUpdateProgressModal({
       title={`${t('updating')} ${robotName}`}
       width="40rem"
       textAlign="center"
-      marginLeft="0"
       onClose={
         hasRobotCompletedInit || error || letUserExitUpdate
           ? completeRobotUpdateHandler

--- a/components/src/modals/Modal.tsx
+++ b/components/src/modals/Modal.tsx
@@ -90,8 +90,6 @@ export const Modal = (props: ModalProps): JSX.Element => {
       width={styleProps.width ?? '31.25rem'}
       header={hasHeader ? modalHeader : undefined}
       onOutsideClick={(closeOnOutsideClick ?? false) ? onClose : undefined}
-      // center within viewport aside from nav
-      marginLeft={styleProps.marginLeft ?? '5.656rem'}
       {...styleProps}
       footer={footer}
     >

--- a/components/src/modals/__tests__/Modal.test.tsx
+++ b/components/src/modals/__tests__/Modal.test.tsx
@@ -61,8 +61,5 @@ describe('Modal', () => {
     expect(screen.getByLabelText('ModalShell_ModalArea')).toHaveStyle(
       'width: 31.25rem'
     )
-    expect(screen.getByLabelText('ModalShell_ModalArea')).toHaveStyle(
-      'margin-left: 5.656rem'
-    )
   })
 })

--- a/opentrons-ai-client/src/components/molecules/ExitConfirmModal/index.tsx
+++ b/opentrons-ai-client/src/components/molecules/ExitConfirmModal/index.tsx
@@ -35,7 +35,7 @@ export function ExitConfirmModal(): JSX.Element {
   }
 
   return (
-    <Modal type="info" title={t('exit_confirmation_title')} marginLeft="0">
+    <Modal type="info" title={t('exit_confirmation_title')}>
       <Flex flexDirection={DIRECTION_COLUMN}>
         <StyledText
           paddingTop={`${SPACING.spacing8}`}

--- a/opentrons-ai-client/src/components/organisms/FeatureFlagsModal/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/FeatureFlagsModal/index.tsx
@@ -21,7 +21,7 @@ export function FeatureFlagsModal(): JSX.Element {
   const { t } = useTranslation('feature_flags')
 
   return (
-    <Modal type="info" title={t('feature_flags_title')} marginLeft="0">
+    <Modal type="info" title={t('feature_flags_title')}>
       <Flex flexDirection={DIRECTION_COLUMN}>
         <StyledText
           paddingTop={`${SPACING.spacing8}`}

--- a/opentrons-ai-client/src/components/organisms/LabwareModal/index.tsx
+++ b/opentrons-ai-client/src/components/organisms/LabwareModal/index.tsx
@@ -131,7 +131,7 @@ export function LabwareModal({
     <>
       {displayLabwareModal &&
         createPortal(
-          <Modal type="info" title={t('add_opentrons_labware')} marginLeft="0">
+          <Modal type="info" title={t('add_opentrons_labware')}>
             <Flex flexDirection={DIRECTION_COLUMN}>
               <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
                 <Flex

--- a/opentrons-ai-client/src/resources/AiAppFallback.tsx
+++ b/opentrons-ai-client/src/resources/AiAppFallback.tsx
@@ -23,7 +23,7 @@ export function AiAppFallback({
   }
 
   return (
-    <Modal type="warning" title={t('error_boundary_title')} marginLeft="0">
+    <Modal type="warning" title={t('error_boundary_title')}>
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing32}>
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
           <StyledText desktopStyle="bodyDefaultRegular">

--- a/protocol-designer/src/components/organisms/AnnouncementModal/index.tsx
+++ b/protocol-designer/src/components/organisms/AnnouncementModal/index.tsx
@@ -60,7 +60,6 @@ export const AnnouncementModal = (
       {showAnnouncementModal && (
         <Modal
           childrenPadding={SPACING.spacing24}
-          marginLeft="0"
           title={heading}
           type="info"
           width="47rem"

--- a/protocol-designer/src/components/organisms/BlockingHintModal/index.tsx
+++ b/protocol-designer/src/components/organisms/BlockingHintModal/index.tsx
@@ -54,7 +54,6 @@ export function BlockingHintModal(props: HintProps): JSX.Element {
 
   return createPortal(
     <Modal
-      marginLeft="0"
       type="warning"
       zIndexOverlay={1001}
       title={t(`hint.${hintKey}.title`)}

--- a/protocol-designer/src/components/organisms/ConfirmDeleteEntityInUseModal/index.tsx
+++ b/protocol-designer/src/components/organisms/ConfirmDeleteEntityInUseModal/index.tsx
@@ -28,7 +28,6 @@ export function ConfirmDeleteEntityInUseModal(
   return createPortal(
     <HandleEnter onEnter={onConfirm}>
       <Modal
-        marginLeft="0"
         zIndexOverlay={11}
         title={t(`are_you_sure_clear_slot`)}
         type="warning"

--- a/protocol-designer/src/components/organisms/ConfirmDeleteModal/index.tsx
+++ b/protocol-designer/src/components/organisms/ConfirmDeleteModal/index.tsx
@@ -67,7 +67,6 @@ export function ConfirmDeleteModal(props: Props): JSX.Element {
   }
   return createPortal(
     <Modal
-      marginLeft="0"
       title={t(`confirm_delete_modal.${modalType}.title`)}
       titleElement1={
         <Icon name="ot-alert" color={COLORS.yellow50} size="1.25rem" />

--- a/protocol-designer/src/components/organisms/ConfirmDeleteStagingAreaModal/index.tsx
+++ b/protocol-designer/src/components/organisms/ConfirmDeleteStagingAreaModal/index.tsx
@@ -28,7 +28,6 @@ export function ConfirmDeleteStagingAreaModal(
   return createPortal(
     <HandleEnter onEnter={onConfirm}>
       <Modal
-        marginLeft="0"
         zIndexOverlay={11}
         title={t('staging_area_has_labware')}
         type="info"

--- a/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/DefineLiquidsModal/index.tsx
@@ -181,7 +181,6 @@ export function DefineLiquidsModal(
       }}
     >
       <Modal
-        marginLeft="0"
         zIndexOverlay={15}
         width="37.125rem"
         title={

--- a/protocol-designer/src/components/organisms/EditInstrumentsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/EditInstrumentsModal/index.tsx
@@ -144,7 +144,6 @@ export function EditInstrumentsModal(
   return createPortal(
     <HandleEnter onEnter={handleOnSave}>
       <Modal
-        marginLeft="0"
         title={page === 'add' ? t('edit_pipette') : t('edit_instruments')}
         type="info"
         closeOnOutsideClick

--- a/protocol-designer/src/components/organisms/EditLabwareQuantityModal/index.tsx
+++ b/protocol-designer/src/components/organisms/EditLabwareQuantityModal/index.tsx
@@ -225,7 +225,6 @@ export function EditLabwareQuantityModal(
       }}
     >
       <Modal
-        marginLeft="0"
         width="37.125rem"
         title={t('edit_labware_quantity')}
         type="info"

--- a/protocol-designer/src/components/organisms/EditNickNameModal/index.tsx
+++ b/protocol-designer/src/components/organisms/EditNickNameModal/index.tsx
@@ -58,7 +58,6 @@ export function EditNickNameModal(props: EditNickNameModalProps): JSX.Element {
       }}
     >
       <Modal
-        marginLeft="0"
         title={t('rename_labware')}
         type="info"
         onClose={onClose}

--- a/protocol-designer/src/components/organisms/EditProtocolMetadataModal/index.tsx
+++ b/protocol-designer/src/components/organisms/EditProtocolMetadataModal/index.tsx
@@ -55,7 +55,6 @@ export function EditProtocolMetadataModal(
 
   return createPortal(
     <Modal
-      marginLeft="0"
       title={t('shared:edit_protocol_metadata')}
       type="info"
       onClose={onClose}

--- a/protocol-designer/src/components/organisms/FileUploadMessagesModal/index.tsx
+++ b/protocol-designer/src/components/organisms/FileUploadMessagesModal/index.tsx
@@ -52,7 +52,6 @@ export function FileUploadMessagesModal(): JSX.Element | null {
 
   return (
     <Modal
-      marginLeft="0"
       type={message?.isError ? 'error' : 'info'}
       title={title}
       {...(!isMigration

--- a/protocol-designer/src/components/organisms/HintsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/HintsModal/index.tsx
@@ -98,7 +98,6 @@ export const HintsModal = (): JSX.Element | null => {
 
   return createPortal(
     <Modal
-      marginLeft="0"
       type="warning"
       zIndexOverlay={15}
       title={t(`hint.${hint.hintKey}.title`, i18nValues)}

--- a/protocol-designer/src/components/organisms/IncompatibleTipsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/IncompatibleTipsModal/index.tsx
@@ -32,7 +32,6 @@ export function IncompatibleTipsModal(
   return (
     <HandleEnter onEnter={handleShowAllTips}>
       <Modal
-        marginLeft="0"
         title={t('incompatible_tips')}
         type="warning"
         closeOnOutsideClick

--- a/protocol-designer/src/components/organisms/LabwareNotCompatibleModal/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareNotCompatibleModal/index.tsx
@@ -26,7 +26,6 @@ export function LabwareNotCompatibleModal(
 
   return createPortal(
     <Modal
-      marginLeft="0"
       type="warning"
       title={t('delete_labware')}
       onClose={onClose}

--- a/protocol-designer/src/components/organisms/LabwareUploadModal/index.tsx
+++ b/protocol-designer/src/components/organisms/LabwareUploadModal/index.tsx
@@ -46,7 +46,6 @@ export function LabwareUploadModal(): JSX.Element | null {
 
   return (
     <Modal
-      marginLeft="0"
       type={
         message.messageType === 'ASK_FOR_LABWARE_OVERWRITE'
           ? 'warning'

--- a/protocol-designer/src/components/organisms/Ot2ProtocolModal/index.tsx
+++ b/protocol-designer/src/components/organisms/Ot2ProtocolModal/index.tsx
@@ -25,7 +25,6 @@ export function Ot2ProtocolModal({
   return createPortal(
     <Modal
       type="warning"
-      marginLeft="0"
       onClose={onClose}
       title={t('redirect_to_ot2_pd.title')}
       footer={

--- a/protocol-designer/src/components/organisms/RenameStepModal/index.tsx
+++ b/protocol-designer/src/components/organisms/RenameStepModal/index.tsx
@@ -55,7 +55,6 @@ export function RenameStepModal(props: RenameStepModalProps): JSX.Element {
 
   return createPortal(
     <Modal
-      marginLeft="0"
       title={t('shared:name_step')}
       type="info"
       closeOnOutsideClick

--- a/protocol-designer/src/components/organisms/ResetSettingsModal.tsx
+++ b/protocol-designer/src/components/organisms/ResetSettingsModal.tsx
@@ -42,7 +42,6 @@ export function ResetSettingsModal(
 
   return createPortal(
     <Modal
-      marginLeft="0"
       title={t(`protocol_steps:reset_settings`, { tab })}
       titleElement1={
         <Icon name="ot-alert" color={COLORS.yellow50} size="1.25rem" />

--- a/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectLabwareModal/index.tsx
@@ -520,7 +520,6 @@ export function SelectLabwareModal(
 
   return createPortal(
     <Modal
-      marginLeft="0"
       title={t('add_labware')}
       type="info"
       width="37.125rem"

--- a/protocol-designer/src/components/organisms/SelectPipetteModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectPipetteModal/index.tsx
@@ -115,7 +115,6 @@ export function SelectPipetteModal(
       />
     ) : (
       <Modal
-        marginLeft="0"
         width="37.125rem"
         type="info"
         title={t('add_pipette')}

--- a/protocol-designer/src/components/organisms/SelectWellsModal/index.tsx
+++ b/protocol-designer/src/components/organisms/SelectWellsModal/index.tsx
@@ -109,7 +109,6 @@ export const SelectWellsModal = (
 
   return (
     <Modal
-      marginLeft="0"
       width="42.0625rem"
       zIndex={15}
       zIndexOverlay={11}

--- a/protocol-designer/src/components/organisms/TipPositionModal/ZTipPositionModal.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/ZTipPositionModal.tsx
@@ -144,7 +144,6 @@ export function ZTipPositionModal(props: ZTipPositionModalProps): JSX.Element {
 
   return createPortal(
     <Modal
-      marginLeft="0"
       type="info"
       width="37.125rem"
       closeOnOutsideClick

--- a/protocol-designer/src/components/organisms/TipPositionModal/index.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/index.tsx
@@ -282,7 +282,6 @@ export function TipPositionModal(
 
   return createPortal(
     <Modal
-      marginLeft="0"
       type="info"
       width="47rem"
       closeOnOutsideClick

--- a/protocol-designer/src/components/organisms/WellOrderModal/index.tsx
+++ b/protocol-designer/src/components/organisms/WellOrderModal/index.tsx
@@ -157,7 +157,6 @@ export function WellOrderModal(props: WellOrderModalProps): JSX.Element | null {
 
   return createPortal(
     <Modal
-      marginLeft="0"
       width="37.125rem"
       closeOnOutsideClick
       type="info"

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerProfileModal.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerProfileModal.tsx
@@ -63,7 +63,6 @@ export function ThermocyclerProfileModal(
 
   return (
     <Modal
-      marginLeft="0"
       zIndexOverlay={11} // toolbox zIndex is set to 10
       title={t('form:step_edit_form.field.thermocyclerProfile.edit')}
       width="45rem"

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/VacuumProfileModal.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/VacuumTools/VacuumProfile/VacuumProfileModal.tsx
@@ -94,7 +94,6 @@ export function VacuumProfileModal(
       maxHeight="45rem"
       childrenPadding={SPACING.spacing24}
       onClose={onClose}
-      marginLeft="0"
       footer={footer}
     >
       <div className={styles.vacuum_profile_modal_body}>

--- a/protocol-designer/src/resources/ProtocolDesignerAppFallback.tsx
+++ b/protocol-designer/src/resources/ProtocolDesignerAppFallback.tsx
@@ -44,7 +44,7 @@ export function ProtocolDesignerAppFallback({
   }, [error, errorId])
 
   return (
-    <Modal type="warning" title={t('error_boundary_title')} marginLeft="0">
+    <Modal type="warning" title={t('error_boundary_title')}>
       <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing32}>
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing8}>
           <StyledText desktopStyle="bodyDefaultRegular">


### PR DESCRIPTION
# Overview
remove marginLeft from modal + remove marginLeft="0"
Mel accepted this change for Opentrons AI.


closes AUTH-3033

app
<img width="1024" height="768" alt="Screenshot 2026-06-18 at 5 12 32 PM" src="https://github.com/user-attachments/assets/767c9ea2-3ce4-4940-baa8-78d90b156795" />


pd
top: edge and bottom: prod

<img width="1302" height="1953" alt="Screenshot 2026-06-18 at 5 17 48 PM" src="https://github.com/user-attachments/assets/f5c23082-4311-4659-ab32-c23aa5e1f452" />


## Test Plan and Hands on Testing
- not needed

## Changelog
- remove `marginLeft`

## Review requests


## Risk assessment
low
