### PR TITLE
fix(protocol-designer): consider all 384-wells in WellSelector

### DIFF
--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -246,12 +246,30 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
       nozzleConfiguration,
       labwareDef
     )
-    const primaryWells = getWellsToCheck(
+    
+    // getWellsToCheck is designed for tipracks (96-well format). For labware like
+    // 384-well plates, skipEveryOtherWell means A1's cascading wells only covers odd rows
+    // Add gaps to primaries so wellToPrimaryStatus has an entry for every well in the labware.
+    const initialPrimaries = getWellsToCheck(
       nozzleConfiguration,
       labwareDef.ordering,
       channels,
       primaryNozzle
     )
+    const coveredByInitialPrimaries = new Set<string>()
+    initialPrimaries.forEach(well => {
+      getEntireWellSelection(
+        well,
+        labwareDef.ordering,
+        nozzleConfiguration,
+        primaryNozzle,
+        channels
+      ).forEach(well => coveredByInitialPrimaries.add(well))
+    })
+    const primaryWells = [
+      ...initialPrimaries,
+      ...allWells.flat().filter(w => !coveredByInitialPrimaries.has(w)),
+    ]
     return primaryWells.reduce<
       Record<string, { isAccessible: boolean; affectedWells: string[] }>
     >((acc, wellName) => {
@@ -289,6 +307,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
     pipetteId,
     labwareId,
     tiprackId,
+    allWells,
   ])
 
   // propogate each primary's status to all its cascading wells

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/WellSelector.tsx
@@ -246,7 +246,7 @@ export function WellSelector(props: WellSelectorProps): JSX.Element {
       nozzleConfiguration,
       labwareDef
     )
-    
+
     // getWellsToCheck is designed for tipracks (96-well format). For labware like
     // 384-well plates, skipEveryOtherWell means A1's cascading wells only covers odd rows
     // Add gaps to primaries so wellToPrimaryStatus has an entry for every well in the labware.


### PR DESCRIPTION
# Overview

ensure we consider all possible target wells in a 384-wellplate

Closes RQA-5681

## Test Plan and Hands on Testing
[test.py](https://github.com/user-attachments/files/29310006/asd.py)

- work with a protocol with a 384-wellplate and create a transfer step with 8ch full column configuration
- open well selector and verify that rows B, D, etc. are selectable
- change nozzles to partial column
- verify that non-collision-producing target wells in rows B, D, etc. are selectable 

## Changelog

- fix implementation in WellSelector to consider wellplates of arbitrary wells

## Review requests

see test plan

## Risk assessment

low