### PR TITLE
added more args to allow for no CLI inputs

### DIFF
--- a/abr-testing/abr_testing/data_collection/read_robot_logs.py
+++ b/abr-testing/abr_testing/data_collection/read_robot_logs.py
@@ -477,7 +477,7 @@ def hs_commands(file_results: Dict[str, Any]) -> Dict[str, float]:
     hs_temp: float = 0.0
     hs_home_count: float = 0.0
     hs_speed: float = 0.0
-    hs_rotations: Dict[str, float] = dict()
+    hs_rotations: Dict[float, float] = dict()
     hs_temps: Dict[float, float] = dict()
     temp_time = None
     shake_time = None

--- a/abr-testing/abr_testing/data_collection/robot_fleet_error.py
+++ b/abr-testing/abr_testing/data_collection/robot_fleet_error.py
@@ -929,11 +929,38 @@ if __name__ == "__main__":
         nargs=1,
         help="Path to long term storage directory for run logs.",
     )
+    parser.add_argument(
+        "--ip_address",
+        metavar="IP",
+        default=None,
+        type=str,
+        help="Robot IP address",
+    )
+    parser.add_argument(
+        "--project_key",
+        metavar="PROJECT_KEY",
+        default=None,
+        type=str,
+        help="ABR or RQA",
+    )
+    parser.add_argument(
+        "--title",
+        metavar="TITLE",
+        default=None,
+        type=str,
+        help="Enter ticket title",
+    )
     args = parser.parse_args()
     storage_directory = args.storage_directory[0]
+    ip = args.ip_address
+    project_key = args.project_key
+    title = args.title
     jira_credentials = jira_tool.get_credentials(storage_directory)
     # Simplify the main section
-    inputs = init_ticketing()
+    if ip is None or project_key is None or title is None:
+        inputs = init_ticketing()
+    else:
+        inputs = ticketInputs(project_key, ip, title)
     ticket = jira_tool.JiraTicket(jira_credentials.api_token, jira_credentials.email)
     error_runs, protocol_ids = get_error_runs_from_robot(inputs.ip)
     data = organize_ticket_data(


### PR DESCRIPTION
# Overview

Added 3 optional arguments, IP, project (RABR or RQA), and title to the script. This allows for the script to be ran entirely without CLI inputs (yay!) for greater automation.

## Test Plan and Hands on Testing

Tested without args, performed as before. Tested with args, no inputs needed. Output was as expected.

## Changelog

Simply added 3 optional args inside of main of robot_fleet_error.py. The change in read_robot_logs was a lint pickup.

## Review requests

look at the code, see if the new stuff is sensible.

## Risk assessment

Low, changes almost nothing in a file that almost nobody uses
