### PR TITLE
chore(js-package-testing): sync lockfile after vite 7.3.5 bump

### DIFF
--- a/js-package-testing/pnpm-lock.yaml
+++ b/js-package-testing/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
         version: 18.2.0
       '@vitejs/plugin-react':
         specifier: 4.2.0
-        version: 4.2.0(vite@7.3.2(@types/node@18.19.130))
+        version: 4.2.0(vite@7.3.5(@types/node@18.19.130))
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -70,8 +70,8 @@ importers:
         specifier: 5.3.3
         version: 5.3.3
       vite:
-        specifier: 7.3.2
-        version: 7.3.2(@types/node@18.19.130)
+        specifier: 7.3.5
+        version: 7.3.5(@types/node@18.19.130)
 
 packages:
 
@@ -1786,8 +1786,8 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -2762,14 +2762,14 @@ snapshots:
 
   '@types/scheduler@0.26.0': {}
 
-  '@vitejs/plugin-react@4.2.0(vite@7.3.2(@types/node@18.19.130))':
+  '@vitejs/plugin-react@4.2.0(vite@7.3.5(@types/node@18.19.130))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 7.3.2(@types/node@18.19.130)
+      vite: 7.3.5(@types/node@18.19.130)
     transitivePeerDependencies:
       - supports-color
 
@@ -3641,7 +3641,7 @@ snapshots:
   uuid@9.0.1:
     optional: true
 
-  vite@7.3.2(@types/node@18.19.130):
+  vite@7.3.5(@types/node@18.19.130):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.3)


### PR DESCRIPTION
## Overview

#21870 bumped `vite` to `7.3.5` in `js-package-testing/package.json` but did not update `pnpm-lock.yaml`. That mismatch breaks oe-core Flex image builds on `edge`, where `opentrons-robot-app` runs `make setup` in `js-package-testing` (which uses `pnpm install --frozen-lockfile`).

This PR refreshes the lockfile so manifest and lockfile agree on `vite@7.3.5`.

Related CI failure: https://github.com/Opentrons/oe-core/actions/runs/28880755869/job/85668315895

## Test Plan and Hands on Testing

- [x] `pnpm install --frozen-lockfile` in `js-package-testing` succeeds locally after this change

## Changelog

- Fix `js-package-testing` lockfile drift after the vite 7.3.5 dependency bump

## Review requests

- Confirm the lockfile diff only reflects the intended vite 7.3.5 resolution

## Risk assessment

- **Attention level**: low
- **Trade-offs**: lockfile-only change; no runtime behavior change beyond matching the already-bumped vite version
- **Blast radius**: `js-package-testing` and oe-core robot-app configure step
- Frozen-lockfile install now passes, which is the same check used in CI image builds