### PR TITLE
fix(api): prevent duplicate module entries during USB reconnect

### DIFF
--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -112,6 +112,21 @@ class AttachedModulesControl:
         # time it experiences an EMI disconnect
         return self._available_modules + self._recently_removed_modules
 
+    def _dedupe_available_modules(self, new_mod: modules.AbstractModule) -> None:
+        """
+        Remove any existing entry in _available_modules that shares new_mod's
+        serial, then append new_mod and re-sort.
+        """
+        serial = new_mod.serial_number
+        if serial is not None:
+            self._available_modules = [
+                m for m in self._available_modules if m.serial_number != serial
+            ]
+        self._available_modules.append(new_mod)
+        self._available_modules = sorted(
+            self._available_modules, key=modules.AbstractModule.sort_key
+        )
+
     async def clean_up(self) -> None:
         """Clean up all registered modules and emulator scanning tasks (if any)."""
         for module in self._available_modules:
@@ -137,10 +152,7 @@ class AttachedModulesControl:
         module = await self.build_module(
             "", simulated_usb_port, type, sim_model, sim_serial_number=None
         )
-        self._available_modules.append(module)
-        self._available_modules = sorted(
-            self._available_modules, key=modules.AbstractModule.sort_key
-        )
+        self._dedupe_available_modules(module)
         return module
 
     async def build_module(
@@ -223,7 +235,8 @@ class AttachedModulesControl:
             # removed so that the recursion terminates next loop
             old_mod.disconnected_callback()
             log.info(f"did not find {old_mod.serial_number}")
-            self._recently_removed_modules.remove(old_mod)
+            if old_mod in self._recently_removed_modules:
+                self._recently_removed_modules.remove(old_mod)
 
     async def _reconnect_patch(self, attempts_left: int) -> None:
         if attempts_left == 0:
@@ -233,33 +246,32 @@ class AttachedModulesControl:
 
         await asyncio.sleep(1)
         try:
-            for old_mod in self._recently_removed_modules:
+            for old_mod in list(self._recently_removed_modules):
                 log.info(
                     f"Attempting to find and reconect {old_mod.serial_number} attempt {RECONNECT_ATTEMPTS-attempts_left+1}"
                 )
-                for attached_mod in self._available_modules:
-                    if attached_mod.serial_number == old_mod.serial_number:
-                        log.info(f"Found {old_mod.serial_number} was reconnected")
-                        # module reattached to a new virtual port, create a symlink to it
-                        await attached_mod.cleanup()
-                        if attached_mod.port != old_mod.port:
-                            log.info(
-                                f"module moved from {old_mod.port} to {attached_mod.port}"
-                            )
-                            await old_mod.move_port(
-                                attached_mod.port, attached_mod.usb_port
-                            )
-                        await old_mod.attempt_reconnect()
-                        self._available_modules.remove(attached_mod)
-                        self._available_modules.append(old_mod)
-                        self._recently_removed_modules.remove(old_mod)
-                        self._available_modules = sorted(
-                            self._available_modules, key=modules.AbstractModule.sort_key
-                        )
+                await self._reconnect_single_module(old_mod)
         except BaseException:
             log.exception("Encountered an error during reconnect attempt.")
         if len(self._recently_removed_modules) > 0:
             self._api.loop.create_task(self._reconnect_patch(attempts_left - 1))
+
+    async def _reconnect_single_module(self, old_mod: modules.AbstractModule) -> None:
+        """Find an attached module matching old_mod's serial and swap it in."""
+        for attached_mod in list(self._available_modules):
+            if attached_mod.serial_number != old_mod.serial_number:
+                continue
+            log.info(f"Found {old_mod.serial_number} was reconnected")
+            # module reattached to a new virtual port, create a symlink to it
+            await attached_mod.cleanup()
+            if attached_mod.port != old_mod.port:
+                log.info(f"module moved from {old_mod.port} to {attached_mod.port}")
+                await old_mod.move_port(attached_mod.port, attached_mod.usb_port)
+            await old_mod.attempt_reconnect()
+            if old_mod in self._recently_removed_modules:
+                self._recently_removed_modules.remove(old_mod)
+            self._dedupe_available_modules(old_mod)
+            break
 
     async def unregister_modules(  # noqa: C901
         self,
@@ -345,7 +357,7 @@ class AttachedModulesControl:
                         mod.model if isinstance(mod, SimulatingModuleAtPort) else None
                     ),
                 )
-                self._available_modules.append(new_instance)
+                self._dedupe_available_modules(new_instance)
                 log.info(
                     f"Module {mod.name} discovered and attached"
                     f" at port {mod.port}, new_instance: {new_instance}"
@@ -354,9 +366,6 @@ class AttachedModulesControl:
                 log.exception(
                     f"Failed to build module {mod.name} at port {mod.port}: {e}"
                 )
-        self._available_modules = sorted(
-            self._available_modules, key=modules.AbstractModule.sort_key
-        )
 
     def scan(self) -> List[modules.ModuleAtPort]:
         """Scan for connected modules and return list of

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -118,14 +118,17 @@ class AttachedModulesControl:
         serial, then append new_mod and re-sort.
         Also evicts any stale entry with the same serial.
         """
-        serial = new_mod.serial_number
-        if serial is not None:
-            self._available_modules = [
-                m for m in self._available_modules if m.serial_number != serial
-            ]
-            self._recently_removed_modules = [
-                m for m in self._recently_removed_modules if m.serial_number != serial
-            ]
+        if not self._api.is_simulator:
+            serial = new_mod.serial_number
+            if serial is not None:
+                self._available_modules = [
+                    m for m in self._available_modules if m.serial_number != serial
+                ]
+                self._recently_removed_modules = [
+                    m
+                    for m in self._recently_removed_modules
+                    if m.serial_number != serial
+                ]
         self._available_modules.append(new_mod)
         self._available_modules = sorted(
             self._available_modules, key=modules.AbstractModule.sort_key

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -115,12 +115,16 @@ class AttachedModulesControl:
     def _dedupe_available_modules(self, new_mod: modules.AbstractModule) -> None:
         """
         Remove any existing entry in _available_modules that shares new_mod's
-        serial, then append new_mod and re-sort.
+        serial, then append new_mod and re-sort. 
+        Also evicts any stale entry with the same serial.
         """
         serial = new_mod.serial_number
         if serial is not None:
             self._available_modules = [
                 m for m in self._available_modules if m.serial_number != serial
+            ]
+            self._recently_removed_modules = [
+                m for m in self._recently_removed_modules if m.serial_number != serial
             ]
         self._available_modules.append(new_mod)
         self._available_modules = sorted(

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -115,7 +115,7 @@ class AttachedModulesControl:
     def _dedupe_available_modules(self, new_mod: modules.AbstractModule) -> None:
         """
         Remove any existing entry in _available_modules that shares new_mod's
-        serial, then append new_mod and re-sort. 
+        serial, then append new_mod and re-sort.
         Also evicts any stale entry with the same serial.
         """
         serial = new_mod.serial_number

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -354,9 +354,13 @@ class TempDeckReader(Reader):
     def on_error(self, exception: Exception) -> None:
         self._debounce_count -= 1
         if self._error_callback:
-            if self._debounce_count != 0:
+            if self._debounce_count > 0:
                 log.error(
                     f"Reader encountered error {exception} but has {self._debounce_count} tries left"
                 )
             else:
+                # Reached the terminal state: fire the callback and reset the
+                # counter so a future error cycle can fire again instead of
+                # running the counter negative and never recovering.
                 self._error_callback(exception)
+                self._debounce_count = DEFAULT_COMMAND_RETRIES

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -359,8 +359,5 @@ class TempDeckReader(Reader):
                     f"Reader encountered error {exception} but has {self._debounce_count} tries left"
                 )
             else:
-                # Reached the terminal state: fire the callback and reset the
-                # counter so a future error cycle can fire again instead of
-                # running the counter negative and never recovering.
                 self._error_callback(exception)
                 self._debounce_count = DEFAULT_COMMAND_RETRIES

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -8,6 +8,7 @@ from opentrons_shared_data.errors.exceptions import ModuleCommunicationError
 from opentrons.drivers.asyncio.communication.errors import SerialException
 
 from opentrons.config import IS_ROBOT
+from serial.serialutil import SerialException as PySerialSerialException  # type: ignore[import-untyped]
 
 log = logging.getLogger(__name__)
 
@@ -120,7 +121,7 @@ class Poller:
         except AbsorbanceReaderDisconnectedError as e:
             self._error_callback(e)
             self._complete_all(e, previous_waiters)
-        except SerialException as se:
+        except (SerialException, PySerialSerialException) as se:
             log.error(f"Polling gcode error: {se}")
             self._error_callback(se)
             self._complete_all(se, previous_waiters)

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -10,7 +10,8 @@ from opentrons.hardware_control.modules.types import (
 )
 from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.hardware_control import modules, ExecutionManager
-from opentrons.hardware_control.modules.tempdeck import TempDeck
+from opentrons.hardware_control.modules.tempdeck import TempDeck, TempDeckReader
+from opentrons.drivers.temp_deck import DEFAULT_COMMAND_RETRIES
 
 
 @pytest.fixture
@@ -141,3 +142,60 @@ async def test_error_callback(
             exc, "temperatureModuleV1", "/dev/ot_module_sim_tempdeck0", "dummySerialTD"
         )
     )
+
+
+def test_tempdeck_reader_on_error_fires_callback_after_retries_exhausted(
+    decoy: Decoy,
+) -> None:
+    """TempDeckReader.on_error should invoke the error callback exactly once
+    after DEFAULT_COMMAND_RETRIES consecutive errors."""
+    driver = decoy.mock(name="driver")
+    reader = TempDeckReader(driver=driver)
+    cb = decoy.mock(name="error_callback")
+    reader.set_error_callback(cb)
+
+    exc = Exception("boom")
+    for _ in range(DEFAULT_COMMAND_RETRIES):
+        reader.on_error(exc)
+
+    decoy.verify(cb(exc), times=1)
+
+
+def test_tempdeck_reader_on_error_recovers_after_firing(decoy: Decoy) -> None:
+    """After the callback fires and resets the debounce counter, a fresh burst
+    of errors should fire the callback again rather than running the counter
+    negative and never recovering.
+    """
+    driver = decoy.mock(name="driver")
+    reader = TempDeckReader(driver=driver)
+    cb = decoy.mock(name="error_callback")
+    reader.set_error_callback(cb)
+
+    exc = Exception("boom")
+    for _ in range(DEFAULT_COMMAND_RETRIES):
+        reader.on_error(exc)
+    for _ in range(DEFAULT_COMMAND_RETRIES):
+        reader.on_error(exc)
+
+    decoy.verify(cb(exc), times=2)
+
+
+def test_tempdeck_reader_on_error_resets_on_successful_read(decoy: Decoy) -> None:
+    """A successful read resets the debounce counter, so the next error burst
+    must again exhaust all retries before firing."""
+    driver = decoy.mock(name="driver")
+    reader = TempDeckReader(driver=driver)
+    cb = decoy.mock(name="error_callback")
+    reader.set_error_callback(cb)
+
+    exc = Exception("boom")
+    # One error short of firing.
+    for _ in range(DEFAULT_COMMAND_RETRIES - 1):
+        reader.on_error(exc)
+    decoy.verify(cb(matchers.Anything()), times=0)
+
+    reader._debounce_count = DEFAULT_COMMAND_RETRIES
+
+    for _ in range(DEFAULT_COMMAND_RETRIES - 1):
+        reader.on_error(exc)
+    decoy.verify(cb(matchers.Anything()), times=0)

--- a/api/tests/opentrons/hardware_control/test_module_control.py
+++ b/api/tests/opentrons/hardware_control/test_module_control.py
@@ -1,5 +1,7 @@
 """Tests for opentrons.hardware_control.module_control."""
 
+import asyncio
+
 import pytest
 from decoy import Decoy, matchers
 from typing import Awaitable, Callable, cast, Union, List
@@ -13,7 +15,25 @@ from opentrons.hardware_control.modules.types import (
     ModuleType,
     SimulatingModuleAtPort,
 )
-from opentrons.hardware_control.module_control import AttachedModulesControl
+from opentrons.hardware_control.module_control import (
+    AttachedModulesControl,
+    RECONNECT_ATTEMPTS,
+)
+
+
+def _make_module(
+    decoy: Decoy,
+    *,
+    serial: str = "serial-1",
+    port: str = "/dev/ot_module_tempdeck0",
+    usb_port: USBPort = USBPort(name="a", port_number=1),
+) -> AbstractModule:
+    """Build a decoy AbstractModule."""
+    module = decoy.mock(cls=AbstractModule)
+    decoy.when(module.serial_number).then_return(serial)
+    decoy.when(module.usb_port).then_return(usb_port)
+    decoy.when(module.port).then_return(port)
+    return module
 
 
 @pytest.fixture()
@@ -178,3 +198,254 @@ async def test_register_modules_sort(
     result = subject.available_modules
 
     assert result == [module_5, module_4, module_3, module_2, module_1]
+
+
+async def test_dedupe_available_modules_replaces_stale_entry(
+    decoy: Decoy,
+    subject: AttachedModulesControl,
+) -> None:
+    """_dedupe_available_modules should replace an existing entry with the same serial."""
+    stale = _make_module(decoy, serial="ABC", port="/dev/ot_module_tempdeck0")
+    fresh = _make_module(decoy, serial="ABC", port="/dev/ot_module_tempdeck0")
+
+    subject._available_modules.append(stale)
+
+    subject._dedupe_available_modules(fresh)
+
+    assert subject._available_modules == [fresh]
+
+
+async def test_dedupe_available_modules_keeps_other_serials(
+    decoy: Decoy,
+    subject: AttachedModulesControl,
+) -> None:
+    """_dedupe_available_modules should only remove entries sharing the serial."""
+    other = _make_module(
+        decoy,
+        serial="OTHER",
+        port="/dev/ot_module_tempdeck1",
+        usb_port=USBPort(name="b", port_number=2),
+    )
+    stale_same = _make_module(decoy, serial="ABC", port="/dev/ot_module_tempdeck0")
+    fresh_same = _make_module(
+        decoy,
+        serial="ABC",
+        port="/dev/ot_module_tempdeck0",
+        usb_port=USBPort(name="c", port_number=3),
+    )
+
+    subject._available_modules = [other, stale_same]
+
+    subject._dedupe_available_modules(fresh_same)
+
+    assert subject._available_modules == [other, fresh_same]
+
+
+async def test_dedupe_available_modules_appends_when_no_existing(
+    decoy: Decoy,
+    subject: AttachedModulesControl,
+) -> None:
+    """_dedupe_available_modules should append when no matching serial exists."""
+    mod = _make_module(decoy, serial="NEW")
+
+    subject._dedupe_available_modules(mod)
+
+    assert subject._available_modules == [mod]
+
+
+async def test_register_modules_dedupes_on_attach(
+    decoy: Decoy,
+    usb_bus: USBDriverInterface,
+    build_module: Callable[..., Awaitable[AbstractModule]],
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """register_modules should not create a duplicate when a stale entry exists."""
+    stale = _make_module(decoy, serial="DUP", port="/dev/foo")
+    fresh = _make_module(
+        decoy,
+        serial="DUP",
+        port="/dev/foo",
+        usb_port=USBPort(name="baz", port_number=0),
+    )
+
+    subject._available_modules.append(stale)
+
+    mods_at_port = [ModuleAtPort(port="/dev/foo", name="tempdeck")]
+    decoy.when(usb_bus.match_virtual_ports(mods_at_port)).then_return(
+        [
+            ModuleAtPort(
+                port="/dev/foo",
+                name="tempdeck",
+                usb_port=USBPort(name="baz", port_number=0),
+            )
+        ]
+    )
+    decoy.when(
+        await build_module(
+            port="/dev/foo",
+            usb_port=USBPort(name="baz", port_number=0),
+            type=ModuleType.TEMPERATURE,
+            sim_serial_number=None,
+            sim_model=None,
+        )
+    ).then_return(fresh)
+
+    await subject.register_modules(new_mods_at_ports=mods_at_port)
+
+    assert subject.available_modules == [fresh]
+
+
+async def test_reconnect_patch_breaks_after_first_match(
+    decoy: Decoy,
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """_reconnect_patch should process a reconnected module exactly once."""
+    old_mod = _make_module(
+        decoy,
+        serial="XYZ",
+        port="/dev/ot_module_tempdeck0",
+        usb_port=USBPort(name="a", port_number=1),
+    )
+    attached_mod = _make_module(
+        decoy,
+        serial="XYZ",
+        port="/dev/ot_module_tempdeck0",
+        usb_port=USBPort(name="a", port_number=1),
+    )
+
+    subject._recently_removed_modules = [old_mod]
+    subject._available_modules = [attached_mod]
+
+    decoy.when(hardware_api.is_simulator).then_return(False)
+    decoy.when(await attached_mod.cleanup())
+    decoy.when(await old_mod.attempt_reconnect())
+
+    await subject._reconnect_patch(attempts_left=RECONNECT_ATTEMPTS)
+
+    assert subject._available_modules == [old_mod]
+    assert subject._recently_removed_modules == []
+
+
+async def test_reconnect_patch_dedupes_when_fresh_already_present(
+    decoy: Decoy,
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """_reconnect_patch should not leave two entries for one serial."""
+    old_mod = _make_module(
+        decoy,
+        serial="RACE",
+        port="/dev/ot_module_tempdeck0",
+        usb_port=USBPort(name="a", port_number=1),
+    )
+    fresh = _make_module(
+        decoy,
+        serial="RACE",
+        port="/dev/ot_module_tempdeck0",
+        usb_port=USBPort(name="a", port_number=1),
+    )
+
+    subject._recently_removed_modules = [old_mod]
+    # fresh already registered by the concurrent CREATE path
+    subject._available_modules = [fresh]
+
+    decoy.when(hardware_api.is_simulator).then_return(False)
+    decoy.when(await fresh.cleanup())
+    decoy.when(await old_mod.attempt_reconnect())
+
+    await subject._reconnect_patch(attempts_left=RECONNECT_ATTEMPTS)
+
+    assert subject._available_modules == [old_mod]
+    assert len(subject._available_modules) == 1
+
+
+async def test_clear_old_modules_guarded_remove(
+    decoy: Decoy,
+    subject: AttachedModulesControl,
+) -> None:
+    """_clear_old_modules should not raise if the entry was already removed."""
+    old_mod = _make_module(decoy, serial="GONE")
+    subject._recently_removed_modules = [old_mod]
+
+    decoy.when(old_mod.disconnected_callback())
+
+    # First call removes it normally.
+    subject._clear_old_modules()
+    assert subject._recently_removed_modules == []
+
+    # Second call must not raise ValueError on the now-empty list.
+    subject._clear_old_modules()
+    assert subject._recently_removed_modules == []
+
+
+async def test_reconnect_patch_guarded_remove(
+    decoy: Decoy,
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """_reconnect_patch should not raise if old_mod was concurrently removed.
+
+    If _clear_old_modules (or a prior _reconnect_patch attempt) already removed
+    old_mod from _recently_removed_modules, the membership guard keeps this
+    attempt from crashing with ValueError.
+    """
+    old_mod = _make_module(
+        decoy,
+        serial="CONCURRENT",
+        port="/dev/ot_module_tempdeck0",
+        usb_port=USBPort(name="a", port_number=1),
+    )
+    attached_mod = _make_module(
+        decoy,
+        serial="CONCURRENT",
+        port="/dev/ot_module_tempdeck0",
+        usb_port=USBPort(name="a", port_number=1),
+    )
+
+    subject._recently_removed_modules = [old_mod]
+    subject._available_modules = [attached_mod]
+
+    decoy.when(hardware_api.is_simulator).then_return(False)
+    decoy.when(await attached_mod.cleanup())
+
+    # Simulate concurrent removal: empty the list before _reconnect_patch
+    # reaches its own .remove() call. We do this by having attempt_reconnect
+    # clear the list as a side effect.
+    async def _clear_concurrently() -> None:
+        subject._recently_removed_modules.clear()
+
+    decoy.when(await old_mod.attempt_reconnect()).then_do(  # type: ignore[func-returns-value]
+        _clear_concurrently
+    )
+
+    # Must not raise ValueError.
+    await subject._reconnect_patch(attempts_left=RECONNECT_ATTEMPTS)
+
+    assert subject._available_modules == [old_mod]
+
+
+async def test_reconnect_patch_no_match_retries(
+    decoy: Decoy,
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """_reconnect_patch should reschedule when no match is found yet."""
+    old_mod = _make_module(decoy, serial="MISSING")
+
+    subject._recently_removed_modules = [old_mod]
+    subject._available_modules = []
+
+    stub_loop = decoy.mock(cls=asyncio.AbstractEventLoop)
+
+    decoy.when(hardware_api.is_simulator).then_return(False)
+    decoy.when(hardware_api.loop).then_return(stub_loop)
+
+    decoy.when(stub_loop.create_task(matchers.Anything())).then_do(
+        lambda coro: coro.close()
+    )
+
+    await subject._reconnect_patch(attempts_left=RECONNECT_ATTEMPTS)
+
+    assert subject._recently_removed_modules == [old_mod]

--- a/api/tests/opentrons/hardware_control/test_module_control.py
+++ b/api/tests/opentrons/hardware_control/test_module_control.py
@@ -253,6 +253,26 @@ async def test_dedupe_available_modules_appends_when_no_existing(
     assert subject._available_modules == [mod]
 
 
+async def test_dedupe_available_modules_evicts_parked_entry_same_serial(
+    decoy: Decoy,
+    subject: AttachedModulesControl,
+) -> None:
+    """_dedupe_available_modules should evict a stale entry parked in
+    _recently_removed_modules when a fresh instance with the same serial lands.
+    """
+    parked = _make_module(decoy, serial="DUP", port="/dev/ot_module_tempdeck0")
+    fresh = _make_module(decoy, serial="DUP", port="/dev/ot_module_tempdeck0")
+
+    subject._recently_removed_modules = [parked]
+    subject._available_modules = []
+
+    subject._dedupe_available_modules(fresh)
+
+    assert subject._available_modules == [fresh]
+    assert subject._recently_removed_modules == []
+    assert subject.available_modules == [fresh]
+
+
 async def test_register_modules_dedupes_on_attach(
     decoy: Decoy,
     usb_bus: USBDriverInterface,
@@ -385,12 +405,7 @@ async def test_reconnect_patch_guarded_remove(
     hardware_api: HardwareAPI,
     subject: AttachedModulesControl,
 ) -> None:
-    """_reconnect_patch should not raise if old_mod was concurrently removed.
-
-    If _clear_old_modules (or a prior _reconnect_patch attempt) already removed
-    old_mod from _recently_removed_modules, the membership guard keeps this
-    attempt from crashing with ValueError.
-    """
+    """_reconnect_patch should not raise if old_mod was concurrently removed."""
     old_mod = _make_module(
         decoy,
         serial="CONCURRENT",
@@ -410,9 +425,6 @@ async def test_reconnect_patch_guarded_remove(
     decoy.when(hardware_api.is_simulator).then_return(False)
     decoy.when(await attached_mod.cleanup())
 
-    # Simulate concurrent removal: empty the list before _reconnect_patch
-    # reaches its own .remove() call. We do this by having attempt_reconnect
-    # clear the list as a side effect.
     async def _clear_concurrently() -> None:
         subject._recently_removed_modules.clear()
 

--- a/api/tests/opentrons/hardware_control/test_module_control.py
+++ b/api/tests/opentrons/hardware_control/test_module_control.py
@@ -202,9 +202,11 @@ async def test_register_modules_sort(
 
 async def test_dedupe_available_modules_replaces_stale_entry(
     decoy: Decoy,
+    hardware_api: HardwareAPI,
     subject: AttachedModulesControl,
 ) -> None:
     """_dedupe_available_modules should replace an existing entry with the same serial."""
+    decoy.when(hardware_api.is_simulator).then_return(False)
     stale = _make_module(decoy, serial="ABC", port="/dev/ot_module_tempdeck0")
     fresh = _make_module(decoy, serial="ABC", port="/dev/ot_module_tempdeck0")
 
@@ -217,9 +219,11 @@ async def test_dedupe_available_modules_replaces_stale_entry(
 
 async def test_dedupe_available_modules_keeps_other_serials(
     decoy: Decoy,
+    hardware_api: HardwareAPI,
     subject: AttachedModulesControl,
 ) -> None:
     """_dedupe_available_modules should only remove entries sharing the serial."""
+    decoy.when(hardware_api.is_simulator).then_return(False)
     other = _make_module(
         decoy,
         serial="OTHER",
@@ -243,9 +247,11 @@ async def test_dedupe_available_modules_keeps_other_serials(
 
 async def test_dedupe_available_modules_appends_when_no_existing(
     decoy: Decoy,
+    hardware_api: HardwareAPI,
     subject: AttachedModulesControl,
 ) -> None:
     """_dedupe_available_modules should append when no matching serial exists."""
+    decoy.when(hardware_api.is_simulator).then_return(False)
     mod = _make_module(decoy, serial="NEW")
 
     subject._dedupe_available_modules(mod)
@@ -255,11 +261,13 @@ async def test_dedupe_available_modules_appends_when_no_existing(
 
 async def test_dedupe_available_modules_evicts_parked_entry_same_serial(
     decoy: Decoy,
+    hardware_api: HardwareAPI,
     subject: AttachedModulesControl,
 ) -> None:
     """_dedupe_available_modules should evict a stale entry parked in
     _recently_removed_modules when a fresh instance with the same serial lands.
     """
+    decoy.when(hardware_api.is_simulator).then_return(False)
     parked = _make_module(decoy, serial="DUP", port="/dev/ot_module_tempdeck0")
     fresh = _make_module(decoy, serial="DUP", port="/dev/ot_module_tempdeck0")
 
@@ -281,6 +289,7 @@ async def test_register_modules_dedupes_on_attach(
     subject: AttachedModulesControl,
 ) -> None:
     """register_modules should not create a duplicate when a stale entry exists."""
+    decoy.when(hardware_api.is_simulator).then_return(False)
     stale = _make_module(decoy, serial="DUP", port="/dev/foo")
     fresh = _make_module(
         decoy,


### PR DESCRIPTION
# Overview

When a gcode-based module is physically disconnected and reconnected, two unsynchronized event-loop paths can append a module with the same serial into `_available_modules`:

1. `register_modules` (aionotify `CREATE`) builds a fresh instance and appends it.
2. `_reconnect_patch` finds that fresh instance, then appends the original old_mod back on top of it.

Neither path checked whether an entry with the same serial already existed, so the list accumulated two entries for one physical device, returning the stale instance with a closed serial port.

This was latent until #21834 landed: previously `build_module` failed on reconnect, so no fresh instance ever entered the list and the duplicate never formed.

## Test Plan and Hands on Testing

Tested using the following protocol, running the protocol several times to confirm correct behavior:

```
def run(protocol: protocol_api.ProtocolContext) -> None:
    temp_module = protocol.load_module("temperature module gen2", "D1")
    temp_labware = temp_module.load_labware("nest_96_wellplate_100ul_pcr_full_skirt")

    protocol.comment("Temperature Module loaded in D1. Starting test sequence.")


    temp_module.set_temperature(40)
    protocol.pause("Heated to 40C. Test bounce, then resume.")
    temp_module.deactivate()
    protocol.pause("Deactivated. Test bounce, then resume.")

    temp_module.set_temperature(30)
    protocol.pause("Heated to 30C. Test bounce, then resume.")
    temp_module.deactivate()

    protocol.comment("Temperature Module disconnect recovery test complete.")
```

## Changelog

- Fixed a bug in which certain modules may fail a protocol run with a `PortNotOpen` error after reconnecting. 

## Risk assessment

- low, relatively straightforward
