### PR TITLE
feat(components): add ResizableContainer component for Opentrons AI

### DIFF
--- a/components/src/molecules/ResizableContainer/ResizableContainer.stories.tsx
+++ b/components/src/molecules/ResizableContainer/ResizableContainer.stories.tsx
@@ -1,0 +1,82 @@
+import { Meta, StoryObj } from '@storybook/react'
+
+import { ResizableContainer } from './'
+import styles from './resizablecontainer.stories.module.css'
+
+const meta: Meta<typeof ResizableContainer> = {
+  title: 'Helix/Molecules/ResizableContainer',
+  component: ResizableContainer,
+  argTypes: {
+    edge: {
+      control: 'radio',
+      options: ['left', 'right'],
+    },
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof ResizableContainer>
+
+export const TwoColumnLayout: Story = {
+  render: () => (
+    <div className={styles.layout}>
+      <ResizableContainer
+        minWidth={150}
+        maxWidth={400}
+        edge="right"
+        defaultWidth={250}
+      >
+        <div className={styles.side_content}>
+          <h3>Left Column</h3>
+        </div>
+      </ResizableContainer>
+
+      <main className={styles.main}>
+        <div>
+          <h2>Main Content Area</h2>
+          <p>This is the center content</p>
+          <p>The width of this part is decided by the left col</p>
+        </div>
+      </main>
+    </div>
+  ),
+}
+
+export const ThreeColumnLayout: Story = {
+  render: () => (
+    <div className={styles.layout}>
+      <ResizableContainer
+        minWidth={150}
+        maxWidth={400}
+        edge="right"
+        defaultWidth={250}
+      >
+        <div className={styles.sideContent}>
+          <h3>Left Column</h3>
+        </div>
+      </ResizableContainer>
+
+      <main className={styles.main}>
+        <div>
+          <h2>Main Content Area</h2>
+          <p>This is the center content</p>
+          <p>
+            The width of this part is decided by the right col and the left col
+          </p>
+        </div>
+      </main>
+
+      <ResizableContainer
+        minWidth={200}
+        maxWidth={500}
+        edge="left"
+        defaultWidth={300}
+      >
+        <div className={styles.sideContent}>
+          <h3>Right Column</h3>
+        </div>
+      </ResizableContainer>
+    </div>
+  ),
+}

--- a/components/src/molecules/ResizableContainer/ResizableContainer.stories.tsx
+++ b/components/src/molecules/ResizableContainer/ResizableContainer.stories.tsx
@@ -26,6 +26,7 @@ export const TwoColumnLayout: Story = {
         maxWidth={400}
         edge="right"
         defaultWidth={250}
+        aria-label="Left Container"
       >
         <div className={styles.side_content}>
           <h3>Left Column</h3>
@@ -51,6 +52,7 @@ export const ThreeColumnLayout: Story = {
         maxWidth={400}
         edge="right"
         defaultWidth={250}
+        aria-label="Left Container"
       >
         <div className={styles.sideContent}>
           <h3>Left Column</h3>
@@ -72,6 +74,7 @@ export const ThreeColumnLayout: Story = {
         maxWidth={500}
         edge="left"
         defaultWidth={300}
+        aria-label="Right Container"
       >
         <div className={styles.sideContent}>
           <h3>Right Column</h3>

--- a/components/src/molecules/ResizableContainer/ResizableContainer.stories.tsx
+++ b/components/src/molecules/ResizableContainer/ResizableContainer.stories.tsx
@@ -1,7 +1,7 @@
-import { Meta, StoryObj } from '@storybook/react'
-
 import { ResizableContainer } from './'
 import styles from './resizablecontainer.stories.module.css'
+
+import type { Meta, StoryObj } from '@storybook/react'
 
 const meta: Meta<typeof ResizableContainer> = {
   title: 'Helix/Molecules/ResizableContainer',

--- a/components/src/molecules/ResizableContainer/index.tsx
+++ b/components/src/molecules/ResizableContainer/index.tsx
@@ -39,13 +39,15 @@ export const ResizableContainer: React.FC<ResizableContainerProps> = (
   const startWidthRef = useRef<number>(0)
 
   useEffect(() => {
-    if (defaultWidth === undefined && containerRef.current) {
+    if (defaultWidth === undefined && containerRef.current != null) {
       setWidth(containerRef.current.getBoundingClientRect().width)
     }
   }, [defaultWidth])
 
-  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!containerRef.current) return
+  const handlePointerDown = (e: PointerEvent<HTMLDivElement>): void => {
+    if (containerRef.current == null) {
+      return
+    }
 
     const handleElement = e.currentTarget
     handleElement.setPointerCapture(e.pointerId)
@@ -58,8 +60,10 @@ export const ResizableContainer: React.FC<ResizableContainerProps> = (
     document.body.style.userSelect = 'none'
   }
 
-  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (!isResizing) return
+  const handlePointerMove = (e: PointerEvent<HTMLDivElement>): void => {
+    if (!isResizing) {
+      return
+    }
 
     const deltaX = e.clientX - startXRef.current
 
@@ -71,7 +75,9 @@ export const ResizableContainer: React.FC<ResizableContainerProps> = (
   }
 
   const handlePointerUp = (e: PointerEvent<HTMLDivElement>): void => {
-    if (!isResizing) return
+    if (!isResizing) {
+      return
+    }
 
     e.currentTarget.releasePointerCapture(e.pointerId)
 

--- a/components/src/molecules/ResizableContainer/index.tsx
+++ b/components/src/molecules/ResizableContainer/index.tsx
@@ -6,17 +6,31 @@ import styles from './resizablecontainer.module.css'
 import type { CSSProperties, PointerEvent, ReactNode } from 'react'
 
 export interface ResizableContainerProps {
+  // contesnt
   children: ReactNode
+  // aria-label for a container
+  'aria-label': string
+  // minimum width of the contaienr
   minWidth: number
+  // maximum width of the contaienr
   maxWidth: number
+  // container's draggable edge
   edge: 'left' | 'right'
+  // the default width of the container
   defaultWidth?: number
 }
 
 export const ResizableContainer: React.FC<ResizableContainerProps> = (
   props: ResizableContainerProps
 ) => {
-  const { children, minWidth = 300, maxWidth, edge, defaultWidth } = props
+  const {
+    children,
+    'aria-label': ariaLabel,
+    minWidth = 300,
+    maxWidth,
+    edge,
+    defaultWidth,
+  } = props
   const [width, setWidth] = useState<number | null>(defaultWidth ?? null)
   const [isResizing, setIsResizing] = useState(false)
 
@@ -75,6 +89,12 @@ export const ResizableContainer: React.FC<ResizableContainerProps> = (
 
       {/* handle part */}
       <div
+        role="separator"
+        aria-label={ariaLabel}
+        aria-orientation="vertical"
+        aria-valuenow={width ?? undefined}
+        aria-valuemin={minWidth}
+        aria-valuemax={maxWidth}
         className={clsx(
           styles.handle,
           styles[edge],

--- a/components/src/molecules/ResizableContainer/index.tsx
+++ b/components/src/molecules/ResizableContainer/index.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useRef, useState } from 'react'
+import clsx from 'clsx'
+
+import styles from './resizablecontainer.module.css'
+
+import type { CSSProperties, PointerEvent, ReactNode } from 'react'
+
+export interface ResizableContainerProps {
+  children: ReactNode
+  minWidth: number
+  maxWidth: number
+  edge: 'left' | 'right'
+  defaultWidth?: number
+}
+
+export const ResizableContainer: React.FC<ResizableContainerProps> = (
+  props: ResizableContainerProps
+) => {
+  const { children, minWidth = 300, maxWidth, edge, defaultWidth } = props
+  const [width, setWidth] = useState<number | null>(defaultWidth ?? null)
+  const [isResizing, setIsResizing] = useState(false)
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const startXRef = useRef<number>(0)
+  const startWidthRef = useRef<number>(0)
+
+  useEffect(() => {
+    if (defaultWidth === undefined && containerRef.current) {
+      setWidth(containerRef.current.getBoundingClientRect().width)
+    }
+  }, [defaultWidth])
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!containerRef.current) return
+
+    const handleElement = e.currentTarget
+    handleElement.setPointerCapture(e.pointerId)
+
+    setIsResizing(true)
+    startXRef.current = e.clientX
+    startWidthRef.current = containerRef.current.getBoundingClientRect().width
+
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+  }
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isResizing) return
+
+    const deltaX = e.clientX - startXRef.current
+
+    const directionMultiplier = edge === 'right' ? 1 : -1
+    const nextWidth = startWidthRef.current + deltaX * directionMultiplier
+
+    const clampedWidth = Math.max(minWidth, Math.min(maxWidth, nextWidth))
+    setWidth(clampedWidth)
+  }
+
+  const handlePointerUp = (e: PointerEvent<HTMLDivElement>): void => {
+    if (!isResizing) return
+
+    e.currentTarget.releasePointerCapture(e.pointerId)
+
+    setIsResizing(false)
+
+    document.body.style.cursor = ''
+    document.body.style.userSelect = ''
+  }
+
+  const style: CSSProperties = width !== null ? { width: `${width}px` } : {}
+
+  return (
+    <div ref={containerRef} className={styles.container} style={style}>
+      {children}
+
+      {/* handle part */}
+      <div
+        className={clsx(
+          styles.handle,
+          styles[edge],
+          isResizing && styles.resizing
+        )}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+      />
+    </div>
+  )
+}

--- a/components/src/molecules/ResizableContainer/resizablecontainer.module.css
+++ b/components/src/molecules/ResizableContainer/resizablecontainer.module.css
@@ -1,0 +1,37 @@
+.container {
+  position: relative;
+  min-width: 0;
+  height: 100%;
+  box-sizing: border-box;
+  padding: var(--spacing-12);
+}
+
+.handle {
+  position: absolute;
+  z-index: 10;
+  top: 0;
+  bottom: 0;
+  width: 0.5rem;
+  cursor: col-resize;
+  touch-action: none;
+  transition: background-color 0.2s ease;
+}
+
+.handle.left {
+  left: calc(var(--spacing-4) * -1);
+}
+
+.handle.right {
+  right: calc(var(--spacing-4) * -1);
+}
+
+.handle:hover::after,
+.handle.resizing::after {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 2px;
+  background-color: var(--blue-50);
+  content: '';
+}

--- a/components/src/molecules/ResizableContainer/resizablecontainer.stories.module.css
+++ b/components/src/molecules/ResizableContainer/resizablecontainer.stories.module.css
@@ -1,0 +1,26 @@
+.layout {
+  display: flex;
+  overflow: hidden;
+  width: 100%;
+  height: 100vh;
+  border: 1px solid var(--black-90);
+  background-color: var(--grey-20);
+}
+
+.main {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-20);
+  border-right: 1px solid var(--grey-10);
+  border-left: 1px solid var(--grey-10);
+  background-color: var(--white);
+  text-align: center;
+}
+
+.side_content {
+  overflow: hidden;
+  padding: var(--spacing-20);
+}


### PR DESCRIPTION


# Overview
add ResizableContainer component for Opentrons AI
this component will be used in `protocol-designer` and `protocol-visualization`

https://github.com/user-attachments/assets/365f8e22-f2c5-446b-a401-cd8f95e2fb53



closes AUTH-3016

## Test Plan and Hands on Testing
- make -C components dev

## Changelog
- add ResizableContainer component and its stories

## Review requests


## Risk assessment
low
