### PR TITLE
fix(app-shell-odd): dont fail to update if checking

### DIFF
--- a/app-shell-odd/src/system-update/__tests__/handler.test.ts
+++ b/app-shell-odd/src/system-update/__tests__/handler.test.ts
@@ -493,7 +493,7 @@ describe('update driver', () => {
         progress =>
           new Promise(resolve => {
             progress({
-              version: null,
+              version: '1.2.3',
               files: { system: null, releaseNotes: null },
               downloadProgress: 0,
               releaseNotes: null,
@@ -501,13 +501,19 @@ describe('update driver', () => {
             progress({
               version: '1.2.3',
               files: { system: null, releaseNotes: null },
-              downloadProgress: 0,
+              downloadProgress: 1,
               releaseNotes: null,
             })
             progress({
               version: '1.2.3',
               files: { system: null, releaseNotes: null },
               downloadProgress: 50,
+              releaseNotes: null,
+            })
+            progress({
+              version: '1.2.3',
+              files: { system: null, releaseNotes: null },
+              downloadProgress: 50.1,
               releaseNotes: null,
             })
             progress({
@@ -542,22 +548,17 @@ describe('update driver', () => {
         })
         expect(dispatch).toHaveBeenNthCalledWith(2, {
           type: 'robotUpdate:DOWNLOAD_PROGRESS',
-          payload: { progress: 50, target: 'flex' },
+          payload: { progress: 1, target: 'flex' },
         })
         expect(dispatch).toHaveBeenNthCalledWith(3, {
-          type: 'robotUpdate:UPDATE_INFO',
-          payload: {
-            version: '1.2.3',
-            releaseNotes: 'some release notes',
-            force: false,
-            target: 'flex',
-          },
+          type: 'robotUpdate:DOWNLOAD_PROGRESS',
+          payload: { progress: 50, target: 'flex' },
+        })
+        expect(dispatch).not.toHaveBeenCalledWith({
+          type: 'robotUpdate:DOWNLOAD_PROGRESS',
+          payload: { progress: 50.1, target: 'flex' },
         })
         expect(dispatch).toHaveBeenNthCalledWith(4, {
-          type: 'robotUpdate:UPDATE_VERSION',
-          payload: { version: '1.2.3', force: false, target: 'flex' },
-        })
-        expect(dispatch).toHaveBeenNthCalledWith(5, {
           type: 'robotUpdate:UPDATE_INFO',
           payload: {
             version: '1.2.3',
@@ -566,9 +567,26 @@ describe('update driver', () => {
             target: 'flex',
           },
         })
-        expect(dispatch).toHaveBeenNthCalledWith(6, {
+        expect(dispatch).toHaveBeenNthCalledWith(5, {
           type: 'robotUpdate:UPDATE_VERSION',
           payload: { version: '1.2.3', force: false, target: 'flex' },
+        })
+        expect(dispatch).toHaveBeenNthCalledWith(6, {
+          type: 'robotUpdate:UPDATE_INFO',
+          payload: {
+            version: '1.2.3',
+            releaseNotes: 'some release notes',
+            force: false,
+            target: 'flex',
+          },
+        })
+        expect(dispatch).toHaveBeenNthCalledWith(7, {
+          type: 'robotUpdate:UPDATE_VERSION',
+          payload: { version: '1.2.3', force: false, target: 'flex' },
+        })
+        expect(dispatch).toHaveBeenNthCalledWith(8, {
+          type: 'robotUpdate:DOWNLOAD_DONE',
+          payload: 'flex',
         })
       })
   })

--- a/app-shell-odd/src/system-update/__tests__/handler.test.ts
+++ b/app-shell-odd/src/system-update/__tests__/handler.test.ts
@@ -406,6 +406,82 @@ describe('update driver', () => {
         })
       })
   })
+  it('does not clear update data if a scan fails because a check is ongoing', async () => {
+    const thisSubject = subject!
+    when(getConfig)
+      .calledWith('update')
+      .thenReturn({ automaticallyDownloadUpdates: false })
+    when(fakeProvider.scanUpdate)
+      .calledWith(expect.any(Function))
+      .thenDo(
+        progress =>
+          new Promise(resolve => {
+            progress({
+              version: '1.2.3',
+              files: {
+                system: null,
+                releaseNotes: '/some/path/to/releasenotes.md',
+              },
+              downloadProgress: 0,
+              releaseNotes: 'hello',
+            })
+            resolve({
+              version: '1.2.3',
+              files: {
+                system: null,
+                releaseNotes: '/some/path/to/releasenotes.md',
+              },
+              downloadProgress: 0,
+              releaseNotes: 'hello',
+            })
+          })
+      )
+    await thisSubject.handleAction({
+      type: 'shell:CHECK_UPDATE',
+      meta: { shell: true },
+    })
+    expect(dispatch).toHaveBeenNthCalledWith(1, {
+      type: 'robotUpdate:UPDATE_VERSION',
+      payload: { version: '1.2.3', force: false, target: 'flex' },
+    })
+    expect(dispatch).toHaveBeenNthCalledWith(2, {
+      type: 'robotUpdate:UPDATE_INFO',
+      payload: {
+        version: '1.2.3',
+        force: false,
+        target: 'flex',
+        releaseNotes: 'hello',
+      },
+    })
+    when(fakeProvider.scanUpdate)
+      .calledWith(expect.any(Function))
+      .thenReject(new Error('ongoing'))
+    await thisSubject.handleAction({
+      type: 'shell:CHECK_UPDATE',
+      meta: { shell: true },
+    })
+    expect(dispatch).toHaveBeenNthCalledWith(3, {
+      type: 'robotUpdate:UPDATE_VERSION',
+      payload: {
+        version: '1.2.3',
+        force: false,
+        target: 'flex',
+      },
+    })
+    expect(dispatch).toHaveBeenNthCalledWith(4, {
+      type: 'robotUpdate:UPDATE_INFO',
+      payload: {
+        version: '1.2.3',
+        force: false,
+        target: 'flex',
+        releaseNotes: 'hello',
+      },
+    })
+    expect(dispatch).not.toHaveBeenCalledWith({
+      type: 'robotUpdate:UPDATE_VERSION',
+      payload: { version: null, force: false, target: 'flex' },
+    })
+  })
   it('downloads updates when told and no USB updates are present and updates are on', () => {
     when(getConfig)
       .calledWith('update')

--- a/app-shell-odd/src/system-update/from-web/provider.ts
+++ b/app-shell-odd/src/system-update/from-web/provider.ts
@@ -299,6 +299,7 @@ export function getProvider(
 
     teardown: () => {
       lockCache()
+      log.warn('tearing down and removing cache dir because teardown()')
       return rm(from.updateCacheDirectory, { recursive: true, force: true })
     },
     lockUpdateCache: lockCache,

--- a/app-shell-odd/src/system-update/from-web/provider.ts
+++ b/app-shell-odd/src/system-update/from-web/provider.ts
@@ -276,7 +276,7 @@ export function getProvider(
     getUpdateDetails: () => currentUpdate.update,
     scanUpdate: (progress: ProgressCallback) => {
       if (currentCheck != null) {
-        return Promise.reject(new Error('Check already ongoing'))
+        return Promise.reject(new Error('ongoing'))
       } else {
         const checkerPromise = updateChecker(progress)
         currentCheck = checkerPromise
@@ -287,7 +287,7 @@ export function getProvider(
     },
     downloadUpdate: (progress: ProgressCallback) => {
       if (currentCheck != null) {
-        return Promise.reject(new Error('Check already ongoing'))
+        return Promise.reject(new Error('ongoing'))
       } else {
         const updaterPromise = updater(progress)
         currentCheck = updaterPromise

--- a/app-shell-odd/src/system-update/from-web/provider.ts
+++ b/app-shell-odd/src/system-update/from-web/provider.ts
@@ -276,6 +276,7 @@ export function getProvider(
     getUpdateDetails: () => currentUpdate.update,
     scanUpdate: (progress: ProgressCallback) => {
       if (currentCheck != null) {
+        // callers check for this exact message. im sorry
         return Promise.reject(new Error('ongoing'))
       } else {
         const checkerPromise = updateChecker(progress)
@@ -287,6 +288,7 @@ export function getProvider(
     },
     downloadUpdate: (progress: ProgressCallback) => {
       if (currentCheck != null) {
+        // callers check for this exact message. im sorry
         return Promise.reject(new Error('ongoing'))
       } else {
         const updaterPromise = updater(progress)

--- a/app-shell-odd/src/system-update/handler.ts
+++ b/app-shell-odd/src/system-update/handler.ts
@@ -138,7 +138,7 @@ export function createUpdateDriver(dispatch: Dispatch): UpdateDriver {
               }
             })
             .catch(err => {
-              if (err.name === 'ongoing') {
+              if (err?.message === 'ongoing') {
                 return webUpdate
               } else {
                 log.warn(

--- a/app-shell-odd/src/system-update/handler.ts
+++ b/app-shell-odd/src/system-update/handler.ts
@@ -226,7 +226,7 @@ export function createUpdateDriver(dispatch: Dispatch): UpdateDriver {
                 } as const
               })
               .then(result => {
-                log.info(`Update download complete: ${result}`)
+                log.info('Update download complete')
                 webUpdate = result
                 dispatchStaticUpdateData()
                 dispatch({ type: 'robotUpdate:DOWNLOAD_DONE', payload: 'flex' })

--- a/app-shell-odd/src/system-update/handler.ts
+++ b/app-shell-odd/src/system-update/handler.ts
@@ -138,17 +138,21 @@ export function createUpdateDriver(dispatch: Dispatch): UpdateDriver {
               }
             })
             .catch(err => {
-              log.warn(
-                `Error finding updates with ${webProvider.name()}: ${
-                  err.name
-                }: ${err.message}`
-              )
-              return {
-                version: null,
-                files: { system: null, releaseNotes: null },
-                downloadProgress: 0,
-                releaseNotes: null,
-              } as const
+              if (err.name === 'ongoing') {
+                return webUpdate
+              } else {
+                log.warn(
+                  `Error finding updates with ${webProvider.name()}: ${
+                    err.name
+                  }: ${err.message}`
+                )
+                return {
+                  version: null,
+                  files: { system: null, releaseNotes: null },
+                  downloadProgress: 0,
+                  releaseNotes: null,
+                } as const
+              }
             })
             .then(result => {
               webUpdate = result

--- a/app-shell-odd/src/system-update/handler.ts
+++ b/app-shell-odd/src/system-update/handler.ts
@@ -170,57 +170,69 @@ export function createUpdateDriver(dispatch: Dispatch): UpdateDriver {
                 })
               }
             })
-        case 'robotUpdate:DOWNLOAD_UPDATE':
-          return webProvider
-            .downloadUpdate(updateStatus => {
-              webUpdate = updateStatus
-              if (
-                updateStatus.version != null &&
-                updateStatus.files.system == null &&
-                updateStatus.downloadProgress === 0
-              ) {
-                dispatch({
-                  type: 'robotUpdate:UPDATE_VERSION',
-                  payload: {
-                    version: updateStatus.version,
-                    force: false,
-                    target: 'flex',
-                  },
-                })
-              } else if (
-                updateStatus.version != null &&
-                updateStatus.files.system == null &&
-                updateStatus.downloadProgress !== 0
-              ) {
-                dispatch({
-                  // TODO: change this action type to 'systemUpdate:DOWNLOAD_PROGRESS'
-                  type: 'robotUpdate:DOWNLOAD_PROGRESS',
-                  payload: {
-                    progress: updateStatus.downloadProgress,
-                    target: 'flex',
-                  },
-                })
-              } else if (updateStatus.files.system != null) {
+        case 'robotUpdate:DOWNLOAD_UPDATE': {
+          const check = webProvider.ongoingCheck() ?? Promise.resolve()
+          log.info('enqueueing download now')
+          return check.then(() => {
+            log.info('beginning download of robot update now')
+            let lastProgress = 0
+            return webProvider
+              .downloadUpdate(updateStatus => {
+                webUpdate = updateStatus
+                if (
+                  updateStatus.version != null &&
+                  updateStatus.files.system == null &&
+                  updateStatus.downloadProgress === 0
+                ) {
+                  dispatch({
+                    type: 'robotUpdate:UPDATE_VERSION',
+                    payload: {
+                      version: updateStatus.version,
+                      force: false,
+                      target: 'flex',
+                    },
+                  })
+                } else if (
+                  updateStatus.version != null &&
+                  updateStatus.files.system == null &&
+                  updateStatus.downloadProgress !== 0
+                ) {
+                  if (updateStatus.downloadProgress - lastProgress >= 1) {
+                    dispatch({
+                      // TODO: change this action type to 'systemUpdate:DOWNLOAD_PROGRESS'
+                      type: 'robotUpdate:DOWNLOAD_PROGRESS',
+                      payload: {
+                        progress: updateStatus.downloadProgress,
+                        target: 'flex',
+                      },
+                    })
+                    lastProgress = updateStatus.downloadProgress
+                  }
+                } else if (updateStatus.files.system != null) {
+                  dispatchStaticUpdateData()
+                }
+              })
+              .catch(err => {
+                log.warn(
+                  `Error finding updates with ${webProvider.name()}: ${
+                    err.name
+                  }: ${err.message}`
+                )
+                return {
+                  version: null,
+                  files: { system: null, releaseNotes: null },
+                  downloadProgress: 0,
+                  releaseNotes: null,
+                } as const
+              })
+              .then(result => {
+                log.info(`Update download complete: ${result}`)
+                webUpdate = result
                 dispatchStaticUpdateData()
-              }
-            })
-            .catch(err => {
-              log.warn(
-                `Error finding updates with ${webProvider.name()}: ${
-                  err.name
-                }: ${err.message}`
-              )
-              return {
-                version: null,
-                files: { system: null, releaseNotes: null },
-                downloadProgress: 0,
-                releaseNotes: null,
-              } as const
-            })
-            .then(result => {
-              webUpdate = result
-              dispatchStaticUpdateData()
-            })
+                dispatch({ type: 'robotUpdate:DOWNLOAD_DONE', payload: 'flex' })
+              })
+          })
+        }
         case 'shell:ROBOT_MASS_STORAGE_DEVICE_ENUMERATED':
           log.info(
             `mass storage device enumerated at ${action.payload.rootPath}`

--- a/app/src/organisms/UpdateRobotSoftware/UpdateSoftware.tsx
+++ b/app/src/organisms/UpdateRobotSoftware/UpdateSoftware.tsx
@@ -31,7 +31,7 @@ export function UpdateSoftware({
       case 'installing':
         return t('installing_software')
       default:
-        console.warn('Update software has an issue')
+        console.warn(`update software: unknown updateType: ${updateType}`)
         return null
     }
   }

--- a/app/src/organisms/UpdateRobotSoftware/index.tsx
+++ b/app/src/organisms/UpdateRobotSoftware/index.tsx
@@ -70,9 +70,7 @@ export function UpdateRobotSoftware(
   if (step === 'finished') {
     return <CompleteUpdateSoftware robotName={robotName} />
   } else {
-    if (isDownloading && (step === 'restart' || step === 'restarting')) {
-      updateType = 'downloading'
-    } else if (step === 'getToken' || step === 'uploadFile') {
+    if (step === 'getToken' || step === 'uploadFile') {
       updateType = 'sendingFile'
     } else if (step === 'processFile' || step === 'commitUpdate') {
       if (stage === 'awaiting-file' || stage === 'validating') {
@@ -81,6 +79,8 @@ export function UpdateRobotSoftware(
         updateType = 'installing'
         beforeCommittingSuccessfulUpdate && beforeCommittingSuccessfulUpdate()
       }
+    } else if (isDownloading) {
+      updateType = 'downloading'
     }
     return <UpdateSoftware updateType={updateType} />
   }


### PR DESCRIPTION
There's an anti-concurrency mechanism in the web update checker that won't let a scan happen while an update flow is ongoing, but that mechanism would reject a promise which would clear the current update state. Time it up right, and the UI just says there's no update available anymore because the error handler cleared the cached update state.

## Testing
- Put it on a robot with no downloaded updates and the autodownload setting off
- Really spam the update button when an update is detected 

Closes RQA-5693
