### PR TITLE
fix(hardware-testing): The logic for download hw-testing source was wrong

### DIFF
--- a/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
+++ b/hardware-testing/hardware_testing/gravimetric/protocol_replacement/gravimetric.py
@@ -88,7 +88,7 @@ def _download_and_extract(version_str: str, base_dir: str) -> None:
         ver_file.write(version_str)
 
 
-if not IS_ROBOT or importlib.util.find_spec("hardware_testing") is None:
+if not IS_ROBOT and importlib.util.find_spec("hardware_testing") is None:
     # we're simulating or there is not a vaild hardware-testing yet
     base_dir = str(infer_config_base_dir())
     release = f"{version.replace('a', '-alpha.').replace('b', '-beta.')}"


### PR DESCRIPTION
# Overview
So when running make test in hardware-testing the logic meant for downloading the hardware-testing source for in-app analysis was triggering. Since in the US the lag of downloading was so small I just never noticed however when I got to SZ It took soooo long that I looked more into it and found this logic error.

This code is only meant to download the source zip when we're analyzing in the APP, and it syncs to the App's version so it would only happen once per app update. however running it locally changes the reference all the time and it just kept downloading. and then would still run against the in-source hardware-testing anyway.