### PR TITLE
feat(api-client, react-api-client): add binding support for `requiresClosedDoor`

### DIFF
--- a/api-client/src/maintenance_runs/createMaintenanceCommand.ts
+++ b/api-client/src/maintenance_runs/createMaintenanceCommand.ts
@@ -2,14 +2,15 @@ import { POST, request } from '../request'
 
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { ResponsePromise } from '../request'
-import type { CommandData, CreateCommandParams } from '../runs/types'
+import type { CommandData } from '../runs/types'
 import type { HostConfig } from '../types'
+import type { CreateMaintenanceCommandParams } from './types'
 
 export function createMaintenanceCommand(
   config: HostConfig,
   maintenanceRunId: string,
   data: CreateCommand,
-  params?: CreateCommandParams,
+  params?: CreateMaintenanceCommandParams,
   userNotes?: string
 ): ResponsePromise<CommandData> {
   return request<CommandData, { data: CreateCommand }>(

--- a/api-client/src/maintenance_runs/types.ts
+++ b/api-client/src/maintenance_runs/types.ts
@@ -11,6 +11,7 @@ import type {
   RunCommandSummary,
   RunStatus,
 } from '../runs'
+import type { CreateCommandParams } from '../runs/commands/types'
 
 export interface MaintenanceRunData {
   id: string
@@ -44,6 +45,10 @@ export interface MaintenanceRunError {
 
 export interface CreateMaintenanceRunData {
   labwareOffsets?: LegacyLabwareOffsetCreateData[] | LabwareOffsetCreateData[]
+}
+
+export interface CreateMaintenanceCommandParams extends CreateCommandParams {
+  requiresClosedDoor?: boolean
 }
 
 export interface LabwareDefinitionSummary {

--- a/react-api-client/src/maintenance_runs/useCreateMaintenanceCommandMutation.ts
+++ b/react-api-client/src/maintenance_runs/useCreateMaintenanceCommandMutation.ts
@@ -10,16 +10,17 @@ import type {
   UseMutationOptions,
   UseMutationResult,
 } from 'react-query'
-import type { CommandData, CreateCommandParams } from '@opentrons/api-client'
+import type {
+  CommandData,
+  CreateMaintenanceCommandParams,
+} from '@opentrons/api-client'
 import type { CreateCommand } from '@opentrons/shared-data'
 import type { DocumentationState, DocumentedAction } from '../accessControl'
 import type { DocumentedMutationParameters } from '../accessControl/types'
 
-interface CreateMaintenanceCommandMutateParams extends CreateCommandParams {
+interface CreateMaintenanceCommandMutateParams extends CreateMaintenanceCommandParams {
   maintenanceRunId: string
   command: CreateCommand
-  waitUntilComplete?: boolean
-  timeout?: number
 }
 
 export type UseCreateMaintenanceCommandMutationResult = UseMutationResult<
@@ -56,7 +57,13 @@ export function useCreateMaintenanceCommandMutation(
     documentationState,
     actionsToDocument,
     ({
-      variables: { maintenanceRunId, command, waitUntilComplete, timeout },
+      variables: {
+        maintenanceRunId,
+        command,
+        waitUntilComplete,
+        timeout,
+        requiresClosedDoor = true,
+      },
       userNotes,
     }: DocumentedMutationParameters<CreateMaintenanceCommandMutateParams>) =>
       createMaintenanceCommand(
@@ -66,6 +73,7 @@ export function useCreateMaintenanceCommandMutation(
         {
           waitUntilComplete,
           timeout,
+          requiresClosedDoor,
         },
         userNotes
       )


### PR DESCRIPTION
Closes [EXEC-2830](https://opentrons.atlassian.net/browse/EXEC-2830)

# Overview

Adds the `requiresClosedDoor` param to `useCreateMaintenanceRunCommandMutation` and defaults the value to `true`. This change effectively applies to all desktop app and ODD issued maintenance commands.

Note that there are no UI affordances for the new behavior in this PR. We'll tackle those on a flow-by-flow basis in follow-ups. Maintenance run flows will show likely confusing errors until we do so. 

https://github.com/user-attachments/assets/3408532c-06a0-4234-ae37-579cb0daffb6

## Test Plan and Hands on Testing

- See video.
- Confirmed that keeping the door closed does allow users to proceed through maintenance run flows unimpeded. 

## Changelog

- The desktop app and ODD will now throw errors on maintenance run command issuance if the robot door is not closed.

## Risk assessment

- high in the sense that we now need to audit all maintenance runs and ensure we create proper UI affordances for each possible entry point...it's a lot of code to cover


[EXEC-2830]: https://opentrons.atlassian.net/browse/EXEC-2830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ