### PR TITLE
refactor(auth-server,api-client): Remove scopes from /auth/users responses

### DIFF
--- a/api-client/src/auth/users/types.ts
+++ b/api-client/src/auth/users/types.ts
@@ -4,7 +4,6 @@ export interface AuthUser {
   username: string
   fullName: string
   accountType: AuthUserAccountType
-  scopes: string[]
   locked: boolean
   resetPassword: boolean
 }

--- a/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
+++ b/app/src/organisms/Desktop/LoginModal/__tests__/LoginModal.test.tsx
@@ -46,7 +46,6 @@ const AUTH_USER: AuthUser = {
   username: 'alice',
   fullName: 'Alice',
   accountType: 'user',
-  scopes: [],
   locked: false,
   resetPassword: false,
 }

--- a/app/src/organisms/ODD/OnDeviceLogin/__tests__/LoginModal.test.tsx
+++ b/app/src/organisms/ODD/OnDeviceLogin/__tests__/LoginModal.test.tsx
@@ -37,7 +37,6 @@ function mockAuthUser(overrides: Partial<AuthUser> = {}): AuthUser {
     username: 'alice',
     fullName: 'Alice',
     accountType: 'user',
-    scopes: [],
     locked: false,
     resetPassword: false,
     ...overrides,

--- a/app/src/pages/ODD/Account/__tests__/hooks.test.tsx
+++ b/app/src/pages/ODD/Account/__tests__/hooks.test.tsx
@@ -76,7 +76,6 @@ describe('useAccountInfo', () => {
           username: 'test-user',
           fullName: 'Test User Name',
           accountType: 'user',
-          scopes: [],
           locked: false,
           resetPassword: false,
         },

--- a/app/src/resources/auth/hooks/__tests__/useOAuth2PasswordLogin.test.ts
+++ b/app/src/resources/auth/hooks/__tests__/useOAuth2PasswordLogin.test.ts
@@ -82,7 +82,6 @@ describe('useOAuth2PasswordLogin', () => {
           username: 'alice',
           fullName: 'Alice',
           accountType: 'user',
-          scopes: [],
           locked: false,
           resetPassword: false,
         },
@@ -112,7 +111,6 @@ describe('useOAuth2PasswordLogin', () => {
       username: 'alice',
       fullName: 'Alice',
       accountType: 'user',
-      scopes: [],
       locked: false,
       resetPassword: true,
     }

--- a/app/src/resources/auth/hooks/__tests__/useSetNewPasswordAndSignIn.test.ts
+++ b/app/src/resources/auth/hooks/__tests__/useSetNewPasswordAndSignIn.test.ts
@@ -46,7 +46,6 @@ describe('useSetNewPasswordAndSignIn', () => {
         username: 'alice',
         fullName: 'Alice',
         accountType: 'user',
-        scopes: [],
         locked: false,
         resetPassword: false,
       },

--- a/auth-server/auth_server/users/models.py
+++ b/auth-server/auth_server/users/models.py
@@ -107,7 +107,6 @@ class UserResponse(BaseModel):
     username: str
     fullName: str
     accountType: AccountType
-    scopes: list[str]
     locked: bool
     resetPassword: bool
 

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -63,8 +63,6 @@ async def post_users(
     ],
 ) -> PydanticResponse[SimpleBody[UserResponse]]:
     """Create a user."""
-    # todo(mm, 2026-02-20): The new user's scopes should either depend on their account type,
-    # or they should be passed in the request body.
     user_create = request_body.data
     try:
         new_user = user_data_manager.create_user(

--- a/auth-server/auth_server/users/user_data_manager.py
+++ b/auth-server/auth_server/users/user_data_manager.py
@@ -135,13 +135,11 @@ class UserDataManager:
         )
 
         account_type = AccountType(user.account_type)
-        scopes = sorted(scope.api_name for scope in get_scope_set_of_user(user))
 
         return UserResponse(
             username=user.username,
             fullName=user.full_name,
             accountType=account_type,
-            scopes=scopes,
             locked=is_currently_locked,
             resetPassword=user.reset_password,
         )

--- a/auth-server/tests/conftest.py
+++ b/auth-server/tests/conftest.py
@@ -9,7 +9,6 @@ from tests.dev_server import DevServer
 
 from auth_server.users.models import (
     ACCOUNT_TYPE_TO_SCOPES,
-    RESET_PASSWORD_SCOPES,
     AccountType,
 )
 
@@ -26,24 +25,6 @@ def admin_scopes_str() -> str:
 def user_scopes_str() -> str:
     """All the OAuth 2 scopes that a regular user should have, as a space-separated string."""
     return serialize_scopes(set(ACCOUNT_TYPE_TO_SCOPES[AccountType.USER]))
-
-
-@pytest.fixture
-def reset_password_scopes_list() -> list[str]:
-    """Scopes returned on a user record while they must reset their password."""
-    return sorted(scope.api_name for scope in RESET_PASSWORD_SCOPES)
-
-
-@pytest.fixture
-def admin_scopes_list() -> list[str]:
-    """All the OAuth 2 scopes that an admin should have, as a list."""
-    return sorted(scope.api_name for scope in ACCOUNT_TYPE_TO_SCOPES[AccountType.ADMIN])
-
-
-@pytest.fixture
-def user_scopes_list() -> list[str]:
-    """All the OAuth 2 scopes that a regular user should have, as a list."""
-    return sorted(scope.api_name for scope in ACCOUNT_TYPE_TO_SCOPES[AccountType.USER])
 
 
 @pytest.fixture

--- a/auth-server/tests/integration/test_reset_password_flow.tavern.yaml
+++ b/auth-server/tests/integration/test_reset_password_flow.tavern.yaml
@@ -4,8 +4,6 @@ marks:
   - usefixtures:
       - run_server
       - admin_access_token
-      - user_scopes_list
-      - reset_password_scopes_list
 
 stages:
   - name: Create a user for the reset-password flow
@@ -28,7 +26,6 @@ stages:
           fullName: Reset Password Flow User
           accountType: user
           locked: false
-          scopes: !force_original_structure '{user_scopes_list}'
           resetPassword: false
 
   - name: Admin resets the user password to a temporary password
@@ -48,7 +45,6 @@ stages:
           fullName: Reset Password Flow User
           accountType: user
           locked: false
-          scopes: !force_original_structure '{reset_password_scopes_list}'
           resetPassword: true
           temporaryPassword: !anystr
 
@@ -104,7 +100,6 @@ stages:
           fullName: Reset Password Flow User
           accountType: user
           locked: false
-          scopes: !force_original_structure '{user_scopes_list}'
           resetPassword: false
 
   - name: User can log in with the chosen password and gets full scopes back
@@ -146,8 +141,6 @@ marks:
   - usefixtures:
       - run_server
       - admin_access_token
-      - user_scopes_list
-      - reset_password_scopes_list
 
 stages:
   - name: Create a user for the self update reset-password flow
@@ -170,7 +163,6 @@ stages:
           fullName: Self Update Reset Password User
           accountType: user
           locked: false
-          scopes: !force_original_structure '{user_scopes_list}'
           resetPassword: false
 
   - name: Admin resets the user password to a temporary password
@@ -190,7 +182,6 @@ stages:
           fullName: Self Update Reset Password User
           accountType: user
           locked: false
-          scopes: !force_original_structure '{reset_password_scopes_list}'
           resetPassword: true
           temporaryPassword: !anystr
 
@@ -232,7 +223,6 @@ stages:
           fullName: Self Update Reset Password User
           accountType: user
           locked: false
-          scopes: !force_original_structure '{user_scopes_list}'
           resetPassword: false
 
   - name: User can log in with the new password and gets full scopes back

--- a/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_user_crud_flows.tavern.yaml
@@ -4,9 +4,6 @@ marks:
   - usefixtures:
       - run_server
       - admin_access_token
-      - admin_scopes_list
-      - user_scopes_list
-      - reset_password_scopes_list
 
 stages:
   - name: Create a new user
@@ -29,7 +26,6 @@ stages:
           fullName: Test New User
           accountType: user
           locked: false
-          scopes: !force_original_structure '{user_scopes_list}'
           resetPassword: false
   - name: Get a user information
     request:
@@ -45,7 +41,6 @@ stages:
           fullName: Test New User
           username: test_new_user
           locked: false
-          scopes: !force_original_structure '{user_scopes_list}'
           resetPassword: false
   - name: Update the user
     request:
@@ -65,7 +60,6 @@ stages:
           fullName: Test New User Updated
           username: test_new_user
           locked: false
-          scopes: !force_original_structure '{admin_scopes_list}'
           resetPassword: false
   - name: Update the username and password
     request:
@@ -85,7 +79,6 @@ stages:
           fullName: Test New User Updated
           username: test_new_user_updated
           locked: false
-          scopes: !force_original_structure '{admin_scopes_list}'
           resetPassword: false
   - name: Update the reset password flag
     request:
@@ -104,7 +97,6 @@ stages:
           fullName: Test New User Updated
           username: test_new_user_updated
           locked: false
-          scopes: !force_original_structure '{reset_password_scopes_list}'
           resetPassword: true
   - name: Get the user information
     request:
@@ -120,7 +112,6 @@ stages:
           fullName: Test New User Updated
           username: test_new_user_updated
           locked: false
-          scopes: !force_original_structure '{reset_password_scopes_list}'
           resetPassword: true
   - name: Reset the user's password to a temporary password
     request:
@@ -139,7 +130,6 @@ stages:
           fullName: Test New User Updated
           username: test_new_user_updated
           locked: false
-          scopes: !force_original_structure '{reset_password_scopes_list}'
           resetPassword: true
           temporaryPassword: !anystr
 
@@ -194,7 +184,6 @@ stages:
           fullName: Test New User Updated
           username: test_new_user_updated
           locked: false
-          scopes: !force_original_structure '{admin_scopes_list}'
           resetPassword: false
 
   - name: Get a new access token with the updated username and password

--- a/auth-server/tests/users/test_dependencies.py
+++ b/auth-server/tests/users/test_dependencies.py
@@ -14,7 +14,6 @@ async def test_get_user_by_username_returns_user(decoy: Decoy) -> None:
         username="alice",
         fullName="Alice",
         accountType=AccountType.USER,
-        scopes=[],
         locked=False,
         resetPassword=False,
     )

--- a/auth-server/tests/users/test_user_data_manager.py
+++ b/auth-server/tests/users/test_user_data_manager.py
@@ -7,8 +7,6 @@ from auth_server.persistence.orm_models import User
 from auth_server.settings.models import SettingsResponseData
 from auth_server.settings.store import SettingsStore
 from auth_server.users.models import (
-    ACCOUNT_TYPE_TO_SCOPES,
-    RESET_PASSWORD_SCOPES,
     AccountType,
     UserResponse,
 )
@@ -110,9 +108,6 @@ def test_create_user_success(
         username="new_user",
         fullName="New User",
         accountType=AccountType.USER,
-        scopes=sorted(
-            scope.api_name for scope in ACCOUNT_TYPE_TO_SCOPES[AccountType.USER]
-        ),
         locked=False,
         resetPassword=False,
     )
@@ -141,9 +136,6 @@ def test_create_user_hashes_password(
         username="hash_check",
         fullName="X",
         accountType=AccountType.USER,
-        scopes=sorted(
-            scope.api_name for scope in ACCOUNT_TYPE_TO_SCOPES[AccountType.USER]
-        ),
         locked=False,
         resetPassword=False,
     )
@@ -295,9 +287,6 @@ def test_get_user_returns_existing(
         username="admin",
         fullName="Full Name",
         accountType=AccountType.ADMIN,
-        scopes=sorted(
-            scope.api_name for scope in ACCOUNT_TYPE_TO_SCOPES[AccountType.ADMIN]
-        ),
         locked=False,
         resetPassword=False,
     )
@@ -322,9 +311,6 @@ def test_get_user_locked_when_failed_logins_reach_limit(
         username="alice",
         fullName="Alice",
         accountType=AccountType.USER,
-        scopes=sorted(
-            scope.api_name for scope in ACCOUNT_TYPE_TO_SCOPES[AccountType.USER]
-        ),
         locked=True,
         resetPassword=False,
     )
@@ -390,9 +376,6 @@ def test_update_user_username(
         username="new_name",
         fullName="Name Test",
         accountType=AccountType.USER,
-        scopes=sorted(
-            scope.api_name for scope in ACCOUNT_TYPE_TO_SCOPES[AccountType.USER]
-        ),
         locked=False,
         resetPassword=False,
     )
@@ -479,7 +462,6 @@ def test_reset_user_password(
 
     assert result.username == "reset_me"
     assert result.resetPassword is True
-    assert result.scopes == sorted(scope.api_name for scope in RESET_PASSWORD_SCOPES)
     assert len(result.temporaryPassword) == 8
     assert all(
         c in string.ascii_letters + string.digits for c in result.temporaryPassword


### PR DESCRIPTION
## Overview

Different account types (user, admin, ...) have different OAuth 2 scopes ("read users," "write protocols," ...). We were exposing those scopes in endpoints like `GET /users/byUsername/{username}`, mostly for debugging. This PR removes them from those endpoints.

Rationale:

* Practically, it would be a pain to integrate with EXEC-2774. With EXEC-2774, a user's scopes will automatically get restricted when their password expires. We would need to update all the places we're constructing these responses to understand the current time and the current `passwordResetTime` setting. That complexity didn't seem worthwhile for a debug-only field.
* In general, I don't want clients to depend on our exact breakdown of scopes. I have a hunch it's going to change from release to release. Clients may instead depend on account types.
* If a client really does need to depend on the exact breakdown of scopes, we still have the `/auth/oauth2/token` endpoint, which is the canonical source that's actually load-bearing for access control.

## Test Plan and Hands on Testing

Just automated tests.

## Review requests

Agreed in principle?

## Risk assessment

Low.
