### PR TITLE
feat(api): Implement Vacuum module type serializations for subprocess support

### DIFF
--- a/api/src/opentrons/drivers/vacuum_module/types.py
+++ b/api/src/opentrons/drivers/vacuum_module/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict
+from typing import Any, Dict
 
 from opentrons_shared_data.util import StrEnum
 
@@ -114,6 +114,33 @@ class VacuumState:
     vacuum_duration: int
     vent_state: VentState
 
+    @staticmethod
+    def to_pyro_dict(obj: "VacuumState") -> Dict[str, Any]:
+        return {
+            "__class__": f"{obj.__module__}.{obj.__class__.__qualname__}",
+            "target_gauge_pressure": obj.target_gauge_pressure,
+            "current_gauge_pressure": obj.current_gauge_pressure,
+            "pressure_abs_a": obj.pressure_abs_a,
+            "pressure_abs_b": obj.pressure_abs_b,
+            "pressure_atm": obj.pressure_atm,
+            "vacuum_enabled": obj.vacuum_enabled,
+            "vacuum_duration": obj.vacuum_duration,
+            "vent_state": obj.vent_state.value,
+        }
+
+    @staticmethod
+    def from_pyro_dict(classname: Any, data: Dict[str, Any]) -> "VacuumState":
+        return VacuumState(
+            target_gauge_pressure=data["target_gauge_pressure"],
+            current_gauge_pressure=data["current_gauge_pressure"],
+            pressure_abs_a=data["pressure_abs_a"],
+            pressure_abs_b=data["pressure_abs_b"],
+            pressure_atm=data["pressure_atm"],
+            vacuum_enabled=data["vacuum_enabled"],
+            vacuum_duration=data["vacuum_duration"],
+            vent_state=VentState(data["vent_state"]),
+        )
+
 
 @dataclass
 class PressureControlTunings:
@@ -154,3 +181,26 @@ class PumpState:
     current_pwm: float
     pump_running: bool
     manual_control: bool
+
+    @staticmethod
+    def to_pyro_dict(obj: "PumpState") -> Dict[str, Any]:
+        return {
+            "__class__": f"{obj.__module__}.{obj.__class__.__qualname__}",
+            "target_rpm": obj.target_rpm,
+            "current_rpm": obj.current_rpm,
+            "target_pwm": obj.target_pwm,
+            "current_pwm": obj.current_pwm,
+            "pump_running": obj.pump_running,
+            "manual_control": obj.manual_control,
+        }
+
+    @staticmethod
+    def from_pyro_dict(classname: Any, data: Dict[str, Any]) -> "PumpState":
+        return PumpState(
+            target_rpm=data["target_rpm"],
+            current_rpm=data["current_rpm"],
+            target_pwm=data["target_pwm"],
+            current_pwm=data["current_pwm"],
+            pump_running=data["pump_running"],
+            manual_control=data["manual_control"],
+        )

--- a/api/src/opentrons/drivers/vacuum_module/types.py
+++ b/api/src/opentrons/drivers/vacuum_module/types.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any, Dict
 
@@ -116,29 +116,23 @@ class VacuumState:
 
     @staticmethod
     def to_pyro_dict(obj: "VacuumState") -> Dict[str, Any]:
-        """Convert to a Pyro Dictionary."""
-        pyro_dict: Dict[str, Any] = {
-            "__class__": f"{obj.__module__}.{obj.__class__.__qualname__}"
-        }
-        for k, v in obj.__annotations__.items():
-            if k == "vent_state":
-                pyro_dict[k] = obj.vent_state.value
-            else:
-                pyro_dict[k] = getattr(obj, k)
+        """Consumed by Serpent, convert type to a Pyro Dictionary."""
+        pyro_dict = asdict(obj)
+        # Override specific variables for safe conversion
+        pyro_dict["__class__"] = f"{obj.__module__}.{obj.__class__.__qualname__}"
+        pyro_dict["vent_state"] = obj.vent_state.value
+
         return pyro_dict
 
     @staticmethod
     def from_pyro_dict(classname: Any, data: Dict[str, Any]) -> "VacuumState":
-        """Convert from a Pyro Dictionary."""
+        """Consumed by Serpent, convert to type from a Pyro Dictionary."""
+        data.pop("__class__", None)
         return VacuumState(
-            target_gauge_pressure=data["target_gauge_pressure"],
-            current_gauge_pressure=data["current_gauge_pressure"],
-            pressure_abs_a=data["pressure_abs_a"],
-            pressure_abs_b=data["pressure_abs_b"],
-            pressure_atm=data["pressure_atm"],
-            vacuum_enabled=data["vacuum_enabled"],
-            vacuum_duration=data["vacuum_duration"],
-            vent_state=VentState(data["vent_state"]),
+            **{  # type: ignore
+                key: (VentState(data[key]) if key == "vent_state" else data[key])
+                for key, value in data.items()
+            }
         )
 
 
@@ -184,20 +178,13 @@ class PumpState:
 
     @staticmethod
     def to_pyro_dict(obj: "PumpState") -> Dict[str, Any]:
-        """Convert to a Pyro Dictionary."""
-        pyro_dict = {"__class__": f"{obj.__module__}.{obj.__class__.__qualname__}"}
-        for k, v in obj.__annotations__.items():
-            pyro_dict[k] = getattr(obj, k)
+        """Consumed by Serpent, convert type to a Pyro Dictionary."""
+        pyro_dict = asdict(obj)
+        pyro_dict["__class__"] = f"{obj.__module__}.{obj.__class__.__qualname__}"
         return pyro_dict
 
     @staticmethod
     def from_pyro_dict(classname: Any, data: Dict[str, Any]) -> "PumpState":
         """Convert from a Pyro Dictionary."""
-        return PumpState(
-            target_rpm=data["target_rpm"],
-            current_rpm=data["current_rpm"],
-            target_pwm=data["target_pwm"],
-            current_pwm=data["current_pwm"],
-            pump_running=data["pump_running"],
-            manual_control=data["manual_control"],
-        )
+        data.pop("__class__", None)
+        return PumpState(**data)

--- a/api/src/opentrons/drivers/vacuum_module/types.py
+++ b/api/src/opentrons/drivers/vacuum_module/types.py
@@ -116,20 +116,20 @@ class VacuumState:
 
     @staticmethod
     def to_pyro_dict(obj: "VacuumState") -> Dict[str, Any]:
-        return {
-            "__class__": f"{obj.__module__}.{obj.__class__.__qualname__}",
-            "target_gauge_pressure": obj.target_gauge_pressure,
-            "current_gauge_pressure": obj.current_gauge_pressure,
-            "pressure_abs_a": obj.pressure_abs_a,
-            "pressure_abs_b": obj.pressure_abs_b,
-            "pressure_atm": obj.pressure_atm,
-            "vacuum_enabled": obj.vacuum_enabled,
-            "vacuum_duration": obj.vacuum_duration,
-            "vent_state": obj.vent_state.value,
+        """Convert to a Pyro Dictionary."""
+        pyro_dict: Dict[str, Any] = {
+            "__class__": f"{obj.__module__}.{obj.__class__.__qualname__}"
         }
+        for k, v in obj.__annotations__.items():
+            if k == "vent_state":
+                pyro_dict[k] = obj.vent_state.value
+            else:
+                pyro_dict[k] = getattr(obj, k)
+        return pyro_dict
 
     @staticmethod
     def from_pyro_dict(classname: Any, data: Dict[str, Any]) -> "VacuumState":
+        """Convert from a Pyro Dictionary."""
         return VacuumState(
             target_gauge_pressure=data["target_gauge_pressure"],
             current_gauge_pressure=data["current_gauge_pressure"],
@@ -184,18 +184,15 @@ class PumpState:
 
     @staticmethod
     def to_pyro_dict(obj: "PumpState") -> Dict[str, Any]:
-        return {
-            "__class__": f"{obj.__module__}.{obj.__class__.__qualname__}",
-            "target_rpm": obj.target_rpm,
-            "current_rpm": obj.current_rpm,
-            "target_pwm": obj.target_pwm,
-            "current_pwm": obj.current_pwm,
-            "pump_running": obj.pump_running,
-            "manual_control": obj.manual_control,
-        }
+        """Convert to a Pyro Dictionary."""
+        pyro_dict = {"__class__": f"{obj.__module__}.{obj.__class__.__qualname__}"}
+        for k, v in obj.__annotations__.items():
+            pyro_dict[k] = getattr(obj, k)
+        return pyro_dict
 
     @staticmethod
     def from_pyro_dict(classname: Any, data: Dict[str, Any]) -> "PumpState":
+        """Convert from a Pyro Dictionary."""
         return PumpState(
             target_rpm=data["target_rpm"],
             current_rpm=data["current_rpm"],

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -32,14 +32,14 @@ from opentrons.calibration_storage.ot3.models.v1 import CalibrationStatus
 from opentrons.hardware_control import modules
 from opentrons.util.pyro.pyro_serialization import (
     OpentronsPyroSerializer,
+    enumerated_error_class_to_dict,
+    enumerated_error_dict_to_class,
     find_enums_in_packages,
     find_pydantic_classes_in_packages,
     find_typed_dict_classes_in_packages,
     register_enumerated_errors,
     register_type_to_serpent,
     serpent_enum_registration,
-    enumerated_error_class_to_dict,
-    enumerated_error_dict_to_class,
 )
 
 Pyro5.config.SERPENT_BYTES_REPR = True  # type: ignore
@@ -509,7 +509,6 @@ def _error_notif_dict_to_class(  # type: ignore
     )
 
 
-
 def _module_model_reconstructor(
     module_str: str,
 ) -> modules.types.ModuleModel:
@@ -540,7 +539,10 @@ def _async_mod_error_notif_dict_to_class(  # type: ignore
 ) -> opentrons.hardware_control.types.AsynchronousModuleErrorNotification:
     return opentrons.hardware_control.types.AsynchronousModuleErrorNotification(
         event=opentrons.hardware_control.types.HardwareEventType(d["event"]["value"]),  # type: ignore
-        exception=enumerated_error_dict_to_class(class_name="opentrons.hardware_control.types.EnumeratedError", d=d["exception"]),
+        exception=enumerated_error_dict_to_class(
+            class_name="opentrons.hardware_control.types.EnumeratedError",
+            d=d["exception"],
+        ),
         module_serial=d["module_serial"],
         module_model=_module_model_reconstructor(d["module_model"]),
         port=d["port"],
@@ -878,19 +880,20 @@ def register_hardware_types() -> None:
         class_to_dict=_ABSMeasurementConfig_class_to_dict,
     )
 
-    # VacuumState registration
-    register_type_to_serpent(
-        class_type=opentrons.drivers.vacuum_module.types.VacuumState,
-        dict_to_class=opentrons.drivers.vacuum_module.types.VacuumState.from_pyro_dict,
-        class_to_dict=opentrons.drivers.vacuum_module.types.VacuumState.to_pyro_dict,
-    )
+    # Dataclass generic registration
+    # todo(chb, 07-08-2026): This should probably be changes to automatically detect our pyro compatible dataclasses once the cross-layer classes all have `to_pyro` and `from_pyro` methods
+    # todo(chb, 07-08-2026): Once the others all contain to and from methods the above restrigries can be removed
+    opentrons_dataclass_types = [
+        opentrons.drivers.vacuum_module.types.VacuumState,
+        opentrons.drivers.vacuum_module.types.PumpState,
+    ]
 
-    # PumpState registration
-    register_type_to_serpent(
-        class_type=opentrons.drivers.vacuum_module.types.PumpState,
-        dict_to_class=opentrons.drivers.vacuum_module.types.PumpState.from_pyro_dict,
-        class_to_dict=opentrons.drivers.vacuum_module.types.PumpState.to_pyro_dict,
-    )
+    for dataclass_type in opentrons_dataclass_types:
+        register_type_to_serpent(
+            class_type=dataclass_type,
+            dict_to_class=dataclass_type.from_pyro_dict,  # type: ignore
+            class_to_dict=dataclass_type.to_pyro_dict,  # type: ignore
+        )
 
     # handle Typed Dicts for the hardware controller
     OpentronsPyroSerializer.register_opentrons_typed_dicts(_typed_dict_dict_to_class)

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -18,6 +18,7 @@ import opentrons.calibration_storage.types
 import opentrons.config.types
 import opentrons.drivers.rpi_drivers.types
 import opentrons.drivers.types
+import opentrons.drivers.vacuum_module.types
 import opentrons.hardware_control.dev_types
 import opentrons.hardware_control.instruments.ot3.instrument_calibration
 import opentrons.hardware_control.modules.module_calibration
@@ -37,6 +38,8 @@ from opentrons.util.pyro.pyro_serialization import (
     register_enumerated_errors,
     register_type_to_serpent,
     serpent_enum_registration,
+    enumerated_error_class_to_dict,
+    enumerated_error_dict_to_class,
 )
 
 Pyro5.config.SERPENT_BYTES_REPR = True  # type: ignore
@@ -506,38 +509,6 @@ def _error_notif_dict_to_class(  # type: ignore
     )
 
 
-# enumerate error helpers
-def _enumerated_error_deconstructor(e_obj) -> Dict:  # type: ignore
-    # unzip the error and any nested ones
-    return {
-        "code": e_obj.code,
-        "message": e_obj.message,
-        "detail": e_obj.detail,
-        "wrapping": None
-        if e_obj.wrapping is None
-        else [
-            _enumerated_error_deconstructor(wrapped_item)
-            for wrapped_item in e_obj.wrapping
-        ],
-    }
-
-
-def _enumerated_error_reconstructor(
-    e_dict: Dict[str, Any],
-) -> opentrons.hardware_control.types.EnumeratedError:  # type: ignore
-    # reassmble the error and any nested ones
-    return opentrons.hardware_control.types.EnumeratedError(  # type: ignore
-        code=opentrons_shared_data.errors.codes.ErrorCodes(e_dict["code"]["value"]),
-        message=e_dict["message"],
-        detail=e_dict["detail"],
-        wrapping=None
-        if e_dict["wrapping"] is None
-        else [
-            _enumerated_error_reconstructor(wrapped_dict)
-            for wrapped_dict in e_dict["wrapping"]
-        ],
-    )
-
 
 def _module_model_reconstructor(
     module_str: str,
@@ -557,7 +528,7 @@ def _async_mod_error_notif_class_to_dict(obj) -> Dict:  # type: ignore
     return {
         "__class__": "opentrons.hardware_control.types.AsynchronousModuleErrorNotification",
         "event": obj.event,
-        "exception": _enumerated_error_deconstructor(obj.exception),
+        "exception": enumerated_error_class_to_dict(obj.exception),
         "module_serial": obj.module_serial,
         "module_model": obj.module_model.name,
         "port": obj.port,
@@ -569,7 +540,7 @@ def _async_mod_error_notif_dict_to_class(  # type: ignore
 ) -> opentrons.hardware_control.types.AsynchronousModuleErrorNotification:
     return opentrons.hardware_control.types.AsynchronousModuleErrorNotification(
         event=opentrons.hardware_control.types.HardwareEventType(d["event"]["value"]),  # type: ignore
-        exception=_enumerated_error_reconstructor(d["exception"]),
+        exception=enumerated_error_dict_to_class(class_name="opentrons.hardware_control.types.EnumeratedError", d=d["exception"]),
         module_serial=d["module_serial"],
         module_model=_module_model_reconstructor(d["module_model"]),
         port=d["port"],
@@ -740,6 +711,7 @@ def register_hardware_types() -> None:
             opentrons.calibration_storage.types,
             opentrons.drivers.types,
             opentrons.hardware_control.modules.types,
+            opentrons.drivers.vacuum_module.types,
         ]
     )
 
@@ -904,6 +876,20 @@ def register_hardware_types() -> None:
         class_type=opentrons.drivers.types.ABSMeasurementConfig,
         dict_to_class=_ABSMeasurementConfig_dict_to_class,
         class_to_dict=_ABSMeasurementConfig_class_to_dict,
+    )
+
+    # VacuumState registration
+    register_type_to_serpent(
+        class_type=opentrons.drivers.vacuum_module.types.VacuumState,
+        dict_to_class=opentrons.drivers.vacuum_module.types.VacuumState.from_pyro_dict,
+        class_to_dict=opentrons.drivers.vacuum_module.types.VacuumState.to_pyro_dict,
+    )
+
+    # PumpState registration
+    register_type_to_serpent(
+        class_type=opentrons.drivers.vacuum_module.types.PumpState,
+        dict_to_class=opentrons.drivers.vacuum_module.types.PumpState.from_pyro_dict,
+        class_to_dict=opentrons.drivers.vacuum_module.types.PumpState.to_pyro_dict,
     )
 
     # handle Typed Dicts for the hardware controller

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -881,7 +881,7 @@ def register_hardware_types() -> None:
     )
 
     # Dataclass generic registration
-    # todo(chb, 07-08-2026): This should probably be changes to automatically detect our pyro compatible dataclasses once the cross-layer classes all have `to_pyro` and `from_pyro` methods
+    # todo(chb, 07-08-2026): This should probably be changed to automatically detect our pyro compatible dataclasses once the cross-layer classes all have `to_pyro` and `from_pyro` methods
     # todo(chb, 07-08-2026): Once the others all contain to and from methods the above restrigries can be removed
     opentrons_dataclass_types = [
         opentrons.drivers.vacuum_module.types.VacuumState,

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -108,14 +108,14 @@ def register_type_to_serpent(
     return class_path
 
 
-def _enumerated_error_class_to_dict(obj: EnumeratedError) -> dict[str, Any]:
+def enumerated_error_class_to_dict(obj: EnumeratedError) -> dict[str, Any]:
     return {
         "__class__": "opentrons_shared_data.errors.exceptions.EnumeratedError",
         "bytes": pickle.dumps(obj),
     }
 
 
-def _enumerated_error_dict_to_class(
+def enumerated_error_dict_to_class(
     class_name: str, d: dict[str, Any]
 ) -> EnumeratedError:
     """Deserializes errors via pickle."""
@@ -131,8 +131,8 @@ def register_enumerated_errors() -> None:
     """Registers serializer and deserializer for enumerated errors."""
     register_type_to_serpent(
         class_type=EnumeratedError,
-        dict_to_class=_enumerated_error_dict_to_class,
-        class_to_dict=_enumerated_error_class_to_dict,
+        dict_to_class=enumerated_error_dict_to_class,
+        class_to_dict=enumerated_error_class_to_dict,
     )
 
 

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -109,6 +109,7 @@ def register_type_to_serpent(
 
 
 def enumerated_error_class_to_dict(obj: EnumeratedError) -> dict[str, Any]:
+    """Serializes enumerated errors to a bytes dictionary."""
     return {
         "__class__": "opentrons_shared_data.errors.exceptions.EnumeratedError",
         "bytes": pickle.dumps(obj),

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
@@ -29,6 +29,10 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.thermocycler.simulator import (
     SimulatingDriver as ThermocyclerSimulatingDriver,
 )
+from opentrons.drivers.vacuum_module.simulator import (
+    SimulatingDriver as VacuumModuleSimulatingDriver,
+)
+from opentrons.drivers.vacuum_module.types import PumpState, VacuumState
 from opentrons.hardware_control import ExecutionManager, ThreadManager, modules
 from opentrons.hardware_control import types as hw_types
 from opentrons.hardware_control.instruments.ot3 import (
@@ -48,7 +52,9 @@ from opentrons.hardware_control.modules.thermocycler import ThermocyclerReader
 from opentrons.hardware_control.modules.types import (
     ModuleDisconnectedCallback,
     ModuleErrorCallback,
+    VacuumModuleStatus,
 )
+from opentrons.hardware_control.modules.vacuum_module import VacuumModuleReader
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.poller import Poller
 from opentrons.hardware_control.pyro_utils.serpent_type_registry import (
@@ -101,6 +107,12 @@ def mock_driver(decoy: Decoy) -> SimulatingDriver:
 def mock_thermo_driver(decoy: Decoy) -> ThermocyclerSimulatingDriver:
     """Get a mocked simulating driver of the thermocycler."""
     return decoy.mock(cls=ThermocyclerSimulatingDriver)
+
+
+@pytest.fixture
+def mock_vm_driver(decoy: Decoy) -> VacuumModuleSimulatingDriver:
+    """Get a mocked simulating driver of the vacuum module."""
+    return decoy.mock(cls=VacuumModuleSimulatingDriver)
 
 
 @pytest.fixture
@@ -462,6 +474,97 @@ async def test_pyro_module_properties(
     assert async_remote_tc.hopper_door_state is None
     assert async_remote_tc.bundled_fw == tc.bundled_fw
     assert async_remote_tc.name() == "thermocycler"
+
+    ot3_proxy._pyroRelease()  # type: ignore
+
+
+async def test_pyro_vacuum_module_serialization(
+    ot3_hardware: ThreadManager[OT3API],
+    mock_vm_driver: VacuumModuleSimulatingDriver,
+    decoy: Decoy,
+    mock_execution_manager: ExecutionManager,
+    module_error_callback: ModuleErrorCallback,
+    module_disconnected_callback: ModuleDisconnectedCallback,
+) -> None:
+    """Test to ensure that proxy module calls to the vacuum module serialize and deserialize properly."""
+    sock = socket.socket()
+    sock.bind(("localhost", 0))
+    host, port = sock.getsockname()
+    sock.close()
+
+    pyro.config.NS_HOST = host
+    pyro.config.NS_PORT = port
+
+    name_server_ready = threading.Event()
+    # Module mocks
+    api = ot3_hardware.wrapped()
+    api._backend.module_controls = decoy.mock(cls=AttachedModulesControl)
+
+    vm = VacuumModule(
+        port="/dev/ot_module_sim_vac0",
+        usb_port=USBPort(
+            name="port1",
+            port_number=1,
+            port_group="main",
+            hub=False,
+            hub_port=None,
+            device_path="",
+        ),
+        hw_control_loop=api._loop,
+        driver=mock_vm_driver,
+        reader=VacuumModuleReader(driver=mock_vm_driver),
+        poller=Poller(VacuumModuleReader(driver=mock_vm_driver), interval=0.01),
+        device_info={"serial": "awesome_serial_123"},
+        execution_manager=mock_execution_manager,
+        error_callback=module_error_callback,
+        disconnected_callback=module_disconnected_callback,
+    )
+
+    decoy.when(api._backend.module_controls.available_modules).then_return([vm])
+
+    def _nameserver_loop() -> None:
+        # start_ns returns (nameserver, daemon, uri)
+        _, ns_daemon, _ = nameserver.start_ns(host=host, port=port)  # type: ignore
+        name_server_ready.set()
+        # Run until the test process exits; thread is marked daemon=True.
+        ns_daemon.requestLoop()
+
+    def _pyro_daemon() -> None:
+        # Wait for the nameserver to be ready so locate_ns can succeed.
+        name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
+        create_pyro_daemon("OT3API", ot3_hardware, register_hardware_types)
+
+    ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
+    server_thread = threading.Thread(target=_pyro_daemon, daemon=True)
+
+    ns_thread.start()
+    server_thread.start()
+
+    # Client-side requests below
+    register_hardware_types()
+    name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
+    ns = pyro.locate_ns()
+
+    retries_counter = 0
+    while ns.count() < 2:
+        # Wait and try again, the resource isnt registered yet
+        await asyncio.sleep(0.01)
+        retries_counter += 1
+        if retries_counter > 10:
+            # Stop waiting for the nameserver, will fail on pyro.resolve (something is wrong with nameserver and/or daemon)
+            raise TimeoutError("TEST FAILURE ON PYRO NAMESERVER.")
+
+    uri = pyro.resolve(uri="PYRONAME:OT3API")
+    ot3_proxy = pyro.Proxy(uri)  # type: ignore
+    ot3_async = AsyncClientPyroObject(ot3_proxy)
+    ot3api = cast(OT3API, ot3_async)
+
+    # Ensure that functions which provide proxies also are wrapped asynchronously
+    async_remote_vm = cast(VacuumModule, ot3api.attached_modules[0])
+
+    assert isinstance(async_remote_vm.pump_state, PumpState)
+    assert isinstance(async_remote_vm.vacuum_state, VacuumState)
+    assert isinstance(async_remote_vm.status, VacuumModuleStatus)
 
     ot3_proxy._pyroRelease()  # type: ignore
 

--- a/api/tests/opentrons/util/test_pyro_serialization.py
+++ b/api/tests/opentrons/util/test_pyro_serialization.py
@@ -15,8 +15,8 @@ from opentrons.protocol_engine.types.module import ModuleModel
 from opentrons.types import DeckSlotName
 from opentrons.util.pyro.pyro_serialization import (
     OpentronsPyroSerializer,
-    _enumerated_error_class_to_dict,
-    _enumerated_error_dict_to_class,
+    enumerated_error_class_to_dict,
+    enumerated_error_dict_to_class,
 )
 
 
@@ -108,7 +108,7 @@ def test_enumerated_error_serialization() -> None:
         wrapping=[PythonException(exc=RuntimeError("foo"))],
     )
 
-    test_dict = _enumerated_error_class_to_dict(test_error)
+    test_dict = enumerated_error_class_to_dict(test_error)
 
     assert test_dict.get("bytes") is not None
     assert (
@@ -116,6 +116,6 @@ def test_enumerated_error_serialization() -> None:
         == "opentrons_shared_data.errors.exceptions.EnumeratedError"
     )
 
-    result = _enumerated_error_dict_to_class("", test_dict)
+    result = enumerated_error_dict_to_class("", test_dict)
 
     assert result == test_error


### PR DESCRIPTION
# Overview

There are some Enums and dataclasses used by the Vacuum module driver layer that cross layers up to the protocol engine, so they need serialization coverage to unblock full vacuum module and error recovery support in subprocess mode.

In this same PR I've started to change the pattern for how we register dataclass serialization. Early on dataclasses had bespoke serialization rules in our hardware api serpent registry. For cleanliness and to enable adding more specific integration testing I have begun the transition over to a solution in which dataclasses that are going to cross layers (and that haven't been replaced by pydantic models) contain specific `to_pyro_dict` and `from_pyro_dict` methods that are used by the serpent registry to detail how a given class should be serialized. This should not require a given definition to import anything related to serpent or pyro on an individual basis.

## Test Plan and Hands on Testing

- [x] Expand unit tests to cover vacuum module serialization
- [x] Run the test from [This async error recovery PR](https://github.com/Opentrons/opentrons/pull/21871) to ensure we can run full error recovery on the vacuum modules without pyro issues

## Changelog
Added serializations for the vacuum module driver types that cross layers between the hardware api and the protocol engine.

## Review requests

## Risk assessment
Low - only effects subprocess mode and is mostly in line with the rest of our serializaiton logic.