### PR TITLE
feat(api-client, robot-server): explicitly delete run output files

### DIFF
--- a/api-client/src/runs/deleteRun.ts
+++ b/api-client/src/runs/deleteRun.ts
@@ -2,17 +2,17 @@ import { DELETE, request } from '../request'
 
 import type { ResponsePromise } from '../request'
 import type { EmptyResponse, HostConfig } from '../types'
-import type { DeleteRunData } from './types'
+import type { DeleteRunParams } from './types'
 
 export function deleteRun(
   config: HostConfig,
   runId: string,
-  data: DeleteRunData = {}
+  params?: DeleteRunParams
 ): ResponsePromise<EmptyResponse> {
-  return request<EmptyResponse, { data: DeleteRunData }>(
+  return request<EmptyResponse, { data: DeleteRunParams }>(
     DELETE,
     `/runs/${runId}`,
     config,
-    { body: { data } }
+    { queryParams: { ...params } }
   )
 }

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -251,6 +251,6 @@ export interface FlexStackerState {
 }
 
 export interface DeleteRunParams {
-  /** If true, also delete this run's input and output data files from disk, in addition to the run record. */
+  /** If true, also delete this run's output data files and images from disk, in addition to the run record. */
   shouldDeleteAllRunFiles?: boolean
 }

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -250,6 +250,7 @@ export interface FlexStackerState {
   maxCount: number
 }
 
-export interface DeleteRunData {
+export interface DeleteRunParams {
+  /** If true, also delete this run's input and output data files from disk, in addition to the run record. */
   shouldDeleteAllRunFiles?: boolean
 }

--- a/react-api-client/src/runs/useDeleteRunMutation.ts
+++ b/react-api-client/src/runs/useDeleteRunMutation.ts
@@ -9,11 +9,14 @@ import type {
   UseMutationOptions,
   UseMutationResult,
 } from 'react-query'
-import type { DeleteRunData, EmptyResponse } from '@opentrons/api-client'
+import type {
+  DeleteRunParams as DeleteRunParamsType,
+  EmptyResponse,
+} from '@opentrons/api-client'
 
 export interface DeleteRunParams {
   runId: string
-  settings?: DeleteRunData
+  queryParams?: DeleteRunParamsType
 }
 
 export type UseDeleteRunMutationResult = UseMutationResult<
@@ -37,8 +40,8 @@ export function useDeleteRunMutation(
   const queryClient = useQueryClient()
 
   const mutation = useMutation<EmptyResponse, unknown, DeleteRunParams>(
-    ({ runId, settings }) =>
-      deleteRun(host!, runId, settings).then(response => {
+    ({ runId, queryParams }) =>
+      deleteRun(host!, runId, queryParams).then(response => {
         queryClient.removeQueries(getQueryKey(host, 'runs', runId))
         queryClient
           .invalidateQueries(getQueryKey(host, 'runs'))

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -27,7 +27,11 @@ from robot_server.camera.settings.store import (
     CameraSettingStore,
     get_camera_setting_store,
 )
-from robot_server.data_files.dependencies import get_data_file_auto_deleter
+from robot_server.data_files.data_files_store import DataFilesStore
+from robot_server.data_files.dependencies import (
+    get_data_file_auto_deleter,
+    get_data_files_store,
+)
 from robot_server.data_files.file_auto_deleter import DataFileAutoDeleter
 from robot_server.deletion_planner import RunDeletionPlanner
 from robot_server.error_recovery.settings.store import (
@@ -233,6 +237,7 @@ async def get_run_data_manager(
         CameraSettingStore, Depends(get_camera_setting_store)
     ],
     file_provider: Annotated[FileProvider, Depends(get_file_provider)],
+    data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
 ) -> RunDataManager:
     """Get a singleton run data manager to keep track of current/historical run data."""
     run_data_manager = _run_data_manager_accessor.get_from(app_state)
@@ -246,6 +251,7 @@ async def get_run_data_manager(
             task_runner=task_runner,
             runs_publisher=runs_publisher,
             file_provider=file_provider,
+            data_files_store=data_files_store,
         )
         _run_data_manager_accessor.set_on(app_state, run_data_manager)
 

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -375,15 +375,32 @@ async def get_run(
 async def remove_run(
     runId: str,
     run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
+    data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
+    shouldDeleteAllRunFiles: Annotated[
+        bool,
+        Query(
+            description=(
+                "If true, also delete this run's images and output data files"
+                " from disk, in addition to the run record."
+            ),
+        ),
+    ] = False,
 ) -> PydanticResponse[SimpleEmptyBody]:
     """Delete a run by its ID.
 
     Arguments:
         runId: Run ID pulled from URL.
         run_data_manager: Current and historical run data management.
+        data_files_store: Database of data file resources.
+        shouldDeleteAllRunFiles: If true, also delete this run's images and
+            output data files from disk, in addition to the run record.
     """
     try:
-        await run_data_manager.delete(runId)
+        await run_data_manager.delete(
+            runId,
+            data_files_store=data_files_store,
+            should_delete_all_run_files=shouldDeleteAllRunFiles,
+        )
 
     except RunConflictError as e:
         raise RunNotIdle().as_error(status.HTTP_409_CONFLICT) from e

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -375,7 +375,6 @@ async def get_run(
 async def remove_run(
     runId: str,
     run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
-    data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
     shouldDeleteAllRunFiles: Annotated[
         bool,
         Query(
@@ -391,14 +390,12 @@ async def remove_run(
     Arguments:
         runId: Run ID pulled from URL.
         run_data_manager: Current and historical run data management.
-        data_files_store: Database of data file resources.
         shouldDeleteAllRunFiles: If true, also delete this run's images and
             output data files from disk, in addition to the run record.
     """
     try:
         await run_data_manager.delete(
             runId,
-            data_files_store=data_files_store,
             should_delete_all_run_files=shouldDeleteAllRunFiles,
         )
 

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -37,6 +37,7 @@ from .run_models import BadRun, Run, RunDataError
 from .run_orchestrator_store import RunOrchestratorStore
 from .run_store import BadRunResource, BadStateSummary, RunResource, RunStore
 from robot_server.camera.settings.store import CameraSettingStore
+from robot_server.data_files.data_files_store import DataFilesStore
 from robot_server.error_recovery.settings.store import ErrorRecoverySettingStore
 from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.service.notifications import RunsPublisher
@@ -372,11 +373,20 @@ class RunDataManager:
             for run_resource in self._run_store.get_all(length)
         ]
 
-    async def delete(self, run_id: str) -> None:
+    async def delete(
+        self,
+        run_id: str,
+        data_files_store: DataFilesStore,
+        should_delete_all_run_files: bool = False,
+    ) -> None:
         """Delete a current or historical run.
 
         Args:
             run_id: The identifier of the run to remove.
+            data_files_store: Database of data file resources, required if
+                should_delete_all_run_files is True.
+            should_delete_all_run_files: If true, also delete this run's output
+                data files and images from disk.
 
         Raises:
             RunConflictError: If deleting the current run, the current run
@@ -387,6 +397,9 @@ class RunDataManager:
             await self._run_orchestrator_store.clear()
 
         self._runs_publisher.clean_up_run(run_id=run_id)
+
+        if should_delete_all_run_files and data_files_store is not None:
+            data_files_store.remove_all_by_run_id(run_id)
 
         self._run_store.remove(run_id=run_id)
 

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -169,6 +169,7 @@ class RunDataManager:
         task_runner: TaskRunner,
         runs_publisher: RunsPublisher,
         file_provider: FileProvider,
+        data_files_store: DataFilesStore,
     ) -> None:
         self._run_orchestrator_store = run_orchestrator_store
         self._run_store = run_store
@@ -184,6 +185,7 @@ class RunDataManager:
         self._task_runner = task_runner
         self._runs_publisher = runs_publisher
         self._file_provider = file_provider
+        self._data_files_store = data_files_store
 
     @property
     def current_run_id(self) -> Optional[str]:
@@ -376,15 +378,12 @@ class RunDataManager:
     async def delete(
         self,
         run_id: str,
-        data_files_store: DataFilesStore,
         should_delete_all_run_files: bool = False,
     ) -> None:
         """Delete a current or historical run.
 
         Args:
             run_id: The identifier of the run to remove.
-            data_files_store: Database of data file resources, required if
-                should_delete_all_run_files is True.
             should_delete_all_run_files: If true, also delete this run's output
                 data files and images from disk.
 
@@ -398,8 +397,8 @@ class RunDataManager:
 
         self._runs_publisher.clean_up_run(run_id=run_id)
 
-        if should_delete_all_run_files and data_files_store is not None:
-            data_files_store.remove_all_by_run_id(run_id)
+        if should_delete_all_run_files:
+            self._data_files_store.remove_all_by_run_id(run_id)
 
         self._run_store.remove(run_id=run_id)
 

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -551,19 +551,16 @@ async def test_get_runs_not_empty(
 async def test_delete_run_by_id(
     decoy: Decoy,
     mock_run_data_manager: RunDataManager,
-    mock_data_files_store: DataFilesStore,
 ) -> None:
     """It should be able to remove a run by ID."""
     result = await remove_run(
         runId="run-id",
         run_data_manager=mock_run_data_manager,
-        data_files_store=mock_data_files_store,
     )
 
     decoy.verify(
         await mock_run_data_manager.delete(
             "run-id",
-            data_files_store=mock_data_files_store,
             should_delete_all_run_files=False,
         ),
         times=1,
@@ -576,7 +573,6 @@ async def test_delete_run_by_id(
 async def test_delete_run_with_bad_id(
     decoy: Decoy,
     mock_run_data_manager: RunDataManager,
-    mock_data_files_store: DataFilesStore,
 ) -> None:
     """It should 404 if the run ID does not exist."""
     key_error = RunNotFoundError(run_id="run-id")
@@ -584,7 +580,6 @@ async def test_delete_run_with_bad_id(
     decoy.when(
         await mock_run_data_manager.delete(  # type: ignore[func-returns-value]
             "run-id",
-            data_files_store=mock_data_files_store,
             should_delete_all_run_files=False,
         )
     ).then_raise(key_error)
@@ -593,7 +588,6 @@ async def test_delete_run_with_bad_id(
         await remove_run(
             runId="run-id",
             run_data_manager=mock_run_data_manager,
-            data_files_store=mock_data_files_store,
         )
 
     assert exc_info.value.status_code == 404
@@ -603,13 +597,11 @@ async def test_delete_run_with_bad_id(
 async def test_delete_active_run(
     decoy: Decoy,
     mock_run_data_manager: RunDataManager,
-    mock_data_files_store: DataFilesStore,
 ) -> None:
     """It should 409 if the run is not finished."""
     decoy.when(
         await mock_run_data_manager.delete(  # type: ignore[func-returns-value]
             "run-id",
-            data_files_store=mock_data_files_store,
             should_delete_all_run_files=False,
         )
     ).then_raise(RunConflictError("oh no"))
@@ -618,7 +610,6 @@ async def test_delete_active_run(
         await remove_run(
             runId="run-id",
             run_data_manager=mock_run_data_manager,
-            data_files_store=mock_data_files_store,
         )
 
     assert exc_info.value.status_code == 409

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -551,11 +551,23 @@ async def test_get_runs_not_empty(
 async def test_delete_run_by_id(
     decoy: Decoy,
     mock_run_data_manager: RunDataManager,
+    mock_data_files_store: DataFilesStore,
 ) -> None:
     """It should be able to remove a run by ID."""
-    result = await remove_run(runId="run-id", run_data_manager=mock_run_data_manager)
+    result = await remove_run(
+        runId="run-id",
+        run_data_manager=mock_run_data_manager,
+        data_files_store=mock_data_files_store,
+    )
 
-    decoy.verify(await mock_run_data_manager.delete("run-id"), times=1)
+    decoy.verify(
+        await mock_run_data_manager.delete(
+            "run-id",
+            data_files_store=mock_data_files_store,
+            should_delete_all_run_files=False,
+        ),
+        times=1,
+    )
 
     assert result.content == SimpleEmptyBody()
     assert result.status_code == 200
@@ -564,14 +576,25 @@ async def test_delete_run_by_id(
 async def test_delete_run_with_bad_id(
     decoy: Decoy,
     mock_run_data_manager: RunDataManager,
+    mock_data_files_store: DataFilesStore,
 ) -> None:
     """It should 404 if the run ID does not exist."""
     key_error = RunNotFoundError(run_id="run-id")
 
-    decoy.when(await mock_run_data_manager.delete("run-id")).then_raise(key_error)  # type: ignore[func-returns-value]
+    decoy.when(
+        await mock_run_data_manager.delete(  # type: ignore[func-returns-value]
+            "run-id",
+            data_files_store=mock_data_files_store,
+            should_delete_all_run_files=False,
+        )
+    ).then_raise(key_error)
 
     with pytest.raises(ApiError) as exc_info:
-        await remove_run(runId="run-id", run_data_manager=mock_run_data_manager)
+        await remove_run(
+            runId="run-id",
+            run_data_manager=mock_run_data_manager,
+            data_files_store=mock_data_files_store,
+        )
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.content["errors"][0]["id"] == "RunNotFound"
@@ -580,14 +603,23 @@ async def test_delete_run_with_bad_id(
 async def test_delete_active_run(
     decoy: Decoy,
     mock_run_data_manager: RunDataManager,
+    mock_data_files_store: DataFilesStore,
 ) -> None:
     """It should 409 if the run is not finished."""
-    decoy.when(await mock_run_data_manager.delete("run-id")).then_raise(  # type: ignore[func-returns-value]
-        RunConflictError("oh no")
-    )
+    decoy.when(
+        await mock_run_data_manager.delete(  # type: ignore[func-returns-value]
+            "run-id",
+            data_files_store=mock_data_files_store,
+            should_delete_all_run_files=False,
+        )
+    ).then_raise(RunConflictError("oh no"))
 
     with pytest.raises(ApiError) as exc_info:
-        await remove_run(runId="run-id", run_data_manager=mock_run_data_manager)
+        await remove_run(
+            runId="run-id",
+            run_data_manager=mock_run_data_manager,
+            data_files_store=mock_data_files_store,
+        )
 
     assert exc_info.value.status_code == 409
     assert exc_info.value.content["errors"][0]["id"] == "RunNotIdle"

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -43,6 +43,7 @@ from opentrons_shared_data.labware.labware_definition import LabwareDefinition2
 
 from robot_server.camera.provider import CameraProviderWrapper
 from robot_server.camera.settings.store import CameraSettingStore
+from robot_server.data_files.data_files_store import DataFilesStore
 from robot_server.error_recovery.settings.store import ErrorRecoverySettingStore
 from robot_server.file_provider.provider import (
     FileProviderExecutor,
@@ -722,8 +723,9 @@ async def test_delete_current_run(
     """It should delete the current run from the engine."""
     run_id = "hello world"
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id)
+    mock_data_files_store = decoy.mock(cls=DataFilesStore)
 
-    await subject.delete(run_id=run_id)
+    await subject.delete(run_id=run_id, data_files_store=mock_data_files_store)
 
     decoy.verify(
         await mock_run_orchestrator_store.clear(),
@@ -740,11 +742,55 @@ async def test_delete_historical_run(
     """It should delete a historical run from the store."""
     run_id = "hello world"
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("some other id")
+    mock_data_files_store = decoy.mock(cls=DataFilesStore)
 
-    await subject.delete(run_id=run_id)
+    await subject.delete(run_id=run_id, data_files_store=mock_data_files_store)
 
     decoy.verify(await mock_run_orchestrator_store.clear(), times=0)
     decoy.verify(mock_run_store.remove(run_id=run_id), times=1)
+
+
+async def test_delete_run_with_all_run_files(
+    decoy: Decoy,
+    mock_run_orchestrator_store: RunOrchestratorStore,
+    mock_run_store: RunStore,
+    subject: RunDataManager,
+) -> None:
+    """It should remove the run's data files from disk when requested."""
+    run_id = "hello world"
+    mock_data_files_store = decoy.mock(cls=DataFilesStore)
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("some other id")
+
+    await subject.delete(
+        run_id=run_id,
+        data_files_store=mock_data_files_store,
+        should_delete_all_run_files=True,
+    )
+
+    decoy.verify(
+        mock_data_files_store.remove_all_by_run_id(run_id),
+        mock_run_store.remove(run_id=run_id),
+    )
+
+
+async def test_delete_run_without_all_run_files(
+    decoy: Decoy,
+    mock_run_orchestrator_store: RunOrchestratorStore,
+    mock_run_store: RunStore,
+    subject: RunDataManager,
+) -> None:
+    """It should not touch the data files store when not requested."""
+    run_id = "hello world"
+    mock_data_files_store = decoy.mock(cls=DataFilesStore)
+    decoy.when(mock_run_orchestrator_store.current_run_id).then_return("some other id")
+
+    await subject.delete(
+        run_id=run_id,
+        data_files_store=mock_data_files_store,
+        should_delete_all_run_files=False,
+    )
+
+    decoy.verify(mock_data_files_store.remove_all_by_run_id(run_id), times=0)
 
 
 async def test_update_current(

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -103,6 +103,12 @@ def mock_camera_setting_store(decoy: Decoy) -> CameraSettingStore:
     return decoy.mock(cls=CameraSettingStore)
 
 
+@pytest.fixture
+def mock_data_files_store(decoy: Decoy) -> DataFilesStore:
+    """Get a mock DataFilesStore."""
+    return decoy.mock(cls=DataFilesStore)
+
+
 @pytest.fixture()
 def mock_task_runner(decoy: Decoy) -> TaskRunner:
     """Get a mock background TaskRunner."""
@@ -252,6 +258,7 @@ def subject(
     mock_task_runner: TaskRunner,
     mock_runs_publisher: RunsPublisher,
     mock_file_provider: FileProvider,
+    mock_data_files_store: DataFilesStore,
 ) -> RunDataManager:
     """Get a RunDataManager test subject."""
     return RunDataManager(
@@ -262,6 +269,7 @@ def subject(
         task_runner=mock_task_runner,
         runs_publisher=mock_runs_publisher,
         file_provider=mock_file_provider,
+        data_files_store=mock_data_files_store,
     )
 
 
@@ -723,9 +731,8 @@ async def test_delete_current_run(
     """It should delete the current run from the engine."""
     run_id = "hello world"
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id)
-    mock_data_files_store = decoy.mock(cls=DataFilesStore)
 
-    await subject.delete(run_id=run_id, data_files_store=mock_data_files_store)
+    await subject.delete(run_id=run_id)
 
     decoy.verify(
         await mock_run_orchestrator_store.clear(),
@@ -742,9 +749,8 @@ async def test_delete_historical_run(
     """It should delete a historical run from the store."""
     run_id = "hello world"
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("some other id")
-    mock_data_files_store = decoy.mock(cls=DataFilesStore)
 
-    await subject.delete(run_id=run_id, data_files_store=mock_data_files_store)
+    await subject.delete(run_id=run_id)
 
     decoy.verify(await mock_run_orchestrator_store.clear(), times=0)
     decoy.verify(mock_run_store.remove(run_id=run_id), times=1)
@@ -754,18 +760,14 @@ async def test_delete_run_with_all_run_files(
     decoy: Decoy,
     mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
+    mock_data_files_store: DataFilesStore,
     subject: RunDataManager,
 ) -> None:
     """It should remove the run's data files from disk when requested."""
     run_id = "hello world"
-    mock_data_files_store = decoy.mock(cls=DataFilesStore)
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("some other id")
 
-    await subject.delete(
-        run_id=run_id,
-        data_files_store=mock_data_files_store,
-        should_delete_all_run_files=True,
-    )
+    await subject.delete(run_id=run_id, should_delete_all_run_files=True)
 
     decoy.verify(
         mock_data_files_store.remove_all_by_run_id(run_id),
@@ -777,18 +779,14 @@ async def test_delete_run_without_all_run_files(
     decoy: Decoy,
     mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
+    mock_data_files_store: DataFilesStore,
     subject: RunDataManager,
 ) -> None:
     """It should not touch the data files store when not requested."""
     run_id = "hello world"
-    mock_data_files_store = decoy.mock(cls=DataFilesStore)
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("some other id")
 
-    await subject.delete(
-        run_id=run_id,
-        data_files_store=mock_data_files_store,
-        should_delete_all_run_files=False,
-    )
+    await subject.delete(run_id=run_id, should_delete_all_run_files=False)
 
     decoy.verify(mock_data_files_store.remove_all_by_run_id(run_id), times=0)
 


### PR DESCRIPTION
# Overview

This PR adds logic to the robot server's remove_run routing function and cascading logic to delete output files associated with a run if a query param is explicitly provided to do so. If the query param is provided, `RunDataManager.delete(...)`calls `DataFilesStore.remove_all_by_run_id(...)`, which handles removing images and output data files tied to the run. Protocol source files and input RTP files are intentionally not scoped here.

Closes EXEC-2809

## Test Plan and Hands on Testing

Not much to test hands on yet. I added several unit tests on the server for now.

## Changelog

#### api-client, react-api-client
- change delete request body to query params following better convention (see: `api-client/src/runs/commands/createCommand.ts`)

#### robot-server
- add `shouldDeleteAllRunFiles` query param to runs base router's `remove_run` (hit by api-client's `deleteRun`)
- pass that param down to `RunDataManager.delete(...)`
- conditionally call `DataFilesStore.remove_all_by_run_id(...)` if `shouldDeleteAllRunFiles` is true

## Review requests

Please review that the conditional call to the existing `remove_all_by_run_id` function makes sense philosophically. 

An open question remains, concerning how we link user actions to a run, and whether those should be deleted if triggered through this flow. That can be addressed in a followon.

## Risk assessment

Low. The query param resulting in cascading run-related file deletion is not yet wired up anywhere.