### PR TITLE
fix(update-server): Clean up sessions deterministically

### DIFF
--- a/update-server/otupdate/common/session.py
+++ b/update-server/otupdate/common/session.py
@@ -45,7 +45,6 @@ class UpdateSession:
         self._error: Optional[Value] = None
         self._storage_path = storage_path
         self._setup_dl_area()
-        self._rootfs_file: Optional[str] = None
         LOG.info(f"update session: created {self._token}")
 
     def _setup_dl_area(self) -> None:
@@ -79,10 +78,6 @@ class UpdateSession:
     @property
     def download_path(self) -> str:
         return self._storage_path
-
-    @property
-    def rootfs_file(self) -> Optional[str]:
-        return self._rootfs_file
 
     @property
     def token(self) -> str:

--- a/update-server/otupdate/common/session.py
+++ b/update-server/otupdate/common/session.py
@@ -127,5 +127,9 @@ class UpdateSession:
             }
 
 
-def session_from_request(request: web.Request) -> Optional[UpdateSession]:
+def get_current_session(request: web.Request) -> UpdateSession | None:
     return request.app.get(SESSION_VARNAME, None)  # type: ignore[no-any-return]
+
+
+def set_current_session(request: web.Request, session: UpdateSession | None) -> None:
+    request.app[SESSION_VARNAME] = session

--- a/update-server/otupdate/common/session.py
+++ b/update-server/otupdate/common/session.py
@@ -52,10 +52,10 @@ class UpdateSession:
             shutil.rmtree(self._storage_path)
         os.makedirs(self._storage_path, mode=0o700, exist_ok=True)
 
-    def __del__(self) -> None:
-        if hasattr(self, "_storage_path"):
-            shutil.rmtree(self._storage_path)
-        LOG.info(f"Update session: removed {getattr(self, '_token', '<unknown>')}")
+    def close(self) -> None:
+        """Clean up the storage used by this session."""
+        shutil.rmtree(self._storage_path)
+        LOG.info(f"Update session: removed {self._token}")
 
     def set_stage(self, stage: Stages) -> None:
         """Convenience method to set the stage and lookup message"""

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -81,7 +81,15 @@ async def begin(request: web.Request) -> web.Response:
 
 @auth.require_scopes(Scope.UPDATES_WRITE)
 async def cancel(request: web.Request) -> web.Response:
-    set_current_session(request, None)
+    session = get_current_session(request)
+    if session is not None:
+        # fixme(mm, 2026-07-06):
+        #   * This is a concurrency hazard: it might close a session and delete its
+        #     storage while a background task is still using it.
+        #   * session.close() currently only cleans up storage. We also need to clean
+        #     up background tasks.
+        session.close()
+        set_current_session(request, None)
     return web.json_response(data={"message": "Session cancelled"}, status=200)
 
 

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -18,15 +18,14 @@ from typing_extensions import Protocol
 from server_utils.auth.scopes import Scope
 
 from . import auth, config, update_actions
-from .constants import APP_VARIABLE_PREFIX, RESTART_LOCK_NAME
+from .constants import RESTART_LOCK_NAME
 from .handler_type import Handler
-from .session import Stages, UpdateSession
+from .session import Stages, UpdateSession, get_current_session, set_current_session
 from otupdate.buildroot.update_actions import UPDATE_PKG_BR
 from otupdate.openembedded.update_actions import UPDATE_PKG_OE
 
 VALID_UPDATE_PKG = UPDATE_PKG_OE + UPDATE_PKG_BR
 
-SESSION_VARNAME = APP_VARIABLE_PREFIX + "session"
 LOG = logging.getLogger(__name__)
 
 
@@ -41,17 +40,13 @@ class _HandlerWithSession(Protocol):
     ) -> web.Response: ...
 
 
-def session_from_request(request: web.Request) -> Optional[UpdateSession]:
-    return request.app.get(SESSION_VARNAME, None)  # type: ignore[no-any-return]
-
-
 def require_session(handler: _HandlerWithSession) -> Handler:
     """Decorator to ensure a session is properly in the request"""
 
     @functools.wraps(handler)
     async def decorated(request: web.Request) -> web.Response:
         request_session_token = request.match_info["session"]
-        session = session_from_request(request)
+        session = get_current_session(request)
         if not session or request_session_token != session.token:
             LOG.warning(f"request for invalid session {request_session_token}")
             return web.json_response(
@@ -69,7 +64,7 @@ def require_session(handler: _HandlerWithSession) -> Handler:
 @auth.require_scopes(Scope.UPDATES_WRITE)
 async def begin(request: web.Request) -> web.Response:
     """Begin a session"""
-    if None is not session_from_request(request):
+    if None is not get_current_session(request):
         LOG.warning("begin: requested with active session")
         return web.json_response(
             data={
@@ -80,13 +75,13 @@ async def begin(request: web.Request) -> web.Response:
         )
 
     session = UpdateSession(config.config_from_request(request).download_storage_path)
-    request.app[SESSION_VARNAME] = session
+    set_current_session(request, session)
     return web.json_response(data={"token": session.token}, status=201)
 
 
 @auth.require_scopes(Scope.UPDATES_WRITE)
 async def cancel(request: web.Request) -> web.Response:
-    request.app.pop(SESSION_VARNAME, None)
+    set_current_session(request, None)
     return web.json_response(data={"message": "Session cancelled"}, status=200)
 
 

--- a/update-server/tests/common/test_update.py
+++ b/update-server/tests/common/test_update.py
@@ -18,7 +18,7 @@ from tests.openembedded.conftest import (
 
 from otupdate.buildroot import config, update, update_actions
 from otupdate.common import file_actions
-from otupdate.common.session import Stages, UpdateSession
+from otupdate.common.session import SESSION_VARNAME, Stages, UpdateSession
 from otupdate.common.update_actions import UpdateActionsInterface
 from otupdate.openembedded import OT3UpdateActions, RootFSInterface
 
@@ -41,8 +41,8 @@ async def test_begin(test_cli: Tuple[HTTPTestClient, str]):
     body = await resp.json()
     assert resp.status == 201
     assert "token" in body
-    assert test_cli[0].server.app.get(update.SESSION_VARNAME)
-    assert test_cli[0].server.app[update.SESSION_VARNAME].token == body["token"]
+    assert test_cli[0].server.app.get(SESSION_VARNAME)
+    assert test_cli[0].server.app[SESSION_VARNAME].token == body["token"]
 
     # Creating a session twice shouldn’t
     resp = await test_cli[0].post("/server/update/begin")
@@ -54,11 +54,11 @@ async def test_begin(test_cli: Tuple[HTTPTestClient, str]):
 async def test_cancel(test_cli: Tuple[HTTPTestClient, str]):
     # cancelling when there’s a session should work great
     resp = await test_cli[0].post("/server/update/begin")
-    assert test_cli[0].server.app.get(update.SESSION_VARNAME)
+    assert test_cli[0].server.app.get(SESSION_VARNAME)
 
     resp = await test_cli[0].post("/server/update/cancel")
     assert resp.status == 200
-    assert test_cli[0].server.app.get(update.SESSION_VARNAME) is None
+    assert test_cli[0].server.app.get(SESSION_VARNAME) is None
 
     # and so should cancelling when there isn’t one
 


### PR DESCRIPTION
## Overview

This closes EXEC-1073 and goes towards EXEC-2794.

## Test Plan and Hands on Testing

I will smoke-test this as part of other update-server work related to Compliance Ready Software.

## Changelog

* Instead of cleaning up files in `__del__`, clean them up in an explicit `close()` method. See [my soapbox](https://opentrons.atlassian.net/wiki/spaces/RPDO/pages/5172397602/Patterns+for+resource+lifetimes+in+Python#Don%E2%80%99t-use-__del__()) for why `__del__` is dangerous.
* Deduplicate some code for getting and setting the current session.
* Delete the `session.rootfs_file` property, which was unused.

## Review requests

Agreed that this is an improvement, despite the risk?

## Risk assessment

High. It's hard to guarantee exactly when `__del__` was being called before, so it's hard to preserve exact behavior.

For example, a background task with a reference to `session` (potentially a transitive reference) will keep it in-memory beyond the point where the session is `cancel()`'d. Before, with `__del__`, that would have deferred the `shutil.rmtree()`. Now, the `shutil.rmtree()` will always happen at the point of `cancel()`.

If that was happening before, I think it would have been broken in other ways (see the hypothetical in EXEC-1073). So I don't think we were implicitly depending on that behavior. But it illustrates how touchy this is.