### PR TITLE
fix(api, shared-data): center 96-channel properly for labware with rows

### DIFF
--- a/api/src/opentrons/hardware_control/nozzle_manager.py
+++ b/api/src/opentrons/hardware_control/nozzle_manager.py
@@ -173,6 +173,14 @@ class NozzleMap(BaseModel):
         )
 
     @property
+    def x_center_offset(self) -> Point:
+        """The position in the center of the primary row of the map."""
+        back_right = next(reversed(list(self.columns.values())))[0]
+        difference = self.map_store[back_right] - self.map_store[self.back_left]
+        return self.map_store[self.back_left] + Point(difference[0] / 2, 0, 0)
+
+
+    @property
     def y_center_offset(self) -> Point:
         """The position in the center of the primary column of the map."""
         front_left = next(reversed(list(self.rows.values())))[0]

--- a/api/src/opentrons/hardware_control/nozzle_manager.py
+++ b/api/src/opentrons/hardware_control/nozzle_manager.py
@@ -179,7 +179,6 @@ class NozzleMap(BaseModel):
         difference = self.map_store[back_right] - self.map_store[self.back_left]
         return self.map_store[self.back_left] + Point(difference[0] / 2, 0, 0)
 
-
     @property
     def y_center_offset(self) -> Point:
         """The position in the center of the primary column of the map."""

--- a/api/src/opentrons/hardware_control/nozzle_manager.py
+++ b/api/src/opentrons/hardware_control/nozzle_manager.py
@@ -425,6 +425,8 @@ class NozzleConfigurationManager:
             )
         elif cp_override == CriticalPoint.XY_CENTER:
             current_nozzle = self._current_nozzle_configuration.xy_center_offset
+        elif cp_override == CriticalPoint.X_CENTER:
+            current_nozzle = self._current_nozzle_configuration.x_center_offset
         elif cp_override == CriticalPoint.Y_CENTER:
             current_nozzle = self._current_nozzle_configuration.y_center_offset
         elif cp_override == CriticalPoint.FRONT_NOZZLE:

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -566,6 +566,16 @@ class CriticalPoint(enum.Enum):
     channel pipette.
     """
 
+    X_CENTER = enum.auto()
+    """
+    Similar to Y_CENTER, but here the X_CENTER critical point that is the same
+    Y coordinate as the default nozzle point, but halfway in between the X axis
+    bounding box of the pipette. In other words it is the XY center of the first
+    row of the pipette. This is only relevant for the 96 channel when interfacing
+    with labware with rows. On an eight or one channel this will be the same as the
+    starting nozzle.
+    """
+
 
 class ExecutionState(enum.Enum):
     RUNNING = enum.auto()

--- a/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
+++ b/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
@@ -160,6 +160,7 @@ DEFAULT_LABWARE_VERSIONS: DefaultLabwareVersions = {
         "opentrons_tough_12_reservoir_22ml": 3,
         "opentrons_tough_1_reservoir_300ml": 3,
         "opentrons_tough_4_reservoir_72ml": 2,
+        "nest_8_reservoir_22ml": 2,
     },
 }
 

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -722,6 +722,18 @@ class LabwareView:
         """True if a labware is a reservoir with a 12-grid of sub-wells."""
         return self.get_has_quirk(labware_id, "offsetPipetteFor12GridSubwells")
 
+    def get_is_column_labware(self, labware_id: str) -> bool:
+        """True if a labware is a series of column-length wells. One well reservoirs do not count."""
+        definition = self.get_definition(labware_id)
+        return len(definition.wells) > 1 and all(
+            len(column) == 1 for column in definition.ordering
+        )
+
+    def get_is_row_labware(self, labware_id: str) -> bool:
+        """True if a labware is a series of row-length wells. One well reservoirs do not count."""
+        definition = self.get_definition(labware_id)
+        return len(definition.wells) > 1 and len(definition.ordering) == 1
+
     def get_well_definition(
         self,
         labware_id: str,

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -685,16 +685,13 @@ class LabwareView:
         definition = self.get_definition(labware_id)
         return definition.parameters.quirks or []
 
-    def get_should_center_column_on_target_well(self, labware_id: str) -> bool:
-        """True if a pipette moving to this labware should center its active column on the target.
+    def get_should_center_column_or_row_on_target_well(self, labware_id: str) -> bool:
+        """True if a pipette moving to this labware should center its active column or row on the target.
 
-        This is true for labware that have wells spanning entire columns.
+        This is true for labware that have wells spanning entire columns or rows.
         """
         has_quirk = self.get_has_quirk(labware_id, "centerMultichannelOnWells")
-        return has_quirk and (
-            len(self.get_definition(labware_id).wells) > 1
-            and len(self.get_definition(labware_id).wells) < 96
-        )
+        return has_quirk and 1 < len(self.get_definition(labware_id).wells) < 96
 
     def get_labware_stacking_maximum(self, labware: LabwareDefinition) -> int:
         """Returns the maximum number of labware allowed in a stack for a given labware definition.

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -123,7 +123,7 @@ class MotionView:
         self, labware_id: str
     ) -> CriticalPoint | None:
         """Get the appropriate critical point override for this labware."""
-        if self._labware.get_should_center_column_on_target_well(labware_id):
+        if self._labware.get_should_center_column_or_row_on_target_well(labware_id):
             if self._labware.get_is_column_labware(labware_id):
                 return CriticalPoint.Y_CENTER
             elif self._labware.get_is_row_labware(labware_id):

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -124,7 +124,12 @@ class MotionView:
     ) -> CriticalPoint | None:
         """Get the appropriate critical point override for this labware."""
         if self._labware.get_should_center_column_on_target_well(labware_id):
-            return CriticalPoint.Y_CENTER
+            if self._labware.get_is_column_labware(labware_id):
+                return CriticalPoint.Y_CENTER
+            elif self._labware.get_is_row_labware(labware_id):
+                return CriticalPoint.X_CENTER
+            else:
+                return None
         elif self._labware.get_should_center_pipette_on_target_well(labware_id):
             return CriticalPoint.XY_CENTER
         else:

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -777,6 +777,8 @@ class PipetteView:
                 return nozzle_map.instrument_xy_center_offset
             case CriticalPoint.XY_CENTER:
                 return nozzle_map.xy_center_offset
+            case CriticalPoint.X_CENTER:
+                return nozzle_map.x_center_offset
             case CriticalPoint.Y_CENTER:
                 return nozzle_map.y_center_offset
             case CriticalPoint.FRONT_NOZZLE:

--- a/api/tests/opentrons/hardware_control/instruments/test_nozzle_manager.py
+++ b/api/tests/opentrons/hardware_control/instruments/test_nozzle_manager.py
@@ -1042,11 +1042,13 @@ def test_96_config_geometry(
         starting_nozzle: str,
         front_nozzle: str,
         xy_center_between: Union[str, Tuple[str, str]],
+        x_center_between: Union[str, Tuple[str, str]],
         y_center_between: Union[str, Tuple[str, str]],
     ) -> None:
         assert_offset_in_center_of(
             nozzlemap.xy_center_offset, xy_center_between, config
         )
+        assert_offset_in_center_of(nozzlemap.x_center_offset, x_center_between, config)
         assert_offset_in_center_of(nozzlemap.y_center_offset, y_center_between, config)
 
         assert nozzlemap.front_nozzle_offset == Point(*config.nozzle_map[front_nozzle])
@@ -1055,12 +1057,23 @@ def test_96_config_geometry(
         )
 
     test_map_geometry(
-        config, subject.current_configuration, "A1", "H1", ("A1", "H12"), ("A1", "H1")
+        config,
+        subject.current_configuration,
+        "A1",
+        "H1",
+        ("A1", "H12"),
+        ("A1", "A12"),
+        ("A1", "H1"),
     )
-
     subject.update_nozzle_configuration("A1", "H1")
     test_map_geometry(
-        config, subject.current_configuration, "A1", "H1", ("A1", "H1"), ("A1", "H1")
+        config,
+        subject.current_configuration,
+        "A1",
+        "H1",
+        ("A1", "H1"),
+        "A1",
+        ("A1", "H1"),
     )
 
     subject.update_nozzle_configuration("A12", "H12")
@@ -1070,25 +1083,39 @@ def test_96_config_geometry(
         "A12",
         "H12",
         ("A12", "H12"),
+        "A12",
         ("A12", "H12"),
     )
 
     subject.update_nozzle_configuration("A1", "A12")
     test_map_geometry(
-        config, subject.current_configuration, "A1", "A1", ("A1", "A12"), "A1"
+        config,
+        subject.current_configuration,
+        "A1",
+        "A1",
+        ("A1", "A12"),
+        ("A1", "A12"),
+        "A1",
     )
 
     subject.update_nozzle_configuration("H1", "H12")
     test_map_geometry(
-        config, subject.current_configuration, "H1", "H1", ("H1", "H12"), "H1"
+        config,
+        subject.current_configuration,
+        "H1",
+        "H1",
+        ("H1", "H12"),
+        ("H1", "H12"),
+        "H1",
     )
 
     subject.update_nozzle_configuration("A1", "D6")
     test_map_geometry(
-        config, subject.current_configuration, "A1", "D1", ("A1", "D6"), ("A1", "D1")
-    )
-
-    subject.update_nozzle_configuration("E7", "H12")
-    test_map_geometry(
-        config, subject.current_configuration, "E7", "H7", ("E7", "H12"), ("E7", "H7")
+        config,
+        subject.current_configuration,
+        "A1",
+        "D1",
+        ("A1", "D6"),
+        ("A1", "A6"),
+        ("A1", "D1"),
     )

--- a/api/tests/opentrons/hardware_control/instruments/test_nozzle_manager.py
+++ b/api/tests/opentrons/hardware_control/instruments/test_nozzle_manager.py
@@ -344,6 +344,7 @@ def test_single_pipette_map_geometry(
 
     def test_map_geometry(nozzlemap: nozzle_manager.NozzleMap) -> None:
         assert nozzlemap.xy_center_offset == Point(*config.nozzle_map["A1"])
+        assert nozzlemap.x_center_offset == Point(*config.nozzle_map["A1"])
         assert nozzlemap.y_center_offset == Point(*config.nozzle_map["A1"])
         assert nozzlemap.front_nozzle_offset == Point(*config.nozzle_map["A1"])
         assert nozzlemap.starting_nozzle_offset == Point(*config.nozzle_map["A1"])
@@ -516,10 +517,14 @@ def test_multi_config_geometry(
         front_nozzle: str,
         starting_nozzle: str,
         xy_center_in_center_of: Union[Tuple[str, str], str],
+        x_center_in_center_of: Union[Tuple[str, str], str],
         y_center_in_center_of: Union[Tuple[str, str], str],
     ) -> None:
         assert_offset_in_center_of(
             nozzlemap.xy_center_offset, xy_center_in_center_of, config
+        )
+        assert_offset_in_center_of(
+            nozzlemap.x_center_offset, x_center_in_center_of, config
         )
         assert_offset_in_center_of(
             nozzlemap.y_center_offset, y_center_in_center_of, config
@@ -531,20 +536,20 @@ def test_multi_config_geometry(
         )
 
     test_map_geometry(
-        subject.current_configuration, "H1", "A1", ("A1", "H1"), ("A1", "H1")
+        subject.current_configuration, "H1", "A1", ("A1", "H1"), "A1", ("A1", "H1")
     )
 
     subject.update_nozzle_configuration("A1", "A1", "A1")
-    test_map_geometry(subject.current_configuration, "A1", "A1", "A1", "A1")
+    test_map_geometry(subject.current_configuration, "A1", "A1", "A1", "A1", "A1")
 
     subject.update_nozzle_configuration("E1", "H1", "E1")
     test_map_geometry(
-        subject.current_configuration, "H1", "E1", ("E1", "H1"), ("E1", "H1")
+        subject.current_configuration, "H1", "E1", ("E1", "H1"), "E1", ("E1", "H1")
     )
 
     subject.reset_to_default_configuration()
     test_map_geometry(
-        subject.current_configuration, "H1", "A1", ("A1", "H1"), ("A1", "H1")
+        subject.current_configuration, "H1", "A1", ("A1", "H1"), "A1", ("A1", "H1")
     )
 
 

--- a/api/tests/opentrons/protocol_engine/state/test_labware_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_state.py
@@ -152,3 +152,151 @@ def test_raise_if_wells_are_invalid(ot3_standard_deck_def: DeckDefinitionV5) -> 
         )
     with pytest.raises(errors.WellDoesNotExistError):
         subject_view.raise_if_wells_are_invalid("labware-id", ["well-5"])
+
+
+def test_get_is_column_labware(ot3_standard_deck_def: DeckDefinitionV5) -> None:
+    """It should return True if the labware is made up of multiple column wide wells, and False otherwise."""
+    subject = LabwareStore(deck_definition=ot3_standard_deck_def, deck_fixed_labware=[])
+    subject_view = LabwareView(subject.state)
+
+    def _load_labware(labware_id: str, definition: LabwareDefinition3):
+        load_labware_update = update_types.LoadedLabwareUpdate(
+            labware_id=labware_id,
+            new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),
+            offset_id=None,
+            display_name="Display Name",
+            definition=definition,
+        )
+        subject.handle_action(
+            actions.SucceedCommandAction(
+                state_update=update_types.StateUpdate(
+                    loaded_labware=load_labware_update
+                ),
+                command=_dummy_command(),
+            )
+        )
+
+    column_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+            "well-2": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123"], ["456"]],
+    )
+    _load_labware("column-id", column_labware_def)
+    assert subject_view.get_is_column_labware("column-id")
+
+    row_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+            "well-2": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123", "456"]],
+    )
+    _load_labware("row-id", row_labware_def)
+    assert not subject_view.get_is_column_labware("row-id")
+
+    reservoir_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123"]],
+    )
+    _load_labware("reservoir-id", reservoir_labware_def)
+    assert not subject_view.get_is_column_labware("reservoir-id")
+
+    multi_well_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+            "well-2": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123", "456"], ["654", "321"]],
+    )
+    _load_labware("multi-well-id", multi_well_labware_def)
+    assert not subject_view.get_is_column_labware("multi-well-id")
+
+
+def test_get_is_row_labware(ot3_standard_deck_def: DeckDefinitionV5) -> None:
+    """It should return True if the labware is made up of multiple row wide wells, and False otherwise."""
+    subject = LabwareStore(deck_definition=ot3_standard_deck_def, deck_fixed_labware=[])
+    subject_view = LabwareView(subject.state)
+
+    def _load_labware(labware_id: str, definition: LabwareDefinition3):
+        load_labware_update = update_types.LoadedLabwareUpdate(
+            labware_id=labware_id,
+            new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),
+            offset_id=None,
+            display_name="Display Name",
+            definition=definition,
+        )
+        subject.handle_action(
+            actions.SucceedCommandAction(
+                state_update=update_types.StateUpdate(
+                    loaded_labware=load_labware_update
+                ),
+                command=_dummy_command(),
+            )
+        )
+
+    row_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+            "well-2": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123", "456"]],
+    )
+    _load_labware("row-id", row_labware_def)
+    assert subject_view.get_is_row_labware("row-id")
+
+    column_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+            "well-2": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123"], ["456"]],
+    )
+    _load_labware("column-id", column_labware_def)
+    assert not subject_view.get_is_row_labware("column-id")
+
+    reservoir_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123"]],
+    )
+    _load_labware("reservoir-id", reservoir_labware_def)
+    assert not subject_view.get_is_row_labware("reservoir-id")
+
+    multi_well_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+            "well-2": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123", "456"], ["654", "321"]],
+    )
+    _load_labware("multi-well-id", multi_well_labware_def)
+    assert not subject_view.get_is_row_labware("multi-well-id")

--- a/api/tests/opentrons/protocol_engine/state/test_labware_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_state.py
@@ -159,7 +159,7 @@ def test_get_is_column_labware(ot3_standard_deck_def: DeckDefinitionV5) -> None:
     subject = LabwareStore(deck_definition=ot3_standard_deck_def, deck_fixed_labware=[])
     subject_view = LabwareView(subject.state)
 
-    def _load_labware(labware_id: str, definition: LabwareDefinition3):
+    def _load_labware(labware_id: str, definition: LabwareDefinition3) -> None:
         load_labware_update = update_types.LoadedLabwareUpdate(
             labware_id=labware_id,
             new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),
@@ -233,7 +233,7 @@ def test_get_is_row_labware(ot3_standard_deck_def: DeckDefinitionV5) -> None:
     subject = LabwareStore(deck_definition=ot3_standard_deck_def, deck_fixed_labware=[])
     subject_view = LabwareView(subject.state)
 
-    def _load_labware(labware_id: str, definition: LabwareDefinition3):
+    def _load_labware(labware_id: str, definition: LabwareDefinition3) -> None:
         load_labware_update = update_types.LoadedLabwareUpdate(
             labware_id=labware_id,
             new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -381,6 +381,7 @@ def test_get_pipette_location_override_current_location_x_center(
         critical_point=CriticalPoint.X_CENTER,
     )
 
+
 def test_get_pipette_location_override_current_location_y_center(
     decoy: Decoy,
     labware_view: LabwareView,

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -158,6 +158,41 @@ def test_get_pipette_location_with_no_current_location(
     assert result == PipetteLocationData(mount=MountType.LEFT, critical_point=None)
 
 
+def test_get_pipette_location_with_current_location_with_x_center(
+    decoy: Decoy,
+    labware_view: LabwareView,
+    pipette_view: PipetteView,
+    subject: MotionView,
+) -> None:
+    """It should return cp=X_CENTER if location labware requests."""
+    decoy.when(pipette_view.get_current_location()).then_return(
+        CurrentWell(pipette_id="pipette-id", labware_id="reservoir-id", well_name="A1")
+    )
+
+    decoy.when(pipette_view.get("pipette-id")).then_return(
+        LoadedPipette(
+            id="pipette-id",
+            mount=MountType.RIGHT,
+            pipetteName=PipetteNameType.P300_SINGLE,
+        )
+    )
+
+    decoy.when(
+        labware_view.get_should_center_column_on_target_well(
+            "reservoir-id",
+        )
+    ).then_return(True)
+
+    decoy.when(labware_view.get_is_row_labware("reservoir-id")).then_return(True)
+
+    result = subject.get_pipette_location("pipette-id")
+
+    assert result == PipetteLocationData(
+        mount=MountType.RIGHT,
+        critical_point=CriticalPoint.X_CENTER,
+    )
+
+
 def test_get_pipette_location_with_current_location_with_y_center(
     decoy: Decoy,
     labware_view: LabwareView,
@@ -307,13 +342,52 @@ def test_get_pipette_location_override_current_location_xy_center(
     )
 
 
+def test_get_pipette_location_override_current_location_x_center(
+    decoy: Decoy,
+    labware_view: LabwareView,
+    pipette_view: PipetteView,
+    subject: MotionView,
+) -> None:
+    """It should calculate pipette location from a passed in deck location with x override."""
+    current_well = CurrentWell(
+        pipette_id="pipette-id",
+        labware_id="reservoir-id",
+        well_name="A1",
+    )
+
+    decoy.when(pipette_view.get("pipette-id")).then_return(
+        LoadedPipette(
+            id="pipette-id",
+            mount=MountType.RIGHT,
+            pipetteName=PipetteNameType.P300_SINGLE,
+        )
+    )
+
+    decoy.when(
+        labware_view.get_should_center_column_on_target_well(
+            "reservoir-id",
+        )
+    ).then_return(True)
+
+    decoy.when(labware_view.get_is_row_labware("reservoir-id")).then_return(True)
+
+    result = subject.get_pipette_location(
+        pipette_id="pipette-id",
+        current_location=current_well,
+    )
+
+    assert result == PipetteLocationData(
+        mount=MountType.RIGHT,
+        critical_point=CriticalPoint.X_CENTER,
+    )
+
 def test_get_pipette_location_override_current_location_y_center(
     decoy: Decoy,
     labware_view: LabwareView,
     pipette_view: PipetteView,
     subject: MotionView,
 ) -> None:
-    """It should calculate pipette location from a passed in deck location with xy override."""
+    """It should calculate pipette location from a passed in deck location with y override."""
     current_well = CurrentWell(
         pipette_id="pipette-id",
         labware_id="reservoir-id",
@@ -464,6 +538,94 @@ def test_get_pipette_offset_for_reservoirs(
     )
 
     assert result is sentinel.waypoints
+
+
+def test_get_movement_waypoints_to_well_for_x_center(
+    decoy: Decoy,
+    labware_view: LabwareView,
+    pipette_view: PipetteView,
+    geometry_view: GeometryView,
+    mock_module_view: ModuleView,
+    subject: MotionView,
+) -> None:
+    """It should call get_waypoints() with the correct args to move to a well."""
+    location = CurrentWell(pipette_id="123", labware_id="456", well_name="abc")
+
+    decoy.when(pipette_view.get_current_location()).then_return(location)
+
+    decoy.when(
+        labware_view.get_should_center_column_on_target_well(
+            "labware-id",
+        )
+    ).then_return(True)
+    decoy.when(
+        labware_view.get_should_center_pipette_on_target_well(
+            "labware-id",
+        )
+    ).then_return(False)
+    decoy.when(labware_view.get_is_row_labware("labware-id")).then_return(True)
+
+    decoy.when(
+        geometry_view.get_well_position(
+            "labware-id", "well-name", WellLocation(), None, "pipette-id"
+        )
+    ).then_return(Point(x=4, y=5, z=6))
+
+    decoy.when(
+        _move_types.get_move_type_to_well(
+            "pipette-id", "labware-id", "well-name", location, True
+        )
+    ).then_return(motion_planning.MoveType.GENERAL_ARC)
+    decoy.when(
+        geometry_view.get_min_travel_z("pipette-id", "labware-id", location, 123)
+    ).then_return(42.0)
+
+    decoy.when(geometry_view.get_ancestor_slot_name("labware-id")).then_return(
+        DeckSlotName.SLOT_2
+    )
+    decoy.when(pipette_view.get_config("pipette-id")).then_return(
+        _fake_static_pipette_config(1)
+    )
+
+    decoy.when(
+        geometry_view.get_extra_waypoints(location, DeckSlotName.SLOT_2)
+    ).then_return([(456, 789)])
+
+    waypoints = [
+        motion_planning.Waypoint(
+            position=Point(1, 2, 3), critical_point=CriticalPoint.X_CENTER
+        ),
+        motion_planning.Waypoint(
+            position=Point(4, 5, 6), critical_point=CriticalPoint.MOUNT
+        ),
+    ]
+
+    decoy.when(
+        motion_planning.get_waypoints(
+            move_type=motion_planning.MoveType.GENERAL_ARC,
+            origin=Point(x=1, y=2, z=3),
+            origin_cp=CriticalPoint.MOUNT,
+            max_travel_z=1337,
+            min_travel_z=42,
+            dest=Point(x=4, y=5, z=6),
+            dest_cp=CriticalPoint.X_CENTER,
+            xy_waypoints=[(456, 789)],
+        )
+    ).then_return(waypoints)
+
+    result = subject.get_movement_waypoints_to_well(
+        pipette_id="pipette-id",
+        labware_id="labware-id",
+        well_name="well-name",
+        well_location=WellLocation(),
+        origin=Point(x=1, y=2, z=3),
+        origin_cp=CriticalPoint.MOUNT,
+        max_travel_z=1337,
+        force_direct=True,
+        minimum_z_height=123,
+    )
+
+    assert result == waypoints
 
 
 def test_get_movement_waypoints_to_well_for_y_center(

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -183,6 +183,8 @@ def test_get_pipette_location_with_current_location_with_y_center(
         )
     ).then_return(True)
 
+    decoy.when(labware_view.get_is_column_labware("reservoir-id")).then_return(True)
+
     result = subject.get_pipette_location("pipette-id")
 
     assert result == PipetteLocationData(
@@ -332,6 +334,8 @@ def test_get_pipette_location_override_current_location_y_center(
         )
     ).then_return(True)
 
+    decoy.when(labware_view.get_is_column_labware("reservoir-id")).then_return(True)
+
     result = subject.get_pipette_location(
         pipette_id="pipette-id",
         current_location=current_well,
@@ -391,6 +395,7 @@ def test_get_pipette_offset_for_reservoirs(
             "labware-id",
         )
     ).then_return(False)
+    decoy.when(labware_view.get_is_column_labware("labware-id")).then_return(True)
 
     fake_well_position = Point(x=4, y=5, z=6)
     decoy.when(
@@ -484,6 +489,7 @@ def test_get_movement_waypoints_to_well_for_y_center(
             "labware-id",
         )
     ).then_return(False)
+    decoy.when(labware_view.get_is_column_labware("labware-id")).then_return(True)
 
     decoy.when(
         geometry_view.get_well_position(

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -178,7 +178,7 @@ def test_get_pipette_location_with_current_location_with_x_center(
     )
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "reservoir-id",
         )
     ).then_return(True)
@@ -213,7 +213,7 @@ def test_get_pipette_location_with_current_location_with_y_center(
     )
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "reservoir-id",
         )
     ).then_return(True)
@@ -285,7 +285,7 @@ def test_get_pipette_location_with_current_location_different_pipette(
     )
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "reservoir-id",
         )
     ).then_return(False)
@@ -364,7 +364,7 @@ def test_get_pipette_location_override_current_location_x_center(
     )
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "reservoir-id",
         )
     ).then_return(True)
@@ -404,7 +404,7 @@ def test_get_pipette_location_override_current_location_y_center(
     )
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "reservoir-id",
         )
     ).then_return(True)
@@ -461,7 +461,7 @@ def test_get_pipette_offset_for_reservoirs(
     decoy.when(labware_view.get_has_12_subwells("labware-id")).then_return(has_12_grid)
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "labware-id",
         )
     ).then_return(True)
@@ -555,7 +555,7 @@ def test_get_movement_waypoints_to_well_for_x_center(
     decoy.when(pipette_view.get_current_location()).then_return(location)
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "labware-id",
         )
     ).then_return(True)
@@ -643,7 +643,7 @@ def test_get_movement_waypoints_to_well_for_y_center(
     decoy.when(pipette_view.get_current_location()).then_return(location)
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "labware-id",
         )
     ).then_return(True)
@@ -731,7 +731,7 @@ def test_get_movement_waypoints_to_well_for_xy_center(
     decoy.when(pipette_view.get_current_location()).then_return(location)
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "labware-id",
         )
     ).then_return(False)
@@ -1251,7 +1251,7 @@ def test_get_touch_tip_waypoints(
         labware_view.get_should_center_pipette_on_target_well("labware-id")
     ).then_return(True)
     decoy.when(
-        labware_view.get_should_center_column_on_target_well("labware-id")
+        labware_view.get_should_center_column_or_row_on_target_well("labware-id")
     ).then_return(False)
 
     decoy.when(pipette_view.get_mount("pipette-id")).then_return(MountType.LEFT)

--- a/shared-data/labware/definitions/2/nest_8_reservoir_22ml/1.json
+++ b/shared-data/labware/definitions/2/nest_8_reservoir_22ml/1.json
@@ -113,6 +113,7 @@
       "wells": ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"]
     }
   ],
+  "parameters": {
     "format": "trough",
     "quirks": [],
     "isTiprack": false,

--- a/shared-data/labware/definitions/2/nest_8_reservoir_22ml/1.json
+++ b/shared-data/labware/definitions/2/nest_8_reservoir_22ml/1.json
@@ -115,7 +115,7 @@
   ],
   "parameters": {
     "format": "trough",
-    "quirks": [],
+    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "nest_8_reservoir_22ml"

--- a/shared-data/labware/definitions/2/nest_8_reservoir_22ml/2.json
+++ b/shared-data/labware/definitions/2/nest_8_reservoir_22ml/2.json
@@ -113,14 +113,15 @@
       "wells": ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"]
     }
   ],
+  "parameters": {
     "format": "trough",
-    "quirks": [],
+    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"],
     "isTiprack": false,
     "isMagneticModuleCompatible": false,
     "loadName": "nest_8_reservoir_22ml"
   },
   "namespace": "opentrons",
-  "version": 1,
+  "version": 2,
   "schemaVersion": 2,
   "cornerOffsetFromSlot": {
     "x": 0,


### PR DESCRIPTION
# Overview

Addresses EXEC-2737 and [RESC-587](https://opentrons.atlassian.net/browse/RESC-587).

This PR fixes an issue discovered with 96-channel pipettes in a partial row configuration (nozzles A1-A12 or H1-H12) did not center themselves properly onto labware made up of 8 row-length wells. This was occurring for several reasons. One, the labware in question (`nest_8_reservoir_22ml`), did not have the proper `centerMultichannelOnWells` quirk that tells our critical point position logic to not use the primary nozzle as the critical point. The second issue was there was no logic for centering on the X-axis of the active *row*, only a Y-axis and XY-axis for columns and single well reservoirs.

This issue was fixed in the following manner.

- The `centerMultichannelOnWells` was added to the labware definition, along with the `touchTipDisabled` quirk for good measure.
- A `x_center_offset` was added to the nozzle manager that finds the X-axis point by calculating the back-rightmost nozzle, and splitting the X-distance difference with that and the back-left nozzle, then adding that X-axis offset to the back-left nozzle. In practice, this will produce the point in between nozzles 6 and 7 for a full row configuration. For a full 96-channel configuration, this will be between nozzles A6 and A7. This is useful if one wants to aspirate/dispense from a row-based labware with a full 96 channel, as targeting well `A1` will correctly align the entire 96-channel with the labware.
- Additional logic was added to check if a labware is column-based or row-based before assigning it either a `Y_CENTER` offset or `X_CENTER` offset respectively. We determine this via the `ordering` and `wells` field of the labware defintion, where a column-based labware is defined as having more than one well, and an `ordering` list of length `1` sublists, while row based has more than one well and an ordering list of a single sublist. If a labware has the quirk, wells between 1 and 96, but does **not** conform to this pattern, we will default to no critical point.

## Test Plan and Hands on Testing

On robot testing with the following protocols to test row access, and regression test column and single well reservoir access:

```python
from opentrons import protocol_api

metadata = {
    "protocolName": "Row access on row labware",
}

requirements = {"robotType": "Flex", "apiLevel": "2.29"}

def run(protocol):
    tip_rack_1 = protocol.load_labware("opentrons_flex_96_filtertiprack_200ul",location="B1")
    tiprack_adapter = protocol.load_adapter("opentrons_flex_96_tiprack_adapter", "B3")
    tiprack_with_adapter = tiprack_adapter.load_labware("opentrons_flex_96_filtertiprack_200ul")
    reservoir_1 = protocol.load_labware(
        "nest_8_reservoir_22ml",
        location="C2",
        namespace="opentrons",
        version=1,
    )

    pipette = protocol.load_instrument("flex_96channel_1000")

    trash_bin_1 = protocol.load_trash_bin("A3")

    pipette.pick_up_tip(tiprack_with_adapter)
    for well in ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"]:
        pipette.aspirate(100, reservoir_1[well])
        pipette.dispense()
    pipette.return_tip()

    pipette.configure_nozzle_layout(
        protocol_api.ROW,
        start="H1",
    )

    pipette.pick_up_tip(tip_rack_1)
    for well in ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"]:
        pipette.aspirate(100, reservoir_1[well])
        pipette.dispense()
    pipette.return_tip()

    tip_rack_1.reset()
```

```python
from opentrons import protocol_api

metadata = {
    "protocolName": "Column access on column labware",
}

requirements = {"robotType": "Flex", "apiLevel": "2.29"}

def run(protocol):
    tip_rack_1 = protocol.load_labware("opentrons_flex_96_filtertiprack_200ul",location="B3")
    tiprack_adapter = protocol.load_adapter("opentrons_flex_96_tiprack_adapter", "A1")
    tiprack_with_adapter = tiprack_adapter.load_labware("opentrons_flex_96_filtertiprack_200ul")
    reservoir_1 = protocol.load_labware(
        "nest_12_reservoir_15ml",
        location="C3",
    )
    reservoir_2 = protocol.load_labware(
        "nest_1_reservoir_290ml",
        location="B1",
    )

    pipette = protocol.load_instrument("flex_96channel_1000")

    trash_bin_1 = protocol.load_trash_bin("A3")

    pipette.pick_up_tip(tiprack_with_adapter)
    pipette.aspirate(100, reservoir_2["A1"])
    pipette.dispense()
    pipette.return_tip()

    pipette.configure_nozzle_layout(
        protocol_api.COLUMN,
        start="A12",
    )

    pipette.pick_up_tip(tip_rack_1)
    pipette.aspirate(100, reservoir_1["A1"])
    pipette.aspirate(100, reservoir_1["A2"])
    pipette.dispense()
    pipette.return_tip()
```

## Changelog

- Added `centerMultichannelOnWells` and `touchTipDisabled` quirks to `nest_8_reservoir_22ml` labware definition
- Added `X_CENTER` offset for labware to center on the X-axis for the primary (backmost) row of a nozzle configuration
- Added checks to see if a labware is column or row based and return `Y_CENTER` or `X_CENTER` offset respectively

## Review requests

Are we good with the new way of determining column and row-based labware, and should we add the quirks to the existing definition as I have it, or create a new definition?

## Risk assessment

Medium-low, there's now new logic to determine both row based (which was **not** working previously) as well as column based, which is a refactor. All labware with the `centerMultichannelOnWells` that are columns will pass the new check, and it does make this logic more accurate, but this is a refactor of existing logic.

[RESC-587]: https://opentrons.atlassian.net/browse/RESC-587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ