### PR TITLE
feat(audit-server): add GET /audit/external/logPeriods endpoint to audit-server

### DIFF
--- a/audit-server/audit_server/app.py
+++ b/audit-server/audit_server/app.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 from server_utils import systemd_utils
 from server_utils.keys.fastapi import build_key_client, install_key_client
 
+from audit_server.log_export.router import router as log_export_router
 from audit_server.log_ingest.router import router as ingest_router
 from audit_server.persistence.database import sql_engine_ctx
 from audit_server.persistence.fastapi_dependencies import (
@@ -88,4 +89,5 @@ app = FastAPI(
 )
 
 app.include_router(ingest_router)
+app.include_router(log_export_router)
 app.include_router(settings_router)

--- a/audit-server/audit_server/log_export/__init__.py
+++ b/audit-server/audit_server/log_export/__init__.py
@@ -1,0 +1,1 @@
+"""Code for managing the export of log data."""

--- a/audit-server/audit_server/log_export/router.py
+++ b/audit-server/audit_server/log_export/router.py
@@ -1,0 +1,33 @@
+"""Route handlers for audit log export endpoints."""
+
+from typing import Annotated
+
+import fastapi
+
+from server_utils.fastapi_utils.models.json_api import MultiBodyMeta, SimpleMultiBody
+
+from audit_server.log_storage.dependency import get_log_store
+from audit_server.log_storage.models import LogPeriodSummary
+from audit_server.log_storage.store import LogStore
+
+router = fastapi.APIRouter()
+
+
+@router.get(
+    "/audit/external/logPeriods",
+    summary="Get all audit log periods",
+    description=(
+        "Returns all stored audit log periods, ordered newest first. "
+        "Each period includes its start time, end time (null if still active), "
+        "and total entry count."
+    ),
+)
+async def get_log_periods(
+    log_store: Annotated[LogStore, fastapi.Depends(get_log_store)],
+) -> SimpleMultiBody[LogPeriodSummary]:
+    """Get all audit log periods."""
+    periods = log_store.list_periods()
+    return SimpleMultiBody.model_construct(
+        data=periods,
+        meta=MultiBodyMeta(cursor=0, totalLength=len(periods)),
+    )

--- a/audit-server/audit_server/log_export/router.py
+++ b/audit-server/audit_server/log_export/router.py
@@ -16,11 +16,7 @@ router = fastapi.APIRouter()
 @router.get(
     "/audit/external/logPeriods",
     summary="Get all audit log periods",
-    description=(
-        "Returns all stored audit log periods, ordered newest first. "
-        "Each period includes its start time, end time (null if still active), "
-        "and total entry count."
-    ),
+    description="Returns all stored audit log periods, ordered oldest first.",
 )
 async def get_log_periods(
     log_store: Annotated[LogStore, fastapi.Depends(get_log_store)],

--- a/audit-server/audit_server/log_storage/models.py
+++ b/audit-server/audit_server/log_storage/models.py
@@ -9,6 +9,14 @@ import pydantic
 class LogPeriodSummary(pydantic.BaseModel):
     """Summary of a single audit log period."""
 
-    id: str
+    id: int = pydantic.Field(
+        description=(
+            "A monotonically increasing integer that uniquely identifies this log period. "
+            "Use this value to reference the period in other API calls. "
+            "Values are not guaranteed to be contiguous."
+        )
+    )
     startedAt: datetime
-    endedAt: Optional[datetime]
+    endedAt: Optional[datetime] = pydantic.Field(
+        description="The time this period ended, or null if the period is still active."
+    )

--- a/audit-server/audit_server/log_storage/models.py
+++ b/audit-server/audit_server/log_storage/models.py
@@ -1,0 +1,14 @@
+"""Request and response models for the audit log export endpoints."""
+
+from datetime import datetime
+from typing import Optional
+
+import pydantic
+
+
+class LogPeriodSummary(pydantic.BaseModel):
+    """Summary of a single audit log period."""
+
+    id: str
+    startedAt: datetime
+    endedAt: Optional[datetime]

--- a/audit-server/audit_server/log_storage/store.py
+++ b/audit-server/audit_server/log_storage/store.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.engine import Engine as SQLEngine
 from sqlalchemy.orm import Session, sessionmaker
 
+from .models import LogPeriodSummary
 from .types import StoredLog
 from audit_server.persistence.orm_models import LogEntry, LogPeriod
 
@@ -120,3 +121,18 @@ class LogStore:
         with self._session() as session:
             latest_record = await self._tail_log(session)
             return latest_record.message_hash
+
+    def list_periods(self) -> list[LogPeriodSummary]:
+        """Return all log periods, newest first, with their entry IDs in ordinal order."""
+        with self._session() as session:
+            periods = session.scalars(
+                select(LogPeriod).order_by(LogPeriod.started_at.desc())
+            ).all()
+            return [
+                LogPeriodSummary(
+                    id=str(period.id),
+                    startedAt=period.started_at,
+                    endedAt=period.ended_at,
+                )
+                for period in periods
+            ]

--- a/audit-server/audit_server/log_storage/store.py
+++ b/audit-server/audit_server/log_storage/store.py
@@ -123,14 +123,14 @@ class LogStore:
             return latest_record.message_hash
 
     def list_periods(self) -> list[LogPeriodSummary]:
-        """Return all log periods, newest first, with their entry IDs in ordinal order."""
+        """Return all log periods, oldest first, with their entry IDs in ordinal order."""
         with self._session() as session:
             periods = session.scalars(
-                select(LogPeriod).order_by(LogPeriod.started_at.desc())
+                select(LogPeriod).order_by(LogPeriod.started_at.asc())
             ).all()
             return [
                 LogPeriodSummary(
-                    id=str(period.id),
+                    id=period.id,
                     startedAt=period.started_at,
                     endedAt=period.ended_at,
                 )

--- a/audit-server/tests/log_export/test_router.py
+++ b/audit-server/tests/log_export/test_router.py
@@ -1,0 +1,133 @@
+"""Unit tests for the `GET /audit/external/logPeriods` route."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import AsyncGenerator, Generator
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from audit_server.log_export.router import router as log_export_router
+from audit_server.log_storage.store import LogStore
+from audit_server.log_storage.types import StoredLog
+from audit_server.persistence.database import create_schema, sql_engine_ctx
+from audit_server.persistence.fastapi_dependencies import set_sql_engine
+
+_ENDPOINT_PATH = "/audit/external/logPeriods"
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> Generator[TestClient, None, None]:
+    """A TestClient for an app wired up with a real LogStore and database."""
+    db_path = tmp_path / "test_audit.db"
+    with sql_engine_ctx(db_path) as engine:
+        create_schema(engine)
+        app = FastAPI()
+        set_sql_engine(app.state, engine)
+        app.include_router(log_export_router)
+        with TestClient(app) as test_client:
+            yield test_client
+
+
+@pytest.fixture
+async def client_with_periods(tmp_path: Path) -> AsyncGenerator[TestClient, None]:
+    """A TestClient pre-populated with one completed and one active log period."""
+    db_path = tmp_path / "test_audit.db"
+    with sql_engine_ctx(db_path) as engine:
+        create_schema(engine)
+        store = LogStore(sql_engine=engine)
+
+        # First period: completed
+        await store.start_period(
+            StoredLog(
+                message="p1 start", message_hash="h1", message_sig="s1", sig_version="1"
+            )
+        )
+        await store.end_period(
+            StoredLog(
+                message="p1 end", message_hash="h2", message_sig="s2", sig_version="1"
+            )
+        )
+
+        # Second period: still active
+        await store.start_period(
+            StoredLog(
+                message="p2 start", message_hash="h3", message_sig="s3", sig_version="1"
+            )
+        )
+
+        app = FastAPI()
+        set_sql_engine(app.state, engine)
+        app.include_router(log_export_router)
+        with TestClient(app) as test_client:
+            yield test_client
+
+
+def test_get_log_periods_empty(client: TestClient) -> None:
+    """GET logPeriods returns an empty list when no periods exist."""
+    response = client.get(_ENDPOINT_PATH)
+    assert response.status_code == 200
+    body = response.json()
+    assert body["data"] == []
+    assert body["meta"]["totalLength"] == 0
+
+
+def test_get_log_periods_returns_periods(
+    client_with_periods: TestClient,
+) -> None:
+    """GET logPeriods returns all periods."""
+    response = client_with_periods.get(_ENDPOINT_PATH)
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert len(data) == 2
+
+
+def test_get_log_periods_newest_first(
+    client_with_periods: TestClient,
+) -> None:
+    """GET logPeriods returns periods ordered newest first."""
+    response = client_with_periods.get(_ENDPOINT_PATH)
+    data = response.json()["data"]
+    assert len(data) == 2
+    # Active period (started second) should be first
+    assert data[0]["endedAt"] is None
+    assert data[1]["endedAt"] is not None
+
+
+def test_get_log_periods_active_period_has_null_ended_at(
+    client_with_periods: TestClient,
+) -> None:
+    """An in-progress period must have endedAt: null."""
+    response = client_with_periods.get(_ENDPOINT_PATH)
+    active = next(p for p in response.json()["data"] if p["endedAt"] is None)
+    assert active is not None
+    assert active["startedAt"] is not None
+
+
+def test_get_log_periods_completed_period_has_ended_at(
+    client_with_periods: TestClient,
+) -> None:
+    """A completed period must have a non-null endedAt."""
+    response = client_with_periods.get(_ENDPOINT_PATH)
+    completed = next(p for p in response.json()["data"] if p["endedAt"] is not None)
+    assert completed is not None
+
+
+def test_get_log_periods_ids_are_strings(
+    client_with_periods: TestClient,
+) -> None:
+    """Period IDs in the response must be strings."""
+    response = client_with_periods.get(_ENDPOINT_PATH)
+    for period in response.json()["data"]:
+        assert isinstance(period["id"], str)
+
+
+def test_get_log_periods_response_shape(
+    client_with_periods: TestClient,
+) -> None:
+    """Each period in the response must have exactly the expected fields."""
+    response = client_with_periods.get(_ENDPOINT_PATH)
+    for period in response.json()["data"]:
+        assert set(period.keys()) == {"id", "startedAt", "endedAt"}

--- a/audit-server/tests/log_export/test_router.py
+++ b/audit-server/tests/log_export/test_router.py
@@ -2,132 +2,69 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import AsyncGenerator, Generator
+from datetime import datetime, timezone
 
 import pytest
-from fastapi import FastAPI
-from starlette.testclient import TestClient
+from decoy import Decoy
 
-from audit_server.log_export.router import router as log_export_router
+from audit_server.log_export.router import get_log_periods
+from audit_server.log_storage.models import LogPeriodSummary
 from audit_server.log_storage.store import LogStore
-from audit_server.log_storage.types import StoredLog
-from audit_server.persistence.database import create_schema, sql_engine_ctx
-from audit_server.persistence.fastapi_dependencies import set_sql_engine
 
-_ENDPOINT_PATH = "/audit/external/logPeriods"
+_OLDER_PERIOD = LogPeriodSummary(
+    id=1,
+    startedAt=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    endedAt=datetime(2024, 1, 2, tzinfo=timezone.utc),
+)
 
-
-@pytest.fixture
-def client(tmp_path: Path) -> Generator[TestClient, None, None]:
-    """A TestClient for an app wired up with a real LogStore and database."""
-    db_path = tmp_path / "test_audit.db"
-    with sql_engine_ctx(db_path) as engine:
-        create_schema(engine)
-        app = FastAPI()
-        set_sql_engine(app.state, engine)
-        app.include_router(log_export_router)
-        with TestClient(app) as test_client:
-            yield test_client
+_NEWER_PERIOD = LogPeriodSummary(
+    id=2,
+    startedAt=datetime(2024, 2, 1, tzinfo=timezone.utc),
+    endedAt=None,
+)
 
 
 @pytest.fixture
-async def client_with_periods(tmp_path: Path) -> AsyncGenerator[TestClient, None]:
-    """A TestClient pre-populated with one completed and one active log period."""
-    db_path = tmp_path / "test_audit.db"
-    with sql_engine_ctx(db_path) as engine:
-        create_schema(engine)
-        store = LogStore(sql_engine=engine)
-
-        # First period: completed
-        await store.start_period(
-            StoredLog(
-                message="p1 start", message_hash="h1", message_sig="s1", sig_version="1"
-            )
-        )
-        await store.end_period(
-            StoredLog(
-                message="p1 end", message_hash="h2", message_sig="s2", sig_version="1"
-            )
-        )
-
-        # Second period: still active
-        await store.start_period(
-            StoredLog(
-                message="p2 start", message_hash="h3", message_sig="s3", sig_version="1"
-            )
-        )
-
-        app = FastAPI()
-        set_sql_engine(app.state, engine)
-        app.include_router(log_export_router)
-        with TestClient(app) as test_client:
-            yield test_client
+def log_store(decoy: Decoy) -> LogStore:
+    """A mocked LogStore."""
+    return decoy.mock(cls=LogStore)
 
 
-def test_get_log_periods_empty(client: TestClient) -> None:
-    """GET logPeriods returns an empty list when no periods exist."""
-    response = client.get(_ENDPOINT_PATH)
-    assert response.status_code == 200
-    body = response.json()
-    assert body["data"] == []
-    assert body["meta"]["totalLength"] == 0
-
-
-def test_get_log_periods_returns_periods(
-    client_with_periods: TestClient,
+async def test_get_log_periods_empty(
+    decoy: Decoy,
+    log_store: LogStore,
 ) -> None:
-    """GET logPeriods returns all periods."""
-    response = client_with_periods.get(_ENDPOINT_PATH)
-    assert response.status_code == 200
-    data = response.json()["data"]
-    assert len(data) == 2
+    """It should return an empty data list and totalLength of 0."""
+    decoy.when(log_store.list_periods()).then_return([])
+
+    result = await get_log_periods(log_store=log_store)
+
+    assert result.data == []
+    assert result.meta.totalLength == 0
 
 
-def test_get_log_periods_newest_first(
-    client_with_periods: TestClient,
+async def test_get_log_periods_returns_all_periods(
+    decoy: Decoy,
+    log_store: LogStore,
 ) -> None:
-    """GET logPeriods returns periods ordered newest first."""
-    response = client_with_periods.get(_ENDPOINT_PATH)
-    data = response.json()["data"]
-    assert len(data) == 2
-    # Active period (started second) should be first
-    assert data[0]["endedAt"] is None
-    assert data[1]["endedAt"] is not None
+    """It should return all periods returned by the store."""
+    decoy.when(log_store.list_periods()).then_return([_NEWER_PERIOD, _OLDER_PERIOD])
+
+    result = await get_log_periods(log_store=log_store)
+
+    assert len(result.data) == 2
+    assert result.meta.totalLength == 2
 
 
-def test_get_log_periods_active_period_has_null_ended_at(
-    client_with_periods: TestClient,
+async def test_get_log_periods_preserves_store_order(
+    decoy: Decoy,
+    log_store: LogStore,
 ) -> None:
-    """An in-progress period must have endedAt: null."""
-    response = client_with_periods.get(_ENDPOINT_PATH)
-    active = next(p for p in response.json()["data"] if p["endedAt"] is None)
-    assert active is not None
-    assert active["startedAt"] is not None
+    """It should return periods in the same order the store provides them."""
+    decoy.when(log_store.list_periods()).then_return([_NEWER_PERIOD, _OLDER_PERIOD])
 
+    result = await get_log_periods(log_store=log_store)
 
-def test_get_log_periods_completed_period_has_ended_at(
-    client_with_periods: TestClient,
-) -> None:
-    """A completed period must have a non-null endedAt."""
-    response = client_with_periods.get(_ENDPOINT_PATH)
-    completed = next(p for p in response.json()["data"] if p["endedAt"] is not None)
-    assert completed is not None
-
-
-def test_get_log_periods_ids_are_strings(
-    client_with_periods: TestClient,
-) -> None:
-    """Period IDs in the response must be strings."""
-    response = client_with_periods.get(_ENDPOINT_PATH)
-    for period in response.json()["data"]:
-        assert isinstance(period["id"], str)
-
-
-def test_get_log_periods_response_shape(
-    client_with_periods: TestClient,
-) -> None:
-    """Each period in the response must have exactly the expected fields."""
-    response = client_with_periods.get(_ENDPOINT_PATH)
-    for period in response.json()["data"]:
-        assert set(period.keys()) == {"id", "startedAt", "endedAt"}
+    assert result.data[0].startedAt > result.data[1].startedAt
+    assert result.data[0].endedAt is None
+    assert result.data[1].endedAt is not None

--- a/audit-server/tests/log_storage/test_store.py
+++ b/audit-server/tests/log_storage/test_store.py
@@ -244,10 +244,10 @@ async def test_list_periods_returns_completed_period(
     assert periods[0].endedAt is not None
 
 
-async def test_list_periods_ordered_newest_first(
+async def test_list_periods_ordered_oldest_first(
     subject: LogStore,
 ) -> None:
-    """It should return periods ordered with the newest started_at first."""
+    """It should return periods ordered with the oldest started_at first."""
     await subject.start_period(
         StoredLog(message="first", message_hash="h1", message_sig="s1", sig_version="1")
     )
@@ -264,15 +264,6 @@ async def test_list_periods_ordered_newest_first(
 
     periods = subject.list_periods()
     assert len(periods) == 2
-    # Newest period (second) should come first
-    assert periods[0].endedAt is None
-    assert periods[1].endedAt is not None
-
-
-async def test_list_periods_ids_are_strings(
-    subject_with_period: LogStore,
-) -> None:
-    """It should return period IDs as strings, not ints."""
-    periods = subject_with_period.list_periods()
-    assert len(periods) == 1
-    assert isinstance(periods[0].id, str)
+    assert periods[1].startedAt > periods[0].startedAt
+    assert periods[0].endedAt is not None
+    assert periods[1].endedAt is None

--- a/audit-server/tests/log_storage/test_store.py
+++ b/audit-server/tests/log_storage/test_store.py
@@ -208,3 +208,71 @@ async def test_get_tail_hash_fails_if_no_period_active(
     )
     with pytest.raises(NoActivePeriodError):
         await subject_with_period.tail_hash()
+
+
+async def test_list_periods_returns_empty_when_no_periods(
+    subject: LogStore,
+) -> None:
+    """It should return an empty list when no periods exist."""
+    assert subject.list_periods() == []
+
+
+async def test_list_periods_returns_active_period(
+    subject_with_period: LogStore,
+) -> None:
+    """It should return the active period with endedAt as None."""
+    periods = subject_with_period.list_periods()
+    assert len(periods) == 1
+    assert periods[0].endedAt is None
+    assert periods[0].startedAt is not None
+
+
+async def test_list_periods_returns_completed_period(
+    subject_with_period: LogStore,
+) -> None:
+    """It should return a completed period with endedAt set."""
+    await subject_with_period.end_period(
+        StoredLog(
+            message="ending",
+            message_hash="end_hash",
+            message_sig="end_sig",
+            sig_version="1",
+        )
+    )
+    periods = subject_with_period.list_periods()
+    assert len(periods) == 1
+    assert periods[0].endedAt is not None
+
+
+async def test_list_periods_ordered_newest_first(
+    subject: LogStore,
+) -> None:
+    """It should return periods ordered with the newest started_at first."""
+    await subject.start_period(
+        StoredLog(message="first", message_hash="h1", message_sig="s1", sig_version="1")
+    )
+    await subject.end_period(
+        StoredLog(
+            message="end first", message_hash="h2", message_sig="s2", sig_version="1"
+        )
+    )
+    await subject.start_period(
+        StoredLog(
+            message="second", message_hash="h3", message_sig="s3", sig_version="1"
+        )
+    )
+
+    periods = subject.list_periods()
+    assert len(periods) == 2
+    # Newest period (second) should come first
+    assert periods[0].endedAt is None
+    assert periods[1].endedAt is not None
+
+
+async def test_list_periods_ids_are_strings(
+    subject_with_period: LogStore,
+) -> None:
+    """It should return period IDs as strings, not ints."""
+    periods = subject_with_period.list_periods()
+    assert len(periods) == 1
+    assert isinstance(periods[0].id, str)


### PR DESCRIPTION
# Overview

Adds the first read endpoint to the audit-server's external API. `GET /audit/external/logPeriods` returns all stored log periods ordered oldest-first, each with `id`, `startedAt`, and `endedAt` (null if the period is still active).

Implementation adds a `log_export` module (models.py, router.py) to keep export concerns separate from log ingestion, a `list_periods()` method on `LogStore`, and `LogPeriodSummary` in `log_storage/models.py` so the storage layer owns its own response type (as opposed to maintaining this response model in `log_export`. The router is registered in `app.py` alongside the existing ingest and settings routers.

Closes EXEC-2783

## Test Plan and Hands on Testing

- wrote and updated unit tests for router and new `list_periods` method 
- sent `GET http://localhost:33970/audit/external/logPeriods` to a locally running audit-server and verified a 200 response:
```
{
    "data": [],
    "meta": {
        "cursor": 0,
        "totalLength": 0
    }
}
```

## Changelog

- Adds GET /audit/external/logPeriods endpoint returning all log periods ordered newest-first
- Adds list_periods() method to LogStore
- Adds new log_export module (models.py, router.py) to separate export concerns from log ingestion
- Adds LogPeriodSummary response model with id, startedAt, and endedAt fields
- Registers log_export_router in app.py
- Adds unit tests for list_periods() and the new route

## Review requests

See test plan for review.

## Risk assessment

Low. All changes are additive at this point