### PR TITLE
fix(api): reconnect serial modules on transient port closure

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from typing import Type, Literal, AsyncIterator
 import os
+from serial import PortNotOpenError  # type: ignore[import-untyped]
 from opentrons.drivers.command_builder import CommandBuilder
 
 from .errors import (
@@ -203,11 +204,16 @@ class SerialConnection:
         data_encode = data.encode()
 
         for retry in range(retries + 1):
-            log.debug(f"{self.name}: Write -> {data_encode!r}")
-            await self._serial.write(data=data_encode)
+            try:
+                log.debug(f"{self.name}: Write -> {data_encode!r}")
+                await self._serial.write(data=data_encode)
 
-            response = await self._serial.read_until(match=self._ack)
-            log.debug(f"{self.name}: Read <- {response!r}")
+                response = await self._serial.read_until(match=self._ack)
+                log.debug(f"{self.name}: Read <- {response!r}")
+            except PortNotOpenError:
+                log.warning(f"{self.name}: port was closed; reopening and retrying.")
+                await self.open()
+                continue
 
             if (
                 self._ack in response

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -4,6 +4,7 @@ from _pytest.fixtures import SubRequest
 from mock import AsyncMock, call
 import mock
 from unittest.mock import patch
+from serial import PortNotOpenError  # type: ignore[import-untyped]
 from opentrons.drivers.asyncio.communication.async_serial import AsyncSerial
 from opentrons.drivers.asyncio.communication.serial_connection import (
     SerialConnection,
@@ -86,6 +87,20 @@ async def async_subject(
 
 
 @pytest.fixture
+async def sync_subject(mock_serial_port: AsyncMock, ack: str) -> SerialConnection:
+    """Create a base SerialConnection test subject."""
+    return SerialConnection(
+        serial=mock_serial_port,
+        ack=ack,
+        name="name",
+        port="port",
+        retry_wait_time_seconds=0,
+        error_keyword="error",
+        alarm_keyword="alarm",
+    )
+
+
+@pytest.fixture
 async def subject_raise_on_error_patched(
     async_subject: AsyncResponseSerialConnection,
 ) -> AsyncGenerator[AsyncResponseSerialConnection, None]:
@@ -127,6 +142,23 @@ async def test_send_command_with_retry(
             call(match=ack.encode()),
         ]
     )
+
+
+async def test_send_command_reopens_port_on_port_not_open(
+    mock_serial_port: AsyncMock, sync_subject: SerialConnection, ack: str
+) -> None:
+    """It should reopen and retry when the port is closed out from under it."""
+    serial_response = "response data " + ack
+    mock_serial_port.write.side_effect = [PortNotOpenError, None]
+    mock_serial_port.read_until.return_value = serial_response.encode()
+
+    await sync_subject.send_data(data="send data", retries=1)
+
+    mock_serial_port.open.assert_called_once()
+    mock_serial_port.write.assert_has_calls(
+        calls=[call(data=b"send data"), call(data=b"send data")]
+    )
+    mock_serial_port.read_until.assert_called_once_with(match=ack.encode())
 
 
 async def test_send_command_with_zero_retries(


### PR DESCRIPTION
# Overview

When a module's serial port is closed out from under its driver, typically a USB re-enumeration that the module controller doesn't react to, the next write raised `PortNotOpenError` and surfaced a hard failure, even though the symlink still resolves to the re-enumerated device. `SerialConnection._send_data` now catches `PortNotOpenError`, reopens the connection, and lets the existing retry loop continue. 

Recovery is bounded by the same retry count that already governs timeouts; if the device is truly gone, `open()` raises and behavior is unchanged. This covers modules that use the base `SerialConnection`. Other modules use use `AsyncResponseSerialConnection`, which already recovers via its own `BaseException `catch in `_send_data_multiack`.

## Test Plan and Hands on Testing

- We haven't been able to reproduce this exact issue on-site, but user reports confirm this treatment fixes the seen `PortNotOpenError` issue. The exact fix a user implemented was the following in `api/src/opentrons/drivers/temp_deck/driver.py`:

```
try:
            return await self._connection.send_command(
                command=command, retries=DEFAULT_COMMAND_RETRIES
            )
        except PortNotOpenError:
            log.warning("Temp-Deck port was closed; reopening and retrying once.")
            await self._connection.open()
            return await self._connection.send_command(
                command=command, retries=DEFAULT_COMMAND_RETRIES
            )
```

The fix in this PR diff should be the same, but on a different level of abstraction to cover all modules implementing the base `SerialConnection`.

## Changelog

- Fixed a terminal `PortNotOpenError` causing protocol runs to fail without recovery.

## Review requests

- Double check me on the fix -- I believe this mirrors the user-implemented fix, just on a higher level of abstraction.

## Risk assessment

- low, just more try-catch error handling