### PR TITLE
feat(app, robot-server): add total disk space to DiskMonitor and wireup in client

### DIFF
--- a/api-client/src/health/types.ts
+++ b/api-client/src/health/types.ts
@@ -1,5 +1,6 @@
 export interface DiskDetails {
   systemAvailableMb: number
+  systemTotalMb: number
   imagesDirectorySizeMb: number
 }
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/RobotStorage.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/RobotStorage.tsx
@@ -1,18 +1,25 @@
 import { useTranslation } from 'react-i18next'
 
 import { StorageBar, StyledText } from '@opentrons/components'
+import { useHealth } from '@opentrons/react-api-client'
 
 import styles from './robotsettingsfilemanager.module.css'
 
 export function RobotStorage(): JSX.Element {
   const { t } = useTranslation('device_details')
+  const health = useHealth()
+
+  const totalMb = health?.disk_details?.systemTotalMb ?? 0
+  const availableMb = health?.disk_details?.systemAvailableMb ?? 0
+  const percentUsed =
+    totalMb > 0 ? Math.round(((totalMb - availableMb) / totalMb) * 100) : 0
+
   return (
     <div className={styles.file_management_group}>
       <StyledText desktopStyle="bodyLargeSemiBold">
         {t('robot_storage')}
       </StyledText>
-      {/* TODO: add logic for getting actual storage remaining on the robot */}
-      <StorageBar percentUsed={33} label={t('file_capacity')} />
+      <StorageBar percentUsed={percentUsed} label={t('file_capacity')} />
     </div>
   )
 }

--- a/robot-server/robot_server/disk_monitor/monitor.py
+++ b/robot-server/robot_server/disk_monitor/monitor.py
@@ -34,6 +34,16 @@ class DiskMonitor:
 
         return available_bytes / (1024 * 1024)
 
+    def get_total_disk_space_mb(self) -> float:
+        """Get the total disk space of the /data partition in megabytes."""
+        if sys.platform == "win32" or not hasattr(os, "statvfs"):
+            return _FALLBACK_DEFAULT_DISK_SPACE_MB
+
+        stat = os.statvfs(self._images_directory)
+        total_bytes = stat.f_blocks * stat.f_frsize
+
+        return total_bytes / (1024 * 1024)
+
     def is_disk_space_low(self) -> bool:
         """Check if available disk space is below the configured threshold."""
         available_mb = self.get_available_disk_space_mb()

--- a/robot-server/robot_server/health/models.py
+++ b/robot-server/robot_server/health/models.py
@@ -14,6 +14,9 @@ class DiskDetails(BaseModel):
     systemAvailableMb: float = Field(
         ..., description="The system's available disk space in MB."
     )
+    systemTotalMb: float = Field(
+        ..., description="The total disk space of the /data partition in MB."
+    )
     imagesDirectorySizeMb: float = Field(
         ..., description="The system's images directory disk size in MB."
     )

--- a/robot-server/robot_server/health/router.py
+++ b/robot-server/robot_server/health/router.py
@@ -177,6 +177,7 @@ async def get_health(
         robot_serial=(await hardware.get_serial_number()),
         disk_details=DiskDetails(
             systemAvailableMb=disk_monitor.get_available_disk_space_mb(),
+            systemTotalMb=disk_monitor.get_total_disk_space_mb(),
             imagesDirectorySizeMb=disk_monitor.get_images_directory_size_mb(),
         ),
     )

--- a/robot-server/tests/disk_monitor/test_disk_monitor.py
+++ b/robot-server/tests/disk_monitor/test_disk_monitor.py
@@ -47,6 +47,30 @@ def test_get_available_disk_space_mb_on_windows(subject: DiskMonitor) -> None:
         assert available_space == _FALLBACK_DEFAULT_DISK_SPACE_MB
 
 
+def test_get_total_disk_space_mb_on_windows(subject: DiskMonitor) -> None:
+    """It should return a constant value on Windows."""
+    with patch.object(sys, "platform", "win32"):
+        total_space = subject.get_total_disk_space_mb()
+        assert total_space == _FALLBACK_DEFAULT_DISK_SPACE_MB
+
+
+def test_get_total_disk_space_mb_returns_positive(subject: DiskMonitor) -> None:
+    """It should return a positive value reflecting the partition total."""
+    if sys.platform == "win32" or not hasattr(os, "statvfs"):
+        pytest.skip("statvfs not available on this platform")
+    total_space = subject.get_total_disk_space_mb()
+    assert total_space > 0
+
+
+def test_get_total_disk_space_mb_greater_than_available(subject: DiskMonitor) -> None:
+    """Total disk space should always be >= available disk space."""
+    if sys.platform == "win32" or not hasattr(os, "statvfs"):
+        pytest.skip("statvfs not available on this platform")
+    total = subject.get_total_disk_space_mb()
+    available = subject.get_available_disk_space_mb()
+    assert total >= available
+
+
 def test_is_disk_space_low_when_below_threshold(subject: DiskMonitor) -> None:
     """It should return True when available space is below threshold."""
     with patch.object(subject, "get_available_disk_space_mb", return_value=500.0):

--- a/robot-server/tests/health/test_health_router.py
+++ b/robot-server/tests/health/test_health_router.py
@@ -32,6 +32,7 @@ def disk_monitor(decoy: Decoy) -> DiskMonitor:
     """Get a mocked out DiskMonitor interface."""
     mock = decoy.mock(cls=DiskMonitor)
     decoy.when(mock.get_available_disk_space_mb()).then_return(1000.0)
+    decoy.when(mock.get_total_disk_space_mb()).then_return(5000.0)
     decoy.when(mock.get_images_directory_size_mb()).then_return(500.0)
     return mock
 
@@ -85,6 +86,7 @@ async def test_get_health(
         "robot_serial": "mytestserial",
         "disk_details": {
             "systemAvailableMb": 1000.0,
+            "systemTotalMb": 5000.0,
             "imagesDirectorySizeMb": 500.0,
         },
     }
@@ -140,6 +142,7 @@ async def test_get_health_with_none_version(
         },
         "disk_details": {
             "systemAvailableMb": 1000.0,
+            "systemTotalMb": 5000.0,
             "imagesDirectorySizeMb": 500.0,
         },
     }


### PR DESCRIPTION
# Overview

This PR adds a getter function to robot server's `DiskMonitor` to get the total available disk space in the `/data` partition, and reports back this new datum when hitting the `/health` endpoint. It also updates the reported type for this data in `api-client`, and wires up the storage space logic in the RobotStorage component of the `FileManager`.

Closes EXEC-2825

## Test Plan and Hands on Testing

- pushed robot-server changes to a live robot
- inspected robot settings file manager > robot storage

## Changelog

#### robot-server
- add getter to `DiskMonitor` for getting total space in `/data` partition
- update `DiskDetails` model accordingly
- return this data in `get_health`
- add unit tests

#### api-client
- update `DiskDetails` interface according to the above data update

#### app
- wire up actual storage information in `RobotStorage` component

## Review requests

See test plan. Specifically, please give feedback on `get_total_disk_space_mb` logic for getting total disk space for the `/data` partition

## Risk assessment

low