### PR TITLE
fix(app, odd): fix LPC prompting for documentation on mount

### DIFF
--- a/app/src/local-resources/access-control/__tests__/useMaintenanceRunDocumentation.test.ts
+++ b/app/src/local-resources/access-control/__tests__/useMaintenanceRunDocumentation.test.ts
@@ -169,4 +169,32 @@ describe('useMaintenanceRunDocumentation', () => {
 
     expect(mockShowDocumentationRequiredModal).toHaveBeenCalledTimes(2)
   })
+
+  it('does not auto-prompt when promptEnabled is false', async () => {
+    const { result, rerender } = renderHook(
+      ({ promptEnabled }) =>
+        useMaintenanceRunDocumentation(
+          'lpc_flow',
+          undefined,
+          undefined,
+          promptEnabled
+        ),
+      {
+        wrapper,
+        initialProps: { promptEnabled: false },
+      }
+    )
+
+    await waitFor(() => {
+      expect(!result.current.commandDocState.isLoading).toBe(true)
+    })
+
+    expect(mockShowDocumentationRequiredModal).not.toHaveBeenCalled()
+
+    rerender({ promptEnabled: true })
+
+    await waitFor(() => {
+      expect(mockShowDocumentationRequiredModal).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/app/src/local-resources/access-control/__tests__/usePromptForDocumentation.test.ts
+++ b/app/src/local-resources/access-control/__tests__/usePromptForDocumentation.test.ts
@@ -170,4 +170,34 @@ describe('usePromptForDocumentation', () => {
       }
     })
   })
+
+  it('does not prompt when promptEnabled is false', async () => {
+    const { result, rerender } = renderHook(
+      ({ promptEnabled }) =>
+        usePromptForDocumentation(
+          ['lpc_flow'],
+          undefined,
+          undefined,
+          promptEnabled
+        ),
+      {
+        wrapper,
+        initialProps: { promptEnabled: false },
+      }
+    )
+
+    await waitFor(() => {
+      expect(
+        !result.current.isLoading && result.current.accessControlEnabled
+      ).toBe(true)
+    })
+
+    expect(mockShowDocumentationRequiredModal).not.toHaveBeenCalled()
+
+    rerender({ promptEnabled: true })
+
+    await waitFor(() => {
+      expect(mockShowDocumentationRequiredModal).toHaveBeenCalledTimes(1)
+    })
+  })
 })

--- a/app/src/local-resources/access-control/useMaintenanceRunDocumentation.ts
+++ b/app/src/local-resources/access-control/useMaintenanceRunDocumentation.ts
@@ -16,6 +16,7 @@ import type {
  * @param maintenanceRunName: The name of the maintenance run, to be displayed in the initial documentation modal.
  * @param onCancelStart: Optional callback when the user backs out of the initial documentation modal.
  * @param initialDocstate: An optional documentation state - to be used in flows like attaching where prompting needs to occur before the first mutation.
+ * @param promptEnabled: When false, defer the command documentation prompt until set to true. Defaults to true.
  *
  * @returns commandDocState: DocumentationState to be passed to the creation hook and the maintenance run commands.
  * @returns deletionDocState: DocumentationState to be passed to the deletion hook.
@@ -25,7 +26,8 @@ import type {
 export const useMaintenanceRunDocumentation = (
   maintenanceRunName: DocumentedAction,
   onCancelStart?: () => void,
-  initialDocstate?: DocumentationState
+  initialDocstate?: DocumentationState,
+  promptEnabled: boolean = true
 ): {
   commandDocState: DocumentationState
   deletionDocState: DocumentationState
@@ -39,7 +41,8 @@ export const useMaintenanceRunDocumentation = (
   const commandDocState = usePromptForDocumentation(
     [maintenanceRunName],
     onCancelStart,
-    initialDocstate
+    initialDocstate,
+    promptEnabled
   )
   const deletionDocState = useDocumentationState()
 

--- a/app/src/local-resources/access-control/usePromptForDocumentation.ts
+++ b/app/src/local-resources/access-control/usePromptForDocumentation.ts
@@ -17,12 +17,14 @@ import type {
  * If mutations can prompt for documentation themselves, use useDocumentationState instead.
  *
  *  @param initialDocstate - an optional documentation state to use as a base. To be used when a flow needs to sometimes but not always prompt before the first mutation.
+ *  @param promptEnabled - when false, defer prompting until set to true. Defaults to true.
  *
  */
 export const usePromptForDocumentation = (
   actionsToDocument: DocumentedAction[],
   onCancel?: () => void,
-  initialDocstate?: DocumentationState
+  initialDocstate?: DocumentationState,
+  promptEnabled: boolean = true
 ): DocumentationState => {
   const [docReport, setDocReport] = useState<DocumentationReport>()
   const docStateToUse =
@@ -36,6 +38,12 @@ export const usePromptForDocumentation = (
   const promptInFlight = useRef(false)
 
   useEffect(() => {
+    if (!promptEnabled) {
+      setDocReport(undefined)
+      promptInFlight.current = false
+      return
+    }
+
     const promptForDocumentation = async (): Promise<void> => {
       if (
         !docState.isLoading &&
@@ -56,7 +64,7 @@ export const usePromptForDocumentation = (
     if (!docState.isLoading) {
       void promptForDocumentation()
     }
-  }, [actionsToDocument, docReport, docState, onCancel])
+  }, [actionsToDocument, docReport, docState, onCancel, promptEnabled])
 
   return docState
 }

--- a/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
+++ b/app/src/organisms/LabwarePositionCheck/LPCFlows/useLPCFlows.ts
@@ -8,6 +8,7 @@ import {
 import { FLEX_ROBOT_TYPE, OT2_ROBOT_TYPE } from '@opentrons/shared-data'
 
 import { useMaintenanceRunDocumentation } from '/app/local-resources/access-control/useMaintenanceRunDocumentation'
+import { isDocumentationProvided } from '/app/local-resources/access-control/utils'
 import { useInitLPCStore } from '/app/organisms/LabwarePositionCheck/LPCFlows/hooks/useInitLPCStore'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 import {
@@ -77,6 +78,7 @@ export function useLPCFlows({
   const [maintenanceRunId, setMaintenanceRunId] = useState<string | null>(null)
   const [isLaunching, setIsLaunching] = useState(false)
   const [hasCreatedLPCRun, setHasCreatedLPCRun] = useState(false)
+  const [promptForDocumentation, setPromptForDocumentation] = useState(false)
 
   // if launchLPC is called while other queries are still loading, we will return a constructed promise and store any provided callbacks in this ref
   // once unblocked, the useEffect will launch LPC and resolve the constructed promise with the results
@@ -88,6 +90,7 @@ export function useLPCFlows({
       pendingLaunchRef.current = null
       reject(new Error('Documentation cancelled'))
     }
+    setPromptForDocumentation(false)
     setIsLaunching(false)
   }, [])
 
@@ -97,7 +100,12 @@ export function useLPCFlows({
     actionsToDocument,
     addActionToDocument,
     isLoading: isDocumentationLoading,
-  } = useMaintenanceRunDocumentation('lpc_flow', handleDocumentationCancel)
+  } = useMaintenanceRunDocumentation(
+    'lpc_flow',
+    handleDocumentationCancel,
+    undefined,
+    promptForDocumentation
+  )
 
   const isFlex = robotType === FLEX_ROBOT_TYPE
   const deckConfig = useNotifyDeckConfigurationQuery().data
@@ -193,8 +201,12 @@ export function useLPCFlows({
   )
 
   const isFlexLPCInitializing = flexOffsets == null
+  const isWaitingForDocumentation =
+    promptForDocumentation && !isDocumentationProvided(commandDocState)
   const isLaunchBlocked =
-    isDocumentationLoading || (isFlex && isFlexLPCInitializing)
+    isDocumentationLoading ||
+    (isFlex && isFlexLPCInitializing) ||
+    !isDocumentationProvided(commandDocState)
 
   const createLPCMaintenanceRun = useCallback((): Promise<void> => {
     // Inject OT-2 offsets into the maintenance run upon creation.
@@ -230,6 +242,7 @@ export function useLPCFlows({
     }
 
     analytics.reportLaunchLpcWizard()
+    setPromptForDocumentation(true)
     setIsLaunching(true)
 
     if (isLaunchBlocked) {
@@ -286,7 +299,8 @@ export function useLPCFlows({
       }
     : {
         launchLPC,
-        isLaunchingLPC: isLaunching || isDocumentationLoading,
+        isLaunchingLPC:
+          isLaunching || isWaitingForDocumentation || isDocumentationLoading,
         isFlexLPCInitializing,
         lpcProps: null,
         showLPC,


### PR DESCRIPTION
# Overview

Fixes a bug where a documentation required modal would pop up as soon as the `useLPCFlows` hook mounts in protocol setup. I fixed this by patching `useMaintenanceRunDocumentation` - prompting immediately works for all other flows where this hook mounts with the wizard launch, but since this flow has a separate 'launchLPC' function, it needed special handling. 

## Test Plan and Hands on Testing

Go to setup a protocol, no documentation required modal should pop up that lists 'launching LPC' as its action. LPC should still work normally. 

## Risk assessment

Low