### PR TITLE
feat(app): add a filter to sentry init for n+1 api call

### DIFF
--- a/app-shell/src/sentry.ts
+++ b/app-shell/src/sentry.ts
@@ -75,6 +75,12 @@ export const initializeSentry = (isAnalyticsEnabled: boolean): void => {
         }
         return event
       },
+      beforeSendTransaction(event) {
+        if (event.transaction === '/') {
+          return null
+        }
+        return event
+      },
     })
 
     isSentryInitialized = true

--- a/app/src/App/sentry.ts
+++ b/app/src/App/sentry.ts
@@ -94,6 +94,12 @@ export const initializeSentry = (isAnalyticsEnabled: boolean): void => {
 
         return event
       },
+      beforeSendTransaction(event) {
+        if (event.transaction === '/') {
+          return null
+        }
+        return event
+      },
     })
 
     isSentryInitialized = true


### PR DESCRIPTION
# Overview
The ideal solution would be to review each API call individually, but this change will prevent any single project from consuming the entire usage quota.

https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-beforesendtransaction

Since we use the old version of axios and we don't use any unique feature from axios, we could switch from `axios` to `fetch`


## Test Plan and Hands on Testing
none

## Changelog
- add `beforeSendTransaction` for N + 1 API Call

## Review requests


## Risk assessment
low
