### PR TITLE
refactor(server-utils): Minor refactors and reorganization

### DIFF
--- a/robot-server/robot_server/service/notifications/models.py
+++ b/robot-server/robot_server/service/notifications/models.py
@@ -1,0 +1,22 @@
+"""MQTT notification message body models."""
+
+from pydantic import BaseModel
+
+
+class NotifyRefetchBody(BaseModel):
+    """A notification response that returns a flag for refetching via HTTP."""
+
+    model_config = {"strict": True}
+
+    refetch: bool = True
+
+
+class NotifyUnsubscribeBody(BaseModel):
+    """A notification response.
+
+    Returns flags for unsubscribing from a topic.
+    """
+
+    model_config = {"strict": True}
+
+    unsubscribe: bool = True

--- a/robot-server/robot_server/service/notifications/notification_client.py
+++ b/robot-server/robot_server/service/notifications/notification_client.py
@@ -14,6 +14,7 @@ from server_utils.fastapi_utils.app_state import (
     AppStateAccessor,
     get_app_state,
 )
+
 from .models import NotifyRefetchBody, NotifyUnsubscribeBody
 from .topics import TopicName
 

--- a/robot-server/robot_server/service/notifications/notification_client.py
+++ b/robot-server/robot_server/service/notifications/notification_client.py
@@ -14,11 +14,7 @@ from server_utils.fastapi_utils.app_state import (
     AppStateAccessor,
     get_app_state,
 )
-from server_utils.fastapi_utils.models.json_api import (
-    NotifyRefetchBody,
-    NotifyUnsubscribeBody,
-)
-
+from .models import NotifyRefetchBody, NotifyUnsubscribeBody
 from .topics import TopicName
 
 log: logging.Logger = logging.getLogger(__name__)

--- a/server-utils/server_utils/fastapi_utils/documented_interaction.py
+++ b/server-utils/server_utils/fastapi_utils/documented_interaction.py
@@ -4,8 +4,6 @@ from typing import Final
 
 from fastapi import Request
 
-from .models.json_api.request import parse_supplied_user_notes
-
 _MUTATING_METHODS: Final = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
 USER_NOTES_HEADER: Final[str] = "Opentrons-User-Notes"
@@ -13,6 +11,7 @@ USER_NOTES_HEADER: Final[str] = "Opentrons-User-Notes"
 
 # TODO(TZ, 5-26-26): Support encoded header values (e.g. ``b64:`` prefix + base64) so clients can
 # send arbitrary Unicode and control characters, not only printable ASCII.
+# https://opentrons.atlassian.net/browse/EXEC-2727
 
 
 async def get_supplied_user_notes(request: Request) -> str | None:
@@ -20,4 +19,12 @@ async def get_supplied_user_notes(request: Request) -> str | None:
     if request.method not in _MUTATING_METHODS:
         return None
 
-    return parse_supplied_user_notes(request.headers.get(USER_NOTES_HEADER))
+    return _parse_supplied_user_notes(request.headers.get(USER_NOTES_HEADER))
+
+
+def _parse_supplied_user_notes(user_notes: str | None) -> str | None:
+    """Return non-empty audit notes, or ``None`` if absent or whitespace-only."""
+    if user_notes is None:
+        return None
+    stripped = user_notes.strip()
+    return stripped if stripped else None

--- a/server-utils/server_utils/fastapi_utils/models/json_api/__init__.py
+++ b/server-utils/server_utils/fastapi_utils/models/json_api/__init__.py
@@ -11,8 +11,6 @@ from .response import (
     EmptyBody,
     MultiBody,
     MultiBodyMeta,
-    NotifyRefetchBody,
-    NotifyUnsubscribeBody,
     PydanticResponse,
     ResourceModel,
     SimpleBody,
@@ -45,7 +43,4 @@ __all__ = [
     "DeprecatedResponseDataModel",
     "DeprecatedResponseModel",
     "DeprecatedMultiResponseModel",
-    # notify models
-    "NotifyRefetchBody",
-    "NotifyUnsubscribeBody",
 ]

--- a/server-utils/server_utils/fastapi_utils/models/json_api/request.py
+++ b/server-utils/server_utils/fastapi_utils/models/json_api/request.py
@@ -7,14 +7,6 @@ from pydantic import BaseModel, Field
 RequestDataT = TypeVar("RequestDataT")
 
 
-def parse_supplied_user_notes(user_notes: str | None) -> str | None:
-    """Return non-empty audit notes, or ``None`` if absent or whitespace-only."""
-    if user_notes is None:
-        return None
-    stripped = user_notes.strip()
-    return stripped if stripped else None
-
-
 class RequestModel(BaseModel, Generic[RequestDataT]):
     """A request model."""
 

--- a/server-utils/server_utils/fastapi_utils/models/json_api/response.py
+++ b/server-utils/server_utils/fastapi_utils/models/json_api/response.py
@@ -307,4 +307,3 @@ class DeprecatedMultiResponseModel(
         None,
         description=DESCRIPTION_LINKS,
     )
-

--- a/server-utils/server_utils/fastapi_utils/models/json_api/response.py
+++ b/server-utils/server_utils/fastapi_utils/models/json_api/response.py
@@ -308,17 +308,3 @@ class DeprecatedMultiResponseModel(
         description=DESCRIPTION_LINKS,
     )
 
-
-class NotifyRefetchBody(BaseResponseBody):
-    """A notification response that returns a flag for refetching via HTTP."""
-
-    refetch: bool = True
-
-
-class NotifyUnsubscribeBody(BaseResponseBody):
-    """A notification response.
-
-    Returns flags for unsubscribing from a topic.
-    """
-
-    unsubscribe: bool = True

--- a/server-utils/tests/fastapi_utils/json_api/test_response.py
+++ b/server-utils/tests/fastapi_utils/json_api/test_response.py
@@ -13,8 +13,6 @@ from server_utils.fastapi_utils.models.json_api.response import (
     EmptyBody,
     MultiBody,
     MultiBodyMeta,
-    NotifyRefetchBody,
-    NotifyUnsubscribeBody,
     ResourceModel,
     SimpleBody,
     SimpleEmptyBody,
@@ -118,11 +116,6 @@ RESPONSE_SPECS = [
             "data": [{"id": "hello", "val": None}, {"id": "goodbye", "val": None}],
             "links": {"sibling": {"href": "/bar", "meta": None}},
         },
-    ),
-    ResponseSpec(subject=NotifyRefetchBody(), expected={"refetch": True}),
-    ResponseSpec(
-        subject=NotifyUnsubscribeBody(),
-        expected={"unsubscribe": True},
     ),
 ]
 


### PR DESCRIPTION
## Changelog

Minor refactors to some models that are used for [robot-server's MQTT notifications](https://github.com/Opentrons/opentrons/blob/f1297bc9b68154c6af880e1ea83fef08d3114484/robot-server/README_NOTIFICATIONS.md).

* These are only used by robot-server, so instead of having them live inside server-utils, have them live inside robot-server, with the rest of its MQTT stuff.
* Inherit from Pydantic's `BaseModel` instead of our `BaseResponseBody`. `BaseResponseBody` has Pydantic v1 baggage, and it's for the HTTP API, not the MQTT API.
* Enable `{"strict": True}`, because it's a good practice in general, and it's easy to see that it's a safe change to make here.

Also:

* Do not publicly export `parse_supplied_user_notes()` from `models`. It's not a model and it's also only used internally.

## Test Plan and Hands on Testing

I think CI is sufficient.

## Review requests

None.

## Risk assessment

Low.