### PR TITLE
fix(app): fix stale i18n on app update available toast

### DIFF
--- a/app/src/LocalizationProvider.tsx
+++ b/app/src/LocalizationProvider.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo } from 'react'
 import { I18nextProvider } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import reduce from 'lodash/reduce'
@@ -24,35 +25,47 @@ export function LocalizationProvider(
   const language = useSelector(getAppLanguage)
 
   // iterate through language resources, nested files, substitute anonymous file for branded file for OEM mode
-  const anonResources = reduce(
-    resources,
-    (acc, resource, language) => {
-      const anonFiles = reduce(
-        resource,
-        (acc, file, fileName) => {
-          if (fileName === BRANDED_RESOURCE && isOEMMode) {
-            return acc
-          } else if (fileName === ANONYMOUS_RESOURCE) {
-            return isOEMMode ? { ...acc, [BRANDED_RESOURCE]: file } : acc
-          } else {
-            return { ...acc, [fileName]: file }
-          }
+  const anonResources = useMemo(
+    () =>
+      reduce(
+        resources,
+        (acc, resource, lang) => {
+          const anonFiles = reduce(
+            resource,
+            (acc, file, fileName) => {
+              if (fileName === BRANDED_RESOURCE && isOEMMode) {
+                return acc
+              } else if (fileName === ANONYMOUS_RESOURCE) {
+                return isOEMMode ? { ...acc, [BRANDED_RESOURCE]: file } : acc
+              } else {
+                return { ...acc, [fileName]: file }
+              }
+            },
+            {}
+          )
+          return { ...acc, [lang]: anonFiles }
         },
         {}
-      )
-      return { ...acc, [language]: anonFiles }
-    },
-    {}
+      ),
+    [isOEMMode]
   )
 
-  const anonI18n = i18n.createInstance(
-    {
-      ...i18nConfig,
-      lng: language ?? 'en',
-      resources: anonResources,
-    },
-    i18nCb
+  const anonI18n = useMemo(
+    () =>
+      i18n.createInstance(
+        {
+          ...i18nConfig,
+          lng: 'en',
+          resources: anonResources,
+        },
+        i18nCb
+      ),
+    [anonResources]
   )
+
+  useEffect(() => {
+    void anonI18n.changeLanguage(language ?? 'en')
+  }, [anonI18n, language])
 
   return <I18nextProvider i18n={anonI18n}>{props.children}</I18nextProvider>
 }

--- a/app/src/organisms/Desktop/Alerts/AlertsModal.tsx
+++ b/app/src/organisms/Desktop/Alerts/AlertsModal.tsx
@@ -25,7 +25,7 @@ interface AlertsModalProps {
 export function AlertsModal({ toastIdRef }: AlertsModalProps): JSX.Element {
   const dispatch = useDispatch<Dispatch>()
   const [showUpdateModal, setShowUpdateModal] = useState<boolean>(false)
-  const { t } = useTranslation(['app_settings', 'branded'])
+  const { t, i18n } = useTranslation(['app_settings', 'branded'])
   const { makeToast } = useToaster()
   const { removeActiveAppUpdateToast } = useRemoveActiveAppUpdateToast()
 
@@ -75,6 +75,9 @@ export function AlertsModal({ toastIdRef }: AlertsModalProps): JSX.Element {
   useEffect(
     () => {
       if (createAppUpdateAvailableToast) {
+        if (toastIdRef.current != null) {
+          removeActiveAppUpdateToast()
+        }
         toastIdRef.current = makeToast(
           t('branded:opentrons_app_update_available_variation') as string,
           WARNING_TOAST,
@@ -91,9 +94,8 @@ export function AlertsModal({ toastIdRef }: AlertsModalProps): JSX.Element {
         removeActiveAppUpdateToast()
       }
     },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isAppUpdateAvailable, isAppUpdateIgnored]
+    [createAppUpdateAvailableToast, removeToast, i18n.language]
   )
 
   return (


### PR DESCRIPTION
Closes [RQA-5662](https://opentrons.atlassian.net/browse/RQA-5662)

# Overview

The “App update available” toast captured translated strings once at creation and did not refresh when the user changed language. Toggling locale could also show the wrong language because the toast effect ran on Redux appLanguage before i18n had switched.

This PR:

- Keeps a stable i18n instance in LocalizationProvider.
- Recreates the update toast when `i18n.language` changes, after dismissing the previous one, so message and “View update” link use the active locale.


### Current Behavior

https://github.com/user-attachments/assets/3b845e75-926a-4ca5-9a92-ec00f8cccb35

### Fixed Behavior

https://github.com/user-attachments/assets/396e5485-2d71-42d5-b26e-03f5d8271c87

## Test Plan and Hands on Testing

- See video.

## Changelog

- Fixed a bug in the "Update app" toast in which the toast would not display the correct language.

## Review requests

- This is a low prio bug. Do we think this PR is worth merging into 9.1.0 given where we are on timing? 

## Risk assessment

- low

[RQA-5662]: https://opentrons.atlassian.net/browse/RQA-5662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ