### PR TITLE
feat(api-client, react-api-client): add new API functions for new audit log and run interactions

### DIFF
--- a/api-client/src/audit/deleteLogPeriod.ts
+++ b/api-client/src/audit/deleteLogPeriod.ts
@@ -1,0 +1,17 @@
+import { DELETE, request } from '../request'
+
+import type { ResponsePromise } from '../request'
+import type { EmptyResponse, HostConfig } from '../types'
+
+// TODO(nd, 2026-07-09): server endpoint is not implemented yet; confirm the
+// actual response shape once it lands and drop EmptyResponse if it differs.
+export function deleteLogPeriod(
+  config: HostConfig,
+  logPeriodId: string
+): ResponsePromise<EmptyResponse> {
+  return request<EmptyResponse>(
+    DELETE,
+    `/audit/external/logPeriods/${logPeriodId}`,
+    config
+  )
+}

--- a/api-client/src/audit/getLogPeriodRaw.ts
+++ b/api-client/src/audit/getLogPeriodRaw.ts
@@ -1,0 +1,18 @@
+import { GET, request } from '../request'
+
+import type { RequestConfig, ResponsePromise } from '../request'
+import type { HostConfig } from '../types'
+import type { DownloadedLogPeriodResponse } from './types'
+
+export function getLogPeriodRaw(
+  config: HostConfig,
+  logPeriodId: string,
+  responseType?: RequestConfig<unknown>['responseType']
+): ResponsePromise<DownloadedLogPeriodResponse> {
+  return request<DownloadedLogPeriodResponse>(
+    GET,
+    `/audit/external/logPeriods/${logPeriodId}/download`,
+    config,
+    { responseType }
+  )
+}

--- a/api-client/src/audit/index.ts
+++ b/api-client/src/audit/index.ts
@@ -1,2 +1,4 @@
 export { getLogPeriodSummaries } from './getLogPeriodSummaries'
+export { getLogPeriodRaw } from './getLogPeriodRaw'
+export { deleteLogPeriod } from './deleteLogPeriod'
 export * from './types'

--- a/api-client/src/audit/types.ts
+++ b/api-client/src/audit/types.ts
@@ -8,3 +8,5 @@ export interface LogPeriodSummariesResponse {
   data: LogPeriodSummary[]
   meta: { totalLength: number }
 }
+
+export type DownloadedLogPeriodResponse = Blob | string

--- a/api-client/src/runs/getRunRaw.ts
+++ b/api-client/src/runs/getRunRaw.ts
@@ -1,0 +1,18 @@
+import { GET, request } from '../request'
+
+import type { RequestConfig, ResponsePromise } from '../request'
+import type { HostConfig } from '../types'
+import type { DownloadedRunResponse } from './types'
+
+export function getRunRaw(
+  config: HostConfig,
+  runId: string,
+  responseType?: RequestConfig<unknown>['responseType']
+): ResponsePromise<DownloadedRunResponse> {
+  return request<DownloadedRunResponse>(
+    GET,
+    `/runs/${runId}/download`,
+    config,
+    { responseType }
+  )
+}

--- a/api-client/src/runs/index.ts
+++ b/api-client/src/runs/index.ts
@@ -1,4 +1,5 @@
 export { getRun } from './getRun'
+export { getRunRaw } from './getRunRaw'
 export { deleteRun } from './deleteRun'
 export { createRun } from './createRun'
 export { getRuns } from './getRuns'

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -223,6 +223,8 @@ export interface UpdateErrorRecoveryPolicyRequest {
 export type UpdateErrorRecoveryPolicyResponse = Record<string, never>
 export type ErrorRecoveryPolicyResponse = UpdateErrorRecoveryPolicyRequest
 
+export type DownloadedRunResponse = Blob | string
+
 /**
  * Current Run State Data
  */

--- a/react-api-client/src/audit/index.ts
+++ b/react-api-client/src/audit/index.ts
@@ -1,1 +1,3 @@
+export { useDeleteLogPeriodMutation } from './useDeleteLogPeriodMutation'
+export { useLogPeriodRawQuery } from './useLogPeriodRawQuery'
 export { useLogPeriodSummariesQuery } from './useLogPeriodSummariesQuery'

--- a/react-api-client/src/audit/useDeleteLogPeriodMutation.ts
+++ b/react-api-client/src/audit/useDeleteLogPeriodMutation.ts
@@ -1,0 +1,53 @@
+import { useMutation, useQueryClient } from 'react-query'
+
+import { deleteLogPeriod } from '@opentrons/api-client'
+
+import { getQueryKey, useHost } from '../api'
+
+import type {
+  UseMutateFunction,
+  UseMutationOptions,
+  UseMutationResult,
+} from 'react-query'
+import type { EmptyResponse } from '@opentrons/api-client'
+
+// TODO(nd, 2026-07-09): mirrors the TODO in deleteLogPeriod.ts — drop
+// EmptyResponse here too if the real server response shape differs.
+export type UseDeleteLogPeriodMutationResult = UseMutationResult<
+  EmptyResponse,
+  unknown,
+  string
+> & {
+  deleteLogPeriod: UseMutateFunction<EmptyResponse, unknown, string>
+}
+
+export type UseDeleteLogPeriodMutationOptions = UseMutationOptions<
+  EmptyResponse,
+  unknown,
+  string
+>
+
+export function useDeleteLogPeriodMutation(
+  options: UseDeleteLogPeriodMutationOptions = {}
+): UseDeleteLogPeriodMutationResult {
+  const host = useHost()
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation<EmptyResponse, unknown, string>(
+    logPeriodId =>
+      deleteLogPeriod(host!, logPeriodId).then(response => {
+        queryClient
+          .invalidateQueries(getQueryKey(host, 'audit', 'logPeriods'))
+          .catch((e: Error) => {
+            console.error(`error invalidating logPeriods query: ${e.message}`)
+          })
+        return response.data
+      }),
+    options
+  )
+
+  return {
+    ...mutation,
+    deleteLogPeriod: mutation.mutate,
+  }
+}

--- a/react-api-client/src/audit/useLogPeriodRawQuery.ts
+++ b/react-api-client/src/audit/useLogPeriodRawQuery.ts
@@ -1,0 +1,33 @@
+import { useQuery } from 'react-query'
+
+import { getLogPeriodRaw } from '@opentrons/api-client'
+
+import { getQueryKey, useHost } from '../api'
+
+import type { UseQueryOptions, UseQueryResult } from 'react-query'
+import type {
+  DownloadedLogPeriodResponse,
+  RequestConfig,
+} from '@opentrons/api-client'
+
+export function useLogPeriodRawQuery(
+  logPeriodId: string,
+  options?: UseQueryOptions<DownloadedLogPeriodResponse>,
+  responseType?: RequestConfig<unknown>['responseType']
+): UseQueryResult<DownloadedLogPeriodResponse> {
+  const host = useHost()
+  const allOptions: UseQueryOptions<DownloadedLogPeriodResponse> = {
+    ...options,
+    enabled: host !== null && logPeriodId !== null,
+  }
+
+  const query = useQuery<DownloadedLogPeriodResponse>(
+    getQueryKey(host, 'audit', 'logPeriods', logPeriodId, 'download'),
+    () =>
+      getLogPeriodRaw(host!, logPeriodId, responseType).then(
+        response => response.data
+      ),
+    allOptions
+  )
+  return query
+}

--- a/react-api-client/src/runs/index.ts
+++ b/react-api-client/src/runs/index.ts
@@ -1,5 +1,6 @@
 export { useAllRunsQuery } from './useAllRunsQuery'
 export { useRunQuery } from './useRunQuery'
+export { useRunRawQuery } from './useRunRawQuery'
 export { useRunCurrentState } from './useRunCurrentState'
 export { useCreateRunMutation } from './useCreateRunMutation'
 export { useDeleteRunMutation } from './useDeleteRunMutation'

--- a/react-api-client/src/runs/useRunRawQuery.ts
+++ b/react-api-client/src/runs/useRunRawQuery.ts
@@ -1,0 +1,30 @@
+import { useQuery } from 'react-query'
+
+import { getRunRaw } from '@opentrons/api-client'
+
+import { getQueryKey, useHost } from '../api'
+
+import type { UseQueryOptions, UseQueryResult } from 'react-query'
+import type {
+  DownloadedRunResponse,
+  RequestConfig,
+} from '@opentrons/api-client'
+
+export function useRunRawQuery(
+  runId: string,
+  options?: UseQueryOptions<DownloadedRunResponse>,
+  responseType?: RequestConfig<unknown>['responseType']
+): UseQueryResult<DownloadedRunResponse> {
+  const host = useHost()
+  const allOptions: UseQueryOptions<DownloadedRunResponse> = {
+    ...options,
+    enabled: host !== null && runId !== null,
+  }
+
+  const query = useQuery<DownloadedRunResponse>(
+    getQueryKey(host, 'runs', runId, 'download'),
+    () => getRunRaw(host!, runId, responseType).then(response => response.data),
+    allOptions
+  )
+  return query
+}


### PR DESCRIPTION
# Overview

Adds the 3 new api-client and react-api-client functions backing two new server capabilities for the file manager work: deleting an audit log period and downloading raw audit log period / run data. This introduces `deleteLogPeriod`, `getLogPeriodRaw`, and `getRunRaw` in `api-client`, along with their react-query hooks `useDeleteLogPeriodMutation`, `useLogPeriodRawQuery`, and `useRunRawQuery` in `react-api-client`.

This is client scaffolding only— the corresponding server endpoints (`DELETE /audit/external/logPeriods/{logPeriodId}`, `GET /audit/external/logPeriods/{logPeriodId}/download`, `GET /runs/{runId}/download`) aren't implemented yet, so these calls will 404 until the server side lands.

## Test Plan and Hands on Testing

Nothing in practice yet. Just confirmed typechecks pass and sanity-checked placeholder endpoints with robot-server devs

## Changelog

- Added `deleteLogPeriod` to `api-client` (`DELETE /audit/external/logPeriods/{logPeriodId}`)
- Added `getLogPeriodRaw` to `api-client` (`GET /audit/external/logPeriods/{logPeriodId}/download`)
- Added `getRunRaw` to `api-client` (`GET /runs/{runId}/download`)
- Added `DownloadedLogPeriodResponse` type to `api-client/src/audit/types.ts`
- Added `DownloadedRunResponse` type to `api-client/src/runs/types.ts`
- Added `useDeleteLogPeriodMutation` to `react-api-client`
- Added `useLogPeriodRawQuery` to `react-api-client`
- Added `useRunRawQuery` to `react-api-client`

## Review requests

Just review the code please.

## Risk assessment

Low. Nothing is wired up.