### PR TITLE
fix(robot-server): Threadsafe calls on notify publishers in subprocess mode

### DIFF
--- a/robot-server/robot_server/service/pyro_utils/pyro_resource.py
+++ b/robot-server/robot_server/service/pyro_utils/pyro_resource.py
@@ -246,7 +246,7 @@ class RobotServerPyroResource:
         if self._notify_publishers:
 
             def call_soon_notify_publishers() -> None:
-                # Call soon on the thread notification publisher locally executes from
+                # Call soon on the thread notification publisher locally executes
                 assert self._notify_publishers is not None
                 self._loop.call_soon_threadsafe(self._notify_publishers)
 

--- a/robot-server/robot_server/service/pyro_utils/pyro_resource.py
+++ b/robot-server/robot_server/service/pyro_utils/pyro_resource.py
@@ -243,7 +243,16 @@ class RobotServerPyroResource:
         the Robot Server.
         """
 
-        return self._notify_publishers
+        if self._notify_publishers:
+
+            def call_soon_notify_publishers() -> None:
+                # Call soon on the thread notification publisher locally executes from
+                assert self._notify_publishers is not None
+                self._loop.call_soon_threadsafe(self._notify_publishers)
+
+            return call_soon_notify_publishers
+        else:
+            return None
 
     @pyro_behavior(specialty_func=convert_result_to_proxy, apply_local=False)
     def create_hardware_state_update_callback(self) -> HardwareEventHandler:


### PR DESCRIPTION
# Overview

Previously notify publishers was just called directly through a pyro-exposed method. This meant it was called from the pyro daemon's thread, and would block the response to the PE proxy calls. This created some slight slowdown, and real bad slowdown when short, small commands were executed lots of times in a row. As an example, if the user called `configure_nozzle_layout` 100 times in a row the run progress screen on the app would stop updating, request response on the app from the robot server would be pending for a long time and eventually the app would return to the devices page. Eventually once all the nozzle layout steps were passed in the run the robot and its run view would appear in the app again.

With this slight change to use `call_soon_threadsafe` we're ensuring that the notify publishers callback can return before having to call the robot server's notify publisher, and when the publisher *is* called it's called in the main thread not in the pyro daemon thread. This solves the problem of the robot server having pending responses and blocking calls for these high volume instances, as well as generally speeding up notifications when in subprocess mode.

## Test Plan and Hands on Testing

- [x] Ensure the following protocol causes no issues when viewing the run preview, and that robot server endpoints response in an acceptable amount of time:
```
def run(protocol_context: ProtocolContext):
    tip_rack = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C2")

    instrument = protocol_context.load_instrument('flex_8channel_50', mount="right", tip_racks=[tip_rack])
    
    # This is the part to watch out for!
    for i in range(100):
        instrument.configure_nozzle_layout(style=SINGLE, start="H1", tip_racks=[tip_rack])
        instrument.configure_nozzle_layout(style=ALL, tip_racks=[tip_rack])

    instrument.configure_nozzle_layout(style=SINGLE, start="H1", tip_racks=[tip_rack])
    instrument.pick_up_tip()
    instrument.return_tip()

    instrument.configure_nozzle_layout(style=ALL, tip_racks=[tip_rack])
    instrument.pick_up_tip()
    instrument.return_tip()
```

## Changelog

Updated the pyro resource notify publishers callback to not block returning to the PE and to call notify publishers in the main thread, instead of the daemon thread

## Review requests


## Risk assessment
Low - only effect subprocess mode and fixes some of our slowdown and high volume throughput problems