### PR TITLE
docs: quick typo fix for followup deploy

### DIFF
--- a/api/src/opentrons/protocol_api/protocol_context.py
+++ b/api/src/opentrons/protocol_api/protocol_context.py
@@ -1948,7 +1948,7 @@ class ProtocolContext(CommandPublisher):
     def create_and_start_step_group(
         self, name: str, description: Optional[str] = None
     ) -> GroupedSteps:
-        """Start a group of commands for visualization in your Pytyon protocol or in the Opentrons App.
+        """Start a group of commands for visualization in your Python protocol or in the Opentrons App.
         This returns a step group object, which can be closed by calling
         [`end_group()`][opentrons.protocol_api._command_annotations.GroupedSteps.end_group].
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -103,7 +103,7 @@ extra_css:
   - python-api.css
 
 extra:
-  apiLevel: 2.28
-  robot_stack_version: 9.0.0
+  apiLevel: 2.29
+  robot_stack_version: 9.1.1
 
 copyright: '© Opentrons 2026. All rights reserved. <br /> Trademarks: Opentrons®, Opentrons drop logo (Opentrons Labworks, Inc.). <br /> Registered names, trademarks, etc. used in this document, even when not specifically marked as such, are not to be considered unprotected by law.'

--- a/docs/python-api/docs/versioning.md
+++ b/docs/python-api/docs/versioning.md
@@ -110,7 +110,6 @@ This table lists the correspondence between Protocol API versions and robot soft
 - Organize groups of commands within your Python protocols using new methods: 
     - [`group_steps()`][opentrons.protocol_api.ProtocolContext.group_steps]
     - the paired [`create_and_start_step_group()`][opentrons.protocol_api.ProtocolContext.create_and_start_step_group] and [`end_group()`][opentrons.protocol_api._command_annotations.GroupedSteps.end_group] methods.
-- Use the [`set_empty()`][opentrons.protocol_api.labware.Labware.set_empty] method to label a tip rack on the deck as empty. This lets you return used tips to an empty tip rack throughout your protocol.
 
 ### Version 2.28
 
@@ -122,6 +121,7 @@ This table lists the correspondence between Protocol API versions and robot soft
 - Use the load name `opentrons_flex_96_tiprack_20ul` to use Flex 20 μL pipette tips in your protocols. The tips are fully compatible with [liquid class](liquid-classes/using.md) commands and with Flex 1- and 8-Channel (1–50 μL range) and 96-Channel (1–200 μL range) pipettes.
 - Control how quickly the Thermocycler Module's block heats or cools with the [`set_block_temperature()`][opentrons.protocol_api.ThermocyclerContext.set_block_temperature] and [`start_set_block_temperature()`][opentrons.protocol_api.ThermocyclerContext.start_set_block_temperature] methods' optional `ramp_rate` parameter.
 - Use the [`drop_tip()`][opentrons.protocol_api.InstrumentContext.drop_tip] method's optional `alternate_drop_location` argument to vary the tip drop location in a waste container, preventing tips from piling up in a single location.
+- Use the [`set_empty()`][opentrons.protocol_api.labware.Labware.set_empty] method to label a tip rack on the deck as empty. This lets you return used tips to an empty tip rack throughout your protocol.
 - In protocols using API version 2.28, the API raises an error when calling [`touch_tip()`][opentrons.protocol_api.InstrumentContext.touch_tip] in large spaces, like reservoirs and large well plates.
 
 ### Version 2.27

--- a/docs/python-api/docs/versioning.md
+++ b/docs/python-api/docs/versioning.md
@@ -110,7 +110,7 @@ This table lists the correspondence between Protocol API versions and robot soft
 - Organize groups of commands within your Python protocols using new methods: 
     - [`group_steps()`][opentrons.protocol_api.ProtocolContext.group_steps]
     - the paired [`create_and_start_step_group()`][opentrons.protocol_api.ProtocolContext.create_and_start_step_group] and [`end_group()`][opentrons.protocol_api._command_annotations.GroupedSteps.end_group] methods.
-- Use the [`set_empty()][opentrons.protocol_api.labware.Labware.set_empty] method to label a tip rack on the deck as empty. This lets you return used tips to an empty tip rack throughout your protocol.
+- Use the [`set_empty()`][opentrons.protocol_api.labware.Labware.set_empty] method to label a tip rack on the deck as empty. This lets you return used tips to an empty tip rack throughout your protocol.
 
 ### Version 2.28
 

--- a/docs/python-api/docs/versioning.md
+++ b/docs/python-api/docs/versioning.md
@@ -71,8 +71,8 @@ This table lists the correspondence between Protocol API versions and robot soft
 
 | API Version | Introduced in Robot Software |
 |-------------|------------------------------|
-| 2.29        | 9.1.0                        |
-| 2.28        | 9.0.0 / OT-2 26.06.0         |
+| 2.29        | 9.1.1                        |
+| 2.28        | 9.0.0 / OT-2 26.6.0          |
 | 2.27        | 8.8.0                        |
 | 2.26        | 8.7.0                        |
 | 2.25        | 8.6.0                        |


### PR DESCRIPTION
# Overview

fixing two small typos before the next docs deploy. 

## Test Plan and Hands on Testing



## Changelog

two tiny changes; not functional

## Review requests



## Risk assessment

low.
