### PR TITLE
fix(app-shell-odd): remove old update dls on boot

### DIFF
--- a/app-shell-odd/src/system-update/__tests__/handler.test.ts
+++ b/app-shell-odd/src/system-update/__tests__/handler.test.ts
@@ -102,10 +102,12 @@ describe('update driver manager', () => {
       updateCacheDirectory: testDir,
       currentVersion: CURRENT_SYSTEM_VERSION,
     } as WebUpdateSource
+    const mockCleanup = vi.fn() as () => Promise<void>
     when(getWebProvider)
       .calledWith(webDriverPayload)
       .thenReturn({
         source: () => webDriverPayload,
+        cleanup: mockCleanup,
       } as UpdateProvider<WebUpdateSource>)
     const driver = manageDriver(dispatch)
     let wrappedDriver: null | UpdateDriver = null
@@ -120,6 +122,7 @@ describe('update driver manager', () => {
         expect(wrappedDriver).not.toBeNull()
         expect(getConfig).toHaveBeenCalledOnce()
         expect(getWebProvider).toHaveBeenCalledWith(webDriverPayload)
+        expect(mockCleanup).toHaveBeenCalled()
       })
       .then(() =>
         driver.handleAction({
@@ -143,6 +146,7 @@ describe('update driver manager', () => {
       unlockUpdateCache: vi.fn(),
       name: vi.fn(),
       source: () => ({ channel: 'alpha' }) as any as WebUpdateSource,
+      cleanup: () => Promise.resolve(),
     }
     const fakeProvider2 = {
       ...fakeProvider,
@@ -216,6 +220,7 @@ describe('update driver', () => {
     unlockUpdateCache: vi.fn(),
     name: vi.fn(),
     source: () => ({ channel: 'alpha' }) as any as WebUpdateSource,
+    cleanup: () => Promise.resolve(),
   }
   const fakeUsbProviders: Record<string, UpdateProvider<USBUpdateSource>> = {
     first: {
@@ -229,6 +234,7 @@ describe('update driver', () => {
         ({
           massStorageRootPath: '/some/usb/path',
         }) as any as USBUpdateSource,
+      cleanup: () => Promise.resolve(),
     },
   }
 
@@ -259,6 +265,7 @@ describe('update driver', () => {
         ({
           massStorageRootPath: '/some/usb/path',
         }) as any as USBUpdateSource,
+      cleanup: () => Promise.resolve(),
     }
     fakeUsbProviders.second = {
       teardown: vi.fn(),
@@ -271,6 +278,7 @@ describe('update driver', () => {
         ({
           massStorageRootPath: '/some/other/usb/path',
         }) as any as USBUpdateSource,
+      cleanup: () => Promise.resolve(),
     }
     subject = createUpdateDriver(dispatch)
   })

--- a/app-shell-odd/src/system-update/from-usb/provider.ts
+++ b/app-shell-odd/src/system-update/from-usb/provider.ts
@@ -109,5 +109,6 @@ export function getProvider(
     },
     name: () => `USBUpdateProvider from ${from.massStorageDeviceRoot}`,
     source: () => from,
+    cleanup: () => Promise.resolve(),
   }
 }

--- a/app-shell-odd/src/system-update/from-web/__tests__/provider.test.ts
+++ b/app-shell-odd/src/system-update/from-web/__tests__/provider.test.ts
@@ -3,7 +3,10 @@ import { when } from 'vitest-when'
 
 import { LocalAbortError } from '../../../http'
 import { getProvider } from '../provider'
-import { cleanUpAndGetOrDownloadReleaseFiles as _cleanUpAndGetOrDownloadReleaseFiles } from '../release-files'
+import {
+  cleanUpAndGetOrDownloadReleaseFiles as _cleanUpAndGetOrDownloadReleaseFiles,
+  removeTemporaryDownloads as _removeTemporaryDownloads,
+} from '../release-files'
 import { getOrDownloadManifest as _getOrDownloadManifest } from '../release-manifest'
 
 vi.mock('../../../log')
@@ -21,6 +24,25 @@ const getOrDownloadManifest = vi.mocked(_getOrDownloadManifest)
 const cleanUpAndGetOrDownloadReleaseFiles = vi.mocked(
   _cleanUpAndGetOrDownloadReleaseFiles
 )
+const removeTemporaryDownloads = vi.mocked(_removeTemporaryDownloads)
+
+describe('provider.cleanup', () => {
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+  it('calls removeTemporaryDownloads on cleanup', async () => {
+    const provider = getProvider({
+      manifestUrl: 'http://opentrons.com/releases.json',
+      channel: 'release',
+      updateCacheDirectory: '/some/random/directory',
+      currentVersion: '1.2.3',
+    })
+    await provider.cleanup()
+    expect(removeTemporaryDownloads).toHaveBeenCalledExactlyOnceWith(
+      '/some/random/directory'
+    )
+  })
+})
 
 describe('provider.refreshUpdateCache happy paths', () => {
   afterEach(() => {

--- a/app-shell-odd/src/system-update/from-web/__tests__/provider.test.ts
+++ b/app-shell-odd/src/system-update/from-web/__tests__/provider.test.ts
@@ -34,7 +34,7 @@ describe('provider.cleanup', () => {
     const provider = getProvider({
       manifestUrl: 'http://opentrons.com/releases.json',
       channel: 'release',
-      updateCacheDirectory: '/some/random/directory',
+      updateCacheDirectory: '/some/random/directory/versions',
       currentVersion: '1.2.3',
     })
     await provider.cleanup()

--- a/app-shell-odd/src/system-update/from-web/__tests__/provider.test.ts
+++ b/app-shell-odd/src/system-update/from-web/__tests__/provider.test.ts
@@ -34,12 +34,12 @@ describe('provider.cleanup', () => {
     const provider = getProvider({
       manifestUrl: 'http://opentrons.com/releases.json',
       channel: 'release',
-      updateCacheDirectory: '/some/random/directory/versions',
+      updateCacheDirectory: '/some/random/directory',
       currentVersion: '1.2.3',
     })
     await provider.cleanup()
     expect(removeTemporaryDownloads).toHaveBeenCalledExactlyOnceWith(
-      '/some/random/directory'
+      '/some/random/directory/versions'
     )
   })
 })

--- a/app-shell-odd/src/system-update/from-web/__tests__/release-files.test.ts
+++ b/app-shell-odd/src/system-update/from-web/__tests__/release-files.test.ts
@@ -11,6 +11,7 @@ import {
   ensureCleanReleaseCacheForVersion,
   getOrDownloadReleaseFiles,
   getReleaseFiles,
+  removeTemporaryDownloads,
 } from '../release-files'
 
 import type { ReleaseSetUrls } from '../../types'
@@ -518,4 +519,62 @@ describe('getOrDownloadReleaseFiles', () => {
         )
       ).rejects.toThrow()
     }))
+})
+
+describe('removeTemporaryDownloads', () => {
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+  it('should remove files with the .odd-download suffix', async () => {
+    await directoryWithCleanup(async directory => {
+      await fs.mkdir(path.join(directory, 'fake-version-1'))
+      await fs.writeFile(
+        path.join(directory, 'fake-version-1', 'something.zip.odd-download'),
+        'hello'
+      )
+      await fs.writeFile(
+        path.join(directory, 'fake-version-1', 'something.md.odd-download'),
+        'goodbye'
+      )
+      await fs.mkdir(path.join(directory, 'fake-version-2'))
+      await fs.writeFile(
+        path.join(directory, 'fake-version-2', 'fakedl.zip.odd-download'),
+        'woohoo'
+      )
+      await removeTemporaryDownloads(directory)
+      const fv1dir = await fs.readdir(path.join(directory, 'fake-version-1'))
+      expect(fv1dir).toEqual([])
+      const fv2dir = await fs.readdir(path.join(directory, 'fake-version-2'))
+      expect(fv2dir).toEqual([])
+    })
+  })
+  it('should not remove files without the .odd-download suffix', async () => {
+    await directoryWithCleanup(async directory => {
+      await fs.mkdir(path.join(directory, 'fake-version-1'))
+      await fs.writeFile(
+        path.join(directory, 'fake-version-1', 'something.zip'),
+        'hello'
+      )
+      await fs.writeFile(
+        path.join(directory, 'fake-version-1', 'something.md'),
+        'goodbye'
+      )
+      await fs.mkdir(path.join(directory, 'fake-version-2'))
+      await fs.writeFile(
+        path.join(directory, 'fake-version-2', 'fakedl.zip'),
+        'woohoo'
+      )
+      await removeTemporaryDownloads(directory)
+      const fv1dir = await fs.readdir(path.join(directory, 'fake-version-1'))
+      expect(fv1dir).toEqual(['something.md', 'something.zip'])
+      const fv2dir = await fs.readdir(path.join(directory, 'fake-version-2'))
+      expect(fv2dir).toEqual(['fakedl.zip'])
+    })
+  })
+  it('should not throw if directories cant be read', async () => {
+    await directoryWithCleanup(async directory => {
+      await fs.writeFile(path.join(directory, 'something'), 'hi')
+      await removeTemporaryDownloads(directory)
+    })
+  })
 })

--- a/app-shell-odd/src/system-update/from-web/provider.ts
+++ b/app-shell-odd/src/system-update/from-web/provider.ts
@@ -206,6 +206,9 @@ export function getProvider(
     name: () =>
       `WebUpdateProvider from ${from.manifestUrl} channel ${from.channel}`,
     source: () => from,
-    cleanup: () => removeTemporaryDownloads(from.updateCacheDirectory),
+    cleanup: () =>
+      removeTemporaryDownloads(
+        path.join(from.updateCacheDirectory, 'versions')
+      ),
   }
 }

--- a/app-shell-odd/src/system-update/from-web/provider.ts
+++ b/app-shell-odd/src/system-update/from-web/provider.ts
@@ -4,7 +4,10 @@ import path from 'path'
 import { LocalAbortError } from '../../http'
 import { createLogger } from '../../log'
 import { latestVersionForChannel, shouldUpdate } from './latest-update'
-import { cleanUpAndGetOrDownloadReleaseFiles } from './release-files'
+import {
+  cleanUpAndGetOrDownloadReleaseFiles,
+  removeTemporaryDownloads,
+} from './release-files'
 import { getOrDownloadManifest, getReleaseSet } from './release-manifest'
 
 import type { DownloadProgress } from '../../http'
@@ -203,5 +206,6 @@ export function getProvider(
     name: () =>
       `WebUpdateProvider from ${from.manifestUrl} channel ${from.channel}`,
     source: () => from,
+    cleanup: () => removeTemporaryDownloads(from.updateCacheDirectory),
   }
 }

--- a/app-shell-odd/src/system-update/from-web/release-files.ts
+++ b/app-shell-odd/src/system-update/from-web/release-files.ts
@@ -1,7 +1,7 @@
 // functions for downloading and storing release files
 
 import path from 'path'
-import { mkdirp, move, readdir, readFile, rm } from 'fs-extra'
+import { glob, mkdirp, move, readdir, readFile, rm } from 'fs-extra'
 
 import { fetchToFile } from '../../http'
 import { createLogger } from '../../log'
@@ -17,7 +17,7 @@ const outPath = (dir: string, url: string): string => {
   return path.join(dir, path.basename(url))
 }
 const dlPath = (dir: string, url: string): string => {
-  return path.join(dir, path.basename(url)) + '.odd-download'
+  return path.join(dir, path.basename(url)) + DOWNLOAD_ARTIFACT_SUFFIX
 }
 const outPathFromDlPath = (dlPath: string): string => {
   return dlPath.slice(0, -DOWNLOAD_ARTIFACT_SUFFIX.length)
@@ -260,3 +260,34 @@ const readReleaseNotes = (path: string | null): Promise<string | null> =>
         )
         return null
       })
+
+const removeTemporaryDownloadsFromReleaseDir = async (
+  releaseDir: string
+): Promise<void> => {
+  try {
+    const releaseContents = await readdir(releaseDir, { withFileTypes: true })
+    const tempDls = releaseContents.filter(contentsDirent =>
+      contentsDirent.name.endsWith(DOWNLOAD_ARTIFACT_SUFFIX)
+    )
+    log.warn(`Found ${tempDls.length} leftover downloads in ${releaseDir}`)
+    await Promise.all(
+      tempDls.map(tdl => rm(path.join(tdl.parentPath, tdl.name)))
+    )
+  } catch (e: unknown) {
+    log.warn(`Failed to read ${releaseDir}: ${e}`)
+    return
+  }
+}
+
+export const removeTemporaryDownloads = async (
+  baseDirectory: string
+): Promise<void> => {
+  const releaseDirs = await ensureReleaseCache(baseDirectory)
+  await Promise.all(
+    releaseDirs.map(releaseDirent =>
+      removeTemporaryDownloadsFromReleaseDir(
+        path.join(releaseDirent.parentPath, releaseDirent.name)
+      )
+    )
+  )
+}

--- a/app-shell-odd/src/system-update/from-web/release-files.ts
+++ b/app-shell-odd/src/system-update/from-web/release-files.ts
@@ -1,7 +1,7 @@
 // functions for downloading and storing release files
 
 import path from 'path'
-import { glob, mkdirp, move, readdir, readFile, rm } from 'fs-extra'
+import { mkdirp, move, readdir, readFile, rm } from 'fs-extra'
 
 import { fetchToFile } from '../../http'
 import { createLogger } from '../../log'
@@ -275,7 +275,6 @@ const removeTemporaryDownloadsFromReleaseDir = async (
     )
   } catch (e: unknown) {
     log.warn(`Failed to read ${releaseDir}: ${e}`)
-    return
   }
 }
 

--- a/app-shell-odd/src/system-update/from-web/release-files.ts
+++ b/app-shell-odd/src/system-update/from-web/release-files.ts
@@ -270,7 +270,7 @@ const removeTemporaryDownloadsFromReleaseDir = async (
       contentsDirent.name.endsWith(DOWNLOAD_ARTIFACT_SUFFIX)
     )
     log.warn(`Found ${tempDls.length} leftover downloads in ${releaseDir}`)
-    await Promise.all(
+    await Promise.allSettled(
       tempDls.map(tdl => rm(path.join(tdl.parentPath, tdl.name)))
     )
   } catch (e: unknown) {
@@ -282,7 +282,7 @@ export const removeTemporaryDownloads = async (
   baseDirectory: string
 ): Promise<void> => {
   const releaseDirs = await ensureReleaseCache(baseDirectory)
-  await Promise.all(
+  await Promise.allSettled(
     releaseDirs.map(releaseDirent =>
       removeTemporaryDownloadsFromReleaseDir(
         path.join(releaseDirent.parentPath, releaseDirent.name)

--- a/app-shell-odd/src/system-update/handler.ts
+++ b/app-shell-odd/src/system-update/handler.ts
@@ -24,6 +24,7 @@ export interface UpdateDriver {
   reload: () => Promise<void>
   shouldReload: () => boolean
   teardown: () => Promise<void>
+  cleanup: () => Promise<void>
 }
 
 export function createUpdateDriver(dispatch: Dispatch): UpdateDriver {
@@ -321,6 +322,16 @@ export function createUpdateDriver(dispatch: Dispatch): UpdateDriver {
           log.info('all providers torn down')
         })
     },
+    cleanup: async () => {
+      try {
+        await Promise.allSettled([
+          webProvider.cleanup(),
+          ...Object.values(usbProviders).map(provider => provider.cleanup()),
+        ])
+      } catch (err: unknown) {
+        log.warn(`provider cleanup failed: ${err}`)
+      }
+    },
   }
 }
 
@@ -336,17 +347,13 @@ export function manageDriver(dispatch: Dispatch): UpdatableDriver {
       if (updateDriver == null) {
         if (action.type === CONFIG_INITIALIZED) {
           log.info('Initializing update driver')
-          return new Promise(resolve => {
-            updateDriver = createUpdateDriver(dispatch)
-            resolve()
-          })
+          updateDriver = createUpdateDriver(dispatch)
+          return updateDriver.cleanup()
         } else {
-          return new Promise(resolve => {
-            log.warn(
-              `update driver manager received action ${action.type} before initialization`
-            )
-            resolve()
-          })
+          log.warn(
+            `update driver manager received action ${action.type} before initialization`
+          )
+          return Promise.resolve()
         }
       } else {
         if (

--- a/app-shell-odd/src/system-update/types.ts
+++ b/app-shell-odd/src/system-update/types.ts
@@ -59,4 +59,6 @@ export interface UpdateProvider<UpdateSourceDetails> {
   name: () => string
   // get the current source
   source: () => UpdateSourceDetails
+  // clean up previous attempts
+  cleanup: () => Promise<void>
 }


### PR DESCRIPTION
if you turn off the robot or stop the ODD while it's downloading an update, we might leave the temporary downloads in place. we need to remove them when we boot.

## testing
- [x] put it on a machine; force a download; kill the ODD; make sure that the file is present when the process dies and gets deleted when it boots.