### PR TITLE
fix(app): fixes sending and running protocols on CRS robots

### DIFF
--- a/api-client/src/protocols/createProtocol.ts
+++ b/api-client/src/protocols/createProtocol.ts
@@ -14,7 +14,8 @@ export function createProtocol(
   protocolKey?: string,
   protocolKind?: string,
   runTimeParameterValues?: RunTimeParameterValuesCreateData,
-  runTimeParameterFiles?: RunTimeParameterFilesCreateData
+  runTimeParameterFiles?: RunTimeParameterFilesCreateData,
+  userNotes?: string
 ): ResponsePromise<Protocol> {
   const formData = new FormData()
   files.forEach(file => {
@@ -41,5 +42,6 @@ export function createProtocol(
 
   return request<Protocol, FormData>(POST, '/protocols', config, {
     body: formData,
+    userNotes,
   })
 }

--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -30,5 +30,6 @@
   "attach_pipette_right": "Launching attach pipette on right mount flow",
   "finish_attach_gripper": "Finishing attach gripper flow",
   "finish_detach_gripper": "Finishing detach gripper flow",
-  "finish_recalibrate_gripper": "Finishing recalibrate gripper flow"
+  "finish_recalibrate_gripper": "Finishing recalibrate gripper flow",
+  "create_protocol": "Creating protocol"
 }

--- a/app/src/local-resources/access-control/__tests__/maintenanceRunDocumentation.test.tsx
+++ b/app/src/local-resources/access-control/__tests__/maintenanceRunDocumentation.test.tsx
@@ -71,8 +71,8 @@ vi.mock('/app/redux/robot-auth', async importOriginal => {
   const actual = await importOriginal()
   return {
     ...(actual as any),
-    useCurrentUsername: vi.fn(() => 'alice'),
     useCurrentRobotName: vi.fn(() => 'otie'),
+    useUsernameForRobot: vi.fn(() => 'alice'),
   }
 })
 

--- a/app/src/local-resources/access-control/__tests__/useDocumentationState.test.ts
+++ b/app/src/local-resources/access-control/__tests__/useDocumentationState.test.ts
@@ -6,7 +6,7 @@ import {
   useAuthSettingsQuery,
 } from '@opentrons/react-api-client'
 
-import { useCurrentUsername } from '/app/redux/robot-auth'
+import { useUsernameForRobot } from '/app/redux/robot-auth'
 
 import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../__fixtures__/documentationState'
 import { useDocumentationState } from '../useDocumentationState'
@@ -37,8 +37,8 @@ vi.mock('/app/redux/robot-auth', async importOriginal => {
   const actual = await importOriginal()
   return {
     ...(actual as any),
-    useCurrentUsername: vi.fn(() => 'alice'),
     useCurrentRobotName: vi.fn(() => 'otie'),
+    useUsernameForRobot: vi.fn(() => 'alice'),
   }
 })
 
@@ -158,7 +158,7 @@ describe('useDocumentationState', () => {
     }
   })
   it('opens login modal when username is not provided', async () => {
-    vi.mocked(useCurrentUsername).mockReturnValue(null)
+    vi.mocked(useUsernameForRobot).mockReturnValue(null)
     const { result } = renderHook(() => useDocumentationState(), { wrapper })
 
     await act(async () => {
@@ -176,7 +176,7 @@ describe('useDocumentationState', () => {
   })
 
   it('calls onCancel when login modal is dismissed without logging in', async () => {
-    vi.mocked(useCurrentUsername).mockReturnValue(null)
+    vi.mocked(useUsernameForRobot).mockReturnValue(null)
     vi.mocked(mockShowLoginModal).mockResolvedValue(null)
     const onCancel = vi.fn()
     const { result } = renderHook(() => useDocumentationState(), { wrapper })

--- a/app/src/local-resources/access-control/__tests__/useMaintenanceRunDocumentation.test.ts
+++ b/app/src/local-resources/access-control/__tests__/useMaintenanceRunDocumentation.test.ts
@@ -42,8 +42,8 @@ vi.mock('/app/redux/robot-auth', async importOriginal => {
   const actual = await importOriginal()
   return {
     ...(actual as any),
-    useCurrentUsername: vi.fn(() => 'alice'),
     useCurrentRobotName: vi.fn(() => 'otie'),
+    useUsernameForRobot: vi.fn(() => 'alice'),
   }
 })
 

--- a/app/src/local-resources/access-control/__tests__/usePromptForDocumentation.test.ts
+++ b/app/src/local-resources/access-control/__tests__/usePromptForDocumentation.test.ts
@@ -6,7 +6,7 @@ import {
   useAuthSettingsQuery,
 } from '@opentrons/react-api-client'
 
-import { useCurrentUsername } from '/app/redux/robot-auth'
+import { useUsernameForRobot } from '/app/redux/robot-auth'
 
 import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../__fixtures__/documentationState'
 import { usePromptForDocumentation } from '../usePromptForDocumentation'
@@ -37,7 +37,7 @@ vi.mock('/app/redux/robot-auth', async importOriginal => {
   const actual = await importOriginal()
   return {
     ...(actual as any),
-    useCurrentUsername: vi.fn(() => 'alice'),
+    useUsernameForRobot: vi.fn(() => 'alice'),
     useCurrentRobotName: vi.fn(() => 'otie'),
   }
 })
@@ -130,7 +130,7 @@ describe('usePromptForDocumentation', () => {
     expect(mockShowDocumentationRequiredModal).not.toHaveBeenCalled()
   })
   it('calls onCancel when login modal is dismissed without logging in', async () => {
-    vi.mocked(useCurrentUsername).mockReturnValue(null)
+    vi.mocked(useUsernameForRobot).mockReturnValue(null)
     vi.mocked(mockShowLoginModal).mockResolvedValue(null)
     const onCancel = vi.fn()
 

--- a/app/src/local-resources/access-control/useDocumentationState.ts
+++ b/app/src/local-resources/access-control/useDocumentationState.ts
@@ -5,7 +5,7 @@ import {
   useAuthSettingsQuery,
 } from '@opentrons/react-api-client'
 
-import { useCurrentRobotName, useCurrentUsername } from '/app/redux/robot-auth'
+import { useCurrentRobotName, useUsernameForRobot } from '/app/redux/robot-auth'
 
 import { DocumentationRequiredModalContext } from './DocumentationRequiredModalContext'
 
@@ -31,13 +31,15 @@ import type {
  * @param docreport - optional pre-provided documentation report
  */
 export function useDocumentationState(
-  docreport?: DocumentationReport
+  docreport?: DocumentationReport,
+  robotName?: string | null
 ): DocumentationState {
   const authSettingsQuery = useAuthSettingsQuery()
   const accessControlEnabledQuery = useAccessControlEnabledQuery()
 
-  const currentUsername = useCurrentUsername()
-  const currentRobotName = useCurrentRobotName()
+  const foundName = useCurrentRobotName()
+  const currentRobotName = robotName ?? foundName
+  const currentUsername = useUsernameForRobot(currentRobotName)
 
   const accessControlEnabled =
     accessControlEnabledQuery?.data?.data?.accessControlEnabled ?? false
@@ -72,6 +74,7 @@ export function useDocumentationState(
     ) => {
       let username = usernameOverride ?? currentUsername
       if (username == null || username.length === 0) {
+        console.log('calling requireLogin', currentRobotName)
         const loginResult = await requireLogin({
           robotName: currentRobotName ?? '',
         })

--- a/app/src/local-resources/access-control/useDocumentationState.ts
+++ b/app/src/local-resources/access-control/useDocumentationState.ts
@@ -9,6 +9,7 @@ import { useCurrentRobotName, useUsernameForRobot } from '/app/redux/robot-auth'
 
 import { DocumentationRequiredModalContext } from './DocumentationRequiredModalContext'
 
+import type { HostConfig } from '@opentrons/api-client'
 import type {
   DocumentationReport,
   DocumentationState,
@@ -18,24 +19,28 @@ import type {
 } from '@opentrons/react-api-client'
 
 /**
- * API for the access-control gate.
- *
- *  Runs the access-control gate and returns the following states:
- *   1. If access control is disabled on the robot, the gate returns { reasonForInteractionRequired: false}
- *   2. If access control is enabled and documentation is provided from state, the gate returns the provided docreport
- *   3. If access control is enabled and documentation is not provided or is invalid, the gate returns a function that, when invoked,
- *   opens the documentation modal and returns the documentation report
- *
- *  This documentation state is designed to be passed along to the useDocumentedMutation hook.
+ * Provides a documentation state for use in the useDocumentedMutation hook.
+ * Runs the appropriate auth settings queries to see what login or documentation checks are needed.
+ * When a mutation runs, if no initial docreport is provided, the documentation modal will pop up.
+ * Notably, the result of this modal is not stored, and only passed along to the single mutation that called it.
+ * If you need to pass one docreport along to multiple mutations, use either useMaintenanceRunDocumentation or useLinkedDocumentationState.
  *
  * @param docreport - optional pre-provided documentation report
+ * @param robotName - for use when this is called on the desktop but not from a /devices/<robotName> route
+ * @returns a documentation state object
  */
 export function useDocumentationState(
   docreport?: DocumentationReport,
-  robotName?: string | null
+  robotName?: string | null,
+  hostOverride?: HostConfig | null,
+  onPromptForDocumentation?: (docreport: DocumentationReport) => void,
+  providedActionsToDocument?: DocumentedAction[]
 ): DocumentationState {
-  const authSettingsQuery = useAuthSettingsQuery()
-  const accessControlEnabledQuery = useAccessControlEnabledQuery()
+  const authSettingsQuery = useAuthSettingsQuery(undefined, hostOverride)
+  const accessControlEnabledQuery = useAccessControlEnabledQuery(
+    undefined,
+    hostOverride
+  )
 
   const foundName = useCurrentRobotName()
   const currentRobotName = robotName ?? foundName
@@ -87,13 +92,21 @@ export function useDocumentationState(
       }
       const docResult = await requireDocumentation(
         username ?? '',
-        actionsToDocument,
+        providedActionsToDocument ?? actionsToDocument,
         handleCancel,
         initialDocreport
       )
+      onPromptForDocumentation?.(docResult)
       return docResult
     },
-    [currentRobotName, currentUsername, requireDocumentation, requireLogin]
+    [
+      currentRobotName,
+      currentUsername,
+      onPromptForDocumentation,
+      providedActionsToDocument,
+      requireDocumentation,
+      requireLogin,
+    ]
   )
 
   const askForLogin = useCallback(async () => {

--- a/app/src/local-resources/access-control/useLinkedDocumentationState.ts
+++ b/app/src/local-resources/access-control/useLinkedDocumentationState.ts
@@ -18,7 +18,9 @@ export const useLinkedDocumentationState = (
 
   const onPromptForDocumentation = useCallback(
     (docreport: DocumentationReport) => {
-      setDocreport(docreport)
+      if (docreport.length > 0) {
+        setDocreport(docreport)
+      }
     },
     []
   )

--- a/app/src/local-resources/access-control/useLinkedDocumentationState.ts
+++ b/app/src/local-resources/access-control/useLinkedDocumentationState.ts
@@ -1,0 +1,35 @@
+import { useCallback, useState } from 'react'
+
+import { useDocumentationState } from './useDocumentationState'
+
+import type { HostConfig } from '@opentrons/api-client'
+import type {
+  DocumentationReport,
+  DocumentationState,
+  DocumentedAction,
+} from '@opentrons/react-api-client'
+
+export const useLinkedDocumentationState = (
+  actionsToDocument: DocumentedAction[],
+  robotName?: string | null,
+  hostOverride?: HostConfig | null
+): DocumentationState => {
+  const [docreport, setDocreport] = useState<DocumentationReport>()
+
+  const onPromptForDocumentation = useCallback(
+    (docreport: DocumentationReport) => {
+      setDocreport(docreport)
+    },
+    []
+  )
+
+  const documentationState = useDocumentationState(
+    docreport,
+    robotName,
+    hostOverride,
+    onPromptForDocumentation,
+    actionsToDocument
+  )
+
+  return documentationState
+}

--- a/app/src/local-resources/api-host-provider/ApiHostProvider.tsx
+++ b/app/src/local-resources/api-host-provider/ApiHostProvider.tsx
@@ -40,6 +40,7 @@ export function ApiHostProvider({
             port: robot.port,
             requestor: requestorToUse,
             token,
+            robotName,
           }
         : null,
     [requestorToUse, robot?.ip, robot?.port, robotName, token]

--- a/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
@@ -175,16 +175,7 @@ export function ChooseProtocolSlideoutComponent(
     robot.ip
   )
 
-  const { uploadCsvFile } = useUploadCsvFileMutation(
-    {},
-    robot != null
-      ? {
-          hostname: robot.ip,
-          requestor:
-            robot?.ip === OPENTRONS_USB ? appShellUSBRequestor : undefined,
-        }
-      : null
-  )
+  const { uploadCsvFile } = useUploadCsvFileMutation()
 
   const srcFileObjects =
     selectedProtocol != null
@@ -221,7 +212,7 @@ export function ChooseProtocolSlideoutComponent(
         })
       },
     },
-    { hostname: robot.ip },
+    undefined,
     shouldApplyOffsets
       ? offsetCandidates.map(({ vector, location, definitionUri }) => ({
           vector,
@@ -671,7 +662,7 @@ export function ChooseProtocolSlideoutComponent(
       maxSteps={hasRunTimeParameters ? 2 : 1}
       title={t('choose_protocol_to_run', { name })}
       footer={
-        <ApiHostProvider robotName={name}>
+        <>
           {currentPage === 1
             ? !isFlex && (
                 <LegacyApplyHistoricOffsets
@@ -697,7 +688,7 @@ export function ChooseProtocolSlideoutComponent(
               )
             : null}
           {hasRunTimeParameters ? multiPageFooter : singlePageFooter}
-        </ApiHostProvider>
+          </>
       }
     >
       {showSlideout ? (

--- a/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
@@ -52,9 +52,7 @@ import { getAnalysisStatus } from '/app/organisms/Desktop/ProtocolsLanding/utils
 import { LegacyApplyHistoricOffsets } from '/app/organisms/LegacyApplyHistoricOffsets'
 import { useOffsetCandidatesForAnalysis } from '/app/organisms/LegacyApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
 import { useRobotType } from '/app/redux-resources/robots'
-import { OPENTRONS_USB } from '/app/redux/discovery'
 import { getStoredProtocols } from '/app/redux/protocol-storage'
-import { appShellUSBRequestor } from '/app/redux/shell/remote'
 import {
   getRunTimeParameterFilesForRun,
   getRunTimeParameterValuesForRun,

--- a/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
@@ -723,7 +723,11 @@ export function ChooseProtocolSlideoutComponent(
 export function ChooseProtocolSlideout(
   props: ChooseProtocolSlideoutProps
 ): JSX.Element | null {
-  return <ChooseProtocolSlideoutComponent {...props} />
+  return (
+    <ApiHostProvider robotName={props.robot.name}>
+      <ChooseProtocolSlideoutComponent {...props} />
+    </ApiHostProvider>
+  )
 }
 
 interface StoredProtocolListProps {

--- a/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseProtocolSlideout/index.tsx
@@ -686,7 +686,7 @@ export function ChooseProtocolSlideoutComponent(
               )
             : null}
           {hasRunTimeParameters ? multiPageFooter : singlePageFooter}
-          </>
+        </>
       }
     >
       {showSlideout ? (

--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
@@ -9,6 +9,7 @@ import {
   useHost,
 } from '@opentrons/react-api-client'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { getValidCustomLabwareFiles } from '/app/redux/custom-labware/selectors'
 
 import type { UseMutateFunction } from 'react-query'
@@ -49,12 +50,15 @@ export function useCreateRunFromProtocol(
     getValidCustomLabwareFiles(state)
   )
 
+  const documentationState = useDocumentationState(undefined, host?.robotName)
+
   const {
     createRun,
     isLoading: isCreatingRun,
     reset: resetRunMutation,
     error: runError,
   } = useCreateRunMutation(
+    documentationState,
     {
       ...options,
       onSuccess: (...args) => {
@@ -74,6 +78,7 @@ export function useCreateRunFromProtocol(
     error: protocolError,
     reset: resetProtocolMutation,
   } = useCreateProtocolMutation(
+    documentationState,
     {
       onSuccess: (data, { runTimeParameterValues, runTimeParameterFiles }) => {
         createRun({

--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/useCreateRunFromProtocol.ts
@@ -9,7 +9,7 @@ import {
   useHost,
 } from '@opentrons/react-api-client'
 
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { getValidCustomLabwareFiles } from '/app/redux/custom-labware/selectors'
 
 import type { UseMutateFunction } from 'react-query'
@@ -50,7 +50,11 @@ export function useCreateRunFromProtocol(
     getValidCustomLabwareFiles(state)
   )
 
-  const documentationState = useDocumentationState(undefined, host?.robotName)
+  const documentationState = useLinkedDocumentationState(
+    ['create_protocol', 'play_run'],
+    host?.robotName,
+    host
+  )
 
   const {
     createRun,

--- a/app/src/organisms/Desktop/SendProtocolToFlexSlideout/index.tsx
+++ b/app/src/organisms/Desktop/SendProtocolToFlexSlideout/index.tsx
@@ -11,6 +11,7 @@ import {
 import { useCreateProtocolMutation } from '@opentrons/react-api-client'
 import { FLEX_DISPLAY_NAME, FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useToaster } from '/app/organisms/ToasterOven'
 import { getValidCustomLabwareFiles } from '/app/redux/custom-labware'
 import { OPENTRONS_USB } from '/app/redux/discovery'
@@ -53,7 +54,13 @@ export function SendProtocolToFlexSlideout(
 
   const { eatToast, makeToast } = useToaster()
 
+  const documentationState = useDocumentationState(
+    undefined,
+    selectedRobot?.name
+  )
+
   const { mutateAsync: createProtocolAsync } = useCreateProtocolMutation(
+    documentationState,
     {},
     selectedRobot != null
       ? {

--- a/app/src/organisms/Desktop/SendProtocolToFlexSlideout/index.tsx
+++ b/app/src/organisms/Desktop/SendProtocolToFlexSlideout/index.tsx
@@ -58,6 +58,7 @@ export function SendProtocolToFlexSlideout(
 
   const token = useAccessTokenForRobot(selectedRobot?.name ?? null)
 
+  // TODO(jj, 2026-07-08): Remove all manual host configs
   const hostConfig = useMemo(() => {
     return selectedRobot != null
       ? {

--- a/app/src/organisms/Desktop/SendProtocolToFlexSlideout/index.tsx
+++ b/app/src/organisms/Desktop/SendProtocolToFlexSlideout/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
@@ -12,10 +12,12 @@ import { useCreateProtocolMutation } from '@opentrons/react-api-client'
 import { FLEX_DISPLAY_NAME, FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { ApiHostProvider } from '/app/local-resources/api-host-provider/ApiHostProvider'
 import { useToaster } from '/app/organisms/ToasterOven'
 import { getValidCustomLabwareFiles } from '/app/redux/custom-labware'
 import { OPENTRONS_USB } from '/app/redux/discovery'
 import { getIsProtocolAnalysisInProgress } from '/app/redux/protocol-storage'
+import { useAccessTokenForRobot } from '/app/redux/robot-auth'
 import { useIsRobotOnWrongVersionOfSoftware } from '/app/redux/robot-update'
 import { appShellUSBRequestor } from '/app/redux/shell/remote'
 import { getAnalysisStatus } from '/app/transformations/analysis'
@@ -54,23 +56,33 @@ export function SendProtocolToFlexSlideout(
 
   const { eatToast, makeToast } = useToaster()
 
-  const documentationState = useDocumentationState(
-    undefined,
-    selectedRobot?.name
-  )
+  const token = useAccessTokenForRobot(selectedRobot?.name ?? null)
 
-  const { mutateAsync: createProtocolAsync } = useCreateProtocolMutation(
-    documentationState,
-    {},
-    selectedRobot != null
+  const hostConfig = useMemo(() => {
+    return selectedRobot != null
       ? {
           hostname: selectedRobot.ip,
+          robotName: selectedRobot.name,
+          token,
+          port: selectedRobot.port,
           requestor:
             selectedRobot?.ip === OPENTRONS_USB
               ? appShellUSBRequestor
               : undefined,
         }
       : null
+  }, [selectedRobot, token])
+
+  const documentationState = useDocumentationState(
+    undefined,
+    selectedRobot?.name,
+    hostConfig
+  )
+
+  const { mutateAsync: createProtocolAsync } = useCreateProtocolMutation(
+    documentationState,
+    {},
+    hostConfig
   )
 
   const isAnalyzing = useSelector((state: State) =>
@@ -147,31 +159,33 @@ export function SendProtocolToFlexSlideout(
   }
 
   return (
-    <ChooseRobotSlideout
-      isExpanded={isExpanded}
-      isSelectedRobotOnDifferentSoftwareVersion={
-        isSelectedRobotOnDifferentSoftwareVersion
-      }
-      onCloseClick={onCloseClick}
-      title={t('protocol_list:send_to_robot', {
-        robot_display_name: FLEX_DISPLAY_NAME,
-      })}
-      footer={
-        <PrimaryButton
-          disabled={
-            selectedRobot == null || isSelectedRobotOnDifferentSoftwareVersion
-          }
-          onClick={handleSendClick}
-          width="100%"
-        >
-          {t('protocol_details:send')}
-        </PrimaryButton>
-      }
-      selectedRobot={selectedRobot}
-      setSelectedRobot={setSelectedRobot}
-      robotType={FLEX_ROBOT_TYPE}
-      isAnalysisError={analysisStatus === 'error'}
-      isAnalysisStale={analysisStatus === 'stale'}
-    />
+    <ApiHostProvider robotName={selectedRobot?.name ?? null}>
+      <ChooseRobotSlideout
+        isExpanded={isExpanded}
+        isSelectedRobotOnDifferentSoftwareVersion={
+          isSelectedRobotOnDifferentSoftwareVersion
+        }
+        onCloseClick={onCloseClick}
+        title={t('protocol_list:send_to_robot', {
+          robot_display_name: FLEX_DISPLAY_NAME,
+        })}
+        footer={
+          <PrimaryButton
+            disabled={
+              selectedRobot == null || isSelectedRobotOnDifferentSoftwareVersion
+            }
+            onClick={handleSendClick}
+            width="100%"
+          >
+            {t('protocol_details:send')}
+          </PrimaryButton>
+        }
+        selectedRobot={selectedRobot}
+        setSelectedRobot={setSelectedRobot}
+        robotType={FLEX_ROBOT_TYPE}
+        isAnalysisError={analysisStatus === 'error'}
+        isAnalysisStale={analysisStatus === 'stale'}
+      />
+    </ApiHostProvider>
   )
 }

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/ProtocolSetupParameters.tsx
@@ -22,6 +22,7 @@ import {
 } from '@opentrons/shared-data'
 
 import { useScrollRef } from '/app/App/hooks/useModuleAttachedToast'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 import { useToaster } from '/app/organisms/ToasterOven'
 import {
@@ -175,15 +176,20 @@ export function ProtocolSetupParameters({
 
   const { uploadCsvFile } = useUploadCsvFileMutation({}, host)
 
-  const { createRun, isLoading: isRunLoading } = useCreateRunMutation({
-    onSuccess: data => {
-      queryClient
-        .invalidateQueries(getQueryKey(host, 'runs'))
-        .catch((e: Error) => {
-          console.error(`could not invalidate runs cache: ${e.message}`)
-        })
-    },
-  })
+  const documentationState = useDocumentationState()
+
+  const { createRun, isLoading: isRunLoading } = useCreateRunMutation(
+    documentationState,
+    {
+      onSuccess: data => {
+        queryClient
+          .invalidateQueries(getQueryKey(host, 'runs'))
+          .catch((e: Error) => {
+            console.error(`could not invalidate runs cache: ${e.message}`)
+          })
+      },
+    }
+  )
   const handleConfirmValues = (): void => {
     if (hasMissingFileParam) {
       makeSnackbar(t('protocol_requires_csv') as string)

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/ProtocolSetupParameters.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/ProtocolSetupParameters.test.tsx
@@ -12,6 +12,7 @@ import {
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useToaster } from '/app/organisms/ToasterOven'
 
 import { ProtocolSetupParameters } from '..'
@@ -42,6 +43,9 @@ vi.mock('react-router-dom', async importOriginal => {
   }
 })
 vi.mock('/app/redux/config')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 
 const MOCK_HOST_CONFIG: HostConfig = { hostname: 'MOCK_HOST' }
 const mockCreateProtocolAnalysis = vi.fn()
@@ -76,7 +80,7 @@ describe('ProtocolSetupParameters', () => {
       .calledWith(expect.anything(), expect.anything())
       .thenReturn({ createProtocolAnalysis: mockCreateProtocolAnalysis } as any)
     when(vi.mocked(useCreateRunMutation))
-      .calledWith(expect.anything())
+      .calledWith(expect.anything(), expect.anything())
       .thenReturn({ createRun: mockCreateRun } as any)
     when(vi.mocked(useUploadCsvFileMutation))
       .calledWith(expect.anything(), expect.anything())

--- a/app/src/organisms/ODD/QuickTransferFlow/SummaryAndSettings.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/SummaryAndSettings.tsx
@@ -19,6 +19,7 @@ import {
   useHost,
 } from '@opentrons/react-api-client'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 import { useTrackEventWithRobotSerial } from '/app/redux-resources/analytics'
 import {
@@ -73,9 +74,12 @@ export function SummaryAndSettings(
     initializeSummaryState
   )
 
-  const { mutateAsync: createProtocolAsync } = useCreateProtocolMutation()
+  const documentationState = useDocumentationState()
+  const { mutateAsync: createProtocolAsync } =
+    useCreateProtocolMutation(documentationState)
 
   const { createRun } = useCreateRunMutation(
+    documentationState,
     {
       onSuccess: data => {
         queryClient

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/SummaryAndSettings.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/SummaryAndSettings.test.tsx
@@ -9,6 +9,7 @@ import { TRASH_BIN_ADAPTER_FIXTURE } from '@opentrons/shared-data'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useTrackEventWithRobotSerial } from '/app/redux-resources/analytics'
 import { ANALYTICS_QUICK_TRANSFER_RUN_NOW } from '/app/redux/analytics'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
@@ -48,6 +49,9 @@ vi.mock('../utils', async () => {
 vi.mock('../utils/createQuickTransferFile')
 vi.mock('@opentrons/react-api-client')
 vi.mock('/app/resources/deck_configuration')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 
 const render = (props: ComponentProps<typeof SummaryAndSettings>) => {
   return renderWithProviders(<SummaryAndSettings {...props} />, {

--- a/app/src/pages/ODD/ProtocolDashboard/LongPressModal.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/LongPressModal.tsx
@@ -16,6 +16,7 @@ import { useCreateRunMutation } from '@opentrons/react-api-client'
 
 import { MAXIMUM_PINNED_PROTOCOLS } from '/app/App/constants'
 import { getTopPortalEl } from '/app/App/portal'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { SmallModalChildren } from '/app/molecules/OddModal'
 import { useToaster } from '/app/organisms/ToasterOven'
 import { getPinnedProtocolIds, updateConfigValue } from '/app/redux/config'
@@ -45,6 +46,7 @@ export function LongPressModal({
   const pinned = pinnedProtocolIds.includes(protocolId)
 
   const [showMaxPinsAlert, setShowMaxPinsAlert] = useState<boolean>(false)
+  const documentationState = useDocumentationState()
 
   // This looks totally bonkers, and it is. This construction is to make
   // it easier to use in unit tests, where we have to mock both the mutation
@@ -54,7 +56,7 @@ export function LongPressModal({
   //
   // Having the empty function fallback lets the mocks get called. In real use it
   // shouldn't ever get needed.
-  const createRunUse = useCreateRunMutation({
+  const createRunUse = useCreateRunMutation(documentationState, {
     onSuccess: data => {
       const runId: string = data.data.id
       navigate(`/runs/${runId}/setup`)

--- a/app/src/pages/ODD/ProtocolDashboard/__tests__/LongPressModal.test.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/__tests__/LongPressModal.test.tsx
@@ -8,6 +8,7 @@ import { useCreateRunMutation, useHost } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 
 import { LongPressModal } from '../LongPressModal'
 
@@ -21,6 +22,9 @@ const mockSetTargetProtocolId = vi.fn()
 
 vi.mock('@opentrons/api-client')
 vi.mock('@opentrons/react-api-client')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 
 const render = (longPress: UseLongPressResult) => {
   return renderWithProviders(

--- a/app/src/pages/ODD/ProtocolDashboard/__tests__/PinnedProtocol.test.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/__tests__/PinnedProtocol.test.tsx
@@ -6,6 +6,7 @@ import { COLORS, TYPOGRAPHY } from '@opentrons/components'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useFeatureFlag } from '/app/redux/config'
 
 import { PinnedProtocol } from '../PinnedProtocol'
@@ -26,6 +27,9 @@ vi.mock('react-router-dom', async importOriginal => {
   }
 })
 vi.mock('/app/redux/config')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 vi.mock('@opentrons/components', async () => {
   const actual = await vi.importActual('@opentrons/components')
   return {

--- a/app/src/pages/ODD/ProtocolDashboard/__tests__/ProtocolCard.test.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/__tests__/ProtocolCard.test.tsx
@@ -9,6 +9,7 @@ import {
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useFeatureFlag } from '/app/redux/config'
 
 import { ProtocolCard } from '../ProtocolCard'
@@ -34,6 +35,9 @@ vi.mock('react-router-dom', async importOriginal => {
 })
 vi.mock('@opentrons/react-api-client')
 vi.mock('/app/redux/config')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 vi.mock('@opentrons/components', async importOriginal => {
   const actual = await importOriginal<typeof Chip>()
   return {

--- a/app/src/pages/ODD/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -15,6 +15,7 @@ import {
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useScrollPosition } from '/app/local-resources/dom-utils'
 import { useOffsetCandidatesForAnalysis } from '/app/organisms/LegacyApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
 import { mockRunTimeParameterData } from '/app/organisms/ODD/ProtocolSetup/__fixtures__'
@@ -49,6 +50,9 @@ vi.mock('../Labware')
 vi.mock('../Parameters')
 vi.mock('/app/redux/config')
 vi.mock('/app/local-resources/dom-utils')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 
 const MOCK_HOST_CONFIG = {} as HostConfig
 const mockCreateRun = vi.fn((id: string) => {})

--- a/app/src/pages/ODD/ProtocolDetails/index.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/index.tsx
@@ -36,6 +36,7 @@ import {
 
 import { MAXIMUM_PINNED_PROTOCOLS } from '/app/App/constants'
 import { MediumButton, SmallButton } from '/app/atoms/buttons'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useScrollPosition } from '/app/local-resources/dom-utils'
 import { OddModal, SmallModalChildren } from '/app/molecules/OddModal'
 import {
@@ -344,8 +345,8 @@ export function ProtocolDetails(): JSX.Element | null {
     last(protocolRecord?.data.analysisSummaries)?.id ?? null,
     { enabled: protocolRecord != null }
   )
-
-  const { createRun } = useCreateRunMutation({
+  const documentationState = useDocumentationState()
+  const { createRun } = useCreateRunMutation(documentationState, {
     onSuccess: data => {
       queryClient
         .invalidateQueries(getQueryKey(host, 'runs'))

--- a/app/src/pages/ODD/QuickTransferDetails/__tests__/QuickTransferDetails.test.tsx
+++ b/app/src/pages/ODD/QuickTransferDetails/__tests__/QuickTransferDetails.test.tsx
@@ -12,6 +12,7 @@ import {
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useScrollPosition } from '/app/local-resources/dom-utils'
 import { useOffsetCandidatesForAnalysis } from '/app/organisms/LegacyApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
 import { useHardwareStatusText } from '/app/organisms/ODD/RobotDashboard/hooks'
@@ -46,6 +47,9 @@ vi.mock('../Hardware')
 vi.mock('../Labware')
 vi.mock('/app/redux/config')
 vi.mock('/app/local-resources/dom-utils')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 
 const MOCK_HOST_CONFIG = {} as HostConfig
 const mockCreateRun = vi.fn((id: string) => {})

--- a/app/src/pages/ODD/QuickTransferDetails/index.tsx
+++ b/app/src/pages/ODD/QuickTransferDetails/index.tsx
@@ -33,6 +33,7 @@ import {
 
 import { MAXIMUM_PINNED_PROTOCOLS } from '/app/App/constants'
 import { MediumButton, SmallButton } from '/app/atoms/buttons'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useScrollPosition } from '/app/local-resources/dom-utils'
 import { SmallModalChildren } from '/app/molecules/OddModal'
 import {
@@ -325,8 +326,9 @@ export function QuickTransferDetails(): JSX.Element | null {
 
   let pinnedTransferIds = useSelector(getPinnedQuickTransferIds) ?? []
   const pinned = pinnedTransferIds.includes(transferId)
+  const documentationState = useDocumentationState()
 
-  const { createRun } = useCreateRunMutation({
+  const { createRun } = useCreateRunMutation(documentationState, {
     onSuccess: data => {
       queryClient
         .invalidateQueries(getQueryKey(host, 'runs'))

--- a/app/src/resources/runs/__tests__/useCloneRun.test.tsx
+++ b/app/src/resources/runs/__tests__/useCloneRun.test.tsx
@@ -9,6 +9,8 @@ import {
   useHost,
 } from '@opentrons/react-api-client'
 
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
+
 import { useCloneRun } from '../useCloneRun'
 import { useNotifyRunQuery } from '../useNotifyRunQuery'
 
@@ -17,6 +19,9 @@ import type { HostConfig, LabwareOffset } from '@opentrons/api-client'
 
 vi.mock('@opentrons/react-api-client')
 vi.mock('/app/resources/runs/useNotifyRunQuery')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 
 const HOST_CONFIG: HostConfig = { hostname: 'localhost' }
 const RUN_ID_NO_RTP: string = 'run_id_no_rtp'
@@ -128,7 +133,7 @@ describe('useCloneRun hook', () => {
       } as any)
 
     when(vi.mocked(useCreateRunMutation))
-      .calledWith(expect.anything())
+      .calledWith(expect.anything(), expect.anything())
       .thenReturn({ createRun: vi.fn() } as any)
     vi.mocked(useCreateProtocolAnalysisMutation).mockReturnValue({
       createProtocolAnalysis: vi.fn(),

--- a/app/src/resources/runs/useCloneRun.ts
+++ b/app/src/resources/runs/useCloneRun.ts
@@ -8,6 +8,7 @@ import {
   useHost,
 } from '@opentrons/react-api-client'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import {
   getRunTimeParameterFilesForRun,
   getRunTimeParameterValuesForRun,
@@ -32,22 +33,26 @@ export function useCloneRun(
   const queryClient = useQueryClient()
   const { data: runRecord, isLoading: isLoadingRun } = useNotifyRunQuery(runId)
   const protocolKey = runRecord?.data.protocolId ?? null
-  const { createRun, isLoading: isCloning } = useCreateRunMutation({
-    onSuccess: response => {
-      const invalidateRuns = queryClient.invalidateQueries(
-        getQueryKey(host, 'runs')
-      )
-      const invalidateProtocols = queryClient.invalidateQueries(
-        getQueryKey(host, 'protocols', protocolKey)
-      )
-      Promise.all([invalidateRuns, invalidateProtocols]).catch((e: Error) => {
-        console.error(`error invalidating runs query: ${e.message}`)
-      })
-      // The onSuccess callback is not awaited until query invalidation, because currently, in every instance this
-      // onSuccessCallback is utilized, we only use it for navigating. We may need to revisit this.
-      onSuccessCallback?.(response)
-    },
-  })
+  const documentationState = useDocumentationState()
+  const { createRun, isLoading: isCloning } = useCreateRunMutation(
+    documentationState,
+    {
+      onSuccess: response => {
+        const invalidateRuns = queryClient.invalidateQueries(
+          getQueryKey(host, 'runs')
+        )
+        const invalidateProtocols = queryClient.invalidateQueries(
+          getQueryKey(host, 'protocols', protocolKey)
+        )
+        Promise.all([invalidateRuns, invalidateProtocols]).catch((e: Error) => {
+          console.error(`error invalidating runs query: ${e.message}`)
+        })
+        // The onSuccess callback is not awaited until query invalidation, because currently, in every instance this
+        // onSuccessCallback is utilized, we only use it for navigating. We may need to revisit this.
+        onSuccessCallback?.(response)
+      },
+    }
+  )
   const { createProtocolAnalysis } = useCreateProtocolAnalysisMutation(
     protocolKey,
     host

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -158,9 +158,7 @@ export type DocumentedAction =
  * login_cancelled: user closed out of the login modal
  */
 export type DocumentedMutationErrorType =
-  | 'no_documentation_report'
-  | 'access_control_loading'
-  | 'login_cancelled'
+  'no_documentation_report' | 'access_control_loading' | 'login_cancelled'
 
 const DOCUMENTED_MUTATION_ERROR_MESSAGES: Record<
   DocumentedMutationErrorType,

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -140,7 +140,7 @@ type AuditLogAction =
   | 'end_drop_tips'
   | 'attach_pipette_left'
   | 'attach_pipette_right'
-
+  | 'create_protocol'
 /**
  * Type used for DocumentedActions - keys and info to enable correct rendering of actions in the 'list actions' popup in the Documentation Required Modal.
  */
@@ -157,7 +157,9 @@ export type DocumentedAction =
  * login_cancelled: user closed out of the login modal
  */
 export type DocumentedMutationErrorType =
-  'no_documentation_report' | 'access_control_loading' | 'login_cancelled'
+  | 'no_documentation_report'
+  | 'access_control_loading'
+  | 'login_cancelled'
 
 const DOCUMENTED_MUTATION_ERROR_MESSAGES: Record<
   DocumentedMutationErrorType,

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -141,6 +141,7 @@ type AuditLogAction =
   | 'attach_pipette_left'
   | 'attach_pipette_right'
   | 'create_protocol'
+
 /**
  * Type used for DocumentedActions - keys and info to enable correct rendering of actions in the 'list actions' popup in the Documentation Required Modal.
  */

--- a/react-api-client/src/accessControl/useDocumentedMutation.ts
+++ b/react-api-client/src/accessControl/useDocumentedMutation.ts
@@ -88,6 +88,12 @@ async function runMutation<TData, TVariables>(
   >,
   variables: TVariables
 ): Promise<TData> {
+  console.log('running mutation', {
+    documentationState,
+    actionsToDocument,
+    mutationFnRef,
+    variables,
+  })
   if (documentationState.isLoading) {
     throw new DocumentedMutationError('access_control_loading')
   }

--- a/react-api-client/src/accessControl/useDocumentedMutation.ts
+++ b/react-api-client/src/accessControl/useDocumentedMutation.ts
@@ -152,11 +152,14 @@ async function runMutation<TData, TVariables>(
           : '',
     })
     .catch(async e => {
+      console.log('hit error', e)
+      console.log(documentationState)
       if (
         e.isAxiosError &&
         e.response?.status === 401 &&
         documentationState.accessControlEnabled
       ) {
+        console.log('hit 401')
         return await runMutation(
           { ...documentationState, loginExpired: true },
           actionsToDocument,

--- a/react-api-client/src/protocols/__tests__/useCreateProtocolMutation.test.tsx
+++ b/react-api-client/src/protocols/__tests__/useCreateProtocolMutation.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createProtocol } from '@opentrons/api-client'
 
 import { useCreateProtocolMutation } from '..'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../accessControl/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -59,9 +60,13 @@ describe('useCreateProtocolMutation hook', () => {
     vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
     vi.mocked(createProtocol).mockRejectedValue('oh no')
 
-    const { result } = renderHook(() => useCreateProtocolMutation(), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () =>
+        useCreateProtocolMutation(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+      {
+        wrapper,
+      }
+    )
 
     expect(result.current.data).toBeUndefined()
     result.current.createProtocol({ files: createProtocolData })
@@ -76,9 +81,13 @@ describe('useCreateProtocolMutation hook', () => {
       data: PROTOCOL_RESPONSE,
     } as Response<Protocol>)
 
-    const { result } = renderHook(() => useCreateProtocolMutation(), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () =>
+        useCreateProtocolMutation(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+      {
+        wrapper,
+      }
+    )
     act(() => result.current.createProtocol({ files: createProtocolData }))
 
     await waitFor(() => {
@@ -92,9 +101,13 @@ describe('useCreateProtocolMutation hook', () => {
       data: PROTOCOL_RESPONSE,
     } as Response<Protocol>)
 
-    const { result } = renderHook(() => useCreateProtocolMutation(), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () =>
+        useCreateProtocolMutation(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+      {
+        wrapper,
+      }
+    )
     act(() =>
       result.current.createProtocol({
         files: createProtocolData,

--- a/react-api-client/src/protocols/useCreateProtocolMutation.ts
+++ b/react-api-client/src/protocols/useCreateProtocolMutation.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from 'react-query'
 
 import { createProtocol } from '@opentrons/api-client'
 
+import { DocumentationState, useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
 import type { AxiosError } from 'axios'
@@ -44,6 +45,7 @@ export type UseCreateProtocolMutationOptions = UseMutationOptions<
 >
 
 export function useCreateProtocolMutation(
+  documentationState: DocumentationState,
   options: UseCreateProtocolMutationOptions = {},
   hostOverride?: HostConfig | null
 ): UseCreateProtocolMutationResult {
@@ -52,18 +54,23 @@ export function useCreateProtocolMutation(
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
   const queryClient = useQueryClient()
 
-  const mutation = useMutation<
+  const mutation = useDocumentedMutation<
     Protocol,
     AxiosError<ErrorResponse>,
     CreateProtocolVariables
   >(
+    documentationState,
+    ['create_protocol'],
     getQueryKey(host, 'protocols'),
     ({
-      files: protocolFiles,
-      protocolKey,
-      protocolKind = 'standard',
-      runTimeParameterValues,
-      runTimeParameterFiles,
+      variables: {
+        files: protocolFiles,
+        protocolKey,
+        protocolKind = 'standard',
+        runTimeParameterValues,
+        runTimeParameterFiles,
+      },
+      userNotes,
     }) =>
       createProtocol(
         host!,
@@ -71,7 +78,8 @@ export function useCreateProtocolMutation(
         protocolKey,
         protocolKind,
         runTimeParameterValues,
-        runTimeParameterFiles
+        runTimeParameterFiles,
+        userNotes
       )
         .then(response => {
           const protocolId = response.data.data.id

--- a/react-api-client/src/protocols/useCreateProtocolMutation.ts
+++ b/react-api-client/src/protocols/useCreateProtocolMutation.ts
@@ -1,8 +1,8 @@
-import { useMutation, useQueryClient } from 'react-query'
+import { useQueryClient } from 'react-query'
 
 import { createProtocol } from '@opentrons/api-client'
 
-import { DocumentationState, useDocumentedMutation } from '../accessControl'
+import { useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
 import type { AxiosError } from 'axios'
@@ -18,6 +18,7 @@ import type {
   RunTimeParameterFilesCreateData,
   RunTimeParameterValuesCreateData,
 } from '@opentrons/api-client'
+import type { DocumentationState } from '../accessControl'
 
 export interface CreateProtocolVariables {
   files: File[]

--- a/react-api-client/src/runs/__tests__/useCreateRunMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/useCreateRunMutation.test.tsx
@@ -6,6 +6,7 @@ import { createRun } from '@opentrons/api-client'
 
 import { useCreateRunMutation } from '..'
 import { mockRunResponse, PROTOCOL_ID } from '../__fixtures__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../accessControl/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -41,9 +42,12 @@ describe('useCreateRunMutation hook', () => {
     vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
     vi.mocked(createRun).mockRejectedValue('oh no')
 
-    const { result } = renderHook(() => useCreateRunMutation(), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useCreateRunMutation(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+      {
+        wrapper,
+      }
+    )
 
     expect(result.current.data).toBeUndefined()
     result.current.createRun({})
@@ -58,9 +62,12 @@ describe('useCreateRunMutation hook', () => {
       data: mockRunResponse,
     } as Response<Run>)
 
-    const { result } = renderHook(() => useCreateRunMutation(), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useCreateRunMutation(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+      {
+        wrapper,
+      }
+    )
     act(() => result.current.createRun(createRunData))
 
     await waitFor(() => {
@@ -75,9 +82,12 @@ describe('useCreateRunMutation hook', () => {
       data: mockRunResponse,
     } as Response<Run>)
 
-    const { result } = renderHook(() => useCreateRunMutation(), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useCreateRunMutation(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+      {
+        wrapper,
+      }
+    )
     act(() => result.current.createRun(createRunData))
 
     await waitFor(() => {

--- a/react-api-client/src/runs/useCreateRunMutation.ts
+++ b/react-api-client/src/runs/useCreateRunMutation.ts
@@ -1,7 +1,6 @@
-import { useMutation } from 'react-query'
-
 import { createRun } from '@opentrons/api-client'
 
+import { useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
 import type { AxiosError } from 'axios'
@@ -11,6 +10,10 @@ import type {
   UseMutationResult,
 } from 'react-query'
 import type { CreateRunData, HostConfig, Run } from '@opentrons/api-client'
+import type {
+  DocumentationState,
+  DocumentedMutationParameters,
+} from '../accessControl/types'
 
 export type UseCreateRunMutationResult = UseMutationResult<
   Run,
@@ -27,15 +30,21 @@ export type UseCreateRunMutationOptions = UseMutationOptions<
 >
 
 export function useCreateRunMutation(
+  documentationState: DocumentationState,
   options: UseCreateRunMutationOptions = {},
   hostOverride?: HostConfig | null
 ): UseCreateRunMutationResult {
   const contextHost = useHost()
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
-  const mutation = useMutation<Run, AxiosError, CreateRunData>(
+  const mutation = useDocumentedMutation<Run, AxiosError, CreateRunData>(
+    documentationState,
+    ['play_run'],
     getQueryKey(host, 'runs'),
-    createRunData =>
+    ({
+      variables: createRunData,
+      userNotes,
+    }: DocumentedMutationParameters<CreateRunData>) =>
       createRun(host!, createRunData)
         .then(response => response.data)
         .catch(e => {


### PR DESCRIPTION
# Overview

https://github.com/user-attachments/assets/f3d06e0e-991c-46de-a98c-510555f73691

https://github.com/user-attachments/assets/f53e301a-8340-4444-93a8-014b292e14e9

https://github.com/user-attachments/assets/c8a48504-1757-4267-b1c1-40fc778ed3da

https://github.com/user-attachments/assets/e937c8ac-9822-4c7d-b7da-16443ac8e1d2

Fixes uploading and running protocols on Compliance Ready robots from the desktop app. Additionally adds a new hook for stateful DocumentationState managing.

## Test Plan and Hands on Testing

On:
- The devices page 'run protocol' dropdown,
- an individual robot 'run protocol' dropdown, 
- the protocol page 'send to flex' option
- the protocol page 'start setup' option
These all should prompt for login and then documentation on compliance ready robots, and correctly send/launch protocol runs

## Review requests

Are there any other weird places that you can launch/send protocols from in the desktop app?

## Risk assessment

Low