### PR TITLE
feat(robot-server): support `requiresClosedDoor` for maintenance run commands

### DIFF
--- a/robot-server/robot_server/maintenance_runs/router/commands_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/commands_router.py
@@ -6,11 +6,16 @@ from typing import Annotated, Optional, Union
 from fastapi import Depends, Query, status
 from typing_extensions import Final, Literal
 
+from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.types import DoorState
 from opentrons.protocol_engine import (
     CommandPointer,
 )
 from opentrons.protocol_engine import (
     commands as pe_commands,
+)
+from opentrons.protocol_engine import (
+    errors as pe_errors,
 )
 from opentrons.protocol_engine.errors import CommandDoesNotExistError
 from server_utils.auth.resource_server.fastapi import require_scopes
@@ -33,6 +38,7 @@ from ..maintenance_run_models import MaintenanceRunNotFoundError
 from ..maintenance_run_orchestrator_store import MaintenanceRunOrchestratorStore
 from .base_router import RunNotFound
 from robot_server.errors.error_responses import ErrorBody, ErrorDetails
+from robot_server.hardware import get_hardware
 from robot_server.robot.control.dependencies import require_estop_in_good_state
 from robot_server.runs.command_models import (
     CommandCollectionLinks,
@@ -58,6 +64,13 @@ class CommandNotAllowed(ErrorDetails):
 
     id: Literal["CommandNotAllowed"] = "CommandNotAllowed"
     title: str = "Setup Command Not Allowed"
+
+
+class MaintenanceCommandDoorOpen(ErrorDetails):
+    """An error if a command sent with `requiresClosedDoor` is enqueued while the door is open."""
+
+    id: Literal["MaintenanceCommandDoorOpen"] = "MaintenanceCommandDoorOpen"
+    title: str = "Door Open"
 
 
 async def get_current_run_from_url(
@@ -99,7 +112,12 @@ async def get_current_run_from_url(
     responses={
         status.HTTP_201_CREATED: {"model": SimpleBody[pe_commands.Command]},
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
-        status.HTTP_409_CONFLICT: {"model": ErrorBody[CommandNotAllowed]},
+        status.HTTP_409_CONFLICT: {
+            "model": Union[
+                ErrorBody[CommandNotAllowed],
+                ErrorBody[MaintenanceCommandDoorOpen],
+            ]
+        },
     },
     dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
 )
@@ -110,6 +128,7 @@ async def create_run_command(
     ],
     run_id: Annotated[str, Depends(get_current_run_from_url)],
     check_estop: Annotated[bool, Depends(require_estop_in_good_state)],
+    hardware: Annotated[HardwareControlAPI, Depends(get_hardware)],
     waitUntilComplete: Annotated[
         bool,
         Query(
@@ -142,6 +161,15 @@ async def create_run_command(
             ),
         ),
     ] = None,
+    requiresClosedDoor: Annotated[
+        bool,
+        Query(
+            description=(
+                "If `true`, the command will be rejected if the robot's"
+                " front door is open at enqueue time."
+            ),
+        ),
+    ] = False,
 ) -> PydanticResponse[SimpleBody[pe_commands.Command]]:
     """Enqueue a protocol command.
 
@@ -156,14 +184,27 @@ async def create_run_command(
             command will be enqueued.
         check_estop: Dependency to verify the estop is in a valid state.
         run_id: Run identification to attach command to.
+        hardware: The hardware API.
+        requiresClosedDoor: If True, reject the command when the door is open.
     """
     # TODO(mc, 2022-05-26): increment the HTTP API version so that default
     # behavior is to pass through `command_intent` without overriding it
     command_intent = pe_commands.CommandIntent.SETUP
     command_create = request_body.data.model_copy(update={"intent": command_intent})
-    command = await run_orchestrator_store.add_command_and_wait_for_interval(
-        request=command_create, wait_until_complete=waitUntilComplete, timeout=timeout
-    )
+
+    if requiresClosedDoor and hardware.door_state == DoorState.OPEN:
+        raise MaintenanceCommandDoorOpen(
+            detail="This command requires the robot's door to be closed."
+        ).as_error(status.HTTP_409_CONFLICT)
+
+    try:
+        command = await run_orchestrator_store.add_command_and_wait_for_interval(
+            request=command_create,
+            wait_until_complete=waitUntilComplete,
+            timeout=timeout,
+        )
+    except pe_errors.SetupCommandNotAllowedError as e:
+        raise CommandNotAllowed.from_exc(e).as_error(status.HTTP_409_CONFLICT)
 
     response_data = run_orchestrator_store.get_command(command.id)
 

--- a/robot-server/robot_server/maintenance_runs/router/commands_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/commands_router.py
@@ -165,11 +165,11 @@ async def create_run_command(
         bool,
         Query(
             description=(
-                "If `true`, the command will be rejected if the robot's"
-                " front door is open at enqueue time."
+                "If `True`, the command will be rejected if"
+                " the robot's front door is open at enqueue time."
             ),
         ),
-    ] = False,
+    ] = True,
 ) -> PydanticResponse[SimpleBody[pe_commands.Command]]:
     """Enqueue a protocol command.
 

--- a/robot-server/tests/maintenance_runs/router/conftest.py
+++ b/robot-server/tests/maintenance_runs/router/conftest.py
@@ -3,6 +3,7 @@
 import pytest
 from decoy import Decoy
 
+from opentrons.hardware_control import HardwareControlAPI, OT3HardwareControlAPI
 from opentrons.protocol_engine import ProtocolEngine
 
 from robot_server.deck_configuration.store import DeckConfigurationStore
@@ -27,6 +28,12 @@ def mock_maintenance_run_orchestrator_store(
 def mock_protocol_engine(decoy: Decoy) -> ProtocolEngine:
     """Get a mock MaintenanceRunOrchestratorStore interface."""
     return decoy.mock(cls=ProtocolEngine)
+
+
+@pytest.fixture
+def mock_hardware_api(decoy: Decoy) -> HardwareControlAPI:
+    """Get a mock HardwareControlAPI."""
+    return decoy.mock(cls=OT3HardwareControlAPI)
 
 
 @pytest.fixture

--- a/robot-server/tests/maintenance_runs/router/test_commands_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_commands_router.py
@@ -98,6 +98,8 @@ async def test_create_run_command(
         params=pe_commands.WaitForResumeParams(message="Hello"),
     )
 
+    decoy.when(mock_hardware_api.door_state).then_return(DoorState.CLOSED)
+
     decoy.when(
         await mock_maintenance_run_orchestrator_store.add_command_and_wait_for_interval(
             request=pe_commands.WaitForResumeCreate(
@@ -147,6 +149,8 @@ async def test_create_run_command_blocking_completion(
         result=pe_commands.WaitForResumeResult(),
     )
 
+    decoy.when(mock_hardware_api.door_state).then_return(DoorState.CLOSED)
+
     decoy.when(
         await mock_maintenance_run_orchestrator_store.add_command_and_wait_for_interval(
             request=command_request, wait_until_complete=True, timeout=999
@@ -171,12 +175,12 @@ async def test_create_run_command_blocking_completion(
     assert result.status_code == 201
 
 
-async def test_create_run_command_door_open_blocks_when_requires_closed_door(
+async def test_create_run_command_door_open_blocks_by_default(
     decoy: Decoy,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     mock_hardware_api: HardwareControlAPI,
 ) -> None:
-    """It should return a 409 when requiresClosedDoor=True and the door is open."""
+    """It should return a 409 by default when the door is open."""
     command_request = pe_commands.HomeCreate(params=pe_commands.HomeParams())
 
     decoy.when(mock_hardware_api.door_state).then_return(DoorState.OPEN)
@@ -190,19 +194,18 @@ async def test_create_run_command_door_open_blocks_when_requires_closed_door(
             timeout=None,
             check_estop=True,
             hardware=mock_hardware_api,
-            requiresClosedDoor=True,
         )
 
     assert exc_info.value.status_code == 409
     assert exc_info.value.content["errors"][0]["id"] == "MaintenanceCommandDoorOpen"
 
 
-async def test_create_run_command_door_open_allows_when_not_required(
+async def test_create_run_command_door_open_allows_when_opted_out(
     decoy: Decoy,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     mock_hardware_api: HardwareControlAPI,
 ) -> None:
-    """It should allow commands through when requiresClosedDoor is not set, even if the door is open."""
+    """It should allow commands through when requiresClosedDoor is False, even if the door is open."""
     command_request = pe_commands.HomeCreate(params=pe_commands.HomeParams())
 
     command_once_added = pe_commands.Home(

--- a/robot-server/tests/maintenance_runs/router/test_commands_router.py
+++ b/robot-server/tests/maintenance_runs/router/test_commands_router.py
@@ -5,6 +5,8 @@ from datetime import datetime
 import pytest
 from decoy import Decoy, matchers
 
+from opentrons.hardware_control import HardwareControlAPI
+from opentrons.hardware_control.types import DoorState
 from opentrons.protocol_engine import (
     CommandPointer,
     CommandSlice,
@@ -81,6 +83,7 @@ async def test_get_current_run_from_url_not_current(
 async def test_create_run_command(
     decoy: Decoy,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
+    mock_hardware_api: HardwareControlAPI,
 ) -> None:
     """It should add the requested command to the ProtocolEngine and return it."""
     command_request = pe_commands.WaitForResumeCreate(
@@ -117,6 +120,7 @@ async def test_create_run_command(
         run_orchestrator_store=mock_maintenance_run_orchestrator_store,
         timeout=None,
         check_estop=True,
+        hardware=mock_hardware_api,
     )
 
     assert result.content.data == command_once_added
@@ -126,6 +130,7 @@ async def test_create_run_command(
 async def test_create_run_command_blocking_completion(
     decoy: Decoy,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
+    mock_hardware_api: HardwareControlAPI,
 ) -> None:
     """It should be able to create a command and wait for it to execute."""
     command_request = pe_commands.WaitForResumeCreate(
@@ -159,9 +164,84 @@ async def test_create_run_command_blocking_completion(
         timeout=999,
         run_orchestrator_store=mock_maintenance_run_orchestrator_store,
         check_estop=True,
+        hardware=mock_hardware_api,
     )
 
     assert result.content.data == command_once_completed
+    assert result.status_code == 201
+
+
+async def test_create_run_command_door_open_blocks_when_requires_closed_door(
+    decoy: Decoy,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
+    mock_hardware_api: HardwareControlAPI,
+) -> None:
+    """It should return a 409 when requiresClosedDoor=True and the door is open."""
+    command_request = pe_commands.HomeCreate(params=pe_commands.HomeParams())
+
+    decoy.when(mock_hardware_api.door_state).then_return(DoorState.OPEN)
+
+    with pytest.raises(ApiError) as exc_info:
+        await create_run_command(
+            run_id="run-id",
+            request_body=RequestModel(data=command_request),
+            waitUntilComplete=False,
+            run_orchestrator_store=mock_maintenance_run_orchestrator_store,
+            timeout=None,
+            check_estop=True,
+            hardware=mock_hardware_api,
+            requiresClosedDoor=True,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.content["errors"][0]["id"] == "MaintenanceCommandDoorOpen"
+
+
+async def test_create_run_command_door_open_allows_when_not_required(
+    decoy: Decoy,
+    mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
+    mock_hardware_api: HardwareControlAPI,
+) -> None:
+    """It should allow commands through when requiresClosedDoor is not set, even if the door is open."""
+    command_request = pe_commands.HomeCreate(params=pe_commands.HomeParams())
+
+    command_once_added = pe_commands.Home(
+        id="command-id",
+        key="command-key",
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=pe_commands.CommandStatus.QUEUED,
+        params=pe_commands.HomeParams(),
+    )
+
+    decoy.when(mock_hardware_api.door_state).then_return(DoorState.OPEN)
+
+    decoy.when(
+        await mock_maintenance_run_orchestrator_store.add_command_and_wait_for_interval(
+            request=pe_commands.HomeCreate(
+                params=pe_commands.HomeParams(),
+                intent=pe_commands.CommandIntent.SETUP,
+            ),
+            wait_until_complete=False,
+            timeout=None,
+        )
+    ).then_return(command_once_added)
+
+    decoy.when(
+        mock_maintenance_run_orchestrator_store.get_command("command-id")
+    ).then_return(command_once_added)
+
+    result = await create_run_command(
+        run_id="run-id",
+        request_body=RequestModel(data=command_request),
+        waitUntilComplete=False,
+        run_orchestrator_store=mock_maintenance_run_orchestrator_store,
+        timeout=None,
+        check_estop=True,
+        hardware=mock_hardware_api,
+        requiresClosedDoor=False,
+    )
+
+    assert result.content.data == command_once_added
     assert result.status_code == 201
 
 


### PR DESCRIPTION
Closes [EXEC-2829](https://opentrons.atlassian.net/browse/EXEC-2829)

# Overview

We'd like to ensure that `SETUP` type commands emitted by the app and ODD conditionally error out if the door is open. To support this end, this PR adds a new optional parameter to our `POST /maintenance_runs/{runId}/commands` route, called `requiresClosedDoor`. If set to true, the command network request responds with a `409` error, `MaintenanceCommandDoorOpen`. We default to `true`, partly for footgun-future-proofing sake, and because we believe this behavior more closely aligned to what should occur in reality.

While there are various ways to approach an implementation here, this approach is the least invasive. It does come with the tradeoff that we do not check the door status _during_ an active maintenance run command, only when the command is issued, but Product has determined that this behavior is acceptable.

## Test Plan and Hands on Testing

- Verified that sending a maintenance run command to a robot successfully errors out if the door is open and `requiresClosedDoor` is true.
- Verified no regressions in current behavior.

## Changelog

- `POST /maintenance_runs/{runId}/commands` now accepts an optional `requiresClosedDoor` property, which fails the command if the door is open at the time the request is received by the server.

## Review requests

- Are we ok with the general approach here?

## Risk assessment

- very low, orthogonal and auditable 


[EXEC-2829]: https://opentrons.atlassian.net/browse/EXEC-2829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ