### PR TITLE
feat(app): adds support for re-prompting login after idle logout

### DIFF
--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -114,20 +114,20 @@ export const DesktopApp = (): JSX.Element => {
 
   return (
     <LocalizationProvider>
-      <NiceModal.Provider>
-        <ErrorBoundary FallbackComponent={DesktopAppFallback}>
-          <ReactQueryDevtools />
-          <SystemLanguagePreferenceModal />
-          <Navbar routes={desktopRoutes} />
-          <ToasterOven>
-            <EmergencyStopContext.Provider
-              value={{
-                isEmergencyStopModalDismissed,
-                setIsEmergencyStopModalDismissed,
-              }}
-            >
-              <DocumentationRequiredModalContext.Provider
-                value={{ showDocumentationRequiredModal, showLoginModal }}
+      <DocumentationRequiredModalContext.Provider
+        value={{ showDocumentationRequiredModal, showLoginModal }}
+      >
+        <NiceModal.Provider>
+          <ErrorBoundary FallbackComponent={DesktopAppFallback}>
+            <ReactQueryDevtools />
+            <SystemLanguagePreferenceModal />
+            <Navbar routes={desktopRoutes} />
+            <ToasterOven>
+              <EmergencyStopContext.Provider
+                value={{
+                  isEmergencyStopModalDismissed,
+                  setIsEmergencyStopModalDismissed,
+                }}
               >
                 <Box width="100%" height="100vh">
                   <Alerts>
@@ -171,11 +171,11 @@ export const DesktopApp = (): JSX.Element => {
                     <RobotControlTakeover />
                   </Alerts>
                 </Box>
-              </DocumentationRequiredModalContext.Provider>
-            </EmergencyStopContext.Provider>
-          </ToasterOven>
-        </ErrorBoundary>
-      </NiceModal.Provider>
+              </EmergencyStopContext.Provider>
+            </ToasterOven>
+          </ErrorBoundary>
+        </NiceModal.Provider>
+      </DocumentationRequiredModalContext.Provider>
     </LocalizationProvider>
   )
 }

--- a/app/src/local-resources/access-control/DocumentationRequiredModalContext.tsx
+++ b/app/src/local-resources/access-control/DocumentationRequiredModalContext.tsx
@@ -9,7 +9,8 @@ export interface DocumentationRequiredModalContextType {
   showDocumentationRequiredModal: (
     username: string,
     actionsToDocument: DocumentedAction[],
-    onCancel?: () => void
+    onCancel?: () => void,
+    initialDocreport?: DocumentationReport
   ) => Promise<DocumentationReport>
   showLoginModal: ({
     robotName,
@@ -26,7 +27,8 @@ export const DocumentationRequiredModalContext =
     showDocumentationRequiredModal: (
       username: string,
       actionsToDocument: DocumentedAction[],
-      onCancel?: () => void
+      onCancel?: () => void,
+      initialDocreport?: DocumentationReport
     ) => {
       return Promise.resolve('' as DocumentationReport)
     },

--- a/app/src/local-resources/access-control/__fixtures__/documentationState.ts
+++ b/app/src/local-resources/access-control/__fixtures__/documentationState.ts
@@ -9,7 +9,8 @@ import type {
 type AskForDocumentation = (
   actionsToDocument: DocumentedAction[],
   onCancel?: () => void,
-  defaultDocReport?: DocumentationReport | null
+  defaultDocReport?: DocumentationReport | null,
+  username?: string
 ) => Promise<DocumentationReport>
 
 export const ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE: DocumentationState = {
@@ -22,7 +23,7 @@ export function createReasonNotRequiredDocumentationState(): DocumentationState 
     isLoading: false,
     accessControlEnabled: true,
     loginExpired: false,
-    askForLogin: vi.fn(async () => {}),
+    askForLogin: vi.fn(async () => ({ username: 'alice' })),
     reasonForInteractionRequired: false,
   }
 }
@@ -34,7 +35,7 @@ export function createReasonRequiredWithDocReport(
     isLoading: false,
     accessControlEnabled: true,
     loginExpired: false,
-    askForLogin: vi.fn(async () => {}),
+    askForLogin: vi.fn(async () => ({ username: 'alice' })),
     reasonForInteractionRequired: true,
     docreport,
     askForDocumentation: vi.fn(),
@@ -48,7 +49,7 @@ export function createReasonRequiredWithoutDocReport(
     isLoading: false,
     accessControlEnabled: true,
     loginExpired: false,
-    askForLogin: vi.fn(async () => {}),
+    askForLogin: vi.fn(async () => ({ username: 'alice' })),
     reasonForInteractionRequired: true,
     docreport: null,
     askForDocumentation,

--- a/app/src/local-resources/access-control/__fixtures__/documentationState.ts
+++ b/app/src/local-resources/access-control/__fixtures__/documentationState.ts
@@ -1,0 +1,56 @@
+import { vi } from 'vitest'
+
+import type {
+  DocumentationReport,
+  DocumentationState,
+  DocumentedAction,
+} from '@opentrons/react-api-client'
+
+type AskForDocumentation = (
+  actionsToDocument: DocumentedAction[],
+  onCancel?: () => void,
+  defaultDocReport?: DocumentationReport | null
+) => Promise<DocumentationReport>
+
+export const ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE: DocumentationState = {
+  isLoading: false,
+  accessControlEnabled: false,
+}
+
+export function createReasonNotRequiredDocumentationState(): DocumentationState {
+  return {
+    isLoading: false,
+    accessControlEnabled: true,
+    loginExpired: false,
+    askForLogin: vi.fn(async () => {}),
+    reasonForInteractionRequired: false,
+  }
+}
+
+export function createReasonRequiredWithDocReport(
+  docreport: DocumentationReport
+): DocumentationState {
+  return {
+    isLoading: false,
+    accessControlEnabled: true,
+    loginExpired: false,
+    askForLogin: vi.fn(async () => {}),
+    reasonForInteractionRequired: true,
+    docreport,
+    askForDocumentation: vi.fn(),
+  }
+}
+
+export function createReasonRequiredWithoutDocReport(
+  askForDocumentation: AskForDocumentation
+): DocumentationState {
+  return {
+    isLoading: false,
+    accessControlEnabled: true,
+    loginExpired: false,
+    askForLogin: vi.fn(async () => {}),
+    reasonForInteractionRequired: true,
+    docreport: null,
+    askForDocumentation,
+  }
+}

--- a/app/src/local-resources/access-control/__tests__/maintenanceRunDocumentation.test.tsx
+++ b/app/src/local-resources/access-control/__tests__/maintenanceRunDocumentation.test.tsx
@@ -193,9 +193,15 @@ describe('maintenance run documentation flow', () => {
     await waitFor(() => {
       expect(
         !result.current.commandDocState.isLoading &&
-          result.current.commandDocState.reasonForInteractionRequired &&
-          result.current.commandDocState.docreport
-      ).toEqual(MOCK_DOCREPORT)
+          result.current.commandDocState.accessControlEnabled
+      ).toBe(true)
+      if (
+        !result.current.commandDocState.isLoading &&
+        result.current.commandDocState.accessControlEnabled &&
+        result.current.commandDocState.reasonForInteractionRequired
+      ) {
+        expect(result.current.commandDocState.docreport).toEqual(MOCK_DOCREPORT)
+      }
     })
 
     const { deletionDocState } = result.current
@@ -203,20 +209,16 @@ describe('maintenance run documentation flow', () => {
     // The deletion gate is in place but has NOT prompted yet — it is set up
     // to prompt only when the deletion mutation actually runs.
     expect(
-      !deletionDocState.isLoading &&
-        deletionDocState.reasonForInteractionRequired
+      !deletionDocState.isLoading && deletionDocState.accessControlEnabled
     ).toBe(true)
-    expect(
+    if (
       !deletionDocState.isLoading &&
-        deletionDocState.reasonForInteractionRequired &&
-        deletionDocState.docreport
-    ).toBeNull()
-    expect(
-      !deletionDocState.isLoading &&
-        deletionDocState.reasonForInteractionRequired &&
-        deletionDocState.docreport == null &&
-        deletionDocState.askForDocumentation
-    ).toBeDefined()
+      deletionDocState.accessControlEnabled &&
+      deletionDocState.reasonForInteractionRequired
+    ) {
+      expect(deletionDocState.docreport).toBeNull()
+      expect(deletionDocState.askForDocumentation).toBeDefined()
+    }
 
     // 2) Every step of the maintenance run executes against the same
     //    captured documentation report — running them must NOT trigger any
@@ -242,11 +244,13 @@ describe('maintenance run documentation flow', () => {
     // Still only the single launch prompt — every step reused the
     // commandDocState's report rather than asking the user again.
     expect(mockShowDocumentationRequiredModal).toHaveBeenCalledTimes(1)
-    expect(
+    if (
       !result.current.commandDocState.isLoading &&
-        result.current.commandDocState.reasonForInteractionRequired &&
-        result.current.commandDocState.docreport
-    ).toEqual(MOCK_DOCREPORT)
+      result.current.commandDocState.accessControlEnabled &&
+      result.current.commandDocState.reasonForInteractionRequired
+    ) {
+      expect(result.current.commandDocState.docreport).toEqual(MOCK_DOCREPORT)
+    }
 
     // 3) Tearing the run down via the deletion mutation prompts the user
     //    a second time for documentation right before the end of the run.

--- a/app/src/local-resources/access-control/__tests__/useGuardedAction.test.ts
+++ b/app/src/local-resources/access-control/__tests__/useGuardedAction.test.ts
@@ -174,4 +174,65 @@ describe('useGuardedAction', () => {
 
     expect(mockShowLoginModal).toHaveBeenCalled()
   })
+
+  it('calls onCancel when login modal is dismissed without logging in', async () => {
+    vi.mocked(useCurrentUsername).mockReturnValue(null)
+    vi.mocked(mockShowLoginModal).mockResolvedValue(null)
+    const onCancel = vi.fn()
+    const { result } = renderHook(() => useGuardedAction(), { wrapper })
+
+    await act(async () => {
+      if (
+        !result.current.isLoading &&
+        result.current.accessControlEnabled &&
+        result.current.reasonForInteractionRequired &&
+        result.current.docreport == null
+      ) {
+        const report = await result.current.askForDocumentation([], onCancel)
+        expect(report).toBe('')
+      }
+    })
+
+    expect(mockShowLoginModal).toHaveBeenCalled()
+    expect(mockShowDocumentationRequiredModal).not.toHaveBeenCalled()
+    expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('passes initialDocreport to the documentation modal', async () => {
+    const initialDocreport = 'previous note' as DocumentationReport
+    const { result } = renderHook(() => useGuardedAction(), { wrapper })
+
+    await act(async () => {
+      if (
+        !result.current.isLoading &&
+        result.current.accessControlEnabled &&
+        result.current.reasonForInteractionRequired
+      ) {
+        await result.current.askForDocumentation(
+          ['play_run'],
+          undefined,
+          initialDocreport,
+          'alice'
+        )
+      }
+    })
+
+    expect(mockShowDocumentationRequiredModal).toHaveBeenCalledWith(
+      'alice',
+      ['play_run'],
+      undefined,
+      initialDocreport
+    )
+  })
+
+  it('exposes askForLogin when access control is enabled', async () => {
+    const { result } = renderHook(() => useGuardedAction(), { wrapper })
+
+    expect(
+      !result.current.isLoading && result.current.accessControlEnabled
+    ).toBe(true)
+    if (!result.current.isLoading && result.current.accessControlEnabled) {
+      expect(result.current.askForLogin).toEqual(expect.any(Function))
+    }
+  })
 })

--- a/app/src/local-resources/access-control/__tests__/useGuardedAction.test.ts
+++ b/app/src/local-resources/access-control/__tests__/useGuardedAction.test.ts
@@ -8,6 +8,7 @@ import {
 
 import { useCurrentUsername } from '/app/redux/robot-auth'
 
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../__fixtures__/documentationState'
 import { useGuardedAction } from '../useGuardedAction'
 import {
   mockShowDocumentationRequiredModal,
@@ -85,12 +86,11 @@ describe('useGuardedAction', () => {
 
     const { result } = renderHook(() => useGuardedAction(), { wrapper })
 
-    const currentResult = await act(
-      () =>
-        !result.current.isLoading &&
-        !result.current.reasonForInteractionRequired
-    )
-    expect(currentResult).toBe(true)
+    await act(async () => {
+      expect(result.current).toEqual(
+        ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+      )
+    })
     expect(mockShowDocumentationRequiredModal).not.toHaveBeenCalled()
   })
   it('skips both guards when access control is enabled but require reason for interaction is disabled', async () => {
@@ -112,12 +112,14 @@ describe('useGuardedAction', () => {
 
     const { result } = renderHook(() => useGuardedAction(), { wrapper })
 
-    const currentResult = await act(
-      () =>
-        !result.current.isLoading &&
-        !result.current.reasonForInteractionRequired
-    )
-    expect(currentResult).toBe(true)
+    await act(async () => {
+      expect(
+        !result.current.isLoading && result.current.accessControlEnabled
+      ).toBe(true)
+      if (!result.current.isLoading && result.current.accessControlEnabled) {
+        expect(result.current.reasonForInteractionRequired).toBe(false)
+      }
+    })
     expect(mockShowDocumentationRequiredModal).not.toHaveBeenCalled()
   })
 
@@ -129,32 +131,31 @@ describe('useGuardedAction', () => {
     })
 
     expect(
-      !result.current.isLoading && result.current.reasonForInteractionRequired
+      !result.current.isLoading && result.current.accessControlEnabled
     ).toBe(true)
-    expect(
+    if (
       !result.current.isLoading &&
-        result.current.reasonForInteractionRequired &&
-        result.current.docreport
-    ).toBe(docreport)
+      result.current.accessControlEnabled &&
+      result.current.reasonForInteractionRequired
+    ) {
+      expect(result.current.docreport).toBe(docreport)
+    }
   })
 
   it('returns callback to open modal when documentation is not provided', async () => {
     const { result } = renderHook(() => useGuardedAction(), { wrapper })
 
     expect(
-      !result.current.isLoading && result.current.reasonForInteractionRequired
+      !result.current.isLoading && result.current.accessControlEnabled
     ).toBe(true)
-    expect(
+    if (
       !result.current.isLoading &&
-        result.current.reasonForInteractionRequired &&
-        result.current.docreport
-    ).toBeNull()
-    expect(
-      !result.current.isLoading &&
-        result.current.reasonForInteractionRequired &&
-        result.current.docreport == null &&
-        result.current.askForDocumentation
-    ).toBeDefined()
+      result.current.accessControlEnabled &&
+      result.current.reasonForInteractionRequired
+    ) {
+      expect(result.current.docreport).toBeNull()
+      expect(result.current.askForDocumentation).toBeDefined()
+    }
   })
   it('opens login modal when username is not provided', async () => {
     vi.mocked(useCurrentUsername).mockReturnValue(null)
@@ -163,6 +164,7 @@ describe('useGuardedAction', () => {
     await act(async () => {
       if (
         !result.current.isLoading &&
+        result.current.accessControlEnabled &&
         result.current.reasonForInteractionRequired &&
         result.current.docreport == null
       ) {

--- a/app/src/local-resources/access-control/__tests__/useMaintenanceRunDocumentation.test.ts
+++ b/app/src/local-resources/access-control/__tests__/useMaintenanceRunDocumentation.test.ts
@@ -6,6 +6,11 @@ import {
   useAuthSettingsQuery,
 } from '@opentrons/react-api-client'
 
+import {
+  ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+  createReasonRequiredWithDocReport,
+  createReasonRequiredWithoutDocReport,
+} from '../__fixtures__/documentationState'
 import { useMaintenanceRunDocumentation } from '../useMaintenanceRunDocumentation'
 import { isDocumentationProvided } from '../utils'
 import {
@@ -47,31 +52,23 @@ const wrapper = wrapWithDocumentationRequiredModal()
 
 describe('isDocumentationProvided', () => {
   it('returns true when access control is disabled', () => {
-    const state: DocumentationState = {
-      reasonForInteractionRequired: false,
-      isLoading: false,
-    }
+    const state: DocumentationState =
+      ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
 
     expect(isDocumentationProvided(state)).toBe(true)
   })
 
   it('returns true when documentation is provided', () => {
-    const state: DocumentationState = {
-      reasonForInteractionRequired: true,
-      docreport: mockDocreport,
-      isLoading: false,
-    }
+    const state: DocumentationState =
+      createReasonRequiredWithDocReport(mockDocreport)
 
     expect(isDocumentationProvided(state)).toBe(true)
   })
 
   it('returns false when access control is enabled and documentation is missing', () => {
-    const state: DocumentationState = {
-      reasonForInteractionRequired: true,
-      docreport: null,
-      askForDocumentation: vi.fn(),
-      isLoading: false,
-    }
+    const state: DocumentationState = createReasonRequiredWithoutDocReport(
+      vi.fn()
+    )
 
     expect(isDocumentationProvided(state)).toBe(false)
   })
@@ -118,26 +115,30 @@ describe('useMaintenanceRunDocumentation', () => {
     await waitFor(() => {
       expect(
         !result.current.commandDocState.isLoading &&
-          result.current.commandDocState.reasonForInteractionRequired &&
-          result.current.commandDocState.docreport
-      ).toEqual(mockDocreport)
+          result.current.commandDocState.accessControlEnabled
+      ).toBe(true)
+      if (
+        !result.current.commandDocState.isLoading &&
+        result.current.commandDocState.accessControlEnabled &&
+        result.current.commandDocState.reasonForInteractionRequired
+      ) {
+        expect(result.current.commandDocState.docreport).toEqual(mockDocreport)
+      }
     })
 
+    const { deletionDocState } = result.current
+
     expect(
-      !result.current.deletionDocState.isLoading &&
-        result.current.deletionDocState.reasonForInteractionRequired
+      !deletionDocState.isLoading && deletionDocState.accessControlEnabled
     ).toBe(true)
-    expect(
-      !result.current.deletionDocState.isLoading &&
-        result.current.deletionDocState.reasonForInteractionRequired &&
-        result.current.deletionDocState.docreport
-    ).toBeNull()
-    expect(
-      !result.current.deletionDocState.isLoading &&
-        result.current.deletionDocState.reasonForInteractionRequired &&
-        result.current.deletionDocState.docreport == null &&
-        result.current.deletionDocState.askForDocumentation
-    ).toBeDefined()
+    if (
+      !deletionDocState.isLoading &&
+      deletionDocState.accessControlEnabled &&
+      deletionDocState.reasonForInteractionRequired
+    ) {
+      expect(deletionDocState.docreport).toBeNull()
+      expect(deletionDocState.askForDocumentation).toBeDefined()
+    }
   })
 
   it('prompts for deletion documentation only when askForDocumentation is invoked', async () => {
@@ -153,12 +154,14 @@ describe('useMaintenanceRunDocumentation', () => {
     })
 
     await act(async () => {
+      const { deletionDocState } = result.current
       if (
-        !result.current.deletionDocState.isLoading &&
-        result.current.deletionDocState.reasonForInteractionRequired &&
-        result.current.deletionDocState.docreport == null
+        !deletionDocState.isLoading &&
+        deletionDocState.accessControlEnabled &&
+        deletionDocState.reasonForInteractionRequired &&
+        deletionDocState.docreport == null
       ) {
-        await result.current.deletionDocState.askForDocumentation(
+        await deletionDocState.askForDocumentation(
           result.current.actionsToDocument
         )
       }

--- a/app/src/local-resources/access-control/__tests__/usePromptForInteractionReason.test.ts
+++ b/app/src/local-resources/access-control/__tests__/usePromptForInteractionReason.test.ts
@@ -6,10 +6,13 @@ import {
   useAuthSettingsQuery,
 } from '@opentrons/react-api-client'
 
+import { useCurrentUsername } from '/app/redux/robot-auth'
+
 import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../__fixtures__/documentationState'
 import { usePromptForInteractionReason } from '../usePromptForInteractionReason'
 import {
   mockShowDocumentationRequiredModal,
+  mockShowLoginModal,
   wrapWithDocumentationRequiredModal,
 } from './documentationRequiredModalTestUtils'
 
@@ -126,6 +129,22 @@ describe('usePromptForInteractionReason', () => {
     }
     expect(mockShowDocumentationRequiredModal).not.toHaveBeenCalled()
   })
+  it('calls onCancel when login modal is dismissed without logging in', async () => {
+    vi.mocked(useCurrentUsername).mockReturnValue(null)
+    vi.mocked(mockShowLoginModal).mockResolvedValue(null)
+    const onCancel = vi.fn()
+
+    renderHook(() => usePromptForInteractionReason(['lpc_flow'], onCancel), {
+      wrapper,
+    })
+
+    await waitFor(() => {
+      expect(mockShowLoginModal).toHaveBeenCalled()
+    })
+    expect(mockShowDocumentationRequiredModal).not.toHaveBeenCalled()
+    expect(onCancel).toHaveBeenCalled()
+  })
+
   it('prompts for documentation when access control is enabled', async () => {
     const { result } = renderHook(
       () => usePromptForInteractionReason(['lpc_flow']),

--- a/app/src/local-resources/access-control/__tests__/usePromptForInteractionReason.test.ts
+++ b/app/src/local-resources/access-control/__tests__/usePromptForInteractionReason.test.ts
@@ -6,6 +6,7 @@ import {
   useAuthSettingsQuery,
 } from '@opentrons/react-api-client'
 
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../__fixtures__/documentationState'
 import { usePromptForInteractionReason } from '../usePromptForInteractionReason'
 import {
   mockShowDocumentationRequiredModal,
@@ -91,9 +92,7 @@ describe('usePromptForInteractionReason', () => {
       }
     )
 
-    expect(
-      !result.current.isLoading && result.current.reasonForInteractionRequired
-    ).toBe(false)
+    expect(result.current).toEqual(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE)
     expect(mockShowDocumentationRequiredModal).not.toHaveBeenCalled()
   })
 
@@ -120,8 +119,11 @@ describe('usePromptForInteractionReason', () => {
       }
     )
     expect(
-      !result.current.isLoading && result.current.reasonForInteractionRequired
-    ).toBe(false)
+      !result.current.isLoading && result.current.accessControlEnabled
+    ).toBe(true)
+    if (!result.current.isLoading && result.current.accessControlEnabled) {
+      expect(result.current.reasonForInteractionRequired).toBe(false)
+    }
     expect(mockShowDocumentationRequiredModal).not.toHaveBeenCalled()
   })
   it('prompts for documentation when access control is enabled', async () => {
@@ -138,13 +140,15 @@ describe('usePromptForInteractionReason', () => {
 
     await waitFor(() => {
       expect(
-        !result.current.isLoading && result.current.reasonForInteractionRequired
+        !result.current.isLoading && result.current.accessControlEnabled
       ).toBe(true)
-      expect(
+      if (
         !result.current.isLoading &&
-          result.current.reasonForInteractionRequired &&
-          result.current.docreport
-      ).toEqual(mockDocreport)
+        result.current.accessControlEnabled &&
+        result.current.reasonForInteractionRequired
+      ) {
+        expect(result.current.docreport).toEqual(mockDocreport)
+      }
     })
   })
 })

--- a/app/src/local-resources/access-control/useGuardedAction.ts
+++ b/app/src/local-resources/access-control/useGuardedAction.ts
@@ -78,6 +78,11 @@ export function useGuardedAction(
           robotName: currentRobotName ?? '',
         })
         username = loginResult?.username ?? ''
+        // if user cancels login, cancel the whole mutation
+        if (username == null || username.length === 0) {
+          handleCancel?.()
+          return '' as DocumentationReport
+        }
       }
       const docResult = await requireDocumentation(
         username ?? '',

--- a/app/src/local-resources/access-control/useGuardedAction.ts
+++ b/app/src/local-resources/access-control/useGuardedAction.ts
@@ -68,10 +68,12 @@ export function useGuardedAction(
   const showDocumentationModal = useCallback(
     async (
       actionsToDocument: DocumentedAction[],
-      handleCancel?: () => void
+      handleCancel?: () => void,
+      initialDocreport?: DocumentationReport,
+      usernameOverride?: string
     ) => {
-      let username = currentUsername
-      if (currentUsername == null || currentUsername.length === 0) {
+      let username = usernameOverride ?? currentUsername
+      if (username == null || username.length === 0) {
         const loginResult = await requireLogin({
           robotName: currentRobotName ?? '',
         })
@@ -80,7 +82,8 @@ export function useGuardedAction(
       const docResult = await requireDocumentation(
         username ?? '',
         actionsToDocument,
-        handleCancel
+        handleCancel,
+        initialDocreport
       )
       return docResult
     },
@@ -88,7 +91,7 @@ export function useGuardedAction(
   )
 
   const askForLogin = useCallback(async () => {
-    void requireLogin({ robotName: currentRobotName ?? '' })
+    return await requireLogin({ robotName: currentRobotName ?? '' })
   }, [currentRobotName, requireLogin])
 
   const docState: DocumentationState = useMemo(() => {

--- a/app/src/local-resources/access-control/useGuardedAction.ts
+++ b/app/src/local-resources/access-control/useGuardedAction.ts
@@ -8,13 +8,16 @@ import {
 import { useCurrentRobotName, useCurrentUsername } from '/app/redux/robot-auth'
 
 import { DocumentationRequiredModalContext } from './DocumentationRequiredModalContext'
-import { isDocumentationReportValid } from './utils'
 
 import type {
   DocumentationReport,
   DocumentationState,
   DocumentedAction,
 } from '@opentrons/react-api-client'
+import type {
+  MutationAuthenticationState,
+  MutationDocumentationState,
+} from '@opentrons/react-api-client/src/access_control/types'
 
 /**
  * API for the access-control gate.
@@ -42,8 +45,10 @@ export function useGuardedAction(
     accessControlEnabledQuery?.data?.data?.accessControlEnabled ?? false
   const requireReasonForInteraction =
     authSettingsQuery?.data?.data?.requireReasonForInteraction ?? false
-  const minLengthOfReasonForInteraction =
-    authSettingsQuery?.data?.data?.minLengthOfReasonForInteraction ?? 0
+
+  // TODO(jj): add length check for documentation report
+  // const minLengthOfReasonForInteraction =
+  //   authSettingsQuery?.data?.data?.minLengthOfReasonForInteraction ?? 0
 
   const reasonForInteractionLoading = useMemo(
     () => authSettingsQuery?.isLoading || accessControlEnabledQuery?.isLoading,
@@ -82,30 +87,45 @@ export function useGuardedAction(
     [currentRobotName, currentUsername, requireDocumentation, requireLogin]
   )
 
+  const askForLogin = useCallback(async () => {
+    void requireLogin({ robotName: currentRobotName ?? '' })
+  }, [currentRobotName, requireLogin])
+
   const docState: DocumentationState = useMemo(() => {
     if (reasonForInteractionLoading) {
       return { isLoading: true }
     }
-    if (!reasonForInteractionRequired) {
-      return { reasonForInteractionRequired: false, isLoading: false }
+
+    if (!accessControlEnabled) {
+      return { isLoading: false, accessControlEnabled: false }
     }
 
-    if (
-      docreport != null &&
-      isDocumentationReportValid(docreport, minLengthOfReasonForInteraction)
-    ) {
-      return { reasonForInteractionRequired: true, docreport, isLoading: false }
+    const mutationAuthState: MutationAuthenticationState = {
+      accessControlEnabled: true,
+      loginExpired: false,
+      askForLogin,
     }
+
+    const mutationDocState: MutationDocumentationState =
+      reasonForInteractionRequired
+        ? {
+            reasonForInteractionRequired: true,
+            docreport: docreport ?? null,
+            askForDocumentation: showDocumentationModal,
+          }
+        : {
+            reasonForInteractionRequired: false,
+          }
 
     return {
-      reasonForInteractionRequired: true,
-      docreport: null,
-      askForDocumentation: showDocumentationModal,
       isLoading: false,
+      ...mutationAuthState,
+      ...mutationDocState,
     }
   }, [
+    accessControlEnabled,
+    askForLogin,
     docreport,
-    minLengthOfReasonForInteraction,
     reasonForInteractionLoading,
     reasonForInteractionRequired,
     showDocumentationModal,

--- a/app/src/local-resources/access-control/usePromptForInteractionReason.ts
+++ b/app/src/local-resources/access-control/usePromptForInteractionReason.ts
@@ -15,7 +15,7 @@ import type {
  * Use this to prompt for a documentation report to pass between multiple mutations that only need to be prompted once.
  * e.g. maintenance run commands
  * If mutations can prompt for documentation themselves, use useGuardedAction instead.
- * 
+ *
  *  @param initialDocstate - an optional documentation state to use as a base. To be used when a flow needs to sometimes but not always prompt before the first mutation.
  *
  */
@@ -26,7 +26,10 @@ export const usePromptForInteractionReason = (
 ): DocumentationState => {
   const [docReport, setDocReport] = useState<DocumentationReport>()
   const docStateToUse =
-    !initialDocstate?.isLoading && initialDocstate?.reasonForInteractionRequired
+    initialDocstate != null &&
+    !initialDocstate.isLoading &&
+    initialDocstate.accessControlEnabled &&
+    initialDocstate.reasonForInteractionRequired
       ? initialDocstate.docreport
       : docReport
   const docState = useGuardedAction(docStateToUse ?? undefined)
@@ -34,7 +37,11 @@ export const usePromptForInteractionReason = (
 
   useEffect(() => {
     const promptForDocumentation = async (): Promise<void> => {
-      if (!docState.isLoading && docState.reasonForInteractionRequired) {
+      if (
+        !docState.isLoading &&
+        docState.accessControlEnabled &&
+        docState.reasonForInteractionRequired
+      ) {
         if (docState.docreport == null && !promptInFlight.current) {
           promptInFlight.current = true
           await docState

--- a/app/src/local-resources/access-control/utils.ts
+++ b/app/src/local-resources/access-control/utils.ts
@@ -16,6 +16,9 @@ export function isDocumentationProvided(state: DocumentationState): boolean {
   if (state.isLoading) {
     return false
   }
+  if (!state.accessControlEnabled) {
+    return true
+  }
   if (!state.reasonForInteractionRequired) {
     return true
   }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ConfirmCancelModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ConfirmCancelModal.tsx
@@ -18,6 +18,7 @@ import {
 import { useStopRunMutation } from '@opentrons/react-api-client'
 
 import { getTopPortalEl } from '/app/App/portal'
+import { useGuardedAction } from '/app/local-resources/access-control/useGuardedAction'
 import { isStoppingOrStopped } from '/app/local-resources/runs/utils'
 import { useTrackProtocolRunEvent } from '/app/redux-resources/analytics'
 import { useIsFlex } from '/app/redux-resources/robots'
@@ -52,11 +53,8 @@ export function ConfirmCancelModal(
   props: ConfirmCancelModalProps
 ): JSX.Element {
   const { onClose, runId, robotName, runStatus } = props
-  // TODO(jj): add doc state to desktop app
-  const { stopRun } = useStopRunMutation({
-    reasonForInteractionRequired: false,
-    isLoading: false,
-  })
+  const documentationState = useGuardedAction()
+  const { stopRun } = useStopRunMutation(documentationState)
   const isFlex = useIsFlex(robotName)
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)
   const [isCanceling, setIsCanceling] = useState(false)

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/__tests__/ConfirmCancelModal.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/__tests__/ConfirmCancelModal.test.tsx
@@ -13,6 +13,7 @@ import { useStopRunMutation } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useTrackProtocolRunEvent } from '/app/redux-resources/analytics'
 import { useIsFlex } from '/app/redux-resources/robots'
 import { useTrackEvent } from '/app/redux/analytics'
@@ -32,6 +33,9 @@ vi.mock('@opentrons/react-api-client', async importOriginal => {
 vi.mock('/app/redux/analytics')
 vi.mock('/app/redux-resources/analytics')
 vi.mock('/app/redux-resources/robots')
+vi.mock('/app/local-resources/access-control/useGuardedAction', () => ({
+  useGuardedAction: vi.fn(() => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+}))
 
 const render = (props: ComponentProps<typeof ConfirmCancelModal>) => {
   return renderWithProviders(<ConfirmCancelModal {...props} />, {

--- a/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequired.tsx
+++ b/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequired.tsx
@@ -13,14 +13,17 @@ import { ActionList } from '/app/organisms/ActionItems/ActionList'
 
 import styles from './documentationrequired.module.css'
 
-import type { DocumentedAction } from '@opentrons/react-api-client'
+import type {
+  DocumentationReport,
+  DocumentedAction,
+} from '@opentrons/react-api-client'
 
 interface DocumentationRequiredProps {
   username: string
   actionsToDocument: DocumentedAction[]
   onConfirm: (note: string) => void
-
   onClose: () => void
+  initialDocreport?: DocumentationReport
 }
 
 export function DocumentationRequired({
@@ -28,9 +31,10 @@ export function DocumentationRequired({
   actionsToDocument,
   onConfirm,
   onClose,
+  initialDocreport,
 }: DocumentationRequiredProps): JSX.Element {
   const { t } = useTranslation(['access_control', 'shared'])
-  const [inputText, setInputText] = useState<string>('')
+  const [inputText, setInputText] = useState<string>(initialDocreport ?? '')
 
   const trimmedNote = inputText.trim()
   // TODO(jj): check against min length

--- a/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequiredModal.tsx
+++ b/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequiredModal.tsx
@@ -15,10 +15,12 @@ const DocumentationRequiredModalImpl = NiceModal.create(
     username,
     actionsToDocument,
     onCancel,
+    initialDocreport,
   }: {
     username: string
     actionsToDocument: DocumentedAction[]
     onCancel?: () => void
+    initialDocreport?: DocumentationReport
   }): JSX.Element => {
     const modal = useModal()
 
@@ -40,6 +42,7 @@ const DocumentationRequiredModalImpl = NiceModal.create(
         actionsToDocument={actionsToDocument}
         onConfirm={handleConfirm}
         onClose={handleBack}
+        initialDocreport={initialDocreport}
       />,
       getTopPortalEl()
     )
@@ -49,10 +52,12 @@ const DocumentationRequiredModalImpl = NiceModal.create(
 export const showDocumentationRequiredModal = (
   username: string,
   actionsToDocument: DocumentedAction[],
-  onCancel?: () => void
+  onCancel?: () => void,
+  initialDocreport?: DocumentationReport
 ): Promise<DocumentationReport> =>
   NiceModal.show(DocumentationRequiredModalImpl, {
     username,
     actionsToDocument,
     onCancel,
+    initialDocreport,
   })

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryActionMutation.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryActionMutation.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { usePlayRunMutation } from '@opentrons/react-api-client'
 
 import { RECOVERY_MAP } from '../../constants'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useRecoveryActionMutation } from '../useRecoveryActionMutation'
 
 import type { Mock } from 'vitest'
@@ -36,7 +37,7 @@ describe('useRecoveryActionMutation', () => {
         {
           proceedToRouteAndStep: mockProceedToRouteAndStep,
         } as any,
-        { reasonForInteractionRequired: false, isLoading: false }
+        ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
       )
     )
 
@@ -52,7 +53,7 @@ describe('useRecoveryActionMutation', () => {
         {
           proceedToRouteAndStep: mockProceedToRouteAndStep,
         } as any,
-        { reasonForInteractionRequired: false, isLoading: false }
+        ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
       )
     )
 
@@ -76,7 +77,7 @@ describe('useRecoveryActionMutation', () => {
         {
           proceedToRouteAndStep: mockProceedToRouteAndStep,
         } as any,
-        { reasonForInteractionRequired: false, isLoading: false }
+        ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
       )
     )
 
@@ -94,7 +95,7 @@ describe('useRecoveryActionMutation', () => {
         {
           proceedToRouteAndStep: mockProceedToRouteAndStep,
         } as any,
-        { reasonForInteractionRequired: false, isLoading: false }
+        ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
       )
     )
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryActionMutation.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryActionMutation.test.ts
@@ -3,8 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { usePlayRunMutation } from '@opentrons/react-api-client'
 
-import { RECOVERY_MAP } from '../../constants'
 import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
+
+import { RECOVERY_MAP } from '../../constants'
 import { useRecoveryActionMutation } from '../useRecoveryActionMutation'
 
 import type { Mock } from 'vitest'

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
@@ -8,6 +8,7 @@ import {
   useStopRunMutation,
 } from '@opentrons/react-api-client'
 
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { getErrorKind } from '/app/organisms/ErrorRecoveryFlows/utils'
 import {
   useChainRunCommands,
@@ -28,6 +29,9 @@ import {
 vi.mock('@opentrons/react-api-client')
 vi.mock('/app/resources/runs')
 vi.mock('/app/organisms/ErrorRecoveryFlows/utils')
+vi.mock('/app/local-resources/access-control/useGuardedAction', () => ({
+  useGuardedAction: vi.fn(() => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+}))
 
 describe('useRecoveryCommands', () => {
   const mockFailedCommand = {

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -5,6 +5,7 @@ import {
   useRunCurrentState,
 } from '@opentrons/react-api-client'
 
+import { useGuardedAction } from '/app/local-resources/access-control/useGuardedAction'
 import { useRecoveryAnalytics } from '/app/redux-resources/analytics'
 import { getRunningStepCountsFrom } from '/app/resources/protocols'
 import {
@@ -185,11 +186,11 @@ export function useERUtils({
     recoveryMap,
   })
 
-  // TODO (jj): popup doc modal in desktop app
+  const documentationState = useGuardedAction()
   const recoveryActionMutationUtils = useRecoveryActionMutation(
     runId,
     routeUpdateActions,
-    { reasonForInteractionRequired: false, isLoading: false }
+    documentationState
   )
 
   // TODO(jh, 06-14-24): Ensure other string build utilities that are internal to ErrorRecoveryFlows are exported under

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -9,6 +9,7 @@ import {
 } from '@opentrons/react-api-client'
 import { WELL_ORIGIN_TOP } from '@opentrons/shared-data'
 
+import { useGuardedAction } from '/app/local-resources/access-control/useGuardedAction'
 import { getErrorKind } from '/app/organisms/ErrorRecoveryFlows/utils'
 import {
   useChainRunCommands,
@@ -122,11 +123,8 @@ export function useRecoveryCommands({
   const { mutateAsync: resumeRunFromRecoveryAssumingFalsePositive } =
     useResumeRunFromRecoveryAssumingFalsePositiveMutation()
 
-  // TODO(jj): add doc state to desktop app
-  const { stopRun } = useStopRunMutation({
-    reasonForInteractionRequired: false,
-    isLoading: false,
-  })
+  const documentationState = useGuardedAction()
+  const { stopRun } = useStopRunMutation(documentationState)
   const updateErrorRecoveryPolicy = useUpdateRecoveryPolicyWithStrategy(runId)
   const currentRecoveryPolicy = useErrorRecoveryPolicy(runId)?.data?.data
   const { chainRunCommands } = useChainRunCommands(

--- a/app/src/organisms/GripperWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { InProgressModal } from '/app/molecules/InProgressModal/InProgressModal'
@@ -34,10 +35,7 @@ describe('BeforeBeginning', () => {
       setErrorMessage: vi.fn(),
       errorMessage: null,
       createdMaintenanceRunId: null,
-      documentationState: {
-        reasonForInteractionRequired: false,
-        isLoading: false,
-      },
+      documentationState: ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
     }
     vi.mocked(InProgressModal).mockReturnValue(<div>mock in progress</div>)
   })

--- a/app/src/organisms/GripperWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/GripperWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -1,9 +1,9 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { InProgressModal } from '/app/molecules/InProgressModal/InProgressModal'
 import { RUN_ID_1 } from '/app/resources/runs/__fixtures__'
 

--- a/app/src/organisms/GripperWizardFlows/index.tsx
+++ b/app/src/organisms/GripperWizardFlows/index.tsx
@@ -15,6 +15,7 @@ import {
   WizardHeader,
 } from '@opentrons/components'
 import {
+  isDocumentedMutationError,
   useCreateMaintenanceCommandMutation,
   useDeleteMaintenanceRunMutation,
 } from '@opentrons/react-api-client'
@@ -106,8 +107,11 @@ export function GripperWizardFlows(
       onSuccess: response => {
         setCreatedMaintenanceRunId(response.data.id)
       },
-      onError: error => {
-        setErrorMessage(error.message)
+      onError: (error: unknown) => {
+        if (isDocumentedMutationError(error)) {
+          return
+        }
+        setErrorMessage(error instanceof Error ? error.message : String(error))
       },
     })
 
@@ -206,7 +210,14 @@ export function GripperWizardFlows(
       handleCleanUpAndClose={handleCleanUpAndClose}
       handleClose={handleClose}
       chainRunCommands={chainRunCommands}
-      createRunCommand={createMaintenanceCommand}
+      createRunCommand={params =>
+        createMaintenanceCommand(params).catch(error => {
+          if (isDocumentedMutationError(error)) {
+            return new Promise(() => {})
+          }
+          return Promise.reject(error)
+        })
+      }
       errorMessage={errorMessage}
       setErrorMessage={setErrorMessage}
       isExiting={isExiting}

--- a/app/src/organisms/LegacyLabwarePositionCheck/LegacyLabwarePositionCheckComponent.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/LegacyLabwarePositionCheckComponent.tsx
@@ -47,6 +47,7 @@ import type {
   LegacyLabwareOffsetCreateData,
   LegacyLabwareOffsetLocation,
 } from '@opentrons/api-client'
+import type { DocumentationState } from '@opentrons/react-api-client'
 import type {
   CompletedProtocolAnalysis,
   CreateCommand,
@@ -271,15 +272,19 @@ export const LegacyLabwarePositionCheckComponent = (
   }
 
   const [isExiting, setIsExiting] = useState(false)
+  const accessControlDisabledDocumentationState: DocumentationState = {
+    isLoading: false,
+    accessControlEnabled: false,
+  }
   const { createMaintenanceCommand: createSilentCommand } =
     useCreateMaintenanceCommandMutation(
-      { reasonForInteractionRequired: false, isLoading: false },
+      accessControlDisabledDocumentationState,
       [],
       () => {}
     ) // No ACM on the OT-2
   const { chainRunCommands, isCommandMutationLoading: isCommandChainLoading } =
     useChainMaintenanceCommands(
-      { reasonForInteractionRequired: false, isLoading: false },
+      accessControlDisabledDocumentationState,
       [],
       () => {}
     ) // No ACM on the OT-2

--- a/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.tsx
@@ -11,13 +11,17 @@ import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 import { ActionsView } from './ActionsView'
 import styles from './documentationrequired.module.css'
 
-import type { DocumentedAction } from '@opentrons/react-api-client'
+import type {
+  DocumentationReport,
+  DocumentedAction,
+} from '@opentrons/react-api-client'
 
 interface DocumentationRequiredProps {
   username: string
   actionsToDocument: DocumentedAction[]
   onConfirm: (note: string) => void
   onBack: () => void
+  initialDocreport?: DocumentationReport
 }
 
 export function DocumentationRequired({
@@ -25,9 +29,10 @@ export function DocumentationRequired({
   actionsToDocument,
   onConfirm,
   onBack,
+  initialDocreport,
 }: DocumentationRequiredProps): JSX.Element {
   const { t } = useTranslation(['access_control', 'shared'])
-  const [inputText, setInputText] = useState<string>('')
+  const [inputText, setInputText] = useState<string>(initialDocreport ?? '')
   const [keyboardExpanded, setKeyboardExpanded] = useState(true)
   const keyboardRef = useRef(null)
   const textAreaRef = useRef<HTMLTextAreaElement>(null)

--- a/app/src/organisms/ODD/DocumentationRequired/DocumentationRequiredModal.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/DocumentationRequiredModal.tsx
@@ -13,10 +13,12 @@ const DocumentationRequiredModalImpl = NiceModal.create(
     username,
     actionsToDocument,
     onCancel,
+    initialDocreport,
   }: {
     username: string
     actionsToDocument: DocumentedAction[]
     onCancel?: () => void
+    initialDocreport?: DocumentationReport
   }): JSX.Element => {
     const modal = useModal()
 
@@ -39,6 +41,7 @@ const DocumentationRequiredModalImpl = NiceModal.create(
           actionsToDocument={actionsToDocument}
           onConfirm={handleConfirm}
           onBack={handleBack}
+          initialDocreport={initialDocreport}
         />
       </div>
     )
@@ -48,10 +51,12 @@ const DocumentationRequiredModalImpl = NiceModal.create(
 export const showDocumentationRequiredModal = (
   username: string,
   actionsToDocument: DocumentedAction[],
-  onCancel?: () => void
+  onCancel?: () => void,
+  initialDocreport?: DocumentationReport
 ): Promise<DocumentationReport> =>
   NiceModal.show(DocumentationRequiredModalImpl, {
     username,
     actionsToDocument,
     onCancel,
+    initialDocreport,
   })

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/__tests__/RunFailedModal.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/__tests__/RunFailedModal.test.tsx
@@ -5,9 +5,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { RUN_STATUS_FAILED } from '@opentrons/api-client'
 import { useStopRunMutation } from '@opentrons/react-api-client'
 
-import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 
 import { RunFailedModal } from '..'
 import { ErrorContent } from '../ErrorContent'

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/__tests__/RunFailedModal.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/__tests__/RunFailedModal.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { RUN_STATUS_FAILED } from '@opentrons/api-client'
 import { useStopRunMutation } from '@opentrons/react-api-client'
 
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 
@@ -17,10 +18,7 @@ import type { NavigateFunction } from 'react-router-dom'
 vi.mock('@opentrons/react-api-client')
 vi.mock('../ErrorContent')
 vi.mock('/app/local-resources/access-control/useGuardedAction', () => ({
-  useGuardedAction: () => ({
-    reasonForInteractionRequired: false,
-    isLoading: false,
-  }),
+  useGuardedAction: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
 }))
 
 const RUN_ID = 'mock_runID'

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -8,9 +8,9 @@ import {
   SINGLE_MOUNT_PIPETTES,
 } from '@opentrons/shared-data'
 
-import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { InProgressModal } from '/app/molecules/InProgressModal/InProgressModal'
 import { mockAttachedPipetteInformation } from '/app/resources/instruments/__fixtures__'
 // import { NeedHelpLink } from '/app/molecules/OT2CalibrationNeedHelpLink'

--- a/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/BeforeBeginning.test.tsx
@@ -8,6 +8,7 @@ import {
   SINGLE_MOUNT_PIPETTES,
 } from '@opentrons/shared-data'
 
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { InProgressModal } from '/app/molecules/InProgressModal/InProgressModal'
@@ -65,10 +66,7 @@ describe('BeforeBeginning', () => {
       requiredPipette: undefined,
       createdMaintenanceRunId: null,
       deckConfig: mockDeckConfig,
-      documentationState: {
-        reasonForInteractionRequired: false,
-        isLoading: false,
-      },
+      documentationState: ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
     }
     // mockNeedHelpLink.mockReturnValue(<div>mock need help link</div>)
     vi.mocked(InProgressModal).mockReturnValue(<div>mock in progress</div>)

--- a/app/src/organisms/PipetteWizardFlows/index.tsx
+++ b/app/src/organisms/PipetteWizardFlows/index.tsx
@@ -12,6 +12,7 @@ import {
   WizardHeader,
 } from '@opentrons/components'
 import {
+  isDocumentedMutationError,
   useDeleteMaintenanceRunMutation,
   useHost,
 } from '@opentrons/react-api-client'
@@ -235,8 +236,13 @@ export const PipetteWizardFlows = (
         onSuccess: response => {
           setCreatedMaintenanceRunId(response.data.id)
         },
-        onError: error => {
-          setShowErrorMessage(error.message)
+        onError: (error: unknown) => {
+          if (isDocumentedMutationError(error)) {
+            return
+          }
+          setShowErrorMessage(
+            error instanceof Error ? error.message : String(error)
+          )
         },
       },
       host

--- a/app/src/organisms/RunTimeControl/__tests__/hooks.test.tsx
+++ b/app/src/organisms/RunTimeControl/__tests__/hooks.test.tsx
@@ -7,6 +7,7 @@ import '@testing-library/jest-dom/vitest'
 import { RUN_STATUS_RUNNING } from '@opentrons/api-client'
 import { useRunActionMutations } from '@opentrons/react-api-client'
 
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import {
   useCloneRun,
   useCurrentRunId,
@@ -45,10 +46,7 @@ describe('useRunControls hook', () => {
     const mockResumeRunFromRecoveryAssumingFalsePositive = vi.fn()
 
     when(useRunActionMutations)
-      .calledWith(mockPausedRun.id, {
-        reasonForInteractionRequired: false,
-        isLoading: false,
-      })
+      .calledWith(mockPausedRun.id, ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE)
       .thenReturn({
         playRun: mockPlayRun,
         pauseRun: mockPauseRun,

--- a/app/src/organisms/RunTimeControl/hooks.ts
+++ b/app/src/organisms/RunTimeControl/hooks.ts
@@ -41,8 +41,8 @@ export function useRunControls(
     isStopRunActionLoading,
     isResumeRunFromRecoveryActionLoading,
   } = useRunActionMutations(runId!, {
-    reasonForInteractionRequired: false,
     isLoading: false,
+    accessControlEnabled: false,
   })
 
   const {

--- a/app/src/organisms/TakeoverModal/__tests__/MaintenanceRunTakeover.test.tsx
+++ b/app/src/organisms/TakeoverModal/__tests__/MaintenanceRunTakeover.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
 
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useNotifyCurrentMaintenanceRun } from '/app/resources/maintenance_runs'
@@ -16,10 +17,7 @@ import type { MaintenanceRunStatus } from '../MaintenanceRunStatusProvider'
 vi.mock('../useMaintenanceRunTakeover')
 vi.mock('/app/resources/maintenance_runs')
 vi.mock('/app/local-resources/access-control/useGuardedAction', () => ({
-  useGuardedAction: () => ({
-    reasonForInteractionRequired: false,
-    isLoading: false,
-  }),
+  useGuardedAction: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
 }))
 
 const MOCK_MAINTENANCE_RUN: MaintenanceRunStatus = {

--- a/app/src/organisms/TakeoverModal/__tests__/MaintenanceRunTakeover.test.tsx
+++ b/app/src/organisms/TakeoverModal/__tests__/MaintenanceRunTakeover.test.tsx
@@ -3,9 +3,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
 
-import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useNotifyCurrentMaintenanceRun } from '/app/resources/maintenance_runs'
 
 import { MaintenanceRunTakeover } from '../MaintenanceRunTakeover'

--- a/app/src/pages/ODD/RunningProtocol/__tests__/RunningProtocol.test.tsx
+++ b/app/src/pages/ODD/RunningProtocol/__tests__/RunningProtocol.test.tsx
@@ -15,9 +15,9 @@ import {
   useProtocolQuery,
   useRunActionMutations,
 } from '@opentrons/react-api-client'
-import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 
 import { renderWithProviders } from '/app/__testing-utils__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { mockRobotSideAnalysis } from '/app/molecules/Command/__fixtures__'
 /* eslint-disable-next-line opentrons/no-imports-across-applications */
 import { mockUseAllCommandsResponseNonDeterministic } from '/app/organisms/Desktop/RunProgressMeter/__fixtures__'

--- a/app/src/pages/ODD/RunningProtocol/__tests__/RunningProtocol.test.tsx
+++ b/app/src/pages/ODD/RunningProtocol/__tests__/RunningProtocol.test.tsx
@@ -15,6 +15,7 @@ import {
   useProtocolQuery,
   useRunActionMutations,
 } from '@opentrons/react-api-client'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { mockRobotSideAnalysis } from '/app/molecules/Command/__fixtures__'
@@ -143,10 +144,7 @@ describe('RunningProtocol', () => {
       completedAt: '2022-05-04T18:24:41.833862+00:00',
     })
     when(vi.mocked(useRunActionMutations))
-      .calledWith(RUN_ID, {
-        reasonForInteractionRequired: false,
-        isLoading: false,
-      })
+      .calledWith(RUN_ID, ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE)
       .thenReturn({
         playRun: mockPlayRun,
         pauseRun: mockPauseRun,

--- a/app/src/resources/maintenance_runs/hooks/useChainMaintenanceCommands.ts
+++ b/app/src/resources/maintenance_runs/hooks/useChainMaintenanceCommands.ts
@@ -1,9 +1,13 @@
 import { useState } from 'react'
 
-import { useCreateMaintenanceCommandMutation } from '@opentrons/react-api-client'
+import {
+  isDocumentedMutationError,
+  useCreateMaintenanceCommandMutation,
+} from '@opentrons/react-api-client'
 
 import { chainMaintenanceCommandsRecursive } from '../../runs'
 
+import type { CommandData } from '@opentrons/api-client'
 import type {
   DocumentationState,
   DocumentedAction,
@@ -40,7 +44,12 @@ export function useChainMaintenanceCommands(
         createMaintenanceCommand,
         continuePastCommandFailure,
         setIsLoading
-      ),
+      ).catch(error => {
+        if (isDocumentedMutationError(error)) {
+          return new Promise<CommandData[]>(() => {})
+        }
+        return Promise.reject(error)
+      }),
     isCommandMutationLoading: isLoading,
   }
 }

--- a/react-api-client/src/access_control/__fixtures__/documentationState.ts
+++ b/react-api-client/src/access_control/__fixtures__/documentationState.ts
@@ -1,0 +1,56 @@
+import { vi } from 'vitest'
+
+import type {
+  DocumentationReport,
+  DocumentationState,
+  DocumentedAction,
+} from '../types'
+
+type AskForDocumentation = (
+  actionsToDocument: DocumentedAction[],
+  onCancel?: () => void,
+  defaultDocReport?: DocumentationReport | null
+) => Promise<DocumentationReport>
+
+export const ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE: DocumentationState = {
+  isLoading: false,
+  accessControlEnabled: false,
+}
+
+export function createReasonNotRequiredDocumentationState(): DocumentationState {
+  return {
+    isLoading: false,
+    accessControlEnabled: true,
+    loginExpired: false,
+    askForLogin: vi.fn(async () => {}),
+    reasonForInteractionRequired: false,
+  }
+}
+
+export function createReasonRequiredWithDocReport(
+  docreport: DocumentationReport
+): DocumentationState {
+  return {
+    isLoading: false,
+    accessControlEnabled: true,
+    loginExpired: false,
+    askForLogin: vi.fn(async () => {}),
+    reasonForInteractionRequired: true,
+    docreport,
+    askForDocumentation: vi.fn(),
+  }
+}
+
+export function createReasonRequiredWithoutDocReport(
+  askForDocumentation: AskForDocumentation
+): DocumentationState {
+  return {
+    isLoading: false,
+    accessControlEnabled: true,
+    loginExpired: false,
+    askForLogin: vi.fn(async () => {}),
+    reasonForInteractionRequired: true,
+    docreport: null,
+    askForDocumentation,
+  }
+}

--- a/react-api-client/src/access_control/__fixtures__/documentationState.ts
+++ b/react-api-client/src/access_control/__fixtures__/documentationState.ts
@@ -9,7 +9,8 @@ import type {
 type AskForDocumentation = (
   actionsToDocument: DocumentedAction[],
   onCancel?: () => void,
-  defaultDocReport?: DocumentationReport | null
+  defaultDocReport?: DocumentationReport | null,
+  username?: string
 ) => Promise<DocumentationReport>
 
 export const ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE: DocumentationState = {
@@ -22,7 +23,7 @@ export function createReasonNotRequiredDocumentationState(): DocumentationState 
     isLoading: false,
     accessControlEnabled: true,
     loginExpired: false,
-    askForLogin: vi.fn(async () => {}),
+    askForLogin: vi.fn(async () => ({ username: 'alice' })),
     reasonForInteractionRequired: false,
   }
 }
@@ -34,7 +35,7 @@ export function createReasonRequiredWithDocReport(
     isLoading: false,
     accessControlEnabled: true,
     loginExpired: false,
-    askForLogin: vi.fn(async () => {}),
+    askForLogin: vi.fn(async () => ({ username: 'alice' })),
     reasonForInteractionRequired: true,
     docreport,
     askForDocumentation: vi.fn(),
@@ -48,7 +49,7 @@ export function createReasonRequiredWithoutDocReport(
     isLoading: false,
     accessControlEnabled: true,
     loginExpired: false,
-    askForLogin: vi.fn(async () => {}),
+    askForLogin: vi.fn(async () => ({ username: 'alice' })),
     reasonForInteractionRequired: true,
     docreport: null,
     askForDocumentation,

--- a/react-api-client/src/access_control/__tests__/useDocumentedMutation.test.tsx
+++ b/react-api-client/src/access_control/__tests__/useDocumentedMutation.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+  createReasonNotRequiredDocumentationState,
   createReasonRequiredWithDocReport,
   createReasonRequiredWithoutDocReport,
 } from '../__fixtures__/documentationState'
@@ -12,11 +13,18 @@ import { useDocumentedMutation } from '../useDocumentedMutation'
 
 import type { AxiosError } from 'axios'
 import type * as React from 'react'
-import type { DocumentationReport } from '../types'
+import type { DocumentationReport, DocumentationState } from '../types'
 
 const MOCK_REPORT = 'test note' as DocumentationReport
 
 const testMutationKey = ['acm', 'useDocumentedMutation', 'test'] as const
+
+function createAxios401Error(): AxiosError {
+  return {
+    isAxiosError: true,
+    response: { status: 401 },
+  } as AxiosError
+}
 
 describe('useDocumentedMutation', () => {
   let wrapper: React.FunctionComponent<{ children: React.ReactNode }>
@@ -29,6 +37,34 @@ describe('useDocumentedMutation', () => {
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     )
     wrapper = clientProvider
+  })
+
+  it('returns a working mutation when access control is on but reasonForInteractionRequired is off', async () => {
+    const mutationFn = vi.fn(async (n: number) => n + 1)
+
+    const { result } = renderHook(
+      () =>
+        useDocumentedMutation<number, AxiosError, number>(
+          createReasonNotRequiredDocumentationState(),
+          ['play_run'],
+          testMutationKey,
+          ({ variables: n, userNotes }) => {
+            expect(userNotes).toBe('')
+            return mutationFn(n)
+          },
+          {}
+        ),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.mutate(5)
+    })
+
+    await waitFor(() => {
+      expect(result.current.data).toBe(6)
+    })
+    expect(mutationFn).toHaveBeenCalledWith(5)
   })
 
   it('returns a working mutation when access control is disabled', async () => {
@@ -157,6 +193,205 @@ describe('useDocumentedMutation', () => {
       type: 'access_control_loading',
     })
     expect(mutationFn).not.toHaveBeenCalled()
+  })
+
+  it('prompts for login but not documentation after a 401 when reason is not required', async () => {
+    const askForLogin = vi.fn().mockResolvedValue({ username: 'alice' })
+    const askForDocumentation = vi.fn()
+    const mutationFn = vi
+      .fn()
+      .mockImplementationOnce(() => Promise.reject(createAxios401Error()))
+      .mockImplementationOnce(({ variables }: { variables: number }) =>
+        Promise.resolve(variables + 1)
+      )
+
+    const { result } = renderHook(
+      () =>
+        useDocumentedMutation<number, AxiosError, number>(
+          {
+            isLoading: false,
+            accessControlEnabled: true,
+            loginExpired: false,
+            askForLogin,
+            reasonForInteractionRequired: false,
+            askForDocumentation,
+          } as DocumentationState,
+          ['play_run'],
+          testMutationKey,
+          ({ variables }) => mutationFn({ variables }),
+          {}
+        ),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.mutate(5)
+    })
+
+    await waitFor(() => {
+      expect(result.current.data).toBe(6)
+    })
+    expect(askForLogin).toHaveBeenCalledTimes(1)
+    expect(askForDocumentation).not.toHaveBeenCalled()
+    expect(mutationFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('propagates non-401 errors without prompting for login', async () => {
+    const askForLogin = vi.fn()
+    const mutationFn = vi.fn().mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 500 },
+    } as AxiosError)
+
+    const askForDocumentation = vi.fn()
+    const { result } = renderHook(
+      () =>
+        useDocumentedMutation<number, AxiosError, number>(
+          {
+            isLoading: false,
+            accessControlEnabled: true,
+            loginExpired: false,
+            askForLogin,
+            reasonForInteractionRequired: true,
+            docreport: MOCK_REPORT,
+            askForDocumentation,
+          },
+          ['play_run'],
+          testMutationKey,
+          ({ variables: n }) => mutationFn(n),
+          {}
+        ),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.mutate(5)
+    })
+
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined()
+    })
+    expect(askForLogin).not.toHaveBeenCalled()
+    expect(mutationFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not prompt for login after a 401 when access control is disabled', async () => {
+    const mutationFn = vi.fn().mockRejectedValue(createAxios401Error())
+
+    const { result } = renderHook(
+      () =>
+        useDocumentedMutation<number, AxiosError, number>(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+          ['play_run'],
+          testMutationKey,
+          ({ variables: n }) => mutationFn(n),
+          {}
+        ),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.mutate(5)
+    })
+
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined()
+    })
+    expect(mutationFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('prompts for login and re-documents after a 401, then reruns the mutation', async () => {
+    const askForLogin = vi.fn().mockResolvedValue({ username: 'alice' })
+    const askForDocumentation = vi.fn().mockResolvedValue(MOCK_REPORT)
+    const mutationFn = vi
+      .fn()
+      .mockImplementationOnce(() => Promise.reject(createAxios401Error()))
+      .mockImplementationOnce(({ variables }: { variables: string }) =>
+        Promise.resolve(`${variables}-ok`)
+      )
+
+    const { result } = renderHook(
+      () =>
+        useDocumentedMutation<string, AxiosError, string>(
+          {
+            isLoading: false,
+            accessControlEnabled: true,
+            loginExpired: false,
+            askForLogin,
+            reasonForInteractionRequired: true,
+            docreport: MOCK_REPORT,
+            askForDocumentation,
+          },
+          ['play_run'],
+          testMutationKey,
+          ({ variables }) => mutationFn({ variables }),
+          {}
+        ),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.mutate('run')
+    })
+
+    await waitFor(() => {
+      expect(result.current.data).toBe('run-ok')
+    })
+    expect(askForLogin).toHaveBeenCalledTimes(1)
+    expect(askForDocumentation).toHaveBeenCalledWith(
+      ['play_run'],
+      undefined,
+      MOCK_REPORT,
+      'alice'
+    )
+    expect(mutationFn).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws when user cancels re-documentation after login', async () => {
+    const askForLogin = vi.fn().mockResolvedValue({ username: 'alice' })
+    const askForDocumentation = vi
+      .fn()
+      .mockResolvedValue('' as DocumentationReport)
+    const mutationFn = vi.fn().mockRejectedValue(createAxios401Error())
+
+    const { result } = renderHook(
+      () =>
+        useDocumentedMutation<number, DocumentedMutationError, number>(
+          {
+            isLoading: false,
+            accessControlEnabled: true,
+            loginExpired: false,
+            askForLogin,
+            reasonForInteractionRequired: true,
+            docreport: MOCK_REPORT,
+            askForDocumentation,
+          },
+          ['play_run'],
+          testMutationKey,
+          ({ variables: n }) => mutationFn(n),
+          {}
+        ),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.mutate(5)
+    })
+
+    await waitFor(() => {
+      expect(result.current.error).toBeInstanceOf(DocumentedMutationError)
+    })
+    expect(result.current.error).toMatchObject({
+      type: 'no_documentation_report',
+    })
+    expect(askForLogin).toHaveBeenCalledTimes(1)
+    expect(askForDocumentation).toHaveBeenCalledWith(
+      ['play_run'],
+      undefined,
+      MOCK_REPORT,
+      'alice'
+    )
+    expect(mutationFn).toHaveBeenCalledTimes(1)
   })
 
   it('throws DocumentedMutationError when documentation is required but not provided', async () => {

--- a/react-api-client/src/access_control/__tests__/useDocumentedMutation.test.tsx
+++ b/react-api-client/src/access_control/__tests__/useDocumentedMutation.test.tsx
@@ -2,6 +2,11 @@ import { QueryClient, QueryClientProvider } from 'react-query'
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import {
+  ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+  createReasonRequiredWithDocReport,
+  createReasonRequiredWithoutDocReport,
+} from '../__fixtures__/documentationState'
 import { DocumentedMutationError } from '../types'
 import { useDocumentedMutation } from '../useDocumentedMutation'
 
@@ -32,7 +37,7 @@ describe('useDocumentedMutation', () => {
     const { result } = renderHook(
       () =>
         useDocumentedMutation<number, AxiosError, number>(
-          { reasonForInteractionRequired: false, isLoading: false },
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
           ['play_run'],
           testMutationKey,
           ({ variables: n }) => mutationFn(n),
@@ -57,11 +62,7 @@ describe('useDocumentedMutation', () => {
     const { result } = renderHook(
       () =>
         useDocumentedMutation<number, AxiosError, number>(
-          {
-            reasonForInteractionRequired: true,
-            docreport: MOCK_REPORT,
-            isLoading: false,
-          },
+          createReasonRequiredWithDocReport(MOCK_REPORT),
           ['play_run'],
           testMutationKey,
           ({ variables: x }) => mutationFn(x),
@@ -87,12 +88,7 @@ describe('useDocumentedMutation', () => {
     const { result } = renderHook(
       () =>
         useDocumentedMutation<string, AxiosError, string>(
-          {
-            reasonForInteractionRequired: true,
-            docreport: null,
-            askForDocumentation,
-            isLoading: false,
-          },
+          createReasonRequiredWithoutDocReport(askForDocumentation),
           ['play_run'],
           testMutationKey,
           ({ variables: s }) => mutationFn(s),
@@ -117,12 +113,7 @@ describe('useDocumentedMutation', () => {
     const { result } = renderHook(
       () =>
         useDocumentedMutation<string, AxiosError, string>(
-          {
-            reasonForInteractionRequired: true,
-            docreport: null,
-            askForDocumentation,
-            isLoading: false,
-          },
+          createReasonRequiredWithoutDocReport(askForDocumentation),
           ['play_run'],
           testMutationKey,
           ({ variables: s }) => mutationFn(s),
@@ -177,12 +168,7 @@ describe('useDocumentedMutation', () => {
     const { result } = renderHook(
       () =>
         useDocumentedMutation<number, DocumentedMutationError, number>(
-          {
-            reasonForInteractionRequired: true,
-            docreport: null,
-            askForDocumentation,
-            isLoading: false,
-          },
+          createReasonRequiredWithoutDocReport(askForDocumentation),
           ['play_run'],
           testMutationKey,
           ({ variables: n }) => mutationFn(n),

--- a/react-api-client/src/access_control/types.ts
+++ b/react-api-client/src/access_control/types.ts
@@ -60,7 +60,7 @@ export type DocumentationState =
 export interface MutationAuthenticationState {
   accessControlEnabled: true
   loginExpired: boolean
-  askForLogin: () => Promise<void>
+  askForLogin: () => Promise<{ username: string } | null>
 }
 
 export type MutationDocumentationState =
@@ -73,7 +73,8 @@ export type MutationDocumentationState =
       askForDocumentation: (
         actionsToDocument: DocumentedAction[],
         onCancel?: () => void,
-        defaultDocReport?: DocumentationReport | null
+        initialDocreport?: DocumentationReport,
+        username?: string
       ) => Promise<DocumentationReport>
     }
 

--- a/react-api-client/src/access_control/types.ts
+++ b/react-api-client/src/access_control/types.ts
@@ -48,20 +48,33 @@ export function isDocumentedMutationError(
  */
 export type DocumentationState =
   | { isLoading: true }
-  | { reasonForInteractionRequired: false; isLoading: false }
   | {
-      reasonForInteractionRequired: true
-      docreport: DocumentationReport
       isLoading: false
+      accessControlEnabled: false
+    }
+  | ({
+      isLoading: false
+    } & MutationAuthenticationState &
+      MutationDocumentationState)
+
+export interface MutationAuthenticationState {
+  accessControlEnabled: true
+  loginExpired: boolean
+  askForLogin: () => Promise<void>
+}
+
+export type MutationDocumentationState =
+  | {
+      reasonForInteractionRequired: false
     }
   | {
       reasonForInteractionRequired: true
-      docreport: null
+      docreport: DocumentationReport | null
       askForDocumentation: (
         actionsToDocument: DocumentedAction[],
-        onCancel?: () => void
+        onCancel?: () => void,
+        defaultDocReport?: DocumentationReport | null
       ) => Promise<DocumentationReport>
-      isLoading: false
     }
 
 export interface DocumentedMutationParameters<TVariables = void> {

--- a/react-api-client/src/access_control/types.ts
+++ b/react-api-client/src/access_control/types.ts
@@ -13,6 +13,7 @@ export type DocumentationReport = string & {
 export type DocumentedMutationErrorType =
   | 'no_documentation_report'
   | 'access_control_loading'
+  | 'login_cancelled'
 
 const DOCUMENTED_MUTATION_ERROR_MESSAGES: Record<
   DocumentedMutationErrorType,
@@ -20,6 +21,7 @@ const DOCUMENTED_MUTATION_ERROR_MESSAGES: Record<
 > = {
   no_documentation_report: 'No documentation report provided',
   access_control_loading: 'Access control queries are still loading',
+  login_cancelled: 'Login cancelled by user',
 }
 
 export class DocumentedMutationError extends Error {

--- a/react-api-client/src/access_control/useDocumentedMutation.ts
+++ b/react-api-client/src/access_control/useDocumentedMutation.ts
@@ -30,8 +30,6 @@ import type {
  *
  * useGuardedAction is a helper hook in /app that generates a documentation state.
  *
- * TODO(jj): actually pass along the documentation report to the mutation.
- *
  * Call signatures live in ./types as `UseDocumentedMutation`.
  */
 export const useDocumentedMutation: UseDocumentedMutation = (

--- a/react-api-client/src/access_control/useDocumentedMutation.ts
+++ b/react-api-client/src/access_control/useDocumentedMutation.ts
@@ -1,8 +1,9 @@
-import { useCallback } from 'react'
+import { useCallback, useRef } from 'react'
 import { useMutation } from 'react-query'
 
 import { DocumentedMutationError } from './types'
 
+import type { MutableRefObject } from 'react'
 import type {
   MutationFunction,
   MutationKey,
@@ -62,16 +63,21 @@ function useWrappedMutationFn<TData, TVariables>(
   documentationState: DocumentationState,
   actionsToDocument: DocumentedAction[]
 ): MutationFunction<TData, TVariables> {
+  // using a ref avoids stale mutation functions after a change in the host causes a rerender
+  // i.e. when the user is prompted to log in again
+  const mutationFnRef = useRef(mutationFn)
+  mutationFnRef.current = mutationFn
+
   const wrappedMutationFn = useCallback(
     async (variables: TVariables) => {
       return await runMutation(
         documentationState,
         actionsToDocument,
-        mutationFn,
+        mutationFnRef,
         variables
       )
     },
-    [actionsToDocument, documentationState, mutationFn]
+    [actionsToDocument, documentationState]
   )
   return wrappedMutationFn
 }
@@ -79,7 +85,9 @@ function useWrappedMutationFn<TData, TVariables>(
 async function runMutation<TData, TVariables>(
   documentationState: DocumentationState,
   actionsToDocument: DocumentedAction[],
-  mutationFn: DocumentedMutationFunction<TData, TVariables>,
+  mutationFnRef: MutableRefObject<
+    DocumentedMutationFunction<TData, TVariables>
+  >,
   variables: TVariables
 ): Promise<TData> {
   if (documentationState.isLoading) {
@@ -99,7 +107,7 @@ async function runMutation<TData, TVariables>(
       return await runMutation(
         { ...documentationState, docreport: dr },
         actionsToDocument,
-        mutationFn,
+        mutationFnRef,
         variables
       )
     }
@@ -109,41 +117,44 @@ async function runMutation<TData, TVariables>(
     documentationState.accessControlEnabled &&
     documentationState.loginExpired
   ) {
-    await documentationState.askForLogin()
+    const loginResult = await documentationState.askForLogin()
     if (documentationState.reasonForInteractionRequired) {
       const dr = await documentationState.askForDocumentation(
         actionsToDocument,
         undefined,
-        documentationState.docreport
+        documentationState.docreport ?? undefined,
+        loginResult?.username
       )
       return await runMutation(
         { ...documentationState, docreport: dr, loginExpired: false },
         actionsToDocument,
-        mutationFn,
+        mutationFnRef,
         variables
       )
     }
   }
 
-  return await mutationFn({
-    variables,
-    userNotes:
-      documentationState.accessControlEnabled &&
-      documentationState.reasonForInteractionRequired
-        ? (documentationState.docreport ?? '')
-        : '',
-  }).catch(async e => {
-    if (
-      e.isAxiosError &&
-      e.response?.status === 401 &&
-      documentationState.accessControlEnabled
-    ) {
-      return await runMutation(
-        { ...documentationState, loginExpired: true },
-        actionsToDocument,
-        mutationFn,
-        variables
-      )
-    } else throw e
-  })
+  return await mutationFnRef
+    .current({
+      variables,
+      userNotes:
+        documentationState.accessControlEnabled &&
+        documentationState.reasonForInteractionRequired
+          ? (documentationState.docreport ?? '')
+          : '',
+    })
+    .catch(async e => {
+      if (
+        e.isAxiosError &&
+        e.response?.status === 401 &&
+        documentationState.accessControlEnabled
+      ) {
+        return await runMutation(
+          { ...documentationState, loginExpired: true },
+          actionsToDocument,
+          mutationFnRef,
+          variables
+        )
+      } else throw e
+    })
 }

--- a/react-api-client/src/access_control/useDocumentedMutation.ts
+++ b/react-api-client/src/access_control/useDocumentedMutation.ts
@@ -9,7 +9,6 @@ import type {
   UseMutationOptions,
 } from 'react-query'
 import type {
-  DocumentationReport,
   DocumentationState,
   DocumentedAction,
   DocumentedMutationFunction,
@@ -58,22 +57,6 @@ export const useDocumentedMutation: UseDocumentedMutation = (
   })
 }
 
-const checkDocumentationReport = async (
-  documentationState: DocumentationState,
-  actionsToDocument: DocumentedAction[]
-): Promise<DocumentationReport | null> => {
-  if (
-    documentationState.isLoading ||
-    !documentationState.reasonForInteractionRequired
-  ) {
-    return null
-  }
-  if (documentationState.docreport != null) {
-    return documentationState.docreport
-  }
-  return await documentationState.askForDocumentation(actionsToDocument)
-}
-
 function useWrappedMutationFn<TData, TVariables>(
   mutationFn: DocumentedMutationFunction<TData, TVariables>,
   documentationState: DocumentationState,
@@ -81,32 +64,86 @@ function useWrappedMutationFn<TData, TVariables>(
 ): MutationFunction<TData, TVariables> {
   const wrappedMutationFn = useCallback(
     async (variables: TVariables) => {
-      const docreport = await checkDocumentationReport(
+      return await runMutation(
         documentationState,
-        actionsToDocument
+        actionsToDocument,
+        mutationFn,
+        variables
       )
-      if (documentationState.isLoading) {
-        throw new DocumentedMutationError('access_control_loading')
-      }
-      if (!isDocumentationProvided(documentationState, docreport)) {
-        throw new DocumentedMutationError('no_documentation_report')
-      }
-      return await mutationFn({ variables, userNotes: docreport ?? '' })
     },
     [actionsToDocument, documentationState, mutationFn]
   )
   return wrappedMutationFn
 }
 
-const isDocumentationProvided = (
-  state: DocumentationState,
-  docreport: DocumentationReport | null
-): boolean => {
-  if (state.isLoading) {
-    return false
+async function runMutation<TData, TVariables>(
+  documentationState: DocumentationState,
+  actionsToDocument: DocumentedAction[],
+  mutationFn: DocumentedMutationFunction<TData, TVariables>,
+  variables: TVariables
+): Promise<TData> {
+  if (documentationState.isLoading) {
+    throw new DocumentedMutationError('access_control_loading')
   }
-  if (!state.reasonForInteractionRequired) {
-    return true
+  if (
+    documentationState.accessControlEnabled &&
+    documentationState.reasonForInteractionRequired
+  ) {
+    // user has backed out of the documentation modal
+    if (documentationState.docreport === '') {
+      throw new DocumentedMutationError('no_documentation_report')
+    }
+    // no documentation report yet, ask for it
+    if (documentationState.docreport == null) {
+      const dr = await documentationState.askForDocumentation(actionsToDocument)
+      return await runMutation(
+        { ...documentationState, docreport: dr },
+        actionsToDocument,
+        mutationFn,
+        variables
+      )
+    }
   }
-  return docreport != null && docreport.length > 0
+
+  if (
+    documentationState.accessControlEnabled &&
+    documentationState.loginExpired
+  ) {
+    await documentationState.askForLogin()
+    if (documentationState.reasonForInteractionRequired) {
+      const dr = await documentationState.askForDocumentation(
+        actionsToDocument,
+        undefined,
+        documentationState.docreport
+      )
+      return await runMutation(
+        { ...documentationState, docreport: dr, loginExpired: false },
+        actionsToDocument,
+        mutationFn,
+        variables
+      )
+    }
+  }
+
+  return await mutationFn({
+    variables,
+    userNotes:
+      documentationState.accessControlEnabled &&
+      documentationState.reasonForInteractionRequired
+        ? (documentationState.docreport ?? '')
+        : '',
+  }).catch(async e => {
+    if (
+      e.isAxiosError &&
+      e.response?.status === 401 &&
+      documentationState.accessControlEnabled
+    ) {
+      return await runMutation(
+        { ...documentationState, loginExpired: true },
+        actionsToDocument,
+        mutationFn,
+        variables
+      )
+    } else throw e
+  })
 }

--- a/react-api-client/src/access_control/useDocumentedMutation.ts
+++ b/react-api-client/src/access_control/useDocumentedMutation.ts
@@ -116,6 +116,10 @@ async function runMutation<TData, TVariables>(
     documentationState.loginExpired
   ) {
     const loginResult = await documentationState.askForLogin()
+    if (loginResult == null || loginResult.username.length === 0) {
+      throw new DocumentedMutationError('login_cancelled')
+    }
+
     if (documentationState.reasonForInteractionRequired) {
       const dr = await documentationState.askForDocumentation(
         actionsToDocument,

--- a/react-api-client/src/maintenance_runs/__tests__/useCreateMaintenanceCommandMutation.test.tsx
+++ b/react-api-client/src/maintenance_runs/__tests__/useCreateMaintenanceCommandMutation.test.tsx
@@ -6,6 +6,7 @@ import { createMaintenanceCommand } from '@opentrons/api-client'
 
 import { useCreateMaintenanceCommandMutation } from '..'
 import { MAINTENANCE_RUN_ID, mockAnonLoadCommand } from '../__fixtures__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../access_control/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -38,7 +39,7 @@ describe('useCreateMaintenanceCommandMutation hook', () => {
     const { result } = renderHook(
       () =>
         useCreateMaintenanceCommandMutation(
-          { reasonForInteractionRequired: false, isLoading: false },
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
           ['lpc_flow'],
           () => {}
         ),
@@ -69,7 +70,7 @@ describe('useCreateMaintenanceCommandMutation hook', () => {
     const { result } = renderHook(
       () =>
         useCreateMaintenanceCommandMutation(
-          { reasonForInteractionRequired: false, isLoading: false },
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
           ['lpc_flow'],
           () => {}
         ),

--- a/react-api-client/src/maintenance_runs/__tests__/useCreateMaintenanceRunMutation.test.tsx
+++ b/react-api-client/src/maintenance_runs/__tests__/useCreateMaintenanceRunMutation.test.tsx
@@ -6,6 +6,7 @@ import { createMaintenanceRun } from '@opentrons/api-client'
 
 import { useCreateMaintenanceRunMutation } from '..'
 import { mockMaintenanceRunResponse } from '../__fixtures__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../access_control/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -41,7 +42,7 @@ describe('useCreateMaintenanceRunMutation hook', () => {
     const { result } = renderHook(
       () =>
         useCreateMaintenanceRunMutation(
-          { reasonForInteractionRequired: false, isLoading: false },
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
           ['lpc_flow']
         ),
       {
@@ -71,7 +72,7 @@ describe('useCreateMaintenanceRunMutation hook', () => {
     const { result } = renderHook(
       () =>
         useCreateMaintenanceRunMutation(
-          { reasonForInteractionRequired: false, isLoading: false },
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
           ['lpc_flow']
         ),
       {

--- a/react-api-client/src/maintenance_runs/__tests__/useDeleteMaintenanceRunMutation.test.tsx
+++ b/react-api-client/src/maintenance_runs/__tests__/useDeleteMaintenanceRunMutation.test.tsx
@@ -6,6 +6,7 @@ import { deleteMaintenanceRun } from '@opentrons/api-client'
 
 import { useDeleteMaintenanceRunMutation } from '..'
 import { MAINTENANCE_RUN_ID } from '../__fixtures__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../access_control/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -37,7 +38,7 @@ describe('useDeleteMaintenanceRunMutation hook', () => {
     const { result } = renderHook(
       () =>
         useDeleteMaintenanceRunMutation(
-          { reasonForInteractionRequired: false, isLoading: false },
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
           []
         ),
       {
@@ -61,7 +62,7 @@ describe('useDeleteMaintenanceRunMutation hook', () => {
     const { result } = renderHook(
       () =>
         useDeleteMaintenanceRunMutation(
-          { reasonForInteractionRequired: false, isLoading: false },
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
           []
         ),
       {

--- a/react-api-client/src/runs/__tests__/usePlayRunMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/usePlayRunMutation.test.tsx
@@ -6,6 +6,7 @@ import { createRunAction } from '@opentrons/api-client'
 
 import { usePlayRunMutation } from '..'
 import { mockPlayRunAction, RUN_ID_1 } from '../__fixtures__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../access_control/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -37,11 +38,7 @@ describe('usePlayRunMutation hook', () => {
     vi.mocked(createRunAction).mockRejectedValue('oh no')
 
     const { result } = renderHook(
-      () =>
-        usePlayRunMutation({
-          reasonForInteractionRequired: false,
-          isLoading: false,
-        }),
+      () => usePlayRunMutation(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
       { wrapper }
     )
 
@@ -59,11 +56,7 @@ describe('usePlayRunMutation hook', () => {
     } as Response<RunAction>)
 
     const { result } = renderHook(
-      () =>
-        usePlayRunMutation({
-          reasonForInteractionRequired: false,
-          isLoading: false,
-        }),
+      () => usePlayRunMutation(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
       {
         wrapper,
       }

--- a/react-api-client/src/runs/__tests__/useRunActionMutations.test.tsx
+++ b/react-api-client/src/runs/__tests__/useRunActionMutations.test.tsx
@@ -11,6 +11,7 @@ import {
   useStopRunMutation,
 } from '..'
 import { RUN_ID_1 } from '../__fixtures__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../access_control/__fixtures__/documentationState'
 
 import type * as React from 'react'
 import type {
@@ -75,10 +76,10 @@ describe('useRunActionMutations hook', () => {
 
     const { result } = renderHook(
       () =>
-        useRunActionMutations(RUN_ID_1, {
-          reasonForInteractionRequired: false,
-          isLoading: false,
-        }),
+        useRunActionMutations(
+          RUN_ID_1,
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+        ),
       {
         wrapper,
       }

--- a/react-api-client/src/runs/__tests__/useStopRunMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/useStopRunMutation.test.tsx
@@ -6,6 +6,7 @@ import { createRunAction } from '@opentrons/api-client'
 
 import { useStopRunMutation } from '..'
 import { mockStopRunAction, RUN_ID_1 } from '../__fixtures__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../access_control/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -34,11 +35,7 @@ describe('useStopRunMutation hook', () => {
     vi.mocked(createRunAction).mockRejectedValue('oops')
 
     const { result } = renderHook(
-      () =>
-        useStopRunMutation({
-          reasonForInteractionRequired: false,
-          isLoading: false,
-        }),
+      () => useStopRunMutation(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
       {
         wrapper,
       }
@@ -58,11 +55,7 @@ describe('useStopRunMutation hook', () => {
     } as Response<RunAction>)
 
     const { result } = renderHook(
-      () =>
-        useStopRunMutation({
-          reasonForInteractionRequired: false,
-          isLoading: false,
-        }),
+      () => useStopRunMutation(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
       {
         wrapper,
       }


### PR DESCRIPTION
# Overview


https://github.com/user-attachments/assets/d605e962-fb34-4571-824f-071e52a4c2ad

Adds support so that if a user is logged out during a maintenance run or while documenting an action, they are prompted to log in again.

## Test Plan and Hands on Testing

1. On a compliance ready bot, set the idle logout time to ~30 seconds. 
2. Start a maintenance run or take another action requiring documentation - you should be prompted to log in. Log in and fill out the documentation modal.
3. Wait 30 seconds until you're idle logged out again. 
4. Click submit on the documentation modal, or next on the maintenance run. 
5. You should be prompted to log in again, and once you log in, the documentation modal should pop up again. 
6. Backing out of the login modal should return you to whatever step in the flow you were previously on.

## Risk assessment

Medium - there might be weird edge cases remaining. 

This PR also does not deal with the encryption keys or a current bug in the action list on desktop documentation modals.