### PR TITLE
docs(auth-server): Use tags to organize HTTP API documentation

### DIFF
--- a/auth-server/auth_server/app.py
+++ b/auth-server/auth_server/app.py
@@ -79,6 +79,21 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         yield
 
 
+_OAUTH_2_TAG = {
+    "name": "OAuth 2",
+    "description": "Flows for user authentication, following the OAuth 2 standard."
+}
+_AUTH_SETTINGS_TAG = {
+    "name": "Auth settings",
+    "description": "Settings related to authentication and authorization."
+}
+_USERS_TAG = {
+    "name": "Users",
+    "description": "Endpoints for managing users."
+}
+_TAGS = [_OAUTH_2_TAG, _AUTH_SETTINGS_TAG, _USERS_TAG]
+
+
 app = FastAPI(
     title="Opentrons Auth Server",
     openapi_url="/auth/openapi.json",
@@ -86,15 +101,16 @@ app = FastAPI(
     # redoc_url is replaced by our own /redoc router, below.
     redoc_url=None,
     lifespan=_lifespan,
+    openapi_tags=_TAGS
 )
 
 
 app.exception_handler(AuthorizationError)(handle_authorization_error)
 
 
-app.include_router(oauth2_router)
-app.include_router(settings_router)
-app.include_router(users_router)
+app.include_router(oauth2_router, tags=[_OAUTH_2_TAG["name"]])
+app.include_router(settings_router, tags=[_AUTH_SETTINGS_TAG["name"]])
+app.include_router(users_router, tags=[_USERS_TAG["name"]])
 
 
 # This is a workaround for a broken /redoc page in versions of FastAPI <0.115.3.

--- a/auth-server/auth_server/app.py
+++ b/auth-server/auth_server/app.py
@@ -81,16 +81,13 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 _OAUTH_2_TAG = {
     "name": "OAuth 2",
-    "description": "Flows for user authentication, following the OAuth 2 standard."
+    "description": "Flows for user authentication, following the OAuth 2 standard.",
 }
 _AUTH_SETTINGS_TAG = {
     "name": "Auth settings",
-    "description": "Settings related to authentication and authorization."
+    "description": "Settings related to authentication and authorization.",
 }
-_USERS_TAG = {
-    "name": "Users",
-    "description": "Endpoints for managing users."
-}
+_USERS_TAG = {"name": "Users", "description": "Endpoints for managing users."}
 _TAGS = [_OAUTH_2_TAG, _AUTH_SETTINGS_TAG, _USERS_TAG]
 
 
@@ -101,7 +98,7 @@ app = FastAPI(
     # redoc_url is replaced by our own /redoc router, below.
     redoc_url=None,
     lifespan=_lifespan,
-    openapi_tags=_TAGS
+    openapi_tags=_TAGS,
 )
 
 


### PR DESCRIPTION
## Overview

auth-server has grown to have 14 endpoints now, which are difficult to scan through as a flat list in the OpenAPI documentation. This groups them into human-readable tags, similar to what robot-server does.

## Test Plan and Hands on Testing

* [x] Run `make dev-backend-flex`, visit http://localhost:31950/auth/redoc, and make sure it renders nicely.

## Review requests

None.

## Risk assessment

Very low.
