### PR TITLE
fix(protocol-designer) fix designer page layout issue

### DIFF
--- a/protocol-designer/src/ProtocolRoutes/index.tsx
+++ b/protocol-designer/src/ProtocolRoutes/index.tsx
@@ -98,7 +98,7 @@ export function ProtocolRoutes(): JSX.Element {
     >
       <Navigation />
       <Kitchen>
-        <main className={styles.main_contaienr}>
+        <main className={styles.main_container}>
           <GateModal />
           <LabwareUploadModal />
           <FileUploadMessagesModal />


### PR DESCRIPTION
# Overview
the issue is my typo

### before
<img width="1679" height="1186" alt="Screenshot 2026-06-18 at 8 03 49 PM" src="https://github.com/user-attachments/assets/4aa213dc-1631-4f59-8c98-8bbff19d00a8" />

### after
<img width="1674" height="1227" alt="Screenshot 2026-06-18 at 8 52 11 PM" src="https://github.com/user-attachments/assets/f1cbaf54-a662-4d27-923c-a84f60958ad5" />


## Test Plan and Hands on Testing
- create a protocol
- go to design page 
check there is no space under the main content

## Changelog
- fix typo

## Review requests


## Risk assessment
low
