### PR TITLE
refactor(audit-server): integrate log data manager

### DIFF
--- a/audit-server/audit_server/app.py
+++ b/audit-server/audit_server/app.py
@@ -3,12 +3,15 @@
 import logging
 from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
-from typing import AsyncGenerator, Optional
+from typing import AsyncGenerator, Optional, override
 
 from fastapi import FastAPI
+from opentrons_shared_data.errors.exceptions import AuditLoggingError
 
 from server_utils import systemd_utils
 from server_utils.keys.fastapi import build_key_client, install_key_client
+from server_utils.keys.key_server import Client as KeyClientABC
+from server_utils.keys.key_server import SignedMessageData, SignMessageData
 
 from audit_server.log_export.router import router as log_export_router
 from audit_server.log_ingest.router import router as ingest_router
@@ -42,6 +45,14 @@ def _get_persistence_directory_root(
     return configuration.persistence_directory
 
 
+class _NoOpFailKeyClient(KeyClientABC):
+    """A local key client for when the server is unconfigured that fails to sign."""
+
+    @override
+    async def sign_message(self, message: SignMessageData) -> SignedMessageData:
+        raise AuditLoggingError(message="Key server unavailable (not configured)")
+
+
 @asynccontextmanager
 async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     configuration = get_configuration()
@@ -68,7 +79,6 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                     key_server_url=configuration.key_server_url,
                 )
             )
-            install_key_client(app.state, key_client)
         else:
             _log.warning(
                 "key-server is not configured."
@@ -76,6 +86,8 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 " Set OT_AUDIT_SERVER_key_server_uds or OT_AUDIT_SERVER_key_server_url"
                 " to enable logging."
             )
+            key_client = _NoOpFailKeyClient()
+        install_key_client(app.state, key_client)
         log_store = build_log_store(app.state, engine)
         log_data_manager = build_log_data_manager(
             app.state, log_store, settings_store, key_client

--- a/audit-server/audit_server/app.py
+++ b/audit-server/audit_server/app.py
@@ -12,6 +12,7 @@ from server_utils.keys.fastapi import build_key_client, install_key_client
 
 from audit_server.log_export.router import router as log_export_router
 from audit_server.log_ingest.router import router as ingest_router
+from audit_server.log_storage.dependency import build_log_data_manager, build_log_store
 from audit_server.persistence.database import sql_engine_ctx
 from audit_server.persistence.fastapi_dependencies import (
     set_persistence_directory,
@@ -54,8 +55,8 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     async with AsyncExitStack() as exit_stack:
         engine = exit_stack.enter_context(sql_engine_ctx(db_path))
         set_sql_engine(app.state, engine)
-
-        install_settings_store(app.state, SettingsStore(sql_engine=engine))
+        settings_store = SettingsStore(sql_engine=engine)
+        install_settings_store(app.state, settings_store)
 
         if (
             configuration.key_server_uds is not None
@@ -75,7 +76,11 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 " Set OT_AUDIT_SERVER_key_server_uds or OT_AUDIT_SERVER_key_server_url"
                 " to enable logging."
             )
-
+        log_store = build_log_store(app.state, engine)
+        log_data_manager = build_log_data_manager(
+            app.state, log_store, settings_store, key_client
+        )
+        await log_data_manager.rotate_periods()
         systemd_utils.notify_up()
         yield
 

--- a/audit-server/audit_server/log_export/router.py
+++ b/audit-server/audit_server/log_export/router.py
@@ -6,9 +6,9 @@ import fastapi
 
 from server_utils.fastapi_utils.models.json_api import MultiBodyMeta, SimpleMultiBody
 
-from audit_server.log_storage.dependency import get_log_store
+from audit_server.log_storage.dependency import get_log_data_manager
+from audit_server.log_storage.log_data_manager import LogDataManager
 from audit_server.log_storage.models import LogPeriodSummary
-from audit_server.log_storage.store import LogStore
 
 router = fastapi.APIRouter()
 
@@ -19,10 +19,10 @@ router = fastapi.APIRouter()
     description="Returns all stored audit log periods, ordered oldest first.",
 )
 async def get_log_periods(
-    log_store: Annotated[LogStore, fastapi.Depends(get_log_store)],
+    log_data_manager: Annotated[LogDataManager, fastapi.Depends(get_log_data_manager)],
 ) -> SimpleMultiBody[LogPeriodSummary]:
     """Get all audit log periods."""
-    periods = log_store.list_periods()
+    periods = log_data_manager.get_log_periods()
     return SimpleMultiBody.model_construct(
         data=periods,
         meta=MultiBodyMeta(cursor=0, totalLength=len(periods)),

--- a/audit-server/audit_server/log_ingest/router.py
+++ b/audit-server/audit_server/log_ingest/router.py
@@ -4,23 +4,25 @@ import datetime
 from logging import getLogger
 from typing import Annotated
 
-import aiohttp
 import fastapi
+from opentrons_shared_data.errors.exceptions import (
+    AuditLoggingError,
+    KeyStorageUnavailableError,
+)
 
 from server_utils.fastapi_utils.models.json_api import (
     PydanticResponse,
     RequestModel,
     SimpleBody,
 )
-from server_utils.keys.fastapi import get_key_client
-from server_utils.keys.key_server import Client as KeyClient
-from server_utils.keys.key_server import SignMessageData
 
 from .models import (
     AuditLogMessage,
     SubmitAuditLogMessageData,
     SubmitAuditLogSuccessData,
 )
+from audit_server.log_storage.dependency import get_log_data_manager
+from audit_server.log_storage.log_data_manager import LogDataManager
 
 LOG = getLogger(__name__)
 
@@ -41,11 +43,14 @@ router = fastapi.APIRouter()
                 " could not be signed."
             ),
         },
+        fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR: {
+            "description": "The audit log request failed for an unknown reason."
+        },
     },
 )
 async def post_log_message(
     request_body: RequestModel[SubmitAuditLogMessageData],
-    key_client: Annotated[KeyClient, fastapi.Depends(get_key_client)],
+    log_data_manager: Annotated[LogDataManager, fastapi.Depends(get_log_data_manager)],
 ) -> PydanticResponse[SimpleBody[SubmitAuditLogSuccessData]]:
     """Log an audit message."""
     ingest_time = datetime.datetime.now(datetime.timezone.utc)
@@ -59,23 +64,19 @@ async def post_log_message(
     )
     message_str = message.model_dump_json(indent=None)
     try:
-        signed_message = await key_client.sign_message(
-            SignMessageData(message=message_str, previousHash=None)
-        )
-    except aiohttp.ClientConnectionError as exc:
-        # The key-server is unreachable. We refuse to ingest the message rather
-        # than persisting it without a signature, so callers can retry once the
-        # key-server is back up.
-        LOG.warning("Key-server is unreachable: %s", exc)
+        await log_data_manager.store_log(message_str)
+    except KeyStorageUnavailableError as exc:
         raise fastapi.HTTPException(
             status_code=fastapi.status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=(
                 "Audit log message could not be signed: key-server is unavailable."
             ),
         ) from exc
-    LOG.info(
-        f"Logged message={signed_message.message} hash={signed_message.messageHash} sig={signed_message.messageSignature} ver={signed_message.signatureVersion}"
-    )
+    except AuditLoggingError as exc:
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Audit log could not be stored.",
+        ) from exc
     return await PydanticResponse.create(
         status_code=fastapi.status.HTTP_201_CREATED,
         content=SimpleBody(data=SubmitAuditLogSuccessData(loggedAt=ingest_time)),

--- a/audit-server/audit_server/log_storage/dependency.py
+++ b/audit-server/audit_server/log_storage/dependency.py
@@ -8,11 +8,16 @@ from server_utils.fastapi_utils.app_state import (
     AppStateAccessor,
     get_app_state,
 )
+from server_utils.keys.fastapi import get_key_client
+from server_utils.keys.key_server import Client as KeyClient
 
+from .log_data_manager import LogDataManager
 from .store import LogStore
 from audit_server.persistence.fastapi_dependencies import get_sql_engine
+from audit_server.settings.store import SettingsStore, get_settings_store
 
 _log_store_accessor = AppStateAccessor[LogStore]("log_store")
+_log_data_manager_accessor = AppStateAccessor[LogDataManager]("log_data_manager")
 
 
 def build_log_store(app_state: AppState, sql_engine: SQLEngine) -> LogStore:
@@ -31,3 +36,28 @@ async def get_log_store(
     if log_store is None:
         return build_log_store(app_state, sql_engine)
     return log_store
+
+
+def build_log_data_manager(
+    app_state: AppState,
+    log_store: LogStore,
+    settings_store: SettingsStore,
+    key_client: KeyClient,
+) -> LogDataManager:
+    """Build log data manager."""
+    data_manager = LogDataManager(key_client, log_store, settings_store)
+    _log_data_manager_accessor.set_on(app_state, data_manager)
+    return data_manager
+
+
+async def get_log_data_manager(
+    app_state: Annotated[AppState, Depends(get_app_state)],
+    log_store: Annotated[LogStore, Depends(get_log_store)],
+    settings_store: Annotated[SettingsStore, Depends(get_settings_store)],
+    key_client: Annotated[KeyClient, Depends(get_key_client)],
+) -> LogDataManager:
+    """Get the singleton LogDataManager."""
+    log_data_manager = _log_data_manager_accessor.get_from(app_state)
+    if log_data_manager is None:
+        return build_log_data_manager(app_state, log_store, settings_store, key_client)
+    return log_data_manager

--- a/audit-server/audit_server/log_storage/log_data_manager.py
+++ b/audit-server/audit_server/log_storage/log_data_manager.py
@@ -120,7 +120,7 @@ class LogDataManager:
         return message_obj.model_dump_json(indent=None)
 
     def _build_sign_error_message(
-        self, sign_error: BaseException, previous_hash: str
+        self, sign_error: BaseException, previous_hash: str | None
     ) -> StoredLog:
         """If the key server isn't running, we need to be able to log that.
 
@@ -160,7 +160,7 @@ class LogDataManager:
             # signing errors are swallowed here because log rotation is an automated
             # process during boot that we can't cancel.
             if sign_error:
-                ending_messages.append(self._build_sign_error_message(sign_error, ""))
+                ending_messages.append(self._build_sign_error_message(sign_error, None))
                 current_tail_hash = ""
 
         # the actual end message required for log validity
@@ -172,7 +172,7 @@ class LogDataManager:
         # signing errors are swallowed here because log rotation is an automated process
         # during boot that we can't handle.
         if sign_error:
-            ending_messages.append(self._build_sign_error_message(sign_error, ""))
+            ending_messages.append(self._build_sign_error_message(sign_error, None))
         ending_messages.append(signed_end_log)
         return self._store.end_period(ending_messages)
 
@@ -184,7 +184,7 @@ class LogDataManager:
             action=constants.ACTION_LOG_PERIOD_START,
             message=constants.MESSAGE_LOG_PERIOD_START,
         )
-        tracking_tail_hash = stop_result if isinstance(stop_result, str) else ""
+        tracking_tail_hash = stop_result if isinstance(stop_result, str) else None
         signed_start, sign_error = await self._sign_log(
             start_message, tracking_tail_hash
         )
@@ -222,7 +222,7 @@ class LogDataManager:
         return self._store.start_period(start_messages)
 
     async def _sign_log(
-        self, log: str, previous_hash: str
+        self, log: str, previous_hash: str | None
     ) -> tuple[StoredLog, Exception | None]:
         """Sign a log message and return it, or a stand-in and an error.
 
@@ -231,6 +231,8 @@ class LogDataManager:
         log rotation and needs to write SOMETHING down, or maybe it's a human and
         needs to reject the action.
         """
+        if previous_hash == "":
+            previous_hash = None
         try:
             signed_message = await self._key_client.sign_message(
                 SignMessageData(message=log, previousHash=previous_hash)

--- a/audit-server/audit_server/log_storage/log_data_manager.py
+++ b/audit-server/audit_server/log_storage/log_data_manager.py
@@ -51,7 +51,7 @@ class LogDataManager:
 
         Returns the hash of the final message in the period.
         """
-        if not self._settings.get_logging_enabled_settings().loggingEnabled:
+        if not self._settings.get_logging_enabled():
             return ""
         async with self._lock:
             return await self._do_rotate_periods()
@@ -62,7 +62,7 @@ class LogDataManager:
         If the key server is not available, this method raises before storing
         the current log, but it will log an (unsigned) error message first.
         """
-        if not self._settings.get_logging_enabled_settings().loggingEnabled:
+        if not self._settings.get_logging_enabled():
             return ""
         async with self._lock:
             return await self._do_store_log(log_message)

--- a/audit-server/audit_server/log_storage/log_data_manager.py
+++ b/audit-server/audit_server/log_storage/log_data_manager.py
@@ -14,6 +14,7 @@ from server_utils.keys.key_server import Client as KeyClient
 from server_utils.keys.key_server import SignMessageData
 
 from . import constants
+from .models import LogPeriodSummary
 from .store import LogStore, NoActivePeriodError, NoLogInPeriodError
 from .types import StoredLog
 from audit_server.log_ingest.models import AuditLogMessage
@@ -65,6 +66,10 @@ class LogDataManager:
             return ""
         async with self._lock:
             return await self._do_store_log(log_message)
+
+    def get_log_periods(self) -> list[LogPeriodSummary]:
+        """Get a list of log periods, active or inactive."""
+        return self._store.list_periods()
 
     async def _do_store_log(self, log_message: str) -> str:
         previous_hash = self._store.tail_hash()

--- a/audit-server/audit_server/settings/models.py
+++ b/audit-server/audit_server/settings/models.py
@@ -45,11 +45,7 @@ class LoggingEnabledResponseData(pydantic.BaseModel):
 class PatchLoggingEnabledRequestData(_StrictBaseModel):
     """A request to change the logging-enabled setting."""
 
-    loggingEnabled: Annotated[
-        bool,
-        pydantic.Field(
-            description=(
-                "Set to `true` to enable audit logging, or `false` to disable it."
-            )
-        ),
-    ]
+    loggingEnabled: bool
+    accountName: str
+    legalName: str
+    reason: str | None

--- a/audit-server/audit_server/settings/router.py
+++ b/audit-server/audit_server/settings/router.py
@@ -5,12 +5,14 @@ internal-only routes under ``/audit/internal``. All other (generic) settings are
 served under ``/audit/external``.
 """
 
+import datetime
 from textwrap import dedent
 from typing import Annotated
 
 import fastapi
 
 from server_utils.fastapi_utils.models.json_api import (
+    PydanticResponse,
     RequestModel,
     SimpleBody,
 )
@@ -22,12 +24,21 @@ from .models import (
     SettingsResponseData,
 )
 from .store import SettingsStore, get_settings_store
+from audit_server.log_ingest.models import AuditLogMessage
+from audit_server.log_storage.dependency import get_log_data_manager
+from audit_server.log_storage.log_data_manager import LogDataManager
 
 router = fastapi.APIRouter()
 
+MESSAGE_LOG_ENABLE = "Logging was enabled."
+MESSAGE_LOG_DISABLE = "Logging was disabled."
+ACTION_LOG_ENABLE = "log-enable"
+ACTION_LOG_DISABLE = "log-disable"
 
-@router.get(
-    "/audit/internal/loggingEnabled",
+
+@PydanticResponse.wrap_route(
+    router.get,
+    path="/audit/internal/loggingEnabled",
     summary="Get the logging-enabled setting",
     description=dedent(
         """\
@@ -40,38 +51,80 @@ router = fastapi.APIRouter()
 )
 async def get_logging_enabled_settings(  # noqa: D103
     settings_store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],
-) -> SimpleBody[LoggingEnabledResponseData]:
-    logging_enabled = settings_store.get_logging_enabled_settings()
-    return SimpleBody.model_construct(data=logging_enabled)
+) -> PydanticResponse[SimpleBody[LoggingEnabledResponseData]]:
+    logging_enabled = settings_store.get_logging_enabled()
+    return await PydanticResponse.create(
+        status_code=fastapi.status.HTTP_200_OK,
+        content=SimpleBody.model_construct(
+            data=LoggingEnabledResponseData(loggingEnabled=logging_enabled)
+        ),
+    )
 
 
-@router.patch(
-    "/audit/internal/loggingEnabled",
+@PydanticResponse.wrap_route(
+    router.patch,
+    path="/audit/internal/loggingEnabled",
     summary="Change the logging-enabled setting",
     description="Enable or disable audit logging.",
 )
 async def patch_logging_enabled_settings(  # noqa: D103
     request_body: RequestModel[PatchLoggingEnabledRequestData],
     settings_store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],
-) -> SimpleBody[LoggingEnabledResponseData]:
-    logging_enabled = settings_store.patch_logging_enabled(request_body.data)
-    return SimpleBody.model_construct(data=logging_enabled)
+    log_data_manager: Annotated[LogDataManager, fastapi.Depends(get_log_data_manager)],
+) -> PydanticResponse[SimpleBody[LoggingEnabledResponseData]]:
+    was_logging_enabled = settings_store.get_logging_enabled()
+    if was_logging_enabled and not request_body.data.loggingEnabled:
+        message = AuditLogMessage(
+            action=ACTION_LOG_DISABLE,
+            accountName=request_body.data.accountName,
+            legalName=request_body.data.legalName,
+            message=MESSAGE_LOG_DISABLE,
+            reason=request_body.data.reason,
+            loggedAt=datetime.datetime.now(datetime.timezone.utc),
+        )
+        await log_data_manager.store_log(message.model_dump_json(indent=None))
+    is_logging_enabled = settings_store.patch_logging_enabled(
+        request_body.data.loggingEnabled
+    )
+    if is_logging_enabled and not was_logging_enabled:
+        await log_data_manager.rotate_periods()
+        message = AuditLogMessage(
+            action=ACTION_LOG_ENABLE,
+            accountName=request_body.data.accountName,
+            legalName=request_body.data.legalName,
+            message=MESSAGE_LOG_ENABLE,
+            reason=request_body.data.reason,
+            loggedAt=datetime.datetime.now(datetime.timezone.utc),
+        )
+        await log_data_manager.store_log(message.model_dump_json(indent=None))
+
+    return await PydanticResponse.create(
+        status_code=fastapi.status.HTTP_200_OK,
+        content=SimpleBody.model_construct(
+            data=LoggingEnabledResponseData(loggingEnabled=is_logging_enabled)
+        ),
+    )
 
 
-@router.get(
-    "/audit/external/settings",
+@PydanticResponse.wrap_route(
+    router.get,
+    path="/audit/external/settings",
     summary="Get audit settings",
     description="Get the current audit-server settings.",
 )
 async def get_settings(  # noqa: D103
     settings_store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],
-) -> SimpleBody[SettingsResponseData]:
+) -> PydanticResponse[SimpleBody[SettingsResponseData]]:
     settings = settings_store.get_settings()
-    return SimpleBody.model_construct(data=settings)
+    return await PydanticResponse.create(
+        status_code=fastapi.status.HTTP_200_OK,
+        content=SimpleBody.model_construct(data=settings),
+    )
 
 
-@router.patch(
-    "/audit/external/settings",
+@PydanticResponse.wrap_route(
+    router.patch,
+    path="/audit/external/settings",
     summary="Change audit settings",
     description=dedent(
         """\
@@ -85,13 +138,17 @@ async def get_settings(  # noqa: D103
 async def patch_settings(  # noqa: D103
     request_body: RequestModel[PatchSettingsRequestData],
     settings_store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],
-) -> SimpleBody[SettingsResponseData]:
+) -> PydanticResponse[SimpleBody[SettingsResponseData]]:
     new_settings = settings_store.patch_settings(request_body.data)
-    return SimpleBody.model_construct(data=new_settings)
+    return await PydanticResponse.create(
+        status_code=fastapi.status.HTTP_200_OK,
+        content=SimpleBody.model_construct(data=new_settings),
+    )
 
 
-@router.delete(
-    "/audit/external/settings",
+@PydanticResponse.wrap_route(
+    router.delete,
+    path="/audit/external/settings",
     summary="Reset audit settings",
     description=dedent(
         """\
@@ -103,6 +160,9 @@ async def patch_settings(  # noqa: D103
 )
 async def delete_settings(  # noqa: D103
     settings_store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],
-) -> SimpleBody[SettingsResponseData]:
+) -> PydanticResponse[SimpleBody[SettingsResponseData]]:
     new_settings = settings_store.reset_settings()
-    return SimpleBody.model_construct(data=new_settings)
+    return await PydanticResponse.create(
+        status_code=fastapi.status.HTTP_200_OK,
+        content=SimpleBody.model_construct(data=new_settings),
+    )

--- a/audit-server/audit_server/settings/store.py
+++ b/audit-server/audit_server/settings/store.py
@@ -17,8 +17,6 @@ from server_utils.sql_utils import JsonPythonValue
 from audit_server.persistence.fastapi_dependencies import get_sql_engine
 from audit_server.persistence.orm_models import LoggingEnabled, Setting
 from audit_server.settings.models import (
-    LoggingEnabledResponseData,
-    PatchLoggingEnabledRequestData,
     PatchSettingsRequestData,
     SettingsResponseData,
 )
@@ -87,10 +85,10 @@ class SettingsStore:
                 return None
             return bool(row.enabled)
 
-    def get_logging_enabled_settings(self) -> LoggingEnabledResponseData:
+    def get_logging_enabled(self) -> bool:
         """Get the current logging-enabled setting (defaults to False)."""
         enabled = self._get_logging_enabled()
-        return LoggingEnabledResponseData(loggingEnabled=enabled or False)
+        return enabled or False
 
     def update_logging_enabled_table(self, loggingEnabled: bool) -> None:
         """Set the logging-enabled setting."""
@@ -104,16 +102,14 @@ class SettingsStore:
                 row.enabled = loggingEnabled
             session.commit()
 
-    def patch_logging_enabled(
-        self, patch: PatchLoggingEnabledRequestData
-    ) -> LoggingEnabledResponseData:
+    def patch_logging_enabled(self, new_state: bool) -> bool:
         """Patch the logging-enabled setting.
 
         Unlike auth-server's access-control flag, this is freely toggleable in
         both directions. An omitted ``loggingEnabled`` leaves the setting as-is.
         """
-        self.update_logging_enabled_table(patch.loggingEnabled)
-        return self.get_logging_enabled_settings()
+        self.update_logging_enabled_table(new_state)
+        return self.get_logging_enabled()
 
 
 _accessor = AppStateAccessor[SettingsStore]("settings_store")

--- a/audit-server/audit_server/settings/store.py
+++ b/audit-server/audit_server/settings/store.py
@@ -106,7 +106,7 @@ class SettingsStore:
         """Patch the logging-enabled setting.
 
         Unlike auth-server's access-control flag, this is freely toggleable in
-        both directions. An omitted ``loggingEnabled`` leaves the setting as-is.
+        both directions.
         """
         self.update_logging_enabled_table(new_state)
         return self.get_logging_enabled()

--- a/audit-server/tests/__init__.py
+++ b/audit-server/tests/__init__.py
@@ -1,1 +1,55 @@
-# noqa: D104
+"""Tests for audit server."""
+
+import datetime
+from typing import Any, Callable
+
+from audit_server.log_ingest.models import AuditLogMessage, SubmitAuditLogMessageData
+
+
+class RecentTimestampMatcher:
+    def __eq__(self, other: object) -> bool:
+        assert isinstance(other, datetime.datetime)
+        return bool(_assert_loggedat_is_recent_utc_iso(other))
+
+
+class LogPayloadMatcher:
+    """Decoy matcher for capturing a message."""
+
+    def __init__(
+        self,
+        message: SubmitAuditLogMessageData,
+        loggedAt: Any,
+        extra: Callable[[str], bool] | None = None,
+    ) -> None:
+        self._message = message
+        self._loggedAt = loggedAt
+        self._extra = extra
+
+    def __eq__(self, other: object) -> bool:
+        assert isinstance(other, str)
+        incoming = AuditLogMessage.model_validate_json(other)
+        assert incoming.action == self._message.action
+        assert incoming.accountName == self._message.accountName
+        assert incoming.legalName == self._message.legalName
+        assert incoming.message == self._message.message
+        assert incoming.reason == self._message.reason
+        assert incoming.loggedAt == self._loggedAt
+        if self._extra:
+            self._extra(other)
+        return True
+
+
+def _assert_loggedat_is_recent_utc_iso(parsed: datetime.datetime) -> datetime.datetime:
+    """Assert ``value`` is an ISO-8601 UTC datetime near the current wall clock."""
+
+    assert parsed.tzinfo is not None, f"loggedAt {parsed!r} must include tz info"
+    assert parsed.utcoffset() == datetime.timedelta(0), (
+        f"loggedAt {parsed!r} must be UTC"
+    )
+    # The route stamps loggedAt at request handling time; allow a generous skew so
+    # the test isn't flaky on slow CI.
+    now = datetime.datetime.now(datetime.timezone.utc)
+    assert abs((now - parsed).total_seconds()) < 60, (
+        f"loggedAt {parsed!r} is too far from now {now.isoformat()}"
+    )
+    return parsed

--- a/audit-server/tests/__init__.py
+++ b/audit-server/tests/__init__.py
@@ -8,8 +8,9 @@ from audit_server.log_ingest.models import AuditLogMessage, SubmitAuditLogMessag
 
 class RecentTimestampMatcher:
     def __eq__(self, other: object) -> bool:
-        assert isinstance(other, datetime.datetime)
-        return bool(_assert_loggedat_is_recent_utc_iso(other))
+        return isinstance(other, datetime.datetime) and _loggedat_is_recent_utc_iso(
+            other
+        )
 
 
 class LogPayloadMatcher:
@@ -26,30 +27,30 @@ class LogPayloadMatcher:
         self._extra = extra
 
     def __eq__(self, other: object) -> bool:
-        assert isinstance(other, str)
+        if not isinstance(other, str):
+            return False
         incoming = AuditLogMessage.model_validate_json(other)
-        assert incoming.action == self._message.action
-        assert incoming.accountName == self._message.accountName
-        assert incoming.legalName == self._message.legalName
-        assert incoming.message == self._message.message
-        assert incoming.reason == self._message.reason
-        assert incoming.loggedAt == self._loggedAt
-        if self._extra:
-            self._extra(other)
-        return True
+        return (
+            incoming.action == self._message.action
+            and incoming.accountName == self._message.accountName
+            and incoming.legalName == self._message.legalName
+            and incoming.message == self._message.message
+            and incoming.reason == self._message.reason
+            and incoming.loggedAt == self._loggedAt
+            and (self._extra(other) if self._extra else True)
+        )
 
 
-def _assert_loggedat_is_recent_utc_iso(parsed: datetime.datetime) -> datetime.datetime:
+def _loggedat_is_recent_utc_iso(parsed: datetime.datetime) -> bool:
     """Assert ``value`` is an ISO-8601 UTC datetime near the current wall clock."""
 
-    assert parsed.tzinfo is not None, f"loggedAt {parsed!r} must include tz info"
-    assert parsed.utcoffset() == datetime.timedelta(0), (
-        f"loggedAt {parsed!r} must be UTC"
-    )
+    if parsed.tzinfo is None:
+        return False
+    if parsed.utcoffset() != datetime.timedelta(0):
+        return False
     # The route stamps loggedAt at request handling time; allow a generous skew so
     # the test isn't flaky on slow CI.
     now = datetime.datetime.now(datetime.timezone.utc)
-    assert abs((now - parsed).total_seconds()) < 60, (
-        f"loggedAt {parsed!r} is too far from now {now.isoformat()}"
-    )
-    return parsed
+    if (now - parsed).total_seconds() > 60:
+        return False
+    return True

--- a/audit-server/tests/conftest.py
+++ b/audit-server/tests/conftest.py
@@ -7,10 +7,13 @@ from typing import Callable, Generator
 import aiohttp.web
 import pytest
 import requests
+from decoy import Decoy
 from sqlalchemy.engine import Engine as SQLEngine
 
+from server_utils.keys.key_server import Client as KeyClient
 from tests.dev_server import DevServer
 
+from audit_server.log_storage.log_data_manager import LogDataManager
 from audit_server.persistence.database import create_schema, sql_engine_ctx
 
 _INTEGRATION_SERVER_STARTUP_TIMEOUT_S = 30
@@ -41,6 +44,17 @@ def configure_test_logs(caplog: pytest.LogCaptureFixture) -> None:
     # WARNING, even if you pass --log-level=DEBUG to pytest on the command line.
     # See: https://docs.sqlalchemy.org/en/14/core/engines.html#configuring-logging
     caplog.set_level("NOTSET", logger="sqlalchemy")
+
+
+@pytest.fixture
+def mock_key_client(decoy: Decoy) -> KeyClient:
+    """A decoy mock key client."""
+    return decoy.mock(cls=KeyClient)
+
+
+@pytest.fixture
+def mock_log_data_manager(decoy: Decoy) -> LogDataManager:
+    return decoy.mock(cls=LogDataManager)
 
 
 @pytest.fixture

--- a/audit-server/tests/integration/conftest.py
+++ b/audit-server/tests/integration/conftest.py
@@ -1,0 +1,15 @@
+import httpx
+import pytest
+
+from ..dev_server import DevServer
+
+
+@pytest.fixture
+async def enable_logging(run_server: DevServer) -> None:
+    """Enable logging to the database."""
+    async with httpx.AsyncClient() as client:
+        response = await client.patch(
+            f"{run_server.base_url}/audit/internal/loggingEnabled",
+            json={"data": {"loggingEnabled": True}},
+        )
+        response.raise_for_status()

--- a/audit-server/tests/integration/conftest.py
+++ b/audit-server/tests/integration/conftest.py
@@ -10,6 +10,13 @@ async def enable_logging(run_server: DevServer) -> None:
     async with httpx.AsyncClient() as client:
         response = await client.patch(
             f"{run_server.base_url}/audit/internal/loggingEnabled",
-            json={"data": {"loggingEnabled": True}},
+            json={
+                "data": {
+                    "loggingEnabled": True,
+                    "accountName": "test",
+                    "legalName": "Test",
+                    "reason": "enabled for integration testing",
+                }
+            },
         )
         response.raise_for_status()

--- a/audit-server/tests/integration/test_logMessage.tavern.yaml
+++ b/audit-server/tests/integration/test_logMessage.tavern.yaml
@@ -3,6 +3,7 @@ test_name: logMessage endpoint
 marks:
   - usefixtures:
       - run_server
+      - enable_logging
 
 stages:
   - name: POST /audit/internal/logMessage logs valid message with reason

--- a/audit-server/tests/integration/test_logPeriods.tavern.yaml
+++ b/audit-server/tests/integration/test_logPeriods.tavern.yaml
@@ -14,7 +14,7 @@ stages:
       status_code: 200
       json:
         data:
-          - id: 0
+          - id: 1
             startedAt: !anystr
             endedAt: null
         meta:

--- a/audit-server/tests/integration/test_logPeriods.tavern.yaml
+++ b/audit-server/tests/integration/test_logPeriods.tavern.yaml
@@ -1,0 +1,22 @@
+test_name: logPeriods endpoint
+
+marks:
+  - usefixtures:
+      - run_server
+      - enable_logging
+
+stages:
+  - name: GET /audit/external/logPeriods gets newly-rotated period
+    request:
+      method: GET
+      url: '{run_server.base_url}/audit/external/logPeriods'
+    response:
+      status_code: 200
+      json:
+        data:
+          - id: 0
+            startedAt: !anystr
+            endedAt: null
+        meta:
+          cursor: 0
+          totalLength: 1

--- a/audit-server/tests/integration/test_settings.tavern.yaml
+++ b/audit-server/tests/integration/test_settings.tavern.yaml
@@ -22,6 +22,9 @@ stages:
       json:
         data:
           loggingEnabled: true
+          accountName: test
+          legalName: Test
+          reason: null
     response:
       status_code: 200
       json:
@@ -45,6 +48,10 @@ stages:
       json:
         data:
           loggingEnabled: false
+          accountName: test
+          legalName: Test
+          reason: null
+
     response:
       status_code: 200
       json:

--- a/audit-server/tests/log_export/test_router.py
+++ b/audit-server/tests/log_export/test_router.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-import pytest
 from decoy import Decoy
 
 from audit_server.log_export.router import get_log_periods
+from audit_server.log_storage.log_data_manager import LogDataManager
 from audit_server.log_storage.models import LogPeriodSummary
-from audit_server.log_storage.store import LogStore
 
 _OLDER_PERIOD = LogPeriodSummary(
     id=1,
@@ -24,46 +23,42 @@ _NEWER_PERIOD = LogPeriodSummary(
 )
 
 
-@pytest.fixture
-def log_store(decoy: Decoy) -> LogStore:
-    """A mocked LogStore."""
-    return decoy.mock(cls=LogStore)
-
-
 async def test_get_log_periods_empty(
     decoy: Decoy,
-    log_store: LogStore,
+    mock_log_data_manager: LogDataManager,
 ) -> None:
     """It should return an empty data list and totalLength of 0."""
-    decoy.when(log_store.list_periods()).then_return([])
+    decoy.when(mock_log_data_manager.get_log_periods()).then_return([])
 
-    result = await get_log_periods(log_store=log_store)
+    result = await get_log_periods(log_data_manager=mock_log_data_manager)
 
     assert result.data == []
     assert result.meta.totalLength == 0
 
 
 async def test_get_log_periods_returns_all_periods(
-    decoy: Decoy,
-    log_store: LogStore,
+    decoy: Decoy, mock_log_data_manager: LogDataManager
 ) -> None:
     """It should return all periods returned by the store."""
-    decoy.when(log_store.list_periods()).then_return([_NEWER_PERIOD, _OLDER_PERIOD])
+    decoy.when(mock_log_data_manager.get_log_periods()).then_return(
+        [_NEWER_PERIOD, _OLDER_PERIOD]
+    )
 
-    result = await get_log_periods(log_store=log_store)
+    result = await get_log_periods(log_data_manager=mock_log_data_manager)
 
     assert len(result.data) == 2
     assert result.meta.totalLength == 2
 
 
 async def test_get_log_periods_preserves_store_order(
-    decoy: Decoy,
-    log_store: LogStore,
+    decoy: Decoy, mock_log_data_manager: LogDataManager
 ) -> None:
     """It should return periods in the same order the store provides them."""
-    decoy.when(log_store.list_periods()).then_return([_NEWER_PERIOD, _OLDER_PERIOD])
+    decoy.when(mock_log_data_manager.get_log_periods()).then_return(
+        [_NEWER_PERIOD, _OLDER_PERIOD]
+    )
 
-    result = await get_log_periods(log_store=log_store)
+    result = await get_log_periods(log_data_manager=mock_log_data_manager)
 
     assert result.data[0].startedAt > result.data[1].startedAt
     assert result.data[0].endedAt is None

--- a/audit-server/tests/log_ingest/test_router.py
+++ b/audit-server/tests/log_ingest/test_router.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import datetime
 import json
-from typing import Any, Callable, cast
+from typing import Any, cast
 
 import fastapi
 import pytest
@@ -13,58 +12,10 @@ from opentrons_shared_data.errors.exceptions import KeyStorageUnavailableError
 
 from server_utils.fastapi_utils.models.json_api import RequestModel
 
-from audit_server.log_ingest.models import AuditLogMessage, SubmitAuditLogMessageData
+from .. import LogPayloadMatcher, RecentTimestampMatcher
+from audit_server.log_ingest.models import SubmitAuditLogMessageData
 from audit_server.log_ingest.router import post_log_message
 from audit_server.log_storage.log_data_manager import LogDataManager
-
-
-class RecentTimestampMatcher:
-    def __eq__(self, other: object) -> bool:
-        assert isinstance(other, datetime.datetime)
-        return bool(_assert_loggedat_is_recent_utc_iso(other))
-
-
-class LogPayloadMatcher:
-    """Decoy matcher for capturing a message."""
-
-    def __init__(
-        self,
-        message: SubmitAuditLogMessageData,
-        loggedAt: Any,
-        extra: Callable[[str], bool] | None = None,
-    ) -> None:
-        self._message = message
-        self._loggedAt = loggedAt
-        self._extra = extra
-
-    def __eq__(self, other: object) -> bool:
-        assert isinstance(other, str)
-        incoming = AuditLogMessage.model_validate_json(other)
-        assert incoming.action == self._message.action
-        assert incoming.accountName == self._message.accountName
-        assert incoming.legalName == self._message.legalName
-        assert incoming.message == self._message.message
-        assert incoming.reason == self._message.reason
-        assert incoming.loggedAt == self._loggedAt
-        if self._extra:
-            self._extra(other)
-        return True
-
-
-def _assert_loggedat_is_recent_utc_iso(parsed: datetime.datetime) -> datetime.datetime:
-    """Assert ``value`` is an ISO-8601 UTC datetime near the current wall clock."""
-
-    assert parsed.tzinfo is not None, f"loggedAt {parsed!r} must include tz info"
-    assert parsed.utcoffset() == datetime.timedelta(0), (
-        f"loggedAt {parsed!r} must be UTC"
-    )
-    # The route stamps loggedAt at request handling time; allow a generous skew so
-    # the test isn't flaky on slow CI.
-    now = datetime.datetime.now(datetime.timezone.utc)
-    assert abs((now - parsed).total_seconds()) < 60, (
-        f"loggedAt {parsed!r} is too far from now {now.isoformat()}"
-    )
-    return parsed
 
 
 async def test_full_request_body_forwarded_to_ldm(

--- a/audit-server/tests/log_ingest/test_router.py
+++ b/audit-server/tests/log_ingest/test_router.py
@@ -85,7 +85,7 @@ async def test_non_ascii_utf8_message_forwarded_verbatim(
     mock_log_data_manager: LogDataManager, decoy: Decoy
 ) -> None:
     """Non-ASCII characters that round-trip cleanly through UTF-8 must reach
-    the LDM with their code points intact."""
+    the log data manager with their code points intact."""
     # Includes Latin diacritics, CJK ideographs, a zero-width joiner emoji
     # sequence, and a high-plane emoji to cover BMP + supplementary planes.
     non_ascii_message = "Démarrage du protocole №1: 实验开始 — 🧬👩‍🔬🚀 (β=½)"

--- a/audit-server/tests/log_ingest/test_router.py
+++ b/audit-server/tests/log_ingest/test_router.py
@@ -4,219 +4,209 @@ from __future__ import annotations
 
 import datetime
 import json
-from typing import Generator
+from typing import Any, Callable, cast
 
-import aiohttp
+import fastapi
 import pytest
-from fastapi import FastAPI
-from starlette.testclient import TestClient
+from decoy import Decoy
+from opentrons_shared_data.errors.exceptions import KeyStorageUnavailableError
 
-from server_utils.keys.fastapi import install_key_client
-from server_utils.keys.key_server import (
-    Client as KeyClient,
-)
-from server_utils.keys.key_server import (
-    SignedMessageData,
-    SignMessageData,
-)
+from server_utils.fastapi_utils.models.json_api import RequestModel
 
-from audit_server.log_ingest.router import router as ingest_router
-
-_ENDPOINT_PATH = "/audit/internal/logMessage"
-
-_CANNED_SIGNED_MESSAGE = SignedMessageData(
-    message="<placeholder>",
-    messageHash="sha256:ZmFrZQ==",
-    messageSignature="ed25519:ZmFrZQ==",
-    signatureVersion=1,
-)
+from audit_server.log_ingest.models import AuditLogMessage, SubmitAuditLogMessageData
+from audit_server.log_ingest.router import post_log_message
+from audit_server.log_storage.log_data_manager import LogDataManager
 
 
-class StubKeyClient(KeyClient):
-    """A hand-rolled mock of the key-server `Client`.
-
-    Captures every call to `sign_message` in `calls` and, by default, returns
-    `_CANNED_SIGNED_MESSAGE`. Setting `raise_on_sign` to an exception makes
-    the next call raise that exception instead, simulating a key-server that's
-    unreachable or otherwise broken.
-    """
-
-    def __init__(self) -> None:
-        self.calls: list[SignMessageData] = []
-        self.response: SignedMessageData = _CANNED_SIGNED_MESSAGE
-        self.raise_on_sign: Exception | None = None
-
-    async def sign_message(self, message: SignMessageData) -> SignedMessageData:
-        self.calls.append(message)
-        if self.raise_on_sign is not None:
-            raise self.raise_on_sign
-        return self.response
+class RecentTimestampMatcher:
+    def __eq__(self, other: object) -> bool:
+        assert isinstance(other, datetime.datetime)
+        return bool(_assert_loggedat_is_recent_utc_iso(other))
 
 
-@pytest.fixture
-def stub_key_client() -> StubKeyClient:
-    """A fresh `StubKeyClient` for each test."""
-    return StubKeyClient()
+class LogPayloadMatcher:
+    """Decoy matcher for capturing a message."""
+
+    def __init__(
+        self,
+        message: SubmitAuditLogMessageData,
+        loggedAt: Any,
+        extra: Callable[[str], bool] | None = None,
+    ) -> None:
+        self._message = message
+        self._loggedAt = loggedAt
+        self._extra = extra
+
+    def __eq__(self, other: object) -> bool:
+        assert isinstance(other, str)
+        incoming = AuditLogMessage.model_validate_json(other)
+        assert incoming.action == self._message.action
+        assert incoming.accountName == self._message.accountName
+        assert incoming.legalName == self._message.legalName
+        assert incoming.message == self._message.message
+        assert incoming.reason == self._message.reason
+        assert incoming.loggedAt == self._loggedAt
+        if self._extra:
+            self._extra(other)
+        return True
 
 
-@pytest.fixture
-def app(stub_key_client: StubKeyClient) -> FastAPI:
-    """A minimal FastAPI app wired up with the log-ingest router and a stub key client."""
-    app = FastAPI()
-    install_key_client(app.state, stub_key_client)
-    app.include_router(ingest_router)
-    return app
-
-
-@pytest.fixture
-def client(app: FastAPI) -> Generator[TestClient, None, None]:
-    """A starlette `TestClient` for the FastAPI app."""
-    with TestClient(app) as test_client:
-        yield test_client
-
-
-def _assert_loggedat_is_recent_utc_iso(value: object) -> datetime.datetime:
+def _assert_loggedat_is_recent_utc_iso(parsed: datetime.datetime) -> datetime.datetime:
     """Assert ``value`` is an ISO-8601 UTC datetime near the current wall clock."""
-    assert isinstance(value, str)
-    parsed = datetime.datetime.fromisoformat(value)
-    assert parsed.tzinfo is not None, f"loggedAt {value!r} must include tz info"
+
+    assert parsed.tzinfo is not None, f"loggedAt {parsed!r} must include tz info"
     assert parsed.utcoffset() == datetime.timedelta(0), (
-        f"loggedAt {value!r} must be UTC"
+        f"loggedAt {parsed!r} must be UTC"
     )
     # The route stamps loggedAt at request handling time; allow a generous skew so
     # the test isn't flaky on slow CI.
     now = datetime.datetime.now(datetime.timezone.utc)
     assert abs((now - parsed).total_seconds()) < 60, (
-        f"loggedAt {value!r} is too far from now {now.isoformat()}"
+        f"loggedAt {parsed!r} is too far from now {now.isoformat()}"
     )
     return parsed
 
 
-def test_full_request_body_forwarded_to_key_server(
-    client: TestClient,
-    stub_key_client: StubKeyClient,
+async def test_full_request_body_forwarded_to_ldm(
+    decoy: Decoy, mock_log_data_manager: LogDataManager
 ) -> None:
-    """The full request body must be serialized to JSON and forwarded to
-    ``key_client.sign_message`` (along with the server-stamped ``loggedAt``)."""
-    request_body = {
-        "data": {
-            "action": "run.start",
-            "accountName": "alice",
-            "legalName": "Alice Anderson",
-            "message": "Started run abc-123",
-            "reason": "Routine experiment",
-        },
-    }
-    response = client.post(_ENDPOINT_PATH, json=request_body)
+    """The full request body must be sent to the log data manager with a server timestamp."""
+    log_data = SubmitAuditLogMessageData(
+        action="run.start",
+        accountName="alice",
+        legalName="Alice Anderson",
+        message="Started run abc-123",
+        reason="Routine experiment",
+    )
+    decoy.when(
+        await mock_log_data_manager.store_log(
+            cast(
+                Any,
+                LogPayloadMatcher(message=log_data, loggedAt=RecentTimestampMatcher()),
+            )
+        )
+    ).then_return("")
+    response = await post_log_message(
+        RequestModel(data=log_data), log_data_manager=mock_log_data_manager
+    )
 
-    assert response.status_code == 201, response.text
-
-    assert len(stub_key_client.calls) == 1
-    forwarded_arg = stub_key_client.calls[0]
-    assert forwarded_arg.previousHash is None
-
-    forwarded_payload = json.loads(forwarded_arg.message)
-    # Every field from the request body must round-trip into what we ask the
-    # key-server to sign.
-    for key, value in request_body["data"].items():
-        assert forwarded_payload[key] == value
-    # The server also adds an ingest timestamp; verify it's a sensible value.
-    _assert_loggedat_is_recent_utc_iso(forwarded_payload["loggedAt"])
-    # Make sure nothing extra got smuggled in.
-    assert set(forwarded_payload) == set(request_body["data"]) | {"loggedAt"}
+    assert response.status_code == 201
 
 
-def test_full_request_body_forwarded_with_null_reason(
-    client: TestClient,
-    stub_key_client: StubKeyClient,
+async def test_full_request_body_forwarded_with_null_reason(
+    mock_log_data_manager: LogDataManager, decoy: Decoy
 ) -> None:
-    """A `reason: null` request body must round-trip through to the key-server
-    payload as JSON `null` (not omitted)."""
-    request_body = {
-        "data": {
-            "action": "run.start",
-            "accountName": "alice",
-            "legalName": "Alice Anderson",
-            "message": "Started run abc-123",
-            "reason": None,
-        },
-    }
-    response = client.post(_ENDPOINT_PATH, json=request_body)
+    """The full request body must be sent to the log data manager with a server timestamp."""
+    log_data = SubmitAuditLogMessageData(
+        action="run.start",
+        accountName="alice",
+        legalName="Alice Anderson",
+        message="Started run abc-123",
+        reason=None,
+    )
 
-    assert response.status_code == 201, response.text
+    def _null_reason_not_dropped(message_str: str) -> bool:
+        message_data = json.loads(message_str)
+        assert message_data["reason"] is None
+        return True
 
-    assert len(stub_key_client.calls) == 1
-    forwarded_payload = json.loads(stub_key_client.calls[0].message)
-    assert "reason" in forwarded_payload
-    assert forwarded_payload["reason"] is None
+    decoy.when(
+        await mock_log_data_manager.store_log(
+            cast(
+                Any,
+                LogPayloadMatcher(
+                    message=log_data,
+                    loggedAt=RecentTimestampMatcher(),
+                    extra=_null_reason_not_dropped,
+                ),
+            )
+        )
+    ).then_return("")
+
+    response = await post_log_message(
+        RequestModel(data=log_data), log_data_manager=mock_log_data_manager
+    )
+
+    assert response.status_code == 201
 
 
-def test_non_ascii_utf8_message_forwarded_verbatim(
-    client: TestClient,
-    stub_key_client: StubKeyClient,
+async def test_non_ascii_utf8_message_forwarded_verbatim(
+    mock_log_data_manager: LogDataManager, decoy: Decoy
 ) -> None:
     """Non-ASCII characters that round-trip cleanly through UTF-8 must reach
-    the key-server with their code points intact."""
+    the LDM with their code points intact."""
     # Includes Latin diacritics, CJK ideographs, a zero-width joiner emoji
     # sequence, and a high-plane emoji to cover BMP + supplementary planes.
     non_ascii_message = "Démarrage du protocole №1: 实验开始 — 🧬👩‍🔬🚀 (β=½)"
-    request_body = {
-        "data": {
-            "action": "run.start",
-            "accountName": "élise",
-            "legalName": "Élise Müller-中野",
-            "message": non_ascii_message,
-            "reason": "experimentación",
-        },
-    }
-    response = client.post(_ENDPOINT_PATH, json=request_body)
-
-    assert response.status_code == 201, response.text
-
-    assert len(stub_key_client.calls) == 1
-    forwarded_arg = stub_key_client.calls[0]
-    forwarded_payload = json.loads(forwarded_arg.message)
-    assert forwarded_payload["message"] == non_ascii_message
-    assert forwarded_payload["accountName"] == "élise"
-    assert forwarded_payload["legalName"] == "Élise Müller-中野"
-    assert forwarded_payload["reason"] == "experimentación"
-    # The serialized JSON we pass to the key-server must itself round-trip
-    # losslessly through UTF-8, since the key-server hashes UTF-8 bytes.
-    assert (
-        forwarded_arg.message.encode("utf-8").decode("utf-8") == forwarded_arg.message
+    log_data = SubmitAuditLogMessageData(
+        action="run.start",
+        accountName="élise",
+        legalName="Élise Müller-中野",
+        message=non_ascii_message,
+        reason="experimentación",
     )
-    assert non_ascii_message in forwarded_arg.message
+
+    def _test_utf8_stuff(log_message: str) -> bool:
+        forwarded_payload = json.loads(log_message)
+        assert forwarded_payload["message"] == non_ascii_message
+        assert forwarded_payload["accountName"] == "élise"
+        assert forwarded_payload["legalName"] == "Élise Müller-中野"
+        assert forwarded_payload["reason"] == "experimentación"
+        # The serialized JSON we pass to the key-server must itself round-trip
+        # losslessly through UTF-8, since the key-server hashes UTF-8 bytes.
+        assert log_message.encode("utf-8").decode("utf-8") == log_message
+        assert non_ascii_message in log_message
+        return True
+
+    decoy.when(
+        await mock_log_data_manager.store_log(
+            cast(
+                Any,
+                LogPayloadMatcher(
+                    message=log_data,
+                    loggedAt=RecentTimestampMatcher(),
+                    extra=_test_utf8_stuff,
+                ),
+            )
+        )
+    )
+
+    response = await post_log_message(
+        RequestModel(data=log_data), log_data_manager=mock_log_data_manager
+    )
+
+    assert response.status_code == 201
 
 
-def test_returns_503_when_key_server_unavailable(
-    client: TestClient,
-    stub_key_client: StubKeyClient,
+async def test_returns_503_when_key_server_unavailable(
+    mock_log_data_manager: LogDataManager, decoy: Decoy
 ) -> None:
     """If the key-server cannot be contacted, the endpoint must return a
     well-formed HTTP 503 instead of crashing with a 500."""
-    stub_key_client.raise_on_sign = aiohttp.ClientConnectionError("connection refused")
+    log_data = SubmitAuditLogMessageData(
+        action="run.start",
+        accountName="alice",
+        legalName="Alice Anderson",
+        message="Started run abc-123",
+        reason=None,
+    )
+    decoy.when(
+        await mock_log_data_manager.store_log(
+            cast(
+                Any,
+                LogPayloadMatcher(message=log_data, loggedAt=RecentTimestampMatcher()),
+            )
+        )
+    ).then_raise(KeyStorageUnavailableError("oh no"))
 
-    request_body = {
-        "data": {
-            "action": "run.start",
-            "accountName": "alice",
-            "legalName": "Alice Anderson",
-            "message": "Started run abc-123",
-            "reason": None,
-        },
-    }
-    response = client.post(_ENDPOINT_PATH, json=request_body)
+    def _check(exc: BaseException) -> bool:
+        if not isinstance(exc, fastapi.HTTPException):
+            return False
+        if exc.status_code != 503:
+            return False
+        return True
 
-    assert response.status_code == 503
-    assert response.headers["content-type"].startswith("application/json")
-    body = response.json()
-    assert isinstance(body, dict)
-    # FastAPI's standard error envelope: {"detail": "..."}.
-    assert "detail" in body
-    assert isinstance(body["detail"], str) and body["detail"]
-    # The error message should clearly identify key-server as the cause so
-    # the operator knows what to fix.
-    assert "key-server" in body["detail"].lower()
-    # And the stub really was called — proving we did try to reach the key
-    # server before returning 503.
-    assert len(stub_key_client.calls) == 1
+    with pytest.raises(check=_check):
+        await post_log_message(
+            RequestModel(data=log_data), log_data_manager=mock_log_data_manager
+        )

--- a/audit-server/tests/log_storage/test_log_data_manager.py
+++ b/audit-server/tests/log_storage/test_log_data_manager.py
@@ -17,7 +17,6 @@ from audit_server.log_storage.store import (
     NoLogInPeriodError,
 )
 from audit_server.log_storage.types import StoredLog
-from audit_server.settings.models import LoggingEnabledResponseData
 from audit_server.settings.store import SettingsStore
 
 
@@ -39,9 +38,7 @@ def mock_time(decoy: Decoy) -> _GetTime:
 def mock_settings(decoy: Decoy) -> SettingsStore:
     """A mock settings store."""
     settings = decoy.mock(cls=SettingsStore)
-    decoy.when(settings.get_logging_enabled_settings()).then_return(
-        LoggingEnabledResponseData(loggingEnabled=True)
-    )
+    decoy.when(settings.get_logging_enabled()).then_return(True)
     return settings
 
 
@@ -69,9 +66,7 @@ def subject(
 @pytest.fixture
 def disable_logging(mock_settings: SettingsStore, decoy: Decoy) -> None:
     """Force logging off."""
-    decoy.when(mock_settings.get_logging_enabled_settings()).then_return(
-        LoggingEnabledResponseData(loggingEnabled=False)
-    )
+    decoy.when(mock_settings.get_logging_enabled()).then_return(False)
 
 
 async def test_store_log_stores_nothing_if_logging_disabled(

--- a/audit-server/tests/log_storage/test_log_data_manager.py
+++ b/audit-server/tests/log_storage/test_log_data_manager.py
@@ -151,7 +151,8 @@ async def test_store_log_rotates_if_cannot_get_tail_hash(
     decoy.when(
         await mock_key_client.sign_message(
             SignMessageData.model_construct(
-                message=matchers.StringMatching(".*Log period begun.*"), previousHash=""
+                message=matchers.StringMatching(".*Log period begun.*"),
+                previousHash=None,
             )
         )
     ).then_return(
@@ -319,7 +320,7 @@ async def test_rotate_no_previous_period(
                 message=matchers.StringMatching(
                     f".*{constants.ACTION_LOG_PERIOD_START}.*"
                 ),
-                previousHash="",
+                previousHash=None,
             )
         )
     ).then_return(
@@ -383,7 +384,7 @@ async def test_rotate_no_previous_log(
                 message=matchers.StringMatching(
                     f".*{constants.MESSAGE_NO_PREVIOUS_LOG}.*"
                 ),
-                previousHash="",
+                previousHash=None,
             )
         )
     ).then_return(
@@ -496,7 +497,7 @@ async def test_rotate_log_happypath_handles_no_keyserver(
                 message=matchers.StringMatching(
                     f".*{constants.MESSAGE_LOG_PERIOD_START}.*"
                 ),
-                previousHash="",
+                previousHash=None,
             )
         )
     ).then_raise(KeyStorageUnavailableError())
@@ -540,7 +541,7 @@ async def test_rotate_no_previous_period_handles_no_keyserver(
                 message=matchers.StringMatching(
                     f".*{constants.ACTION_LOG_PERIOD_START}.*"
                 ),
-                previousHash="",
+                previousHash=None,
             )
         )
     ).then_raise(KeyStorageUnavailableError())
@@ -550,7 +551,7 @@ async def test_rotate_no_previous_period_handles_no_keyserver(
                 message=matchers.StringMatching(
                     f".*{constants.MESSAGE_NO_PREVIOUS_PERIOD}.*"
                 ),
-                previousHash="",
+                previousHash=None,
             )
         )
     ).then_raise(KeyStorageUnavailableError())
@@ -610,7 +611,7 @@ async def test_rotate_no_previous_log_handles_no_key_server(
                 message=matchers.StringMatching(
                     f".*{constants.MESSAGE_NO_PREVIOUS_LOG}.*"
                 ),
-                previousHash="",
+                previousHash=None,
             )
         )
     ).then_raise(KeyStorageUnavailableError())
@@ -620,7 +621,7 @@ async def test_rotate_no_previous_log_handles_no_key_server(
                 message=matchers.StringMatching(
                     f".*{constants.MESSAGE_LOG_PERIOD_END}.*"
                 ),
-                previousHash="",
+                previousHash=None,
             )
         )
     ).then_raise(KeyStorageUnavailableError())
@@ -664,7 +665,7 @@ async def test_rotate_no_previous_log_handles_no_key_server(
                 message=matchers.StringMatching(
                     f".*{constants.MESSAGE_LOG_PERIOD_START}.*"
                 ),
-                previousHash="",
+                previousHash=None,
             )
         )
     ).then_raise(KeyStorageUnavailableError())

--- a/audit-server/tests/settings/test_router.py
+++ b/audit-server/tests/settings/test_router.py
@@ -3,15 +3,28 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Generator
+from typing import Any, Generator, cast
 
 import pytest
+from decoy import Decoy, matchers
 from fastapi import FastAPI
 from starlette.testclient import TestClient
 
+from server_utils.fastapi_utils.models.json_api import RequestModel
+
+from .. import LogPayloadMatcher, RecentTimestampMatcher
+from audit_server.log_ingest.models import SubmitAuditLogMessageData
+from audit_server.log_storage.log_data_manager import LogDataManager
 from audit_server.persistence.database import create_schema, sql_engine_ctx
 from audit_server.persistence.fastapi_dependencies import set_sql_engine
-from audit_server.settings.router import router as settings_router
+from audit_server.settings.models import PatchLoggingEnabledRequestData
+from audit_server.settings.router import (
+    get_logging_enabled_settings,
+    patch_logging_enabled_settings,
+)
+from audit_server.settings.router import (
+    router as settings_router,
+)
 from audit_server.settings.store import SettingsStore, install_settings_store
 
 _LOGGING_ENABLED_PATH = "/audit/internal/loggingEnabled"
@@ -32,33 +45,148 @@ def client(tmp_path: Path) -> Generator[TestClient, None, None]:
             yield test_client
 
 
-def test_get_logging_enabled_defaults_to_false(client: TestClient) -> None:
+@pytest.fixture
+def mock_store(decoy: Decoy) -> SettingsStore:
+    return decoy.mock(cls=SettingsStore)
+
+
+@pytest.fixture
+def mock_log_data_manager(decoy: Decoy) -> LogDataManager:
+    return decoy.mock(cls=LogDataManager)
+
+
+async def test_get_logging_enabled(mock_store: SettingsStore, decoy: Decoy) -> None:
     """GET loggingEnabled returns False before it's ever set."""
-    response = client.get(_LOGGING_ENABLED_PATH)
+    decoy.when(mock_store.get_logging_enabled()).then_return(True)
+    result = await get_logging_enabled_settings(settings_store=mock_store)
+    assert result.content.data.loggingEnabled is True
+    assert result.status_code == 200
+    decoy.when(mock_store.get_logging_enabled()).then_return(False)
+    result = await get_logging_enabled_settings(settings_store=mock_store)
+    assert result.content.data.loggingEnabled is False
+    assert result.status_code == 200
+
+
+async def test_patch_logging_enabled_logs_when_disabling(
+    mock_store: SettingsStore, mock_log_data_manager: LogDataManager, decoy: Decoy
+) -> None:
+    """It should disable logging and store a log first."""
+    decoy.when(mock_store.get_logging_enabled()).then_return(True)
+    decoy.when(mock_store.patch_logging_enabled(False)).then_return(False)
+    decoy.when(
+        await mock_log_data_manager.store_log(
+            cast(
+                Any,
+                LogPayloadMatcher(
+                    SubmitAuditLogMessageData(
+                        action="log-disable",
+                        accountName="alice",
+                        legalName="Alice",
+                        message="Logging was disabled.",
+                        reason="i wanted to",
+                    ),
+                    loggedAt=RecentTimestampMatcher(),
+                ),
+            )
+        )
+    ).then_return("")
+    response = await patch_logging_enabled_settings(
+        request_body=RequestModel(
+            data=PatchLoggingEnabledRequestData(
+                loggingEnabled=False,
+                accountName="alice",
+                legalName="Alice",
+                reason="i wanted to",
+            )
+        ),
+        settings_store=mock_store,
+        log_data_manager=mock_log_data_manager,
+    )
+
     assert response.status_code == 200
-    assert response.json()["data"] == {"loggingEnabled": False}
+    assert response.content.data.loggingEnabled is False
+    decoy.verify(await mock_log_data_manager.rotate_periods(), times=0)
 
 
-def test_patch_logging_enabled_round_trips(client: TestClient) -> None:
-    """PATCHing loggingEnabled to True is returned and reflected on a later GET."""
-    response = client.patch(
-        _LOGGING_ENABLED_PATH, json={"data": {"loggingEnabled": True}}
+async def test_patch_logging_enabled_rotates_and_logs_when_enabling(
+    mock_store: SettingsStore, mock_log_data_manager: LogDataManager, decoy: Decoy
+) -> None:
+    """It should enable logging and then rotate and log."""
+    decoy.when(mock_store.get_logging_enabled()).then_return(False)
+    decoy.when(mock_store.patch_logging_enabled(True)).then_return(True)
+    decoy.when(
+        await mock_log_data_manager.store_log(
+            cast(
+                Any,
+                LogPayloadMatcher(
+                    SubmitAuditLogMessageData(
+                        action="log-enable",
+                        accountName="alice",
+                        legalName="Alice",
+                        message="Logging was enabled.",
+                        reason="i wanted to",
+                    ),
+                    loggedAt=RecentTimestampMatcher(),
+                ),
+            )
+        )
+    ).then_return("")
+    response = await patch_logging_enabled_settings(
+        request_body=RequestModel(
+            data=PatchLoggingEnabledRequestData(
+                loggingEnabled=True,
+                accountName="alice",
+                legalName="Alice",
+                reason="i wanted to",
+            )
+        ),
+        settings_store=mock_store,
+        log_data_manager=mock_log_data_manager,
     )
     assert response.status_code == 200
-    assert response.json()["data"] == {"loggingEnabled": True}
-
-    response = client.get(_LOGGING_ENABLED_PATH)
-    assert response.json()["data"] == {"loggingEnabled": True}
+    assert response.content.data.loggingEnabled is True
+    decoy.verify(await mock_log_data_manager.rotate_periods(), times=1)
 
 
-def test_patch_logging_enabled_can_disable(client: TestClient) -> None:
-    """loggingEnabled can be turned back off via PATCH."""
-    client.patch(_LOGGING_ENABLED_PATH, json={"data": {"loggingEnabled": True}})
-    response = client.patch(
-        _LOGGING_ENABLED_PATH, json={"data": {"loggingEnabled": False}}
+async def test_patch_logging_enabled_noops_if_no_change(
+    mock_store: SettingsStore, mock_log_data_manager: LogDataManager, decoy: Decoy
+) -> None:
+    decoy.when(mock_store.get_logging_enabled()).then_return(False)
+    decoy.when(mock_store.patch_logging_enabled(False)).then_return(False)
+    response = await patch_logging_enabled_settings(
+        request_body=RequestModel(
+            data=PatchLoggingEnabledRequestData(
+                loggingEnabled=False,
+                accountName="alice",
+                legalName="Alice",
+                reason="i wanted to",
+            )
+        ),
+        settings_store=mock_store,
+        log_data_manager=mock_log_data_manager,
     )
     assert response.status_code == 200
-    assert response.json()["data"] == {"loggingEnabled": False}
+    assert response.content.data.loggingEnabled is False
+    decoy.verify(await mock_log_data_manager.store_log(matchers.Anything()), times=0)
+    decoy.verify(await mock_log_data_manager.rotate_periods(), times=0)
+    decoy.when(mock_store.get_logging_enabled()).then_return(True)
+    decoy.when(mock_store.patch_logging_enabled(True)).then_return(True)
+    response = await patch_logging_enabled_settings(
+        request_body=RequestModel(
+            data=PatchLoggingEnabledRequestData(
+                loggingEnabled=True,
+                accountName="alice",
+                legalName="Alice",
+                reason="i wanted to",
+            )
+        ),
+        settings_store=mock_store,
+        log_data_manager=mock_log_data_manager,
+    )
+    assert response.status_code == 200
+    assert response.content.data.loggingEnabled is True
+    decoy.verify(await mock_log_data_manager.store_log(matchers.Anything()), times=0)
+    decoy.verify(await mock_log_data_manager.rotate_periods(), times=0)
 
 
 def test_get_settings_returns_defaults(client: TestClient) -> None:

--- a/audit-server/tests/settings/test_store.py
+++ b/audit-server/tests/settings/test_store.py
@@ -9,7 +9,6 @@ from sqlalchemy.orm import Session
 
 from audit_server.persistence.orm_models import Setting
 from audit_server.settings.models import (
-    PatchLoggingEnabledRequestData,
     PatchSettingsRequestData,
     SettingsResponseData,
 )
@@ -24,35 +23,30 @@ def settings_store(db_engine: SQLEngine) -> SettingsStore:
 
 def test_logging_enabled_defaults_to_false(settings_store: SettingsStore) -> None:
     """Before it's ever set, loggingEnabled reads as False."""
-    fetched = settings_store.get_logging_enabled_settings()
-    assert fetched.loggingEnabled is False
+    fetched = settings_store.get_logging_enabled()
+    assert fetched is False
 
 
 def test_patch_logging_enabled_enables_and_persists(
     settings_store: SettingsStore,
 ) -> None:
     """Patching loggingEnabled to True is reflected and persisted."""
-    returned = settings_store.patch_logging_enabled(
-        PatchLoggingEnabledRequestData(loggingEnabled=True)
-    )
-    assert returned.loggingEnabled is True
-    assert settings_store.get_logging_enabled_settings().loggingEnabled is True
+    returned = settings_store.patch_logging_enabled(True)
+    assert returned is True
+    assert settings_store.get_logging_enabled() is True
 
 
 def test_patch_logging_enabled_is_toggleable_both_ways(
     settings_store: SettingsStore,
 ) -> None:
     """Unlike auth-server access control, loggingEnabled can be turned back off."""
-    returned_set = settings_store.patch_logging_enabled(
-        PatchLoggingEnabledRequestData(loggingEnabled=True)
-    )
-    assert returned_set.loggingEnabled is True
-    assert settings_store.get_logging_enabled_settings().loggingEnabled is True
-    returned = settings_store.patch_logging_enabled(
-        PatchLoggingEnabledRequestData(loggingEnabled=False)
-    )
-    assert returned.loggingEnabled is False
-    assert settings_store.get_logging_enabled_settings().loggingEnabled is False
+    returned_set = settings_store.patch_logging_enabled(True)
+    assert returned_set is True
+    assert settings_store.get_logging_enabled() is True
+    returned = settings_store.patch_logging_enabled(False)
+
+    assert returned is False
+    assert settings_store.get_logging_enabled() is False
 
 
 def test_get_settings_returns_defaults_when_empty(


### PR DESCRIPTION
# Overview

We now have a log data manager, that rotates log periods. That's pretty cool. But we weren't using it for anything, and now we are.

That means:
- The server rotates periods at boot
- log ingest goes through the data manager, which means it rotates periods if needed and gets good period linking
- period enumeration queries the data manager
- annoyingly, log enable/disable gets much more complex and thus so do its tests and router since it needs to rotate periods and it needs to store messages now


It also means we can hook up log export to the data manager now. Pretty neat! When we do that we'll have to add more integration testing too.

## Test Plan and Hands on Testing

- [x] run it on a robot. enable logs. check that on rebooting the audit server you get appropriate rotations. check that logging stuff internally goes into the database

## Changelog

- Use the LDM on log ingest
- Back period enumeration with LDM
- Integrate LDM into server lifetime

## Review requests

- Normal stuff
- Think of a better way to do the gross integration into settings?

## Risk assessment

Low, nothing uses this yet.

Needs https://github.com/Opentrons/oe-core/pull/342 on the robot

Closes EXEC-2787