### PR TITLE
feat(update-server): Fire-and-forget robot updates

### DIFF
--- a/update-server/otupdate/buildroot/update_actions.py
+++ b/update-server/otupdate/buildroot/update_actions.py
@@ -190,6 +190,14 @@ class OT2UpdateActions(UpdateActionsInterface):
             except Exception:
                 LOG.exception(f"Could not delete update file {filepath}.")
 
+    def restart(self) -> None:
+        """Restart the robot."""
+        subprocess.check_call(["reboot"])
+
+    def shutdown(self) -> None:
+        """Shut down the robot."""
+        subprocess.check_call(["shutdown", "-h", "now"])
+
 
 def _find_unused_partition() -> RootPartitions:
     """Find the currently-unused root partition to write to"""

--- a/update-server/otupdate/common/control.py
+++ b/update-server/otupdate/common/control.py
@@ -6,7 +6,6 @@ This has endpoints like /restart that aren't specific to update tasks or machine
 
 import asyncio
 import logging
-import subprocess
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Callable, Coroutine, Mapping
@@ -15,19 +14,11 @@ from aiohttp import web
 
 from server_utils.auth.scopes import Scope
 
-from . import auth
+from . import auth, update_actions
 from .constants import DEVICE_BOOT_ID_NAME, RESTART_LOCK_NAME, SHUTDOWN_LOCK_NAME
 from .name_management import get_name_synchronizer
 
 LOG = logging.getLogger(__name__)
-
-
-def _do_restart() -> None:
-    subprocess.check_call(["reboot"])
-
-
-def _do_shutdown() -> None:
-    subprocess.check_call(["shutdown", "-h", "now"])
 
 
 @auth.require_scopes(Scope.RESTART_WRITE)
@@ -36,8 +27,18 @@ async def restart(request: web.Request) -> web.Response:
 
     Blocks while the restart lock is held.
     """
+    actions = update_actions.UpdateActionsInterface.from_request(request)
+    if not actions:
+        return web.json_response(
+            data={
+                "error": "no-actions-set",
+                "message": "Internal error: no actions object for hardware",
+            },
+            status=500,
+        )
+
     async with request.app[RESTART_LOCK_NAME]:
-        asyncio.get_event_loop().call_later(1, _do_restart)
+        asyncio.get_event_loop().call_later(1, actions.restart)
     return web.json_response({"message": "Restarting in 1s"}, status=200)
 
 
@@ -47,8 +48,18 @@ async def shutdown(request: web.Request) -> web.Response:
 
     Blocks while the shutdown lock is held.
     """
+    actions = update_actions.UpdateActionsInterface.from_request(request)
+    if not actions:
+        return web.json_response(
+            data={
+                "error": "no-actions-set",
+                "message": "Internal error: no actions object for hardware",
+            },
+            status=500,
+        )
+
     async with request.app[SHUTDOWN_LOCK_NAME]:
-        asyncio.get_event_loop().call_later(1, _do_shutdown)
+        asyncio.get_event_loop().call_later(1, actions.shutdown)
     return web.json_response({"message": "Shutting down in 1s"}, status=200)
 
 

--- a/update-server/otupdate/common/session.py
+++ b/update-server/otupdate/common/session.py
@@ -37,14 +37,24 @@ class UpdateSession:
     State machine for update sessions
     """
 
-    def __init__(self, storage_path: str) -> None:
+    def __init__(
+        self,
+        *,
+        storage_path: str,
+        auto_commit_and_restart: bool,
+    ) -> None:
         self._token = base64.urlsafe_b64encode(uuid.uuid4().bytes).decode().strip("=")
+
         self._stage = Stages.AWAITING_FILE
         self._progress = 0.0
         self._message = ""
         self._error: Optional[Value] = None
+
         self._storage_path = storage_path
+        self._auto_commit_and_restart = auto_commit_and_restart
+
         self._setup_dl_area()
+
         LOG.info(f"update session: created {self._token}")
 
     def _setup_dl_area(self) -> None:
@@ -78,6 +88,10 @@ class UpdateSession:
     @property
     def download_path(self) -> str:
         return self._storage_path
+
+    @property
+    def auto_commit_and_restart(self) -> bool:
+        return self._auto_commit_and_restart
 
     @property
     def token(self) -> str:

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -122,10 +122,9 @@ async def file_upload(request: web.Request, session: UpdateSession) -> web.Respo
             status=400,
         )
 
-    _begin_validation(
+    _begin_validate_and_write(
         session,
         config.config_from_request(request),
-        asyncio.get_event_loop(),
         os.path.join(session.download_path, found_name),
         maybe_actions,
     )
@@ -206,66 +205,41 @@ async def _save_file(part: BodyPartReader, path: str) -> None:
         LOG.exception("File not written")
 
 
-def _begin_write(
-    session: UpdateSession,
-    loop: asyncio.AbstractEventLoop,
-    rootfs_file_path: str,
-    actions: update_actions.UpdateActionsInterface,
-) -> None:
-    """Start the write process."""
-    session.set_progress(0)
-    session.set_stage(Stages.WRITING)
-    write_future = asyncio.ensure_future(
-        loop.run_in_executor(
-            None,
-            actions.write_update,
-            rootfs_file_path,
-            session.set_progress,
-        )
-    )
-
-    def write_done(fut: asyncio.Future[update_actions.Partition]) -> None:
-        exc = fut.exception()
-        if exc:
-            session.set_error(getattr(exc, "short", str(type(exc))), str(exc))
-        else:
-            LOG.info(f"Finished update session {session}")
-            session.set_stage(Stages.DONE)
-
-    write_future.add_done_callback(write_done)
-
-
-def _begin_validation(
+def _begin_validate_and_write(
     session: UpdateSession,
     config: config.Config,
-    loop: asyncio.AbstractEventLoop,
     downloaded_update_path: str,
     actions: update_actions.UpdateActionsInterface,
-) -> asyncio.Future[str]:
-    """Start the validation process."""
-    session.set_stage(Stages.VALIDATING)
-    cert_path = config.update_cert_path if config.signature_required else None
+) -> None:
+    """Start validating and writing the file in the background."""
 
-    validation_future = asyncio.ensure_future(
-        loop.run_in_executor(
-            None,
+    async def background_task() -> None:
+        session.set_stage(Stages.VALIDATING)
+        cert_path = config.update_cert_path if config.signature_required else None
+        rootfs_file = await asyncio.to_thread(
             actions.validate_update,
             downloaded_update_path,
             session.set_progress,
             cert_path,
         )
-    )
 
-    def validation_done(fut: asyncio.Future[str]) -> None:
-        exc = fut.exception()
-        if exc:
+        session.set_progress(0)
+        session.set_stage(Stages.WRITING)
+        await asyncio.to_thread(actions.write_update, rootfs_file, session.set_progress)
+
+        LOG.info(f"Finished update session {session}")
+        session.set_stage(Stages.DONE)
+
+    async def background_task_with_error_handling() -> None:
+        try:
+            await background_task()
+        except Exception as exc:
+            LOG.exception(
+                f"Error in background task for session {session.token}.", exc_info=exc
+            )
             session.set_error(getattr(exc, "short", str(type(exc))), str(exc))
-        else:
-            rootfs_file = fut.result()
-            loop.call_soon_threadsafe(_begin_write, session, loop, rootfs_file, actions)
 
-    validation_future.add_done_callback(validation_done)
-    return validation_future
+    asyncio.create_task(background_task_with_error_handling())
 
 
 async def _extract_and_save_update_file(

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -5,12 +5,14 @@ This has endpoints like update session management, validation, and execution
 """
 
 import asyncio
+import dataclasses
 import functools
+import json
 import logging
 import os
 from pathlib import Path
 from subprocess import CalledProcessError
-from typing import Optional
+from typing import Optional, Self
 
 from aiohttp import BodyPartReader, MultipartReader, web
 from typing_extensions import Protocol
@@ -63,7 +65,36 @@ def _require_session(handler: _HandlerWithSession) -> Handler:
 
 @auth.require_scopes(Scope.UPDATES_WRITE)
 async def begin(request: web.Request) -> web.Response:
-    """Begin a session"""
+    """Begin (create) a session.
+
+    The request body may be empty, or it may be a JSON object like:
+
+    {
+      // If false, the client must manually call `POST /server/update/{session}/commit`
+      // and `POST /server/restart` at the appropriate times. If true, the server
+      // will do those automatically, making the update fire-and-forget.
+      //
+      // The default is false.
+      //
+      // Older servers will not process this field and will always behave as if it's
+      // false.
+      auto_commit_and_restart: boolean
+    }
+
+    The response body will be like:
+
+    {
+      // A token identifying the newly-created session, for use in other endpoints.
+      token: string
+
+      // If the server is new enough to understand the auto_commit_and_restart input,
+      // it will be reflected here.
+      //
+      // Clients should use this to detect whether they need to commit the update and
+      // restart explicitly, or if they can rely on the server.
+      auto_commit_and_restart?: boolean
+    }
+    """
     if None is not get_current_session(request):
         LOG.warning("begin: requested with active session")
         return web.json_response(
@@ -74,9 +105,26 @@ async def begin(request: web.Request) -> web.Response:
             status=409,
         )
 
-    session = UpdateSession(config.config_from_request(request).download_storage_path)
+    try:
+        options = await _BeginSessionOptions.parse_from_request(request)
+    except _BeginSessionOptions.ParseError as e:
+        return web.json_response(
+            data={"error": "invalid-request", "message": e.message_for_response},
+            status=400,
+        )
+
+    session = UpdateSession(
+        storage_path=config.config_from_request(request).download_storage_path,
+        auto_commit_and_restart=options.auto_commit_and_restart,
+    )
     set_current_session(request, session)
-    return web.json_response(data={"token": session.token}, status=201)
+    return web.json_response(
+        data={
+            "token": session.token,
+            "auto_commit_and_restart": session.auto_commit_and_restart,
+        },
+        status=201,
+    )
 
 
 @_require_session
@@ -127,6 +175,7 @@ async def file_upload(request: web.Request, session: UpdateSession) -> web.Respo
         config.config_from_request(request),
         os.path.join(session.download_path, found_name),
         maybe_actions,
+        request.app[RESTART_LOCK_NAME],
     )
 
     return web.json_response(data=session.state, status=201)
@@ -156,20 +205,7 @@ async def commit(request: web.Request, session: UpdateSession) -> web.Response:
             status=500,
         )
 
-    # todo(mm, 2026-06-26): What is the "restart lock" protecting?
-    # Do we also need the "shutdown lock" here?
-    async with request.app[RESTART_LOCK_NAME]:
-        try:
-            with actions.mount_update() as new_part:
-                actions.write_machine_id("/", new_part)
-        except (OSError, CalledProcessError):
-            LOG.exception("Failed to update machine-id")
-        actions.commit_update()
-
-        # Clean up stale update files from the download dir
-        actions.clean_up(session.download_path)
-
-        session.set_stage(Stages.READY_FOR_RESTART)
+    await _commit(request.app[RESTART_LOCK_NAME], actions, session)
 
     return web.json_response(data=session.state, status=200)
 
@@ -186,6 +222,45 @@ async def cancel(request: web.Request) -> web.Response:
         session.close()
         set_current_session(request, None)
     return web.json_response(data={"message": "Session cancelled"}, status=200)
+
+
+@dataclasses.dataclass
+class _BeginSessionOptions:
+    """Client-provided options from a "create session" request body."""
+
+    auto_commit_and_restart: bool
+
+    @classmethod
+    async def parse_from_request(cls, request: web.Request) -> Self:
+        text = await request.text()
+
+        if text.strip() == "":
+            return cls(auto_commit_and_restart=False)
+
+        try:
+            parsed_json = json.loads(text)
+        except json.JSONDecodeError as e:
+            # str(e) is bad practice in general, but it's good for JSONDecodeError.
+            raise cls.ParseError(str(e)) from e
+
+        if not isinstance(parsed_json, dict):
+            raise cls.ParseError("Request body must be a JSON object")
+
+        if "auto_commit_and_restart" in parsed_json:
+            auto_commit_and_restart = parsed_json["auto_commit_and_restart"]
+            if not isinstance(auto_commit_and_restart, bool):
+                raise cls.ParseError("auto_commit_and_restart must be a boolean")
+        else:
+            auto_commit_and_restart = False
+
+        return cls(auto_commit_and_restart=auto_commit_and_restart)
+
+    class ParseError(Exception):
+        """Raised for invalid request bodies."""
+
+        def __init__(self, message_for_response: str) -> None:
+            super().__init__(message_for_response)
+            self.message_for_response = message_for_response
 
 
 async def _save_file(part: BodyPartReader, path: str) -> None:
@@ -210,8 +285,14 @@ def _begin_validate_and_write(
     config: config.Config,
     downloaded_update_path: str,
     actions: update_actions.UpdateActionsInterface,
+    restart_lock: asyncio.Lock,
 ) -> None:
-    """Start validating and writing the file in the background."""
+    """Start validating and writing the file in the background.
+
+    Depending on the parameters passed in when the session was created, it may
+    then auto-commit and auto-restart, or it may wait for explicit confirmation from
+    the client.
+    """
 
     async def background_task() -> None:
         session.set_stage(Stages.VALIDATING)
@@ -230,6 +311,15 @@ def _begin_validate_and_write(
         LOG.info(f"Finished update session {session}")
         session.set_stage(Stages.DONE)
 
+        if not session.auto_commit_and_restart:
+            return
+        await _commit(
+            restart_lock,
+            actions,
+            session,
+        )
+        actions.restart()
+
     async def background_task_with_error_handling() -> None:
         try:
             await background_task()
@@ -240,6 +330,27 @@ def _begin_validate_and_write(
             session.set_error(getattr(exc, "short", str(type(exc))), str(exc))
 
     asyncio.create_task(background_task_with_error_handling())
+
+
+async def _commit(
+    restart_lock: asyncio.Lock,
+    actions: update_actions.UpdateActionsInterface,
+    session: UpdateSession,
+) -> None:
+    # todo(mm, 2026-06-26): What is the "restart lock" protecting?
+    # Do we also need the "shutdown lock" here?
+    async with restart_lock:
+        try:
+            with actions.mount_update() as new_part:
+                actions.write_machine_id("/", new_part)
+        except (OSError, CalledProcessError):
+            LOG.exception("Failed to update machine-id")
+        actions.commit_update()
+
+        # Clean up stale update files from the download dir
+        actions.clean_up(session.download_path)
+
+        session.set_stage(Stages.READY_FOR_RESTART)
 
 
 async def _extract_and_save_update_file(

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -79,6 +79,102 @@ async def begin(request: web.Request) -> web.Response:
     return web.json_response(data={"token": session.token}, status=201)
 
 
+@_require_session
+async def status(request: web.Request, session: UpdateSession) -> web.Response:
+    return web.json_response(data=session.state, status=200)
+
+
+@auth.require_scopes(Scope.UPDATES_WRITE)
+@_require_session
+async def file_upload(request: web.Request, session: UpdateSession) -> web.Response:
+    """Serves /update/:session/file
+
+    Requires multipart (encoding doesn't matter) with a file field in the
+    body called 'system-update.zip'. NOTE: OT2 will also support 'ot2-system.zip'
+    """
+    if session.stage != Stages.AWAITING_FILE:
+        return web.json_response(
+            data={
+                "error": "file-already-uploaded",
+                "message": "A file has already been sent for this update",
+            },
+            status=409,
+        )
+    reader = await request.multipart()
+    found_name = await _read_parts_and_find_update(reader, session)
+
+    maybe_actions = update_actions.UpdateActionsInterface.from_request(request)
+    if not maybe_actions:
+        return web.json_response(
+            data={
+                "error": "no-actions-set",
+                "message": "Internal error: no actions object for hardware",
+            },
+            status=500,
+        )
+
+    if not found_name:
+        return web.json_response(
+            data={
+                "error": "no-file-name",
+                "message": "Request error: no field name for system zip",
+            },
+            status=400,
+        )
+
+    _begin_validation(
+        session,
+        config.config_from_request(request),
+        asyncio.get_event_loop(),
+        os.path.join(session.download_path, found_name),
+        maybe_actions,
+    )
+
+    return web.json_response(data=session.state, status=201)
+
+
+@auth.require_scopes(Scope.UPDATES_WRITE)
+@_require_session
+async def commit(request: web.Request, session: UpdateSession) -> web.Response:
+    """Serves /update/:session/commit"""
+    if session.stage != Stages.DONE:
+        return web.json_response(
+            data={
+                "error": "not-ready",
+                "message": f"System is not ready to commit the update "
+                f"(currently {session.stage.value.short})",
+            },
+            status=409,
+        )
+
+    actions = update_actions.UpdateActionsInterface.from_request(request)
+    if not actions:
+        return web.json_response(
+            data={
+                "error": "no-actions-set",
+                "message": "Internal error: no actions object for hardware",
+            },
+            status=500,
+        )
+
+    # todo(mm, 2026-06-26): What is the "restart lock" protecting?
+    # Do we also need the "shutdown lock" here?
+    async with request.app[RESTART_LOCK_NAME]:
+        try:
+            with actions.mount_update() as new_part:
+                actions.write_machine_id("/", new_part)
+        except (OSError, CalledProcessError):
+            LOG.exception("Failed to update machine-id")
+        actions.commit_update()
+
+        # Clean up stale update files from the download dir
+        actions.clean_up(session.download_path)
+
+        session.set_stage(Stages.READY_FOR_RESTART)
+
+    return web.json_response(data=session.state, status=200)
+
+
 @auth.require_scopes(Scope.UPDATES_WRITE)
 async def cancel(request: web.Request) -> web.Response:
     session = get_current_session(request)
@@ -91,11 +187,6 @@ async def cancel(request: web.Request) -> web.Response:
         session.close()
         set_current_session(request, None)
     return web.json_response(data={"message": "Session cancelled"}, status=200)
-
-
-@_require_session
-async def status(request: web.Request, session: UpdateSession) -> web.Response:
-    return web.json_response(data=session.state, status=200)
 
 
 async def _save_file(part: BodyPartReader, path: str) -> None:
@@ -195,94 +286,3 @@ async def _read_parts_and_find_update(
             await _save_file(part, session.download_path)
             found = part.name
     return found
-
-
-@auth.require_scopes(Scope.UPDATES_WRITE)
-@_require_session
-async def file_upload(request: web.Request, session: UpdateSession) -> web.Response:
-    """Serves /update/:session/file
-
-    Requires multipart (encoding doesn't matter) with a file field in the
-    body called 'system-update.zip'. NOTE: OT2 will also support 'ot2-system.zip'
-    """
-    if session.stage != Stages.AWAITING_FILE:
-        return web.json_response(
-            data={
-                "error": "file-already-uploaded",
-                "message": "A file has already been sent for this update",
-            },
-            status=409,
-        )
-    reader = await request.multipart()
-    found_name = await _read_parts_and_find_update(reader, session)
-
-    maybe_actions = update_actions.UpdateActionsInterface.from_request(request)
-    if not maybe_actions:
-        return web.json_response(
-            data={
-                "error": "no-actions-set",
-                "message": "Internal error: no actions object for hardware",
-            },
-            status=500,
-        )
-
-    if not found_name:
-        return web.json_response(
-            data={
-                "error": "no-file-name",
-                "message": "Request error: no field name for system zip",
-            },
-            status=400,
-        )
-
-    _begin_validation(
-        session,
-        config.config_from_request(request),
-        asyncio.get_event_loop(),
-        os.path.join(session.download_path, found_name),
-        maybe_actions,
-    )
-
-    return web.json_response(data=session.state, status=201)
-
-
-@auth.require_scopes(Scope.UPDATES_WRITE)
-@_require_session
-async def commit(request: web.Request, session: UpdateSession) -> web.Response:
-    """Serves /update/:session/commit"""
-    if session.stage != Stages.DONE:
-        return web.json_response(
-            data={
-                "error": "not-ready",
-                "message": f"System is not ready to commit the update "
-                f"(currently {session.stage.value.short})",
-            },
-            status=409,
-        )
-
-    actions = update_actions.UpdateActionsInterface.from_request(request)
-    if not actions:
-        return web.json_response(
-            data={
-                "error": "no-actions-set",
-                "message": "Internal error: no actions object for hardware",
-            },
-            status=500,
-        )
-
-    # todo(mm, 2026-06-26): What is the "restart lock" protecting?
-    # Do we also need the "shutdown lock" here?
-    async with request.app[RESTART_LOCK_NAME]:
-        try:
-            with actions.mount_update() as new_part:
-                actions.write_machine_id("/", new_part)
-        except (OSError, CalledProcessError):
-            LOG.exception("Failed to update machine-id")
-        actions.commit_update()
-
-        # Clean up stale update files from the download dir
-        actions.clean_up(session.download_path)
-
-        session.set_stage(Stages.READY_FOR_RESTART)
-
-    return web.json_response(data=session.state, status=200)

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -40,7 +40,7 @@ class _HandlerWithSession(Protocol):
     ) -> web.Response: ...
 
 
-def require_session(handler: _HandlerWithSession) -> Handler:
+def _require_session(handler: _HandlerWithSession) -> Handler:
     """Decorator to ensure a session is properly in the request"""
 
     @functools.wraps(handler)
@@ -93,7 +93,7 @@ async def cancel(request: web.Request) -> web.Response:
     return web.json_response(data={"message": "Session cancelled"}, status=200)
 
 
-@require_session
+@_require_session
 async def status(request: web.Request, session: UpdateSession) -> web.Response:
     return web.json_response(data=session.state, status=200)
 
@@ -198,7 +198,7 @@ async def _read_parts_and_find_update(
 
 
 @auth.require_scopes(Scope.UPDATES_WRITE)
-@require_session
+@_require_session
 async def file_upload(request: web.Request, session: UpdateSession) -> web.Response:
     """Serves /update/:session/file
 
@@ -247,7 +247,7 @@ async def file_upload(request: web.Request, session: UpdateSession) -> web.Respo
 
 
 @auth.require_scopes(Scope.UPDATES_WRITE)
-@require_session
+@_require_session
 async def commit(request: web.Request, session: UpdateSession) -> web.Response:
     """Serves /update/:session/commit"""
     if session.stage != Stages.DONE:
@@ -270,6 +270,8 @@ async def commit(request: web.Request, session: UpdateSession) -> web.Response:
             status=500,
         )
 
+    # todo(mm, 2026-06-26): What is the "restart lock" protecting?
+    # Do we also need the "shutdown lock" here?
     async with request.app[RESTART_LOCK_NAME]:
         try:
             with actions.mount_update() as new_part:

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -101,7 +101,7 @@ async def file_upload(request: web.Request, session: UpdateSession) -> web.Respo
             status=409,
         )
     reader = await request.multipart()
-    found_name = await _read_parts_and_find_update(reader, session)
+    found_name = await _extract_and_save_update_file(reader, session)
 
     maybe_actions = update_actions.UpdateActionsInterface.from_request(request)
     if not maybe_actions:
@@ -268,9 +268,14 @@ def _begin_validation(
     return validation_future
 
 
-async def _read_parts_and_find_update(
+async def _extract_and_save_update_file(
     reader: MultipartReader, session: UpdateSession
 ) -> Optional[str]:
+    """Extract an update file from a request.
+
+    Saves to the session's storage directory, and returns the new file name within
+    that directory.
+    """
     found: Optional[str] = None
     async for part in reader:
         if part is None:

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -104,6 +104,9 @@ async def begin(request: web.Request) -> web.Response:
             },
             status=409,
         )
+        # fixme(mm, 2026-07-06): There's a concurrency hazard here because we're checking
+        # for a preexisting session and setting the new session non-atomically. Two
+        # concurrent requests can result in two simultaneous active sessions.
 
     try:
         options = await _BeginSessionOptions.parse_from_request(request)
@@ -186,6 +189,10 @@ async def file_upload(request: web.Request, session: UpdateSession) -> web.Respo
 async def commit(request: web.Request, session: UpdateSession) -> web.Response:
     """Serves /update/:session/commit"""
     if session.stage != Stages.DONE:
+        # fixme(mm, 2026-07-07): This stage check is insufficient; it can allow
+        # multiple commits to run concurrently on a single session, because we
+        # non-atomically enforce Stages.DONE, do commit process, and then set
+        # Stages.READY_FOR_RESTART.
         return web.json_response(
             data={
                 "error": "not-ready",

--- a/update-server/otupdate/common/update_actions.py
+++ b/update-server/otupdate/common/update_actions.py
@@ -99,3 +99,11 @@ class UpdateActionsInterface:
     def clean_up(self, download_dir: str) -> None:
         """Deletes the update files from the download dir."""
         ...
+
+    @abc.abstractmethod
+    def restart(self) -> None:
+        """Restart the robot."""
+
+    @abc.abstractmethod
+    def shutdown(self) -> None:
+        """Shut down the robot."""

--- a/update-server/otupdate/openembedded/update_actions.py
+++ b/update-server/otupdate/openembedded/update_actions.py
@@ -314,3 +314,11 @@ class OT3UpdateActions(UpdateActionsInterface):
                 os.remove(filepath)
             except Exception:
                 LOG.exception(f"Could not delete update file {filepath}.")
+
+    def restart(self) -> None:
+        """Restart the robot."""
+        subprocess.check_call(["reboot"])
+
+    def shutdown(self) -> None:
+        """Shut down the robot."""
+        subprocess.check_call(["shutdown", "-h", "now"])

--- a/update-server/tests/common/test_control.py
+++ b/update-server/tests/common/test_control.py
@@ -7,14 +7,17 @@ from unittest import mock
 # Avoid pytest trying to collect TestClient because it begins with "Test".
 from aiohttp.test_utils import TestClient as HTTPTestClient
 
-from otupdate.common import control
+from otupdate.common.update_actions import UpdateActionsInterface
 
 
 async def test_restart(test_cli: Tuple[HTTPTestClient, str], monkeypatch) -> None:
     """It should restart the robot"""
     restart_mock = mock.Mock()
+    actions_mock = mock.Mock(restart=restart_mock)
 
-    monkeypatch.setattr(control, "_do_restart", restart_mock)
+    monkeypatch.setattr(
+        UpdateActionsInterface, "from_request", lambda request: actions_mock
+    )
     resp = await test_cli[0].post("/server/restart")
 
     assert resp.status == 200

--- a/update-server/tests/common/test_update.py
+++ b/update-server/tests/common/test_update.py
@@ -36,19 +36,64 @@ def session_endpoint(token, endpoint):
 
 
 async def test_begin(test_cli: Tuple[HTTPTestClient, str]):
-    # Creating a session should work
+    # Creating a session with an empty body should work
     resp = await test_cli[0].post("/server/update/begin")
     body = await resp.json()
     assert resp.status == 201
     assert "token" in body
     assert test_cli[0].server.app.get(SESSION_VARNAME)
     assert test_cli[0].server.app[SESSION_VARNAME].token == body["token"]
+    assert body["auto_commit_and_restart"] is False
 
     # Creating a session twice shouldn’t
     resp = await test_cli[0].post("/server/update/begin")
     body = await resp.json()
     assert resp.status == 409
     assert "message" in body
+
+
+@pytest.mark.parametrize("auto_commit_and_restart", [True, False, None])
+async def test_begin_with_params(
+    test_cli: Tuple[HTTPTestClient, str],
+    auto_commit_and_restart: bool | None,
+) -> None:
+    # Creating a session with parameters should reflect those parameters in the response body
+    request_body = {}
+    if auto_commit_and_restart is not None:
+        request_body["auto_commit_and_restart"] = auto_commit_and_restart
+
+    resp = await test_cli[0].post("/server/update/begin", json=request_body)
+    body = await resp.json()
+
+    assert resp.status == 201
+    assert "token" in body
+    assert body["auto_commit_and_restart"] == (auto_commit_and_restart or False)
+
+
+async def test_begin_invalid_request(test_cli: Tuple[HTTPTestClient, str]) -> None:
+    resp = await test_cli[0].post("/server/update/begin", data="not json")
+    body = await resp.json()
+    assert resp.status == 400
+    assert body["error"] == "invalid-request"
+    assert "message" in body
+    assert test_cli[0].server.app.get(SESSION_VARNAME) is None
+
+    resp = await test_cli[0].post(
+        "/server/update/begin",
+        json={"auto_commit_and_restart": 1},
+    )
+    body = await resp.json()
+    assert resp.status == 400
+    assert body["error"] == "invalid-request"
+    assert body["message"] == "auto_commit_and_restart must be a boolean"
+    assert test_cli[0].server.app.get(SESSION_VARNAME) is None
+
+    resp = await test_cli[0].post("/server/update/begin", data="null")
+    body = await resp.json()
+    assert resp.status == 400
+    assert body["error"] == "invalid-request"
+    assert body["message"] == "Request body must be a JSON object"
+    assert test_cli[0].server.app.get(SESSION_VARNAME) is None
 
 
 async def test_cancel(test_cli: Tuple[HTTPTestClient, str]):
@@ -94,7 +139,10 @@ async def test_updater_chain(
     sys_handler,
 ):
     conf = config.load_from_path(otupdate_config)
-    session = UpdateSession(conf.download_storage_path)
+    session = UpdateSession(
+        storage_path=conf.download_storage_path,
+        auto_commit_and_restart=False,
+    )
     fut = update._begin_validation(
         session,
         conf,
@@ -127,7 +175,10 @@ async def test_session_catches_validation_fail(
     sys_handler,
 ):
     conf = config.load_from_path(otupdate_config)
-    session = UpdateSession(conf.download_storage_path)
+    session = UpdateSession(
+        storage_path=conf.download_storage_path,
+        auto_commit_and_restart=False,
+    )
     fut = update._begin_validation(
         session,
         conf,

--- a/update-server/tests/openembedded/test_control.py
+++ b/update-server/tests/openembedded/test_control.py
@@ -8,8 +8,8 @@ from unittest import mock
 from aiohttp.test_utils import TestClient as HTTPTestClient
 from decoy import Decoy
 
-from otupdate.common import control
 from otupdate.common.name_management import NameSynchronizer
+from otupdate.common.update_actions import UpdateActionsInterface
 
 
 async def test_health(
@@ -41,8 +41,11 @@ async def test_health(
 async def test_shutdown(test_cli: HTTPTestClient, monkeypatch) -> None:
     """It should shut down the robot"""
     shutdown_mock = mock.Mock()
+    actions_mock = mock.Mock(shutdown=shutdown_mock)
 
-    monkeypatch.setattr(control, "_do_shutdown", shutdown_mock)
+    monkeypatch.setattr(
+        UpdateActionsInterface, "from_request", lambda request: actions_mock
+    )
     resp = await test_cli.post("/server/shutdown")
 
     assert resp.status == 200


### PR DESCRIPTION
## Overview

This simplifies the HTTP API for pushing an update to a robot.

This closes EXEC-2794. See there for background on why we need this.

## Changelog

Formerly, updating a robot worked like this:

1. The client sends a "create session" request.
2. The client uploads a file.
3. The server validates and writes the file in the background. The client polls for the current progress until this is complete.
4. The client sends a "commit" request.
5. The client sends a "restart" request.

With this PR, it works like this:

1. The client sends a "create session" request with a special setting, `{"auto_commit_and_restart": true}`.
2. The client uploads a file.
3. The server validates and writes the file in the background. When it's done, it will commit and restart automatically. The client polls for the current progress until this is complete.

Because this needs to work across clients and servers with mismatched versions, we need a lightweight "handshake" to opt in to this new behavior. The client requests the new behavior by setting `"auto_commit_and_restart": true`, and the server echoes that back to the client to confirm that it's new enough to do it. The client and server will need to continue to handle the original behavior, where `auto_commit_and_restart` is `false` or not present, indefinitely.

## Test Plan and Hands on Testing

I will test on a real robot: 

* [x] The Opentrons App can still, without modification, push the robot through the update process. This tests that the API is backwards-compatible.
* [x] With Postman: When `auto_commit_and_restart` is set to `true`, after uploading a file, the update process proceeds on its own all the way through to restart.

There are automated testing gaps, unfortunately. There's a combination of preexisting problems in the test suite that needs to be resolved before it can be extended—basically, some internal errors are being misreported as a missing dependency and causing the relevant group of tests to be skipped. I'll try to improve this in a follow-up if I have time.

## Review notes

These commits are trivial refactors and don't deserve much attention:

* d167fc6163 refactor: Move restart and shutdown to the update actions interface.
* ea188f4ab5 refactor: Mark the @require_session decorator as private.
* b7645ac044 refactor: Reorder methods to put public ones up top.
* 5418c301af refactor: Rename a method for clarity and add a docstring.

This commit modernizes some `asyncio` stuff. There should be no functional change here, but it's a little less trivial.

* 4916e74852 refactor: Modernize background thread execution.

These commits are the actual real work of this PR:

* 6ee8497 feat: Add auto_commit and auto_restart.
* e1831d6ab9 docs: Add fixme comments for concurrency hazards.

## Risk assessment

High.

* Any kind of crash of the update-server or failure of the update procedure can leave a robot unusable and difficult to recover.
* There are preexisting concurrency hazards. I've tried to mark them with `# fixme` comments. There's always some chance that my mucking around can make it worse or expose latent bugs.
* This PR is missing automated test coverage. See my excuse in the test plan section above.