### PR TITLE
fix(odd): remove overzealous autofocus in ODD Documentation Required modal

### DIFF
--- a/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.tsx
@@ -89,9 +89,6 @@ export function DocumentationRequired({
                 onChange={e => {
                   setInputText(e.target.value)
                 }}
-                onBlur={e => {
-                  e.target.focus()
-                }}
               />
             </div>
           </div>


### PR DESCRIPTION
# Overview

Fix for [RQA-5688](https://opentrons.atlassian.net/browse/RQA-5688). When login modal is stacked on top of Documentation Required modal, login could never be typed in because of autofocus on the text area.

## Test Plan and Hands on Testing

Load an ACM bot, trigger the documentation required screen, wait for idle logout to trigger the login screen, you should now be able to type in the login field

## Risk assessment

Low

[RQA-5688]: https://opentrons.atlassian.net/browse/RQA-5688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ