### PR TITLE
feat(auth-server): Wire up idleLogout

### DIFF
--- a/auth-server/auth_server/app.py
+++ b/auth-server/auth_server/app.py
@@ -16,7 +16,7 @@ from server_utils.auth.resource_server.fastapi import (
 )
 
 from auth_server.authorization_checker import build_authorization_checker
-from auth_server.oauth2.backend import build as build_oauth2_backend
+from auth_server.oauth2.backend import Backend as OAuth2Backend
 from auth_server.oauth2.fastapi_dependencies import (
     install_oauth2_backend,
 )
@@ -63,7 +63,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
         user_store = UserStore(sql_engine=engine)
         settings_store = SettingsStore(sql_engine=engine)
-        oauth2_backend = build_oauth2_backend(user_store, settings_store)
+        oauth2_backend = OAuth2Backend(user_store, settings_store)
         install_oauth2_backend(app.state, oauth2_backend)
         user_service = UserDataManager(
             user_store=user_store, settings_store=settings_store

--- a/auth-server/auth_server/authorization_checker.py
+++ b/auth-server/auth_server/authorization_checker.py
@@ -97,7 +97,9 @@ class _SelfClient(Client):
 
         # Get a list of key-value tuples and help the type checker see that every value
         # is guaranteed to be a string.
-        request_form_data_kvs = [(k, v )for (k, v )in request_form_data.items() if isinstance(v, str)]
+        request_form_data_kvs = [
+            (k, v) for (k, v) in request_form_data.items() if isinstance(v, str)
+        ]
         assert len(request_form_data_kvs) == len(request_form_data)
 
         raw_response = self._oauth2_backend.create_introspect_response(

--- a/auth-server/auth_server/authorization_checker.py
+++ b/auth-server/auth_server/authorization_checker.py
@@ -94,21 +94,26 @@ class _SelfClient(Client):
             "token": token,
             "client_id": CLIENT_ID,
         }
-        _raw_response_headers, raw_response_body, raw_response_status_code = (
-            self._oauth2_backend.create_introspect_response(
-                # The uri param apparently does not matter.
-                uri="",
-                # The type stubs are wrong; `body` can in fact be a `list[tuple[str, str]]`.
-                body=[(name, value) for name, value in request_form_data.items()],  # type: ignore[arg-type]
-            )
+
+        # Get a list of key-value tuples and help the type checker see that every value
+        # is guaranteed to be a string.
+        request_form_data_kvs = [(k, v )for (k, v )in request_form_data.items() if isinstance(v, str)]
+        assert len(request_form_data_kvs) == len(request_form_data)
+
+        raw_response = self._oauth2_backend.create_introspect_response(
+            # The uri param apparently does not matter.
+            uri="",
+            body_form_data=request_form_data_kvs,
+            headers={},
         )
-        if not 200 <= raw_response_status_code < 300:
+
+        if not 200 <= raw_response.status_code < 300:
             raise RuntimeError(
                 f"Internal token introspection request failed."
-                f" Status code: {raw_response_status_code}."
-                f" Body: {repr(raw_response_body)}."
+                f" Status code: {raw_response.status_code}."
+                f" Body: {repr(raw_response.body)}."
             )
         parsed_response = TokenIntrospectionResponse.model_validate_json(
-            raw_response_body
+            raw_response.body
         )
         return parsed_response

--- a/auth-server/auth_server/authorization_checker.py
+++ b/auth-server/auth_server/authorization_checker.py
@@ -101,8 +101,6 @@ class _SelfClient(Client):
         assert len(request_form_data_kvs) == len(request_form_data)
 
         raw_response = self._oauth2_backend.create_introspect_response(
-            # The uri param apparently does not matter.
-            uri="",
             body_form_data=request_form_data_kvs,
             headers={},
         )

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -416,7 +416,8 @@ class _TokenStore:
 def _is_list_of_type[ElementT](
     alleged_list: object, expected_element_type: type[ElementT]
 ) -> TypeGuard[list[ElementT]]:
-    assert isinstance(alleged_list, list)
+    if not isinstance(alleged_list, list):
+        return False
     return all(
         isinstance(element, expected_element_type)
         for element in cast(list[object], alleged_list)

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -47,7 +47,7 @@ class Backend:
         )
 
     def create_token_response(
-        self, uri: str, body_form_data: list[tuple[str, str]], headers: dict[str, str]
+        self, body_form_data: list[tuple[str, str]], headers: dict[str, str]
     ) -> fastapi.Response:
         token_response: tuple[dict[str, str], str, int] = (
             self._inner_backend.create_token_response(
@@ -68,7 +68,7 @@ class Backend:
 
 
     def create_introspect_response(
-        self, uri: str, body_form_data: list[tuple[str, str]], headers: dict[str, str]
+        self, body_form_data: list[tuple[str, str]], headers: dict[str, str]
     ) -> fastapi.Response:
         headers, body, status_code = self._inner_backend.create_introspect_response(
             # The uri param apparently does not matter.

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -70,7 +70,6 @@ class Backend:
             status_code=status_code,
         )
 
-
     def create_introspect_response(
         self, body_form_data: list[tuple[str, str]], headers: dict[str, str]
     ) -> fastapi.Response:

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -4,8 +4,9 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Any, NotRequired, TypeAlias, TypedDict, TypeGuard, cast, override
+from typing import Any, NotRequired, TypedDict, TypeGuard, cast, override
 
+import fastapi
 import oauthlib.common
 import oauthlib.oauth2
 import pydantic
@@ -29,24 +30,60 @@ _log = logging.getLogger(__name__)
 # https://github.com/oauthlib/oauthlib/issues/641
 _CLIENT_ID = "opentrons_app"
 
-# todo(mm, 2026-01-30): There ought to be some HTTP endpoint to configure this.
-_TOKEN_LIFETIME = timedelta(days=30)
+
+class Backend:
+    """A backend that our server can use to process OAuth 2 requests."""
+
+    def __init__(self, user_store: UserStore, settings_store: SettingsStore) -> None:
+        def get_token_expires_in(request: oauthlib.common.Request) -> int:
+            idle_logout_setting = settings_store.get_settings().idleLogout
+            return int(idle_logout_setting)
+
+        # "Legacy" refers to the fact that it uses the "resource owner password credentials"
+        # grant type.
+        self._inner_backend = oauthlib.oauth2.LegacyApplicationServer(
+            _RequestValidator(_TokenStore(), user_store, settings_store),
+            token_expires_in=get_token_expires_in,
+        )
+
+    def create_token_response(
+        self, uri: str, body_form_data: list[tuple[str, str]], headers: dict[str, str]
+    ) -> fastapi.Response:
+        token_response: tuple[dict[str, str], str, int] = (
+            self._inner_backend.create_token_response(
+                # The uri param apparently does not matter.
+                uri="",
+                # We can assume the request was POST because the FastAPI layer will enforce it.
+                http_method="POST",
+                body=body_form_data,
+                headers=headers,
+            )
+        )
+        headers, body, status_code = token_response
+        return fastapi.Response(
+            headers=headers,
+            content=body,
+            status_code=status_code,
+        )
 
 
-Backend: TypeAlias = oauthlib.oauth2.LegacyApplicationServer
-"""A backend that our server can use to process OAuth 2 requests.
-
-"Legacy" in this case refers to the fact that it uses the "resource owner password
-credentials" grant type.
-"""
-
-
-def build(user_store: UserStore, settings_store: SettingsStore) -> Backend:
-    """Return a backend that our server can use to process OAuth 2 requests."""
-    return oauthlib.oauth2.LegacyApplicationServer(
-        _RequestValidator(_TokenStore(), user_store, settings_store),
-        token_expires_in=int(_TOKEN_LIFETIME.total_seconds()),
-    )
+    def create_introspect_response(
+        self, uri: str, body_form_data: list[tuple[str, str]], headers: dict[str, str]
+    ) -> fastapi.Response:
+        headers, body, status_code = self._inner_backend.create_introspect_response(
+            # The uri param apparently does not matter.
+            uri="",
+            # We can assume the request was POST because the FastAPI layer will enforce it.
+            http_method="POST",
+            # The type stubs are wrong; `body` can in fact be a `list[tuple[str, str]]`.
+            body=body_form_data,  # type: ignore[arg-type]
+            headers=headers,
+        )
+        return fastapi.Response(
+            headers=headers,
+            content=body,
+            status_code=status_code,
+        )
 
 
 @dataclass

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -49,6 +49,10 @@ class Backend:
     def create_token_response(
         self, body_form_data: list[tuple[str, str]], headers: dict[str, str]
     ) -> fastapi.Response:
+        """Process a request to the OAuth 2 token endpoint and return the response.
+
+        This is basically a type-safe wrapper around the underlying oauthlib implementation.
+        """
         token_response: tuple[dict[str, str], str, int] = (
             self._inner_backend.create_token_response(
                 # The uri param apparently does not matter.
@@ -70,6 +74,10 @@ class Backend:
     def create_introspect_response(
         self, body_form_data: list[tuple[str, str]], headers: dict[str, str]
     ) -> fastapi.Response:
+        """Process a request to the OAuth 2 introspection endpoint and return the response.
+
+        This is basically a type-safe wrapper around the underlying oauthlib implementation.
+        """
         headers, body, status_code = self._inner_backend.create_introspect_response(
             # The uri param apparently does not matter.
             uri="",

--- a/auth-server/auth_server/oauth2/fastapi_dependencies.py
+++ b/auth-server/auth_server/oauth2/fastapi_dependencies.py
@@ -9,7 +9,7 @@ from server_utils.fastapi_utils.app_state import (
     get_app_state,
 )
 
-from .backend import Backend, build
+from .backend import Backend
 from auth_server.settings.store import SettingsStore
 from auth_server.users.store import UserStore
 
@@ -31,7 +31,7 @@ def install_oath2_sql_engine(app_state: AppState, sql_engine: SQLEngine) -> None
     """
     user_store = UserStore(sql_engine=sql_engine)
     settings_store = SettingsStore(sql_engine=sql_engine)
-    backend = build(user_store, settings_store)
+    backend = Backend(user_store, settings_store)
     _app_state_accessor.set_on(app_state, backend)
 
 

--- a/auth-server/auth_server/oauth2/router.py
+++ b/auth-server/auth_server/oauth2/router.py
@@ -17,19 +17,10 @@ async def token_endpoint(
 ) -> fastapi.Response:
     """The OAuth 2 token endpoint, as specified in RFC 6749."""
     form_data = await _get_form_data(request)
-    token_response: tuple[dict[str, str], str, int] = (
-        oauth2_backend.create_token_response(
-            uri=str(request.url),
-            http_method=request.method,  # type: ignore[arg-type]
-            body=form_data,
-            headers=dict(request.headers),
-        )
-    )
-    headers, body, status_code = token_response
-    return fastapi.Response(
-        headers=headers,
-        content=body,
-        status_code=status_code,
+    return oauth2_backend.create_token_response(
+        uri=str(request.url),
+        body_form_data=form_data,
+        headers=dict(request.headers),
     )
 
 
@@ -40,17 +31,10 @@ async def introspection_endpoint(
 ) -> fastapi.Response:
     """The OAuth 2 token introspection endpoint, as specified in RFC 7662."""
     form_data = await _get_form_data(request)
-    headers, body, status_code = oauth2_backend.create_introspect_response(
+    return oauth2_backend.create_introspect_response(
         uri=str(request.url),
-        http_method=request.method,  # type: ignore[arg-type]
-        # The type stubs are wrong; `body` can in fact be a `list[tuple[str, str]]`.
-        body=form_data,  # type: ignore[arg-type]
+        body_form_data=form_data,
         headers=dict(request.headers),
-    )
-    return fastapi.Response(
-        headers=headers,
-        content=body,
-        status_code=status_code,
     )
 
 

--- a/auth-server/auth_server/oauth2/router.py
+++ b/auth-server/auth_server/oauth2/router.py
@@ -18,7 +18,6 @@ async def token_endpoint(
     """The OAuth 2 token endpoint, as specified in RFC 6749."""
     form_data = await _get_form_data(request)
     return oauth2_backend.create_token_response(
-        uri=str(request.url),
         body_form_data=form_data,
         headers=dict(request.headers),
     )
@@ -32,7 +31,6 @@ async def introspection_endpoint(
     """The OAuth 2 token introspection endpoint, as specified in RFC 7662."""
     form_data = await _get_form_data(request)
     return oauth2_backend.create_introspect_response(
-        uri=str(request.url),
         body_form_data=form_data,
         headers=dict(request.headers),
     )

--- a/auth-server/tests/integration/test_token_expiration.tavern.yaml
+++ b/auth-server/tests/integration/test_token_expiration.tavern.yaml
@@ -1,0 +1,136 @@
+test_name: The idleLogout setting controls token lifetimes
+
+marks:
+  - usefixtures:
+      - run_server
+      - admin_access_token
+
+stages:
+  - name: PATCH idleLogout to 30
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          idleLogout: 30.0
+    response:
+      status_code: 200
+
+  - name: New tokens should be issued with a 30s lifetime
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data: &password_grant
+        client_id: opentrons_app
+        grant_type: password
+        username: testadmin
+        password: testadminpassword
+    response:
+      status_code: 200
+      json:
+        expires_in: 30
+        access_token: !anystr
+        refresh_token: !anystr
+        token_type: Bearer
+      save:
+        json:
+          access_token: access_token
+          refresh_token: refresh_token
+      strict:
+        - json:off
+
+  - name: Introspection should show the access token as active inside the 30s lifetime
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{access_token}'
+    response:
+      status_code: 200
+      json:
+        active: true
+        username: testadmin
+      strict:
+        - json:off
+
+  - name: The refresh token should work inside the 30s lifetime
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: refresh_token
+        refresh_token: '{refresh_token}'
+    response:
+      status_code: 200
+      json:
+        expires_in: 30
+        access_token: !anystr
+        refresh_token: !anystr
+        token_type: Bearer
+      strict:
+        - json:off
+
+  - name: PATCH idleLogout to 1
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          idleLogout: 1.0
+    response:
+      status_code: 200
+
+  - name: New tokens should be issued with a 1s lifetime
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data: *password_grant
+    response:
+      status_code: 200
+      json:
+        expires_in: 1
+        access_token: !anystr
+        refresh_token: !anystr
+        token_type: Bearer
+      save:
+        json:
+          short_access_token: access_token
+          short_refresh_token: refresh_token
+      strict:
+        - json:off
+
+  - name: Introspection should show the access token as inactive outside the 1s lifetime
+    delay_before: 2
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{short_access_token}'
+    response:
+      status_code: 200
+      json:
+        active: false
+      strict:
+        - json:off
+
+  - name: The refresh token should be rejected outside the 1s lifetime
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: refresh_token
+        refresh_token: '{short_refresh_token}'
+    response:
+      status_code: 400
+      json:
+        error: invalid_grant
+      strict:
+        - json:off


### PR DESCRIPTION
## Overview

This makes the "idle logout" setting actually have an effect on the backend. If you set it to, say, 1 minute, the user will be automatically logged out after 1 minute of activity, and they'll need to enter their username and password again before interacting further with the robot.

This closes EXEC-2772.

## Test Plan and Hands on Testing

I'll test this on a real robot:

* Set the value to something like 10 seconds. There's no UI for this yet; you need to use Postman or something.
* Log in.
* Wait 10 seconds. You should get logged out automatically.

This also includes a Tavern integration test.

## Changelog

This turned out not to be too difficult.

`oauthlib` makes us specify `token_expires_in` up-front, "statically." This was concerning, but it turns out that we can pass a function for oauthlib to call whenever it issues a new access token, and it can return a new value each time. So we just need to implement that function to query auth-server's storage for the current value of the `idleLogout` setting.

Besides that, this PR wraps refactors our OAuth 2 `Backend` type to be wrapped in a custom class, for better type safety.

## Review requests

None in particular.

## Risk assessment

This is a small change to a sensitive part of the code, so it's either perfectly fine or it's totally broken everything. It should be low-risk as long as it passes the manual testing above.