### PR TITLE
chore: fix update-server failing tests and workflow links

### DIFF
--- a/.github/workflows/audit-server-lint-test.yaml
+++ b/.github/workflows/audit-server-lint-test.yaml
@@ -13,6 +13,8 @@ on:
       - '.github/workflows/audit-server-lint-test.yaml'
       - '.github/actions/python/**'
       - 'server-utils/**'
+      - 'shared-data/**'
+      - '!shared-data/js/**'
     branches: # ignore any release-related thing (handled elsewhere)
       - 'edge'
     tags-ignore:
@@ -27,6 +29,8 @@ on:
       - '.github/workflows/audit-server-lint-test.yaml'
       - '.github/actions/python/**'
       - 'server-utils/**'
+      - 'shared-data/**'
+      - '!shared-data/js/**'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/hardware-lint-test.yaml
+++ b/.github/workflows/hardware-lint-test.yaml
@@ -13,6 +13,8 @@ on:
       - 'scripts/**.py'
       - '.github/workflows/hardware-lint-test.yaml'
       - '.github/actions/python/**'
+      - 'shared-data/**'
+      - '!shared-data/js/**'
     branches:
       - 'edge'
       - 'release'
@@ -26,6 +28,8 @@ on:
       - 'scripts/**.py'
       - '.github/workflows/hardware-lint-test.yaml'
       - '.github/actions/python/**'
+      - 'shared-data/**'
+      - '!shared-data/js/**'
 
   workflow_dispatch:
 

--- a/.github/workflows/robot-server-lint-test.yaml
+++ b/.github/workflows/robot-server-lint-test.yaml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'api/**/*'
       - 'hardware/**/*'
+      - 'hardware-testing/**/*'
       - 'Makefile'
       - 'shared-data/**/*'
       - 'server-utils/**/*'
@@ -28,6 +29,7 @@ on:
     paths:
       - 'api/**/*'
       - 'hardware/**/*'
+      - 'hardware-testing/**/*'
       - 'Makefile'
       - 'shared-data/**/*'
       - 'server-utils/**/*'

--- a/.github/workflows/system-server-lint-test.yaml
+++ b/.github/workflows/system-server-lint-test.yaml
@@ -12,7 +12,7 @@ on:
       - 'scripts/**/*.py'
       - '.github/workflows/system-server-lint-test.yaml'
       - '.github/actions/python/**'
-      - 'server-utils/**/*'
+      - 'server-utils/**'
     branches: # ignore any release-related thing (handled elsewhere)
       - 'edge'
     tags-ignore:
@@ -26,7 +26,7 @@ on:
       - 'scripts/**/*.py'
       - '.github/workflows/system-server-lint-test.yaml'
       - '.github/actions/python/**'
-      - 'server-utils/**/*'
+      - 'server-utils/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/update-server-lint-test.yaml
+++ b/.github/workflows/update-server-lint-test.yaml
@@ -6,7 +6,8 @@ name: 'Update Server test/lint'
 on:
   push:
     paths:
-      - 'update-server/**/*'
+      - 'update-server/**'
+      - 'server-utils/**'
       - 'Makefile'
       - 'scripts/**/*.mk'
       - 'scripts/**/*.py'
@@ -19,7 +20,8 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:
-      - 'update-server/**/*'
+      - 'update-server/**'
+      - 'server-utils/**'
       - 'Makefile'
       - 'scripts/**/*.mk'
       - 'scripts/**/*.py'

--- a/update-server/tests/common/test_auth.py
+++ b/update-server/tests/common/test_auth.py
@@ -41,7 +41,7 @@ async def test_bearer_token_extraction_passed_to_checker(
     client, mock_checker = auth_test_cli
     decoy.when(
         await mock_checker.check(matchers.Anything(), matchers.Anything())
-    ).then_return(AuthorizedResult(username="test-username"))
+    ).then_return(AuthorizedResult(username="test-username", fullname="test-fullname"))
 
     # An arbitrary endpoint that requires authorization.
     await client.post(
@@ -59,7 +59,7 @@ async def test_authorized_result(
     """When the AuthorizationChecker returns an AuthorizedResult, the request handler should run as normal."""
     client, mock_checker = auth_test_cli
     decoy.when(await mock_checker.check(None, matchers.Anything())).then_return(
-        AuthorizedResult(username="test-username")
+        AuthorizedResult(username="test-username", fullname="test-fullname")
     )
 
     # An arbitrary endpoint that requires authorization.
@@ -83,9 +83,9 @@ async def test_authorized_result(
 async def test_not_authorized_result(
     auth_test_cli: tuple[HTTPTestClient, AuthorizationChecker],
     decoy: Decoy,
-    authorization_result: MissingTokenResult
-    | NotAnActiveTokenResult
-    | InsufficientScopeResult,
+    authorization_result: (
+        MissingTokenResult | NotAnActiveTokenResult | InsufficientScopeResult
+    ),
     expected_status: int,
     expected_provided_scopes: list[str],
 ) -> None:


### PR DESCRIPTION
# Overview

Update-server lint and test are failing after a server-utils change. update-server tests weren't running based on changes to server-utils. Add that trigger and fix the tests.

## Test Plan and Hands on Testing

Automated tests fine - no application code change

## Review requests

- is the wildcard use right?

## Risk assessment

None
