### PR TITLE
feat(auth-server): send fullname in token introspect

### DIFF
--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -371,12 +371,12 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         else:
             # Values defined by:
             # https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
-            # except ot-fullname, which is custom to us. if you add other custom fields,
+            # except ot_fullname, which is custom to us. if you add other custom fields,
             # please prefix them with ot-.
             return {
                 "scope": serialize_scopes(found_access_token.scopes),
                 "username": found_access_token.username,
-                "ot-fullname": found_access_token.fullname,
+                "ot_fullname": found_access_token.fullname,
                 # "active": True is set implicitly by oauthlib.
             }
 

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -307,6 +307,7 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
                 refresh_token=refresh_token,
                 expires_at=expires_at,
                 scopes=scopes,
+                fullname=user.full_name,
             )
         )
 
@@ -370,9 +371,12 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         else:
             # Values defined by:
             # https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
+            # except ot-fullname, which is custom to us. if you add other custom fields,
+            # please prefix them with ot-.
             return {
                 "scope": serialize_scopes(found_access_token.scopes),
                 "username": found_access_token.username,
+                "ot-fullname": found_access_token.fullname,
                 # "active": True is set implicitly by oauthlib.
             }
 
@@ -424,6 +428,7 @@ class _TokenIssuance:
     # to resist problems from clock adjustment.
     expires_at: datetime
     scopes: set[Scope]
+    fullname: str
 
 
 class _TokenStore:

--- a/auth-server/tests/integration/test_oauth_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_oauth_flows.tavern.yaml
@@ -40,6 +40,7 @@ stages:
       json:
         active: true
         username: testadmin
+        ot-fullname: Test Admin
         scope: *returned_scope
 
   - name: Introspect the refresh token and confirm it's inactive (only access tokens are active)
@@ -89,6 +90,7 @@ stages:
       json:
         active: true
         username: testadmin
+        ot-fullname: Test Admin
         scope: *returned_scope
 
   - name: Introspect the new refresh token and confirm it's inactive (only access tokens are active)

--- a/auth-server/tests/integration/test_oauth_flows.tavern.yaml
+++ b/auth-server/tests/integration/test_oauth_flows.tavern.yaml
@@ -40,7 +40,7 @@ stages:
       json:
         active: true
         username: testadmin
-        ot-fullname: Test Admin
+        ot_fullname: Test Admin
         scope: *returned_scope
 
   - name: Introspect the refresh token and confirm it's inactive (only access tokens are active)
@@ -90,7 +90,7 @@ stages:
       json:
         active: true
         username: testadmin
-        ot-fullname: Test Admin
+        ot_fullname: Test Admin
         scope: *returned_scope
 
   - name: Introspect the new refresh token and confirm it's inactive (only access tokens are active)

--- a/server-utils/server_utils/auth/resource_server/auth_server.py
+++ b/server-utils/server_utils/auth/resource_server/auth_server.py
@@ -147,7 +147,7 @@ class LocalHTTPClient(Client):
 
 
 class _StrictBaseModel(pydantic.BaseModel):
-    model_config = {"strict": True, "validate_by_name": True}
+    model_config = {"strict": True}
 
 
 class TokenIntrospectionResponse(_StrictBaseModel):
@@ -159,7 +159,7 @@ class TokenIntrospectionResponse(_StrictBaseModel):
     active: bool
     scope: str = ""
     username: str | None = None
-    fullname: str | None = pydantic.Field(None, alias="ot-fullname")
+    ot_fullname: str | None = None
 
 
 class TokenIntrospectionRequestFormData(typing.TypedDict):

--- a/server-utils/server_utils/auth/resource_server/auth_server.py
+++ b/server-utils/server_utils/auth/resource_server/auth_server.py
@@ -147,7 +147,7 @@ class LocalHTTPClient(Client):
 
 
 class _StrictBaseModel(pydantic.BaseModel):
-    model_config = {"strict": True}
+    model_config = {"strict": True, "validate_by_name": True}
 
 
 class TokenIntrospectionResponse(_StrictBaseModel):
@@ -159,6 +159,7 @@ class TokenIntrospectionResponse(_StrictBaseModel):
     active: bool
     scope: str = ""
     username: str | None = None
+    fullname: str | None = pydantic.Field(None, alias="ot-fullname")
 
 
 class TokenIntrospectionRequestFormData(typing.TypedDict):

--- a/server-utils/server_utils/auth/resource_server/authorization_checker.py
+++ b/server-utils/server_utils/auth/resource_server/authorization_checker.py
@@ -195,8 +195,16 @@ class AuthServerAuthorizationChecker(AuthorizationChecker):
                     "Username not present in token introspection response."
                     " This is a bug in auth-server."
                 )
+            elif token_info.fullname is None:
+                # Similarly, our custom fullname field should be returned always.
+                raise RuntimeError(
+                    "Fullname not present in token introspection response."
+                    " This is a bug in auth-server."
+                )
             else:
-                return AuthorizedResult(username=token_info.username)
+                return AuthorizedResult(
+                    username=token_info.username, fullname=token_info.fullname
+                )
 
     @override
     async def is_reason_for_interaction_required(self) -> bool:
@@ -228,6 +236,7 @@ class AuthorizedResult:
     """The request is authorized with a valid access token."""
 
     username: str
+    fullname: str
     """The user who issued the request."""
 
 

--- a/server-utils/server_utils/auth/resource_server/authorization_checker.py
+++ b/server-utils/server_utils/auth/resource_server/authorization_checker.py
@@ -195,7 +195,7 @@ class AuthServerAuthorizationChecker(AuthorizationChecker):
                     "Username not present in token introspection response."
                     " This is a bug in auth-server."
                 )
-            elif token_info.fullname is None:
+            elif token_info.ot_fullname is None:
                 # Similarly, our custom fullname field should be returned always.
                 raise RuntimeError(
                     "Fullname not present in token introspection response."
@@ -203,7 +203,7 @@ class AuthServerAuthorizationChecker(AuthorizationChecker):
                 )
             else:
                 return AuthorizedResult(
-                    username=token_info.username, fullname=token_info.fullname
+                    username=token_info.username, fullname=token_info.ot_fullname
                 )
 
     @override

--- a/server-utils/tests/auth/resource_server/test_auth_server.py
+++ b/server-utils/tests/auth/resource_server/test_auth_server.py
@@ -199,14 +199,14 @@ async def test_token_introspection(
         "active": True,
         "scope": "mama_mia papa_pia",
         "username": "test_username",
-        "ot-fullname": "Test Fullname",
+        "ot_fullname": "Test Fullname",
     }
     introspect_response = await client.introspect_token("test-token")
     assert introspect_response == TokenIntrospectionResponse(
         active=True,
         scope="mama_mia papa_pia",
         username="test_username",
-        fullname="Test Fullname",
+        ot_fullname="Test Fullname",
     )
     assert app_mock.introspect_requests == [
         {"token": "test-token", "client_id": CLIENT_ID}

--- a/server-utils/tests/auth/resource_server/test_auth_server.py
+++ b/server-utils/tests/auth/resource_server/test_auth_server.py
@@ -199,12 +199,14 @@ async def test_token_introspection(
         "active": True,
         "scope": "mama_mia papa_pia",
         "username": "test_username",
+        "ot-fullname": "Test Fullname",
     }
     introspect_response = await client.introspect_token("test-token")
     assert introspect_response == TokenIntrospectionResponse(
         active=True,
         scope="mama_mia papa_pia",
         username="test_username",
+        fullname="Test Fullname",
     )
     assert app_mock.introspect_requests == [
         {"token": "test-token", "client_id": CLIENT_ID}

--- a/server-utils/tests/auth/resource_server/test_authorization_checker.py
+++ b/server-utils/tests/auth/resource_server/test_authorization_checker.py
@@ -130,7 +130,7 @@ class TestAuthServerAuthorizationChecker:
                 active=True,
                 scope=serialize_scopes({Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}),
                 username="test-username",
-                fullname="Test Fullname",
+                ot_fullname="Test Fullname",
             )
         )
 

--- a/server-utils/tests/auth/resource_server/test_authorization_checker.py
+++ b/server-utils/tests/auth/resource_server/test_authorization_checker.py
@@ -130,12 +130,13 @@ class TestAuthServerAuthorizationChecker:
                 active=True,
                 scope=serialize_scopes({Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}),
                 username="test-username",
+                fullname="Test Fullname",
             )
         )
 
         assert await subject.check(
             "test-token-abc123", {Scope.ROBOT_CONTROL_WRITE, Scope.USERS_WRITE}
-        ) == AuthorizedResult(username="test-username")
+        ) == AuthorizedResult(username="test-username", fullname="Test Fullname")
 
         # Inactive -> do not authorize
         decoy.when(await mock_client.introspect_token("test-token-abc123")).then_return(


### PR DESCRIPTION
We're going to need the user fullname/legal name in the audit log messages, and anything that sends audit log messages is already using an authorization checker that hits the token introspection endpoint. By adding the fullname to the result of that endpoint, we can skip an extra request.

## Risk
Low, nothing uses this yet and it's another field in the json

Closes EXEC-2834