### PR TITLE
fix(api): retry module build with backoff on transient ParseError/NoResponse

### DIFF
--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -17,6 +17,7 @@ from opentrons.drivers.types import Temperature, RPM, HeaterShakerLabwareLatchSt
 from opentrons.hardware_control.execution_manager import ExecutionManager
 from opentrons.hardware_control.poller import Reader, Poller
 from opentrons.hardware_control.modules import mod_abc, update
+from opentrons.hardware_control.modules.retry import retry_module_init
 from opentrons.hardware_control.modules.types import (
     ModuleDisconnectedCallback,
     ModuleErrorCallback,
@@ -81,11 +82,24 @@ class HeaterShaker(mod_abc.AbstractModule):
         """
         driver: AbstractHeaterShakerDriver
         if not simulating:
-            driver = await HeaterShakerDriver.create(port=port, loop=hw_control_loop)
             poll_interval_seconds = poll_interval_seconds or POLL_PERIOD
+
+            async def _init_driver() -> tuple[
+                AbstractHeaterShakerDriver, Mapping[str, str]
+            ]:
+                d = await HeaterShakerDriver.create(port=port, loop=hw_control_loop)
+                try:
+                    info = await d.get_device_info()
+                    return d, info
+                except BaseException:
+                    await d.disconnect()
+                    raise
+
+            driver, device_info = await retry_module_init(_init_driver, port=port)
         else:
             driver = SimulatingDriver(serial_number=sim_serial_number)
             poll_interval_seconds = poll_interval_seconds or SIMULATING_POLL_PERIOD
+            device_info = await driver.get_device_info()
 
         reader = HeaterShakerReader(driver=driver)
         poller = Poller(reader=reader, interval=poll_interval_seconds)
@@ -95,7 +109,7 @@ class HeaterShaker(mod_abc.AbstractModule):
             driver=driver,
             reader=reader,
             poller=poller,
-            device_info=await driver.get_device_info(),
+            device_info=device_info,
             hw_control_loop=hw_control_loop,
             execution_manager=execution_manager,
             disconnected_callback=disconnected_callback,

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -9,6 +9,7 @@ from opentrons.drivers.mag_deck import (
 from opentrons.drivers.rpi_drivers.types import USBPort
 from ..execution_manager import ExecutionManager
 from . import update, mod_abc, types
+from opentrons.hardware_control.modules.retry import retry_module_init
 
 log = logging.getLogger(__name__)
 
@@ -60,18 +61,29 @@ class MagDeck(mod_abc.AbstractModule):
         """Factory function."""
         driver: AbstractMagDeckDriver
         if not simulating:
-            driver = await MagDeckDriver.create(port=port, loop=hw_control_loop)
+
+            async def _init_driver() -> tuple[AbstractMagDeckDriver, Dict[str, str]]:
+                d = await MagDeckDriver.create(port=port, loop=hw_control_loop)
+                try:
+                    info = await d.get_device_info()
+                    return d, info
+                except BaseException:
+                    await d.disconnect()
+                    raise
+
+            driver, device_info = await retry_module_init(_init_driver, port=port)
         else:
             driver = SimulatingDriver(
                 sim_model=sim_model, serial_number=sim_serial_number
             )
+            device_info = await driver.get_device_info()
 
         mod = cls(
             port=port,
             usb_port=usb_port,
             execution_manager=execution_manager,
             hw_control_loop=hw_control_loop,
-            device_info=await driver.get_device_info(),
+            device_info=device_info,
             driver=driver,
             disconnected_callback=disconnected_callback,
             error_callback=error_callback,

--- a/api/src/opentrons/hardware_control/modules/retry.py
+++ b/api/src/opentrons/hardware_control/modules/retry.py
@@ -1,0 +1,58 @@
+"""Retry/backoff helper for module initialization."""
+
+import asyncio
+import logging
+from typing import Awaitable, Callable, Optional, Tuple, Type, TypeVar
+
+from opentrons.drivers.asyncio.communication.errors import NoResponse
+from opentrons.drivers.utils import ParseError
+
+log = logging.getLogger(__name__)
+
+MODULE_BUILD_RETRIES = 5
+MODULE_BUILD_INITIAL_BACKOFF_S = 0.5
+MODULE_BUILD_MAX_BACKOFF_S = 2.0
+
+# Exceptions that indicate the module is not ready yet and a retry is worthwhile.
+MODULE_BUILD_RETRYABLE_ERRORS: Tuple[Type[BaseException], ...] = (
+    ParseError,
+    NoResponse,
+)
+
+_T = TypeVar("_T")
+
+
+async def retry_module_init(
+    factory: Callable[[], Awaitable[_T]],
+    port: str = "",
+) -> _T:
+    """Run `factory` with retry/backoff on retryable module-init errors.
+
+    Args:
+        factory: A coroutine factory performing the operation that may fail with
+            a retryable error.
+        port: Port string used only for logging context.
+
+    Returns: The result of a successful `factory` call.
+
+    Raises: The last retryable error if all attempts fail, or any non-retryable
+        error raised by `factory`.
+    """
+    backoff = MODULE_BUILD_INITIAL_BACKOFF_S
+    last_exc: Optional[BaseException] = None
+
+    for attempt in range(0, MODULE_BUILD_RETRIES):
+        try:
+            return await factory()
+        except MODULE_BUILD_RETRYABLE_ERRORS as e:
+            last_exc = e
+            log.warning(
+                f"Module build attempt {attempt}/{MODULE_BUILD_RETRIES} on port "
+                f"{port!r} failed with {type(e).__name__}: {e}"
+            )
+            if attempt < MODULE_BUILD_RETRIES:
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, MODULE_BUILD_MAX_BACKOFF_S)
+
+    assert last_exc is not None
+    raise last_exc

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -4,25 +4,26 @@ import asyncio
 import logging
 from typing import Dict, Optional, Callable
 
+from typing_extensions import Final
+
+from opentrons.config import IS_ROBOT
+from opentrons.drivers.rpi_drivers.types import USBPort
+from opentrons.drivers.temp_deck import (
+    DEFAULT_COMMAND_RETRIES,
+    AbstractTempDeckDriver,
+    SimulatingDriver,
+    TempDeckDriver,
+)
+from opentrons.drivers.types import Temperature
+from opentrons.hardware_control.execution_manager import ExecutionManager
+from opentrons.hardware_control.modules import errors, mod_abc, types, update
+from opentrons.hardware_control.modules.retry import retry_module_init
 from opentrons.hardware_control.modules.types import (
     ModuleDisconnectedCallback,
     ModuleErrorCallback,
     TemperatureStatus,
 )
 from opentrons.hardware_control.poller import Reader, Poller
-from typing_extensions import Final
-from opentrons.drivers.types import Temperature
-from opentrons.drivers.temp_deck import (
-    DEFAULT_COMMAND_RETRIES,
-    SimulatingDriver,
-    AbstractTempDeckDriver,
-    TempDeckDriver,
-)
-from opentrons.drivers.rpi_drivers.types import USBPort
-from opentrons.hardware_control.execution_manager import ExecutionManager
-from opentrons.hardware_control.modules import update, mod_abc, types, errors
-
-from opentrons.config import IS_ROBOT
 
 log = logging.getLogger(__name__)
 
@@ -68,13 +69,24 @@ class TempDeck(mod_abc.AbstractModule):
         """
         driver: AbstractTempDeckDriver
         if not simulating:
-            driver = await TempDeckDriver.create(port=port, loop=hw_control_loop)
             poll_interval_seconds = poll_interval_seconds or TEMP_POLL_INTERVAL_SECS
+
+            async def _init_driver() -> tuple[AbstractTempDeckDriver, Dict[str, str]]:
+                d = await TempDeckDriver.create(port=port, loop=hw_control_loop)
+                try:
+                    info = await d.get_device_info()
+                    return d, info
+                except BaseException:
+                    await d.disconnect()
+                    raise
+
+            driver, device_info = await retry_module_init(_init_driver, port=port)
         else:
             driver = SimulatingDriver(
                 sim_model=sim_model, serial_number=sim_serial_number
             )
             poll_interval_seconds = poll_interval_seconds or SIM_TEMP_POLL_INTERVAL_SECS
+            device_info = await driver.get_device_info()
 
         reader = TempDeckReader(driver=driver)
         poller = Poller(reader=reader, interval=poll_interval_seconds)
@@ -85,7 +97,7 @@ class TempDeck(mod_abc.AbstractModule):
             driver=driver,
             reader=reader,
             poller=poller,
-            device_info=await driver.get_device_info(),
+            device_info=device_info,
             hw_control_loop=hw_control_loop,
             disconnected_callback=disconnected_callback,
             error_callback=error_callback,

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -7,6 +7,7 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.types import ThermocyclerLidStatus, Temperature, PlateTemperature
 from opentrons.hardware_control.modules.lid_temp_status import LidTemperatureStatus
 from opentrons.hardware_control.modules.plate_temp_status import PlateTemperatureStatus
+from opentrons.hardware_control.modules.retry import retry_module_init
 from opentrons.hardware_control.modules.types import (
     ModuleDisconnectedCallback,
     ModuleErrorCallback,
@@ -93,13 +94,26 @@ class Thermocycler(mod_abc.AbstractModule):
         """
         driver: AbstractThermocyclerDriver
         if not simulating:
-            driver = await ThermocyclerDriverFactory.create(
-                port=port, loop=hw_control_loop
-            )
             poll_interval_seconds = poll_interval_seconds or POLLING_FREQUENCY_SEC
+
+            async def _init_driver() -> tuple[
+                AbstractThermocyclerDriver, Dict[str, str]
+            ]:
+                d = await ThermocyclerDriverFactory.create(
+                    port=port, loop=hw_control_loop
+                )
+                try:
+                    info = await d.get_device_info()
+                    return d, info
+                except BaseException:
+                    await d.disconnect()
+                    raise
+
+            driver, device_info = await retry_module_init(_init_driver, port=port)
         else:
             driver = SimulatingDriver(model=sim_model, serial_number=sim_serial_number)
             poll_interval_seconds = poll_interval_seconds or SIM_POLLING_FREQUENCY_SEC
+            device_info = await driver.get_device_info()
 
         reader = ThermocyclerReader(driver=driver)
         poller = Poller(reader=reader, interval=poll_interval_seconds)
@@ -109,7 +123,7 @@ class Thermocycler(mod_abc.AbstractModule):
             driver=driver,
             reader=reader,
             poller=poller,
-            device_info=await driver.get_device_info(),
+            device_info=device_info,
             hw_control_loop=hw_control_loop,
             execution_manager=execution_manager,
             disconnected_callback=disconnected_callback,

--- a/api/tests/opentrons/hardware_control/modules/test_retry.py
+++ b/api/tests/opentrons/hardware_control/modules/test_retry.py
@@ -1,0 +1,126 @@
+"""Tests for the module build retry/backoff helper."""
+
+import asyncio
+import pytest
+
+from opentrons.drivers.asyncio.communication.errors import NoResponse
+from opentrons.drivers.utils import ParseError
+from opentrons.hardware_control.modules import retry as retry_module
+from opentrons.hardware_control.modules.retry import (
+    MODULE_BUILD_RETRIES,
+    retry_module_init,
+)
+
+
+@pytest.fixture
+def fast_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch the retry backoff to be effectively instant."""
+    monkeypatch.setattr(retry_module, "MODULE_BUILD_INITIAL_BACKOFF_S", 0)
+    monkeypatch.setattr(retry_module, "MODULE_BUILD_MAX_BACKOFF_S", 0)
+    monkeypatch.setattr(asyncio, "sleep", lambda _: _noop())
+
+
+async def _noop() -> None:
+    return None
+
+
+async def test_returns_on_first_success(fast_backoff: None) -> None:
+    """It should return the factory result when it succeeds immediately."""
+
+    async def factory() -> str:
+        return "ok"
+
+    result = await retry_module_init(factory, port="/dev/test")
+
+    assert result == "ok"
+
+
+async def test_retries_on_parse_error_then_succeeds(
+    fast_backoff: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """It should retry on ParseError and return once the factory succeeds."""
+    call_count = 0
+
+    async def factory() -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise ParseError(error_message="Missing key 'model'", parse_source="")
+        return "ok"
+
+    result = await retry_module_init(factory, port="/dev/test")
+
+    assert result == "ok"
+    assert call_count == 3
+
+
+async def test_retries_on_no_response_then_succeeds(
+    fast_backoff: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """It should retry on NoResponse (ack timeout) and return on success."""
+    call_count = 0
+
+    async def factory() -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise NoResponse(port="/dev/test", command="M115")
+        return "ok"
+
+    result = await retry_module_init(factory, port="/dev/test")
+
+    assert result == "ok"
+    assert call_count == 2
+
+
+async def test_raises_after_exhausting_retries(fast_backoff: None) -> None:
+    """It should re-raise the last retryable error after all attempts fail."""
+    call_count = 0
+
+    async def factory() -> str:
+        nonlocal call_count
+        call_count += 1
+        raise ParseError(error_message="always fails", parse_source="")
+
+    with pytest.raises(ParseError, match="always fails"):
+        await retry_module_init(factory, port="/dev/test")
+
+    assert call_count == MODULE_BUILD_RETRIES
+
+
+async def test_does_not_retry_non_retryable_error(fast_backoff: None) -> None:
+    """It should not retry on exceptions outside the retryable set."""
+    call_count = 0
+
+    async def factory() -> str:
+        nonlocal call_count
+        call_count += 1
+        raise ValueError("not retryable")
+
+    with pytest.raises(ValueError, match="not retryable"):
+        await retry_module_init(factory, port="/dev/test")
+
+    assert call_count == 1
+
+
+async def test_factory_cleanup_called_between_attempts(
+    fast_backoff: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The factory is responsible for cleaning up on failure.
+
+    This documents the contract: the factory's own except block runs before
+    the retry sleep, so partially-constructed drivers get torn down each time.
+    """
+    cleanup_calls: list[BaseException] = []
+
+    async def factory() -> str:
+        try:
+            raise ParseError(error_message="boom", parse_source="")
+        except ParseError as e:
+            cleanup_calls.append(e)
+            raise
+
+    with pytest.raises(ParseError):
+        await retry_module_init(factory, port="/dev/test")
+
+    assert len(cleanup_calls) == MODULE_BUILD_RETRIES


### PR DESCRIPTION
# Overview

When a module's USB connection is disrupted and re-established, the device file reappears almost immediately, but data paths on both the host and the module need to reinitialize. If `build()` queries device info before boot completes, the module may respond with garbage or an empty string  or fail to ack at all.

This PR adds an exponential retry-with-backoff helper that wraps driver creation and `get_device_info()` in each module's `build()` class method on valid retryable errors. This helper applies to TempDeck, MagDeck, HeaterShaker, and Thermocycler, the four gcode-based modules that call a `parse_device_information` variant in `build()`.

## Test Plan and Hands on Testing

- [x] Bounced the temp module's USB port mid-protocol and confirm the module is recovered and the run continues using the following command in an SSH session: `echo 0 > /sys/bus/usb/devices/<dev>/bConfigurationValue && sleep 0.2 && echo 1 > /sys/bus/usb/devices/<dev>/bConfigurationValue`

Tested using the following protocol:

```
def run(protocol: protocol_api.ProtocolContext) -> None:
    temp_module = protocol.load_module("temperature module gen2", "D1")
    temp_labware = temp_module.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")

    protocol.comment("Temperature Module loaded in D1. Starting test sequence.")


    temp_module.set_temperature(40)
    protocol.pause("Heated to 40C. Test bounce, then resume.")
    temp_module.deactivate()
    protocol.pause("Deactivated. Test bounce, then resume.")

    temp_module.set_temperature(30)
    protocol.pause("Heated to 30C. Test bounce, then resume.")
    temp_module.deactivate()

    protocol.comment("Temperature Module disconnect recovery test complete.")
```

## Changelog

- Fixed an issue where a protocol may fail when a module is disconnected. 

## Risk assessment

- low, just additive logic that's auditable
