### PR TITLE
feat(app, api-client, react-api-client): client-side log period deletion key logic

### DIFF
--- a/api-client/src/audit/constants.ts
+++ b/api-client/src/audit/constants.ts
@@ -1,0 +1,3 @@
+/** Response header carrying the one-time deletion key for a downloaded log period. */
+export const LOG_PERIOD_DELETION_KEY_HEADER =
+  'opentrons-log-period-deletion-key'

--- a/api-client/src/audit/deleteLogPeriod.ts
+++ b/api-client/src/audit/deleteLogPeriod.ts
@@ -2,16 +2,19 @@ import { DELETE, request } from '../request'
 
 import type { ResponsePromise } from '../request'
 import type { EmptyResponse, HostConfig } from '../types'
+import type { DeleteLogPeriodQueryParams } from './types'
 
 // TODO(nd, 2026-07-09): server endpoint is not implemented yet; confirm the
 // actual response shape once it lands and drop EmptyResponse if it differs.
 export function deleteLogPeriod(
   config: HostConfig,
-  logPeriodId: string
+  logPeriodId: string,
+  params: DeleteLogPeriodQueryParams
 ): ResponsePromise<EmptyResponse> {
   return request<EmptyResponse>(
     DELETE,
     `/audit/external/logPeriods/${logPeriodId}`,
-    config
+    config,
+    { queryParams: { ...params } }
   )
 }

--- a/api-client/src/audit/index.ts
+++ b/api-client/src/audit/index.ts
@@ -1,4 +1,5 @@
 export { getLogPeriodSummaries } from './getLogPeriodSummaries'
 export { getLogPeriodRaw } from './getLogPeriodRaw'
 export { deleteLogPeriod } from './deleteLogPeriod'
+export * from './constants'
 export * from './types'

--- a/api-client/src/audit/types.ts
+++ b/api-client/src/audit/types.ts
@@ -10,3 +10,7 @@ export interface LogPeriodSummariesResponse {
 }
 
 export type DownloadedLogPeriodResponse = Blob | string
+
+export interface DeleteLogPeriodQueryParams {
+  deletionKey: string
+}

--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -138,6 +138,7 @@
   "location": "Location",
   "location_conflicts": "Location conflicts",
   "log_period": "Log period {{number}}",
+  "log_period_deletion_key_missing": "Download this log period before deleting it.",
   "magdeck_gen1_height": "Height: {{height}}",
   "magdeck_gen2_height": "Height: {{height}} mm",
   "max_engage_height": "Max Engage Height",

--- a/app/src/redux/audit/index.ts
+++ b/app/src/redux/audit/index.ts
@@ -1,0 +1,1 @@
+export * from './slice'

--- a/app/src/redux/audit/slice.ts
+++ b/app/src/redux/audit/slice.ts
@@ -1,0 +1,75 @@
+/** The Redux slice for audit log period deletion keys. */
+
+import { createSlice } from '@reduxjs/toolkit'
+
+import { type ActionTypesFromSlice } from '../ActionTypesFromSlice'
+
+import type { PayloadAction } from '@reduxjs/toolkit'
+import type { State } from '/app/redux/types'
+
+export interface AuditState {
+  /**
+   * The server hands back a one-time deletion key when a log period is
+   * downloaded; that key must be sent along with the delete request. Keyed
+   * by logPeriodId. Intentionally not persisted: a stale tab shouldn't be
+   * able to replay an old deletion key after a reload.
+   */
+  logPeriodDeletionKeysById: {
+    [logPeriodId: string]: string | undefined
+  }
+}
+
+export const INITIAL_AUDIT_STATE: AuditState = {
+  logPeriodDeletionKeysById: {},
+}
+
+interface LogPeriodDeletionKeyReceivedPayload {
+  logPeriodId: string
+  deletionKey: string
+}
+
+interface LogPeriodDeletionKeyConsumedPayload {
+  logPeriodId: string
+}
+
+const auditSlice = createSlice({
+  name: 'audit',
+  initialState: INITIAL_AUDIT_STATE,
+  reducers: {
+    logPeriodDeletionKeyReceived: (
+      stateDraft,
+      action: PayloadAction<LogPeriodDeletionKeyReceivedPayload>
+    ) => {
+      const { logPeriodId, deletionKey } = action.payload
+      stateDraft.logPeriodDeletionKeysById[logPeriodId] = deletionKey
+    },
+    logPeriodDeletionKeyConsumed: (
+      stateDraft,
+      action: PayloadAction<LogPeriodDeletionKeyConsumedPayload>
+    ) => {
+      // dynamic-delete is fine here
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete stateDraft.logPeriodDeletionKeysById[action.payload.logPeriodId]
+    },
+  },
+})
+
+export const auditReducer = auditSlice.reducer
+
+export const { logPeriodDeletionKeyReceived, logPeriodDeletionKeyConsumed } =
+  auditSlice.actions
+
+export type AuditAction = ActionTypesFromSlice<typeof auditSlice.actions>
+
+export function getLogPeriodDeletionKeysById(
+  state: State
+): AuditState['logPeriodDeletionKeysById'] {
+  return state.audit.logPeriodDeletionKeysById
+}
+
+export function getLogPeriodDeletionKey(
+  state: State,
+  logPeriodId: string
+): string | null {
+  return state.audit.logPeriodDeletionKeysById[logPeriodId] ?? null
+}

--- a/app/src/redux/reducer.ts
+++ b/app/src/redux/reducer.ts
@@ -2,6 +2,8 @@ import { combineReducers } from 'redux'
 
 // app-wide alerts state
 import { alertsReducer } from './alerts/reducer'
+// audit log period deletion key state
+import { auditReducer } from './audit/slice'
 // calibration data state
 import { calibrationReducer } from './calibration/reducer'
 // config state
@@ -41,6 +43,7 @@ export const rootReducer: Reducer<State, Action> = (
   action: Action
 ): State => {
   const combinedReducer = combineReducers({
+    audit: auditReducer,
     robotAdmin: robotAdminReducer,
     robotApi: robotApiReducer,
     robotAuth: robotAuthReducer,

--- a/app/src/redux/types.ts
+++ b/app/src/redux/types.ts
@@ -4,6 +4,7 @@ import type { Dispatch as ReduxDispatch, Store as ReduxStore } from 'redux'
 import type { Observable } from 'rxjs'
 import type { AlertsAction, AlertsState } from './alerts/types'
 import type { AnalyticsTriggerAction } from './analytics/types'
+import type { AuditAction, AuditState } from './audit/slice'
 import type { CalibrationAction, CalibrationState } from './calibration/types'
 import type { ConfigAction, ConfigState } from './config/types'
 import type {
@@ -37,6 +38,7 @@ import type {
 import type { SystemInfoAction, SystemInfoState } from './system-info/types'
 
 export interface State {
+  readonly audit: AuditState
   readonly robotApi: RobotApiState
   readonly robotAuth: RobotAuthState
   readonly robotAdmin: RobotAdminState
@@ -56,6 +58,7 @@ export interface State {
 }
 
 export type Action =
+  | AuditAction
   | RobotApiAction
   | RobotAdminAction
   | RobotAuthAction

--- a/react-api-client/src/audit/useDeleteLogPeriodMutation.ts
+++ b/react-api-client/src/audit/useDeleteLogPeriodMutation.ts
@@ -11,20 +11,29 @@ import type {
 } from 'react-query'
 import type { EmptyResponse } from '@opentrons/api-client'
 
+export interface DeleteLogPeriodParams {
+  logPeriodId: string
+  deletionKey: string
+}
+
 // TODO(nd, 2026-07-09): mirrors the TODO in deleteLogPeriod.ts — drop
 // EmptyResponse here too if the real server response shape differs.
 export type UseDeleteLogPeriodMutationResult = UseMutationResult<
   EmptyResponse,
   unknown,
-  string
+  DeleteLogPeriodParams
 > & {
-  deleteLogPeriod: UseMutateFunction<EmptyResponse, unknown, string>
+  deleteLogPeriod: UseMutateFunction<
+    EmptyResponse,
+    unknown,
+    DeleteLogPeriodParams
+  >
 }
 
 export type UseDeleteLogPeriodMutationOptions = UseMutationOptions<
   EmptyResponse,
   unknown,
-  string
+  DeleteLogPeriodParams
 >
 
 export function useDeleteLogPeriodMutation(
@@ -33,9 +42,9 @@ export function useDeleteLogPeriodMutation(
   const host = useHost()
   const queryClient = useQueryClient()
 
-  const mutation = useMutation<EmptyResponse, unknown, string>(
-    logPeriodId =>
-      deleteLogPeriod(host!, logPeriodId).then(response => {
+  const mutation = useMutation<EmptyResponse, unknown, DeleteLogPeriodParams>(
+    ({ logPeriodId, deletionKey }) =>
+      deleteLogPeriod(host!, logPeriodId, { deletionKey }).then(response => {
         queryClient
           .invalidateQueries(getQueryKey(host, 'audit', 'logPeriods'))
           .catch((e: Error) => {


### PR DESCRIPTION
# Overview

Adds the deletion-key requirement for deleting an audit log period. `deleteLogPeriod` and its React Query wrapper hook now require a `deletionKey`as a query param. This matches the server's planned contract that every log period delete carry the one-time key handed back on download (specifically, in the response header to preserve the `DownloadLogPeriodResponse` body)

Also introduces a new `audit` Redux slice (`app/src/redux/audit`) to cache `{logPeriodId: deletionKey}` client-side, sourced from a response header (`LOG_PERIOD_DELETION_KEY_HEADER`) on log period downloads. The server endpoints for log period download/delete aren't implemented yet, so this is client-side scaffolding anticipating server behavior (subject to chagne).

NOTE: The hooks that wire this into the FileManager UI (capturing the key on download, looking it up and enforcing its presence on delete) will follow in a separate PR.

Closes EXEC-2836

## Test Plan and Hands on Testing

Not much to test yet. Reviewed code and confirmed typechecks pass

## Changelog

- `deleteLogPeriod` (api-client) now requires a `deletionKey` query param via a new `DeleteLogPeriodQueryParams` type
- `useDeleteLogPeriodMutation` (react-api-client) mutate input changed from a bare `logPeriodId` string to `{ logPeriodId, deletionKey }`
- Added `LOG_PERIOD_DELETION_KEY_HEADER` constant (api-client) identifying the response header a log period download will carry its deletion key in
- Added a new `audit` Redux slice (`app/src/redux/audit`) storing `logPeriodDeletionKeysById`, with `logPeriodDeletionKeyReceived` / `logPeriodDeletionKeyConsumed` actions and `getLogPeriodDeletionKeysById` / `getLogPeriodDeletionKey` selectors
- Added `log_period_deletion_key_missing` string to `device_details.json`

## Review requests

Please review logic of deletion key retrieval, storage, and sending.

## Risk assessment

Low. New functions and Redux slice, nothing wired up yet.