### PR TITLE
fix(app): fix action list display on desktop

### DIFF
--- a/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequiredModal.tsx
+++ b/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequiredModal.tsx
@@ -2,6 +2,8 @@ import { createPortal } from 'react-dom'
 import NiceModal, { useModal } from '@ebay/nice-modal-react'
 
 import { getTopPortalEl } from '/app/App/portal'
+import { ApiHostProvider } from '/app/local-resources/api-host-provider/ApiHostProvider'
+import { useCurrentRobotName } from '/app/redux/robot-auth'
 
 import { DocumentationRequired } from './DocumentationRequired'
 
@@ -23,6 +25,7 @@ const DocumentationRequiredModalImpl = NiceModal.create(
     initialDocreport?: DocumentationReport
   }): JSX.Element => {
     const modal = useModal()
+    const robotName = useCurrentRobotName()
 
     const handleConfirm = (note: string): void => {
       const result: DocumentationReport = note as DocumentationReport
@@ -37,13 +40,15 @@ const DocumentationRequiredModalImpl = NiceModal.create(
     }
 
     return createPortal(
-      <DocumentationRequired
-        username={username}
-        actionsToDocument={actionsToDocument}
-        onConfirm={handleConfirm}
-        onClose={handleBack}
-        initialDocreport={initialDocreport}
-      />,
+      <ApiHostProvider robotName={robotName}>
+        <DocumentationRequired
+          username={username}
+          actionsToDocument={actionsToDocument}
+          onConfirm={handleConfirm}
+          onClose={handleBack}
+          initialDocreport={initialDocreport}
+        />
+      </ApiHostProvider>,
       getTopPortalEl()
     )
   }


### PR DESCRIPTION
# Overview

https://github.com/user-attachments/assets/f17804c8-6b5b-4469-ba80-a7174ef27847

CommandText components in action lists in Documentation Required modals on desktop were not rendering correctly due to missing maintenance run info. This fixes that

## Test Plan and Hands on Testing

1. Launch a maintenance run on a compliance ready bot from the desktop app
2. Proceed through the run until the end
3. When the final modal pops up, the action list should render correctly with proper display text. 

## Risk assessment

Low