### PR TITLE
chore: update prettier version to 3.9.4

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,5 +1,6 @@
-Docker Guide  
-=======================  
+Docker Guide
+=======================
+
 Included in this repo are the tools to run a containerized Opentrons robot stack in docker.
 
 This includes the `robot-server` connected to the hardware emulation application. The emulation application includes the Smoothie and magnetic, temperature, and thermocycler modules.

--- a/api-client/src/calibration/types.ts
+++ b/api-client/src/calibration/types.ts
@@ -12,20 +12,13 @@ export interface TipLengthDeletionParams {
   pipette_id: string
 }
 export type DeleteCalRequestParams =
-  | PipOffsetDeletionParams
-  | TipLengthDeletionParams
+  PipOffsetDeletionParams | TipLengthDeletionParams
 
 export type FetchCalibrationStatusParams =
-  | PipOffsetDeletionParams
-  | TipLengthDeletionParams
+  PipOffsetDeletionParams | TipLengthDeletionParams
 
 type CalibrationSourceType =
-  | 'default'
-  | 'factory'
-  | 'user'
-  | 'calibration_check'
-  | 'legacy'
-  | 'unknown'
+  'default' | 'factory' | 'user' | 'calibration_check' | 'legacy' | 'unknown'
 interface IndividualCalibrationHealthStatus {
   markedBad: boolean // will be marked bad by a faile cal health check
   source: CalibrationSourceType | null // what actor marked it bad

--- a/api-client/src/labwareOffsets/createLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/createLabwareOffsets.ts
@@ -11,14 +11,12 @@ import type { ANY_LOCATION, StoredLabwareOffset } from './types'
 export interface StoredLabwareOffsetCreate {
   definitionUri: string
   locationSequence:
-    | LabwareOffsetLocationSequenceComponent[]
-    | typeof ANY_LOCATION
+    LabwareOffsetLocationSequenceComponent[] | typeof ANY_LOCATION
   vector: VectorOffset
 }
 
 export type CreateLabwareOffsetData =
-  | StoredLabwareOffsetCreate
-  | StoredLabwareOffsetCreate[]
+  StoredLabwareOffsetCreate | StoredLabwareOffsetCreate[]
 
 export interface CreateLabwareOffsetResponse {
   data: StoredLabwareOffset | StoredLabwareOffset[]

--- a/api-client/src/labwareOffsets/searchLabwareOffsets.ts
+++ b/api-client/src/labwareOffsets/searchLabwareOffsets.ts
@@ -13,8 +13,7 @@ export interface SearchLabwareOffsetsRequest {
     id?: string
     definitionUri?: string
     locationSequence?:
-      | LabwareOffsetLocationSequenceComponent[]
-      | typeof ANY_LOCATION
+      LabwareOffsetLocationSequenceComponent[] | typeof ANY_LOCATION
     mostRecentOnly?: boolean
   }>
 }

--- a/api-client/src/labwareOffsets/types.ts
+++ b/api-client/src/labwareOffsets/types.ts
@@ -6,8 +6,7 @@ export interface StoredLabwareOffset {
   createdAt: string
   definitionUri: string
   locationSequence:
-    | LabwareOffsetLocationSequenceComponent[]
-    | typeof ANY_LOCATION
+    LabwareOffsetLocationSequenceComponent[] | typeof ANY_LOCATION
   vector: VectorOffset
 }
 

--- a/api-client/src/modules/api-types.ts
+++ b/api-client/src/modules/api-types.ts
@@ -10,12 +10,7 @@ interface PhysicalPort {
 }
 
 type ModuleOffsetSource =
-  | 'default'
-  | 'factory'
-  | 'user'
-  | 'calibration_check'
-  | 'legacy'
-  | 'unknown'
+  'default' | 'factory' | 'user' | 'calibration_check' | 'legacy' | 'unknown'
 
 export interface ModuleOffset {
   offset: Vector3D
@@ -100,28 +95,17 @@ export interface VacuumModuleData {
   status: VacuumModuleStatus
 }
 export type TemperatureStatus =
-  | 'idle'
-  | 'holding at target'
-  | 'cooling'
-  | 'heating'
+  'idle' | 'holding at target' | 'cooling' | 'heating'
 
 export type ThermocyclerStatus =
-  | 'idle'
-  | 'holding at target'
-  | 'cooling'
-  | 'heating'
-  | 'error'
+  'idle' | 'holding at target' | 'cooling' | 'heating' | 'error'
 
 export type MagneticStatus = 'engaged' | 'disengaged'
 
 export type HeaterShakerStatus = 'idle' | 'running' | 'error'
 
 export type SpeedStatus =
-  | 'holding at target'
-  | 'speeding up'
-  | 'slowing down'
-  | 'idle'
-  | 'error'
+  'holding at target' | 'speeding up' | 'slowing down' | 'idle' | 'error'
 
 export type LatchStatus =
   | 'opening'
@@ -136,9 +120,4 @@ export type AbsorbanceReaderStatus = 'idle' | 'measuring' | 'error'
 export type FlexStackerStatus = 'idle' | 'dispensing' | 'storing' | 'error'
 
 export type VacuumModuleStatus =
-  | 'idle'
-  | 'ramping'
-  | 'holding'
-  | 'venting'
-  | 'complete'
-  | 'error'
+  'idle' | 'ramping' | 'holding' | 'venting' | 'complete' | 'error'

--- a/api-client/src/networking/types.ts
+++ b/api-client/src/networking/types.ts
@@ -5,9 +5,7 @@ export const SECURITY_WPA_EAP: 'wpa-eap' = 'wpa-eap'
 // GET /wifi/list
 
 export type WifiSecurityType =
-  | typeof SECURITY_NONE
-  | typeof SECURITY_WPA_PSK
-  | typeof SECURITY_WPA_EAP
+  typeof SECURITY_NONE | typeof SECURITY_WPA_PSK | typeof SECURITY_WPA_EAP
 
 export interface WifiNetwork {
   ssid: string

--- a/api-client/src/robot/types.ts
+++ b/api-client/src/robot/types.ts
@@ -6,10 +6,7 @@ export interface DoorStatus {
   }
 }
 export type EstopState =
-  | 'physicallyEngaged'
-  | 'logicallyEngaged'
-  | 'notPresent'
-  | 'disengaged'
+  'physicallyEngaged' | 'logicallyEngaged' | 'notPresent' | 'disengaged'
 
 export type EstopPhysicalStatus = 'engaged' | 'disengaged' | 'notPresent'
 
@@ -32,8 +29,7 @@ export interface SetLightsData {
 export type HomeTarget = 'robot' | 'pipette'
 
 export type HomeData =
-  | { target: 'robot' }
-  | { target: 'pipette'; mount: 'left' | 'right' }
+  { target: 'robot' } | { target: 'pipette'; mount: 'left' | 'right' }
 
 export interface HomeResponse {
   message: string

--- a/app-shell/src/robot-update/index.ts
+++ b/app-shell/src/robot-update/index.ts
@@ -76,18 +76,14 @@ export function registerRobotUpdate(dispatch: Dispatch): Dispatch {
 
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         startPremigration(robot)
-          .then(
-            (): RobotUpdateAction => ({
-              type: 'robotUpdate:PREMIGRATION_DONE',
-              payload: robot.name,
-            })
-          )
-          .catch(
-            (error: Error): RobotUpdateAction => ({
-              type: 'robotUpdate:PREMIGRATION_ERROR',
-              payload: { message: error.message },
-            })
-          )
+          .then((): RobotUpdateAction => ({
+            type: 'robotUpdate:PREMIGRATION_DONE',
+            payload: robot.name,
+          }))
+          .catch((error: Error): RobotUpdateAction => ({
+            type: 'robotUpdate:PREMIGRATION_ERROR',
+            payload: { message: error.message },
+          }))
           .then(dispatch)
 
         break

--- a/app-shell/src/robot-update/types.ts
+++ b/app-shell/src/robot-update/types.ts
@@ -21,15 +21,9 @@ export interface ReleaseSetFilepaths {
 type ComponentVersionKind = 'version' | 'sha' | 'branch'
 
 type ReleaseComponent =
-  | 'robot_server'
-  | 'update_server'
-  | 'system_server'
-  | 'opentrons_api'
+  'robot_server' | 'update_server' | 'system_server' | 'opentrons_api'
 type FlexReleaseComponent =
-  | ReleaseComponent
-  | 'usb_bridge'
-  | 'firmware'
-  | 'openembedded'
+  ReleaseComponent | 'usb_bridge' | 'firmware' | 'openembedded'
 type OT2ReleaseComponent = ReleaseComponent | 'buildroot'
 
 type FlexReleaseComponentVersions =

--- a/app/src/App/__tests__/DesktopApp.test.tsx
+++ b/app/src/App/__tests__/DesktopApp.test.tsx
@@ -20,7 +20,7 @@ import { ProtocolsLanding } from '/app/pages/Desktop/Protocols/ProtocolsLanding'
 
 // TODO(jh, 04-23-25): Prettier import order affects testing. Investigate further.
 // prettier-ignore
-import { AlertsModal } from '/app/organisms/Desktop/Alerts/AlertsModal';
+import { AlertsModal } from '/app/organisms/Desktop/Alerts/AlertsModal'
 
 import { ProtocolVisualization } from '/app/pages/Desktop/Protocols/ProtocolVisualization'
 import { useIsFlex, useRobot } from '/app/redux-resources/robots'

--- a/app/src/App/types.ts
+++ b/app/src/App/types.ts
@@ -27,17 +27,10 @@ export type RobotSettingsTab =
   | 'feature-flags'
 
 export type AppSettingsTab =
-  | 'general'
-  | 'privacy'
-  | 'advanced'
-  | 'feature-flags'
+  'general' | 'privacy' | 'advanced' | 'feature-flags'
 
 export type ProtocolRunDetailsTab =
-  | 'setup'
-  | 'module-controls'
-  | 'run-preview'
-  | 'runtime-parameters'
-  | 'camera'
+  'setup' | 'module-controls' | 'run-preview' | 'runtime-parameters' | 'camera'
 
 /**
  * desktop app route params type definition

--- a/app/src/atoms/SoftwareKeyboard/types.ts
+++ b/app/src/atoms/SoftwareKeyboard/types.ts
@@ -5,19 +5,7 @@ export type LayoutName = 'default' | 'shift' | 'symbols' | 'numbers'
 export type KeyboardLanguage = 'en-US' | 'zh-CN'
 
 export type NumericalKeyboardKey =
-  | '0'
-  | '1'
-  | '2'
-  | '3'
-  | '4'
-  | '5'
-  | '6'
-  | '7'
-  | '8'
-  | '9'
-  | '.'
-  | '-'
-  | 'del'
+  '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '.' | '-' | 'del'
 
 export interface NumericalInputOptions {
   allowDecimal?: boolean

--- a/app/src/atoms/buttons/IconButton.tsx
+++ b/app/src/atoms/buttons/IconButton.tsx
@@ -32,14 +32,14 @@ export function IconButton(props: IconButtonProps): JSX.Element {
         }
         &:focus-visible {
           box-shadow: ${ODD_FOCUS_VISIBLE};
-          background-color: ${hasBackground
-            ? COLORS.grey35
-            : COLORS.transparent};
+          background-color: ${
+            hasBackground ? COLORS.grey35 : COLORS.transparent
+          };
         }
         &:disabled {
-          background-color: ${hasBackground
-            ? COLORS.grey35
-            : COLORS.transparent};
+          background-color: ${
+            hasBackground ? COLORS.grey35 : COLORS.transparent
+          };
           color: ${COLORS.grey50};
         }
         @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {

--- a/app/src/atoms/buttons/MediumButton.tsx
+++ b/app/src/atoms/buttons/MediumButton.tsx
@@ -107,23 +107,28 @@ export function MediumButton(props: MediumButtonProps): JSX.Element {
   }
 
   const MEDIUM_BUTTON_STYLE = css`
-    background-color: ${MEDIUM_BUTTON_PROPS_BY_TYPE[buttonType]
-      .defaultBackgroundColor};
-    border-radius: ${buttonCategory === 'rounded'
-      ? BORDERS.borderRadius40
-      : BORDERS.borderRadius16};
+    background-color: ${
+      MEDIUM_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor
+    };
+    border-radius: ${
+      buttonCategory === 'rounded'
+        ? BORDERS.borderRadius40
+        : BORDERS.borderRadius16
+    };
     box-shadow: none;
     color: ${MEDIUM_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor};
     cursor: ${CURSOR_DEFAULT};
 
     &:focus {
-      background-color: ${MEDIUM_BUTTON_PROPS_BY_TYPE[buttonType]
-        .defaultBackgroundColor};
+      background-color: ${
+        MEDIUM_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor
+      };
       box-shadow: none;
     }
     &:hover {
-      background-color: ${MEDIUM_BUTTON_PROPS_BY_TYPE[buttonType]
-        .defaultBackgroundColor};
+      background-color: ${
+        MEDIUM_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor
+      };
       border: none;
       box-shadow: none;
       color: ${MEDIUM_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor};
@@ -133,13 +138,15 @@ export function MediumButton(props: MediumButtonProps): JSX.Element {
     }
 
     &:active {
-      background-color: ${MEDIUM_BUTTON_PROPS_BY_TYPE[buttonType]
-        .activeBackgroundColor};
+      background-color: ${
+        MEDIUM_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor
+      };
     }
 
     &:disabled {
-      background-color: ${MEDIUM_BUTTON_PROPS_BY_TYPE[buttonType]
-        .disabledBackgroundColor};
+      background-color: ${
+        MEDIUM_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
+      };
       color: ${COLORS.grey50};
     }
   `

--- a/app/src/atoms/buttons/SmallButton.tsx
+++ b/app/src/atoms/buttons/SmallButton.tsx
@@ -21,11 +21,7 @@ import type { MouseEventHandler, ReactNode } from 'react'
 import type { IconName, StyleProps } from '@opentrons/components'
 
 export type SmallButtonTypes =
-  | 'alert'
-  | 'primary'
-  | 'secondary'
-  | 'tertiaryLowLight'
-  | 'tertiaryHighLight'
+  'alert' | 'primary' | 'secondary' | 'tertiaryLowLight' | 'tertiaryHighLight'
 
 export type ButtonCategory = 'default' | 'rounded'
 
@@ -107,47 +103,56 @@ export function SmallButton(props: SmallButtonProps): JSX.Element {
 
   const SMALL_BUTTON_STYLE = css`
     color: ${SMALL_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor};
-    background-color: ${SMALL_BUTTON_PROPS_BY_TYPE[buttonType]
-      .defaultBackgroundColor};
+    background-color: ${
+      SMALL_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor
+    };
     cursor: ${CURSOR_DEFAULT};
-    border-radius: ${buttonCategory === 'rounded'
-      ? BORDERS.borderRadius40
-      : BORDERS.borderRadius16};
+    border-radius: ${
+      buttonCategory === 'rounded'
+        ? BORDERS.borderRadius40
+        : BORDERS.borderRadius16
+    };
     box-shadow: none;
     ${TYPOGRAPHY.pSemiBold}
 
     &:focus {
-      background-color: ${SMALL_BUTTON_PROPS_BY_TYPE[buttonType]
-        .activeBackgroundColor};
+      background-color: ${
+        SMALL_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor
+      };
       box-shadow: none;
     }
     &:hover {
       border: none;
       box-shadow: none;
-      background-color: ${SMALL_BUTTON_PROPS_BY_TYPE[buttonType]
-        .defaultBackgroundColor};
+      background-color: ${
+        SMALL_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor
+      };
       color: ${SMALL_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor};
     }
     &:focus-visible {
       box-shadow: ${ODD_FOCUS_VISIBLE};
-      background-color: ${SMALL_BUTTON_PROPS_BY_TYPE[buttonType]
-        .defaultBackgroundColor};
+      background-color: ${
+        SMALL_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor
+      };
     }
 
     &:active {
-      background-color: ${SMALL_BUTTON_PROPS_BY_TYPE[buttonType]
-        .activeBackgroundColor};
+      background-color: ${
+        SMALL_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor
+      };
     }
 
     &:disabled {
-      background-color: ${SMALL_BUTTON_PROPS_BY_TYPE[buttonType]
-        .disabledBackgroundColor};
+      background-color: ${
+        SMALL_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
+      };
       color: ${SMALL_BUTTON_PROPS_BY_TYPE[buttonType].disabledColor};
     }
 
     &[aria-disabled='true'] {
-      background-color: ${SMALL_BUTTON_PROPS_BY_TYPE[buttonType]
-        .disabledBackgroundColor};
+      background-color: ${
+        SMALL_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
+      };
       color: ${SMALL_BUTTON_PROPS_BY_TYPE[buttonType].disabledColor};
     }
   `

--- a/app/src/logger.ts
+++ b/app/src/logger.ts
@@ -5,13 +5,7 @@ import { remote } from './redux/shell/remote'
 
 // TODO(mc, 2018-05-17): put this type somewhere common to app and app-shell
 export type LogLevel =
-  | 'error'
-  | 'warn'
-  | 'info'
-  | 'http'
-  | 'verbose'
-  | 'debug'
-  | 'silly'
+  'error' | 'warn' | 'info' | 'http' | 'verbose' | 'debug' | 'silly'
 
 export type Log = (message: string, meta?: {}) => void
 

--- a/app/src/molecules/InterventionModal/DeckMapContent.tsx
+++ b/app/src/molecules/InterventionModal/DeckMapContent.tsx
@@ -46,8 +46,7 @@ export interface DeckConfigStyleDeckMapContentProps {
 }
 
 export type DeckMapContentProps =
-  | DeckConfigStyleDeckMapContentProps
-  | InterventionStyleDeckMapContentProps
+  DeckConfigStyleDeckMapContentProps | InterventionStyleDeckMapContentProps
 
 export const DeckMapContent: (
   props: DeckMapContentProps

--- a/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
+++ b/app/src/molecules/InterventionModal/InterventionContent/InterventionInfo.tsx
@@ -42,8 +42,7 @@ export interface InterventionInfoStackedProps extends BaseInterventionInfo {
 }
 
 export type InterventionInfoProps =
-  | InterventionInfoDefaultProps
-  | InterventionInfoStackedProps
+  InterventionInfoDefaultProps | InterventionInfoStackedProps
 
 export function InterventionInfo(props: InterventionInfoProps): JSX.Element {
   const content = buildContent(props)

--- a/app/src/molecules/InterventionModal/ModalContentMixed.tsx
+++ b/app/src/molecules/InterventionModal/ModalContentMixed.tsx
@@ -11,11 +11,7 @@ import {
 } from '@opentrons/components'
 
 export type ModalContentMixedType =
-  | 'icon'
-  | 'image'
-  | 'spinner'
-  | 'no-media'
-  | undefined
+  'icon' | 'image' | 'spinner' | 'no-media' | undefined
 
 export type ModalContentMixedIcons = 'error' | 'caution' | 'neutral'
 
@@ -47,12 +43,10 @@ interface ModalContentMixedNoMediaProps {
 }
 
 type ModalContentMixedMandatoryHeadlineProps =
-  | ModalContentMixedIconProps
-  | ModalContentMixedImageProps
+  ModalContentMixedIconProps | ModalContentMixedImageProps
 
 type ModalContentMixedNoMandatoryHeadlineProps =
-  | ModalContentMixedSpinnerProps
-  | ModalContentMixedNoMediaProps
+  ModalContentMixedSpinnerProps | ModalContentMixedNoMediaProps
 
 interface ModalContentMixedTextProps {
   headline: string

--- a/app/src/molecules/LiquidDetailCard/LiquidDetailCard.tsx
+++ b/app/src/molecules/LiquidDetailCard/LiquidDetailCard.tsx
@@ -89,9 +89,9 @@ export function LiquidDetailCard(props: LiquidDetailCardProps): JSX.Element {
   const ACTIVE_STYLE = css`
     background-color: ${isOnDevice ? COLORS.blue30 : COLORS.blue10};
     border: ${isOnDevice ? SPACING.spacing4 : `1px`} solid ${COLORS.blue50};
-    border-radius: ${isOnDevice
-      ? BORDERS.borderRadius12
-      : BORDERS.borderRadius8};
+    border-radius: ${
+      isOnDevice ? BORDERS.borderRadius12 : BORDERS.borderRadius8
+    };
   `
   const volumePerWellRange = getWellRangeForLiquidLabwarePair(
     volumeByWell,

--- a/app/src/molecules/ODDInfoScreen/OddInfoScreen.tsx
+++ b/app/src/molecules/ODDInfoScreen/OddInfoScreen.tsx
@@ -14,11 +14,7 @@ import {
 import type { IconName, ODDStyles, StyleProps } from '@opentrons/components'
 
 export type OddInfoScreenType =
-  | 'error'
-  | 'alt'
-  | 'neutral'
-  | 'success'
-  | 'warning'
+  'error' | 'alt' | 'neutral' | 'success' | 'warning'
 
 interface OddInfoScreenProps extends StyleProps {
   type: OddInfoScreenType

--- a/app/src/molecules/SimpleWizardBody/SimpleWizardBodyContent.tsx
+++ b/app/src/molecules/SimpleWizardBody/SimpleWizardBodyContent.tsx
@@ -97,8 +97,9 @@ export function SimpleWizardBodyContent(props: Props): JSX.Element {
     padding-bottom: ${SPACING.spacing32};
 
     @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-      justify-content: ${props.justifyContentForOddButton ??
-      JUSTIFY_SPACE_BETWEEN};
+      justify-content: ${
+        props.justifyContentForOddButton ?? JUSTIFY_SPACE_BETWEEN
+      };
       padding-bottom: ${SPACING.spacing32};
       padding-left: ${SPACING.spacing32};
     }

--- a/app/src/organisms/Desktop/Breadcrumbs/index.tsx
+++ b/app/src/organisms/Desktop/Breadcrumbs/index.tsx
@@ -192,9 +192,7 @@ function BreadcrumbsComponent(): JSX.Element | null {
   // determines whether a crumb is displayed for a path, and the displayed name
   const crumbNameByPath: {
     [index: string]:
-      | string
-      | null
-      | { linkPath: string; crumbName: string | null }
+      string | null | { linkPath: string; crumbName: string | null }
   } = {
     '/devices': !(isOnDevice ?? false) ? t('devices') : null,
     [`/devices/${robotName}`]: robotName,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunSetup.tsx
@@ -546,8 +546,7 @@ interface HardwareRequiredStepCompletion {
 }
 
 type StepRightElementProps =
-  | NoHardwareRequiredStepCompletion
-  | HardwareRequiredStepCompletion
+  NoHardwareRequiredStepCompletion | HardwareRequiredStepCompletion
 
 const stepRequiresHW = (
   props: StepRightElementProps

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/LabwareListItem.tsx
@@ -116,8 +116,7 @@ export function LabwareListItem(
   let isCorrectHeaterShakerAttached: boolean = false
   let isHeaterShakerInProtocol: boolean = false
   let latchCommand:
-    | HeaterShakerOpenLatchCreateCommand
-    | HeaterShakerCloseLatchCreateCommand
+    HeaterShakerOpenLatchCreateCommand | HeaterShakerCloseLatchCreateCommand
 
   if (moduleInStack != null) {
     moduleType = getModuleType(moduleInStack.moduleModel)

--- a/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/types.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/ConnectNetwork/types.ts
@@ -21,9 +21,7 @@ export type {
 } from '/app/redux/networking/types'
 
 export type NetworkChangeType =
-  | typeof CONNECT
-  | typeof DISCONNECT
-  | typeof JOIN_OTHER
+  typeof CONNECT | typeof DISCONNECT | typeof JOIN_OTHER
 
 export type NetworkChangeState =
   | { type: typeof CONNECT; ssid: string; network: WifiNetwork }
@@ -69,9 +67,7 @@ export interface ConnectFormSecurityField extends ConnectFormFieldCommon {
 }
 
 export type ConnectFormField =
-  | ConnectFormTextField
-  | ConnectFormKeyField
-  | ConnectFormSecurityField
+  ConnectFormTextField | ConnectFormKeyField | ConnectFormSecurityField
 
 export type ConnectFormFieldProps = Readonly<{
   value: string | null

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/complianceReadySettingsTypes.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/complianceReadySettingsTypes.ts
@@ -49,9 +49,7 @@ export const UI_ONLY_FIELD_IDS = [
 export type UiSettingFieldId = (typeof UI_ONLY_FIELD_IDS)[number]
 
 export type SettingFieldId =
-  | AuthSettingFieldId
-  | UiSettingFieldId
-  | RobotServerSettingFieldId
+  AuthSettingFieldId | UiSettingFieldId | RobotServerSettingFieldId
 
 export function isAuthInputFieldId(
   id: SettingFieldId

--- a/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/useRobotUpdateInfo.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/UpdateBuildroot/useRobotUpdateInfo.ts
@@ -120,12 +120,7 @@ function useFindProgressPercentFrom(
 }
 
 export type UpdateStep =
-  | 'initial'
-  | 'download'
-  | 'install'
-  | 'restart'
-  | 'finished'
-  | 'error'
+  'initial' | 'download' | 'install' | 'restart' | 'finished' | 'error'
 
 function determineUpdateStepFrom(
   session: RobotUpdateSession | null

--- a/app/src/organisms/Desktop/Devices/hooks/usePipetteOffsetCalibrations.ts
+++ b/app/src/organisms/Desktop/Devices/hooks/usePipetteOffsetCalibrations.ts
@@ -5,8 +5,7 @@ import type { PipetteOffsetCalibration } from '/app/redux/calibration/types'
 const CALIBRATION_DATA_POLL_MS = 5000
 
 export function usePipetteOffsetCalibrations():
-  | PipetteOffsetCalibration[]
-  | null {
+  PipetteOffsetCalibration[] | null {
   const pipetteOffsetCalibrations =
     useAllPipetteOffsetCalibrationsQuery({
       refetchInterval: CALIBRATION_DATA_POLL_MS,

--- a/app/src/organisms/Desktop/Devices/hooks/useTrackCreateProtocolRunEvent.ts
+++ b/app/src/organisms/Desktop/Devices/hooks/useTrackCreateProtocolRunEvent.ts
@@ -6,8 +6,7 @@ import { parseProtocolRunAnalyticsData } from '/app/transformations/analytics'
 import type { StoredProtocolData } from '/app/redux/protocol-storage'
 
 type CreateProtocolRunEventName =
-  | 'createProtocolRecordRequest'
-  | 'createProtocolRecordResponse'
+  'createProtocolRecordRequest' | 'createProtocolRecordResponse'
 
 interface CreateProtocolRunAnalyticsEvent {
   name: CreateProtocolRunEventName

--- a/app/src/organisms/Desktop/Devices/utils.ts
+++ b/app/src/organisms/Desktop/Devices/utils.ts
@@ -42,8 +42,7 @@ export function getIs96ChannelPipetteAttached(
 export function getOffsetCalibrationForMount(
   pipetteOffsetCalibrations: PipetteOffsetCalibration[] | null,
   attachedPipettes:
-    | FetchPipettesResponseBody
-    | { left: undefined; right: undefined },
+    FetchPipettesResponseBody | { left: undefined; right: undefined },
   mount: Mount
 ): PipetteOffsetCalibration | null {
   if (pipetteOffsetCalibrations == null) {

--- a/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/AnnotatedSteps/index.tsx
@@ -63,10 +63,7 @@ interface ErrorPastStepsMessageRow {
 }
 
 type AnnotatedStepsRow =
-  | GroupRow
-  | CommandRow
-  | ErrorRow
-  | ErrorPastStepsMessageRow
+  GroupRow | CommandRow | ErrorRow | ErrorPastStepsMessageRow
 
 export interface ItemData {
   rows: AnnotatedStepsRow[]

--- a/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsTabs.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/ProtocolDetailsTabs.tsx
@@ -7,11 +7,7 @@ import { useFeatureFlag } from '/app/redux/config'
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 
 type ProtocolDetailsTab =
-  | 'robot_config'
-  | 'labware'
-  | 'liquids'
-  | 'stats'
-  | 'parameters'
+  'robot_config' | 'labware' | 'liquids' | 'stats' | 'parameters'
 
 export interface ProtocolDetailsTabsProps {
   mostRecentAnalysis: ProtocolAnalysisOutput | null

--- a/app/src/organisms/Desktop/ProtocolDetails/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolDetails/index.tsx
@@ -82,11 +82,7 @@ interface ProtocolDetailsProps extends StoredProtocolData {
 }
 
 export type ProtocolDetailsTab =
-  | 'robot_config'
-  | 'labware'
-  | 'liquids'
-  | 'stats'
-  | 'parameters'
+  'robot_config' | 'labware' | 'liquids' | 'stats' | 'parameters'
 
 export function ProtocolDetailsContents(
   props: ProtocolDetailsProps

--- a/app/src/organisms/Desktop/ProtocolVisualization/StepDetailContainer/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/StepDetailContainer/index.tsx
@@ -75,11 +75,7 @@ export function StepDetailContainer({
   )
 
   type ComponentType =
-    | 'left_pipette'
-    | 'right_pipette'
-    | 'tiprack'
-    | 'labware'
-    | 'disposal'
+    'left_pipette' | 'right_pipette' | 'tiprack' | 'labware' | 'disposal'
 
   const getComponentsToRender = (): ComponentType[] => {
     const components: ComponentType[] = []

--- a/app/src/organisms/Desktop/ProtocolsLanding/utils.ts
+++ b/app/src/organisms/Desktop/ProtocolsLanding/utils.ts
@@ -8,12 +8,7 @@ import type {
 } from '@opentrons/shared-data'
 
 type AnalysisStatus =
-  | 'missing'
-  | 'loading'
-  | 'error'
-  | 'complete'
-  | 'stale'
-  | 'parameterRequired'
+  'missing' | 'loading' | 'error' | 'complete' | 'stale' | 'parameterRequired'
 
 export function getAnalysisStatus(
   isAnalyzing: boolean,

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipLocations.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipLocations.ts
@@ -17,8 +17,7 @@ import type {
 import type { ValidDropTipBlowoutLocation } from '../types'
 
 export type DropTipBlowoutSlotName =
-  | AddressableAreaName
-  | 'CHOOSE_DECK_LOCATION'
+  AddressableAreaName | 'CHOOSE_DECK_LOCATION'
 
 export interface DropTipBlowoutLocationDetails {
   slotName: DropTipBlowoutSlotName

--- a/app/src/organisms/DropTipWizardFlows/types.ts
+++ b/app/src/organisms/DropTipWizardFlows/types.ts
@@ -64,8 +64,4 @@ export type DropTipWizardContainerProps = DropTipWizardProps & {
  * Drop-tip/Blowout location types
  */
 export type ValidDropTipBlowoutLocation =
-  | 'trash-bin'
-  | 'fixed-trash'
-  | 'waste-chute'
-  | 'labware'
-  | 'deck'
+  'trash-bin' | 'fixed-trash' | 'waste-chute' | 'labware' | 'deck'

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -156,9 +156,7 @@ export function useRecoveryCommands({
   )
 
   const buildRetryPrepMove = ():
-    | MoveToCoordinatesCreateCommand
-    | LiquidProbeCreateCommand
-    | null => {
+    MoveToCoordinatesCreateCommand | LiquidProbeCreateCommand | null => {
     type InPlaceCommand =
       | AspirateInPlaceRunTimeCommand
       | BlowoutInPlaceRunTimeCommand
@@ -166,8 +164,7 @@ export function useRecoveryCommands({
       | DropTipInPlaceRunTimeCommand
       | PrepareToAspirateRunTimeCommand
     type CommandsWithDynamicLiquidTracking =
-      | AspirateWhileTrackingRunTimeCommand
-      | DispenseWhileTrackingRunTimeCommand
+      AspirateWhileTrackingRunTimeCommand | DispenseWhileTrackingRunTimeCommand
 
     const IN_PLACE_COMMAND_TYPES = [
       'aspirateInPlace',
@@ -192,8 +189,7 @@ export function useRecoveryCommands({
     const requiresMoveToError = (
       error?: RunCommandError | null
     ): error is
-      | RunCommandErrorOverpressure
-      | RunCommandErrorTipPhysicallyAttached =>
+      RunCommandErrorOverpressure | RunCommandErrorTipPhysicallyAttached =>
       error != null &&
       error.isDefined &&
       (error.errorType === DEFINED_ERROR_TYPES.OVERPRESSURE ||

--- a/app/src/organisms/ErrorRecoveryFlows/index.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/index.tsx
@@ -41,8 +41,7 @@ export interface UseErrorRecoveryInactiveResult extends UseErrorRecoveryResultBa
   isERActive: false
 }
 export type UseErrorRecoveryResult =
-  | UseErrorRecoveryInactiveResult
-  | UseErrorRecoveryActiveResult
+  UseErrorRecoveryInactiveResult | UseErrorRecoveryActiveResult
 
 export function useErrorRecoveryFlows(
   runId: string,

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCAnalytics.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCAnalytics.ts
@@ -218,8 +218,7 @@ export function useLPCAnalytics({
 
 function getSlotNameFrom(
   locationSequence:
-    | LabwareOffsetLocationSequenceComponent[]
-    | typeof ANY_LOCATION
+    LabwareOffsetLocationSequenceComponent[] | typeof ANY_LOCATION
 ): string | null {
   const slot = locationSequence[locationSequence.length - 1]
 
@@ -237,8 +236,7 @@ function getSlotNameFrom(
 
 function getOffsetKindFrom(
   locationSequence:
-    | LabwareOffsetLocationSequenceComponent[]
-    | typeof ANY_LOCATION
+    LabwareOffsetLocationSequenceComponent[] | typeof ANY_LOCATION
 ): 'default' | 'appliedLocation' {
   return locationSequence === ANY_LOCATION ? 'default' : 'appliedLocation'
 }

--- a/app/src/organisms/LegacyLabwarePositionCheck/types.ts
+++ b/app/src/organisms/LegacyLabwarePositionCheck/types.ts
@@ -97,9 +97,7 @@ interface TipPickUpOffsetAction {
   offset: VectorOffset | null
 }
 export type RegisterPositionAction =
-  | InitialPositionAction
-  | FinalPositionAction
-  | TipPickUpOffsetAction
+  InitialPositionAction | FinalPositionAction | TipPickUpOffsetAction
 export interface WorkingOffset {
   labwareId: string
   location: LegacyLabwareOffsetLocation

--- a/app/src/organisms/ModuleCard/hooks.tsx
+++ b/app/src/organisms/ModuleCard/hooks.tsx
@@ -61,8 +61,7 @@ export function useLatchControls(module: AttachedModule): LatchControls {
       module.data.labwareLatchStatus === 'closing')
 
   const latchCommand:
-    | HeaterShakerOpenLatchCreateCommand
-    | HeaterShakerCloseLatchCreateCommand = {
+    HeaterShakerOpenLatchCreateCommand | HeaterShakerCloseLatchCreateCommand = {
     commandType: isLatchClosed
       ? 'heaterShaker/openLabwareLatch'
       : 'heaterShaker/closeLabwareLatch',

--- a/app/src/organisms/ODD/CameraSettings/CameraControls/index.tsx
+++ b/app/src/organisms/ODD/CameraSettings/CameraControls/index.tsx
@@ -14,11 +14,7 @@ import { ZoomSettingsView } from './ZoomSettingsView'
 import type { CameraImageSettings } from '@opentrons/api-client'
 
 export type ActiveControlView =
-  | 'zoom'
-  | 'brightness'
-  | 'contrast'
-  | 'saturation'
-  | null
+  'zoom' | 'brightness' | 'contrast' | 'saturation' | null
 
 export interface CameraControlsProps {
   toggleShowControls: () => void

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
@@ -273,8 +273,7 @@ function LabwareLatch({
   let icon: 'latch-open' | 'latch-closed' | null = null
 
   const latchCommand:
-    | HeaterShakerOpenLatchCreateCommand
-    | HeaterShakerCloseLatchCreateCommand = {
+    HeaterShakerOpenLatchCreateCommand | HeaterShakerCloseLatchCreateCommand = {
     commandType: isLatchClosed
       ? 'heaterShaker/openLabwareLatch'
       : 'heaterShaker/closeLabwareLatch',

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupStep/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupStep/index.tsx
@@ -21,10 +21,7 @@ import { useToaster } from '../../../ToasterOven'
 const CSV_FILE_MAX_LENGTH = 18 // truncated text + three dots
 
 export type ProtocolSetupStepStatus =
-  | 'ready'
-  | 'not ready'
-  | 'general'
-  | 'inform'
+  'ready' | 'not ready' | 'general' | 'inform'
 export interface ProtocolSetupStepProps {
   onClickSetupStep: () => void
   status: ProtocolSetupStepStatus

--- a/app/src/organisms/ODD/QuickTransferFlow/types.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/types.ts
@@ -32,11 +32,7 @@ export interface QuickTransferWizardState {
 }
 export type PathOption = 'single' | 'multiAspirate' | 'multiDispense'
 export type ChangeTipOptions =
-  | 'always'
-  | 'once'
-  | 'never'
-  | 'perDest'
-  | 'perSource'
+  'always' | 'once' | 'never' | 'perDest' | 'perSource'
 export type FlowRateKind = 'aspirate' | 'dispense' | 'blowout'
 export type BlowOutLocation = 'source_well' | 'dest_well' | CutoutConfig
 export type AspirateSettingOption =
@@ -132,9 +128,7 @@ export interface QuickTransferSummaryState {
 }
 
 export type TransferType =
-  | typeof CONSOLIDATE
-  | typeof DISTRIBUTE
-  | typeof TRANSFER
+  typeof CONSOLIDATE | typeof DISTRIBUTE | typeof TRANSFER
 
 export type QuickTransferWizardAction =
   | SelectPipetteAction

--- a/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
+++ b/app/src/organisms/ODD/QuickTransferFlow/utils/generateQuickTransferArgs.ts
@@ -40,10 +40,7 @@ import type {
 import type { QuickTransferSummaryState } from '../types'
 
 export type MoveLiquidStepArgs =
-  | ConsolidateArgs
-  | DistributeArgs
-  | TransferArgs
-  | null
+  ConsolidateArgs | DistributeArgs | TransferArgs | null
 
 const uuid: () => string = uuidv4
 const adapter96ChannelDefUri = 'opentrons/opentrons_flex_96_tiprack_adapter/1'

--- a/app/src/organisms/ODD/RobotSettingsDashboard/NetworkSettings/index.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/NetworkSettings/index.tsx
@@ -106,9 +106,9 @@ function NetworkSettingButton({
 }: NetworkSettingButtonProps): JSX.Element {
   const PUSHED_STATE_STYLE = css`
     &:active {
-      background-color: ${chipType === 'success'
-        ? COLORS.green40
-        : COLORS.grey50};
+      background-color: ${
+        chipType === 'success' ? COLORS.green40 : COLORS.grey50
+      };
     }
   `
 

--- a/app/src/organisms/PipetteWizardFlows/types.ts
+++ b/app/src/organisms/PipetteWizardFlows/types.ts
@@ -18,9 +18,7 @@ export type PipetteWizardStep =
   | AttachWasteChuteStep
 
 export type PipetteWizardFlow =
-  | typeof FLOWS.ATTACH
-  | typeof FLOWS.DETACH
-  | typeof FLOWS.CALIBRATE
+  typeof FLOWS.ATTACH | typeof FLOWS.DETACH | typeof FLOWS.CALIBRATE
 
 export interface BaseStep {
   mount: PipetteMount

--- a/app/src/organisms/PipetteWizardFlows/utils.tsx
+++ b/app/src/organisms/PipetteWizardFlows/utils.tsx
@@ -172,10 +172,11 @@ export function getPipetteAnimations(
       css={css`
         padding-top: ${SPACING.spacing4};
         width: 100%;
-        min-height: ${section === SECTIONS.ATTACH_PROBE ||
-        section === SECTIONS.DETACH_PROBE
-          ? `18rem`
-          : `12rem`};
+        min-height: ${
+          section === SECTIONS.ATTACH_PROBE || section === SECTIONS.DETACH_PROBE
+            ? `18rem`
+            : `12rem`
+        };
       `}
       data-testid={
         section === SECTIONS.ATTACH_PROBE || section === SECTIONS.DETACH_PROBE

--- a/app/src/organisms/UpdateRobotSoftware/index.tsx
+++ b/app/src/organisms/UpdateRobotSoftware/index.tsx
@@ -60,11 +60,7 @@ export function UpdateRobotSoftware(
     afterError(sessionError)
   }
   let updateType:
-    | 'downloading'
-    | 'validating'
-    | 'sendingFile'
-    | 'installing'
-    | null = null
+    'downloading' | 'validating' | 'sendingFile' | 'installing' | null = null
   if (step === 'finished') {
     return <CompleteUpdateSoftware robotName={robotName} />
   } else {

--- a/app/src/pages/Desktop/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength.tsx
+++ b/app/src/pages/Desktop/Devices/CalibrationDashboard/hooks/useDashboardCalibrateTipLength.tsx
@@ -183,13 +183,11 @@ export function useDashboardCalibrateTipLength(
     getTopPortalEl()
   )
 
-  if (
-    !(
-      startingSession ||
-      tipLengthCalibrationSession != null ||
-      showCalBlockModal != null
-    )
-  ) {
+  if (!(
+    startingSession ||
+    tipLengthCalibrationSession != null ||
+    showCalBlockModal != null
+  )) {
     Wizard = null
   }
 

--- a/app/src/pages/Desktop/LivestreamViewer/LivestreamInfoScreen.tsx
+++ b/app/src/pages/Desktop/LivestreamViewer/LivestreamInfoScreen.tsx
@@ -10,12 +10,7 @@ import {
 import type { CameraData, RunStatus } from '@opentrons/api-client'
 
 type LiveStreamInfoScreenType =
-  | 'loading'
-  | 'error'
-  | 'disabled'
-  | 'run-setup'
-  | 'run-terminal'
-  | null
+  'loading' | 'error' | 'disabled' | 'run-setup' | 'run-terminal' | null
 
 export function useLivestreamInfoScreen(
   runStatus: RunStatus | null,

--- a/app/src/redux-resources/analytics/hooks/useModuleAnalytics.ts
+++ b/app/src/redux-resources/analytics/hooks/useModuleAnalytics.ts
@@ -70,8 +70,7 @@ export interface ModuleAnalyticLiveCommand extends BaseModuleAnalytics {
 }
 
 export type ModuleAnalyticType =
-  | ModuleAnalyticProtocolCommand
-  | ModuleAnalyticLiveCommand
+  ModuleAnalyticProtocolCommand | ModuleAnalyticLiveCommand
 
 export interface UseModuleCommandAnalyticsResult {
   reportModuleCommand: (params: ModuleAnalyticType) => void

--- a/app/src/redux-resources/analytics/hooks/useModuleCommandAnalytics.ts
+++ b/app/src/redux-resources/analytics/hooks/useModuleCommandAnalytics.ts
@@ -65,8 +65,7 @@ export interface ModuleAnalyticLiveCommand extends BaseModuleAnalytics {
 }
 
 export type ModuleAnalyticType =
-  | ModuleAnalyticProtocolCommand
-  | ModuleAnalyticLiveCommand
+  ModuleAnalyticProtocolCommand | ModuleAnalyticLiveCommand
 
 export interface UseModuleCommandAnalyticsResult {
   reportModuleCommand: (params: ModuleAnalyticType) => void

--- a/app/src/redux/alerts/types.ts
+++ b/app/src/redux/alerts/types.ts
@@ -6,8 +6,7 @@ import type {
 } from './constants'
 
 export type AlertId =
-  | typeof ALERT_U2E_DRIVER_OUTDATED
-  | typeof ALERT_APP_UPDATE_AVAILABLE
+  typeof ALERT_U2E_DRIVER_OUTDATED | typeof ALERT_APP_UPDATE_AVAILABLE
 
 export interface AlertTriggeredAction {
   type: typeof ALERT_TRIGGERED

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -32,10 +32,7 @@ export type ProtocolsOnDeviceSortKey =
   | 'oldCreated'
 
 export type QuickTransfersOnDeviceSortKey =
-  | 'alphabetical'
-  | 'reverse'
-  | 'recentCreated'
-  | 'oldCreated'
+  'alphabetical' | 'reverse' | 'recentCreated' | 'oldCreated'
 
 export interface OnDeviceDisplaySettings {
   sleepMs: number

--- a/app/src/redux/config/types.ts
+++ b/app/src/redux/config/types.ts
@@ -63,6 +63,4 @@ export type ConfigValueChangeAction =
   | SubtractConfigValueAction
 
 export type ConfigAction =
-  | ConfigValueChangeAction
-  | ConfigValueUpdatedAction
-  | ConfigInitializedAction
+  ConfigValueChangeAction | ConfigValueUpdatedAction | ConfigInitializedAction

--- a/app/src/redux/custom-labware/types.ts
+++ b/app/src/redux/custom-labware/types.ts
@@ -38,9 +38,7 @@ export type CheckedLabwareFile =
   | ValidLabwareFile
 
 export type FailedLabwareFile =
-  | InvalidLabwareFile
-  | DuplicateLabwareFile
-  | OpentronsLabwareFile
+  InvalidLabwareFile | DuplicateLabwareFile | OpentronsLabwareFile
 
 // state types
 

--- a/app/src/redux/discovery/types.ts
+++ b/app/src/redux/discovery/types.ts
@@ -18,9 +18,7 @@ export type { DiscoveryClientRobot, DiscoveryClientRobotAddress, HealthStatus }
 export type RobotsMap = Record<string, DiscoveryClientRobot>
 
 export type ConnectivityStatus =
-  | typeof CONNECTABLE
-  | typeof REACHABLE
-  | typeof UNREACHABLE
+  typeof CONNECTABLE | typeof REACHABLE | typeof UNREACHABLE
 
 export type RobotModel = typeof ROBOT_MODEL_OT2 | typeof ROBOT_MODEL_OT3
 

--- a/app/src/redux/modules/api-types.ts
+++ b/app/src/redux/modules/api-types.ts
@@ -104,28 +104,17 @@ export interface VacuumModuleData {
 }
 
 export type TemperatureStatus =
-  | 'idle'
-  | 'holding at target'
-  | 'cooling'
-  | 'heating'
+  'idle' | 'holding at target' | 'cooling' | 'heating'
 
 export type ThermocyclerStatus =
-  | 'idle'
-  | 'holding at target'
-  | 'cooling'
-  | 'heating'
-  | 'error'
+  'idle' | 'holding at target' | 'cooling' | 'heating' | 'error'
 
 export type MagneticStatus = 'engaged' | 'disengaged'
 
 export type HeaterShakerStatus = 'idle' | 'running' | 'error'
 
 export type SpeedStatus =
-  | 'holding at target'
-  | 'speeding up'
-  | 'slowing down'
-  | 'idle'
-  | 'error'
+  'holding at target' | 'speeding up' | 'slowing down' | 'idle' | 'error'
 
 export type LatchStatus =
   | 'opening'
@@ -140,12 +129,7 @@ export type AbsorbanceReaderStatus = 'idle' | 'measuring' | 'error'
 export type FlexStackerStatus = 'idle' | 'dispensing' | 'storing' | 'error'
 
 export type VacuumModuleStatus =
-  | 'idle'
-  | 'ramping'
-  | 'holding'
-  | 'venting'
-  | 'complete'
-  | 'error'
+  'idle' | 'ramping' | 'holding' | 'venting' | 'complete' | 'error'
 
 export type VacuumMode = 'pressure' | 'power'
 export interface ApiTemperatureModule extends ApiBaseModule {

--- a/app/src/redux/modules/types.ts
+++ b/app/src/redux/modules/types.ts
@@ -28,17 +28,7 @@ export type CommonModuleInfo = Omit<
 >
 
 export type Slot =
-  | '1'
-  | '2'
-  | '3'
-  | '4'
-  | '5'
-  | '6'
-  | '7'
-  | '8'
-  | '9'
-  | '10'
-  | '11'
+  '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | '11'
 
 export interface TemperatureModule extends CommonModuleInfo {
   moduleType: typeof TEMPERATURE_MODULE_TYPE
@@ -135,9 +125,7 @@ export interface UpdateModuleFailureAction {
 // action union
 
 export type ModulesAction =
-  | UpdateModuleAction
-  | UpdateModuleSuccessAction
-  | UpdateModuleFailureAction
+  UpdateModuleAction | UpdateModuleSuccessAction | UpdateModuleFailureAction
 
 // state types
 

--- a/app/src/redux/networking/api-types.ts
+++ b/app/src/redux/networking/api-types.ts
@@ -55,9 +55,7 @@ export interface NetworkingStatusResponse {
 // GET /wifi/list
 
 export type WifiSecurityType =
-  | typeof SECURITY_NONE
-  | typeof SECURITY_WPA_PSK
-  | typeof SECURITY_WPA_EAP
+  typeof SECURITY_NONE | typeof SECURITY_WPA_PSK | typeof SECURITY_WPA_EAP
 
 export interface WifiNetwork {
   ssid: string
@@ -94,9 +92,7 @@ export interface WifiConfigureResponse {
 // GET /wifi/eap-options
 
 export type WifiAuthFieldType =
-  | typeof AUTH_TYPE_STRING
-  | typeof AUTH_TYPE_PASSWORD
-  | typeof AUTH_TYPE_FILE
+  typeof AUTH_TYPE_STRING | typeof AUTH_TYPE_PASSWORD | typeof AUTH_TYPE_FILE
 
 export interface WifiAuthField {
   name: string

--- a/app/src/redux/protocol-analysis/actions.ts
+++ b/app/src/redux/protocol-analysis/actions.ts
@@ -15,8 +15,7 @@ export interface ChangePythonPathOverrideConfigAction {
 }
 
 export type ProtocolAnalysisAction =
-  | OpenPythonInterpreterDirectoryAction
-  | ChangePythonPathOverrideConfigAction
+  OpenPythonInterpreterDirectoryAction | ChangePythonPathOverrideConfigAction
 
 export const openPythonInterpreterDirectory =
   (): OpenPythonInterpreterDirectoryAction => ({

--- a/app/src/redux/protocol-runs/types/lpc/offsets.ts
+++ b/app/src/redux/protocol-runs/types/lpc/offsets.ts
@@ -10,8 +10,7 @@ import type {
 } from '@opentrons/shared-data'
 
 export type LabwareOffsetLocSeqOrAnyLoc =
-  | LabwareOffsetLocationSequence
-  | typeof ANY_LOCATION
+  LabwareOffsetLocationSequence | typeof ANY_LOCATION
 
 export interface ModStackupDetail {
   kind: 'module'
@@ -68,8 +67,7 @@ interface BaseOffsetLocationDetails extends LabwareLocationInfo {
 }
 
 export type OffsetLocationDetails =
-  | DefaultOffsetLocationDetails
-  | LocationSpecificOffsetLocationDetails
+  DefaultOffsetLocationDetails | LocationSpecificOffsetLocationDetails
 
 export interface DefaultOffsetLocationDetails extends BaseOffsetLocationDetails {
   addressableAreaName: FlexAddressableAreaName

--- a/app/src/redux/protocol-runs/types/lpc/ui.ts
+++ b/app/src/redux/protocol-runs/types/lpc/ui.ts
@@ -1,8 +1,5 @@
 export type LPCSnackbarType =
-  | 'defaultAdded'
-  | 'defaultAdjusted'
-  | 'locationSpecificAdjusted'
-  | null
+  'defaultAdded' | 'defaultAdjusted' | 'locationSpecificAdjusted' | null
 
 export interface LPCUiState {
   showDefaultOffsetInfoBanner: boolean

--- a/app/src/redux/protocol-storage/types.ts
+++ b/app/src/redux/protocol-storage/types.ts
@@ -53,10 +53,7 @@ export interface ProtocolStorageState {
 // action types
 
 export type ProtocolListActionSource =
-  | 'poll'
-  | 'initial'
-  | 'protocolAddition'
-  | 'overwriteProtocol'
+  'poll' | 'initial' | 'protocolAddition' | 'overwriteProtocol'
 
 export interface FetchProtocolsAction {
   type: 'protocolStorage:FETCH_PROTOCOLS'

--- a/app/src/redux/robot-admin/types.ts
+++ b/app/src/redux/robot-admin/types.ts
@@ -10,11 +10,7 @@ export type RobotRestartStatus =
   | 'restart-failed'
 
 export type RobotAdminStatus =
-  | 'up'
-  | 'down'
-  | 'restart-pending'
-  | 'restarting'
-  | 'restart-failed'
+  'up' | 'down' | 'restart-pending' | 'restarting' | 'restart-failed'
 
 export interface ResetConfigOption {
   id: string

--- a/app/src/redux/sessions/calibration-check/types.ts
+++ b/app/src/redux/sessions/calibration-check/types.ts
@@ -43,12 +43,10 @@ export type RobotCalibrationCheckStep =
   | typeof CHECK_STEP_CHECK_COMPLETE
 
 export type RobotCalibrationCheckPipetteRank =
-  | typeof CHECK_PIPETTE_RANK_FIRST
-  | typeof CHECK_PIPETTE_RANK_SECOND
+  typeof CHECK_PIPETTE_RANK_FIRST | typeof CHECK_PIPETTE_RANK_SECOND
 
 export type RobotCalibrationCheckStatus =
-  | typeof CHECK_STATUS_IN_THRESHOLD
-  | typeof CHECK_STATUS_OUTSIDE_THRESHOLD
+  typeof CHECK_STATUS_IN_THRESHOLD | typeof CHECK_STATUS_OUTSIDE_THRESHOLD
 
 export interface CalibrationCheckInstrument {
   model: PipetteModel

--- a/app/src/redux/system-info/types.ts
+++ b/app/src/redux/system-info/types.ts
@@ -42,10 +42,7 @@ export interface NetworkInterface {
 }
 
 export type DriverStatus =
-  | typeof NOT_APPLICABLE
-  | typeof UNKNOWN
-  | typeof UP_TO_DATE
-  | typeof OUTDATED
+  typeof NOT_APPLICABLE | typeof UNKNOWN | typeof UP_TO_DATE | typeof OUTDATED
 
 export interface U2EAnalyticsProps {
   'U2E Vendor ID': number

--- a/app/src/resources/health/useRobotInitializationStatus.ts
+++ b/app/src/resources/health/useRobotInitializationStatus.ts
@@ -11,8 +11,7 @@ export const INIT_STATUS = {
 } as const
 
 export type RobotInitializationStatus =
-  | (typeof INIT_STATUS)[keyof typeof INIT_STATUS]
-  | null
+  (typeof INIT_STATUS)[keyof typeof INIT_STATUS] | null
 
 export function useRobotInitializationStatus(): RobotInitializationStatus {
   const responseStatusCode = useRef<number | null>(null)

--- a/app/src/resources/runs/types.ts
+++ b/app/src/resources/runs/types.ts
@@ -3,9 +3,7 @@ import type { TipRackCalibrationData } from '/app/resources/instruments/types'
 import type { INCOMPATIBLE, INEXACT_MATCH, MATCH } from './constants'
 
 export type PipetteCompatibility =
-  | typeof MATCH
-  | typeof INEXACT_MATCH
-  | typeof INCOMPATIBLE
+  typeof MATCH | typeof INEXACT_MATCH | typeof INCOMPATIBLE
 
 export interface PipetteInfo {
   pipetteSpecs: PipetteNameSpecs

--- a/app/src/transformations/analysis/getAnalysisStatus.ts
+++ b/app/src/transformations/analysis/getAnalysisStatus.ts
@@ -1,12 +1,7 @@
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 
 export type AnalysisStatus =
-  | 'missing'
-  | 'loading'
-  | 'error'
-  | 'complete'
-  | 'stale'
-  | 'parameterRequired'
+  'missing' | 'loading' | 'error' | 'complete' | 'stale' | 'parameterRequired'
 
 export function getAnalysisStatus(
   isAnalyzing: boolean,

--- a/app/src/transformations/commands/hooks/types.ts
+++ b/app/src/transformations/commands/hooks/types.ts
@@ -34,7 +34,4 @@ export interface ProtocolFixture {
 }
 
 export type ProtocolHardware =
-  | ProtocolPipette
-  | ProtocolModule
-  | ProtocolGripper
-  | ProtocolFixture
+  ProtocolPipette | ProtocolModule | ProtocolGripper | ProtocolFixture

--- a/components/src/atoms/Chip/index.tsx
+++ b/components/src/atoms/Chip/index.tsx
@@ -114,13 +114,17 @@ export function Chip(props: ChipProps): JSX.Element {
       flexDirection={DIRECTION_ROW}
       height={FLEX_MAX_CONTENT}
       css={css`
-        background-color: ${background === false
-          ? COLORS.transparent
-          : chipProps.backgroundColor30};
+        background-color: ${
+          background === false
+            ? COLORS.transparent
+            : chipProps.backgroundColor30
+        };
 
-        ${chipSize === 'medium'
-          ? MEDIUM_CONTAINER_STYLE(background)
-          : SMALL_CONTAINER_STYLE(background)}
+        ${
+          chipSize === 'medium'
+            ? MEDIUM_CONTAINER_STYLE(background)
+            : SMALL_CONTAINER_STYLE(background)
+        }
 
         /* touchscreen */
         ${background !== false ? BACKGROUND_COLOR_STYLE(type) : ''}
@@ -183,9 +187,11 @@ const TEXT_STYLE = (chipSize: ChipSize): FlattenSimpleInterpolation => css`
   ${chipSize === 'medium' ? WEB_MEDIUM_TEXT_STYLE : WEB_SMALL_TEXT_STYLE}
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    ${chipSize === 'medium'
-      ? TYPOGRAPHY.bodyTextSemiBold
-      : TYPOGRAPHY.smallBodyTextSemiBold}
+    ${
+      chipSize === 'medium'
+        ? TYPOGRAPHY.bodyTextSemiBold
+        : TYPOGRAPHY.smallBodyTextSemiBold
+    }
   }
 `
 

--- a/components/src/atoms/ListButton/index.tsx
+++ b/components/src/atoms/ListButton/index.tsx
@@ -12,11 +12,7 @@ import type { StyleProps } from '../../primitives'
 export * from './ListButtonChildren/index'
 
 type ListButtonType =
-  | 'noActive'
-  | 'connected'
-  | 'notConnected'
-  | 'onColor'
-  | 'error'
+  'noActive' | 'connected' | 'notConnected' | 'onColor' | 'error'
 
 interface ListButtonProps extends StyleProps {
   /** ListButton type */
@@ -129,16 +125,16 @@ const LIST_BUTTON_STYLE = (
   oddListButtonProps: Record<string, string>
 ): FlattenSimpleInterpolation => css`
   cursor: ${disabled ? CURSOR_DEFAULT : CURSOR_POINTER};
-  background-color: ${disabled
-    ? COLORS.grey20
-    : desktopListButtonProps.backgroundColor};
+  background-color: ${
+    disabled ? COLORS.grey20 : desktopListButtonProps.backgroundColor
+  };
   padding: ${styleProps.padding ?? `${SPACING.spacing20} ${SPACING.spacing24}`};
   border-radius: ${BORDERS.borderRadius8};
 
   &:hover {
-    background-color: ${disabled
-      ? COLORS.grey20
-      : desktopListButtonProps.hoverBackgroundColor};
+    background-color: ${
+      disabled ? COLORS.grey20 : desktopListButtonProps.hoverBackgroundColor
+    };
   }
 
   &:focus-visible {
@@ -147,14 +143,14 @@ const LIST_BUTTON_STYLE = (
   }
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
-    background-color: ${disabled
-      ? COLORS.grey35
-      : oddListButtonProps.backgroundColor};
+    background-color: ${
+      disabled ? COLORS.grey35 : oddListButtonProps.backgroundColor
+    };
 
     &:hover {
-      background-color: ${disabled
-        ? COLORS.grey35
-        : oddListButtonProps.hoverBackgroundColor};
+      background-color: ${
+        disabled ? COLORS.grey35 : oddListButtonProps.hoverBackgroundColor
+      };
     }
   }
 `

--- a/components/src/atoms/ListTable/index.tsx
+++ b/components/src/atoms/ListTable/index.tsx
@@ -60,9 +60,11 @@ const TABLE_STYLE = css`
 //  column spacing to be opinionated. Various component designs conflict with feature designs (ex, LPC).
 const trStyle = (numHeaders: number): FlattenSimpleInterpolation => css`
   display: ${DISPLAY_GRID};
-  grid-template-columns: ${numHeaders === 3
-    ? `${FLEX_MAX_CONTENT} 1fr ${FLEX_MAX_CONTENT}`
-    : `repeat(${numHeaders}, 1fr)`};
+  grid-template-columns: ${
+    numHeaders === 3
+      ? `${FLEX_MAX_CONTENT} 1fr ${FLEX_MAX_CONTENT}`
+      : `repeat(${numHeaders}, 1fr)`
+  };
   gap: ${SPACING.spacing24};
 
   @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {

--- a/components/src/atoms/buttons/LargeButton.tsx
+++ b/components/src/atoms/buttons/LargeButton.tsx
@@ -210,8 +210,9 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
 
   const LARGE_BUTTON_STYLE = css`
     color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultColor};
-    background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-      .defaultBackgroundColor};
+    background-color: ${
+      LARGE_BUTTON_PROPS_BY_TYPE[buttonType].defaultBackgroundColor
+    };
     cursor: ${CURSOR_POINTER};
     padding: ${SPACING.spacing16} ${SPACING.spacing24};
     text-align: ${TYPOGRAPHY.textAlignLeft};
@@ -220,8 +221,9 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
     border: ${computedBorderStyle()};
 
     &:active {
-      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-        .activeBackgroundColor};
+      background-color: ${
+        LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor
+      };
       ${activeColorFor(buttonType)};
     }
     &:active #btn-icon {
@@ -230,8 +232,9 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
 
     &:hover {
       color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].hoverColor};
-      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-        .hoverBackgroundColor};
+      background-color: ${
+        LARGE_BUTTON_PROPS_BY_TYPE[buttonType].hoverBackgroundColor
+      };
 
       border: ${computedHoverBorder()};
     }
@@ -242,15 +245,17 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
 
     &:disabled {
       color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledColor};
-      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-        .disabledBackgroundColor};
+      background-color: ${
+        LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
+      };
       border: 4px solid ${COLORS.grey35};
     }
 
     &[aria-disabled='true'] {
       color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledColor};
-      background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-        .disabledBackgroundColor};
+      background-color: ${
+        LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
+      };
       border: 4px solid ${COLORS.grey35};
     }
 
@@ -265,14 +270,18 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       gap: ${SPACING.spacing60};
 
       &:active {
-        background-color: ${computedDisabled
-          ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
-          : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor};
+        background-color: ${
+          computedDisabled
+            ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
+            : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor
+        };
         ${!computedDisabled && activeColorFor(buttonType)};
         outline: 4px solid
-          ${computedDisabled
-            ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
-            : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor};
+          ${
+            computedDisabled
+              ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
+              : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].activeBackgroundColor
+          };
       }
 
       &:active #btn-icon {
@@ -280,24 +289,29 @@ export function LargeButton(props: LargeButtonProps): JSX.Element {
       }
 
       &:focus-visible {
-        background-color: ${computedDisabled
-          ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
-          : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].focusVisibleBackgroundColor};
+        background-color: ${
+          computedDisabled
+            ? LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
+            : LARGE_BUTTON_PROPS_BY_TYPE[buttonType].focusVisibleBackgroundColor
+        };
         ${!computedDisabled && activeColorFor(buttonType)};
         padding: calc(${SPACING.spacing24} + ${SPACING.spacing2});
         border: ${computedBorderStyle()};
-        outline: ${computedDisabled
-          ? 'none'
-          : `3px solid
-    ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].focusVisibleOutlineColor}`};
+        outline: ${
+          computedDisabled
+            ? 'none'
+            : `3px solid
+    ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].focusVisibleOutlineColor}`
+        };
         background-clip: padding-box;
         box-shadow: none;
       }
 
       &:disabled {
         color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledColor};
-        background-color: ${LARGE_BUTTON_PROPS_BY_TYPE[buttonType]
-          .disabledBackgroundColor};
+        background-color: ${
+          LARGE_BUTTON_PROPS_BY_TYPE[buttonType].disabledBackgroundColor
+        };
       }
     }
   `

--- a/components/src/atoms/buttons/RadioButton.tsx
+++ b/components/src/atoms/buttons/RadioButton.tsx
@@ -192,13 +192,13 @@ export function RadioButton(props: RadioButtonProps): JSX.Element {
 const copyContainerStyle = (
   buttonSubLabel: RadioButtonSubLabel | undefined
 ): FlattenSimpleInterpolation => css`
-  flex-direction: ${buttonSubLabel?.align === 'vertical'
-    ? DIRECTION_COLUMN
-    : DIRECTION_ROW};
+  flex-direction: ${
+    buttonSubLabel?.align === 'vertical' ? DIRECTION_COLUMN : DIRECTION_ROW
+  };
   justify-content: ${JUSTIFY_SPACE_BETWEEN};
-  align-items: ${buttonSubLabel?.align === 'vertical'
-    ? ALIGN_START
-    : ALIGN_CENTER};
+  align-items: ${
+    buttonSubLabel?.align === 'vertical' ? ALIGN_START : ALIGN_CENTER
+  };
   width: ${buttonSubLabel != null ? '100%' : ''};
   word-break: break-word;
 `
@@ -231,11 +231,9 @@ const SUBBUTTON_LABEL_STYLE = (
   isSelected: boolean,
   buttonSubLabel: RadioButtonSubLabel
 ): FlattenSimpleInterpolation => css`
-  color: ${disabled
-    ? COLORS.grey50
-    : isSelected
-      ? COLORS.white
-      : COLORS.grey60};
+  color: ${
+    disabled ? COLORS.grey50 : isSelected ? COLORS.white : COLORS.grey60
+  };
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: ${buttonSubLabel?.align === 'vertical' ? 2 : 1};

--- a/components/src/forms/Select.tsx
+++ b/components/src/forms/Select.tsx
@@ -49,9 +49,7 @@ export interface SelectOptionGroup {
 export type SelectOptionOrGroup = SelectOption | SelectOptionGroup
 
 export type SelectPlacement =
-  | typeof PLACEMENT_AUTO
-  | typeof PLACEMENT_BOTTOM
-  | typeof PLACEMENT_TOP
+  typeof PLACEMENT_AUTO | typeof PLACEMENT_BOTTOM | typeof PLACEMENT_TOP
 
 export type SelectPosition = typeof POSITION_ABSOLUTE | typeof POSITION_FIXED
 

--- a/components/src/hardware-sim/BaseDeck/StagingAreaFixture.tsx
+++ b/components/src/hardware-sim/BaseDeck/StagingAreaFixture.tsx
@@ -4,10 +4,7 @@ import type { SVGProps } from 'react'
 import type { DeckDefinition, ModuleType } from '@opentrons/shared-data'
 
 export type StagingAreaLocation =
-  | 'cutoutA3'
-  | 'cutoutB3'
-  | 'cutoutC3'
-  | 'cutoutD3'
+  'cutoutA3' | 'cutoutB3' | 'cutoutC3' | 'cutoutD3'
 
 interface StagingAreaFixtureProps extends SVGProps<SVGGElement> {
   cutoutId: StagingAreaLocation

--- a/components/src/hardware-sim/Deck/RobotWorkSpace.tsx
+++ b/components/src/hardware-sim/Deck/RobotWorkSpace.tsx
@@ -22,7 +22,7 @@ type BaseProps = {
   id?: string
 } & (
   | // Require at least one of deckDef or viewBox,
-  {
+    {
       deckDef: DeckDefinition
     }
   | {

--- a/components/src/molecules/Banner/index.tsx
+++ b/components/src/molecules/Banner/index.tsx
@@ -15,11 +15,7 @@ import type { IconProps } from '../../icons'
 import type { StyleProps } from '../../primitives'
 
 export type BannerType =
-  | 'success'
-  | 'warning'
-  | 'error'
-  | 'updating'
-  | 'informing'
+  'success' | 'warning' | 'error' | 'updating' | 'informing'
 
 export interface BannerProps extends StyleProps {
   /** name constant of the icon to display */

--- a/components/src/molecules/DropdownMenu/index.tsx
+++ b/components/src/molecules/DropdownMenu/index.tsx
@@ -237,9 +237,11 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
     padding: ${SPACING.spacing8} ${SPACING.spacing12};
     border: 1px ${BORDERS.styleSolid}
       ${disabled ? COLORS.grey35 : defaultBorderColor};
-    border-radius: ${dropdownType === 'rounded'
-      ? BORDERS.borderRadiusFull
-      : BORDERS.borderRadius4};
+    border-radius: ${
+      dropdownType === 'rounded'
+        ? BORDERS.borderRadiusFull
+        : BORDERS.borderRadius4
+    };
     align-items: ${ALIGN_CENTER};
     justify-content: ${JUSTIFY_SPACE_BETWEEN};
     width: ${width};
@@ -317,9 +319,11 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
             <Flex
               flexDirection={DIRECTION_COLUMN}
               css={css`
-                font-weight: ${dropdownType === 'rounded'
-                  ? TYPOGRAPHY.pSemiBold
-                  : TYPOGRAPHY.pRegular};
+                font-weight: ${
+                  dropdownType === 'rounded'
+                    ? TYPOGRAPHY.pSemiBold
+                    : TYPOGRAPHY.pRegular
+                };
               `}
             >
               {currentOption.deckLabel !== currentOption.name ? (
@@ -445,7 +449,7 @@ export const LINE_CLAMP_TEXT_STYLE = (
   text-overflow: ellipsis;
   word-wrap: break-word;
   -webkit-line-clamp: ${lineClamp ?? 1};
-  word-break: ${wordBreak === true
-    ? 'normal'
-    : 'break-all'}; // normal for tile and break-all for a non word case like aaaaaaaa
+  word-break: ${
+    wordBreak === true ? 'normal' : 'break-all'
+  }; // normal for tile and break-all for a non word case like aaaaaaaa
 `

--- a/components/src/molecules/InputField/index.tsx
+++ b/components/src/molecules/InputField/index.tsx
@@ -76,8 +76,7 @@ export interface InputFieldProps {
   min?: number | string
   /** horizontal text alignment for title, input, and (sub)captions */
   textAlign?:
-    | typeof TYPOGRAPHY.textAlignLeft
-    | typeof TYPOGRAPHY.textAlignCenter
+    typeof TYPOGRAPHY.textAlignLeft | typeof TYPOGRAPHY.textAlignCenter
   /** small or medium input field height, relevant only */
   size?: 'medium' | 'small'
   /** optional element to display aligned to the left of the input field */
@@ -136,14 +135,16 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
 
     const INPUT_FIELD = css`
       background-color: ${hasBackgroundError ? COLORS.red30 : COLORS.white};
-      border-radius: ${borderRadius != null
-        ? borderRadius
-        : BORDERS.borderRadius4};
+      border-radius: ${
+        borderRadius != null ? borderRadius : BORDERS.borderRadius4
+      };
       padding: ${padding ?? SPACING.spacing8};
-      border: ${hasBackgroundError
-        ? 'none'
-        : `1px ${BORDERS.styleSolid}
-        ${hasError ? COLORS.red50 : COLORS.grey50}`};
+      border: ${
+        hasBackgroundError
+          ? 'none'
+          : `1px ${BORDERS.styleSolid}
+        ${hasError ? COLORS.red50 : COLORS.grey50}`
+      };
       font-size: ${TYPOGRAPHY.fontSizeP};
       width: 100%;
       height: ${size === 'small' ? '2rem' : '2.75rem'};

--- a/components/src/molecules/ListAccordion/index.tsx
+++ b/components/src/molecules/ListAccordion/index.tsx
@@ -84,9 +84,9 @@ const containerStyle = (
     padding: ${SPACING.spacing12};
     border-radius: ${SPACING.spacing8};
     gap: ${SPACING.spacing8};
-    background-color: ${alertKind === 'warning'
-      ? COLORS.yellow30
-      : COLORS.grey20};
+    background-color: ${
+      alertKind === 'warning' ? COLORS.yellow30 : COLORS.grey20
+    };
     transition: ${TRANSITION_STYLE};
 
     &:focus-visible {
@@ -98,22 +98,22 @@ const containerStyle = (
       padding: ${SPACING.spacing24};
       gap: ${SPACING.spacing24};
       border-radius: ${SPACING.spacing16};
-      background-color: ${alertKind === 'warning'
-        ? COLORS.yellow35
-        : COLORS.grey35};
+      background-color: ${
+        alertKind === 'warning' ? COLORS.yellow35 : COLORS.grey35
+      };
 
       &:active {
-        background-color: ${alertKind === 'warning'
-          ? COLORS.yellow40
-          : COLORS.grey40};
+        background-color: ${
+          alertKind === 'warning' ? COLORS.yellow40 : COLORS.grey40
+        };
       }
     }
 
     @media not all and ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
       &:hover {
-        background-color: ${alertKind === 'warning'
-          ? COLORS.yellow30
-          : COLORS.grey30};
+        background-color: ${
+          alertKind === 'warning' ? COLORS.yellow30 : COLORS.grey30
+        };
       }
     }
   `

--- a/components/src/molecules/TouchInputField/index.tsx
+++ b/components/src/molecules/TouchInputField/index.tsx
@@ -55,8 +55,7 @@ export interface TouchInputFieldProps {
   min?: number | string
   /** horizontal text alignment for label, input, and (sub)captions */
   textAlign?:
-    | typeof TYPOGRAPHY.textAlignLeft
-    | typeof TYPOGRAPHY.textAlignCenter
+    typeof TYPOGRAPHY.textAlignLeft | typeof TYPOGRAPHY.textAlignCenter
   /** small or medium input field height */
   size?: 'medium' | 'small'
   /** if true, style the background of input field to error state */

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getLiquidProbeCommandText.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getLiquidProbeCommandText.ts
@@ -10,8 +10,7 @@ import type {
 import type { HandlesCommands } from '../types'
 
 type LiquidProbeRunTimeCommands =
-  | LiquidProbeRunTimeCommand
-  | TryLiquidProbeRunTimeCommand
+  LiquidProbeRunTimeCommand | TryLiquidProbeRunTimeCommand
 
 export function getLiquidProbeCommandText({
   command,

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDisplayLocation.tsx
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareDisplayLocation.tsx
@@ -45,8 +45,7 @@ export interface DisplayLocationFullParams extends Omit<
   location?: LabwareLocation | LabwareLocationSequence | null
 }
 export type DisplayLocationParams =
-  | DisplayLocationSlotOnlyParams
-  | DisplayLocationFullParams
+  DisplayLocationSlotOnlyParams | DisplayLocationFullParams
 
 // detailLevel applies to nested labware. If 'full', return copy that includes the actual peripheral that nests the
 // labware, ex, "in module XYZ in slot C1".

--- a/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareLocation.tsx
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/getLabwareLocation.tsx
@@ -61,12 +61,10 @@ export interface SequenceFullParams extends SequenceBaseParams {
 }
 
 export type GetLabwareLocationParams =
-  | LocationSlotOnlyParams
-  | LocationFullParams
+  LocationSlotOnlyParams | LocationFullParams
 
 export type GetLabwareLocationFromSequenceParams =
-  | SequenceSlotOnlyParams
-  | SequenceFullParams
+  SequenceSlotOnlyParams | SequenceFullParams
 
 export function getLabwareLocationFromSequence(
   params: GetLabwareLocationFromSequenceParams

--- a/discovery-client/src/types.ts
+++ b/discovery-client/src/types.ts
@@ -86,13 +86,7 @@ export interface HealthErrorResponse {
 }
 
 export type LogLevel =
-  | 'error'
-  | 'warn'
-  | 'info'
-  | 'http'
-  | 'verbose'
-  | 'debug'
-  | 'silly'
+  'error' | 'warn' | 'info' | 'http' | 'verbose' | 'debug' | 'silly'
 
 export type Logger = Record<LogLevel, (message: string, meta?: unknown) => void>
 

--- a/labware-library/src/components/website-navigation/types.ts
+++ b/labware-library/src/components/website-navigation/types.ts
@@ -1,11 +1,7 @@
 import type { MouseEvent } from 'react'
 
 export type MenuName =
-  | 'About'
-  | 'Products'
-  | 'Applications'
-  | 'Protocols'
-  | 'Support'
+  'About' | 'Products' | 'Applications' | 'Protocols' | 'Support'
 
 export interface Link {
   name: string
@@ -27,11 +23,7 @@ export interface Submenu {
 }
 
 export type ProtocolSubmenuName =
-  | 'options'
-  | 'designer'
-  | 'library'
-  | 'api'
-  | 'github'
+  'options' | 'designer' | 'library' | 'api' | 'github'
 
 export type ProtocolLinks = Record<ProtocolSubmenuName, Link> & {
   bottomLink: Link

--- a/labware-library/src/labware-creator/components/sections/UploadExisting.tsx
+++ b/labware-library/src/labware-creator/components/sections/UploadExisting.tsx
@@ -12,8 +12,7 @@ interface Props {
   onClick: () => void
   onUpload: (
     event:
-      | React.DragEvent<HTMLLabelElement>
-      | React.ChangeEvent<HTMLInputElement>
+      React.DragEvent<HTMLLabelElement> | React.ChangeEvent<HTMLInputElement>
   ) => void
 }
 

--- a/labware-library/src/labware-creator/fields.ts
+++ b/labware-library/src/labware-creator/fields.ts
@@ -63,11 +63,7 @@ export interface RichOption {
 export type RichOptions = readonly RichOption[]
 
 export type LabwareType =
-  | 'wellPlate'
-  | 'reservoir'
-  | 'tubeRack'
-  | 'aluminumBlock'
-  | 'tipRack'
+  'wellPlate' | 'reservoir' | 'tubeRack' | 'aluminumBlock' | 'tipRack'
 export const labwareTypeOptions: Options = [
   { name: 'Well Plate', value: 'wellPlate' },
   { name: 'Reservoir', value: 'reservoir' },

--- a/labware-library/src/labware-creator/formLevelValidation.ts
+++ b/labware-library/src/labware-creator/formLevelValidation.ts
@@ -22,8 +22,7 @@ type BoundingBoxFields = {
   gridSpacingX: number
   gridSpacingY: number
 } & (
-  | { wellDiameter: number }
-  | { wellXDimension: number; wellYDimension: number }
+  { wellDiameter: number } | { wellXDimension: number; wellYDimension: number }
 )
 
 interface BoundingBoxResult {

--- a/labware-library/src/labware-creator/index.tsx
+++ b/labware-library/src/labware-creator/index.tsx
@@ -248,8 +248,7 @@ export const LabwareCreator = (props: LabwareCreatorProps): JSX.Element => {
   const onUpload = React.useCallback(
     (
       event:
-        | React.DragEvent<HTMLLabelElement>
-        | React.ChangeEvent<HTMLInputElement>
+        React.DragEvent<HTMLLabelElement> | React.ChangeEvent<HTMLInputElement>
     ) => {
       let files: FileList | never[] = []
       if ('dataTransfer' in event && event.dataTransfer.files !== null) {
@@ -595,8 +594,7 @@ interface CreateFileFormProps {
   currentWizardStep: WizardStep
   onUpload: (
     event:
-      | React.DragEvent<HTMLLabelElement>
-      | React.ChangeEvent<HTMLInputElement>
+      React.DragEvent<HTMLLabelElement> | React.ChangeEvent<HTMLInputElement>
   ) => void
   goBack: (stepsBack: number) => void
   onExportClick: () => void

--- a/opentrons-ai-client/src/components/atoms/TextAreaField/index.tsx
+++ b/opentrons-ai-client/src/components/atoms/TextAreaField/index.tsx
@@ -74,8 +74,7 @@ export interface TextAreaFieldProps {
   min?: number
   /** horizontal text alignment for title, textarea, and (sub)captions */
   textAlign?:
-    | typeof TYPOGRAPHY.textAlignLeft
-    | typeof TYPOGRAPHY.textAlignCenter
+    typeof TYPOGRAPHY.textAlignLeft | typeof TYPOGRAPHY.textAlignCenter
   /** react useRef to control textarea field instead of react event */
   ref?: MutableRefObject<HTMLTextAreaElement | null>
   /** optional IconName to display icon aligned to left of textarea field */
@@ -121,9 +120,9 @@ export const TextAreaField = forwardRef<
     @media ${RESPONSIVENESS.touchscreenMediaQuerySpecs} {
       grid-gap: ${SPACING.spacing8};
       &:focus-within {
-        filter: ${hasError
-          ? 'none'
-          : `drop-shadow(0px 0px 10px ${COLORS.blue50})`};
+        filter: ${
+          hasError ? 'none' : `drop-shadow(0px 0px 10px ${COLORS.blue50})`
+        };
       }
     }
   `
@@ -133,10 +132,12 @@ export const TextAreaField = forwardRef<
     background-color: ${hasBackgroundError ? COLORS.red30 : COLORS.white};
     border-radius: ${borderRadius ?? BORDERS.borderRadius4};
     padding: ${padding ?? SPACING.spacing8};
-    border: ${hasBackgroundError
-      ? 'none'
-      : `1px ${BORDERS.styleSolid}
-        ${hasError ? COLORS.red50 : COLORS.grey50}`};
+    border: ${
+      hasBackgroundError
+        ? 'none'
+        : `1px ${BORDERS.styleSolid}
+        ${hasError ? COLORS.red50 : COLORS.grey50}`
+    };
     font-size: ${TYPOGRAPHY.fontSizeP};
     width: 100%;
     height: ${height};

--- a/opentrons-ai-client/src/feature-flags/types.ts
+++ b/opentrons-ai-client/src/feature-flags/types.ts
@@ -9,9 +9,7 @@ export const DEPRECATED_FLAGS = [
 
 // union of feature flag string constant IDs
 export type FlagTypes =
-  | 'enablePrereleaseMode'
-  | 'enablePDProtocolGeneration'
-  | 'enableAnalytics'
+  'enablePrereleaseMode' | 'enablePDProtocolGeneration' | 'enableAnalytics'
 
 // flags that are not in this list only show in prerelease mode
 export const userFacingFlags: FlagTypes[] = ['enableAnalytics']

--- a/opentrons-ai-server/api/data/python_api_219_reference.md
+++ b/opentrons-ai-server/api/data/python_api_219_reference.md
@@ -795,7 +795,7 @@ Nozzle layouts numbering between 2\-7 nozzles, account for the distance from
 
 New in version 2\.16\.
 
-consolidate(_self_, _volume: 'Union\[float_, _Sequence\[float]]'_, _source: 'List\[labware.Well]'_, _dest: 'labware.Well'_, _\\\*args: 'Any'_, _\\\*\\\*kwargs: 'Any'_) → 'InstrumentContext'
+consolidate(_self_, _volume: 'Union\[float_, _Sequence\[float]]'_, _source: 'List\[labware.Well]'_, _dest: 'labware.Well'_, _\\\*args: 'Any'_, _\\\*\\\\*kwargs: 'Any'_) → 'InstrumentContext'
 Move liquid from multiple source wells to a single destination well.
 
 Parameters:
@@ -897,7 +897,7 @@ Changed in version 2\.17: Behavior of the `volume` parameter.
 
 New in version 2\.0\.
 
-distribute(_self_, _volume: 'Union\[float_, _Sequence\[float]]'_, _source: 'labware.Well'_, _dest: 'List\[labware.Well]'_, _\\\*args: 'Any'_, _\\\*\\\*kwargs: 'Any'_) → 'InstrumentContext'
+distribute(_self_, _volume: 'Union\[float_, _Sequence\[float]]'_, _source: 'labware.Well'_, _dest: 'List\[labware.Well]'_, _\\\*args: 'Any'_, _\\\*\\\\*kwargs: 'Any'_) → 'InstrumentContext'
 Move a volume of liquid from one source to multiple destinations.
 
 Parameters:
@@ -1385,7 +1385,7 @@ This instance.
 
 New in version 2\.0\.
 
-transfer(_self_, _volume: 'Union\[float_, _Sequence\[float]]'_, _source: 'AdvancedLiquidHandling'_, _dest: 'AdvancedLiquidHandling'_, _trash: 'bool' \= True_, _\\\*\\\*kwargs: 'Any'_) → 'InstrumentContext'
+transfer(_self_, _volume: 'Union\[float_, _Sequence\[float]]'_, _source: 'AdvancedLiquidHandling'_, _dest: 'AdvancedLiquidHandling'_, _trash: 'bool' \= True_, _\\\*\\\\*kwargs: 'Any'_) → 'InstrumentContext'
 Move liquid from one well or group of wells to another.
 
 Transfer is a higher\-level command, incorporating other

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "postcss-color-mod-function": "3.0.3",
     "postcss-import": "16.0.0",
     "postcss-preset-env": "9.3.0",
-    "prettier": "3.8.4",
+    "prettier": "3.9.4",
     "react": "catalog:react18",
     "react-docgen-typescript": "^1.21.0",
     "react-dom": "catalog:react18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
         version: 3.965.0
       '@chromatic-com/storybook':
         specifier: ^4.1.1
-        version: 4.1.3(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 4.1.3(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@electron/rebuild':
         specifier: 3.7.1
         version: 3.7.1
@@ -59,7 +59,7 @@ importers:
         version: 1.52.2(eslint@8.57.1)(ts-api-utils@2.4.0(typescript@5.3.3))(typescript@5.3.3)
       '@ianvs/prettier-plugin-sort-imports':
         specifier: 4.7.1
-        version: 4.7.1(prettier@3.8.4)
+        version: 4.7.1(prettier@3.9.4)
       '@octokit/rest':
         specifier: ^19.0.5
         version: 19.0.13(encoding@0.1.13)
@@ -71,16 +71,16 @@ importers:
         version: 4.3.0(encoding@0.1.13)
       '@storybook/addon-docs':
         specifier: 10.3.5
-        version: 10.3.5(@types/react@18.2.51)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
+        version: 10.3.5(@types/react@18.2.51)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
       '@storybook/addon-links':
         specifier: 10.3.5
-        version: 10.3.5(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 10.3.5(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@storybook/react':
         specifier: 10.3.5
-        version: 10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
+        version: 10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       '@storybook/react-vite':
         specifier: 10.3.5
-        version: 10.3.5(esbuild@0.27.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
+        version: 10.3.5(esbuild@0.27.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
       '@testing-library/dom':
         specifier: 10.4.0
         version: 10.4.0
@@ -274,8 +274,8 @@ importers:
         specifier: 9.3.0
         version: 9.3.0(postcss@8.5.6)
       prettier:
-        specifier: 3.8.4
-        version: 3.8.4
+        specifier: 3.9.4
+        version: 3.9.4
       react:
         specifier: catalog:react18
         version: 18.2.0
@@ -311,10 +311,10 @@ importers:
         version: 3.36.0
       storybook:
         specifier: 10.3.5
-        version: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       storybook-addon-pseudo-states:
         specifier: 9.1.5
-        version: 9.1.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+        version: 9.1.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       stylelint:
         specifier: 16.25.0
         version: 16.25.0(typescript@5.3.3)
@@ -9785,8 +9785,8 @@ packages:
     resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==}
     engines: {node: '>=4'}
 
-  prettier@3.8.4:
-    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+  prettier@3.9.4:
+    resolution: {integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -13189,13 +13189,13 @@ snapshots:
     dependencies:
       commander: 2.20.3
 
-  '@chromatic-com/storybook@4.1.3(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@chromatic-com/storybook@4.1.3(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
       '@neoconfetti/react': 1.0.0
       chromatic: 13.3.5
       filesize: 10.1.6
       jsonfile: 6.2.0
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       strip-ansi: 7.1.2
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
@@ -13951,13 +13951,13 @@ snapshots:
 
   '@hutson/parse-repository-url@3.0.2': {}
 
-  '@ianvs/prettier-plugin-sort-imports@4.7.1(prettier@3.8.4)':
+  '@ianvs/prettier-plugin-sort-imports@4.7.1(prettier@3.9.4)':
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.29.7
       '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.29.7
-      prettier: 3.8.4
+      prettier: 3.9.4
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
@@ -15590,15 +15590,15 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-docs@10.3.5(@types/react@18.2.51)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))':
+  '@storybook/addon-docs@10.3.5(@types/react@18.2.51)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.2.51)(react@18.2.0)
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
       '@storybook/icons': 2.0.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@storybook/react-dom-shim': 10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@storybook/react-dom-shim': 10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
@@ -15607,17 +15607,17 @@ snapshots:
       - vite
       - webpack
 
-  '@storybook/addon-links@10.3.5(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@storybook/addon-links@10.3.5(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     optionalDependencies:
       react: 18.2.0
 
-  '@storybook/builder-vite@10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))':
+  '@storybook/builder-vite@10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       ts-dedent: 2.2.0
       vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
     transitivePeerDependencies:
@@ -15625,9 +15625,9 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))':
+  '@storybook/csf-plugin@10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))':
     dependencies:
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.2
@@ -15646,25 +15646,25 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@storybook/react-dom-shim@10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
+  '@storybook/react-dom-shim@10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@storybook/react-vite@10.3.5(esbuild@0.27.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))':
+  '@storybook/react-vite@10.3.5(esbuild@0.27.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.3.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
-      '@storybook/builder-vite': 10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
-      '@storybook/react': 10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
+      '@storybook/builder-vite': 10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
+      '@storybook/react': 10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       empathic: 2.0.1
       magic-string: 0.30.21
       react: 18.2.0
       react-docgen: 8.0.3
       react-dom: 18.2.0(react@18.2.0)
       resolve: 1.22.11
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       tsconfig-paths: 4.2.0
       vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
     transitivePeerDependencies:
@@ -15674,15 +15674,15 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react@10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)':
+  '@storybook/react@10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@storybook/react-dom-shim': 10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       react: 18.2.0
       react-docgen: 8.0.3
       react-docgen-typescript: 2.4.0(typescript@5.3.3)
       react-dom: 18.2.0(react@18.2.0)
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -22866,7 +22866,7 @@ snapshots:
 
   prepend-http@2.0.0: {}
 
-  prettier@3.8.4: {}
+  prettier@3.9.4: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -24085,11 +24085,11 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook-addon-pseudo-states@9.1.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)):
+  storybook-addon-pseudo-states@9.1.5(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)):
     dependencies:
-      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.8.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -24105,7 +24105,7 @@ snapshots:
       use-sync-external-store: 1.6.0(react@18.2.0)
       ws: 8.19.0
     optionalDependencies:
-      prettier: 3.8.4
+      prettier: 3.9.4
     transitivePeerDependencies:
       - '@testing-library/dom'
       - bufferutil

--- a/protocol-designer/docs/PYTHON_STEP_GENERATION.md
+++ b/protocol-designer/docs/PYTHON_STEP_GENERATION.md
@@ -8,8 +8,7 @@ The command creators produce a `CommandCreatorResult`. We'll augment that to inc
 
 ```typescript
 export type CommandCreatorResult =
-  | CommandsAndWarnings
-  | CommandCreatorErrorResponse
+  CommandsAndWarnings | CommandCreatorErrorResponse
 
 export interface CommandsAndWarnings {
   commands: CreateCommand[]

--- a/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
+++ b/protocol-designer/src/components/organisms/HardwareConfigurator/AddFixtureModal.tsx
@@ -93,10 +93,7 @@ interface AddFixtureModalProps {
   existingCutoutFixtureId?: CutoutFixtureId
 }
 export type OptionStage =
-  | 'modulesOrFixtures'
-  | 'fixtureOptions'
-  | 'moduleOptions'
-  | 'wasteChuteOptions'
+  'modulesOrFixtures' | 'fixtureOptions' | 'moduleOptions' | 'wasteChuteOptions'
 
 //  TODO: this is similar to the AddFixtureModal in the app but logic varies
 //  quite a bit. Would be ideal to merge them together but not sure how to do

--- a/protocol-designer/src/components/organisms/Ot2Modules/index.tsx
+++ b/protocol-designer/src/components/organisms/Ot2Modules/index.tsx
@@ -66,8 +66,7 @@ import type { StepType } from '/protocol-designer/form-types'
 import type { OT2ModuleType, ThunkDispatch } from '/protocol-designer/types'
 
 type MagneticModuleModels =
-  | typeof MAGNETIC_MODULE_V1
-  | typeof MAGNETIC_MODULE_V2
+  typeof MAGNETIC_MODULE_V1 | typeof MAGNETIC_MODULE_V2
 
 const mapModTypeToStepTypeOt2: Record<OT2ModuleType, StepType> = {
   heaterShakerModuleType: 'heaterShaker',

--- a/protocol-designer/src/components/organisms/TipPositionModal/utils.tsx
+++ b/protocol-designer/src/components/organisms/TipPositionModal/utils.tsx
@@ -66,9 +66,7 @@ export const roundValue = (
 const OUT_OF_BOUNDS: 'OUT_OF_BOUNDS' = 'OUT_OF_BOUNDS'
 const GENERIC: 'GENERIC' = 'GENERIC'
 export type Error =
-  | typeof TOO_MANY_DECIMALS
-  | typeof OUT_OF_BOUNDS
-  | typeof GENERIC
+  typeof TOO_MANY_DECIMALS | typeof OUT_OF_BOUNDS | typeof GENERIC
 
 export const getErrorText = (args: {
   errors: Error[]

--- a/protocol-designer/src/form-types.ts
+++ b/protocol-designer/src/form-types.ts
@@ -656,8 +656,7 @@ export type ReferenceFields =
   | 'mix_position_reference'
 
 export type DelayCheckboxBaseFields =
-  | 'aspirate_delay_checkbox'
-  | 'dispense_delay_checkbox'
+  'aspirate_delay_checkbox' | 'dispense_delay_checkbox'
 export type DelayCheckboxMoveLiquidFields =
   | DelayCheckboxBaseFields
   | 'aspirate_submerge_delay_seconds'
@@ -665,8 +664,7 @@ export type DelayCheckboxMoveLiquidFields =
   | 'dispense_submerge_delay_seconds'
   | 'dispense_retract_delay_seconds'
 export type DelaySecondsBaseFields =
-  | 'aspirate_delay_seconds'
-  | 'dispense_delay_seconds'
+  'aspirate_delay_seconds' | 'dispense_delay_seconds'
 export type DelaySecondsMoveLiquidFields =
   | DelaySecondsBaseFields
   | 'aspirate_submerge_delay_seconds'

--- a/protocol-designer/src/labware-defs/types.ts
+++ b/protocol-designer/src/labware-defs/types.ts
@@ -23,9 +23,7 @@ export type LabwareUploadMessage =
     }
   | {
       messageType:
-        | 'EXACT_LABWARE_MATCH'
-        | 'USES_STANDARD_NAMESPACE'
-        | 'ONLY_TIPRACK'
+        'EXACT_LABWARE_MATCH' | 'USES_STANDARD_NAMESPACE' | 'ONLY_TIPRACK'
     }
   | (NameConflictFields & {
       messageType: 'LABWARE_NAME_CONFLICT'

--- a/protocol-designer/src/labware-ingred/types.ts
+++ b/protocol-designer/src/labware-ingred/types.ts
@@ -25,10 +25,7 @@ export type LiquidGroupsById = Record<string, Ingredient>
 export type AllIngredGroupFields = Record<string, IngredInputs>
 
 export type Fixture =
-  | 'stagingArea'
-  | 'trashBin'
-  | 'wasteChute'
-  | 'wasteChuteAndStagingArea'
+  'stagingArea' | 'trashBin' | 'wasteChute' | 'wasteChuteAndStagingArea'
 
 export interface ZoomedIntoSlotInfoState {
   selectedTopLabware: { labwareDefURI: string | null; amount: number }

--- a/protocol-designer/src/load-file/types.ts
+++ b/protocol-designer/src/load-file/types.ts
@@ -2,9 +2,7 @@ import type { RobotType } from '@opentrons/shared-data'
 import type { PDProtocolFile, PythonDesignerApplication } from '../file-types'
 
 export type FileUploadErrorType =
-  | 'INVALID_FILE_TYPE'
-  | 'INVALID_JSON_FILE'
-  | 'INVALID_PYTHON_FILE'
+  'INVALID_FILE_TYPE' | 'INVALID_JSON_FILE' | 'INVALID_PYTHON_FILE'
 export type FileUploadMessageKey = 'DID_MIGRATE'
 export type FileUploadMessage =
   | {

--- a/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
@@ -55,10 +55,7 @@ export const OT2_MODULE_MODELS: ModuleModel[] = [
 ]
 
 export type Fixture =
-  | 'stagingArea'
-  | 'trashBin'
-  | 'wasteChute'
-  | 'wasteChuteAndStagingArea'
+  'stagingArea' | 'trashBin' | 'wasteChute' | 'wasteChuteAndStagingArea'
 
 export const FIXTURES: Fixture[] = [
   'stagingArea',

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/types.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/TipSelectionWizard/types.ts
@@ -69,6 +69,4 @@ interface InaccessibleStatus extends AccessibilityStatusBase {
 export type AccessibilityStatus = AccessibleStatus | InaccessibleStatus
 
 export type TipSelectionBannerReason =
-  | 'incompletePickup'
-  | 'pickupsRequired'
-  | 'tooManyTips'
+  'incompletePickup' | 'pickupsRequired' | 'tooManyTips'

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerProfileModal.tsx
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/StepTools/ThermocyclerTools/ThermocyclerProfileModal.tsx
@@ -26,8 +26,7 @@ import type { ThermocyclerCycleType } from './ThermocyclerCycle'
 import type { ThermocyclerStepType } from './ThermocyclerStep'
 
 export type ThermocyclerStepTypeGeneral =
-  | ThermocyclerCycleType
-  | ThermocyclerStepType
+  ThermocyclerCycleType | ThermocyclerStepType
 
 interface ThermocyclerModalProps {
   formData: FormData

--- a/protocol-designer/src/resources/sentry.ts
+++ b/protocol-designer/src/resources/sentry.ts
@@ -21,9 +21,7 @@ const sentryDsn = _OT_PD_SENTRY_DSN_ ?? _OT_PD_SENTRY_DEV_DSN_
 const sentryRelease = _OT_PD_SENTRY_RELEASE_ ?? _OT_PD_VERSION_
 
 const resolveSentryEnvironment = ():
-  | 'production'
-  | 'staging'
-  | 'development' => {
+  'production' | 'staging' | 'development' => {
   if (getIsProduction()) {
     return 'production'
   }

--- a/protocol-designer/src/step-forms/actions/index.ts
+++ b/protocol-designer/src/step-forms/actions/index.ts
@@ -71,8 +71,7 @@ export interface StackerLabwareCreationFinishAction {
 }
 
 export type StackerLabwareActions =
-  | StackerLabwareCreationStartAction
-  | StackerLabwareCreationFinishAction
+  StackerLabwareCreationStartAction | StackerLabwareCreationFinishAction
 
 export const stackerLabwareCreationStart =
   (): StackerLabwareCreationStartAction => ({

--- a/protocol-designer/src/step-forms/reducers/index.ts
+++ b/protocol-designer/src/step-forms/reducers/index.ts
@@ -2118,8 +2118,7 @@ export const rootReducer: Reducer<RootState, any> = nestedCombineReducers(
     stackerLabwareReducer: stackerLabwareReducer(
       prevStateFallback.stackerLabwareReducer,
       action as
-        | StackerLabwareCreationStartAction
-        | StackerLabwareCreationFinishAction
+        StackerLabwareCreationStartAction | StackerLabwareCreationFinishAction
     ),
   })
 )

--- a/protocol-designer/src/steplist/generateSubstepItem.ts
+++ b/protocol-designer/src/steplist/generateSubstepItem.ts
@@ -42,10 +42,7 @@ import type {
 
 export type GetIngreds = (labware: string, well: string) => NamedIngred[]
 type TransferLikeArgs =
-  | ConsolidateArgs
-  | DistributeArgs
-  | TransferArgs
-  | MixArgs
+  ConsolidateArgs | DistributeArgs | TransferArgs | MixArgs
 
 function getCommandCreatorForTransferlikeSubsteps(
   stepArgs: TransferLikeArgs

--- a/protocol-designer/src/steplist/types.ts
+++ b/protocol-designer/src/steplist/types.ts
@@ -76,10 +76,7 @@ export interface StepItemSourceDestRow {
 // NOTE: delay is NOT a source-dest-style command creator, this type exists
 // mostly to tell flow that :/
 type SourceDestCommandCreatorName =
-  | 'transfer'
-  | 'distribute'
-  | 'consolidate'
-  | 'mix'
+  'transfer' | 'distribute' | 'consolidate' | 'mix'
 export interface SourceDestSubstepItemSingleChannel {
   substepType: 'sourceDest'
   multichannel: false
@@ -98,8 +95,7 @@ export interface SourceDestSubstepItemMultiChannel {
   // NOTE: "Row" means a tabular row on the steplist, NOT a "row" of wells on the deck
 }
 export type SourceDestSubstepItem =
-  | SourceDestSubstepItemSingleChannel
-  | SourceDestSubstepItemMultiChannel
+  SourceDestSubstepItemSingleChannel | SourceDestSubstepItemMultiChannel
 export interface MagnetSubstepItem {
   substepType: 'magnet'
   engage: boolean

--- a/protocol-designer/src/steplist/utils/stepHierarchy.ts
+++ b/protocol-designer/src/steplist/utils/stepHierarchy.ts
@@ -72,9 +72,7 @@ export interface VacuumStateDurationGroup extends ConcurrentGroupFields {
 }
 
 export type ConcurrentGroup =
-  | ThermocyclerProfileGroup
-  | VacuumProfileGroup
-  | VacuumStateDurationGroup
+  ThermocyclerProfileGroup | VacuumProfileGroup | VacuumStateDurationGroup
 
 export function isConcurrentGroup(
   item: StandaloneStep | ConcurrentGroup
@@ -91,9 +89,7 @@ function isVacuumStateWithPumpDuration(step: FormData): boolean {
 }
 
 type OpenConcurrentGroupKind =
-  | 'thermocycler'
-  | 'vacuumProfile'
-  | 'vacuumStateDuration'
+  'thermocycler' | 'vacuumProfile' | 'vacuumStateDuration'
 
 interface OpenConcurrentGroup {
   kind: OpenConcurrentGroupKind

--- a/protocol-designer/src/top-selectors/well-contents/index.ts
+++ b/protocol-designer/src/top-selectors/well-contents/index.ts
@@ -97,9 +97,8 @@ export const getSelectedWellsCommonValues = createSelector(
       }
     }
     const initialWellContents:
-      | StepGeneration.LocationLiquidState
-      | null
-      | undefined = ingredsInLabware[Object.keys(selectedWells)[0]]
+      StepGeneration.LocationLiquidState | null | undefined =
+      ingredsInLabware[Object.keys(selectedWells)[0]]
     // TODO IMMEDIATELY why arbitrary 0th???
     const initialIngredId: string | null | undefined =
       initialWellContents && Object.keys(initialWellContents)[0]

--- a/protocol-designer/src/types.ts
+++ b/protocol-designer/src/types.ts
@@ -77,5 +77,4 @@ export type OT2ModuleType =
   | typeof HEATERSHAKER_MODULE_TYPE
 
 export type ModuleLabwareCompatibilityKey =
-  | ModuleType
-  | typeof VACUUM_MODULE_TYPE_WITH_LABWARE
+  ModuleType | typeof VACUUM_MODULE_TYPE_WITH_LABWARE

--- a/protocol-designer/src/ui/steps/actions/thunks/index.ts
+++ b/protocol-designer/src/ui/steps/actions/thunks/index.ts
@@ -307,9 +307,7 @@ export const duplicateSelectedSteps: () => ThunkAction<
     },
   }
   const selectNewStepsAction = (():
-    | SelectStepAction
-    | SelectMultipleStepsAction
-    | null => {
+    SelectStepAction | SelectMultipleStepsAction | null => {
     // If we have multiple step IDs to select, dispatch a SELECT_MULTIPLE_STEPS; if we
     // have just one, dispatch a SELECT_STEP. This just preserves prior behavior and
     // I'm not sure the distinction actually matters. We might be able to simplify this

--- a/protocol-designer/src/ui/steps/reducers.ts
+++ b/protocol-designer/src/ui/steps/reducers.ts
@@ -38,9 +38,7 @@ interface TerminalItem {
   id: TerminalItemId
 }
 export type SelectableItem =
-  | SingleSelectedItem
-  | MultipleSelectedItem
-  | TerminalItem
+  SingleSelectedItem | MultipleSelectedItem | TerminalItem
 type SelectedItemState = SelectableItem | null | undefined
 export type HoverableItem = SingleSelectedItem | TerminalItem
 

--- a/protocol-designer/src/utils/labwareStackRendering.ts
+++ b/protocol-designer/src/utils/labwareStackRendering.ts
@@ -33,12 +33,10 @@ export const getRenderingPositionFromBaseNode = (args: {
   const { baseNode, deckDef, deckConfiguration } = args
 
   // If the base node is not a slot or addressable area, return zeros.
-  if (
-    !(
-      typeof baseNode === 'object' &&
-      ('addressableAreaName' in baseNode || 'slotName' in baseNode)
-    )
-  ) {
+  if (!(
+    typeof baseNode === 'object' &&
+    ('addressableAreaName' in baseNode || 'slotName' in baseNode)
+  )) {
     return ZERO_COORDINATE_TUPLE
   }
   const addressableAreaName =

--- a/protocol-visualization/src/organisms/AnnotatedSteps/index.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/index.tsx
@@ -63,10 +63,7 @@ interface ErrorPastStepsMessageRow {
 }
 
 type AnnotatedStepsRow =
-  | GroupRow
-  | CommandRow
-  | ErrorRow
-  | ErrorPastStepsMessageRow
+  GroupRow | CommandRow | ErrorRow | ErrorPastStepsMessageRow
 
 export interface ItemData {
   rows: AnnotatedStepsRow[]

--- a/protocol-visualization/src/organisms/StepDetailContainer/index.tsx
+++ b/protocol-visualization/src/organisms/StepDetailContainer/index.tsx
@@ -73,11 +73,7 @@ export function StepDetailContainer({
   )
 
   type ComponentType =
-    | 'left_pipette'
-    | 'right_pipette'
-    | 'tiprack'
-    | 'labware'
-    | 'disposal'
+    'left_pipette' | 'right_pipette' | 'tiprack' | 'labware' | 'disposal'
 
   const getComponentsToRender = (): ComponentType[] => {
     const components: ComponentType[] = []

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -157,9 +157,7 @@ export type DocumentedAction =
  * login_cancelled: user closed out of the login modal
  */
 export type DocumentedMutationErrorType =
-  | 'no_documentation_report'
-  | 'access_control_loading'
-  | 'login_cancelled'
+  'no_documentation_report' | 'access_control_loading' | 'login_cancelled'
 
 const DOCUMENTED_MUTATION_ERROR_MESSAGES: Record<
   DocumentedMutationErrorType,

--- a/shared-data/command/types/annotation.ts
+++ b/shared-data/command/types/annotation.ts
@@ -3,8 +3,7 @@ import type { CommonCommandCreateInfo, CommonCommandRunTimeInfo } from '.'
 export type AnnotationCreateCommand = CommentCreateCommand | CustomCreateCommand
 
 export type AnnotationRunTimeCommand =
-  | CommentRunTimeCommand
-  | CustomRunTimeCommand
+  CommentRunTimeCommand | CustomRunTimeCommand
 
 export interface CommentCreateCommand extends CommonCommandCreateInfo {
   commandType: 'comment'

--- a/shared-data/command/types/concurrent.ts
+++ b/shared-data/command/types/concurrent.ts
@@ -1,11 +1,9 @@
 import type { CommonCommandCreateInfo, CommonCommandRunTimeInfo } from '.'
 
 export type ConcurrentCreateCommand =
-  | CreateTimerCreateCommand
-  | WaitForTasksCreateCommand
+  CreateTimerCreateCommand | WaitForTasksCreateCommand
 export type ConcurrentRunTimeCommand =
-  | CreateTimerRunTimeCommand
-  | WaitForTasksRunTimeCommand
+  CreateTimerRunTimeCommand | WaitForTasksRunTimeCommand
 export interface CreateTimerParams {
   time: number
   task_id?: string | null

--- a/shared-data/command/types/incidental.ts
+++ b/shared-data/command/types/incidental.ts
@@ -2,12 +2,10 @@ import type { CommonCommandCreateInfo, CommonCommandRunTimeInfo } from '.'
 import type { StatusBarAnimation } from '../../js/types'
 
 export type IncidentalCreateCommand =
-  | SetStatusBarCreateCommand
-  | SetRailLightsCreateCommand
+  SetStatusBarCreateCommand | SetRailLightsCreateCommand
 
 export type IncidentalRunTimeCommand =
-  | SetStatusBarRunTimeCommand
-  | SetRailLightsRunTimeCommand
+  SetStatusBarRunTimeCommand | SetRailLightsRunTimeCommand
 
 export interface SetStatusBarCreateCommand extends CommonCommandCreateInfo {
   commandType: 'setStatusBar'

--- a/shared-data/command/types/index.ts
+++ b/shared-data/command/types/index.ts
@@ -107,12 +107,10 @@ export type RunTimeCommand =
 export type RunCommandError = RunCommandErrorUndefined | DefinedRunCommandError
 
 export type DefinedRunCommandError =
-  | RunCommandRobotActionError
-  | RunCommandFlexStackerError
+  RunCommandRobotActionError | RunCommandFlexStackerError
 
 export type RunCommandRobotActionError =
-  | RunCommandErrorOverpressure
-  | RunCommandErrorTipPhysicallyAttached
+  RunCommandErrorOverpressure | RunCommandErrorTipPhysicallyAttached
 
 export type Failed<CommandT extends RunTimeCommand> = Omit<CommandT, 'result'>
 

--- a/shared-data/command/types/module.ts
+++ b/shared-data/command/types/module.ts
@@ -397,8 +397,7 @@ export interface AtomicVacuumProfileStepPower extends AtomicVacuumProfileStepBas
 }
 
 export type AtomicVacuumProfileStep =
-  | AtomicVacuumProfileStepPressure
-  | AtomicVacuumProfileStepPower
+  AtomicVacuumProfileStepPressure | AtomicVacuumProfileStepPower
 
 export interface VacuumProfileCycle {
   steps: AtomicVacuumProfileStep[]

--- a/shared-data/command/types/setup.ts
+++ b/shared-data/command/types/setup.ts
@@ -237,9 +237,7 @@ interface ReloadLabwareResult {
 }
 
 export type LabwareMovementStrategy =
-  | 'usingGripper'
-  | 'manualMoveWithPause'
-  | 'manualMoveWithoutPause'
+  'usingGripper' | 'manualMoveWithPause' | 'manualMoveWithoutPause'
 
 export interface MoveLabwareParams {
   labwareId: string

--- a/shared-data/command/types/support.ts
+++ b/shared-data/command/types/support.ts
@@ -6,9 +6,7 @@ import type {
 } from '../../js/constants'
 
 type BaseWellOrigin =
-  | typeof WELL_ORIGIN_TOP
-  | typeof WELL_ORIGIN_BOTTOM
-  | typeof WELL_ORIGIN_CENTER
+  typeof WELL_ORIGIN_TOP | typeof WELL_ORIGIN_BOTTOM | typeof WELL_ORIGIN_CENTER
 
 export type WellOrigin = BaseWellOrigin | typeof WELL_ORIGIN_MENISCUS
 export interface WellOffset {

--- a/shared-data/commandAnnotation/types/index.ts
+++ b/shared-data/commandAnnotation/types/index.ts
@@ -14,8 +14,7 @@ export interface SecondOrderCommandAnnotation extends SharedCommandAnnotationPro
   userSpecifiedDescription?: string
 }
 export type CommandAnnotationV1 =
-  | SecondOrderCommandAnnotation
-  | CustomCommandAnnotation
+  SecondOrderCommandAnnotation | CustomCommandAnnotation
 
 export interface UserCommandAnnotation {
   annotationType: 'userCommand'

--- a/shared-data/deck/types/schemaV4.ts
+++ b/shared-data/deck/types/schemaV4.ts
@@ -44,8 +44,7 @@ export type OT2AddressableAreaName =
   | 'fixedTrash'
 
 export type AddressableAreaName =
-  | FlexAddressableAreaName
-  | OT2AddressableAreaName
+  FlexAddressableAreaName | OT2AddressableAreaName
 
 export type CutoutId =
   | 'cutoutD1'
@@ -76,9 +75,7 @@ export type OT2CutoutId =
   | 'cutout12'
 
 export type SingleSlotCutoutFixtureId =
-  | 'singleLeftSlot'
-  | 'singleCenterSlot'
-  | 'singleRightSlot'
+  'singleLeftSlot' | 'singleCenterSlot' | 'singleRightSlot'
 
 export type StagingAreaRightSlotFixtureId = 'stagingAreaRightSlot'
 

--- a/shared-data/deck/types/schemaV5.ts
+++ b/shared-data/deck/types/schemaV5.ts
@@ -87,8 +87,7 @@ export type OT2AddressableAreaName =
   | 'fixedTrash'
 
 export type AddressableAreaName =
-  | FlexAddressableAreaName
-  | OT2AddressableAreaName
+  FlexAddressableAreaName | OT2AddressableAreaName
 
 export type CutoutId =
   | 'cutoutD1'
@@ -119,9 +118,7 @@ export type OT2CutoutId =
   | 'cutout12'
 
 export type SingleSlotCutoutFixtureId =
-  | 'singleLeftSlot'
-  | 'singleCenterSlot'
-  | 'singleRightSlot'
+  'singleLeftSlot' | 'singleCenterSlot' | 'singleRightSlot'
 
 export type StagingAreaRightSlotFixtureId = 'stagingAreaRightSlot'
 

--- a/shared-data/js/constants.ts
+++ b/shared-data/js/constants.ts
@@ -322,10 +322,7 @@ export const FAKE_AA = [
 ]
 
 export type FlexFakeAddressableAreaName =
-  | 'fakeA4'
-  | 'fakeB4'
-  | 'fakeC4'
-  | 'fakeD4'
+  'fakeA4' | 'fakeB4' | 'fakeC4' | 'fakeD4'
 
 export type FakeCutoutFixtureId =
   | 'fakeStagingAreaRightSlot'
@@ -333,8 +330,7 @@ export type FakeCutoutFixtureId =
   | 'fakeStagingSlotWithMagBlockV1'
 
 export type AddressableAreaNamesWithFakes =
-  | AddressableAreaName
-  | FlexFakeAddressableAreaName
+  AddressableAreaName | FlexFakeAddressableAreaName
 
 export type AddressableAreaWithFakes = AddressableArea | FakeAddressableArea
 

--- a/shared-data/js/helpers/__tests__/volume.test.ts
+++ b/shared-data/js/helpers/__tests__/volume.test.ts
@@ -17,9 +17,7 @@ type GetAsciiVolumeUnitsSpec = BaseSpec<typeof helpers.getAsciiVolumeUnits>
 type EnsureVolumeUnitsSpec = BaseSpec<typeof helpers.ensureVolumeUnits>
 
 type TestSpec =
-  | GetDisplayVolumeSpec
-  | GetAsciiVolumeUnitsSpec
-  | EnsureVolumeUnitsSpec
+  GetDisplayVolumeSpec | GetAsciiVolumeUnitsSpec | EnsureVolumeUnitsSpec
 
 describe('volume helpers', () => {
   const SPECS: TestSpec[] = [

--- a/shared-data/js/helpers/parseProtocolData.ts
+++ b/shared-data/js/helpers/parseProtocolData.ts
@@ -44,8 +44,7 @@ export interface PythonProtocolMetadata {
 
 // data may be a full JSON protocol or just a metadata dict from Python
 export type ProtocolData =
-  | JsonProtocolFile
-  | { metadata: PythonProtocolMetadata }
+  JsonProtocolFile | { metadata: PythonProtocolMetadata }
 
 export function parseProtocolData(
   file: File,

--- a/shared-data/js/pipettes.ts
+++ b/shared-data/js/pipettes.ts
@@ -49,8 +49,7 @@ export function getPipetteNameSpecs(
   name: PipetteName
 ): PipetteNameSpecs | null {
   const config = pipetteNameSpecs[name] as
-    | Omit<PipetteNameSpecs, 'name'>
-    | undefined
+    Omit<PipetteNameSpecs, 'name'> | undefined
   return config != null ? { ...config, name } : null
 }
 

--- a/shared-data/js/types.ts
+++ b/shared-data/js/types.ts
@@ -221,8 +221,7 @@ export interface RectangularWellShape {
 }
 
 export type LabwareWellShapeProperties =
-  | CircularWellShape
-  | RectangularWellShape
+  CircularWellShape | RectangularWellShape
 
 // well without x,y,z
 export type LabwareWellProperties = LabwareWellShapeProperties & {
@@ -349,12 +348,7 @@ export interface LocatingFeatures {
 }
 
 export type LabwareRoles =
-  | 'labware'
-  | 'adapter'
-  | 'fixture'
-  | 'maintenance'
-  | 'lid'
-  | 'system'
+  'labware' | 'adapter' | 'fixture' | 'maintenance' | 'lid' | 'system'
 
 // NOTE: must be synced with shared-data/labware/schemas/2.json
 export interface LabwareDefinition2 {
@@ -428,16 +422,13 @@ export type ModuleType =
 
 // ModuleModel corresponds to top-level keys in shared-data/module/definitions/2
 export type MagneticModuleModel =
-  | typeof MAGNETIC_MODULE_V1
-  | typeof MAGNETIC_MODULE_V2
+  typeof MAGNETIC_MODULE_V1 | typeof MAGNETIC_MODULE_V2
 
 export type TemperatureModuleModel =
-  | typeof TEMPERATURE_MODULE_V1
-  | typeof TEMPERATURE_MODULE_V2
+  typeof TEMPERATURE_MODULE_V1 | typeof TEMPERATURE_MODULE_V2
 
 export type ThermocyclerModuleModel =
-  | typeof THERMOCYCLER_MODULE_V1
-  | typeof THERMOCYCLER_MODULE_V2
+  typeof THERMOCYCLER_MODULE_V1 | typeof THERMOCYCLER_MODULE_V2
 
 export type HeaterShakerModuleModel = typeof HEATERSHAKER_MODULE_V1
 
@@ -466,10 +457,7 @@ export type GripperModel =
   | typeof GRIPPER_V1_3
 
 export type ModuleModelWithLegacy =
-  | ModuleModel
-  | typeof THERMOCYCLER
-  | typeof MAGDECK
-  | typeof TEMPDECK
+  ModuleModel | typeof THERMOCYCLER | typeof MAGDECK | typeof TEMPDECK
 
 export interface Dimensions {
   xDimension: number
@@ -689,9 +677,7 @@ export type ModuleOrientation = 'left' | 'right'
 export type PipetteChannels = 1 | 8 | 96
 
 export type ActiveNozzleNumber =
-  | PipetteChannels
-  | PartialNozzles8Channel
-  | RowChannels
+  PipetteChannels | PartialNozzles8Channel | RowChannels
 
 export type PipetteDisplayCategory = typeof GEN1 | typeof GEN2 | typeof FLEX
 
@@ -1064,9 +1050,7 @@ interface StringChoiceParameter extends BaseRunTimeParameter {
 }
 
 export type ChoiceParameter =
-  | NumberChoiceParameter
-  | BooleanChoiceParameter
-  | StringChoiceParameter
+  NumberChoiceParameter | BooleanChoiceParameter | StringChoiceParameter
 
 interface BooleanParameter extends BaseRunTimeParameter {
   type: BooleanParameterType
@@ -1102,10 +1086,7 @@ interface BaseRunTimeParameter {
 export type ValueRunTimeParameter = Exclude<RunTimeParameter, CsvFileParameter>
 
 export type RunTimeParameter =
-  | BooleanParameter
-  | ChoiceParameter
-  | NumberParameter
-  | CsvFileParameter
+  BooleanParameter | ChoiceParameter | NumberParameter | CsvFileParameter
 
 export interface CommandPreconditions {
   isCameraUsed: boolean
@@ -1195,11 +1176,7 @@ export interface GripperDefinition {
 }
 
 export type StatusBarAnimation =
-  | 'idle'
-  | 'confirm'
-  | 'updating'
-  | 'disco'
-  | 'off'
+  'idle' | 'confirm' | 'updating' | 'disco' | 'off'
 
 export type StatusBarAnimations = StatusBarAnimation[]
 
@@ -1219,8 +1196,4 @@ export interface CutoutConfigMap extends CutoutConfigWithoutCutoutFixtureId {
 }
 
 export type NozzleLayoutConfig =
-  | 'single'
-  | 'column'
-  | 'row'
-  | 'full'
-  | 'subrect'
+  'single' | 'column' | 'row' | 'full' | 'subrect'

--- a/shared-data/protocol/types/schemaV6/command/setup.ts
+++ b/shared-data/protocol/types/schemaV6/command/setup.ts
@@ -68,14 +68,10 @@ export type SetupCreateCommand =
   | MoveLabwareCreateCommand
 
 export type LabwareLocation =
-  | { slotName: string }
-  | { moduleId: string }
-  | 'offDeck'
+  { slotName: string } | { moduleId: string } | 'offDeck'
 
 export type LabwareMovementStrategy =
-  | 'usingGripper'
-  | 'manualMoveWithPause'
-  | 'manualMoveWithoutPause'
+  'usingGripper' | 'manualMoveWithPause' | 'manualMoveWithoutPause'
 
 export interface ModuleLocation {
   slotName: string

--- a/shared-data/protocol/types/schemaV7/command/annotation.ts
+++ b/shared-data/protocol/types/schemaV7/command/annotation.ts
@@ -3,8 +3,7 @@ import type { CommonCommandCreateInfo, CommonCommandRunTimeInfo } from '.'
 export type AnnotationCreateCommand = CommentCreateCommand | CustomCreateCommand
 
 export type AnnotationRunTimeCommand =
-  | CommentRunTimeCommand
-  | CustomRunTimeCommand
+  CommentRunTimeCommand | CustomRunTimeCommand
 
 export interface CommentCreateCommand extends CommonCommandCreateInfo {
   commandType: 'comment'

--- a/shared-data/protocol/types/schemaV7/command/setup.ts
+++ b/shared-data/protocol/types/schemaV7/command/setup.ts
@@ -75,9 +75,7 @@ export type LabwareLocation =
   | { labwareId: string }
 
 export type NonStackedLocation =
-  | 'offDeck'
-  | { slotName: string }
-  | { moduleId: string }
+  'offDeck' | { slotName: string } | { moduleId: string }
 
 export interface ModuleLocation {
   slotName: string
@@ -105,9 +103,7 @@ interface LoadLabwareResult {
 }
 
 export type LabwareMovementStrategy =
-  | 'usingGripper'
-  | 'manualMoveWithPause'
-  | 'manualMoveWithoutPause'
+  'usingGripper' | 'manualMoveWithPause' | 'manualMoveWithoutPause'
 
 export interface MoveLabwareParams {
   labwareId: string

--- a/step-generation/src/types.ts
+++ b/step-generation/src/types.ts
@@ -114,9 +114,7 @@ export interface ThermocyclerModuleState {
 
   /** What the thermal block is currently doing. */
   currentBlockActivity:
-    | ProfileBlockActivity
-    | TargetTempBlockActivity
-    | DeactivatedBlockActivity
+    ProfileBlockActivity | TargetTempBlockActivity | DeactivatedBlockActivity
 
   /** If false, closed. If null, unknown. */
   lidOpen: boolean | null
@@ -305,10 +303,7 @@ export interface Ingredients {
 }
 
 export type AdditionalEquipmentName =
-  | 'gripper'
-  | 'wasteChute'
-  | 'stagingArea'
-  | 'trashBin'
+  'gripper' | 'wasteChute' | 'stagingArea' | 'trashBin'
 
 export interface NormalizedAdditionalEquipmentById {
   [additionalEquipmentId: string]: {
@@ -387,11 +382,7 @@ export interface PipetteEntities {
 
 // ===== MIX-IN TYPES =====
 export type ChangeTipOptions =
-  | 'always'
-  | 'once'
-  | 'never'
-  | 'perDest'
-  | 'perSource'
+  'always' | 'once' | 'never' | 'perDest' | 'perSource'
 
 export type PathOption = 'single' | 'multiAspirate' | 'multiDispense'
 
@@ -1135,8 +1126,7 @@ export interface CommandsAndWarnings extends StepInfo {
   python?: string
 }
 export type CommandCreatorResult =
-  | CommandsAndWarnings
-  | CommandCreatorErrorResponse
+  CommandsAndWarnings | CommandCreatorErrorResponse
 export type CommandCreator<Args> = (
   args: Args,
   invariantContext: InvariantContext,
@@ -1185,5 +1175,4 @@ export type UnsafePipetteMovementReason =
     }
 
 export type PipetteMovementSafetyStatus =
-  | { isSafe: true }
-  | { isSafe: false; reason: UnsafePipetteMovementReason }
+  { isSafe: true } | { isSafe: false; reason: UnsafePipetteMovementReason }

--- a/step-generation/src/utils/createTimelineFromRunCommands.ts
+++ b/step-generation/src/utils/createTimelineFromRunCommands.ts
@@ -104,8 +104,7 @@ export function getResultingTimelineFrameFromRunCommands(
           const sequenceMap = locationSequences.reduce(
             (acc: Record<string, LabwareLocationSequence>, subArray) => {
               const firstLabware:
-                | OnLabwareLocationSequenceComponent
-                | undefined = subArray.find(
+                OnLabwareLocationSequenceComponent | undefined = subArray.find(
                 (item): item is OnLabwareLocationSequenceComponent =>
                   item.kind === 'onLabware'
               )
@@ -285,8 +284,7 @@ const getIncrementStoredLabwareCounter = (
 
 const getStoredLabwareIds = (
   command:
-    | FlexStackerSetStoredLabwareRunTimeCommand
-    | FlexStackerFillRunTimeCommand
+    FlexStackerSetStoredLabwareRunTimeCommand | FlexStackerFillRunTimeCommand
 ): string[] => {
   const allStoredLabwareIds: string[] =
     command.result?.storedLabware?.flatMap(stored =>

--- a/usb-bridge/node-client/src/types.ts
+++ b/usb-bridge/node-client/src/types.ts
@@ -1,10 +1,4 @@
 export type LogLevel =
-  | 'error'
-  | 'warn'
-  | 'info'
-  | 'http'
-  | 'verbose'
-  | 'debug'
-  | 'silly'
+  'error' | 'warn' | 'info' | 'http' | 'verbose' | 'debug' | 'silly'
 
 export type Logger = Record<LogLevel, (message: string, meta?: unknown) => void>


### PR DESCRIPTION


# Overview
update prettier version to 3.9.4
https://prettier.io/blog/2026/06/27/3.9.0

this works with the latest prettier extension, v12.4.0

## Test Plan and Hands on Testing
none

## Changelog
- update the prettier version to 3.9.4

## Review requests

## Risk assessment
low
