### PR TITLE
feat(api-client, react-api-client): add an optional body to deleteRun

### DIFF
--- a/api-client/src/runs/deleteRun.ts
+++ b/api-client/src/runs/deleteRun.ts
@@ -2,10 +2,17 @@ import { DELETE, request } from '../request'
 
 import type { ResponsePromise } from '../request'
 import type { EmptyResponse, HostConfig } from '../types'
+import type { DeleteRunData } from './types'
 
 export function deleteRun(
   config: HostConfig,
-  runId: string
+  runId: string,
+  data: DeleteRunData = {}
 ): ResponsePromise<EmptyResponse> {
-  return request<EmptyResponse>(DELETE, `/runs/${runId}`, config)
+  return request<EmptyResponse, { data: DeleteRunData }>(
+    DELETE,
+    `/runs/${runId}`,
+    config,
+    { body: { data } }
+  )
 }

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -249,3 +249,7 @@ export interface FlexStackerState {
   count: number
   maxCount: number
 }
+
+export interface DeleteRunData {
+  shouldDeleteAllRunFiles?: boolean
+}

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRunOverflowMenu.tsx
@@ -185,7 +185,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
   const handleDeleteClick: MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
     e.stopPropagation()
-    deleteRun(runId)
+    deleteRun({ runId })
     closeOverflowMenu(e)
   }
 

--- a/react-api-client/src/runs/useDeleteRunMutation.ts
+++ b/react-api-client/src/runs/useDeleteRunMutation.ts
@@ -13,7 +13,7 @@ import type { DeleteRunData, EmptyResponse } from '@opentrons/api-client'
 
 export interface DeleteRunParams {
   runId: string
-  settings: DeleteRunData
+  settings?: DeleteRunData
 }
 
 export type UseDeleteRunMutationResult = UseMutationResult<

--- a/react-api-client/src/runs/useDeleteRunMutation.ts
+++ b/react-api-client/src/runs/useDeleteRunMutation.ts
@@ -9,20 +9,25 @@ import type {
   UseMutationOptions,
   UseMutationResult,
 } from 'react-query'
-import type { EmptyResponse } from '@opentrons/api-client'
+import type { DeleteRunData, EmptyResponse } from '@opentrons/api-client'
+
+export interface DeleteRunParams {
+  runId: string
+  settings: DeleteRunData
+}
 
 export type UseDeleteRunMutationResult = UseMutationResult<
   EmptyResponse,
   unknown,
-  string
+  DeleteRunParams
 > & {
-  deleteRun: UseMutateFunction<EmptyResponse, unknown, string>
+  deleteRun: UseMutateFunction<EmptyResponse, unknown, DeleteRunParams>
 }
 
 export type UseDeleteRunMutationOptions = UseMutationOptions<
   EmptyResponse,
   unknown,
-  string
+  DeleteRunParams
 >
 
 export function useDeleteRunMutation(
@@ -31,9 +36,9 @@ export function useDeleteRunMutation(
   const host = useHost()
   const queryClient = useQueryClient()
 
-  const mutation = useMutation<EmptyResponse, unknown, string>(
-    (runId: string) =>
-      deleteRun(host!, runId).then(response => {
+  const mutation = useMutation<EmptyResponse, unknown, DeleteRunParams>(
+    ({ runId, settings }) =>
+      deleteRun(host!, runId, settings).then(response => {
         queryClient.removeQueries(getQueryKey(host, 'runs', runId))
         queryClient
           .invalidateQueries(getQueryKey(host, 'runs'))


### PR DESCRIPTION
# Overview

We need to accommodate optionally deleting all files on disk associated with a run during run deletion, rather than just references to those files. This PR addresses the client side of this work, extending `deleteRun` and its corresponding react-api-client hook `useDeleteRunMutation`. Robot server implemmentation will be addressed in a followup PR.

Closes EXEC-2808

## Test Plan and Hands on Testing

Regression smoke tested that deleting a run from a historical protocol run's overflow menu deletes the run. The full file deletions on disk behavior is not yet implemented.

## Changelog

- add optional data parameter to `deleteRun` to accommodate deleting all run files associated with a run
- update ReactQuery wrapper hook `useDeleteRunMutation` accordingly
- update implementation in `HistoricalProtocolRunOverflowMenu`

## Review requests

Please check the structure of `DeleteRunData`, and that its implementation in `deleteRun` matches existing best practices for api-client functions with request bodies

## Risk assessment

lowish