### PR TITLE
refactor(update-server): Enable strict type checking in production code

### DIFF
--- a/update-server/otupdate/buildroot/__init__.py
+++ b/update-server/otupdate/buildroot/__init__.py
@@ -21,6 +21,7 @@ from otupdate.common import (
     update,
 )
 from otupdate.common.file_actions import load_version_file
+from otupdate.common.handler_type import Handler
 
 BR_BUILTIN_VERSION_FILE = "/etc/VERSION.json"
 #: Location of the builtin system version
@@ -29,7 +30,9 @@ LOG = logging.getLogger(__name__)
 
 
 @web.middleware
-async def log_error_middleware(request, handler):
+async def log_error_middleware(
+    request: web.Request, handler: Handler
+) -> web.StreamResponse:
     try:
         resp = await handler(request)
     except Exception:

--- a/update-server/otupdate/buildroot/update_actions.py
+++ b/update-server/otupdate/buildroot/update_actions.py
@@ -47,7 +47,7 @@ class OT2UpdateActions(UpdateActionsInterface):
         filepath: str,
         progress_callback: Callable[[float], None],
         cert_path: Optional[str],
-    ) -> Optional[str]:
+    ) -> str:
         """Worker for validation. Call in an executor (so it can return things)
 
         - Unzips filepath to its directory
@@ -72,7 +72,7 @@ class OT2UpdateActions(UpdateActionsInterface):
             LOG.error(msg)
             raise InvalidPKGName(msg)
 
-        def zip_callback(progress):
+        def zip_callback(progress: float) -> None:
             progress_callback(progress / 2.0)
 
         required = [ROOTFS_NAME, ROOTFS_HASH_NAME]
@@ -80,7 +80,7 @@ class OT2UpdateActions(UpdateActionsInterface):
             required.append(ROOTFS_SIG_NAME)
         files, sizes = unzip_update(filepath, zip_callback, UPDATE_FILES, required)
 
-        def hash_callback(progress):
+        def hash_callback(progress: float) -> None:
             progress_callback(progress / 2.0 + 0.5)
 
         version_file = str(files.get("VERSION.json"))
@@ -217,7 +217,7 @@ def write_file(
     """
     total_written = 0
     with open(infile, "rb") as img, open(outfile, "wb") as part:
-        if None is file_size:
+        if file_size is None:
             file_size = img.seek(0, 2)
             img.seek(0)
             LOG.info(f"write_file: file size calculated as {file_size}B")
@@ -234,7 +234,7 @@ def write_file(
                 break
 
 
-def _mountpoint_root():
+def _mountpoint_root() -> str:
     """provides mountpoint location for :py:meth:`mount_update`.
 
     exists only for ease of mocking

--- a/update-server/otupdate/common/auth.py
+++ b/update-server/otupdate/common/auth.py
@@ -48,7 +48,7 @@ def require_scopes(*required_scopes: Scope) -> Callable[[Handler], Handler]:
 
     def decorator(handler: Handler) -> Handler:
         @functools.wraps(handler)
-        async def wrapped(request: web.Request) -> web.Response:
+        async def wrapped(request: web.Request) -> web.StreamResponse:
             authorization_checker = request.app[_AUTHORIZATION_CHECKER_APP_KEY]
             assert isinstance(authorization_checker, AuthorizationChecker), (
                 "The app is missing its AuthorizationChecker. Forgot to initialize it during server startup?"

--- a/update-server/otupdate/common/control.py
+++ b/update-server/otupdate/common/control.py
@@ -22,11 +22,11 @@ from .name_management import get_name_synchronizer
 LOG = logging.getLogger(__name__)
 
 
-def _do_restart():
+def _do_restart() -> None:
     subprocess.check_call(["reboot"])
 
 
-def _do_shutdown():
+def _do_shutdown() -> None:
     subprocess.check_call(["shutdown", "-h", "now"])
 
 

--- a/update-server/otupdate/common/handler_type.py
+++ b/update-server/otupdate/common/handler_type.py
@@ -1,11 +1,9 @@
+from typing import Awaitable, Callable, TypeAlias
+
 from aiohttp import web
-from typing_extensions import Protocol
 
+Handler: TypeAlias = Callable[[web.Request], Awaitable[web.StreamResponse]]
+"""The type signature of an aiohttp request handler function.
 
-class Handler(Protocol):
-    """The type signature of an aiohttp request handler function.
-
-    Useful for typing function decorators that operate on aiohttp request handlers.
-    """
-
-    async def __call__(self, request: web.Request) -> web.Response: ...
+Useful for typing function decorators that operate on aiohttp request handlers.
+"""

--- a/update-server/otupdate/common/session.py
+++ b/update-server/otupdate/common/session.py
@@ -9,8 +9,7 @@ import logging
 import os
 import shutil
 import uuid
-from collections import namedtuple
-from typing import Mapping, Optional, Union
+from typing import Mapping, NamedTuple, Optional, Union
 
 from aiohttp import web
 
@@ -19,7 +18,10 @@ from . import config, constants
 SESSION_VARNAME = constants.APP_VARIABLE_PREFIX + "session"
 LOG = logging.getLogger(__name__)
 
-Value = namedtuple("Value", ("short", "human"))
+
+class Value(NamedTuple):
+    short: str
+    human: str
 
 
 class Stages(enum.Enum):

--- a/update-server/otupdate/common/session.py
+++ b/update-server/otupdate/common/session.py
@@ -133,4 +133,4 @@ class UpdateSession:
 
 
 def session_from_request(request: web.Request) -> Optional[UpdateSession]:
-    return request.app.get(SESSION_VARNAME, None)
+    return request.app.get(SESSION_VARNAME, None)  # type: ignore[no-any-return]

--- a/update-server/otupdate/common/session.py
+++ b/update-server/otupdate/common/session.py
@@ -4,7 +4,6 @@ Update session object for tracking state across multiple calls
 
 import base64
 import enum
-import functools
 import logging
 import os
 import shutil
@@ -13,7 +12,7 @@ from typing import Mapping, NamedTuple, Optional, Union
 
 from aiohttp import web
 
-from . import config, constants
+from . import constants
 
 SESSION_VARNAME = constants.APP_VARIABLE_PREFIX + "session"
 LOG = logging.getLogger(__name__)
@@ -135,29 +134,3 @@ class UpdateSession:
 
 def session_from_request(request: web.Request) -> Optional[UpdateSession]:
     return request.app.get(SESSION_VARNAME, None)
-
-
-def active_session_check(handler):
-    """decorator to check session status"""
-
-    @functools.wraps(handler)
-    async def decorated(request: web.Request) -> web.Response:
-        # checks if session exists!
-        if session_from_request(request) is not None:
-            LOG.warning("check_session: active session exists!")
-            return web.json_response(
-                data={
-                    "message": "An update session is already active on this robot",
-                    "error": "session-already-active",
-                },
-                status=409,
-            )
-        else:
-            session = UpdateSession(
-                config.config_from_request(request).download_storage_path
-            )
-            request.app[SESSION_VARNAME] = session
-            return web.json_response(data={"token": session.token}, status=201)
-        return await handler(request)
-
-    return decorated

--- a/update-server/otupdate/common/ssh_key_management.py
+++ b/update-server/otupdate/common/ssh_key_management.py
@@ -30,7 +30,7 @@ def require_linklocal(handler: Handler) -> Handler:
     """
 
     @functools.wraps(handler)
-    async def decorated(request: web.Request) -> web.Response:
+    async def decorated(request: web.Request) -> web.StreamResponse:
         ipaddr_str = request.headers.get("x-host-ip")
         invalid_req_data = {
             "error": "bad-interface",

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -42,7 +42,7 @@ class _HandlerWithSession(Protocol):
 
 
 def session_from_request(request: web.Request) -> Optional[UpdateSession]:
-    return request.app.get(SESSION_VARNAME, None)
+    return request.app.get(SESSION_VARNAME, None)  # type: ignore[no-any-return]
 
 
 def require_session(handler: _HandlerWithSession) -> Handler:
@@ -130,7 +130,7 @@ def _begin_write(
         )
     )
 
-    def write_done(fut):
+    def write_done(fut: asyncio.Future[update_actions.Partition]) -> None:
         exc = fut.exception()
         if exc:
             session.set_error(getattr(exc, "short", str(type(exc))), str(exc))
@@ -147,7 +147,7 @@ def _begin_validation(
     loop: asyncio.AbstractEventLoop,
     downloaded_update_path: str,
     actions: update_actions.UpdateActionsInterface,
-) -> "asyncio.futures.Future[Optional[str]]":
+) -> asyncio.Future[str]:
     """Start the validation process."""
     session.set_stage(Stages.VALIDATING)
     cert_path = config.update_cert_path if config.signature_required else None
@@ -162,7 +162,7 @@ def _begin_validation(
         )
     )
 
-    def validation_done(fut):
+    def validation_done(fut: asyncio.Future[str]) -> None:
         exc = fut.exception()
         if exc:
             session.set_error(getattr(exc, "short", str(type(exc))), str(exc))

--- a/update-server/otupdate/common/update_actions.py
+++ b/update-server/otupdate/common/update_actions.py
@@ -45,7 +45,7 @@ class UpdateActionsInterface:
         filepath: str,
         progress_callback: Callable[[float], None],
         cert_path: Optional[str],
-    ) -> Optional[str]:
+    ) -> str:
         """Worker for validation. Call in an executor (so it can return things)
 
         - Unzips filepath to its directory

--- a/update-server/otupdate/openembedded/__init__.py
+++ b/update-server/otupdate/openembedded/__init__.py
@@ -20,6 +20,7 @@ from otupdate.common import (
     update,
 )
 from otupdate.common.file_actions import load_version_file
+from otupdate.common.handler_type import Handler
 from otupdate.common.update_actions import FILE_ACTIONS_VARNAME
 from otupdate.openembedded.update_actions import (
     OT3UpdateActions,
@@ -34,7 +35,9 @@ LOG = logging.getLogger(__name__)
 
 
 @web.middleware
-async def log_error_middleware(request, handler):
+async def log_error_middleware(
+    request: web.Request, handler: Handler
+) -> web.StreamResponse:
     try:
         resp = await handler(request)
     except Exception:

--- a/update-server/otupdate/openembedded/update_actions.py
+++ b/update-server/otupdate/openembedded/update_actions.py
@@ -161,7 +161,7 @@ class OT3UpdateActions(UpdateActionsInterface):
         filepath: str,
         progress_callback: Callable[[float], None],
         cert_path: Optional[str],
-    ) -> Optional[str]:
+    ) -> str:
         """Worker for validation. Call in an executor (so it can return things)
 
         - Unzips filepath to its directory

--- a/update-server/pyproject.toml
+++ b/update-server/pyproject.toml
@@ -138,26 +138,6 @@ ignore_missing_imports = true
 # and remove these overrides when able.
 [[tool.mypy.overrides]]
 module = [
-    "otupdate.common.control",
-    "otupdate.common.session",
-    "otupdate.common.update",
-    "otupdate.buildroot",
-]
-disallow_untyped_defs = false
-disallow_untyped_calls = false
-warn_return_any = false
-
-[[tool.mypy.overrides]]
-module = [
-    "otupdate.buildroot.update_actions",
-    "otupdate.openembedded",
-    "otupdate.openembedded.updater",
-]
-disallow_untyped_defs = false
-disallow_untyped_calls = false
-
-[[tool.mypy.overrides]]
-module = [
     "tests.conftest",
     "tests.buildroot.conftest",
     "tests.buildroot.test_control",


### PR DESCRIPTION
## Overview

We have some old code in update-server that wasn't being fully type-checked. This fixes the type errors and enables type checking.

This only addresses the production code. The test code has its own set of typing problems that's out of scope for this PR.

## Test Plan and Hands on Testing

Just CI.

## Review requests

None.

## Risk assessment

Low. This only changes type annotations.