### PR TITLE
fix: fix storybook's viewport options

### DIFF
--- a/app/src/molecules/DeckInfoLabelTextTag/DeckInfoLabelTextTag.stories.tsx
+++ b/app/src/molecules/DeckInfoLabelTextTag/DeckInfoLabelTextTag.stories.tsx
@@ -1,6 +1,7 @@
 import { RobotInfoLabel, Tag, VIEWPORT } from '@opentrons/components'
 
 import { DeckInfoLabelTextTag as DeckInfoLabelTextTagComponent } from '.'
+import { customViewports } from '../../../../.storybook/preview'
 
 import type { Meta, Story } from '@storybook/react'
 
@@ -22,7 +23,9 @@ export default {
       description: 'Sample text to display in the example child component.',
     },
   },
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
 } as Meta
 
 interface DeckInfoLabelTextTagStoryProps {

--- a/app/src/molecules/HeadlineTagBtn/HeadlineTagBtn.stories.tsx
+++ b/app/src/molecules/HeadlineTagBtn/HeadlineTagBtn.stories.tsx
@@ -1,6 +1,7 @@
 import { Tag, VIEWPORT } from '@opentrons/components'
 
 import { HeadlineTagBtn as HeadlineTagBtnComponent } from '.'
+import { customViewports } from '../../../../.storybook/preview'
 
 import type { Meta, Story } from '@storybook/react'
 
@@ -26,7 +27,9 @@ export default {
       if: { arg: 'hasTag', eq: true },
     },
   },
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
 } as Meta
 
 interface HeadlineTagBtnStoryProps {

--- a/app/src/molecules/MediaContainerContent/MediaContainerContent.stories.tsx
+++ b/app/src/molecules/MediaContainerContent/MediaContainerContent.stories.tsx
@@ -1,5 +1,6 @@
 import { VIEWPORT } from '@opentrons/components'
 
+import { customViewports } from '../../../../.storybook/preview'
 import { MediaContainerContent } from './index'
 
 import type { Meta, StoryObj } from '@storybook/react'
@@ -7,7 +8,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 const meta: Meta<typeof MediaContainerContent> = {
   title: 'App/Molecules/MediaContainer',
   component: MediaContainerContent,
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
   argTypes: {
     state: {
       control: {

--- a/app/src/molecules/MultiDeckLabelTagBtns/MultiDeckLabelTagBtns.stories.tsx
+++ b/app/src/molecules/MultiDeckLabelTagBtns/MultiDeckLabelTagBtns.stories.tsx
@@ -1,6 +1,7 @@
 import { Chip, RobotInfoLabel, Tag, VIEWPORT } from '@opentrons/components'
 
 import { MultiDeckLabelTagBtns as MultiDeckLabelTagBtnsComponent } from '.'
+import { customViewports } from '../../../../.storybook/preview'
 
 import type { Meta, Story } from '@storybook/react'
 
@@ -40,7 +41,9 @@ export default {
       if: { arg: 'hasColThreeSecondaryBtn', eq: true },
     },
   },
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
 } as Meta
 
 interface MultiDeckLabelTagBtnsStoryProps {

--- a/components/src/atoms/Chip/Chip.stories.tsx
+++ b/components/src/atoms/Chip/Chip.stories.tsx
@@ -1,4 +1,5 @@
 import { Chip as ChipComponent } from '.'
+import { customViewports } from '../../../../.storybook/preview'
 import { COLORS } from '../../helix-design-system'
 import { Flex, STYLE_PROPS } from '../../primitives'
 import { SPACING, VIEWPORT } from '../../ui-style-constants'
@@ -40,7 +41,9 @@ const meta: Meta<typeof ChipComponent> = {
     },
   },
   component: ChipComponent,
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
   decorators: [
     Story => (
       <Flex

--- a/components/src/atoms/InlineNotification/InlineNotification.stories.tsx
+++ b/components/src/atoms/InlineNotification/InlineNotification.stories.tsx
@@ -1,3 +1,4 @@
+import { customViewports } from '../../../../.storybook/preview'
 import { VIEWPORT } from '../../ui-style-constants'
 import { InlineNotification } from './index'
 
@@ -51,7 +52,9 @@ export default {
       if: { arg: 'hasLink' },
     },
   },
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
 } as Meta
 
 export interface WrapperProps extends React.ComponentProps<

--- a/components/src/atoms/ListItem/ListItem.stories.tsx
+++ b/components/src/atoms/ListItem/ListItem.stories.tsx
@@ -1,4 +1,5 @@
 import { ListItem as ListItemComponent, ListItemCustomize } from '.'
+import { customViewports } from '../../../../.storybook/preview'
 import { Flex } from '../../primitives'
 import { DIRECTION_COLUMN } from '../../styles'
 import { SPACING, VIEWPORT } from '../../ui-style-constants'
@@ -31,7 +32,9 @@ const meta: Meta<typeof ListItemComponent> = {
       },
     },
   },
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
 }
 
 export default meta

--- a/components/src/atoms/ListTable/ListTable.stories.tsx
+++ b/components/src/atoms/ListTable/ListTable.stories.tsx
@@ -3,6 +3,7 @@ import { css } from 'styled-components'
 import { Flex, VIEWPORT } from '@opentrons/components'
 
 import { ListTable as ListTableComponent } from '.'
+import { customViewports } from '../../../../.storybook/preview'
 
 import type { Meta, Story } from '@storybook/react'
 import type { ComponentProps } from 'react'
@@ -25,7 +26,9 @@ export default {
         'Prefer this component over SubListTable, since it contains the semantic HTML table tags. Include tr tags in the children when applicable. If a table is nested in ListTable, use SubListTable for the nested table.',
     },
   },
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
 } as Meta
 
 interface ListTableStoryProps extends ComponentProps<

--- a/components/src/atoms/MenuList/MenuItem.stories.tsx
+++ b/components/src/atoms/MenuList/MenuItem.stories.tsx
@@ -1,3 +1,4 @@
+import { customViewports } from '../../../../.storybook/preview'
 import { STYLE_PROPS } from '../../primitives'
 import { VIEWPORT } from '../../ui-style-constants'
 import { MenuItem as MenuItemComponent } from './MenuItem'
@@ -7,7 +8,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 const meta: Meta<typeof MenuItemComponent> = {
   title: 'Helix/Atoms/MenuItem',
   component: MenuItemComponent,
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
   argTypes: {
     // Disable all StyleProps
     ...Object.fromEntries(

--- a/components/src/atoms/Snackbar/Snackbar.stories.tsx
+++ b/components/src/atoms/Snackbar/Snackbar.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import { Snackbar as SnackbarComponent } from '.'
+import { customViewports } from '../../../../.storybook/preview'
 import { Flex, STYLE_PROPS } from '../../primitives'
 import {
   ALIGN_CENTER,
@@ -17,7 +18,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 const meta: Meta<typeof SnackbarComponent> = {
   title: 'Helix/Atoms/Snackbar',
   component: SnackbarComponent,
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
   argTypes: {
     // Disable all StyleProps
     ...Object.fromEntries(

--- a/components/src/atoms/StepMeter/StepMeter.stories.tsx
+++ b/components/src/atoms/StepMeter/StepMeter.stories.tsx
@@ -1,3 +1,4 @@
+import { customViewports } from '../../../../.storybook/preview'
 import { VIEWPORT } from '../../ui-style-constants'
 import { StepMeter as StepMeterComponent } from './index'
 
@@ -6,7 +7,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 const meta: Meta<typeof StepMeterComponent> = {
   title: 'Helix/Atoms/StepMeter',
   component: StepMeterComponent,
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
 }
 
 export default meta

--- a/components/src/atoms/SubListTable/SubListTable.stories.tsx
+++ b/components/src/atoms/SubListTable/SubListTable.stories.tsx
@@ -2,6 +2,7 @@ import { css } from 'styled-components'
 
 import { Flex, VIEWPORT } from '@opentrons/components'
 
+import { customViewports } from '../../../../.storybook/preview'
 import { SubListTable as SubListTableComponent } from './index'
 
 import type { Meta, Story } from '@storybook/react'
@@ -25,7 +26,9 @@ export default {
         'Use SubListTable only when there should a table-esque component in a real table (ListTable), otherwise use ListTable.',
     },
   },
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
 } as Meta
 
 interface SubListTableStoryProps extends ComponentProps<

--- a/components/src/atoms/Tag/Tag.stories.tsx
+++ b/components/src/atoms/Tag/Tag.stories.tsx
@@ -1,3 +1,4 @@
+import { customViewports } from '../../../../.storybook/preview'
 import { ICON_DATA_BY_NAME } from '../../icons/icon-data'
 import { Flex } from '../../primitives'
 import { SPACING, VIEWPORT } from '../../ui-style-constants'
@@ -28,7 +29,9 @@ const meta: Meta<typeof TagComponent> = {
     },
   },
   component: TagComponent,
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
   decorators: [
     Story => (
       <Flex padding={SPACING.spacing16} width="59rem">

--- a/components/src/atoms/buttons/RadioButton.stories.tsx
+++ b/components/src/atoms/buttons/RadioButton.stories.tsx
@@ -1,5 +1,6 @@
 import { action } from 'storybook/actions'
 
+import { customViewports } from '../../../../.storybook/preview'
 import { ICON_DATA_BY_NAME } from '../../icons/icon-data'
 import { VIEWPORT } from '../../ui-style-constants'
 import { RadioButton as RadioButtonComponent } from './RadioButton'
@@ -37,7 +38,9 @@ const meta: Meta<typeof RadioButtonComponent> = {
     },
   },
 
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
   args: {
     onChange: action('on-change'),
   },

--- a/components/src/molecules/InputField/InputField.stories.tsx
+++ b/components/src/molecules/InputField/InputField.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 
+import { customViewports } from '../../../../.storybook/preview'
 import { DIRECTION_COLUMN } from '../../styles'
 import { SPACING, VIEWPORT } from '../../ui-style-constants'
 import { InputField as InputFieldComponent } from './index'
@@ -11,7 +12,9 @@ const meta: Meta<typeof InputFieldComponent> = {
   // The unification for this component will be done when the old component is retired completely.
   title: 'Helix/Molecules/InputField',
   component: InputFieldComponent,
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
   argTypes: {
     units: {
       control: {

--- a/components/src/molecules/ListAccordion/ListAccordion.stories.tsx
+++ b/components/src/molecules/ListAccordion/ListAccordion.stories.tsx
@@ -9,6 +9,7 @@ import {
 } from '@opentrons/components'
 
 import { ListAccordion as ListAccordionComponent } from '.'
+import { customViewports } from '../../../../.storybook/preview'
 import { DISPLAY_FLEX, DISPLAY_GRID } from '../../styles'
 
 import type { Meta, Story } from '@storybook/react'
@@ -43,7 +44,9 @@ export default {
       description: 'See header text. Does nothing in Storybook.',
     },
   },
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
 } as Meta
 
 interface ListAccordionStoryProps extends Omit<

--- a/components/src/molecules/Tabs/Tabs.stories.tsx
+++ b/components/src/molecules/Tabs/Tabs.stories.tsx
@@ -1,6 +1,7 @@
 import { useArgs } from 'storybook/preview-api'
 
 import { Tabs as TabsComponent } from '.'
+import { customViewports } from '../../../../.storybook/preview'
 import { VIEWPORT } from '../../ui-style-constants'
 
 import type { Meta, StoryObj } from '@storybook/react'
@@ -8,7 +9,9 @@ import type { Meta, StoryObj } from '@storybook/react'
 const meta: Meta<typeof TabsComponent> = {
   title: 'Helix/Molecules/Tabs',
   component: TabsComponent,
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
   argTypes: {
     tabs: {
       control: {

--- a/components/src/molecules/TextAreaField/TextAreaField.stories.tsx
+++ b/components/src/molecules/TextAreaField/TextAreaField.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react'
 
 import { TextAreaField as TextAreaFieldComponent } from '.'
+import { customViewports } from '../../../../.storybook/preview'
 import { DIRECTION_COLUMN } from '../../styles'
 import { SPACING, VIEWPORT } from '../../ui-style-constants'
 
@@ -10,7 +11,9 @@ import type { ComponentProps } from 'react'
 const meta: Meta<typeof TextAreaFieldComponent> = {
   title: 'Helix/Molecules/TextAreaField',
   component: TextAreaFieldComponent,
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
   argTypes: {},
 }
 

--- a/components/src/molecules/TextListTableContent/TextListTableContent.stories.tsx
+++ b/components/src/molecules/TextListTableContent/TextListTableContent.stories.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { css } from 'styled-components'
 
 import { TextListTableContent as TextListTableContentComponent } from '.'
+import { customViewports } from '../../../../.storybook/preview'
 import { StyledText } from '../../atoms'
 import { DISPLAY_GRID } from '../../styles'
 import { SPACING, VIEWPORT } from '../../ui-style-constants'
@@ -28,7 +29,9 @@ export default {
         'For Storybook only. Number of lorem ipsum text rows to display in the table. ',
     },
   },
-  ...VIEWPORT.touchScreenViewport,
+  viewport: {
+    options: [VIEWPORT.touchScreenViewport, customViewports],
+  },
 } as Meta
 
 interface TextListTableContentStoryProps extends Omit<


### PR DESCRIPTION


# Overview
several components that support non-ODD and ODD use the fixed screen size on Storybook and we cannot change the  screen size now. this pr fix that issue that introduced my previous pr for stories.


<img width="1086" height="665" alt="Screenshot 2026-07-08 at 5 00 00 PM" src="https://github.com/user-attachments/assets/2073b9b5-7295-4265-bf5c-4643398956ad" />


## Test Plan and Hands on Testing
1.  `make -C components dev`
2. go to Helix/atoms/Chip and change the screen size


## Changelog
- fix stories viewport options

## Review requests


## Risk assessment
low
