### PR TITLE
refactor(app): rename documentation state hooks and add...uh....documentation...

### DIFF
--- a/app/src/local-resources/access-control/__tests__/useDocumentationState.test.ts
+++ b/app/src/local-resources/access-control/__tests__/useDocumentationState.test.ts
@@ -9,7 +9,7 @@ import {
 import { useCurrentUsername } from '/app/redux/robot-auth'
 
 import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../__fixtures__/documentationState'
-import { useGuardedAction } from '../useGuardedAction'
+import { useDocumentationState } from '../useDocumentationState'
 import {
   mockShowDocumentationRequiredModal,
   mockShowLoginModal,
@@ -44,7 +44,7 @@ vi.mock('/app/redux/robot-auth', async importOriginal => {
 
 const wrapper = wrapWithDocumentationRequiredModal()
 
-describe('useGuardedAction', () => {
+describe('useDocumentationState', () => {
   beforeEach(() => {
     vi.mocked(useAuthSettingsQuery).mockReturnValue({
       data: {
@@ -84,7 +84,7 @@ describe('useGuardedAction', () => {
       },
     } as ReturnType<typeof useAuthSettingsQuery>)
 
-    const { result } = renderHook(() => useGuardedAction(), { wrapper })
+    const { result } = renderHook(() => useDocumentationState(), { wrapper })
 
     await act(async () => {
       expect(result.current).toEqual(
@@ -110,7 +110,7 @@ describe('useGuardedAction', () => {
       },
     } as ReturnType<typeof useAuthSettingsQuery>)
 
-    const { result } = renderHook(() => useGuardedAction(), { wrapper })
+    const { result } = renderHook(() => useDocumentationState(), { wrapper })
 
     await act(async () => {
       expect(
@@ -126,7 +126,7 @@ describe('useGuardedAction', () => {
   it('skips guards when documentation is provided', async () => {
     const docreport = 'starting calibration' as DocumentationReport
 
-    const { result } = renderHook(() => useGuardedAction(docreport), {
+    const { result } = renderHook(() => useDocumentationState(docreport), {
       wrapper,
     })
 
@@ -143,7 +143,7 @@ describe('useGuardedAction', () => {
   })
 
   it('returns callback to open modal when documentation is not provided', async () => {
-    const { result } = renderHook(() => useGuardedAction(), { wrapper })
+    const { result } = renderHook(() => useDocumentationState(), { wrapper })
 
     expect(
       !result.current.isLoading && result.current.accessControlEnabled
@@ -159,7 +159,7 @@ describe('useGuardedAction', () => {
   })
   it('opens login modal when username is not provided', async () => {
     vi.mocked(useCurrentUsername).mockReturnValue(null)
-    const { result } = renderHook(() => useGuardedAction(), { wrapper })
+    const { result } = renderHook(() => useDocumentationState(), { wrapper })
 
     await act(async () => {
       if (
@@ -179,7 +179,7 @@ describe('useGuardedAction', () => {
     vi.mocked(useCurrentUsername).mockReturnValue(null)
     vi.mocked(mockShowLoginModal).mockResolvedValue(null)
     const onCancel = vi.fn()
-    const { result } = renderHook(() => useGuardedAction(), { wrapper })
+    const { result } = renderHook(() => useDocumentationState(), { wrapper })
 
     await act(async () => {
       if (
@@ -200,7 +200,7 @@ describe('useGuardedAction', () => {
 
   it('passes initialDocreport to the documentation modal', async () => {
     const initialDocreport = 'previous note' as DocumentationReport
-    const { result } = renderHook(() => useGuardedAction(), { wrapper })
+    const { result } = renderHook(() => useDocumentationState(), { wrapper })
 
     await act(async () => {
       if (
@@ -226,7 +226,7 @@ describe('useGuardedAction', () => {
   })
 
   it('exposes askForLogin when access control is enabled', async () => {
-    const { result } = renderHook(() => useGuardedAction(), { wrapper })
+    const { result } = renderHook(() => useDocumentationState(), { wrapper })
 
     expect(
       !result.current.isLoading && result.current.accessControlEnabled

--- a/app/src/local-resources/access-control/__tests__/usePromptForDocumentation.test.ts
+++ b/app/src/local-resources/access-control/__tests__/usePromptForDocumentation.test.ts
@@ -9,7 +9,7 @@ import {
 import { useCurrentUsername } from '/app/redux/robot-auth'
 
 import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../__fixtures__/documentationState'
-import { usePromptForInteractionReason } from '../usePromptForInteractionReason'
+import { usePromptForDocumentation } from '../usePromptForDocumentation'
 import {
   mockShowDocumentationRequiredModal,
   mockShowLoginModal,
@@ -45,7 +45,7 @@ vi.mock('/app/redux/robot-auth', async importOriginal => {
 const mockDocreport = 'starting calibration' as DocumentationReport
 const wrapper = wrapWithDocumentationRequiredModal()
 
-describe('usePromptForInteractionReason', () => {
+describe('usePromptForDocumentation', () => {
   beforeEach(() => {
     vi.mocked(useAuthSettingsQuery).mockReturnValue({
       data: {
@@ -89,7 +89,7 @@ describe('usePromptForInteractionReason', () => {
     } as ReturnType<typeof useAccessControlEnabledQuery>)
 
     const { result } = renderHook(
-      () => usePromptForInteractionReason(['lpc_flow']),
+      () => usePromptForDocumentation(['lpc_flow']),
       {
         wrapper,
       }
@@ -116,7 +116,7 @@ describe('usePromptForInteractionReason', () => {
       },
     } as ReturnType<typeof useAuthSettingsQuery>)
     const { result } = renderHook(
-      () => usePromptForInteractionReason(['lpc_flow']),
+      () => usePromptForDocumentation(['lpc_flow']),
       {
         wrapper,
       }
@@ -134,7 +134,7 @@ describe('usePromptForInteractionReason', () => {
     vi.mocked(mockShowLoginModal).mockResolvedValue(null)
     const onCancel = vi.fn()
 
-    renderHook(() => usePromptForInteractionReason(['lpc_flow'], onCancel), {
+    renderHook(() => usePromptForDocumentation(['lpc_flow'], onCancel), {
       wrapper,
     })
 
@@ -147,7 +147,7 @@ describe('usePromptForInteractionReason', () => {
 
   it('prompts for documentation when access control is enabled', async () => {
     const { result } = renderHook(
-      () => usePromptForInteractionReason(['lpc_flow']),
+      () => usePromptForDocumentation(['lpc_flow']),
       {
         wrapper,
       }

--- a/app/src/local-resources/access-control/useDocumentationState.ts
+++ b/app/src/local-resources/access-control/useDocumentationState.ts
@@ -30,7 +30,7 @@ import type {
  *
  * @param docreport - optional pre-provided documentation report
  */
-export function useGuardedAction(
+export function useDocumentationState(
   docreport?: DocumentationReport
 ): DocumentationState {
   const authSettingsQuery = useAuthSettingsQuery()

--- a/app/src/local-resources/access-control/useMaintenanceRunDocumentation.ts
+++ b/app/src/local-resources/access-control/useMaintenanceRunDocumentation.ts
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react'
 
-import { useGuardedAction } from './useGuardedAction'
-import { usePromptForInteractionReason } from './usePromptForInteractionReason'
+import { useDocumentationState } from './useDocumentationState'
+import { usePromptForDocumentation } from './usePromptForDocumentation'
 
 import type {
   DocumentationState,
@@ -36,12 +36,12 @@ export const useMaintenanceRunDocumentation = (
   const [actionsToDocument, setActionsToDocument] = useState<
     DocumentedAction[]
   >([maintenanceRunName])
-  const commandDocState = usePromptForInteractionReason(
+  const commandDocState = usePromptForDocumentation(
     [maintenanceRunName],
     onCancelStart,
     initialDocstate
   )
-  const deletionDocState = useGuardedAction()
+  const deletionDocState = useDocumentationState()
 
   const addActionToDocument = useCallback((action: DocumentedAction) => {
     setActionsToDocument(prev => [...prev, action])

--- a/app/src/local-resources/access-control/usePromptForDocumentation.ts
+++ b/app/src/local-resources/access-control/usePromptForDocumentation.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
-import { useGuardedAction } from './useGuardedAction'
+import { useDocumentationState } from './useDocumentationState'
 
 import type {
   DocumentationReport,
@@ -9,17 +9,17 @@ import type {
 } from '@opentrons/react-api-client'
 
 /**
- * Immediately prompts for the interaction reason and returns a documentation State.
+ * Immediately prompts for documentation and returns a documentation State.
  *
 
  * Use this to prompt for a documentation report to pass between multiple mutations that only need to be prompted once.
  * e.g. maintenance run commands
- * If mutations can prompt for documentation themselves, use useGuardedAction instead.
+ * If mutations can prompt for documentation themselves, use useDocumentationState instead.
  *
  *  @param initialDocstate - an optional documentation state to use as a base. To be used when a flow needs to sometimes but not always prompt before the first mutation.
  *
  */
-export const usePromptForInteractionReason = (
+export const usePromptForDocumentation = (
   actionsToDocument: DocumentedAction[],
   onCancel?: () => void,
   initialDocstate?: DocumentationState
@@ -32,7 +32,7 @@ export const usePromptForInteractionReason = (
     initialDocstate.reasonForInteractionRequired
       ? initialDocstate.docreport
       : docReport
-  const docState = useGuardedAction(docStateToUse ?? undefined)
+  const docState = useDocumentationState(docStateToUse ?? undefined)
   const promptInFlight = useRef(false)
 
   useEffect(() => {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ConfirmCancelModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ConfirmCancelModal.tsx
@@ -18,7 +18,7 @@ import {
 import { useStopRunMutation } from '@opentrons/react-api-client'
 
 import { getTopPortalEl } from '/app/App/portal'
-import { useGuardedAction } from '/app/local-resources/access-control/useGuardedAction'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { isStoppingOrStopped } from '/app/local-resources/runs/utils'
 import { useTrackProtocolRunEvent } from '/app/redux-resources/analytics'
 import { useIsFlex } from '/app/redux-resources/robots'
@@ -53,7 +53,7 @@ export function ConfirmCancelModal(
   props: ConfirmCancelModalProps
 ): JSX.Element {
   const { onClose, runId, robotName, runStatus } = props
-  const documentationState = useGuardedAction()
+  const documentationState = useDocumentationState()
   const { stopRun } = useStopRunMutation(documentationState)
   const isFlex = useIsFlex(robotName)
   const { trackProtocolRunEvent } = useTrackProtocolRunEvent(runId, robotName)

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/__tests__/ConfirmCancelModal.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/__tests__/ConfirmCancelModal.test.tsx
@@ -33,8 +33,10 @@ vi.mock('@opentrons/react-api-client', async importOriginal => {
 vi.mock('/app/redux/analytics')
 vi.mock('/app/redux-resources/analytics')
 vi.mock('/app/redux-resources/robots')
-vi.mock('/app/local-resources/access-control/useGuardedAction', () => ({
-  useGuardedAction: vi.fn(() => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: vi.fn(
+    () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+  ),
 }))
 
 const render = (props: ComponentProps<typeof ConfirmCancelModal>) => {

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
@@ -29,8 +29,10 @@ import {
 vi.mock('@opentrons/react-api-client')
 vi.mock('/app/resources/runs')
 vi.mock('/app/organisms/ErrorRecoveryFlows/utils')
-vi.mock('/app/local-resources/access-control/useGuardedAction', () => ({
-  useGuardedAction: vi.fn(() => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: vi.fn(
+    () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+  ),
 }))
 
 describe('useRecoveryCommands', () => {

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useERUtils.ts
@@ -5,7 +5,7 @@ import {
   useRunCurrentState,
 } from '@opentrons/react-api-client'
 
-import { useGuardedAction } from '/app/local-resources/access-control/useGuardedAction'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useRecoveryAnalytics } from '/app/redux-resources/analytics'
 import { getRunningStepCountsFrom } from '/app/resources/protocols'
 import {
@@ -186,7 +186,7 @@ export function useERUtils({
     recoveryMap,
   })
 
-  const documentationState = useGuardedAction()
+  const documentationState = useDocumentationState()
   const recoveryActionMutationUtils = useRecoveryActionMutation(
     runId,
     routeUpdateActions,

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -9,7 +9,7 @@ import {
 } from '@opentrons/react-api-client'
 import { WELL_ORIGIN_TOP } from '@opentrons/shared-data'
 
-import { useGuardedAction } from '/app/local-resources/access-control/useGuardedAction'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { getErrorKind } from '/app/organisms/ErrorRecoveryFlows/utils'
 import {
   useChainRunCommands,
@@ -123,7 +123,7 @@ export function useRecoveryCommands({
   const { mutateAsync: resumeRunFromRecoveryAssumingFalsePositive } =
     useResumeRunFromRecoveryAssumingFalsePositiveMutation()
 
-  const documentationState = useGuardedAction()
+  const documentationState = useDocumentationState()
   const { stopRun } = useStopRunMutation(documentationState)
   const updateErrorRecoveryPolicy = useUpdateRecoveryPolicyWithStrategy(runId)
   const currentRecoveryPolicy = useErrorRecoveryPolicy(runId)?.data?.data

--- a/app/src/organisms/ODD/DocumentationRequired/requireDocumentation.ts
+++ b/app/src/organisms/ODD/DocumentationRequired/requireDocumentation.ts
@@ -6,13 +6,8 @@ import type {
 } from '@opentrons/react-api-client'
 
 /**
- * Guard that captures a pops DocumentationRequiredModal and returns the documentation report
+ * Callback that opens the DocumentationRequiredModal and returns the documentation report
  *
- * Assumes access control is enabled and the user is authenticated.
- *
- * TODO(jj): do something with the actionsToDocument
- *
- * @throws {Error} if the documentation report is invalid
  */
 export async function requireDocumentation(
   username: string,

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
@@ -12,7 +12,7 @@ import {
 } from '@opentrons/react-api-client'
 
 import { SmallButton } from '/app/atoms/buttons'
-import { useGuardedAction } from '/app/local-resources/access-control/useGuardedAction'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
 import { useTrackProtocolRunEvent } from '/app/redux-resources/analytics'
 import { ANALYTICS_PROTOCOL_RUN_ACTION } from '/app/redux/analytics'
@@ -38,7 +38,7 @@ export function ConfirmCancelRunModal({
   protocolId,
 }: ConfirmCancelRunModalProps): JSX.Element {
   const { t } = useTranslation(['run_details', 'shared'])
-  const documentationState = useGuardedAction()
+  const documentationState = useDocumentationState()
   const { stopRun } = useStopRunMutation(documentationState)
   const { dismissCurrentRun, isLoading: isDismissing } =
     useDismissCurrentRunMutation()

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/__tests__/RunFailedModal.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/__tests__/RunFailedModal.test.tsx
@@ -17,8 +17,8 @@ import type { NavigateFunction } from 'react-router-dom'
 
 vi.mock('@opentrons/react-api-client')
 vi.mock('../ErrorContent')
-vi.mock('/app/local-resources/access-control/useGuardedAction', () => ({
-  useGuardedAction: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
 }))
 
 const RUN_ID = 'mock_runID'

--- a/app/src/organisms/ODD/RunningProtocol/RunFailedModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/RunFailedModal/index.tsx
@@ -7,7 +7,7 @@ import { LegacyStyledText } from '@opentrons/components'
 import { useStopRunMutation } from '@opentrons/react-api-client'
 
 import { SmallButton } from '/app/atoms/buttons'
-import { useGuardedAction } from '/app/local-resources/access-control/useGuardedAction'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
 import { getHighestPriorityError } from '/app/transformations/runs'
 
@@ -38,7 +38,7 @@ export function RunFailedModal({
 }: RunFailedModalProps): JSX.Element | null {
   const { t, i18n } = useTranslation(['run_details', 'shared', 'branded'])
   const navigate = useNavigate()
-  const documentationState = useGuardedAction()
+  const documentationState = useDocumentationState()
   const { stopRun } = useStopRunMutation(documentationState)
   const [isCanceling, setIsCanceling] = useState(false)
 

--- a/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
+++ b/app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx
@@ -41,7 +41,7 @@ import singleChannelAndEightChannel from '/app/assets/images/change-pip/1_and_8_
 import ninetySixChannel from '/app/assets/images/change-pip/ninety-six-channel.png'
 import { SmallButton } from '/app/atoms/buttons'
 import { i18n } from '/app/i18n'
-import { usePromptForInteractionReason } from '/app/local-resources/access-control/usePromptForInteractionReason'
+import { usePromptForDocumentation } from '/app/local-resources/access-control/usePromptForDocumentation'
 import { isDocumentationProvided } from '/app/local-resources/access-control/utils'
 import { ModalContentOneColSimpleButtons } from '/app/molecules/InterventionModal'
 import { SimpleWizardInProgressBody } from '/app/molecules/SimpleWizardBody'
@@ -130,7 +130,7 @@ export const ChoosePipette = (props: ChoosePipetteProps): JSX.Element => {
 
   const initialAction =
     mount === LEFT ? 'attach_pipette_left' : 'attach_pipette_right'
-  const initialDocstate = usePromptForInteractionReason([initialAction], exit)
+  const initialDocstate = usePromptForDocumentation([initialAction], exit)
   const isWaitingForDocumentation = !isDocumentationProvided(initialDocstate)
 
   const bothMounts = getIsGantryEmpty(attachedPipettesByMount)

--- a/app/src/organisms/PipetteWizardFlows/__tests__/ChoosePipette.test.tsx
+++ b/app/src/organisms/PipetteWizardFlows/__tests__/ChoosePipette.test.tsx
@@ -26,9 +26,9 @@ vi.mock('/app/local-resources/access-control/utils', () => ({
   isDocumentationProvided: vi.fn(() => true),
 }))
 vi.mock(
-  '/app/local-resources/access-control/usePromptForInteractionReason',
+  '/app/local-resources/access-control/usePromptForDocumentation',
   () => ({
-    usePromptForInteractionReason: vi.fn(() => ({
+    usePromptForDocumentation: vi.fn(() => ({
       accessControlEnabled: false,
     })),
   })

--- a/app/src/organisms/TakeoverModal/MaintenanceRunTakeover.tsx
+++ b/app/src/organisms/TakeoverModal/MaintenanceRunTakeover.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { useDeleteMaintenanceRunMutation } from '@opentrons/react-api-client'
 
-import { useGuardedAction } from '/app/local-resources/access-control/useGuardedAction'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 
 import { MaintenanceRunStatusProvider } from './MaintenanceRunStatusProvider'
 import { TakeoverModal } from './TakeoverModal'
@@ -44,7 +44,7 @@ export function MaintenanceRunTakeoverModal(
     isMaintenanceRunCurrent && oddRunId !== currentRunId
 
   // TODO(jj): This needs to access the docstate and actions for the current maintenance run.
-  const docState = useGuardedAction()
+  const docState = useDocumentationState()
 
   const { deleteMaintenanceRun, reset } = useDeleteMaintenanceRunMutation(
     docState,

--- a/app/src/organisms/TakeoverModal/__tests__/MaintenanceRunTakeover.test.tsx
+++ b/app/src/organisms/TakeoverModal/__tests__/MaintenanceRunTakeover.test.tsx
@@ -16,8 +16,8 @@ import type { MaintenanceRunStatus } from '../MaintenanceRunStatusProvider'
 
 vi.mock('../useMaintenanceRunTakeover')
 vi.mock('/app/resources/maintenance_runs')
-vi.mock('/app/local-resources/access-control/useGuardedAction', () => ({
-  useGuardedAction: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
 }))
 
 const MOCK_MAINTENANCE_RUN: MaintenanceRunStatus = {

--- a/app/src/pages/ODD/RunningProtocol/index.tsx
+++ b/app/src/pages/ODD/RunningProtocol/index.tsx
@@ -19,7 +19,7 @@ import {
   useRunActionMutations,
 } from '@opentrons/react-api-client'
 
-import { useGuardedAction } from '/app/local-resources/access-control/useGuardedAction'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useToastOnErrorImage } from '/app/local-resources/images/hooks/useToastOnErrorImage'
 import { useIsDoorOpen } from '/app/organisms/DoorOpenControl/useIsDoorOpen'
 import {
@@ -108,8 +108,7 @@ export function RunningProtocol(): JSX.Element {
     staleTime: Infinity,
   })
 
-  // TODO(jj): figure out what to do with actionsToDocument
-  const docstate = useGuardedAction()
+  const docstate = useDocumentationState()
 
   const protocolName =
     protocolRecord?.data.metadata.protocolName ??

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -10,6 +10,152 @@ export type DocumentationReport = string & {
   readonly _brand: 'DocumentationReport'
 }
 
+/**
+ * Documentation state to be passed to the useDocumentedMutation hook.
+ *
+ * @param isLoading - whether the access control queries are still loading
+ * @param accessControlEnabled - whether access control is enabled
+ * @param loginExpired - whether the login has expired
+ * @param askForLogin - a function that opens the login modal and returns the username
+ * @param reasonForInteractionRequired - whether user documentation is required
+ * @param docreport - the documentation report, a branded string
+ * @param askForDocumentation - a function that opens the documentation modal and returns the documentation report
+ */
+export type DocumentationState =
+  | { isLoading: true }
+  | {
+      isLoading: false
+      accessControlEnabled: false
+    }
+  | ({
+      isLoading: false
+    } & MutationAuthenticationState &
+      MutationDocumentationState)
+
+/**
+ * State of user login and authentication. Necessary to pop up login modal when user is idle logged out.
+ */
+export interface MutationAuthenticationState {
+  accessControlEnabled: true
+  loginExpired: boolean
+  askForLogin: () => Promise<{ username: string } | null>
+}
+
+export type MutationDocumentationState =
+  | {
+      reasonForInteractionRequired: false
+    }
+  | {
+      reasonForInteractionRequired: true
+      docreport: DocumentationReport | null
+      askForDocumentation: (
+        actionsToDocument: DocumentedAction[],
+        onCancel?: () => void,
+        initialDocreport?: DocumentationReport,
+        username?: string
+      ) => Promise<DocumentationReport>
+    }
+
+export interface DocumentedMutationParameters<TVariables = void> {
+  userNotes: string
+  variables: TVariables
+}
+
+/**
+ * Signature to enable passing along documentation state with mutations.
+ * All mutation functions should have this signature.
+ */
+export type DocumentedMutationFunction<TData = unknown, TVariables = void> = (
+  parameters: DocumentedMutationParameters<TVariables>
+) => Promise<TData>
+
+/**
+ * Call signatures for useDocumentedMutation
+ * these mirror the `useMutation` shapes used in this codebase:
+ *   (state, mutationFn, options?)
+ *   (state, mutationKey, mutationFn, options?)
+ */
+export interface UseDocumentedMutation {
+  <TData = unknown, TError = unknown, TVariables = void, TContext = unknown>(
+    documentationState: DocumentationState,
+    actionsToDocument: DocumentedAction[],
+    mutationFn: DocumentedMutationFunction<TData, TVariables>,
+    options?: UseMutationOptions<TData, TError, TVariables, TContext>
+  ): UseMutationResult<TData, TError, TVariables, TContext>
+
+  <TData = unknown, TError = unknown, TVariables = void, TContext = unknown>(
+    documentationState: DocumentationState,
+    actionsToDocument: DocumentedAction[],
+    mutationKey: MutationKey,
+    mutationFn: DocumentedMutationFunction<TData, TVariables>,
+    options?: UseMutationOptions<TData, TError, TVariables, TContext>
+  ): UseMutationResult<TData, TError, TVariables, TContext>
+}
+
+/**
+ * DocumentedActions for pipette wizard flows.
+ */
+export interface PipetteWizardFlowAction {
+  type: 'pipette_wizard_flow'
+  mount: PipetteMount
+  pipette: '96-Channel' | 'Single-Channel_and_8-Channel'
+  flowType: string
+  pipetteInfo: PipetteInformation | null
+  step: 'start' | 'end'
+}
+
+interface PipetteInformation {
+  displayName: string
+}
+
+export interface AttachingModuleAction {
+  module: AttachedModule
+  type: 'attach_module'
+  step: 'start' | 'end'
+}
+
+/**
+ * DocumentedActions for one-off mutations without more needed context.
+ * These should match keys in audit_log.json
+ */
+type AuditLogAction =
+  | 'stop_run'
+  | 'play_run'
+  | 'place_plate_reader_lid'
+  | 'end_plate_reader_lid'
+  | 'home_pipettes'
+  | 'end_home_pipettes'
+  | 'attach_gripper'
+  | 'detach_gripper'
+  | 'recalibrate_gripper'
+  | 'lpc_flow'
+  | 'drop_tips'
+  | 'end_calibration'
+  | 'add_module'
+  | 'end_module_setup'
+  | 'end_lpc_flow'
+  | 'finish_attach_gripper'
+  | 'finish_detach_gripper'
+  | 'finish_recalibrate_gripper'
+  | 'end_drop_tips'
+  | 'attach_pipette_left'
+  | 'attach_pipette_right'
+
+/**
+ * Type used for DocumentedActions - keys and info to enable correct rendering of actions in the 'list actions' popup in the Documentation Required Modal.
+ */
+export type DocumentedAction =
+  | AuditLogAction
+  | RunTimeCommand
+  | PipetteWizardFlowAction
+  | AttachingModuleAction
+
+/**
+ * Error specification for errors thrown by useDocumentedMutation.
+ * no_documentation_report: user closed out of the documentation modal
+ * access_control_loading: access control queries are still loading
+ * login_cancelled: user closed out of the login modal
+ */
 export type DocumentedMutationErrorType =
   | 'no_documentation_report'
   | 'access_control_loading'
@@ -40,121 +186,3 @@ export function isDocumentedMutationError(
 ): error is DocumentedMutationError {
   return error instanceof DocumentedMutationError
 }
-
-/**
- * Documentation state to be passed to the useDocumentedMutation hook.
- *
- * @param accessControlEnabled - whether access control is enabled
- * @param docreport - the documentation report
- * @param askForDocumentation - a function that opens the documentation modal and returns the documentation report
- */
-export type DocumentationState =
-  | { isLoading: true }
-  | {
-      isLoading: false
-      accessControlEnabled: false
-    }
-  | ({
-      isLoading: false
-    } & MutationAuthenticationState &
-      MutationDocumentationState)
-
-export interface MutationAuthenticationState {
-  accessControlEnabled: true
-  loginExpired: boolean
-  askForLogin: () => Promise<{ username: string } | null>
-}
-
-export type MutationDocumentationState =
-  | {
-      reasonForInteractionRequired: false
-    }
-  | {
-      reasonForInteractionRequired: true
-      docreport: DocumentationReport | null
-      askForDocumentation: (
-        actionsToDocument: DocumentedAction[],
-        onCancel?: () => void,
-        initialDocreport?: DocumentationReport,
-        username?: string
-      ) => Promise<DocumentationReport>
-    }
-
-export interface DocumentedMutationParameters<TVariables = void> {
-  userNotes: string
-  variables: TVariables
-}
-
-export type DocumentedMutationFunction<TData = unknown, TVariables = void> = (
-  parameters: DocumentedMutationParameters<TVariables>
-) => Promise<TData>
-
-/**
- * Call signatures for useDocumentedMutation — mirrors the `useMutation`
- * shapes actually used in this codebase:
- *   (state, mutationFn, options?)
- *   (state, mutationKey, mutationFn, options?)
- */
-export interface UseDocumentedMutation {
-  <TData = unknown, TError = unknown, TVariables = void, TContext = unknown>(
-    documentationState: DocumentationState,
-    actionsToDocument: DocumentedAction[],
-    mutationFn: DocumentedMutationFunction<TData, TVariables>,
-    options?: UseMutationOptions<TData, TError, TVariables, TContext>
-  ): UseMutationResult<TData, TError, TVariables, TContext>
-
-  <TData = unknown, TError = unknown, TVariables = void, TContext = unknown>(
-    documentationState: DocumentationState,
-    actionsToDocument: DocumentedAction[],
-    mutationKey: MutationKey,
-    mutationFn: DocumentedMutationFunction<TData, TVariables>,
-    options?: UseMutationOptions<TData, TError, TVariables, TContext>
-  ): UseMutationResult<TData, TError, TVariables, TContext>
-}
-export interface PipetteWizardFlowAction {
-  type: 'pipette_wizard_flow'
-  mount: PipetteMount
-  pipette: '96-Channel' | 'Single-Channel_and_8-Channel'
-  flowType: string
-  pipetteInfo: PipetteInformation | null
-  step: 'start' | 'end'
-}
-
-interface PipetteInformation {
-  displayName: string
-}
-
-export interface AttachingModuleAction {
-  module: AttachedModule
-  type: 'attach_module'
-  step: 'start' | 'end'
-}
-
-type AuditLogAction =
-  | 'stop_run'
-  | 'play_run'
-  | 'place_plate_reader_lid'
-  | 'end_plate_reader_lid'
-  | 'home_pipettes'
-  | 'end_home_pipettes'
-  | 'attach_gripper'
-  | 'detach_gripper'
-  | 'recalibrate_gripper'
-  | 'lpc_flow'
-  | 'drop_tips'
-  | 'end_calibration'
-  | 'add_module'
-  | 'end_module_setup'
-  | 'end_lpc_flow'
-  | 'finish_attach_gripper'
-  | 'finish_detach_gripper'
-  | 'finish_recalibrate_gripper'
-  | 'end_drop_tips'
-  | 'attach_pipette_left'
-  | 'attach_pipette_right'
-
-export type DocumentedAction =
-  | AuditLogAction
-  | RunTimeCommand
-  | PipetteWizardFlowAction
-  | AttachingModuleAction

--- a/react-api-client/src/accessControl/useDocumentedMutation.ts
+++ b/react-api-client/src/accessControl/useDocumentedMutation.ts
@@ -28,7 +28,7 @@ import type {
  *
  * The second option is to be used for one-off mutations where a popup is desired. i.e. playing pausing or canceling a run.
  *
- * useGuardedAction is a helper hook in /app that generates a documentation state.
+ * useDocumentationState is a helper hook in /app that generates a documentation state.
  *
  * Call signatures live in ./types as `UseDocumentedMutation`.
  */


### PR DESCRIPTION
# Overview

Renames some documentation state related hooks for clarity and ease of use by other developers and adds or edits some comments.

## Risk assessment

Very low