### PR TITLE
fix(app): Remove the collapse button from the ODD login screen keyboard

### DIFF
--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldController.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldController.tsx
@@ -14,7 +14,6 @@ export interface LoginFieldControllerProps {
   loginError: string | null
   confirmPasswordError: string | null
   onClearFieldErrors: () => void
-  onFocus: () => void
 }
 
 export function LoginFieldController({
@@ -25,7 +24,6 @@ export function LoginFieldController({
   loginError,
   confirmPasswordError,
   onClearFieldErrors,
-  onFocus,
 }: LoginFieldControllerProps): JSX.Element | null {
   if (step === 'username') {
     return (
@@ -40,7 +38,6 @@ export function LoginFieldController({
             error={null}
             isPasswordField={false}
             onClearError={onClearFieldErrors}
-            onFocus={onFocus}
           />
         )}
       />
@@ -67,7 +64,6 @@ export function LoginFieldController({
             error={passwordError}
             isPasswordField={true}
             onClearError={onClearFieldErrors}
-            onFocus={onFocus}
           />
         )}
       />
@@ -87,7 +83,6 @@ export function LoginFieldController({
             error={confirmPasswordError}
             isPasswordField={true}
             onClearError={onClearFieldErrors}
-            onFocus={onFocus}
           />
         )}
       />

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldController.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldController.tsx
@@ -38,6 +38,7 @@ export function LoginFieldController({
             error={null}
             isPasswordField={false}
             onClearError={onClearFieldErrors}
+            autoFocus
           />
         )}
       />
@@ -64,6 +65,7 @@ export function LoginFieldController({
             error={passwordError}
             isPasswordField={true}
             onClearError={onClearFieldErrors}
+            autoFocus
           />
         )}
       />
@@ -83,6 +85,7 @@ export function LoginFieldController({
             error={confirmPasswordError}
             isPasswordField={true}
             onClearError={onClearFieldErrors}
+            autoFocus
           />
         )}
       />

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
@@ -18,7 +18,6 @@ export interface LoginFieldInputProps<
   error: string | null
   isPasswordField: boolean
   onClearError?: () => void
-  onFocus: () => void
 }
 
 export function LoginFieldInput<
@@ -29,7 +28,6 @@ export function LoginFieldInput<
   error,
   isPasswordField,
   onClearError,
-  onFocus,
 }: LoginFieldInputProps<TFieldName>): JSX.Element {
   const [showPassword, setShowPassword] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -44,18 +42,21 @@ export function LoginFieldInput<
   const inputField = (
     <TouchInputField
       ref={setRefs(inputRef, field.ref)}
+      autoFocus
       type={inputType}
       label={label}
       error={error}
       value={field.value ?? ''}
       name={field.name}
       id={field.name}
-      onBlur={field.onBlur}
+      onBlur={e => {
+        field.onBlur()
+        e.target.focus()
+      }}
       onChange={(e: ChangeEvent<HTMLInputElement>) => {
         field.onChange(e.target.value)
         onClearError?.()
       }}
-      onFocus={onFocus}
     />
   )
 

--- a/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/LoginFieldInput.tsx
@@ -18,6 +18,7 @@ export interface LoginFieldInputProps<
   error: string | null
   isPasswordField: boolean
   onClearError?: () => void
+  autoFocus?: boolean
 }
 
 export function LoginFieldInput<
@@ -28,6 +29,7 @@ export function LoginFieldInput<
   error,
   isPasswordField,
   onClearError,
+  autoFocus,
 }: LoginFieldInputProps<TFieldName>): JSX.Element {
   const [showPassword, setShowPassword] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
@@ -42,7 +44,7 @@ export function LoginFieldInput<
   const inputField = (
     <TouchInputField
       ref={setRefs(inputRef, field.ref)}
-      autoFocus
+      autoFocus={autoFocus}
       type={inputType}
       label={label}
       error={error}

--- a/app/src/organisms/ODD/OnDeviceLogin/index.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/index.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 
-import { AccordionKeyboard } from '/app/atoms/AccordionKeyboard'
 import { FullKeyboard } from '/app/atoms/SoftwareKeyboard'
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 
@@ -58,7 +57,6 @@ export function OnDeviceLogin({
     },
   })
 
-  const [showKeyboard, setShowKeyboard] = useState(false)
   const keyboardRef = useRef<KeyboardReactInterface | null>(null)
 
   const username = watch('username')
@@ -86,11 +84,10 @@ export function OnDeviceLogin({
 
   // reset keyboard input when switching steps
   useEffect(() => {
-    if (!showKeyboard) return
     const kb = keyboardRef.current
     if (kb == null) return
     kb.setInput(keyboardFieldValue)
-  }, [step, showKeyboard, keyboardFieldValue])
+  }, [step, keyboardFieldValue])
 
   const handleNext = useCallback((): void => {
     if (step === 'username') {
@@ -204,28 +201,21 @@ export function OnDeviceLogin({
               loginError={loginError}
               confirmPasswordError={confirmPasswordError}
               onClearFieldErrors={clearFieldErrors}
-              onFocus={() => {
-                setShowKeyboard(true)
-              }}
             />
           </div>
         </div>
       </div>
-      {showKeyboard ? (
-        <div className={styles.keyboard_container}>
-          <AccordionKeyboard isOpen={showKeyboard} onToggle={() => {}}>
-            <FullKeyboard
-              onChange={(input: string) => {
-                setValue(activeFieldName, input, {
-                  shouldDirty: true,
-                  shouldTouch: true,
-                })
-              }}
-              keyboardRef={keyboardRef}
-            />
-          </AccordionKeyboard>
-        </div>
-      ) : null}
+      <div className={styles.keyboard_container}>
+        <FullKeyboard
+          onChange={(input: string) => {
+            setValue(activeFieldName, input, {
+              shouldDirty: true,
+              shouldTouch: true,
+            })
+          }}
+          keyboardRef={keyboardRef}
+        />
+      </div>
     </>
   )
 }


### PR DESCRIPTION
## Overview

On this screen, the on-screen virtual keyboard should not be collapsible. This closes EXEC-2827.

## Test Plan and Hands on Testing

https://github.com/user-attachments/assets/134e9c24-93d2-4867-a7e3-12c2bf5168c0

## Changelog

* Remove the collapse button. Always show the keyboard.
* A couple other minor changes. See comments.

## Review requests

None in particular.

## Risk assessment

Low.
