### PR TITLE
fix(odd, app): change idle logout from 180ms to 180s

### DIFF
--- a/app/src/App/hooks/useRefreshAccessTokenOnActivity.ts
+++ b/app/src/App/hooks/useRefreshAccessTokenOnActivity.ts
@@ -18,7 +18,7 @@ import { appShellUSBRequestor } from '/app/redux/shell/remote'
 import type { HostConfig, RefreshRequest } from '@opentrons/api-client'
 import type { State } from '/app/redux/types'
 
-const THROTTLE_SEC = 30
+const THROTTLE_SEC = 10
 
 /**
  * This keeps the user logged in to their robot while they're actively using the UI.
@@ -65,7 +65,7 @@ export function useRefreshAccessTokenOnActivity(): void {
     try {
       const response = await getOAuth2Token(hostConfig, request)
       const expiresIn = response.data.expires_in ?? null
-      const expiresAt = expiresIn != null ? Date.now() + expiresIn : null
+      const expiresAt = expiresIn != null ? Date.now() + expiresIn * 1000 : null
       dispatch(
         refreshLogin({
           robotName,


### PR DESCRIPTION
# Overview

Fixes issue where idle logout time was not being converted from seconds to milliseconds, requiring users to constantly log back in.

Closes [Exec-5687](https://opentrons.atlassian.net/browse/RQA-5687)

## Test Plan and Hands on Testing

Make an ACM bot, log in, wait 3 minutes, you should be logged out, but not before then. 

## Risk assessment

Low. I did lower the throttle time in here but just because 30 seconds is a common value for us to use in testing for idle logout things, so setting the throttle lower should avoid weird ghost bugs