### PR TITLE
feat(auth-server): Enforce password complexity requirements

### DIFF
--- a/auth-server/auth_server/api_error.py
+++ b/auth-server/auth_server/api_error.py
@@ -1,0 +1,24 @@
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+
+class APIError(Exception):
+    """An endpoint can raise this to return an HTTP error with an arbitrary JSON body.
+
+    todo(mm, 2026-06-24): Unify this with robot-server's ApiError.
+    """
+
+    def __init__(self, status_code: int, body: BaseModel) -> None:
+        self.status_code = status_code
+        self.body = body
+
+
+def handle_api_error(request: object, error: APIError) -> JSONResponse:
+    """Catch an APIError and turn it into an HTTP response.
+
+    This should be installed as a global FastAPI exception handler.
+    """
+    return JSONResponse(
+        status_code=error.status_code,
+        content=error.body.model_dump(by_alias=True),
+    )

--- a/auth-server/auth_server/app.py
+++ b/auth-server/auth_server/app.py
@@ -15,6 +15,7 @@ from server_utils.auth.resource_server.fastapi import (
     install_authorization_checker,
 )
 
+from auth_server.api_error import APIError, handle_api_error
 from auth_server.authorization_checker import build_authorization_checker
 from auth_server.oauth2.backend import Backend as OAuth2Backend
 from auth_server.oauth2.fastapi_dependencies import (
@@ -89,6 +90,7 @@ app = FastAPI(
 )
 
 
+app.exception_handler(APIError)(handle_api_error)
 app.exception_handler(AuthorizationError)(handle_authorization_error)
 
 

--- a/auth-server/auth_server/settings/models.py
+++ b/auth-server/auth_server/settings/models.py
@@ -28,7 +28,7 @@ class SettingsResponseData(_StrictBaseModel):
     )
     passwordComplexityMinimumLength: int | None = pydantic.Field(
         default=None,
-        description="Minimum length of password. Set to null to remove the limit.",
+        description="Minimum length of passwords, measured in Unicode codepoints. Set to null to remove the length requirement.",
     )
     passwordComplexitySpecialCharacters: bool | None = pydantic.Field(
         default=None,
@@ -81,7 +81,9 @@ class PatchSettingsRequestData(_StrictBaseModel):
     ] = None
     passwordComplexityMinimumLength: Annotated[
         int | None,
-        pydantic.Field(description="Minimum length of password."),
+        pydantic.Field(
+            description="Minimum length of passwords, measured in Unicode codepoints. Set to null to remove the length requirement."
+        ),
     ] = None
     passwordComplexitySpecialCharacters: Annotated[
         bool | None,

--- a/auth-server/auth_server/users/models.py
+++ b/auth-server/auth_server/users/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Sequence, TypedDict
 
 from pydantic import BaseModel, Field, SecretStr
 
@@ -121,3 +121,30 @@ class ResetPasswordResponse(UserResponse):
             description="The newly generated temporary password for the user.",
         ),
     ]
+
+
+# todo(mm, 2026-06-23): Deduplicate with robot-server's ErrorBody, via server-utils.
+class ErrorBody[ErrorDetailsT](BaseModel):
+    """A general error response envelope. More specific details will be inside `errors`."""
+
+    errors: Sequence[ErrorDetailsT]
+
+
+class PasswordTooShortErrorDetails(BaseModel):
+    """An error when a new password does not meet the configured length requirements."""
+
+    id: Literal["passwordTooShort"]
+    meta: _PasswordTooShortMeta
+
+
+class _PasswordTooShortMeta(TypedDict):
+    """Extra error information specific to PasswordTooShortErrorDetails."""
+
+    requiredLength: int
+    actualLength: int
+
+
+class PasswordMissingSpecialCharactersErrorDetails(BaseModel):
+    """An error response when a new password does not meet the configured special characters requirements."""
+
+    id: Literal["passwordMissingSpecialCharacters"]

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -17,8 +17,12 @@ from server_utils.fastapi_utils.models.json_api import (
     SimpleEmptyBody,
 )
 
+from auth_server.api_error import APIError
 from auth_server.users.dependencies import get_user_by_username, get_user_data_manager
 from auth_server.users.models import (
+    ErrorBody,
+    PasswordMissingSpecialCharactersErrorDetails,
+    PasswordTooShortErrorDetails,
     ResetPasswordResponse,
     UpdateSelf,
     UpdateUser,
@@ -27,6 +31,8 @@ from auth_server.users.models import (
 )
 from auth_server.users.user_data_manager import (
     InvalidInputError,
+    PasswordMissingSpecialCharactersError,
+    PasswordTooShortError,
     UserAlreadyExistsError,
     UserDataManager,
 )
@@ -41,6 +47,12 @@ router = fastapi.APIRouter()
     description="Create a new user.",
     responses={
         fastapi.status.HTTP_201_CREATED: {"model": SimpleBody[UserResponse]},
+        fastapi.status.HTTP_400_BAD_REQUEST: {
+            "model": ErrorBody[
+                PasswordTooShortErrorDetails
+                | PasswordMissingSpecialCharactersErrorDetails
+            ]
+        },
     },
     dependencies=[fastapi.Depends(require_scopes(Scope.USERS_WRITE))],
 )
@@ -62,11 +74,22 @@ async def post_users(
             account_type=user_create.accountType,
         )
     except UserAlreadyExistsError:
+        # todo(mm, 2026-06-24): Convert this to a more structured error response.
         raise fastapi.HTTPException(
             status_code=fastapi.status.HTTP_400_BAD_REQUEST,
             detail="User already exists",
         )
+    except PasswordTooShortError as e:
+        raise APIError(
+            fastapi.status.HTTP_400_BAD_REQUEST, _build_password_too_short_error(e)
+        ) from e
+    except PasswordMissingSpecialCharactersError as e:
+        raise APIError(
+            fastapi.status.HTTP_400_BAD_REQUEST,
+            _build_password_missing_special_characters_error(e),
+        ) from e
     except InvalidInputError as e:
+        # todo(mm, 2026-06-24): Convert this to a more structured error response.
         raise fastapi.HTTPException(
             status_code=fastapi.status.HTTP_400_BAD_REQUEST,
             detail=str(e),
@@ -129,6 +152,12 @@ async def delete_user(
     description="Update a specific user, identified by their unique username.",
     responses={
         fastapi.status.HTTP_200_OK: {"model": SimpleBody[UserResponse]},
+        fastapi.status.HTTP_400_BAD_REQUEST: {
+            "model": ErrorBody[
+                PasswordTooShortErrorDetails
+                | PasswordMissingSpecialCharactersErrorDetails
+            ]
+        },
     },
     dependencies=[fastapi.Depends(require_scopes(Scope.USERS_WRITE))],
 )
@@ -158,6 +187,15 @@ async def update_user(
             status_code=fastapi.status.HTTP_400_BAD_REQUEST,
             detail="User already exists",
         )
+    except PasswordTooShortError as e:
+        raise APIError(
+            fastapi.status.HTTP_400_BAD_REQUEST, _build_password_too_short_error(e)
+        ) from e
+    except PasswordMissingSpecialCharactersError as e:
+        raise APIError(
+            fastapi.status.HTTP_400_BAD_REQUEST,
+            _build_password_missing_special_characters_error(e),
+        ) from e
     except InvalidInputError as e:
         raise fastapi.HTTPException(
             status_code=fastapi.status.HTTP_400_BAD_REQUEST,
@@ -242,7 +280,12 @@ async def get_self(  # noqa: D103
     ),
     responses={
         fastapi.status.HTTP_200_OK: {"model": SimpleBody[UserResponse]},
-        fastapi.status.HTTP_400_BAD_REQUEST: {},
+        fastapi.status.HTTP_400_BAD_REQUEST: {
+            "model": ErrorBody[
+                PasswordTooShortErrorDetails
+                | PasswordMissingSpecialCharactersErrorDetails
+            ]
+        },
         fastapi.status.HTTP_401_UNAUTHORIZED: {},
     },
 )
@@ -268,6 +311,15 @@ async def update_self(
             authorization_details.username,
             new_password=request_body.data.password.get_secret_value(),
         )
+    except PasswordTooShortError as e:
+        raise APIError(
+            fastapi.status.HTTP_400_BAD_REQUEST, _build_password_too_short_error(e)
+        ) from e
+    except PasswordMissingSpecialCharactersError as e:
+        raise APIError(
+            fastapi.status.HTTP_400_BAD_REQUEST,
+            _build_password_missing_special_characters_error(e),
+        ) from e
     except InvalidInputError as e:
         raise fastapi.HTTPException(
             status_code=fastapi.status.HTTP_400_BAD_REQUEST,
@@ -276,4 +328,32 @@ async def update_self(
     return await PydanticResponse.create(
         status_code=fastapi.status.HTTP_200_OK,
         content=SimpleBody(data=result),
+    )
+
+
+def _build_password_too_short_error(
+    error: PasswordTooShortError,
+) -> ErrorBody[PasswordTooShortErrorDetails]:
+    return ErrorBody(
+        errors=[
+            PasswordTooShortErrorDetails(
+                id="passwordTooShort",
+                meta={
+                    "actualLength": error.actual_length,
+                    "requiredLength": error.required_length,
+                },
+            )
+        ]
+    )
+
+
+def _build_password_missing_special_characters_error(
+    error: PasswordMissingSpecialCharactersError,
+) -> ErrorBody[PasswordMissingSpecialCharactersErrorDetails]:
+    return ErrorBody(
+        errors=[
+            PasswordMissingSpecialCharactersErrorDetails(
+                id="passwordMissingSpecialCharacters"
+            )
+        ]
     )

--- a/auth-server/auth_server/users/user_data_manager.py
+++ b/auth-server/auth_server/users/user_data_manager.py
@@ -52,15 +52,18 @@ def _password_complexity_requirements(
     return min_length, require_special
 
 
-def _validate_password_complexity(password: str, settings: SettingsResponseData) -> None:
+def _validate_password_complexity(
+    password: str, settings: SettingsResponseData
+) -> None:
     """Validate that a user-chosen password meets configured complexity rules."""
     min_length, require_special = _password_complexity_requirements(settings)
-    if len(password) < min_length:
-        raise InvalidInputError(
-            f"Password must be at least {min_length} characters long"
+    actual_length = len(password)
+    if actual_length < min_length:
+        raise PasswordTooShortError(
+            actual_length=actual_length, required_length=min_length
         )
     if require_special and not any(c in _PASSWORD_SPECIAL_CHARACTERS for c in password):
-        raise InvalidInputError("Password must contain at least one special character")
+        raise PasswordMissingSpecialCharactersError()
 
 
 class UserNotFoundError(ValueError):
@@ -73,6 +76,21 @@ class UserAlreadyExistsError(ValueError):
 
 class InvalidInputError(ValueError):
     """Raised when user input fails validation."""
+
+
+class PasswordTooShortError(InvalidInputError):
+    """Raised when a password does not meet the configured length requirements."""
+
+    def __init__(self, *, actual_length: int, required_length: int) -> None:
+        super().__init__(
+            f"Required password length of {required_length} but got {actual_length}."
+        )
+        self.actual_length = actual_length
+        self.required_length = required_length
+
+
+class PasswordMissingSpecialCharactersError(InvalidInputError):
+    """Raised when a password does not meet the configured requirements on special chars."""
 
 
 def _validate_fields_non_empty(

--- a/auth-server/auth_server/users/user_data_manager.py
+++ b/auth-server/auth_server/users/user_data_manager.py
@@ -41,7 +41,7 @@ def _generate_temporary_password(
     )
 
 
-def _temporary_password_requirements(
+def _password_complexity_requirements(
     settings: SettingsResponseData,
 ) -> tuple[int, bool]:
     """Return (min_length, require_special_characters) from auth settings."""
@@ -50,6 +50,17 @@ def _temporary_password_requirements(
     )
     require_special = settings.passwordComplexitySpecialCharacters is True
     return min_length, require_special
+
+
+def _validate_password_complexity(password: str, settings: SettingsResponseData) -> None:
+    """Validate that a user-chosen password meets configured complexity rules."""
+    min_length, require_special = _password_complexity_requirements(settings)
+    if len(password) < min_length:
+        raise InvalidInputError(
+            f"Password must be at least {min_length} characters long"
+        )
+    if require_special and not any(c in _PASSWORD_SPECIAL_CHARACTERS for c in password):
+        raise InvalidInputError("Password must contain at least one special character")
 
 
 class UserNotFoundError(ValueError):
@@ -64,13 +75,13 @@ class InvalidInputError(ValueError):
     """Raised when user input fails validation."""
 
 
-def _validate_fields(
+def _validate_fields_non_empty(
     username: str | None = None,
     password: str | None = None,
     full_name: str | None = None,
     account_type: str | None = None,
 ) -> None:
-    """Validate that provided fields are non-empty and passwords meet length requirements."""
+    """Validate that provided fields are non-empty."""
     for field_name, value in [
         ("username", username),
         ("password", password),
@@ -79,9 +90,6 @@ def _validate_fields(
     ]:
         if value is not None and value == "":
             raise InvalidInputError(f"{field_name} must not be empty")
-
-    if password is not None and len(password) < 8:
-        raise InvalidInputError("Password must be at least 8 characters long")
 
 
 def get_scope_set_of_user(user: User) -> set[Scope]:
@@ -146,12 +154,13 @@ class UserDataManager:
         account_type: str,
     ) -> UserResponse:
         """Validate inputs, check for duplicates, and create a new user."""
-        _validate_fields(
+        _validate_fields_non_empty(
             username=username,
             password=password,
             full_name=full_name,
             account_type=account_type,
         )
+        _validate_password_complexity(password, self._settings_store.get_settings())
         if self._user_store.get(username) is not None:
             raise UserAlreadyExistsError(f"User {username!r} already exists")
         new_user = self._user_store.add(
@@ -187,12 +196,16 @@ class UserDataManager:
         reset_password: bool = False,
     ) -> UserResponse:
         """Validate inputs, then update a user or raise UserNotFoundError."""
-        _validate_fields(
+        _validate_fields_non_empty(
             username=new_username,
             password=new_password,
             full_name=new_full_name,
             account_type=new_account_type,
         )
+        if new_password is not None:
+            _validate_password_complexity(
+                new_password, self._settings_store.get_settings()
+            )
         if (
             new_username is not None
             and new_username != username_to_update
@@ -221,7 +234,7 @@ class UserDataManager:
 
     def reset_user_password(self, username: str) -> ResetPasswordResponse:
         """Reset a user's password to a random temporary password."""
-        min_length, require_special = _temporary_password_requirements(
+        min_length, require_special = _password_complexity_requirements(
             self._settings_store.get_settings()
         )
         temporary_password = _generate_temporary_password(min_length, require_special)

--- a/auth-server/tests/integration/test_password_complexity.tavern.yaml
+++ b/auth-server/tests/integration/test_password_complexity.tavern.yaml
@@ -1,0 +1,266 @@
+test_name: Creating and updating a user enforces password complexity and minimum length
+
+marks:
+  - usefixtures:
+      - run_server
+      - admin_access_token
+
+stages:
+  - name: Set password length and complexity requirements
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          passwordComplexityMinimumLength: 12
+          passwordComplexitySpecialCharacters: true
+    response:
+      status_code: 200
+
+  - name: Reject user creation when password is too short
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/users'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          password: shortpass!
+          username: pw_test_user
+          fullName: Password Test User
+          accountType: user
+    response:
+      status_code: 400
+      json:
+        errors:
+          - id: passwordTooShort
+            meta:
+              requiredLength: 12
+              actualLength: 10
+
+  - name: Reject user creation when password lacks a special character
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/users'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          password: longpasswordlongpassword
+          username: pw_test_user
+          fullName: Password Test User
+          accountType: user
+    response:
+      status_code: 400
+      json:
+        errors:
+          - id: passwordMissingSpecialCharacters
+
+  - name: Accept user creation when password meets complexity requirements
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/users'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          password: longpasswordlongpassword!
+          username: pw_test_user
+          fullName: Password test User
+          accountType: user
+    response:
+      status_code: 201
+
+  - name: Log in as pw_test_user
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        password: longpasswordlongpassword!
+        client_id: opentrons_app
+        grant_type: password
+        username: pw_test_user
+    response:
+      status_code: 200
+      save:
+        json:
+          pw_test_user_access_token: access_token
+      json:
+        access_token: !anystr
+      strict:
+        - json:off
+
+  - name: Reject self password update when password is too short
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        Authorization: 'Bearer {pw_test_user_access_token}'
+      json:
+        data:
+          password: shortpass!
+    response:
+      status_code: 400
+      json:
+        errors:
+          - id: passwordTooShort
+            meta:
+              requiredLength: 12
+              actualLength: 10
+
+  - name: Reject self password update when password lacks a special character
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        Authorization: 'Bearer {pw_test_user_access_token}'
+      json:
+        data:
+          password: longpasswordlongpassword
+    response:
+      status_code: 400
+      json:
+        errors:
+          - id: passwordMissingSpecialCharacters
+
+  - name: Accept self password update when password meets complexity requirements
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        Authorization: 'Bearer {pw_test_user_access_token}'
+      json:
+        data:
+          password: longpasswordlongpassword!
+    response:
+      status_code: 200
+
+  - name: Reject password update of a designated user when password lacks a special character
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/byUsername/pw_test_user'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          password: longpasswordlongpassword
+    response:
+      status_code: 400
+      json:
+        errors:
+          - id: passwordMissingSpecialCharacters
+
+  - name: Reject password update of a designated user when password is too short
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/byUsername/pw_test_user'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          password: shortpass!
+    response:
+      status_code: 400
+      json:
+        errors:
+          - id: passwordTooShort
+            meta:
+              requiredLength: 12
+              actualLength: 10
+
+  - name: Accept password update of a designated user when password meets complexity requirements
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/byUsername/pw_test_user'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          password: longpasswordlongpassword!
+    response:
+      status_code: 200
+
+---
+test_name: Password complexity and minimum length requirements can be disabled
+
+marks:
+  - usefixtures:
+      - run_server
+      - admin_access_token
+
+stages:
+  - name: Disable password length and complexity requirements
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          # fixme(mm, 2026-06-24): The HTTP API docs say we can set `passwordComplexityMinimumLength: null`,
+          # but that does not have the advertised effect of disabling the minimum length requirement.
+          # Setting it to 0 also appears to leave it unchanged.
+          passwordComplexityMinimumLength: 1
+          passwordComplexitySpecialCharacters: false
+    response:
+      status_code: 200
+
+  - name: A dogshit password is accepted when creating a user
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/users'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          password: x
+          username: pw_test_user
+          fullName: Password Test User
+          accountType: user
+    response:
+      status_code: 201
+
+  - name: Log in as pw_test_user
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        password: x
+        client_id: opentrons_app
+        grant_type: password
+        username: pw_test_user
+    response:
+      status_code: 200
+      save:
+        json:
+          pw_test_user_access_token: access_token
+      json:
+        access_token: !anystr
+      strict:
+        - json:off
+
+  - name: A dogshit password is accepted when doing a self update
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/self'
+      headers:
+        Authorization: 'Bearer {pw_test_user_access_token}'
+      json:
+        data:
+          password: longpasswordlongpassword!
+    response:
+      status_code: 200
+
+  - name: A dogshit password is accepted when updating a designated user
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/users/byUsername/pw_test_user'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          password: x
+    response:
+      status_code: 200

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -31,23 +31,6 @@ stages:
           locked: false
           scopes: !force_original_structure '{user_scopes_list}'
           resetPassword: false
-  - name: Create a new user with a password less than 8 characters
-    request:
-      method: POST
-      url: '{run_server.base_url}/auth/users'
-      headers:
-        Authorization: '{admin_access_token}'
-      json:
-        data:
-          username: test_new_user_password_less_than_8_characters
-          password: '1234567'
-          fullName: Test New User
-          accountType: user
-    response:
-      status_code: 400
-      json:
-        detail: Password must be at least 8 characters long
-
   - name: Get a user information
     request:
       method: GET

--- a/auth-server/tests/users/test_user_data_manager.py
+++ b/auth-server/tests/users/test_user_data_manager.py
@@ -15,11 +15,13 @@ from auth_server.users.models import (
 from auth_server.users.store import UserStore
 from auth_server.users.user_data_manager import (
     InvalidInputError,
+    PasswordMissingSpecialCharactersError,
+    PasswordTooShortError,
     UserAlreadyExistsError,
     UserDataManager,
     UserNotFoundError,
     _generate_temporary_password,
-    _temporary_password_requirements,
+    _password_complexity_requirements,
 )
 
 
@@ -32,7 +34,9 @@ def mock_store(decoy: Decoy) -> UserStore:
 @pytest.fixture()
 def mock_settings(decoy: Decoy) -> SettingsStore:
     """Get a mock SettingsStore."""
-    return decoy.mock(cls=SettingsStore)
+    mock = decoy.mock(cls=SettingsStore)
+    decoy.when(mock.get_settings()).then_return(SettingsResponseData())
+    return mock
 
 
 @pytest.fixture()
@@ -181,13 +185,87 @@ def test_create_user_empty_password_raises(manager: UserDataManager) -> None:
 
 
 def test_create_user_short_password_raises(manager: UserDataManager) -> None:
-    with pytest.raises(InvalidInputError, match="at least 8 characters"):
+    with pytest.raises(PasswordTooShortError) as exc_info:
         manager.create_user(
             username="short_pw",
             password="1234567",
             full_name="X",
             account_type=AccountType.USER,
         )
+    assert exc_info.value.actual_length == 7
+    assert exc_info.value.required_length == 8
+
+
+def test_create_user_enforces_password_length(
+    decoy: Decoy,
+    mock_store: UserStore,
+    mock_settings: SettingsStore,
+    manager: UserDataManager,
+) -> None:
+    minimum_length = 12
+    decoy.when(mock_settings.get_settings()).then_return(
+        SettingsResponseData(
+            passwordComplexityMinimumLength=minimum_length,
+            passwordComplexitySpecialCharacters=False,
+        )
+    )
+    decoy.when(
+        mock_store.add(
+            username="test_user",
+            hashed_password=matchers.IsA(str),
+            full_name="Test User",
+            account_type=AccountType.USER,
+        )
+    ).then_return(_make_orm_user(username="test_user"))
+    with pytest.raises(PasswordTooShortError) as exc_info:
+        manager.create_user(
+            password="☃" * (minimum_length - 1),
+            username="test_user",
+            full_name="Test User",
+            account_type=AccountType.USER,
+        )
+    assert exc_info.value.actual_length == minimum_length - 1
+    assert exc_info.value.required_length == minimum_length
+    manager.create_user(  # Should not raise.
+        password="☃" * minimum_length,
+        username="test_user",
+        full_name="Test User",
+        account_type=AccountType.USER,
+    )
+
+
+def test_create_user_enforces_password_special_characters(
+    decoy: Decoy,
+    mock_settings: SettingsStore,
+    mock_store: UserStore,
+    manager: UserDataManager,
+) -> None:
+    decoy.when(mock_settings.get_settings()).then_return(
+        SettingsResponseData(
+            passwordComplexityMinimumLength=3, passwordComplexitySpecialCharacters=True
+        )
+    )
+    decoy.when(
+        mock_store.add(
+            username="test_user",
+            hashed_password=matchers.IsA(str),
+            full_name="Test User",
+            account_type=AccountType.USER,
+        )
+    ).then_return(_make_orm_user(username="test_user"))
+    with pytest.raises(PasswordMissingSpecialCharactersError):
+        manager.create_user(
+            password="aaa",
+            username="test_user",
+            full_name="Test User",
+            account_type=AccountType.USER,
+        )
+    manager.create_user(  # Should not raise.
+        password="aa!",
+        username="test_user",
+        full_name="Test User",
+        account_type=AccountType.USER,
+    )
 
 
 def test_create_user_empty_full_name_raises(manager: UserDataManager) -> None:
@@ -487,7 +565,7 @@ def test_temporary_password_requirements(
     expected_min_length: int,
     expected_require_special: bool,
 ) -> None:
-    min_length, require_special = _temporary_password_requirements(settings)
+    min_length, require_special = _password_complexity_requirements(settings)
     assert min_length == expected_min_length
     assert require_special is expected_require_special
 
@@ -504,5 +582,19 @@ def test_update_user_empty_username_raises(manager: UserDataManager) -> None:
 
 
 def test_update_user_short_password_raises(manager: UserDataManager) -> None:
-    with pytest.raises(InvalidInputError, match="at least 8 characters"):
+    with pytest.raises(PasswordTooShortError) as exc_info:
         manager.update_user("testadmin", new_password="short")
+    assert exc_info.value.actual_length == 5
+    assert exc_info.value.required_length == 8
+
+
+def test_update_user_password_missing_special_character(
+    decoy: Decoy,
+    mock_settings: SettingsStore,
+    manager: UserDataManager,
+) -> None:
+    decoy.when(mock_settings.get_settings()).then_return(
+        SettingsResponseData(passwordComplexitySpecialCharacters=True)
+    )
+    with pytest.raises(PasswordMissingSpecialCharactersError):
+        manager.update_user("testadmin", new_password="validpass123")


### PR DESCRIPTION
## Overview

This enforces the configured requirements on password complexity: minimum length, and special characters. Formerly, the settings could be changed and retrieved, but had no effect.

This closes EXEC-2771.

## Test Plan and Hands on Testing

I think we're covered by the included integration tests.

## Review requests

See comments.

## Risk assessment

Low.
