### PR TITLE
feat(audit-server): Add a log data manager

### DIFF
--- a/audit-server/audit_server/log_storage/constants.py
+++ b/audit-server/audit_server/log_storage/constants.py
@@ -1,0 +1,18 @@
+from typing import Final
+
+MESSAGE_ROBOT_BOOT: Final = "Robot started up"
+MESSAGE_LOG_PERIOD_END: Final = "Log period ended"
+MESSAGE_LOG_PERIOD_START: Final = "Log period begun"
+MESSAGE_NO_PREVIOUS_PERIOD: Final = "There was no previous log period saved. Either this is the first time this robot has booted or the previous log period was deleted."
+MESSAGE_NO_PREVIOUS_LOG: Final = (
+    "There was no previous log message. A log message has been deleted."
+)
+MESSAGE_LOG_SIGNING_UNAVAILABLE: Final = "Log signing is unavailable: "
+
+ACTION_ROBOT_BOOT: Final = "robot-boot"
+ACTION_LOG_PERIOD_START: Final = "log-period-begin"
+ACTION_LOG_PERIOD_END: Final = "log-period-end"
+ACTION_LOG_LOGGING_ERROR: Final = "log-error"
+
+ACCOUNT_NAME_SYSTEM: Final = "system"
+LEGAL_NAME_SYSTEM: Final = ""

--- a/audit-server/audit_server/log_storage/log_data_manager.py
+++ b/audit-server/audit_server/log_storage/log_data_manager.py
@@ -1,0 +1,245 @@
+"""Code for managing log period rotation and storage."""
+
+from datetime import datetime, timezone
+from logging import getLogger
+
+from opentrons_shared_data.errors.exceptions import (
+    AuditLoggingError,
+    KeyStorageUnavailableError,
+    PythonException,
+)
+
+from server_utils.keys.key_server import Client as KeyClient
+from server_utils.keys.key_server import SignMessageData
+
+from . import constants
+from .store import LogStore, NoActivePeriodError, NoLogInPeriodError
+from .types import StoredLog
+from audit_server.log_ingest.models import AuditLogMessage
+from audit_server.settings.store import (
+    SettingsStore,
+)
+
+LOG = getLogger(__name__)
+
+
+class _GetTime:
+    def now(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+
+class LogDataManager:
+    """Object managing log periods and storage."""
+
+    def __init__(
+        self,
+        key_client: KeyClient,
+        log_store: LogStore,
+        settings_store: SettingsStore,
+        time_getter: _GetTime | None = None,
+    ) -> None:
+        self._key_client = key_client
+        self._store = log_store
+        self._settings = settings_store
+        self._time = time_getter or _GetTime()
+
+    async def rotate_periods(self) -> str:
+        """End the previous log period and start a new one.
+
+        Returns the hash of the final message in the period.
+        """
+        if not self._settings.get_logging_enabled_settings().loggingEnabled:
+            return ""
+        return await self._do_rotate_periods()
+
+    async def store_log(self, log_message: str) -> str:
+        """Store a log message to the active period.
+
+        If the key server is not available, this method raises before storing
+        the current log, but it will log an (unsigned) error message first.
+        """
+        if not self._settings.get_logging_enabled_settings().loggingEnabled:
+            return ""
+        return await self._do_store_log(log_message)
+
+    async def _do_store_log(self, log_message: str) -> str:
+        previous_hash = self._store.tail_hash()
+        # regardless of whether there's no current period or no log in the period,
+        # there's something wrong with the current log period so remove it.
+        if not isinstance(previous_hash, str):
+            previous_hash = await self._do_rotate_periods()
+
+        # when storing a log from outside, unlike when storing the system-generated
+        # logs that we make during log rotation, we should reject a log (to prevent
+        # the upstream action that depends on it) if we can't sign it.
+        signed_log, signing_exc = await self._sign_log(log_message, previous_hash)
+        if signing_exc:
+            raise KeyStorageUnavailableError(
+                message="Unable to communicate with key server",
+                wrapping=[PythonException(signing_exc)],
+            )
+
+        stored = self._store.store_log(signed_log)
+        if isinstance(stored, str):
+            return stored
+        else:
+            # this shouldn't happen, because we're past a possible key-signing error
+            # and we just fixed up the log rotations, but if it does we should reject
+            # so we don't get in an infinite loop
+            raise AuditLoggingError(
+                message="Unable to store log", wrapping=[PythonException(stored)]
+            )
+
+    def _build_system_message(self, action: str, message: str) -> str:
+        """Build an audit log message originated by the system.
+
+        The overall goal is that messages should be associated with humans, but sometimes
+        the robot does something because of a human action that isn't mediated through
+        software. For instance, we rotate log periods at boot, and we don't know why we
+        booted up; and we want to log error messages. So we have to be able to build our
+        own messages to log.
+        """
+        log_time = self._time.now()
+        message_obj = AuditLogMessage(
+            action=action,
+            accountName=constants.ACCOUNT_NAME_SYSTEM,
+            legalName=constants.LEGAL_NAME_SYSTEM,
+            message=message,
+            reason="",
+            loggedAt=log_time,
+        )
+        return message_obj.model_dump_json(indent=None)
+
+    def _build_sign_error_message(
+        self, sign_error: BaseException, previous_hash: str
+    ) -> StoredLog:
+        """If the key server isn't running, we need to be able to log that.
+
+        Specifically, we need to skip the signing (because it isn't working) and make
+        a log message directly with an empty hash and signature. Any viewer should
+        mark these as bad messages, because, well, they are - the key server being
+        unavailable is a break in the system as a whole's trustability.
+        """
+        message_str = self._build_system_message(
+            action=constants.ACTION_LOG_LOGGING_ERROR,
+            message=constants.MESSAGE_LOG_SIGNING_UNAVAILABLE,
+        )
+        return StoredLog(
+            message=message_str, message_hash="", message_sig="", sig_version="-1"
+        )
+
+    async def _stop_period(self) -> str | NoActivePeriodError:
+        """Close a period as part of a log period rotation."""
+        ending_messages: list[StoredLog] = []
+
+        # if there's no period to close, then we have nothing to do, and errors
+        # are noted at the beginning of the next period
+        current_tail_hash = self._store.tail_hash()
+        if isinstance(current_tail_hash, NoActivePeriodError):
+            return current_tail_hash
+
+        # if we have a valid period but no logs in it, not even a start, then that's
+        # bad and should be noted, and we can be the one to note it.
+        if isinstance(current_tail_hash, NoLogInPeriodError):
+            error_log_message = self._build_system_message(
+                action=constants.ACTION_LOG_LOGGING_ERROR,
+                message=constants.MESSAGE_NO_PREVIOUS_LOG,
+            )
+            error_log, sign_error = await self._sign_log(error_log_message, "")
+            current_tail_hash = error_log.message_hash
+            ending_messages.append(error_log)
+            # signing errors are swallowed here because log rotation is an automated
+            # process during boot that we can't cancel.
+            if sign_error:
+                ending_messages.append(self._build_sign_error_message(sign_error, ""))
+                current_tail_hash = ""
+
+        # the actual end message required for log validity
+        end_log = self._build_system_message(
+            constants.ACTION_LOG_PERIOD_END,
+            constants.MESSAGE_LOG_PERIOD_END,
+        )
+        signed_end_log, sign_error = await self._sign_log(end_log, current_tail_hash)
+        # signing errors are swallowed here because log rotation is an automated process
+        # during boot that we can't handle.
+        if sign_error:
+            ending_messages.append(self._build_sign_error_message(sign_error, ""))
+        ending_messages.append(signed_end_log)
+        return self._store.end_period(ending_messages)
+
+    async def _do_rotate_periods(self) -> str:
+        """Execute a log period rotation while handling possible error cases."""
+        stop_result = await self._stop_period()
+        start_messages: list[StoredLog] = []
+        start_message = self._build_system_message(
+            action=constants.ACTION_LOG_PERIOD_START,
+            message=constants.MESSAGE_LOG_PERIOD_START,
+        )
+        tracking_tail_hash = stop_result if isinstance(stop_result, str) else ""
+        signed_start, sign_error = await self._sign_log(
+            start_message, tracking_tail_hash
+        )
+        # our start message has to be the first thing in the log, even if there are
+        # errors from the previous log
+        start_messages.append(signed_start)
+        tracking_tail_hash = signed_start.message_hash
+        # signing errors are swallowed here because log rotation is an automated process
+        # during boot that we can't handle.
+        if sign_error:
+            sign_error_message = self._build_sign_error_message(
+                sign_error, tracking_tail_hash
+            )
+            start_messages.append(sign_error_message)
+            tracking_tail_hash = sign_error_message.message_hash
+
+        # now we can note if this is a start after an unstoppe dperiod
+        if isinstance(stop_result, NoActivePeriodError):
+            was_no_period_error = self._build_system_message(
+                constants.ACTION_LOG_LOGGING_ERROR, constants.MESSAGE_NO_PREVIOUS_PERIOD
+            )
+            was_no_period_signed, sign_error = await self._sign_log(
+                was_no_period_error, tracking_tail_hash
+            )
+            start_messages.append(was_no_period_signed)
+            tracking_tail_hash = was_no_period_signed.message_hash
+            # signing errors are swallowed here because log rotation is an automated
+            # process during boot that we can't handle.
+            if sign_error:
+                sign_error_message = self._build_sign_error_message(
+                    sign_error, tracking_tail_hash
+                )
+                start_messages.append(sign_error_message)
+                tracking_tail_hash = sign_error_message.message_hash
+        return self._store.start_period(start_messages)
+
+    async def _sign_log(
+        self, log: str, previous_hash: str
+    ) -> tuple[StoredLog, Exception | None]:
+        """Sign a log message and return it, or a stand-in and an error.
+
+        The caller gets to choose what to do with the error (either raise it or use
+        the unsigned message) because maybe the caller is an automated process like
+        log rotation and needs to write SOMETHING down, or maybe it's a human and
+        needs to reject the action.
+        """
+        try:
+            signed_message = await self._key_client.sign_message(
+                SignMessageData(message=log, previousHash=previous_hash)
+            )
+            return (
+                StoredLog(
+                    message=signed_message.message,
+                    message_hash=signed_message.messageHash,
+                    message_sig=signed_message.messageSignature,
+                    sig_version=str(signed_message.signatureVersion),
+                ),
+                None,
+            )
+        except Exception as exc:
+            LOG.warning(f"Key-server is unreachable: {exc}")
+            return (
+                StoredLog(
+                    message=log, message_hash="", message_sig="", sig_version="-1"
+                ),
+                exc,
+            )

--- a/audit-server/audit_server/log_storage/log_data_manager.py
+++ b/audit-server/audit_server/log_storage/log_data_manager.py
@@ -1,5 +1,6 @@
 """Code for managing log period rotation and storage."""
 
+from asyncio import Lock
 from datetime import datetime, timezone
 from logging import getLogger
 
@@ -42,6 +43,7 @@ class LogDataManager:
         self._store = log_store
         self._settings = settings_store
         self._time = time_getter or _GetTime()
+        self._lock = Lock()
 
     async def rotate_periods(self) -> str:
         """End the previous log period and start a new one.
@@ -50,7 +52,8 @@ class LogDataManager:
         """
         if not self._settings.get_logging_enabled_settings().loggingEnabled:
             return ""
-        return await self._do_rotate_periods()
+        async with self._lock:
+            return await self._do_rotate_periods()
 
     async def store_log(self, log_message: str) -> str:
         """Store a log message to the active period.
@@ -60,7 +63,8 @@ class LogDataManager:
         """
         if not self._settings.get_logging_enabled_settings().loggingEnabled:
             return ""
-        return await self._do_store_log(log_message)
+        async with self._lock:
+            return await self._do_store_log(log_message)
 
     async def _do_store_log(self, log_message: str) -> str:
         previous_hash = self._store.tail_hash()

--- a/audit-server/audit_server/log_storage/store.py
+++ b/audit-server/audit_server/log_storage/store.py
@@ -30,26 +30,28 @@ class LogStore:
     def _session(self) -> Session:
         return self._session_factory()
 
-    async def store_log(
+    def store_log(
         self,
         log: StoredLog,
-    ) -> None:
-        """Store a log message."""
+    ) -> str | NoActivePeriodError | NoLogInPeriodError:
+        """Store a log message. Returns the hash of the stored message."""
         with self._session() as session:
             with session.begin():
-                latest_log = await self._tail_log(session)
-                await self._do_store_log(
+                latest_log = self._tail_log(session)
+                if not isinstance(latest_log, LogEntry):
+                    return latest_log
+                return self._do_store_log(
                     session, log, latest_log.period_ordinal + 1, latest_log.log_period
                 )
 
-    async def _do_store_log(
+    def _do_store_log(
         self,
         session: Session,
         log: StoredLog,
         ordinal: int,
         log_period: LogPeriod,
         end_at: datetime | None = None,
-    ) -> None:
+    ) -> str:
         entry = LogEntry(
             period_ordinal=ordinal,
             log_period=log_period,
@@ -64,62 +66,85 @@ class LogStore:
 
         session.add(entry)
         session.add(log_period)
+        return log.message_hash
 
-    async def end_period(self, end_period_log: StoredLog) -> None:
-        """End a period, with the required end message."""
+    def end_period(self, end_period_logs: list[StoredLog]) -> str | NoActivePeriodError:
+        """End a period, with the required end message and some previous supplemental messages.
+
+        Returns the hash of the final message in the period.
+        """
         with self._session() as session:
             with session.begin():
-                current_period = await self._current_period(session)
-                try:
-                    latest_log = await self._tail_log_of_period(session, current_period)
-                    ordinal = latest_log.period_ordinal + 1
-                except NoLogInPeriodError:
+                current_period = self._current_period(session)
+                if isinstance(current_period, NoActivePeriodError):
+                    return current_period
+                latest_log = self._tail_log_of_period(session, current_period)
+                if isinstance(latest_log, NoLogInPeriodError):
                     ordinal = 0
-                await self._do_store_log(
-                    session,
-                    end_period_log,
-                    ordinal,
-                    latest_log.log_period,
-                    datetime.now(timezone.utc),
-                )
+                else:
+                    ordinal = latest_log.period_ordinal + 1
+                latest_hash = ""
+                for log in end_period_logs:
+                    latest_hash = self._do_store_log(
+                        session,
+                        log,
+                        ordinal,
+                        current_period,
+                        datetime.now(timezone.utc),
+                    )
+                    ordinal += 1
+                return latest_hash
 
-    async def start_period(self, start_period_log: StoredLog) -> None:
-        """Begin a new log period."""
+    def start_period(self, start_period_logs: list[StoredLog]) -> str:
+        """Begin a new log period.
+
+        Returns the hash of the latest message in the period.
+        """
         with self._session() as session:
             with session.begin():
                 new_period = LogPeriod(started_at=datetime.now(timezone.utc))
-                await self._do_store_log(session, start_period_log, 0, new_period)
+                latest_hash = ""
+                ordinal = 0
+                for log in start_period_logs:
+                    latest_hash = self._do_store_log(session, log, ordinal, new_period)
+                    ordinal += 1
+                return latest_hash
 
-    async def _current_period(self, session: Session) -> LogPeriod:
+    def _current_period(self, session: Session) -> LogPeriod | NoActivePeriodError:
         latest_period = session.scalar(
             select(LogPeriod).where(LogPeriod.ended_at == None)  # noqa: E711
         )
         if latest_period is None:
-            raise NoActivePeriodError()
+            return NoActivePeriodError()
         return latest_period
 
-    async def _tail_log_of_period(
+    def _tail_log_of_period(
         self,
         session: Session,
         period: LogPeriod,
-    ) -> LogEntry:
+    ) -> LogEntry | NoLogInPeriodError:
         if len(period.log_entries) == 0:
-            raise NoLogInPeriodError()
+            return NoLogInPeriodError()
         latest_log = period.log_entries[-1]
         if latest_log is None:
-            raise NoLogInPeriodError()
+            return NoLogInPeriodError()
         return latest_log
 
-    async def _tail_log(self, session: Session) -> LogEntry:
+    def _tail_log(
+        self, session: Session
+    ) -> LogEntry | NoLogInPeriodError | NoActivePeriodError:
         """Get the most recently logged message in the period."""
-        latest_period = await self._current_period(session)
-        latest_log = await self._tail_log_of_period(session, latest_period)
-        return latest_log
+        latest_period = self._current_period(session)
+        if isinstance(latest_period, NoActivePeriodError):
+            return latest_period
+        return self._tail_log_of_period(session, latest_period)
 
-    async def tail_hash(self) -> str:
+    def tail_hash(self) -> str | NoLogInPeriodError | NoActivePeriodError:
         """Get the message hash of the most recently logged message in the period."""
         with self._session() as session:
-            latest_record = await self._tail_log(session)
+            latest_record = self._tail_log(session)
+            if not isinstance(latest_record, LogEntry):
+                return latest_record
             return latest_record.message_hash
 
     def list_periods(self) -> list[LogPeriodSummary]:

--- a/audit-server/pyproject.toml
+++ b/audit-server/pyproject.toml
@@ -10,6 +10,7 @@ classifiers = [
 
 dependencies = [
     "server-utils==0.0.0",
+    "opentrons-shared-data==0.0.0",
     "fastapi==0.100.0",
     "pydantic==2.11.7",
     "pydantic-settings==2.4.0",
@@ -27,6 +28,7 @@ dev = {requires-python = ">=3.11"}
 # Robot dependencies - exact versions for robot deployment
 robot = [
     "server-utils==0.0.0",
+    "opentrons-shared-data==0.0.0",
     "fastapi==0.100.0",
     "pydantic==2.11.7",
     "pydantic-settings==2.4.0",
@@ -89,6 +91,7 @@ exclude-newer = "1 week"
 # local editable sources satisfying the 0.0.0 placeholders
 [tool.uv.sources]
 server-utils = { path = "../server-utils", editable = true }
+opentrons-shared-data = { path = "../shared-data", editable = true }
 
 [build-system]
 requires = [
@@ -100,7 +103,7 @@ build-backend = "hatchling.build"
 
 # --- hatch-dependency-coversion: exact co-versioning of specific deps ---
 [tool.hatch.metadata.hooks.dependency-coversion]
-override-versions-of = ["server-utils"]
+override-versions-of = ["server-utils", "opentrons-shared-data"]
 
 # --- hatch-vcs-tunable: VCS-derived version with env-tunable settings ---
 [tool.hatch.build.hooks.vcs-tunable]

--- a/audit-server/tests/log_storage/test_log_data_manager.py
+++ b/audit-server/tests/log_storage/test_log_data_manager.py
@@ -1,0 +1,698 @@
+"""Tests for the log data manager."""
+
+from datetime import datetime, timezone
+
+import pytest
+from decoy import Decoy, matchers
+from opentrons_shared_data.errors.exceptions import KeyStorageUnavailableError
+
+from server_utils.keys.key_server import Client as KeyClient
+from server_utils.keys.key_server import SignedMessageData, SignMessageData
+
+from audit_server.log_storage import constants
+from audit_server.log_storage.log_data_manager import LogDataManager, _GetTime
+from audit_server.log_storage.store import (
+    LogStore,
+    NoActivePeriodError,
+    NoLogInPeriodError,
+)
+from audit_server.log_storage.types import StoredLog
+from audit_server.settings.models import LoggingEnabledResponseData
+from audit_server.settings.store import SettingsStore
+
+
+@pytest.fixture
+def mock_store(decoy: Decoy) -> LogStore:
+    """A mock log store."""
+    return decoy.mock(cls=LogStore)
+
+
+@pytest.fixture
+def mock_time(decoy: Decoy) -> _GetTime:
+    """Handle to alter the timestamps used in logs."""
+    mt = decoy.mock(cls=_GetTime)
+    decoy.when(mt.now()).then_return(datetime.now(timezone.utc))
+    return mt
+
+
+@pytest.fixture
+def mock_settings(decoy: Decoy) -> SettingsStore:
+    """A mock settings store."""
+    settings = decoy.mock(cls=SettingsStore)
+    decoy.when(settings.get_logging_enabled_settings()).then_return(
+        LoggingEnabledResponseData(loggingEnabled=True)
+    )
+    return settings
+
+
+@pytest.fixture
+def mock_key_client(decoy: Decoy) -> KeyClient:
+    return decoy.mock(cls=KeyClient)
+
+
+@pytest.fixture
+def subject(
+    mock_store: LogStore,
+    mock_key_client: KeyClient,
+    mock_settings: SettingsStore,
+    mock_time: _GetTime,
+) -> LogDataManager:
+    """Get a LogDataManager to test."""
+    return LogDataManager(
+        key_client=mock_key_client,
+        log_store=mock_store,
+        settings_store=mock_settings,
+        time_getter=mock_time,
+    )
+
+
+@pytest.fixture
+def disable_logging(mock_settings: SettingsStore, decoy: Decoy) -> None:
+    """Force logging off."""
+    decoy.when(mock_settings.get_logging_enabled_settings()).then_return(
+        LoggingEnabledResponseData(loggingEnabled=False)
+    )
+
+
+async def test_store_log_stores_nothing_if_logging_disabled(
+    subject: LogDataManager, disable_logging: None, mock_store: LogStore, decoy: Decoy
+) -> None:
+    """It should store no data if logging is disabled."""
+    await subject.store_log("asd")
+    decoy.verify(mock_store.tail_hash(), times=0)
+    decoy.verify(mock_store.store_log(matchers.Anything()), times=0)
+
+
+async def test_rotate_periods_does_nothing_if_logging_disabled(
+    subject: LogDataManager,
+    disable_logging: None,
+    mock_store: LogStore,
+    decoy: Decoy,
+) -> None:
+    """It should not interact with the store if logging is disabled."""
+    await subject.rotate_periods()
+    decoy.verify(mock_store.store_log(matchers.Anything()), times=0)
+    decoy.verify(mock_store.start_period(matchers.Anything()), times=0)
+    decoy.verify(mock_store.end_period(matchers.Anything()), times=0)
+
+
+async def test_store_log_stores_log(
+    subject: LogDataManager,
+    mock_store: LogStore,
+    decoy: Decoy,
+    mock_key_client: KeyClient,
+) -> None:
+    """It should store the log it's passsed in and return a hash of its own devising."""
+    log = StoredLog(
+        message="helo",
+        message_hash="helicopter",
+        message_sig="hollycopter",
+        sig_version="3",
+    )
+    decoy.when(mock_store.tail_hash()).then_return("ph")
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData(message="helo", previousHash="ph")
+        )
+    ).then_return(
+        SignedMessageData(
+            message="helo",
+            messageHash="helicopter",
+            messageSignature="hollycopter",
+            signatureVersion=3,
+        )
+    )
+    decoy.when(mock_store.store_log(log)).then_return("fffff")
+    stored_hash = await subject.store_log("helo")
+    assert stored_hash == "fffff"
+
+
+async def test_store_log_raises_keyserver_unavailable(
+    subject: LogDataManager,
+    mock_store: LogStore,
+    decoy: Decoy,
+    mock_key_client: KeyClient,
+) -> None:
+    """It should raise if the key server is unavailable."""
+    decoy.when(mock_store.tail_hash()).then_return("oh well")
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData(message="mymessage", previousHash="oh well")
+        )
+    ).then_raise(Exception("nope im broken"))
+    with pytest.raises(KeyStorageUnavailableError):
+        await subject.store_log("mymessage")
+
+
+async def test_store_log_rotates_if_cannot_get_tail_hash(
+    subject: LogDataManager,
+    mock_store: LogStore,
+    decoy: Decoy,
+    mock_key_client: KeyClient,
+    mock_time: _GetTime,
+) -> None:
+    """It should rotate log periods if it cannot get the last hash."""
+    decoy.when(mock_store.tail_hash()).then_return(NoActivePeriodError())
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(".*Log period begun.*"), previousHash=""
+            )
+        )
+    ).then_return(
+        SignedMessageData(
+            message="log period begun",
+            messageHash="he",
+            messageSignature="lo",
+            signatureVersion=3,
+        )
+    )
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(".*log-error.*"), previousHash="he"
+            )
+        )
+    ).then_return(
+        SignedMessageData(
+            message="log error",
+            messageHash="go",
+            messageSignature="od",
+            signatureVersion=4,
+        )
+    )
+    decoy.when(
+        mock_store.store_log(
+            StoredLog(
+                message="log period begun",
+                message_hash="he",
+                message_sig="lo",
+                sig_version="3",
+            )
+        )
+    ).then_return("he")
+    decoy.when(
+        mock_store.store_log(
+            StoredLog(
+                message="log error",
+                message_hash="go",
+                message_sig="od",
+                sig_version="4",
+            )
+        )
+    ).then_return("od")
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(".*mymessage.*"),
+                previousHash="go",
+            )
+        )
+    ).then_return(
+        SignedMessageData(
+            message="my message",
+            messageHash="by",
+            messageSignature="ee",
+            signatureVersion=5,
+        )
+    )
+    decoy.when(
+        mock_store.store_log(
+            StoredLog(
+                message="my message",
+                message_hash="by",
+                message_sig="ee",
+                sig_version="5",
+            )
+        )
+    ).then_return("ee")
+    decoy.when(
+        mock_store.start_period(
+            [
+                StoredLog(
+                    message="log period begun",
+                    message_hash="he",
+                    message_sig="lo",
+                    sig_version="3",
+                ),
+                StoredLog(
+                    message="log error",
+                    message_hash="go",
+                    message_sig="od",
+                    sig_version="4",
+                ),
+            ]
+        )
+    ).then_return("go")
+    result = await subject.store_log("mymessage")
+    assert result == "ee"
+
+
+async def test_rotate_happypath(
+    subject: LogDataManager,
+    mock_store: LogStore,
+    decoy: Decoy,
+    mock_key_client: KeyClient,
+    mock_time: _GetTime,
+) -> None:
+    """It should rotate log periods without errors cleanly."""
+    decoy.when(mock_store.tail_hash()).then_return("gg")
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.ACTION_LOG_PERIOD_END}.*"
+                ),
+                previousHash="gg",
+            )
+        )
+    ).then_return(
+        SignedMessageData(
+            message="end-log-period",
+            messageHash="ff",
+            messageSignature="s1",
+            signatureVersion=1,
+        )
+    )
+    decoy.when(
+        mock_store.end_period(
+            [
+                StoredLog(
+                    message="end-log-period",
+                    message_hash="ff",
+                    message_sig="s1",
+                    sig_version="1",
+                )
+            ]
+        )
+    ).then_return("ff")
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.ACTION_LOG_PERIOD_START}.*"
+                ),
+                previousHash="ff",
+            )
+        )
+    ).then_return(
+        SignedMessageData(
+            message="start-log-period",
+            messageHash="ee",
+            messageSignature="s2",
+            signatureVersion=2,
+        )
+    )
+    decoy.when(
+        mock_store.start_period([StoredLog("start-log-period", "ee", "s2", "2")])
+    ).then_return("ee")
+    assert await subject.rotate_periods() == "ee"
+
+
+async def test_rotate_no_previous_period(
+    subject: LogDataManager,
+    mock_store: LogStore,
+    decoy: Decoy,
+    mock_key_client: KeyClient,
+    mock_time: _GetTime,
+) -> None:
+    """It should not emit an end-period message if there is no period to end."""
+    decoy.when(mock_store.tail_hash()).then_return(NoActivePeriodError())
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.ACTION_LOG_PERIOD_START}.*"
+                ),
+                previousHash="",
+            )
+        )
+    ).then_return(
+        SignedMessageData(
+            message="start-log-period",
+            messageHash="ff",
+            messageSignature="s1",
+            signatureVersion=1,
+        )
+    )
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.MESSAGE_NO_PREVIOUS_PERIOD}.*"
+                ),
+                previousHash="ff",
+            )
+        )
+    ).then_return(
+        SignedMessageData(
+            message="error-no-period",
+            messageHash="ee",
+            messageSignature="s2",
+            signatureVersion=2,
+        )
+    )
+    decoy.when(
+        mock_store.start_period(
+            [
+                StoredLog(
+                    message="start-log-period",
+                    message_hash="ff",
+                    message_sig="s1",
+                    sig_version="1",
+                ),
+                StoredLog(
+                    message="error-no-period",
+                    message_hash="ee",
+                    message_sig="s2",
+                    sig_version="2",
+                ),
+            ]
+        )
+    ).then_return("ee")
+    assert await subject.rotate_periods() == "ee"
+
+
+async def test_rotate_no_previous_log(
+    subject: LogDataManager,
+    mock_store: LogStore,
+    decoy: Decoy,
+    mock_key_client: KeyClient,
+    mock_time: _GetTime,
+) -> None:
+    """It should emit an end-period message with an empty hash if there is no previous log."""
+    decoy.when(mock_store.tail_hash()).then_return(NoLogInPeriodError())
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.MESSAGE_NO_PREVIOUS_LOG}.*"
+                ),
+                previousHash="",
+            )
+        )
+    ).then_return(
+        SignedMessageData(
+            message="error-no-log",
+            messageHash="ff",
+            messageSignature="s1",
+            signatureVersion=1,
+        )
+    )
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.MESSAGE_LOG_PERIOD_END}.*"
+                ),
+                previousHash="ff",
+            )
+        )
+    ).then_return(
+        SignedMessageData(
+            message="end-period",
+            messageHash="ee",
+            messageSignature="s2",
+            signatureVersion=2,
+        )
+    )
+    decoy.when(
+        mock_store.end_period(
+            [
+                StoredLog("error-no-log", "ff", "s1", "1"),
+                StoredLog("end-period", "ee", "s2", "2"),
+            ]
+        )
+    ).then_return("ee")
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.MESSAGE_LOG_PERIOD_START}.*"
+                ),
+                previousHash="ee",
+            )
+        )
+    ).then_return(
+        SignedMessageData(
+            message="start-period",
+            messageHash="dd",
+            messageSignature="s3",
+            signatureVersion=3,
+        )
+    )
+    decoy.when(
+        mock_store.start_period(
+            [
+                StoredLog(
+                    message="start-period",
+                    message_hash="dd",
+                    message_sig="s3",
+                    sig_version="3",
+                )
+            ]
+        )
+    ).then_return("dd")
+    assert await subject.rotate_periods() == "dd"
+
+
+async def test_rotate_log_happypath_handles_no_keyserver(
+    subject: LogDataManager,
+    mock_store: LogStore,
+    decoy: Decoy,
+    mock_key_client: KeyClient,
+    mock_time: _GetTime,
+) -> None:
+    """It should log key server failures and still rotate period."""
+    decoy.when(mock_store.tail_hash()).then_return("aa")
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.MESSAGE_LOG_PERIOD_END}.*"
+                ),
+                previousHash="aa",
+            )
+        )
+    ).then_raise(KeyStorageUnavailableError())
+    decoy.when(
+        mock_store.end_period(
+            [
+                StoredLog(
+                    message=matchers.StringMatching(
+                        f".*{constants.MESSAGE_LOG_SIGNING_UNAVAILABLE}.*"
+                    ),
+                    message_hash="",
+                    message_sig="",
+                    sig_version="-1",
+                ),
+                StoredLog(
+                    matchers.StringMatching(f".*{constants.MESSAGE_LOG_PERIOD_END}.*"),
+                    "",
+                    "",
+                    "-1",
+                ),
+            ]
+        )
+    ).then_return("")
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.MESSAGE_LOG_PERIOD_START}.*"
+                ),
+                previousHash="",
+            )
+        )
+    ).then_raise(KeyStorageUnavailableError())
+    decoy.when(
+        mock_store.start_period(
+            [
+                StoredLog(
+                    message=matchers.StringMatching(
+                        f".*{constants.MESSAGE_LOG_PERIOD_START}.*"
+                    ),
+                    message_hash="",
+                    message_sig="",
+                    sig_version="-1",
+                ),
+                StoredLog(
+                    message=matchers.StringMatching(
+                        f".*{constants.MESSAGE_LOG_SIGNING_UNAVAILABLE}.*"
+                    ),
+                    message_hash="",
+                    message_sig="",
+                    sig_version="-1",
+                ),
+            ]
+        )
+    ).then_return("dd")
+    assert await subject.rotate_periods() == "dd"
+
+
+async def test_rotate_no_previous_period_handles_no_keyserver(
+    subject: LogDataManager,
+    mock_store: LogStore,
+    decoy: Decoy,
+    mock_key_client: KeyClient,
+    mock_time: _GetTime,
+) -> None:
+    """Its no-previous-period codepath should handle no key server.."""
+    decoy.when(mock_store.tail_hash()).then_return(NoActivePeriodError())
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.ACTION_LOG_PERIOD_START}.*"
+                ),
+                previousHash="",
+            )
+        )
+    ).then_raise(KeyStorageUnavailableError())
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.MESSAGE_NO_PREVIOUS_PERIOD}.*"
+                ),
+                previousHash="",
+            )
+        )
+    ).then_raise(KeyStorageUnavailableError())
+    decoy.when(
+        mock_store.start_period(
+            [
+                StoredLog(
+                    message=matchers.StringMatching(
+                        f".*{constants.MESSAGE_LOG_PERIOD_START}.*"
+                    ),
+                    message_hash="",
+                    message_sig="",
+                    sig_version="-1",
+                ),
+                StoredLog(
+                    message=matchers.StringMatching(
+                        f".*{constants.MESSAGE_LOG_SIGNING_UNAVAILABLE}.*"
+                    ),
+                    message_hash="",
+                    message_sig="",
+                    sig_version="-1",
+                ),
+                StoredLog(
+                    message=matchers.StringMatching(
+                        f".*{constants.MESSAGE_NO_PREVIOUS_PERIOD}.*"
+                    ),
+                    message_hash="",
+                    message_sig="",
+                    sig_version="-1",
+                ),
+                StoredLog(
+                    message=matchers.StringMatching(
+                        f".*{constants.MESSAGE_LOG_SIGNING_UNAVAILABLE}.*"
+                    ),
+                    message_hash="",
+                    message_sig="",
+                    sig_version="-1",
+                ),
+            ]
+        )
+    ).then_return("")
+    assert await subject.rotate_periods() == ""
+
+
+async def test_rotate_no_previous_log_handles_no_key_server(
+    subject: LogDataManager,
+    mock_store: LogStore,
+    decoy: Decoy,
+    mock_key_client: KeyClient,
+    mock_time: _GetTime,
+) -> None:
+    """Rotation after no previous log should handle no key server."""
+    decoy.when(mock_store.tail_hash()).then_return(NoLogInPeriodError())
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.MESSAGE_NO_PREVIOUS_LOG}.*"
+                ),
+                previousHash="",
+            )
+        )
+    ).then_raise(KeyStorageUnavailableError())
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.MESSAGE_LOG_PERIOD_END}.*"
+                ),
+                previousHash="",
+            )
+        )
+    ).then_raise(KeyStorageUnavailableError())
+    decoy.when(
+        mock_store.end_period(
+            [
+                StoredLog(
+                    matchers.StringMatching(f".*{constants.MESSAGE_NO_PREVIOUS_LOG}.*"),
+                    "",
+                    "",
+                    "-1",
+                ),
+                StoredLog(
+                    matchers.StringMatching(
+                        f".*{constants.MESSAGE_LOG_SIGNING_UNAVAILABLE}.*"
+                    ),
+                    "",
+                    "",
+                    "-1",
+                ),
+                StoredLog(
+                    matchers.StringMatching(
+                        f".*{constants.MESSAGE_LOG_SIGNING_UNAVAILABLE}.*"
+                    ),
+                    "",
+                    "",
+                    "-1",
+                ),
+                StoredLog(
+                    matchers.StringMatching(f".*{constants.MESSAGE_LOG_PERIOD_END}.*"),
+                    "",
+                    "",
+                    "-1",
+                ),
+            ]
+        )
+    ).then_return("")
+    decoy.when(
+        await mock_key_client.sign_message(
+            SignMessageData.model_construct(
+                message=matchers.StringMatching(
+                    f".*{constants.MESSAGE_LOG_PERIOD_START}.*"
+                ),
+                previousHash="",
+            )
+        )
+    ).then_raise(KeyStorageUnavailableError())
+    decoy.when(
+        mock_store.start_period(
+            [
+                StoredLog(
+                    message=matchers.StringMatching(
+                        f".*{constants.MESSAGE_LOG_PERIOD_START}.*"
+                    ),
+                    message_hash="",
+                    message_sig="",
+                    sig_version="-1",
+                ),
+                StoredLog(
+                    matchers.StringMatching(
+                        f".*{constants.MESSAGE_LOG_SIGNING_UNAVAILABLE}.*"
+                    ),
+                    "",
+                    "",
+                    "-1",
+                ),
+            ]
+        )
+    ).then_return("")
+    assert await subject.rotate_periods() == ""

--- a/audit-server/tests/log_storage/test_store.py
+++ b/audit-server/tests/log_storage/test_store.py
@@ -20,115 +20,153 @@ def subject(db_engine: SQLEngine) -> LogStore:
 
 
 @pytest.fixture
-async def subject_with_period(db_engine: SQLEngine) -> LogStore:
+def subject_with_period(db_engine: SQLEngine) -> LogStore:
     """A LogStore with an open period ready for logs."""
     store = LogStore(sql_engine=db_engine)
-    await store.start_period(
-        StoredLog(
-            message="starting tests",
-            message_hash="asdasd",
-            message_sig="ddddd",
-            sig_version="1",
-        )
+    store.start_period(
+        [
+            StoredLog(
+                message="starting tests",
+                message_hash="asdasd",
+                message_sig="ddddd",
+                sig_version="1",
+            )
+        ]
     )
     return store
 
 
-async def test_end_period_raises_if_ending_nonexistent_period(
+def test_end_period_handles_ending_with_no_period(
     subject: LogStore,
 ) -> None:
     """It should raise an exception if ending a period that does not exist."""
-    with pytest.raises(NoActivePeriodError):
-        await subject.end_period(
+    result = subject.end_period(
+        [
             StoredLog(
                 message="ending",
                 message_hash="asdasd",
                 message_sig="asdasd",
                 sig_version="2",
             )
-        )
-
-
-async def test_start_period_starts_period(
-    subject: LogStore, db_engine: SQLEngine
-) -> None:
-    """It should add a period entry when commanded."""
-    start_log = StoredLog(
-        message="starting", message_hash="asads", message_sig="dddd", sig_version="3"
+        ]
     )
-    await subject.start_period(start_log)
+    assert isinstance(result, NoActivePeriodError)
+
+
+def test_start_period_starts_period(subject: LogStore, db_engine: SQLEngine) -> None:
+    """It should add a period entry when commanded."""
+    start_logs = [
+        StoredLog(
+            message="starting",
+            message_hash="asads",
+            message_sig="dddd",
+            sig_version="3",
+        ),
+        StoredLog(
+            message="hello", message_hash="", message_sig="fff", sig_version="22"
+        ),
+        StoredLog(
+            message="goodbye", message_hash="afsd", message_sig="iii", sig_version="i+2"
+        ),
+    ]
+    message_hash = subject.start_period(start_logs)
+    assert message_hash == "afsd"
     with Session(db_engine) as session:
         periods = session.scalars(select(LogPeriod)).all()
         assert len(periods) == 1
-        assert len(periods[0].log_entries) == 1
-        assert periods[0].log_entries[0].message == "starting"
-        assert periods[0].log_entries[0].message_hash == "asads"
         assert periods[0].ended_at is None
-        assert periods[0].log_entries[0].period_ordinal == 0
+        period = periods[0]
+        assert len(period.log_entries) == 3
+        assert period.log_entries[0].message == "starting"
+        assert period.log_entries[0].message_hash == "asads"
+        assert period.log_entries[0].period_ordinal == 0
+        assert period.log_entries[0].message_sig == "dddd"
+        assert period.log_entries[0].sig_version == "3"
+
+        assert period.log_entries[1].message == "hello"
+        assert period.log_entries[1].message_hash == ""
+        assert period.log_entries[1].period_ordinal == 1
+        assert period.log_entries[1].message_sig == "fff"
+        assert period.log_entries[1].sig_version == "22"
+
+        assert period.log_entries[2].message == "goodbye"
+        assert period.log_entries[2].message_hash == "afsd"
+        assert period.log_entries[2].period_ordinal == 2
+        assert period.log_entries[2].message_sig == "iii"
+        assert period.log_entries[2].sig_version == "i+2"
 
 
-async def test_end_period_stops_period(
+def test_end_period_stops_period(
     subject_with_period: LogStore, db_engine: SQLEngine
 ) -> None:
     """It should close a period entry when commanded."""
-    await subject_with_period.end_period(
-        StoredLog(
-            message="stopping",
-            message_hash="ffff",
-            message_sig="zzzz",
-            sig_version="11",
-        )
+    message_hash = subject_with_period.end_period(
+        [
+            StoredLog(
+                message="stopping",
+                message_hash="ffff",
+                message_sig="zzzz",
+                sig_version="11",
+            ),
+            StoredLog(
+                message="hohoho",
+                message_hash="lll",
+                message_sig="423",
+                sig_version="1",
+            ),
+            StoredLog(
+                message="heeheehee",
+                message_hash="pppp",
+                message_sig="321",
+                sig_version="-1",
+            ),
+        ],
     )
+    assert message_hash == "pppp"
     with Session(db_engine) as session:
         period = session.scalar(select(LogPeriod))
         assert period is not None
         assert period.ended_at is not None
-        assert len(period.log_entries) == 2
-        assert period.log_entries[-1].period_ordinal == 1
-        assert period.log_entries[-1].message == "stopping"
+        assert len(period.log_entries) == 4
+        assert period.log_entries[1].period_ordinal == 1
+        assert period.log_entries[1].message == "stopping"
+        assert period.log_entries[2].period_ordinal == 2
+        assert period.log_entries[2].message == "hohoho"
+        assert period.log_entries[3].period_ordinal == 3
+        assert period.log_entries[3].message == "heeheehee"
 
 
-async def test_end_period_with_no_period_raises(subject: LogStore) -> None:
-    """It should fail to end a period if no period exists."""
-    with pytest.raises(NoActivePeriodError):
-        await subject.end_period(
-            StoredLog(
-                message="no log here",
-                message_hash="fff",
-                message_sig="zzz",
-                sig_version="11",
-            )
-        )
-
-
-async def test_end_period_with_no_active_period_raises(
+def test_end_period_handles_ending_with_no_active_period(
     subject_with_period: LogStore,
 ) -> None:
     """It should fail to end a period if periods exist but none are active."""
-    await subject_with_period.end_period(
-        StoredLog(
-            message="stopping",
-            message_hash="fffff",
-            message_sig="gggg",
-            sig_version="32",
-        )
+    end_result = subject_with_period.end_period(
+        [
+            StoredLog(
+                message="stopping",
+                message_hash="fffff",
+                message_sig="gggg",
+                sig_version="32",
+            )
+        ]
     )
-    with pytest.raises(NoActivePeriodError):
-        await subject_with_period.end_period(
+    assert not isinstance(end_result, NoActivePeriodError)
+    bad_end_result = subject_with_period.end_period(
+        [
             StoredLog(
                 message="blublublu",
                 message_hash="fhhff",
                 message_sig="gllg",
                 sig_version="31",
             )
-        )
+        ]
+    )
+    assert isinstance(bad_end_result, NoActivePeriodError)
 
 
-async def test_log_to_period(
-    subject_with_period: LogStore, db_engine: SQLEngine
-) -> None:
+def test_log_to_period(subject_with_period: LogStore, db_engine: SQLEngine) -> None:
     """It should store a log to a period with an appropriate ordinal."""
-    await subject_with_period.store_log(
+    stored_hash = subject_with_period.store_log(
         StoredLog(
             message="hello friend",
             message_hash="asdasdasd",
@@ -136,6 +174,7 @@ async def test_log_to_period(
             sig_version="13",
         )
     )
+    assert stored_hash == "asdasdasd"
     with Session(db_engine) as session:
         period = session.scalar(select(LogPeriod))
         assert period is not None
@@ -145,79 +184,92 @@ async def test_log_to_period(
         assert period.log_entries[-1].message == "hello friend"
 
 
-async def test_log_to_period_fails_if_no_period_present(subject: LogStore) -> None:
+def test_log_to_period_fails_if_no_period_present(subject: LogStore) -> None:
     """It should fail to store a log if no log period is present."""
-    with pytest.raises(NoActivePeriodError):
-        await subject.store_log(
-            StoredLog(
-                message="asda",
-                message_hash="ghghgh",
-                message_sig="2314",
-                sig_version="1",
-            )
+    store_result = subject.store_log(
+        StoredLog(
+            message="asda",
+            message_hash="ghghgh",
+            message_sig="2314",
+            sig_version="1",
         )
+    )
+    assert isinstance(store_result, NoActivePeriodError)
 
 
-async def test_log_to_period_fails_if_no_period_active(
+def test_log_to_period_fails_if_no_period_active(
     subject_with_period: LogStore,
 ) -> None:
     """It should fail to store a log if no log period is active."""
-    await subject_with_period.end_period(
+    end_result = subject_with_period.end_period(
+        [
+            StoredLog(
+                message="ending",
+                message_hash="adsa",
+                message_sig="31113",
+                sig_version="h",
+            )
+        ]
+    )
+    assert not isinstance(end_result, NoActivePeriodError)
+    store_result = subject_with_period.store_log(
         StoredLog(
-            message="ending", message_hash="adsa", message_sig="31113", sig_version="h"
+            message="asda",
+            message_hash="ghghgh",
+            message_sig="2314",
+            sig_version="1",
         )
     )
-    with pytest.raises(NoActivePeriodError):
-        await subject_with_period.store_log(
-            StoredLog(
-                message="asda",
-                message_hash="ghghgh",
-                message_sig="2314",
-                sig_version="1",
-            )
-        )
+    assert isinstance(store_result, NoActivePeriodError)
 
 
-async def test_get_tail_hash(subject_with_period: LogStore) -> None:
+def test_get_tail_hash(subject_with_period: LogStore) -> None:
     """It should get the hash of the last message in the period."""
-    starting_hash = await subject_with_period.tail_hash()
+    starting_hash = subject_with_period.tail_hash()
+    assert isinstance(starting_hash, str)
     assert starting_hash == "asdasd"
-    await subject_with_period.store_log(
+    subject_with_period.store_log(
         StoredLog(
             message="hfhfhf", message_hash="zzz", message_sig="4141", sig_version="4"
         )
     )
-    new_starting_hash = await subject_with_period.tail_hash()
+    new_starting_hash = subject_with_period.tail_hash()
+    assert isinstance(new_starting_hash, str)
     assert new_starting_hash == "zzz"
 
 
-async def test_get_tail_hash_fails_if_no_period(subject: LogStore) -> None:
+def test_get_tail_hash_fails_if_no_period(subject: LogStore) -> None:
     """It should fail to get the last hash if no period exists."""
-    with pytest.raises(NoActivePeriodError):
-        await subject.tail_hash()
+    hash_result = subject.tail_hash()
+    assert isinstance(hash_result, NoActivePeriodError)
 
 
-async def test_get_tail_hash_fails_if_no_period_active(
+def test_get_tail_hash_fails_if_no_period_active(
     subject_with_period: LogStore,
 ) -> None:
     """It should fail to get the last hash if no period is active."""
-    await subject_with_period.end_period(
-        StoredLog(
-            message="ending", message_hash="adsa", message_sig="31113", sig_version="h"
-        )
+    subject_with_period.end_period(
+        [
+            StoredLog(
+                message="ending",
+                message_hash="adsa",
+                message_sig="31113",
+                sig_version="h",
+            )
+        ]
     )
-    with pytest.raises(NoActivePeriodError):
-        await subject_with_period.tail_hash()
+    hash_result = subject_with_period.tail_hash()
+    assert isinstance(hash_result, NoActivePeriodError)
 
 
-async def test_list_periods_returns_empty_when_no_periods(
+def test_list_periods_returns_empty_when_no_periods(
     subject: LogStore,
 ) -> None:
     """It should return an empty list when no periods exist."""
     assert subject.list_periods() == []
 
 
-async def test_list_periods_returns_active_period(
+def test_list_periods_returns_active_period(
     subject_with_period: LogStore,
 ) -> None:
     """It should return the active period with endedAt as None."""
@@ -227,39 +279,52 @@ async def test_list_periods_returns_active_period(
     assert periods[0].startedAt is not None
 
 
-async def test_list_periods_returns_completed_period(
+def test_list_periods_returns_completed_period(
     subject_with_period: LogStore,
 ) -> None:
     """It should return a completed period with endedAt set."""
-    await subject_with_period.end_period(
-        StoredLog(
-            message="ending",
-            message_hash="end_hash",
-            message_sig="end_sig",
-            sig_version="1",
-        )
+    subject_with_period.end_period(
+        [
+            StoredLog(
+                message="ending",
+                message_hash="end_hash",
+                message_sig="end_sig",
+                sig_version="1",
+            )
+        ]
     )
     periods = subject_with_period.list_periods()
     assert len(periods) == 1
     assert periods[0].endedAt is not None
 
 
-async def test_list_periods_ordered_oldest_first(
+def test_list_periods_ordered_oldest_first(
     subject: LogStore,
 ) -> None:
     """It should return periods ordered with the oldest started_at first."""
-    await subject.start_period(
-        StoredLog(message="first", message_hash="h1", message_sig="s1", sig_version="1")
+    subject.start_period(
+        [
+            StoredLog(
+                message="first", message_hash="h1", message_sig="s1", sig_version="1"
+            )
+        ]
     )
-    await subject.end_period(
-        StoredLog(
-            message="end first", message_hash="h2", message_sig="s2", sig_version="1"
-        )
+    subject.end_period(
+        [
+            StoredLog(
+                message="end first",
+                message_hash="h2",
+                message_sig="s2",
+                sig_version="1",
+            )
+        ]
     )
-    await subject.start_period(
-        StoredLog(
-            message="second", message_hash="h3", message_sig="s3", sig_version="1"
-        )
+    subject.start_period(
+        [
+            StoredLog(
+                message="second", message_hash="h3", message_sig="s3", sig_version="1"
+            )
+        ]
     )
 
     periods = subject.list_periods()

--- a/audit-server/uv.lock
+++ b/audit-server/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.12"
 
 [options]
-exclude-newer = "2026-05-29T18:56:42.207681Z"
+exclude-newer = "2026-06-16T16:47:04.882027Z"
 exclude-newer-span = "P1W"
 
 [manifest]
@@ -173,6 +173,7 @@ dependencies = [
     { name = "alembic" },
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "opentrons-shared-data" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "server-utils" },
@@ -202,6 +203,7 @@ robot = [
     { name = "alembic" },
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "opentrons-shared-data" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "server-utils" },
@@ -215,6 +217,7 @@ requires-dist = [
     { name = "alembic", specifier = "==1.18.4" },
     { name = "cryptography", specifier = "==42.0.5" },
     { name = "fastapi", specifier = "==0.100.0" },
+    { name = "opentrons-shared-data", editable = "../shared-data" },
     { name = "pydantic", specifier = "==2.11.7" },
     { name = "pydantic-settings", specifier = "==2.4.0" },
     { name = "server-utils", editable = "../server-utils" },
@@ -244,6 +247,7 @@ robot = [
     { name = "alembic", specifier = "==1.18.4" },
     { name = "cryptography", specifier = "==42.0.5" },
     { name = "fastapi", specifier = "==0.100.0" },
+    { name = "opentrons-shared-data", editable = "../shared-data" },
     { name = "pydantic", specifier = "==2.11.7" },
     { name = "pydantic-settings", specifier = "==2.4.0" },
     { name = "server-utils", editable = "../server-utils" },
@@ -1107,6 +1111,68 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "1.26.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/12/8f2020a8e8b8383ac0177dc9570aad031a3beb12e38847f7129bacd96228/numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218", size = 20335901, upload-time = "2024-02-05T23:55:32.801Z" },
+    { url = "https://files.pythonhosted.org/packages/75/5b/ca6c8bd14007e5ca171c7c03102d17b4f4e0ceb53957e8c44343a9546dcc/numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b", size = 13685868, upload-time = "2024-02-05T23:55:56.28Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f8/97f10e6755e2a7d027ca783f63044d5b1bc1ae7acb12afe6a9b4286eac17/numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b", size = 13925109, upload-time = "2024-02-05T23:56:20.368Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/50/de23fde84e45f5c4fda2488c759b69990fd4512387a8632860f3ac9cd225/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed", size = 17950613, upload-time = "2024-02-05T23:56:56.054Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/0c/9c603826b6465e82591e05ca230dfc13376da512b25ccd0894709b054ed0/numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a", size = 13572172, upload-time = "2024-02-05T23:57:21.56Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/2ba3902e1a0fc1c74962ea9bb33a534bb05984ad7ff9515bf8d07527cadd/numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0", size = 17786643, upload-time = "2024-02-05T23:57:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4a/46d9e65106879492374999e76eb85f87b15328e06bd1550668f79f7b18c6/numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110", size = 5677803, upload-time = "2024-02-05T23:58:08.963Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/86f24451c2d530c88daf997cb8d6ac622c1d40d19f5a031ed68a4b73a374/numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818", size = 15517754, upload-time = "2024-02-05T23:58:36.364Z" },
+]
+
+[[package]]
+name = "opentrons-shared-data"
+source = { editable = "../shared-data" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "numpy" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jsonschema", specifier = ">=4.0.0,<5" },
+    { name = "numpy", specifier = "~=1.26.4" },
+    { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
+    { name = "typing-extensions", specifier = ">=4.0.0,<5" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "build", specifier = "~=1.2.0" },
+    { name = "jsonschema", specifier = "==4.17.3" },
+    { name = "mypy", specifier = "==1.19.1" },
+    { name = "numpy", specifier = "==1.26.4" },
+    { name = "pillow" },
+    { name = "pydantic", specifier = "==2.11.7" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-clarity", specifier = "~=1.0.0" },
+    { name = "pytest-cov", specifier = "==4.1.0" },
+    { name = "pytest-xdist", specifier = "~=3.5.0" },
+    { name = "ruff", specifier = "==0.14.10" },
+    { name = "setuptools", specifier = "==80.9.0" },
+    { name = "twine", specifier = "==4.0.0" },
+    { name = "typeguard", specifier = "~=4.4.4" },
+    { name = "types-pillow" },
+    { name = "typing-extensions", specifier = ">=4.0.0,<5" },
+    { name = "wheel", specifier = "==0.37.1" },
+    { name = "zipp", specifier = "==3.21.0" },
+]
+robot = [
+    { name = "jsonschema", specifier = "==4.17.3" },
+    { name = "numpy", specifier = "==1.26.4" },
+    { name = "pydantic", specifier = "==2.11.7" },
+    { name = "zipp", specifier = "==3.21.0" },
 ]
 
 [[package]]

--- a/shared-data/errors/definitions/1/errors.json
+++ b/shared-data/errors/definitions/1/errors.json
@@ -54,6 +54,10 @@
       "detail": "CANBus Bus Error",
       "category": "hardwareCommunicationError"
     },
+    "1009": {
+      "detail": "Key Storage Unavailable",
+      "category": "hardwareCommunicationError"
+    },
     "2000": {
       "detail": "Robotics Control Error",
       "category": "roboticsControlError"
@@ -230,6 +234,7 @@
       "detail": "Barcode scanner failed to find barcode.",
       "category": "roboticsInteractionError"
     },
+
     "4000": {
       "detail": "Unknown or Uncategorized Error",
       "category": "generalError"
@@ -284,6 +289,10 @@
     },
     "4013": {
       "detail": "Camera Related Error",
+      "category": "generalError"
+    },
+    "4014": {
+      "detail": "Audit logging error",
       "category": "generalError"
     }
   }

--- a/shared-data/python/opentrons_shared_data/errors/codes.py
+++ b/shared-data/python/opentrons_shared_data/errors/codes.py
@@ -43,6 +43,7 @@ class ErrorCodes(Enum):
     INTERNAL_MESSAGE_FORMAT_ERROR = _code_from_dict_entry("1006")
     CANBUS_CONFIGURATION_ERROR = _code_from_dict_entry("1007")
     CANBUS_BUS_ERROR = _code_from_dict_entry("1008")
+    KEY_STORAGE_UNAVAILABLE = _code_from_dict_entry("1009")
     ROBOTICS_CONTROL_ERROR = _code_from_dict_entry("2000")
     MOTION_FAILED = _code_from_dict_entry("2001")
     HOMING_FAILED = _code_from_dict_entry("2002")
@@ -101,6 +102,7 @@ class ErrorCodes(Enum):
     INCORRECT_API_VERSION = _code_from_dict_entry("4011")
     LABWARE_LOCATING_FEATURE_ERROR = _code_from_dict_entry("4012")
     CAMERA_ERROR = _code_from_dict_entry("4013")
+    AUDIT_LOGGING_ERROR = _code_from_dict_entry("4014")
 
     @classmethod
     @lru_cache(25)

--- a/shared-data/python/opentrons_shared_data/errors/exceptions.py
+++ b/shared-data/python/opentrons_shared_data/errors/exceptions.py
@@ -372,6 +372,19 @@ class CANBusBusError(CommunicationError):
         super().__init__(ErrorCodes.CANBUS_BUS_ERROR, message, detail, wrapping)
 
 
+class KeyStorageUnavailableError(CommunicationError):
+    """An error indicating a low-level communications failure with key storage."""
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, str]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build a KeyStorageUnavailableError."""
+        super().__init__(ErrorCodes.KEY_STORAGE_UNAVAILABLE, message, detail, wrapping)
+
+
 class MotionFailedError(RoboticsControlError):
     """An error indicating that a motion failed."""
 
@@ -1340,3 +1353,19 @@ class MissingConfigurationData(GeneralError):
         super().__init__(
             ErrorCodes.MISSING_CONFIGURATION_DATA, message, detail, wrapping
         )
+
+
+class AuditLoggingError(GeneralError):
+    """An error indicating that provided configuration data is missing or invalid.
+
+    This will usually be because a pipette configuration does not match the ones provided by the pipette definition.
+    """
+
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        detail: Optional[Dict[str, str]] = None,
+        wrapping: Optional[Sequence[EnumeratedError]] = None,
+    ) -> None:
+        """Build an AuditLoggingError."""
+        super().__init__(ErrorCodes.AUDIT_LOGGING_ERROR, message, detail, wrapping)


### PR DESCRIPTION
# Overview

The log data manager is responsible for rotating logs periods whenever necessary and for handling errors. It's also where the key server integration is moving to, since it has to generate some of its own log messages sometimes and needs to get those logs signed anyway.

This is a bit of a big one and has some long and boring logic bits in the middle; I'm open to ways to change it. Like its predecessors, it isn't yet integrated into anything (I think that's the next PR, though!)

## Test Plan and Hands on Testing

- Unit tests; this isn't integrated into anything

## Review requests

Most importantly, does the error handling for e.g. missing key-server and bad log period handling make sense?

~I think I want to add locking to the top level log data manager methods, so this is marked as draft to remind me, but it's otherwise ready for review.~ done