### PR TITLE
chore(app-shell,app-shell-odd): new manifest key for robot updates

### DIFF
--- a/app-shell-odd/src/system-update/from-web/__tests__/provider.test.ts
+++ b/app-shell-odd/src/system-update/from-web/__tests__/provider.test.ts
@@ -9,6 +9,8 @@ import {
 } from '../release-files'
 import { getOrDownloadManifest as _getOrDownloadManifest } from '../release-manifest'
 
+import type { ReleaseManifest } from '../../types'
+
 vi.mock('../../../log')
 vi.mock('../release-manifest', async importOriginal => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -64,7 +66,7 @@ describe('provider.refreshUpdateCache happy paths', () => {
             releaseNotes: 'http://opentrons.com/releaseNotes.md',
           },
         },
-      })
+      } as ReleaseManifest)
     const progressCallback = vi.fn()
     const provider = getProvider({
       manifestUrl: 'http://opentrons.com/releases.json',

--- a/app-shell-odd/src/system-update/from-web/__tests__/provider.test.ts
+++ b/app-shell-odd/src/system-update/from-web/__tests__/provider.test.ts
@@ -48,7 +48,7 @@ describe('provider.refreshUpdateCache happy paths', () => {
   afterEach(() => {
     vi.resetAllMocks()
   })
-  it('says there is no update if the latest version is the current version', () => {
+  it('says there is no update if the latest update is in the old production key', () => {
     when(getOrDownloadManifest)
       .calledWith(
         'http://opentrons.com/releases.json',
@@ -57,6 +57,59 @@ describe('provider.refreshUpdateCache happy paths', () => {
       )
       .thenResolve({
         production: {
+          '2.0.0': {
+            system: 'http://opentrons.com/system.zip',
+            fullImage: 'http://opentrons.com/fullImage.zip',
+            version: 'http://opentrons.com/version.json',
+            releaseNotes: 'http://opentrons.com/releaseNotes.md',
+          },
+        },
+      })
+    const progressCallback = vi.fn()
+    const provider = getProvider({
+      manifestUrl: 'http://opentrons.com/releases.json',
+      channel: 'release',
+      updateCacheDirectory: '/some/random/directory',
+      currentVersion: '1.2.3',
+    })
+    expect(provider.getUpdateDetails()).toEqual({
+      version: null,
+      files: null,
+      releaseNotes: null,
+      downloadProgress: 0,
+    })
+    return expect(provider.refreshUpdateCache(progressCallback))
+      .resolves.toEqual({
+        version: null,
+        files: null,
+        releaseNotes: null,
+        downloadProgress: 0,
+      })
+      .then(() => {
+        expect(progressCallback).toHaveBeenCalledWith({
+          version: null,
+          files: null,
+          releaseNotes: null,
+          downloadProgress: 0,
+        })
+        expect(provider.getUpdateDetails()).toEqual({
+          version: null,
+          files: null,
+          releaseNotes: null,
+          downloadProgress: 0,
+        })
+        expect(cleanUpAndGetOrDownloadReleaseFiles).not.toHaveBeenCalled()
+      })
+  })
+  it('says there is no update if the latest version is the current version', () => {
+    when(getOrDownloadManifest)
+      .calledWith(
+        'http://opentrons.com/releases.json',
+        '/some/random/directory',
+        expect.any(AbortController)
+      )
+      .thenResolve({
+        productionV2: {
           '1.2.3': {
             system: 'http://opentrons.com/system.zip',
             fullImage: 'http://opentrons.com/fullImage.zip',
@@ -124,7 +177,7 @@ describe('provider.refreshUpdateCache happy paths', () => {
         expect.any(AbortController)
       )
       .thenResolve({
-        production: {
+        productionV2: {
           '1.2.3': releaseUrls,
         },
       })
@@ -191,7 +244,7 @@ describe('provider.refreshUpdateCache happy paths', () => {
         expect.any(AbortController)
       )
       .thenResolve({
-        production: {
+        productionV2: {
           '1.2.3': releaseUrls,
         },
       })
@@ -315,7 +368,7 @@ describe('provider.refreshUpdateCache locking', () => {
         expect.any(AbortController)
       )
       .thenResolve({
-        production: {
+        productionV2: {
           '1.2.3': {
             system: 'http://opentrons.com/system.zip',
             fullImage: 'http://opentrons.com/fullImage.zip',
@@ -353,7 +406,7 @@ describe('provider.refreshUpdateCache locking', () => {
         expect.any(AbortController)
       )
       .thenResolve({
-        production: {
+        productionV2: {
           '1.2.3': releaseUrls,
         },
       })
@@ -441,7 +494,7 @@ describe('provider.refreshUpdateCache locking', () => {
         expect.any(AbortController)
       )
       .thenResolve({
-        production: {
+        productionV2: {
           '1.2.3': releaseUrls,
         },
       })
@@ -479,7 +532,7 @@ describe('provider.refreshUpdateCache locking', () => {
             () =>
               new Promise(resolve => {
                 provider.lockUpdateCache()
-                resolve({ production: { '1.2.3': releaseUrls } })
+                resolve({ productionV2: { '1.2.3': releaseUrls } })
               })
           )
         const progress = vi.fn()
@@ -523,7 +576,7 @@ describe('provider.refreshUpdateCache locking', () => {
         expect.any(AbortController)
       )
       .thenResolve({
-        production: {
+        productionV2: {
           '1.2.3': releaseUrls,
         },
       })
@@ -561,7 +614,7 @@ describe('provider.refreshUpdateCache locking', () => {
             expect.any(AbortController)
           )
           .thenResolve({
-            production: {
+            productionV2: {
               '1.2.3': releaseUrls,
             },
           })
@@ -633,7 +686,7 @@ describe('provider.refreshUpdateCache locking', () => {
         expect.any(AbortController)
       )
       .thenResolve({
-        production: {
+        productionV2: {
           '1.2.3': releaseUrls,
         },
       })
@@ -671,7 +724,7 @@ describe('provider.refreshUpdateCache locking', () => {
             expect.any(AbortController)
           )
           .thenResolve({
-            production: {
+            productionV2: {
               '1.2.3': releaseUrls,
             },
           })
@@ -725,7 +778,7 @@ describe('provider.refreshUpdateCache locking', () => {
         expect.any(AbortController)
       )
       .thenResolve({
-        production: {
+        productionV2: {
           '1.2.3': {
             system: 'http://opentrons.com/system.zip',
             fullImage: 'http://opentrons.com/fullImage.zip',
@@ -761,7 +814,7 @@ describe('provider.refreshUpdateCache locking', () => {
         expect.any(AbortController)
       )
       .thenResolve({
-        production: {
+        productionV2: {
           '1.2.3': {
             system: 'http://opentrons.com/system.zip',
             fullImage: 'http://opentrons.com/fullImage.zip',

--- a/app-shell-odd/src/system-update/from-web/__tests__/provider.test.ts
+++ b/app-shell-odd/src/system-update/from-web/__tests__/provider.test.ts
@@ -66,7 +66,7 @@ describe('provider.refreshUpdateCache happy paths', () => {
             releaseNotes: 'http://opentrons.com/releaseNotes.md',
           },
         },
-      } as ReleaseManifest)
+      } as object as ReleaseManifest)
     const progressCallback = vi.fn()
     const provider = getProvider({
       manifestUrl: 'http://opentrons.com/releases.json',

--- a/app-shell-odd/src/system-update/from-web/__tests__/release-manifest.test.ts
+++ b/app-shell-odd/src/system-update/from-web/__tests__/release-manifest.test.ts
@@ -13,7 +13,7 @@ vi.mock('../../../log')
 const fetchJson = vi.mocked(_fetchJson)
 
 const MOCK_MANIFEST = {
-  production: {
+  productionV2: {
     '1.2.3': {
       fullImage: 'https://opentrons.com/no',
       system: 'https://opentrons.com/no2',
@@ -121,7 +121,7 @@ describe('ensureCacheDirectory', () => {
 
 describe('getOrDownloadManifest', () => {
   const localManifest = {
-    production: {
+    productionV2: {
       '4.5.6': {
         fullImage: 'https://opentrons.com/no',
         system: 'https://opentrons.com/no2',

--- a/app-shell-odd/src/system-update/from-web/provider.ts
+++ b/app-shell-odd/src/system-update/from-web/provider.ts
@@ -91,7 +91,7 @@ export function getProvider(
       return returnNoUpdate()
     }
     const latestVersion = latestVersionForChannel(
-      Object.keys(manifest.productionV2) ?? [],
+      Object.keys(manifest.productionV2 ?? {}),
       from.channel
     )
 

--- a/app-shell-odd/src/system-update/from-web/provider.ts
+++ b/app-shell-odd/src/system-update/from-web/provider.ts
@@ -91,7 +91,7 @@ export function getProvider(
       return returnNoUpdate()
     }
     const latestVersion = latestVersionForChannel(
-      Object.keys(manifest.production),
+      Object.keys(manifest.productionV2) ?? [],
       from.channel
     )
 

--- a/app-shell-odd/src/system-update/from-web/release-manifest.ts
+++ b/app-shell-odd/src/system-update/from-web/release-manifest.ts
@@ -14,7 +14,7 @@ export function getReleaseSet(
   manifest: ReleaseManifest,
   version: string
 ): ReleaseSetUrls | null {
-  return manifest.production[version] ?? null
+  return manifest.productionV2[version] ?? null
 }
 
 export const getCachedReleaseManifest = (

--- a/app-shell-odd/src/system-update/types.ts
+++ b/app-shell-odd/src/system-update/types.ts
@@ -6,9 +6,6 @@ export interface ReleaseSetUrls {
 }
 
 export interface ReleaseManifest {
-  production: {
-    [version: string]: ReleaseSetUrls
-  }
   productionV2: {
     [version: string]: ReleaseSetUrls
   }

--- a/app-shell-odd/src/system-update/types.ts
+++ b/app-shell-odd/src/system-update/types.ts
@@ -9,6 +9,9 @@ export interface ReleaseManifest {
   production: {
     [version: string]: ReleaseSetUrls
   }
+  productionV2: {
+    [version: string]: ReleaseSetUrls
+  }
 }
 
 export interface ReleaseSetFilepaths {

--- a/app-shell-odd/src/types.ts
+++ b/app-shell-odd/src/types.ts
@@ -13,7 +13,7 @@ export type Dispatch = (action: Action) => void
 export type { Logger }
 
 export interface Manifest {
-  production: {
+  productionV2: {
     [version: string]: {
       fullImage: [url: string]
       system: [url: string]

--- a/app-shell/src/robot-update/release-manifest.ts
+++ b/app-shell/src/robot-update/release-manifest.ts
@@ -16,11 +16,10 @@ export function downloadManifest(
     .catch(() => fse.readJson(cacheFilePath))
 }
 
-// TODO(mc, 2019-07-02): retrieve something other than "production"
 export function getReleaseSet(
   manifest: ReleaseManifest,
   version: string
 ): ReleaseSetUrls | null {
   // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions, @typescript-eslint/prefer-nullish-coalescing
-  return manifest.production[version] || null
+  return manifest.productionV2[version] || null
 }

--- a/app-shell/src/robot-update/types.ts
+++ b/app-shell/src/robot-update/types.ts
@@ -8,7 +8,7 @@ export interface ReleaseSetUrls {
 }
 
 export interface ReleaseManifest {
-  production: {
+  productionV2: {
     [version: string]: ReleaseSetUrls | undefined
   }
 }


### PR DESCRIPTION
Machines running 9.0.0 or previous download robot system updates to RAM
temporarily, which can lead to system RAM exhaustion if the rest of the
system is using a lot of RAM. This is particularly bad on 9.0.0, where
the system RAM usage crept up for unrelated reasons, and can lead to the
machine locking up if there's a background download. We fixed the issue
in 018ac3f0af but machines running 9.0.0 and previous are still
vulnerable, so when we release new updates we need to make sure that
9.0.0 and previous machines can't see and download it.

We're going to switch updates to be deployed to a new key in the release
manifest, so this commit is needed to get the app and ODD downloading from the
new key.

## testing
- [x] manually alter the internal-release releases.json to contain a `productionV2` key of a 9.1.1-alpha.0 (you can use the same release files as 9.0.0 or something, it doesn't matter if they're real)
- [x] put a pre-9.1.0 internal-release build on a robot and see that it does not download this new alpha
- [x] run a robot build or push-ot3 of this pr on a robot and see that it does download this new alpha
- [x] run a robot build or push-ot3 of this pr on a robot and see that it doesn't download old alphas
- [x] run an app build of this pr and see that it does download this new alpha
