### PR TITLE
chore: add Flex RS 9.1.1 release notes

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -6,6 +6,14 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 By installing and using Opentrons software, you agree to the Opentrons End-User License Agreement (EULA). You can view the EULA at [opentrons.com/eula](https://opentrons.com/eula).
 
+## Opentrons Robot Software Changes in 9.1.1
+
+Welcome to the v9.1.1 release of the Opentrons Flex robot software! This release includes changes to the way your Flex and the Opentrons App receive and install software updates.
+
+Installing Opentrons Flex v9.1.1 robot software adds a new robot and Opentrons App setting ("Automatically Download Updates") that's turned off by default: 
+- When turned off, app and robot updates will not automatically download.
+- When turned on, app and robot updates will automatically download, but not be installed. 
+
 ## Opentrons Robot Software Changes in 9.1.0
 
 Welcome to the v9.1.0 release of the Opentrons Flex robot software! This release enables step grouping to better visualize and organize Python protocols, along with other new features, improvements, and bug fixes.

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -8,19 +8,15 @@ By installing and using Opentrons software, you agree to the Opentrons End-User 
 
 ## Opentrons Robot Software Changes in 9.1.1
 
-Welcome to the v9.1.1 release of the Opentrons Flex robot software! This release includes changes to the way your Flex and the Opentrons App receive and install software updates.
-
-Installing Opentrons Flex v9.1.1 robot software adds a new robot and Opentrons App setting ("Automatically Download Updates") that's turned off by default: 
-- When turned off, app and robot updates will not automatically download.
-- When turned on, app and robot updates will automatically download, but not be installed. 
-
-## Opentrons Robot Software Changes in 9.1.0
-
-Welcome to the v9.1.0 release of the Opentrons Flex robot software! This release enables step grouping to better visualize and organize Python protocols, along with other new features, improvements, and bug fixes.
+Welcome to the v9.1.1 release of the Opentrons Flex robot software! This release enables step grouping to better visualize and organize Python protocols, along with other new features, improvements, and bug fixes.
 
 ### New Features
 
 - Use new methods to create step groups within your Python protocols. These groups are visible in your protocol file, or in [protocol visualization](https://docs.opentrons.com/flex/opentrons-app/protocol-viz/).
+- Adds a new robot setting ("Automatically Download Updates") that's turned off by default:
+  - When turned off, robot updates will not automatically download.
+  - When turned on, robot updates will automatically download, but not be installed.
+  - After downloading a new robot update, click to install.
 - Use the `set_empty()` method to label a tip rack as empty, and return used tips to an empty rack throughout your protocol.
 - Attach and use a keyboard (via USB) to set up quick transfer protocols, enter passwords and runtime parameters, and more on the Flex touchscreen.
 - Adds the ability to turn off the Flex from the touchscreen. Click the three-dot menu, then click to **Turn off robot**. When it's time to restart your Flex, use the power switch on the rear panel.

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -13,10 +13,6 @@ Welcome to the v9.1.1 release of the Opentrons Flex robot software! This release
 ### New Features
 
 - Use new methods to create step groups within your Python protocols. These groups are visible in your protocol file, or in [protocol visualization](https://docs.opentrons.com/flex/opentrons-app/protocol-viz/).
-- Adds a new robot setting ("Automatically Download Updates") that's turned off by default:
-  - When turned off, robot updates will not automatically download.
-  - When turned on, robot updates will automatically download, but not be installed.
-  - After downloading a new robot update, click to install.
 - Use the `set_empty()` method to label a tip rack as empty, and return used tips to an empty rack throughout your protocol.
 - Attach and use a keyboard (via USB) to set up quick transfer protocols, enter passwords and runtime parameters, and more on the Flex touchscreen.
 - Adds the ability to turn off the Flex from the touchscreen. Click the three-dot menu, then click to **Turn off robot**. When it's time to restart your Flex, use the power switch on the rear panel.

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -17,7 +17,7 @@ You'll need to use the Opentrons App to update from the previous release (v9.0.0
 ### New Features
 
 - Use the updated Opentrons App to control and work with your Flex, including running protocols. Download the OT-2 App to control the OT-2 liquid handling robot.
-- Adds a new Opentrons App and Flex touchscreen setting ("Automatically Download Updates") that's turned off by default:
+- Adds a new setting to both the Opentrons App and Flex touchscreen ("Automatically Download Updates"). On the Flex touchscreen, this is turned off by default:
   - When turned off, robot and app updates will not automatically download.
   - When turned on, robot app updates will automatically download, but not be installed.
   - After downloading an update, click to install.

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -15,7 +15,7 @@ Welcome to the v9.1.1 release of the Opentrons App! This release is designed spe
 ### New Features
 
 - Use the updated Opentrons App to control and work with your Flex, including running protocols. Download the OT-2 App to control the OT-2 liquid handling robot.
-- Adds a new Opentrons App setting ("Automatically Download Updates") that's turned off by default:
+- Adds a new Opentrons App and Flex touchscreen setting ("Automatically Download Updates") that's turned off by default:
   - When turned off, app updates will not automatically download.
   - When turned on, app updates will automatically download, but not be installed.
   - After downloading an app update, click to install.

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -12,7 +12,7 @@ Welcome to the v9.1.1 release of the Opentrons App! This release is designed spe
 
 **OT-2 robots will no longer appear in the Opentrons App.** v9.1.0 will prompt you to get the separate Opentrons OT-2 App, or you can download it directly from <https://opentrons.com/app>.
 
-You'll need to use the Opentrons App to update from the previous release (v9.0.0) to any other release. Read about other changes to software updates below. 
+You'll need to use the Opentrons App to update from the previous release (v9.0.0) to any other release. Read about other changes to software updates below.
 
 ### New Features
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -6,15 +6,19 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 By installing and using Opentrons software, you agree to the Opentrons End-User License Agreement (EULA). You can view the EULA at [opentrons.com/eula](https://opentrons.com/eula).
 
-## Opentrons App Changes in 9.1.0
+## Opentrons App Changes in 9.1.1
 
-Welcome to the v9.1.0 release of the Opentrons App! This release is designed specifically for use with Opentrons Flex and includes other new features, improvements, and bug fixes.
+Welcome to the v9.1.1 release of the Opentrons App! This release is designed specifically for use with Opentrons Flex and includes other new features, improvements, and bug fixes.
 
 **OT-2 robots will no longer appear in the Opentrons App.** v9.1.0 will prompt you to get the separate Opentrons OT-2 App, or you can download it directly from <https://opentrons.com/app>.
 
 ### New Features
 
 - Use the updated Opentrons App to control and work with your Flex, including running protocols. Download the OT-2 App to control the OT-2 liquid handling robot.
+- Adds a new Opentrons App setting ("Automatically Download Updates") that's turned off by default:
+  - When turned off, app updates will not automatically download.
+  - When turned on, app updates will automatically download, but not be installed.
+  - After downloading an app update, click to install.
 - View step groups added to your protocols in [visualization](https://docs.opentrons.com/flex/opentrons-app/protocol-viz/).
 - Attach and use a keyboard (via USB) to set up quick transfer protocols, enter passwords and runtime parameters, and more in the Opentrons App.
 - Adds the ability to turn off the Flex from the Opentrons App. Under Devices, click the three-dot menu for your robot, then click to **Turn off robot**. When it's time to restart your Flex, use the power switch on the rear panel.

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -12,13 +12,15 @@ Welcome to the v9.1.1 release of the Opentrons App! This release is designed spe
 
 **OT-2 robots will no longer appear in the Opentrons App.** v9.1.0 will prompt you to get the separate Opentrons OT-2 App, or you can download it directly from <https://opentrons.com/app>.
 
+You'll need to use the Opentrons App to update from the previous release (v9.0.0) to any other release. Read about other changes to software updates below. 
+
 ### New Features
 
 - Use the updated Opentrons App to control and work with your Flex, including running protocols. Download the OT-2 App to control the OT-2 liquid handling robot.
 - Adds a new Opentrons App and Flex touchscreen setting ("Automatically Download Updates") that's turned off by default:
-  - When turned off, app updates will not automatically download.
-  - When turned on, app updates will automatically download, but not be installed.
-  - After downloading an app update, click to install.
+  - When turned off, robot and app updates will not automatically download.
+  - When turned on, robot app updates will automatically download, but not be installed.
+  - After downloading an update, click to install.
 - View step groups added to your protocols in [visualization](https://docs.opentrons.com/flex/opentrons-app/protocol-viz/).
 - Attach and use a keyboard (via USB) to set up quick transfer protocols, enter passwords and runtime parameters, and more in the Opentrons App.
 - Adds the ability to turn off the Flex from the Opentrons App. Under Devices, click the three-dot menu for your robot, then click to **Turn off robot**. When it's time to restart your Flex, use the power switch on the rear panel.


### PR DESCRIPTION
# Overview

adding 9.1.1 release notes: 
- collapse 9.1.0 notes into 9.1.1 for both the app and robot software; 9.1.0 no longer exists (and we specify API v2.29 as 9.1.0 in [the API docs](https://docs.opentrons.com/python-api/versioning/#api-and-robot-software-versions))
- add a description of the new "Automatically download updates" setting in both the app/on the robot and add as many details as I have about the new update flow

does _not_ include a description of the issue that prompted us to make this change to how the robot/app update


## Test Plan and Hands on Testing



## Changelog



## Review requests

am I describing this correctly? anywhere I can be more specific? 

## Risk assessment

low
