### PR TITLE
feat(audit-server): add auth to settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,10 +340,10 @@ dev-backend:
 .PHONY: dev-backend-flex
 dev-backend-flex:
 	$(python) scripts/run_concurrently.py \
-		$(MAKE) -C auth-server dev ';' \
-		$(MAKE) -C audit-server dev OT_AUDIT_SERVER_key_server_url=http://localhost:33960 ';' \
-		$(MAKE) -C robot-server dev-flex OT_ROBOT_SERVER_auth_server_url=http://localhost:31950 BEHIND_DEV_PROXY=1 ';' \
-		$(MAKE) -C system-server dev OT_SYSTEM_SERVER_auth_server_url=http://localhost:31950 ';' \
+		$(MAKE) -C auth-server dev OT_AUTH_SERVER_audit_server_url=http://localhost:33970 ';' \
+		$(MAKE) -C audit-server dev OT_AUDIT_SERVER_key_server_url=http://localhost:33960 OT_AUDIT_SERVER_auth_server_url=http://localhost:31950 ';' \
+		$(MAKE) -C robot-server dev-flex OT_ROBOT_SERVER_auth_server_url=http://localhost:31950 OT_ROBOT_SERVER_audit_server_url=http://localhost:33970 BEHIND_DEV_PROXY=1 ';' \
+		$(MAKE) -C system-server dev OT_SYSTEM_SERVER_auth_server_url=http://localhost:31950 OT_SYSTEM_SERVER_audit_server_url=http://localhost:33970 ';' \
 		$(MAKE) -C key-server dev-mitmproxy ';' \
 		$(MAKE) dev-proxy ';' \
 		$(MAKE) dev-proxy-tls

--- a/audit-server/audit_server/app.py
+++ b/audit-server/audit_server/app.py
@@ -9,6 +9,9 @@ from fastapi import FastAPI, Request, Response
 from opentrons_shared_data.errors.exceptions import AuditLoggingError
 
 from server_utils import systemd_utils
+from server_utils.auth.resource_server.authorization_checker import (
+    FailedClosedAuthorizationChecker,
+)
 from server_utils.auth.resource_server.fastapi import (
     AuthorizationError,
     build_authorization_checker,
@@ -102,6 +105,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             build_authorization_checker(
                 auth_server_uds=configuration.auth_server_uds,
                 auth_server_url=configuration.auth_server_url,
+                fallback=FailedClosedAuthorizationChecker,
             )
         )
         install_authorization_checker(app.state, authorization_checker)

--- a/audit-server/audit_server/app.py
+++ b/audit-server/audit_server/app.py
@@ -9,6 +9,10 @@ from fastapi import FastAPI
 from opentrons_shared_data.errors.exceptions import AuditLoggingError
 
 from server_utils import systemd_utils
+from server_utils.auth.resource_server.fastapi import (
+    build_authorization_checker,
+    install_authorization_checker,
+)
 from server_utils.keys.fastapi import build_key_client, install_key_client
 from server_utils.keys.key_server import Client as KeyClientABC
 from server_utils.keys.key_server import SignedMessageData, SignMessageData
@@ -92,6 +96,13 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         log_data_manager = build_log_data_manager(
             app.state, log_store, settings_store, key_client
         )
+        authorization_checker = await exit_stack.enter_async_context(
+            build_authorization_checker(
+                auth_server_uds=configuration.auth_server_uds,
+                auth_server_url=configuration.auth_server_url,
+            )
+        )
+        install_authorization_checker(app.state, authorization_checker)
         await log_data_manager.rotate_periods()
         systemd_utils.notify_up()
         yield

--- a/audit-server/audit_server/app.py
+++ b/audit-server/audit_server/app.py
@@ -5,12 +5,14 @@ from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator, Optional, override
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Response
 from opentrons_shared_data.errors.exceptions import AuditLoggingError
 
 from server_utils import systemd_utils
 from server_utils.auth.resource_server.fastapi import (
+    AuthorizationError,
     build_authorization_checker,
+    handle_authorization_error,
     install_authorization_checker,
 )
 from server_utils.keys.fastapi import build_key_client, install_key_client
@@ -108,12 +110,19 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         yield
 
 
+async def _handle_auth_error_async(
+    request: Request, error: AuthorizationError
+) -> Response:
+    return handle_authorization_error(request, error)
+
+
 app = FastAPI(
     title="Opentrons Audit Server",
     openapi_url=None,
     docs_url=None,
     redoc_url=None,
     lifespan=_lifespan,
+    exception_handlers={AuthorizationError: _handle_auth_error_async},
 )
 
 app.include_router(ingest_router)

--- a/audit-server/audit_server/server_configuration.py
+++ b/audit-server/audit_server/server_configuration.py
@@ -63,3 +63,19 @@ class AuditServerConfiguration(BaseSettings):
             " request that requires the key-server client will fail."
         ),
     )
+    auth_server_uds: str | None = Field(
+        default=None,
+        description=(
+            "The path to the Unix domain socket where auth-server is listening."
+            " This is mutually exclusive with auth_server_url."
+            " If both are unset, authentication cannot be checked and modification requests will fail."
+        ),
+    )
+    auth_server_url: str | None = Field(
+        default=None,
+        description=(
+            "The base URL (e.g. `http://localhost:33960`) where auth-server is listening."
+            " This is mutually exclusive with auth_server_uds."
+            " If both are unset, authentication cannot be checked and modification requests will fail."
+        ),
+    )

--- a/audit-server/audit_server/settings/router.py
+++ b/audit-server/audit_server/settings/router.py
@@ -11,6 +11,8 @@ from typing import Annotated
 
 import fastapi
 
+from server_utils.auth.resource_server.fastapi import require_scopes
+from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.models.json_api import (
     PydanticResponse,
     RequestModel,
@@ -40,14 +42,12 @@ ACTION_LOG_DISABLE = "log-disable"
     router.get,
     path="/audit/internal/loggingEnabled",
     summary="Get the logging-enabled setting",
-    description=dedent(
-        """\
+    description=dedent("""\
         Get the current logging-enabled setting.
 
         This is separated from the generic settings endpoints because it is a
         special case controlled through an internal-only API.
-        """
-    ),
+        """),
 )
 async def get_logging_enabled_settings(  # noqa: D103
     settings_store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],
@@ -126,14 +126,13 @@ async def get_settings(  # noqa: D103
     router.patch,
     path="/audit/external/settings",
     summary="Change audit settings",
-    description=dedent(
-        """\
+    description=dedent("""\
         Change audit-server settings.
 
         Only fields present in the request body are updated. The new settings
         are returned.
-        """
-    ),
+        """),
+    dependencies=[fastapi.Depends(require_scopes(Scope.AUTH_SETTINGS_WRITE))],
 )
 async def patch_settings(  # noqa: D103
     request_body: RequestModel[PatchSettingsRequestData],
@@ -150,13 +149,12 @@ async def patch_settings(  # noqa: D103
     router.delete,
     path="/audit/external/settings",
     summary="Reset audit settings",
-    description=dedent(
-        """\
+    description=dedent("""\
         Reset audit-server settings to their defaults.
 
         The new settings are returned.
-        """
-    ),
+        """),
+    dependencies=[fastapi.Depends(require_scopes(Scope.AUTH_SETTINGS_WRITE))],
 )
 async def delete_settings(  # noqa: D103
     settings_store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],

--- a/audit-server/tests/conftest.py
+++ b/audit-server/tests/conftest.py
@@ -58,6 +58,44 @@ def mock_log_data_manager(decoy: Decoy) -> LogDataManager:
 
 
 @pytest.fixture
+def fake_auth_server(
+    unused_tcp_port_factory: Callable[[], int],
+) -> Generator[str, None, None]:
+    """Run a minimal in-process standin for auth-server on a TCP port.
+
+    Yields the base URL. Always pretends that auth is disabled.
+    """
+    port = unused_tcp_port_factory()
+
+    async def fake_auth_off(request: aiohttp.web.Request) -> aiohttp.web.Response:
+        return aiohttp.web.json_response(data={"data": {"accessControlEnabled": False}})
+
+    app = aiohttp.web.Application()
+    app.router.add_get("/auth/settings/accessControlEnabled", fake_auth_off)
+    loop = asyncio.new_event_loop()
+    runner = aiohttp.web.AppRunner(app)
+
+    def serve() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(runner.setup())
+        site = aiohttp.web.TCPSite(runner, host="127.0.0.1", port=port)
+        loop.run_until_complete(site.start())
+        loop.run_forever()
+
+    thread = threading.Thread(target=serve, name="fake-auth-server", daemon=True)
+    thread.start()
+
+    base_url = f"http://127.0.0.1:{port}"
+    _wait_for_tcp(base_url)
+    try:
+        yield base_url
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        asyncio.run(runner.cleanup())
+
+
+@pytest.fixture
 def fake_key_server(
     unused_tcp_port_factory: Callable[[], int],
 ) -> Generator[str, None, None]:
@@ -112,14 +150,17 @@ def fake_key_server(
 
 @pytest.fixture
 def run_server(
-    unused_tcp_port: int, fake_key_server: str
+    unused_tcp_port: int, fake_key_server: str, fake_auth_server: str
 ) -> Generator[DevServer, None, None]:
     """Run a dev server as a fixture scoped to the test.
 
     The dev server is configured to talk to the in-process ``fake_key_server``
     so that routes that depend on the key-server client resolve cleanly.
     """
-    extra_env = {"OT_AUDIT_SERVER_key_server_url": fake_key_server}
+    extra_env = {
+        "OT_AUDIT_SERVER_key_server_url": fake_key_server,
+        "OT_AUDIT_SERVER_auth_server_url": fake_auth_server,
+    }
     with DevServer(port=unused_tcp_port, extra_env=extra_env) as dev_server:
         dev_server.start()
         base_url = f"http://localhost:{dev_server.port}"

--- a/server-utils/server_utils/auth/resource_server/authorization_checker.py
+++ b/server-utils/server_utils/auth/resource_server/authorization_checker.py
@@ -35,6 +35,18 @@ class AuthorizationChecker(ABC):
         pass
 
 
+class FailedClosedAuthorizationChecker(AuthorizationChecker):
+    """An `AuthorizationChecker` that always denies access.
+
+    This is useful as a fail-closed fallback if configuration is missing.
+    """
+
+    @override
+    async def check(self, token: str | None, required_scopes: set[Scope]) -> Result:
+        """See base class for documentation."""
+        return UnableToContactAuthServerResult()
+
+
 class AlwaysAllowedAuthorizationChecker(AuthorizationChecker):
     """An `AuthorizationChecker` that always allows access."""
 
@@ -132,10 +144,18 @@ class NotAnActiveTokenResult:
     pass
 
 
+@dataclass
+class UnableToContactAuthServerResult:
+    """The authorization server couldn't be contacted."""
+
+    pass
+
+
 Result: TypeAlias = (
     AuthorizationNotRequiredResult
     | AuthorizedResult
     | InsufficientScopeResult
     | MissingTokenResult
     | NotAnActiveTokenResult
+    | UnableToContactAuthServerResult
 )

--- a/server-utils/server_utils/auth/resource_server/error_responses.py
+++ b/server-utils/server_utils/auth/resource_server/error_responses.py
@@ -12,6 +12,7 @@ from .authorization_checker import (
     InsufficientScopeResult,
     MissingTokenResult,
     NotAnActiveTokenResult,
+    UnableToContactAuthServerResult,
 )
 from server_utils.auth.scopes import Scope
 
@@ -43,7 +44,12 @@ class AuthorizationErrorResponse(BaseModel):
 
 
 def build_response_for_error(
-    error: MissingTokenResult | NotAnActiveTokenResult | InsufficientScopeResult,
+    error: (
+        MissingTokenResult
+        | NotAnActiveTokenResult
+        | InsufficientScopeResult
+        | UnableToContactAuthServerResult
+    ),
     required_scopes: set[Scope],
 ) -> tuple[int, dict[str, str], AuthorizationErrorResponse]:
     """Turn the given authorization error into an HTTP response.
@@ -86,10 +92,25 @@ def build_response_for_error(
                     providedScopes=provided_scopes_str_list,
                 ),
             )
+        case UnableToContactAuthServerResult():
+            return (
+                fastapi.status.HTTP_503_SERVICE_UNAVAILABLE,
+                headers,
+                AuthorizationErrorResponse(
+                    debugMessage="The auth server cannot be contacted, so this endpoint is unavailable",
+                    requiredScopes=[],
+                    providedScopes=[],
+                ),
+            )
 
 
 def _build_response_headers_for_error(
-    error: MissingTokenResult | NotAnActiveTokenResult | InsufficientScopeResult,
+    error: (
+        MissingTokenResult
+        | NotAnActiveTokenResult
+        | InsufficientScopeResult
+        | UnableToContactAuthServerResult
+    ),
 ) -> dict[str, str]:
     """Return the headers that should be sent for an error response.
 
@@ -124,6 +145,8 @@ def _build_response_headers_for_error(
                     "Bearer", {"error": "insufficient_scope"}
                 )
             }
+        case UnableToContactAuthServerResult():
+            return {}
 
 
 def _www_authenticate(scheme: str, attributes: dict[str, str]) -> str:

--- a/server-utils/server_utils/auth/resource_server/fastapi.py
+++ b/server-utils/server_utils/auth/resource_server/fastapi.py
@@ -11,6 +11,7 @@ from typing import (
     Awaitable,
     Callable,
     Final,
+    Type,
     TypeAlias,
 )
 
@@ -28,6 +29,7 @@ from .authorization_checker import (
     InsufficientScopeResult,
     MissingTokenResult,
     NotAnActiveTokenResult,
+    UnableToContactAuthServerResult,
 )
 from .error_responses import build_response_for_error
 from server_utils.auth.scopes import Scope
@@ -147,7 +149,10 @@ def install_authorization_checker(
 
 @asynccontextmanager
 async def build_authorization_checker(
-    *, auth_server_uds: str | None = None, auth_server_url: str | None = None
+    *,
+    auth_server_uds: str | None = None,
+    auth_server_url: str | None = None,
+    fallback: Type[AuthorizationChecker] = AlwaysAllowedAuthorizationChecker,
 ) -> AsyncGenerator[AuthorizationChecker, None]:
     """Build an `AuthorizationChecker` appropriately configured for most servers.
 
@@ -163,7 +168,7 @@ async def build_authorization_checker(
             " Access control will be disabled."
             " (This is normal in dev mode and on OT-2s.)"
         )
-        yield AlwaysAllowedAuthorizationChecker()
+        yield fallback()
 
     else:
         async with LocalHTTPClient(
@@ -196,9 +201,12 @@ class AuthorizationError(Exception):
 
     def __init__(
         self,
-        authorization_error: InsufficientScopeResult
-        | MissingTokenResult
-        | NotAnActiveTokenResult,
+        authorization_error: (
+            InsufficientScopeResult
+            | MissingTokenResult
+            | NotAnActiveTokenResult
+            | UnableToContactAuthServerResult
+        ),
         required_scopes: set[Scope],
     ) -> None:
         self.authorization_error: Final = authorization_error

--- a/server-utils/tests/auth/resource_server/test_authorization_checker.py
+++ b/server-utils/tests/auth/resource_server/test_authorization_checker.py
@@ -12,9 +12,11 @@ from server_utils.auth.resource_server.authorization_checker import (
     AuthorizationNotRequiredResult,
     AuthorizedResult,
     AuthServerAuthorizationChecker,
+    FailedClosedAuthorizationChecker,
     InsufficientScopeResult,
     MissingTokenResult,
     NotAnActiveTokenResult,
+    UnableToContactAuthServerResult,
 )
 from server_utils.auth.scopes import Scope, serialize_scopes
 
@@ -37,6 +39,21 @@ class TestAlwaysAllowedAuthorizationChecker:
                 token="token-abc123", required_scopes={Scope.USERS_WRITE}
             )
             == AuthorizationNotRequiredResult()
+        )
+
+
+class TestFailedClosedAuthorizationChecker:
+    async def test_check(self) -> None:
+        subject = FailedClosedAuthorizationChecker()
+        assert (
+            await subject.check(token=None, required_scopes={Scope.USERS_WRITE})
+            == UnableToContactAuthServerResult()
+        )
+        assert (
+            await subject.check(
+                token="token-abc1234", required_scopes={Scope.USERS_WRITE}
+            )
+            == UnableToContactAuthServerResult()
         )
 
 


### PR DESCRIPTION
External settings endpoints need to require authentication for altering them.

## Review requests
- Is this the right way to integrate this? Are there some series of tests I should be adding?

Closes EXEC-2835
