### PR TITLE
feat(components): add ModelessModal component

### DIFF
--- a/components/src/molecules/ModelessModal/ModelessModal.stories.tsx
+++ b/components/src/molecules/ModelessModal/ModelessModal.stories.tsx
@@ -41,7 +41,7 @@ const SampleSpotlightContent = (): JSX.Element => (
         borderRadius: BORDERS.borderRadius4,
         alignItems: 'center',
         justifyContent: 'center',
-        border: '1px dashed #cbd5e0',
+        border: `1px dashed ${COLORS.bakck90}`,
         minHeight: '200px',
       }}
     >

--- a/components/src/molecules/ModelessModal/ModelessModal.stories.tsx
+++ b/components/src/molecules/ModelessModal/ModelessModal.stories.tsx
@@ -1,0 +1,158 @@
+import { useState } from 'react'
+
+import { StyledText } from '../../atoms/StyledText'
+import { COLORS } from '../../helix-design-system'
+import { RobotInfoLabel } from '../../molecules/RobotInfoLabel'
+import { SPACING } from '../../ui-style-constants'
+import { ModelessModal } from './'
+import styles from './modelessmodal.stories.module.css'
+
+import type { Meta, StoryObj } from '@storybook/react'
+import type { ComponentProps } from 'react'
+
+const meta: Meta<typeof ModelessModal> = {
+  title: 'Helix/Molecules/ModelessModal',
+  component: ModelessModal,
+  tags: ['autodocs'],
+  argTypes: {
+    onClose: { action: 'closed' },
+    defaultWidth: { control: 'number' },
+    defaultHeight: { control: 'number' },
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof ModelessModal>
+
+const SampleSpotlightContent = (): JSX.Element => (
+  <div className={styles.content_container}>
+    <div>
+      <StyledText desktopStyle="bodyLargeSemiBold">Nickname</StyledText>
+      <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+        Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt
+      </StyledText>
+    </div>
+
+    <div
+      style={{
+        flex: 1,
+        backgroundColor: '#f1f1f1',
+        borderRadius: '4px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        border: '1px dashed #cbd5e0',
+        minHeight: '200px',
+      }}
+    >
+      <span style={{ color: '#718096', fontSize: '14px' }}>
+        [ 96 Well Plate Image Area ]
+      </span>
+    </div>
+  </div>
+)
+
+const InteractiveTemplate = (
+  args: ComponentProps<typeof ModelessModal> & { onClose: () => void }
+): JSX.Element => {
+  const [isOpen, setIsOpen] = useState(true)
+
+  return (
+    <div
+      style={{
+        width: '100vw',
+        height: '100vh',
+        padding: '24px',
+        backgroundColor: '#f7fafc',
+      }}
+    >
+      <StyledText desktopStyle="bodyDefaultRegular">
+        This modal is draggable and resizable
+      </StyledText>
+
+      {!isOpen && (
+        <button
+          onClick={() => {
+            setIsOpen(true)
+          }}
+        >
+          Open modal
+        </button>
+      )}
+
+      {isOpen && (
+        <ModelessModal
+          {...args}
+          onClose={() => {
+            args.onClose()
+            setIsOpen(false)
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+export const Interactive: Story = {
+  render: args => <InteractiveTemplate {...args} />,
+  args: {
+    header: (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          gap: SPACING.spacing8,
+        }}
+      >
+        <RobotInfoLabel deckLabel="A1" />
+        <StyledText desktopStyle="bodyLargeSemiBold">Slot Spotlight</StyledText>
+      </div>
+    ),
+    defaultWidth: 450,
+    defaultHeight: 500,
+    ariaLabelledby: 'Modeless Modal test',
+    'aria-label': 'Close Modal',
+    children: <SampleSpotlightContent />,
+  },
+}
+
+const SimpleVersionTemplate = (
+  args: ComponentProps<typeof ModelessModal>
+): JSX.Element => {
+  const [isOpen, setIsOpen] = useState(true)
+
+  return isOpen ? (
+    <ModelessModal
+      {...args}
+      onClose={() => {
+        setIsOpen(false)
+      }}
+    />
+  ) : (
+    <button
+      onClick={() => {
+        setIsOpen(true)
+      }}
+      style={{ padding: SPACING.spacing16 }}
+    >
+      Open modal
+    </button>
+  )
+}
+
+// no content and string title
+export const SimpleVersion: Story = {
+  render: args => <SimpleVersionTemplate {...args} />,
+  args: {
+    header: 'Header',
+    defaultWidth: 350,
+    defaultHeight: 350,
+    ariaLabelledby: 'Simple Modeless Modal test',
+    'aria-label': 'Close Modal',
+    children: (
+      <div className={styles.simple_content_container}>
+        <StyledText desktopStyle="bodyDefaultRegular">empty</StyledText>
+      </div>
+    ),
+  },
+}

--- a/components/src/molecules/ModelessModal/ModelessModal.stories.tsx
+++ b/components/src/molecules/ModelessModal/ModelessModal.stories.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 
 import { StyledText } from '../../atoms/StyledText'
-import { COLORS } from '../../helix-design-system'
+import { BORDERS, COLORS } from '../../helix-design-system'
 import { RobotInfoLabel } from '../../molecules/RobotInfoLabel'
 import { SPACING } from '../../ui-style-constants'
 import { ModelessModal } from './'
@@ -36,18 +36,18 @@ const SampleSpotlightContent = (): JSX.Element => (
     <div
       style={{
         flex: 1,
-        backgroundColor: '#f1f1f1',
-        borderRadius: '4px',
+        backgroundColor: COLORS.grey10,
         display: 'flex',
+        borderRadius: BORDERS.borderRadius4,
         alignItems: 'center',
         justifyContent: 'center',
         border: '1px dashed #cbd5e0',
         minHeight: '200px',
       }}
     >
-      <span style={{ color: '#718096', fontSize: '14px' }}>
+      <StyledText desktopStyle="bodyDefaultRegular">
         [ 96 Well Plate Image Area ]
-      </span>
+      </StyledText>
     </div>
   </div>
 )
@@ -62,8 +62,8 @@ const InteractiveTemplate = (
       style={{
         width: '100vw',
         height: '100vh',
-        padding: '24px',
-        backgroundColor: '#f7fafc',
+        padding: SPACING.spacing24,
+        backgroundColor: COLORS.white,
       }}
     >
       <StyledText desktopStyle="bodyDefaultRegular">

--- a/components/src/molecules/ModelessModal/index.tsx
+++ b/components/src/molecules/ModelessModal/index.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+import { Icon } from '../../icons'
+import styles from './modelessmodal.module.css'
+
+import type { KeyboardEvent, MouseEvent, ReactNode } from 'react'
+
+const STEP_PX = 10 // move 10px when hitting an arrow key
+const MIN_SIZE_PX = 300 // minimum modal size
+
+interface ModelessModalProps {
+  // header part
+  header: ReactNode | string
+  // modal content - all spacing should be handled by content itself
+  children: ReactNode
+  // modal title
+  'aria-labelledby': string
+  // function to close modal
+  onClose: () => void
+  // aria-label for close modal
+  'aria-label': string
+  // default width
+  defaultWidth?: number
+  // default height
+  defaultHeight?: number
+}
+
+export function ModelessModal({
+  header,
+  children,
+  'aria-labelledby': ariaLabelledby,
+  onClose,
+  'aria-label': ariaLabel,
+  defaultWidth = 400,
+  defaultHeight = 400,
+}: ModelessModalProps): JSX.Element {
+  const modalRef = useRef<HTMLDivElement>(null)
+
+  const [rect, setRect] = useState({
+    subLeft: 100,
+    subTop: 100,
+    width: defaultWidth,
+    height: defaultHeight,
+  })
+  // to avoid memory leaking
+  const dragCleanupRef = useRef<(() => void) | null>(null)
+
+  useEffect(() => {
+    if (modalRef.current != null) {
+      modalRef.current.focus()
+
+      const initialLeft = Math.max(0, (window.innerWidth - defaultWidth) / 2)
+      const initialTop = Math.max(0, (window.innerHeight - defaultHeight) / 2)
+      setRect(prev => ({
+        ...prev,
+        subLeft: initialLeft,
+        subTop: initialTop,
+      }))
+    }
+    return () => {
+      if (dragCleanupRef.current != null) {
+        dragCleanupRef.current()
+      }
+    }
+  }, [defaultWidth, defaultHeight])
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>): void => {
+    if (e.key === 'Escape') {
+      e.stopPropagation()
+      onClose()
+      return
+    }
+
+    const isHeaderFocused = (e.target as HTMLElement).closest(
+      `.${styles.modal_header}`
+    )
+    if (isHeaderFocused == null) {
+      return
+    }
+
+    if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+      e.preventDefault()
+
+      setRect(prev => {
+        let { subLeft, subTop, width, height } = prev
+
+        if (e.shiftKey) {
+          if (e.key === 'ArrowRight') width = width + STEP_PX
+          if (e.key === 'ArrowDown') height = height + STEP_PX
+          if (e.key === 'ArrowLeft') {
+            width = width + STEP_PX
+            subLeft = subLeft - STEP_PX
+          }
+          if (e.key === 'ArrowUp') {
+            height = Math.max(MIN_SIZE_PX, height - STEP_PX)
+          }
+        } else {
+          if (e.key === 'ArrowRight') subLeft += STEP_PX
+          if (e.key === 'ArrowLeft') subLeft -= STEP_PX
+          if (e.key === 'ArrowDown') subTop += STEP_PX
+          if (e.key === 'ArrowUp') subTop = Math.max(0, subTop - STEP_PX)
+        }
+
+        return { subLeft, subTop, width, height }
+      })
+    }
+  }
+
+  const handleHeaderMouseDown = (e: MouseEvent): void => {
+    if ((e.target as HTMLElement).closest('.close_button')) {
+      return
+    }
+
+    const startX = e.clientX - rect.subLeft
+    const startY = e.clientY - rect.subTop
+
+    const handleMouseMove = (moveEvent: globalThis.MouseEvent): void => {
+      setRect(prev => ({
+        ...prev,
+        subLeft: moveEvent.clientX - startX,
+        subTop: Math.max(0, moveEvent.clientY - startY),
+      }))
+    }
+
+    const handleMouseUp = (): void => {
+      window.removeEventListener('mousemove', handleMouseMove)
+      window.removeEventListener('mouseup', handleMouseUp)
+      dragCleanupRef.current = null
+    }
+
+    window.addEventListener('mousemove', handleMouseMove)
+    window.addEventListener('mouseup', handleMouseUp)
+
+    dragCleanupRef.current = () => {
+      window.removeEventListener('mousemove', handleMouseMove)
+      window.removeEventListener('mouseup', handleMouseUp)
+    }
+  }
+
+  const handleResizeMouseDown = (
+    direction: string,
+    startE: MouseEvent
+  ): void => {
+    startE.preventDefault()
+    startE.stopPropagation()
+
+    const startWidth = rect.width
+    const startHeight = rect.height
+    const startX = startE.clientX
+    const startY = startE.clientY
+
+    const handleMouseMove = (moveEvent: globalThis.MouseEvent): void => {
+      const deltaX = moveEvent.clientX - startX
+      const deltaY = moveEvent.clientY - startY
+
+      setRect(prev => {
+        let { subLeft, subTop, width, height } = prev
+
+        if (direction.includes('r')) {
+          width = Math.max(MIN_SIZE_PX, startWidth + deltaX)
+        }
+
+        if (direction.includes('b')) {
+          height = Math.max(MIN_SIZE_PX, startHeight + deltaY)
+        }
+
+        if (direction.includes('l')) {
+          const calculatedWidth = startWidth - deltaX
+          if (calculatedWidth >= MIN_SIZE_PX) {
+            width = calculatedWidth
+            subLeft = rect.subLeft + deltaX
+          }
+        }
+
+        return { subLeft, subTop, width, height }
+      })
+    }
+
+    const handleMouseUp = (): void => {
+      window.removeEventListener('mousemove', handleMouseMove)
+      window.removeEventListener('mouseup', handleMouseUp)
+      dragCleanupRef.current = null
+    }
+
+    window.addEventListener('mousemove', handleMouseMove)
+    window.addEventListener('mouseup', handleMouseUp)
+
+    dragCleanupRef.current = () => {
+      window.removeEventListener('mousemove', handleMouseMove)
+      window.removeEventListener('mouseup', handleMouseUp)
+    }
+  }
+
+  return createPortal(
+    <div
+      ref={modalRef}
+      className={styles.modal_root}
+      style={{
+        left: `${rect.subLeft}px`,
+        top: `${rect.subTop}px`,
+        width: `${rect.width}px`,
+        height: `${rect.height}px`,
+      }}
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby={ariaLabelledby}
+    >
+      <div
+        className={styles.modal_header}
+        onMouseDown={handleHeaderMouseDown}
+        tabIndex={0}
+      >
+        <div className={styles.header_title}>{header}</div>
+        <button
+          className={styles.close_button}
+          onClick={onClose}
+          aria-label={ariaLabel}
+        >
+          <Icon name="close" size="1.75rem" />
+        </button>
+      </div>
+
+      <div className={styles.modal_content}>{children}</div>
+
+      <div
+        className={`${styles.resizer} ${styles.resizer_r}`}
+        onMouseDown={e => {
+          handleResizeMouseDown('r', e)
+        }}
+      />
+      <div
+        className={`${styles.resizer} ${styles.resizer_l}`}
+        onMouseDown={e => {
+          handleResizeMouseDown('l', e)
+        }}
+      />
+      <div
+        className={`${styles.resizer} ${styles.resizer_b}`}
+        onMouseDown={e => {
+          handleResizeMouseDown('b', e)
+        }}
+      />
+      <div
+        className={`${styles.resizer} ${styles.resizer_bl}`}
+        onMouseDown={e => {
+          handleResizeMouseDown('bl', e)
+        }}
+      />
+      <div
+        className={`${styles.resizer} ${styles.resizer_br}`}
+        onMouseDown={e => {
+          handleResizeMouseDown('br', e)
+        }}
+      />
+    </div>,
+    document.body
+  )
+}

--- a/components/src/molecules/ModelessModal/modelessmodal.module.css
+++ b/components/src/molecules/ModelessModal/modelessmodal.module.css
@@ -1,0 +1,100 @@
+.modal_root {
+  position: fixed;
+  z-index: 1000;
+  display: flex;
+  overflow: hidden;
+  flex-direction: column;
+  border-radius: var(--border-radius-8);
+  background-color: var(--white);
+  box-shadow: 0 3px 6px 0 rgb(22 33 45 / 23%);
+}
+
+.modal_header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--spacing-12) var(--spacing-24);
+  border-bottom: 1px solid var(--grey-30);
+  background-color: var(--white);
+  cursor: move;
+  user-select: none;
+}
+
+.modal_header:focus-visible {
+  outline: 2px solid var(--blue-50);
+  outline-offset: -2px;
+}
+
+.header_title {
+  color: var(--black-90);
+}
+
+.close_button {
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.close_button:hover {
+  border-radius: 50%;
+  background-color: var(--transparent-black-20);
+}
+
+.close_button:active {
+  border-radius: 50%;
+  background-color: var(--transparent-black-30);
+}
+
+.modal_content {
+  overflow: auto;
+  flex: 1;
+  padding: 0;
+  background-color: transparent;
+}
+
+.resizer {
+  position: absolute;
+  user-select: none;
+}
+
+.resizer_r {
+  top: 0;
+  right: 0;
+  width: 6px;
+  height: 100%;
+  cursor: e-resize;
+}
+
+.resizer_l {
+  top: 0;
+  left: 0;
+  width: 0.375rem;
+  height: 100%;
+  cursor: w-resize;
+}
+
+.resizer_b {
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 0.375rem;
+  cursor: s-resize;
+}
+
+.resizer_bl {
+  z-index: 2;
+  bottom: 0;
+  left: 0;
+  width: 0.75rem;
+  height: 0.75rem;
+  cursor: sw-resize;
+}
+
+.resizer_br {
+  z-index: 2;
+  right: 0;
+  bottom: 0;
+  width: 0.75rem;
+  height: 0.75rem;
+  cursor: se-resize;
+}

--- a/components/src/molecules/ModelessModal/modelessmodal.stories.module.css
+++ b/components/src/molecules/ModelessModal/modelessmodal.stories.module.css
@@ -7,7 +7,7 @@ button {
   height: 100%;
   flex-direction: column;
   padding: var(--spacing-24);
-  background-color: var(--grey-30);
+  background-color: var(white);
   gap: var(--spacing-16);
 }
 

--- a/components/src/molecules/ModelessModal/modelessmodal.stories.module.css
+++ b/components/src/molecules/ModelessModal/modelessmodal.stories.module.css
@@ -1,0 +1,22 @@
+button {
+  padding: var(--spacing-16);
+}
+
+.content_container {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  padding: var(--spacing-24);
+  background-color: var(--grey-30);
+  gap: var(--spacing-16);
+}
+
+.simple_content_container {
+  display: flex;
+  height: 100%;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-16);
+  background-color: var(--white);
+}

--- a/components/src/styles/global.css
+++ b/components/src/styles/global.css
@@ -95,6 +95,7 @@
   --transparent-black-60: #16212d60;
   --transparent-black-40: #16212d66;
   --transparent-black-30: #16212d4d;
+  --transparent-black-20: #16212d33;
   --transparent-black-10: #16212d1a;
 
   /* flex */


### PR DESCRIPTION


# Overview
add ModelessModal component

closes AUTH-2998

## Test Plan and Hands on Testing
`make -C components dev`
- the modal is draggable (drag & drop the header part)
- the modal is resizable (left, right, bottom edge + bottom right corner, bottom left corner)
- hit tab -> arrow key to move the modal 
- hit tab -> shift + arrow key to resize the modal 

## Changelog
- add ModelessModal component + stories

## Review requests



## Risk assessment
low