### PR TITLE
ci: update code cov action version

### DIFF
--- a/.github/workflows/audit-server-lint-test.yaml
+++ b/.github/workflows/audit-server-lint-test.yaml
@@ -75,7 +75,3 @@ jobs:
           project: 'audit-server'
       - name: Test
         run: make -C audit-server test
-      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          files: ./audit-server/coverage.xml
-          flags: audit-server

--- a/.github/workflows/audit-server-lint-test.yaml
+++ b/.github/workflows/audit-server-lint-test.yaml
@@ -75,7 +75,7 @@ jobs:
           project: 'audit-server'
       - name: Test
         run: make -C audit-server test
-      - uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: ./audit-server/coverage.xml
           flags: audit-server


### PR DESCRIPTION


# Overview
update code cov action version since v3 uses node v20

```shell
git ls-remote https://github.com/codecov/codecov-action.git refs/tags/v7.0.0^{} 
fb8b3582c8e4def4969c97caa2f19720cb33a72f        refs/tags/v7.0.0^{}
```

## Test Plan and Hands on Testing
- pass CI

## Changelog



## Review requests



## Risk assessment
low