### PR TITLE
fix(protocol-visualization, app): allow back scroll updates

### DIFF
--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { List, useDynamicRowHeight, useListCallbackRef } from 'react-window'
 
@@ -146,7 +146,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     return next
   }, [groupedCommands])
   const currentCommandId =
-    currentCommandIndex != null
+    currentCommandIndex != null && currentCommandIndex >= 0
       ? (filteredCommands[currentCommandIndex]?.id ?? null)
       : null
   const lastVisibleAnalysisCommandId = useMemo(
@@ -199,7 +199,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
   ])
 
   useEffect(() => {
-    if (currentCommandId == null || !isGlobalPlaying) {
+    if (currentCommandId == null) {
       return
     }
     if (filteredGroupedCommands != null && filteredGroupedCommands.length > 0) {
@@ -221,12 +221,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     if (scrollTargetId !== currentCommandId) {
       setScrollTargetId(currentCommandId)
     }
-  }, [
-    filteredGroupedCommands,
-    currentCommandId,
-    scrollTargetId,
-    isGlobalPlaying,
-  ])
+  }, [filteredGroupedCommands, currentCommandId, scrollTargetId])
 
   const { rows, rowIndexByCommandId } = useMemo(() => {
     const nextRows: AnnotatedStepsRow[] = []
@@ -282,6 +277,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
           command,
           isHighlighted:
             currentCommandIndex != null &&
+            currentCommandIndex >= 0 &&
             filteredCommands[currentCommandIndex]?.id === command.id,
           fromGroup: false,
           commandNumber: currentCommandNumber,
@@ -322,6 +318,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
   const [listRef, listRefCallback] = useListCallbackRef()
   const [listWidth, setListWidth] = useState(0)
   const [listViewportHeight, setListViewportHeight] = useState(0)
+  const visibleRowRangeRef = useRef({ start: 0, stop: 0 })
   const dynamicRowHeight = useDynamicRowHeight({
     defaultRowHeight: DEFAULT_ROW_HEIGHT_PX,
     key: `${listWidth}-${rows.length}`,
@@ -347,18 +344,34 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     if (scrollTargetId == null) return
     const rowIndex = rowIndexByCommandId.get(scrollTargetId)
     if (rowIndex == null) return
+
+    if (!isGlobalPlaying) {
+      const { start, stop } = visibleRowRangeRef.current
+      const isRowVisible = rowIndex >= start && rowIndex <= stop
+      if (isRowVisible) {
+        return
+      }
+    }
+
     listRef?.scrollToRow({
       index: rowIndex,
       align: rowIndex >= rows.length - 1 ? 'end' : 'auto',
     })
-  }, [scrollTargetId, rowIndexByCommandId, listRef, rows.length])
+  }, [
+    scrollTargetId,
+    rowIndexByCommandId,
+    listRef,
+    rows.length,
+    isGlobalPlaying,
+  ])
 
   useEffect(() => {
     setListElement(listRef?.element ?? null)
   }, [listRef])
 
   const handleRowsRendered = useCallback(
-    ({ stopIndex }: { startIndex: number; stopIndex: number }) => {
+    ({ startIndex, stopIndex }: { startIndex: number; stopIndex: number }) => {
+      visibleRowRangeRef.current = { start: startIndex, stop: stopIndex }
       if (rows.length === 0) {
         setIsAtBottom?.(true)
       } else {

--- a/protocol-visualization/src/organisms/AnnotatedSteps/index.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { List, useDynamicRowHeight, useListCallbackRef } from 'react-window'
 
@@ -125,7 +125,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     [analysis.commands]
   )
   const currentCommandId =
-    currentCommandIndex != null
+    currentCommandIndex != null && currentCommandIndex >= 0
       ? (filteredCommands[currentCommandIndex]?.id ?? null)
       : null
   const filteredGroupedCommands = useMemo(() => {
@@ -197,7 +197,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
   ])
 
   useEffect(() => {
-    if (currentCommandId == null || !isGlobalPlaying) {
+    if (currentCommandId == null) {
       return
     }
     if (filteredGroupedCommands != null && filteredGroupedCommands.length > 0) {
@@ -219,12 +219,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     if (scrollTargetId !== currentCommandId) {
       setScrollTargetId(currentCommandId)
     }
-  }, [
-    filteredGroupedCommands,
-    currentCommandId,
-    scrollTargetId,
-    isGlobalPlaying,
-  ])
+  }, [filteredGroupedCommands, currentCommandId, scrollTargetId])
 
   const { rows, rowIndexByCommandId } = useMemo(() => {
     const nextRows: AnnotatedStepsRow[] = []
@@ -280,6 +275,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
           command,
           isHighlighted:
             currentCommandIndex != null &&
+            currentCommandIndex >= 0 &&
             filteredCommands[currentCommandIndex]?.id === command.id,
           fromGroup: false,
           commandNumber: currentCommandNumber,
@@ -320,6 +316,7 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
   const [listRef, listRefCallback] = useListCallbackRef()
   const [listWidth, setListWidth] = useState(0)
   const [listViewportHeight, setListViewportHeight] = useState(0)
+  const visibleRowRangeRef = useRef({ start: 0, stop: 0 })
   const dynamicRowHeight = useDynamicRowHeight({
     defaultRowHeight: DEFAULT_ROW_HEIGHT_PX,
     key: `${listWidth}-${rows.length}`,
@@ -345,18 +342,34 @@ export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
     if (scrollTargetId == null) return
     const rowIndex = rowIndexByCommandId.get(scrollTargetId)
     if (rowIndex == null) return
+
+    if (!isGlobalPlaying) {
+      const { start, stop } = visibleRowRangeRef.current
+      const isRowVisible = rowIndex >= start && rowIndex <= stop
+      if (isRowVisible) {
+        return
+      }
+    }
+
     listRef?.scrollToRow({
       index: rowIndex,
       align: rowIndex >= rows.length - 1 ? 'end' : 'auto',
     })
-  }, [scrollTargetId, rowIndexByCommandId, listRef, rows.length])
+  }, [
+    scrollTargetId,
+    rowIndexByCommandId,
+    listRef,
+    rows.length,
+    isGlobalPlaying,
+  ])
 
   useEffect(() => {
     setListElement(listRef?.element ?? null)
   }, [listRef])
 
   const handleRowsRendered = useCallback(
-    ({ stopIndex }: { startIndex: number; stopIndex: number }) => {
+    ({ startIndex, stopIndex }: { startIndex: number; stopIndex: number }) => {
+      visibleRowRangeRef.current = { start: startIndex, stop: stopIndex }
       if (rows.length === 0) {
         setIsAtBottom?.(true)
       } else {


### PR DESCRIPTION
closes RQA-5674

# Overview

a past PR added an `!isGlobalPlaying` guard to the `scrollTargetId` sync effect to stop the steps list from jumping when selecting a step. That also broke timeline scrubbing while paused. `scrollTargetId` stayed stuck on the last played step, so earlier steps weren't highlighted or scrolled into view.

https://github.com/user-attachments/assets/39ba09e3-1792-4578-bd46-38ebcf63ee0b

## Test Plan and Hands on Testing

Smoke test the issue listed in the ticket 

## Changelog

- Always sync `scrollTargetId` to `currentCommandId` (reverts the `isGlobalPlaying` guard on that effect)
- When paused, only call `scrollToRow` if the target row is outside the currently visible range
- Track visible row range in a ref (updated from `onRowsRendered`) so manual list scrolling doesn't re-trigger auto-scroll

## Risk assessment

medium, affects PV, all protocols scrolling, so we should smoke test that
