### PR TITLE
feat(app): wire up download/delete logic for all three FileManager sections

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -86,6 +86,7 @@
   "download_run_log": "Download protocol run log",
   "download_selected": "Download selected",
   "downloading_logs": "Downloading logs...",
+  "downloading_run_records": "Downloading run records...",
   "drop_tips": "drop tips",
   "edit_settings": "Edit settings",
   "empty": "Empty",

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/LogPeriodRow.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/LogPeriodRow.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next'
 
-import { CheckboxBasic, Chip, COLORS, Tag } from '@opentrons/components'
+import { CheckboxBasic, Chip, COLORS, Icon, Tag } from '@opentrons/components'
 
 import { formatTimestamp } from '/app/transformations/runs'
 
@@ -11,12 +11,14 @@ import type { LogPeriodSummary } from '@opentrons/api-client'
 interface LogPeriodRowProps {
   period: LogPeriodSummary
   isSelected: boolean
+  isDeleting: boolean
   onToggle: () => void
 }
 
 export function LogPeriodRow({
   period,
   isSelected,
+  isDeleting,
   onToggle,
 }: LogPeriodRowProps): JSX.Element {
   const { t } = useTranslation('device_details')
@@ -24,11 +26,15 @@ export function LogPeriodRow({
 
   return (
     <div className={styles.compliance_period_row}>
-      <CheckboxBasic
-        checked={isSelected}
-        onChange={onToggle}
-        backgroundColor={COLORS.white}
-      />
+      {isDeleting ? (
+        <Icon name="ot-spinner" spin size="1rem" color={COLORS.grey60} />
+      ) : (
+        <CheckboxBasic
+          checked={isSelected}
+          onChange={onToggle}
+          backgroundColor={COLORS.white}
+        />
+      )}
       <div className={styles.compliance_period_card_outer}>
         <div className={styles.compliance_period_card_inner}>
           <div className={styles.log_date_col}>

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/hooks/useDeleteSelectedLogPeriods.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/hooks/useDeleteSelectedLogPeriods.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useQueryClient } from 'react-query'
 import { useDispatch, useSelector } from 'react-redux'
@@ -29,14 +29,6 @@ export function useDeleteSelectedLogPeriods(): UseDeleteSelectedLogPeriodsResult
   const queryClient = useQueryClient()
   const { makeToast } = useToaster()
   const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set())
-  const isMounted = useRef(false)
-
-  useEffect(() => {
-    isMounted.current = true
-    return () => {
-      isMounted.current = false
-    }
-  }, [])
 
   const deleteSelectedLogPeriods = (periods: LogPeriodSummary[]): void => {
     if (host == null || periods.length === 0 || deletingIds.size > 0) {
@@ -82,11 +74,11 @@ export function useDeleteSelectedLogPeriods(): UseDeleteSelectedLogPeriodsResult
           })
       )
       .then(() => {
-        if (isMounted.current) setDeletingIds(new Set())
+        setDeletingIds(new Set())
       })
       .catch((e: Error) => {
         makeToast(e.message, ERROR_TOAST, { closeButton: true })
-        if (isMounted.current) setDeletingIds(new Set())
+        setDeletingIds(new Set())
       })
   }
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/hooks/useDeleteSelectedLogPeriods.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/hooks/useDeleteSelectedLogPeriods.ts
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useQueryClient } from 'react-query'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { deleteLogPeriod } from '@opentrons/api-client'
+import { ERROR_TOAST } from '@opentrons/components'
+import { getQueryKey, useHost } from '@opentrons/react-api-client'
+
+import { useToaster } from '/app/organisms/ToasterOven'
+import {
+  getLogPeriodDeletionKeysById,
+  logPeriodDeletionKeyConsumed,
+} from '/app/redux/audit'
+
+import type { LogPeriodSummary } from '@opentrons/api-client'
+import type { Dispatch } from '/app/redux/types'
+
+interface UseDeleteSelectedLogPeriodsResult {
+  deleteSelectedLogPeriods: (periods: LogPeriodSummary[]) => void
+  deletingIds: Set<string>
+}
+
+export function useDeleteSelectedLogPeriods(): UseDeleteSelectedLogPeriodsResult {
+  const { t } = useTranslation('device_details')
+  const host = useHost()
+  const dispatch = useDispatch<Dispatch>()
+  const deletionKeysById = useSelector(getLogPeriodDeletionKeysById)
+  const queryClient = useQueryClient()
+  const { makeToast } = useToaster()
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set())
+  const isMounted = useRef(false)
+
+  useEffect(() => {
+    isMounted.current = true
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+
+  const deleteSelectedLogPeriods = (periods: LogPeriodSummary[]): void => {
+    if (host == null || periods.length === 0 || deletingIds.size > 0) {
+      return
+    }
+
+    // The server requires the deletion key it handed back on download. If we
+    // never downloaded (or downloaded in an earlier session), refuse to send
+    // the request rather than let the server reject it as malformed.
+    const deletablePeriods = periods.filter(period => {
+      const hasKey = deletionKeysById[period.id] != null
+      if (!hasKey) {
+        makeToast(t('log_period_deletion_key_missing') as string, ERROR_TOAST, {
+          closeButton: true,
+        })
+      }
+      return hasKey
+    })
+
+    if (deletablePeriods.length === 0) {
+      return
+    }
+
+    setDeletingIds(new Set(deletablePeriods.map(period => period.id)))
+
+    Promise.all(
+      deletablePeriods.map(period => {
+        const deletionKey = deletionKeysById[period.id]
+        return deleteLogPeriod(host, period.id, { deletionKey })
+          .then(() => {
+            dispatch(logPeriodDeletionKeyConsumed({ logPeriodId: period.id }))
+          })
+          .catch((e: Error) =>
+            makeToast(e.message, ERROR_TOAST, { closeButton: true })
+          )
+      })
+    )
+      .then(() =>
+        queryClient
+          .invalidateQueries(getQueryKey(host, 'audit', 'logPeriods'))
+          .catch((e: Error) => {
+            console.error(`error invalidating logPeriods query: ${e.message}`)
+          })
+      )
+      .then(() => {
+        if (isMounted.current) setDeletingIds(new Set())
+      })
+      .catch((e: Error) => {
+        makeToast(e.message, ERROR_TOAST, { closeButton: true })
+        if (isMounted.current) setDeletingIds(new Set())
+      })
+  }
+
+  return { deleteSelectedLogPeriods, deletingIds }
+}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/hooks/useDownloadSelectedLogPeriods.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/hooks/useDownloadSelectedLogPeriods.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 import { saveAs } from 'file-saver'
@@ -31,14 +31,6 @@ export function useDownloadSelectedLogPeriods(
   const dispatch = useDispatch<Dispatch>()
   const { makeToast, eatToast } = useToaster()
   const [isDownloading, setIsDownloading] = useState(false)
-  const isMounted = useRef(false)
-
-  useEffect(() => {
-    isMounted.current = true
-    return () => {
-      isMounted.current = false
-    }
-  }, [])
 
   const downloadSelectedLogPeriods = (periods: LogPeriodSummary[]): void => {
     if (host == null || periods.length === 0 || isDownloading) {
@@ -84,17 +76,17 @@ export function useDownloadSelectedLogPeriods(
           .catch((e: Error) => {
             eatToast(toastId)
             makeToast(e.message, ERROR_TOAST, { closeButton: true })
-            if (isMounted.current) setIsDownloading(false)
+            setIsDownloading(false)
           })
       )
       .then(() => {
         eatToast(toastId)
-        if (isMounted.current) setIsDownloading(false)
+        setIsDownloading(false)
       })
       .catch((e: Error) => {
         eatToast(toastId)
         makeToast(e.message, ERROR_TOAST, { closeButton: true })
-        if (isMounted.current) setIsDownloading(false)
+        setIsDownloading(false)
       })
   }
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/hooks/useDownloadSelectedLogPeriods.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/hooks/useDownloadSelectedLogPeriods.ts
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useDispatch } from 'react-redux'
+import { saveAs } from 'file-saver'
+import JSZip from 'jszip'
+
+import {
+  getLogPeriodRaw,
+  LOG_PERIOD_DELETION_KEY_HEADER,
+} from '@opentrons/api-client'
+import { ERROR_TOAST, INFO_TOAST } from '@opentrons/components'
+import { useHost } from '@opentrons/react-api-client'
+
+import { useToaster } from '/app/organisms/ToasterOven'
+import { logPeriodDeletionKeyReceived } from '/app/redux/audit'
+
+import type { LogPeriodSummary } from '@opentrons/api-client'
+import type { IconProps } from '@opentrons/components'
+import type { Dispatch } from '/app/redux/types'
+
+interface UseDownloadSelectedLogPeriodsResult {
+  downloadSelectedLogPeriods: (periods: LogPeriodSummary[]) => void
+  isDownloading: boolean
+}
+
+export function useDownloadSelectedLogPeriods(
+  robotName: string
+): UseDownloadSelectedLogPeriodsResult {
+  const { t } = useTranslation('device_details')
+  const host = useHost()
+  const dispatch = useDispatch<Dispatch>()
+  const { makeToast, eatToast } = useToaster()
+  const [isDownloading, setIsDownloading] = useState(false)
+  const isMounted = useRef(false)
+
+  useEffect(() => {
+    isMounted.current = true
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+
+  const downloadSelectedLogPeriods = (periods: LogPeriodSummary[]): void => {
+    if (host == null || periods.length === 0 || isDownloading) {
+      return
+    }
+
+    setIsDownloading(true)
+    const toastIcon: IconProps = { name: 'ot-spinner', spin: true }
+    const toastId = makeToast(t('downloading_logs') as string, INFO_TOAST, {
+      disableTimeout: true,
+      icon: toastIcon,
+    })
+
+    const zip = new JSZip()
+    Promise.all(
+      periods.map(period =>
+        getLogPeriodRaw(host, period.id, 'blob')
+          .then(res => {
+            zip.file(`${period.id}.log`, res.data)
+            const deletionKey = res.headers?.[LOG_PERIOD_DELETION_KEY_HEADER]
+            // ensure the deletionKey exists on the header
+            if (typeof deletionKey === 'string') {
+              // store the log period deletion key in Redux state
+              dispatch(
+                logPeriodDeletionKeyReceived({
+                  logPeriodId: period.id,
+                  deletionKey,
+                })
+              )
+            }
+          })
+          .catch((e: Error) =>
+            makeToast(e.message, ERROR_TOAST, { closeButton: true })
+          )
+      )
+    )
+      .then(() =>
+        zip
+          .generateAsync({ type: 'blob' })
+          .then(blob => {
+            saveAs(blob, `${robotName}-compliance-logs.zip`)
+          })
+          .catch((e: Error) => {
+            eatToast(toastId)
+            makeToast(e.message, ERROR_TOAST, { closeButton: true })
+            if (isMounted.current) setIsDownloading(false)
+          })
+      )
+      .then(() => {
+        eatToast(toastId)
+        if (isMounted.current) setIsDownloading(false)
+      })
+      .catch((e: Error) => {
+        eatToast(toastId)
+        makeToast(e.message, ERROR_TOAST, { closeButton: true })
+        if (isMounted.current) setIsDownloading(false)
+      })
+  }
+
+  return { downloadSelectedLogPeriods, isDownloading }
+}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
@@ -8,11 +8,9 @@ import {
   ListAccordion,
   StyledText,
   Tag,
-  WARNING_TOAST,
 } from '@opentrons/components'
 import { useLogPeriodSummariesQuery } from '@opentrons/react-api-client'
 
-import { useToaster } from '/app/organisms/ToasterOven'
 import { formatTimestamp } from '/app/transformations/runs'
 
 import { DeleteRecordsModal } from '../../../DeleteRecordsModal'
@@ -20,12 +18,23 @@ import { FileManagementSectionHeader } from '../FileManagementSectionHeader'
 import { useRecordSelection } from '../hooks/useRecordSelection'
 import fileManagerStyles from '../robotsettingsfilemanager.module.css'
 import styles from './compliancereadysoftwarefiles.module.css'
+import { useDeleteSelectedLogPeriods } from './hooks/useDeleteSelectedLogPeriods'
+import { useDownloadSelectedLogPeriods } from './hooks/useDownloadSelectedLogPeriods'
 import { LogPeriodRow } from './LogPeriodRow'
 
-export function ComplianceReadySoftwareFiles(): JSX.Element {
+interface ComplianceReadySoftwareFilesProps {
+  robotName: string
+}
+
+export function ComplianceReadySoftwareFiles({
+  robotName,
+}: ComplianceReadySoftwareFilesProps): JSX.Element {
   const { t } = useTranslation('device_details')
-  const { makeToast } = useToaster()
   const { data: logPeriodSummariesData } = useLogPeriodSummariesQuery()
+  const { downloadSelectedLogPeriods, isDownloading: isDownloadingLogPeriods } =
+    useDownloadSelectedLogPeriods(robotName)
+  const { deleteSelectedLogPeriods, deletingIds } =
+    useDeleteSelectedLogPeriods()
 
   // API returns periods oldest-to-newest; reverse for newest-first display.
   const periods = useMemo(
@@ -57,23 +66,17 @@ export function ComplianceReadySoftwareFiles(): JSX.Element {
       : t('na')
 
   const handleDownloadSelected = (): void => {
-    if (selectedIds.size > 0) {
-      // TODO: useDownloadLogPeriodMutation
-    } else {
-      makeToast(t('select_entry_to_download') as string, WARNING_TOAST, {
-        closeButton: true,
-      })
+    if (selectedIds.size > 0 && !isDownloadingLogPeriods) {
+      downloadSelectedLogPeriods(
+        periods.filter(period => selectedIds.has(period.id))
+      )
     }
   }
 
   const handleDeleteSelected = (): void => {
-    if (selectedIds.size === 0) {
-      makeToast(t('select_entry_to_delete') as string, WARNING_TOAST, {
-        closeButton: true,
-      })
-      return
+    if (selectedIds.size > 0) {
+      setShowDeleteRecordsModal(true)
     }
-    setShowDeleteRecordsModal(true)
   }
   const periodHeaderKeys: Array<'started' | 'ended' | 'status'> = [
     'started',
@@ -89,7 +92,9 @@ export function ComplianceReadySoftwareFiles(): JSX.Element {
             setShowDeleteRecordsModal(false)
           }}
           onConfirm={() => {
-            // TODO: delete all selected log periods
+            deleteSelectedLogPeriods(
+              periods.filter(period => selectedIds.has(period.id))
+            )
             setShowDeleteRecordsModal(false)
           }}
           type="selectedLogs"
@@ -98,6 +103,7 @@ export function ComplianceReadySoftwareFiles(): JSX.Element {
       <div className={fileManagerStyles.file_management_group}>
         <FileManagementSectionHeader
           titleText={t('compliance_ready_software_files')}
+          showButtons={isSomeSelected || isAllSelected}
           onDownloadSelected={handleDownloadSelected}
           onDeleteSelected={handleDeleteSelected}
         />
@@ -176,6 +182,7 @@ export function ComplianceReadySoftwareFiles(): JSX.Element {
                   key={period.id}
                   period={period}
                   isSelected={selectedIds.has(period.id)}
+                  isDeleting={deletingIds.has(period.id)}
                   onToggle={() => {
                     togglePeriod(period.id)
                   }}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/DiagnosticFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/DiagnosticFiles/index.tsx
@@ -1,17 +1,11 @@
 import { useTranslation } from 'react-i18next'
 
-import {
-  CheckboxBasic,
-  COLORS,
-  StyledText,
-  WARNING_TOAST,
-} from '@opentrons/components'
+import { CheckboxBasic, COLORS, StyledText } from '@opentrons/components'
 
 import {
   useDownloadCalibrationData,
   useDownloadRobotLogs,
 } from '/app/organisms/Desktop/Devices/hooks'
-import { useToaster } from '/app/organisms/ToasterOven'
 
 import { FileManagementSectionHeader } from '../FileManagementSectionHeader'
 import { useRecordSelection } from '../hooks/useRecordSelection'
@@ -31,23 +25,20 @@ export function DiagnosticsFiles({
   robotName,
 }: DiagnosticsFilesProps): JSX.Element {
   const { t } = useTranslation('device_details')
-  const { makeToast } = useToaster()
 
-  const { downloadLogs } = useDownloadRobotLogs(robotName)
-  const { downloadCalibration } = useDownloadCalibrationData(robotName)
+  const { downloadLogs, isDownloading: isDownloadingLogs } =
+    useDownloadRobotLogs(robotName)
+  const { downloadCalibration, isLoading: isLoadingCalibration } =
+    useDownloadCalibrationData(robotName)
 
   const { selectedIds, isAllSelected, isSomeSelected, toggleAll, toggleOne } =
     useRecordSelection(DIAGNOSTIC_ROWS)
 
   const handleDownloadSelected = (): void => {
-    if (selectedIds.size === 0) {
-      makeToast(t('select_entry_to_download') as string, WARNING_TOAST)
-      return
-    }
-    if (selectedIds.has('troubleshooting')) {
+    if (selectedIds.has('troubleshooting') && !isDownloadingLogs) {
       downloadLogs()
     }
-    if (selectedIds.has('calibration')) {
+    if (selectedIds.has('calibration') && !isLoadingCalibration) {
       downloadCalibration()
     }
   }
@@ -56,6 +47,7 @@ export function DiagnosticsFiles({
     <div className={fileManagerStyles.file_management_group}>
       <FileManagementSectionHeader
         titleText={t('diagnostic_files')}
+        showButtons={isSomeSelected || isAllSelected}
         onDownloadSelected={handleDownloadSelected}
       />
       <div className={fileManagerStyles.log_table}>

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/FileManagementSectionHeader.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/FileManagementSectionHeader.tsx
@@ -6,6 +6,7 @@ import styles from './robotsettingsfilemanager.module.css'
 
 interface FileManagementSectionHeaderProps {
   titleText: string
+  showButtons: boolean
   onDownloadSelected: () => void
   onDeleteSelected?: () => void
 }
@@ -13,21 +14,23 @@ interface FileManagementSectionHeaderProps {
 export function FileManagementSectionHeader(
   props: FileManagementSectionHeaderProps
 ): JSX.Element {
-  const { titleText, onDownloadSelected, onDeleteSelected } = props
+  const { titleText, onDownloadSelected, onDeleteSelected, showButtons } = props
   const { t } = useTranslation('device_details')
   return (
     <div className={styles.file_management_header}>
       <StyledText desktopStyle="bodyLargeSemiBold">{titleText}</StyledText>
-      <div className={styles.file_management_header_button_group}>
-        <BasicButton onClick={onDownloadSelected} iconName="download">
-          {t('download_selected')}
-        </BasicButton>
-        {onDeleteSelected != null ? (
-          <BasicButton onClick={onDeleteSelected}>
-            {t('delete_selected')}
+      {showButtons ? (
+        <div className={styles.file_management_header_button_group}>
+          <BasicButton onClick={onDownloadSelected} iconName="download">
+            {t('download_selected')}
           </BasicButton>
-        ) : null}
-      </div>
+          {onDeleteSelected != null ? (
+            <BasicButton onClick={onDeleteSelected}>
+              {t('delete_selected')}
+            </BasicButton>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/RunRecord.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/RunRecord.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import {
   CheckboxBasic,
   COLORS,
+  Icon,
   ListAccordion,
   StyledText,
   Tag,
@@ -20,12 +21,14 @@ import type { RunData } from '@opentrons/api-client'
 interface RunRecordProps {
   run: RunData
   isSelected: boolean
+  isDeleting: boolean
   onToggle: () => void
 }
 
 export function RunRecord({
   run,
   isSelected,
+  isDeleting,
   onToggle,
 }: RunRecordProps): JSX.Element {
   const { t } = useTranslation('device_details')
@@ -39,11 +42,15 @@ export function RunRecord({
         e.stopPropagation()
       }}
     >
-      <CheckboxBasic
-        checked={isSelected}
-        onChange={onToggle}
-        backgroundColor={COLORS.white}
-      />
+      {isDeleting ? (
+        <Icon name="ot-spinner" spin size="1rem" color={COLORS.grey60} />
+      ) : (
+        <CheckboxBasic
+          checked={isSelected}
+          onChange={onToggle}
+          backgroundColor={COLORS.white}
+        />
+      )}
     </div>
   )
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/hooks/useDeleteSelectedRuns.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/hooks/useDeleteSelectedRuns.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useState } from 'react'
+import { useQueryClient } from 'react-query'
+
+import { deleteRun } from '@opentrons/api-client'
+import { ERROR_TOAST } from '@opentrons/components'
+import { getQueryKey, useHost } from '@opentrons/react-api-client'
+
+import { useToaster } from '/app/organisms/ToasterOven'
+
+import type { RunData } from '@opentrons/api-client'
+
+interface UseDeleteSelectedRunsResult {
+  deleteSelectedRuns: (runs: RunData[]) => void
+  deletingIds: Set<string>
+}
+
+export function useDeleteSelectedRuns(): UseDeleteSelectedRunsResult {
+  const host = useHost()
+  const queryClient = useQueryClient()
+  const { makeToast } = useToaster()
+  const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set())
+  const isMounted = useRef(false)
+
+  useEffect(() => {
+    isMounted.current = true
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+
+  const deleteSelectedRuns = (runs: RunData[]): void => {
+    if (host == null || runs.length === 0 || deletingIds.size > 0) {
+      return
+    }
+
+    setDeletingIds(new Set(runs.map(run => run.id)))
+
+    Promise.all(
+      runs.map(run =>
+        deleteRun(host, run.id).catch((e: Error) =>
+          makeToast(e.message, ERROR_TOAST, { closeButton: true })
+        )
+      )
+    )
+      .then(() =>
+        queryClient
+          .invalidateQueries(getQueryKey(host, 'runs'))
+          .catch((e: Error) => {
+            console.error(`error invalidating runs query: ${e.message}`)
+          })
+      )
+      .then(() => {
+        if (isMounted.current) setDeletingIds(new Set())
+      })
+      .catch((e: Error) => {
+        makeToast(e.message, ERROR_TOAST, { closeButton: true })
+        if (isMounted.current) setDeletingIds(new Set())
+      })
+  }
+
+  return { deleteSelectedRuns, deletingIds }
+}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/hooks/useDeleteSelectedRuns.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/hooks/useDeleteSelectedRuns.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { useQueryClient } from 'react-query'
 
 import { deleteRun } from '@opentrons/api-client'
@@ -19,14 +19,6 @@ export function useDeleteSelectedRuns(): UseDeleteSelectedRunsResult {
   const queryClient = useQueryClient()
   const { makeToast } = useToaster()
   const [deletingIds, setDeletingIds] = useState<Set<string>>(new Set())
-  const isMounted = useRef(false)
-
-  useEffect(() => {
-    isMounted.current = true
-    return () => {
-      isMounted.current = false
-    }
-  }, [])
 
   const deleteSelectedRuns = (runs: RunData[]): void => {
     if (host == null || runs.length === 0 || deletingIds.size > 0) {
@@ -50,11 +42,11 @@ export function useDeleteSelectedRuns(): UseDeleteSelectedRunsResult {
           })
       )
       .then(() => {
-        if (isMounted.current) setDeletingIds(new Set())
+        setDeletingIds(new Set())
       })
       .catch((e: Error) => {
         makeToast(e.message, ERROR_TOAST, { closeButton: true })
-        if (isMounted.current) setDeletingIds(new Set())
+        setDeletingIds(new Set())
       })
   }
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/hooks/useDownloadSelectedRuns.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/hooks/useDownloadSelectedRuns.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { saveAs } from 'file-saver'
 import JSZip from 'jszip'
@@ -24,14 +24,6 @@ export function useDownloadSelectedRuns(
   const host = useHost()
   const { makeToast, eatToast } = useToaster()
   const [isDownloading, setIsDownloading] = useState(false)
-  const isMounted = useRef(false)
-
-  useEffect(() => {
-    isMounted.current = true
-    return () => {
-      isMounted.current = false
-    }
-  }, [])
 
   const downloadSelectedRuns = (runs: RunData[]): void => {
     if (host == null || runs.length === 0 || isDownloading) {
@@ -67,17 +59,17 @@ export function useDownloadSelectedRuns(
           .catch((e: Error) => {
             eatToast(toastId)
             makeToast(e.message, ERROR_TOAST, { closeButton: true })
-            if (isMounted.current) setIsDownloading(false)
+            setIsDownloading(false)
           })
       )
       .then(() => {
         eatToast(toastId)
-        if (isMounted.current) setIsDownloading(false)
+        setIsDownloading(false)
       })
       .catch((e: Error) => {
         eatToast(toastId)
         makeToast(e.message, ERROR_TOAST, { closeButton: true })
-        if (isMounted.current) setIsDownloading(false)
+        setIsDownloading(false)
       })
   }
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/hooks/useDownloadSelectedRuns.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/hooks/useDownloadSelectedRuns.ts
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { saveAs } from 'file-saver'
+import JSZip from 'jszip'
+
+import { getRunRaw } from '@opentrons/api-client'
+import { ERROR_TOAST, INFO_TOAST } from '@opentrons/components'
+import { useHost } from '@opentrons/react-api-client'
+
+import { useToaster } from '/app/organisms/ToasterOven'
+
+import type { RunData } from '@opentrons/api-client'
+import type { IconProps } from '@opentrons/components'
+
+interface UseDownloadSelectedRunsResult {
+  downloadSelectedRuns: (runs: RunData[]) => void
+  isDownloading: boolean
+}
+
+export function useDownloadSelectedRuns(
+  robotName: string
+): UseDownloadSelectedRunsResult {
+  const { t } = useTranslation('device_details')
+  const host = useHost()
+  const { makeToast, eatToast } = useToaster()
+  const [isDownloading, setIsDownloading] = useState(false)
+  const isMounted = useRef(false)
+
+  useEffect(() => {
+    isMounted.current = true
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
+
+  const downloadSelectedRuns = (runs: RunData[]): void => {
+    if (host == null || runs.length === 0 || isDownloading) {
+      return
+    }
+
+    setIsDownloading(true)
+    const toastIcon: IconProps = { name: 'ot-spinner', spin: true }
+    const toastId = makeToast(
+      t('downloading_run_records') as string,
+      INFO_TOAST,
+      { disableTimeout: true, icon: toastIcon }
+    )
+
+    const zip = new JSZip()
+    Promise.all(
+      runs.map(run =>
+        getRunRaw(host, run.id, 'blob')
+          .then(res => {
+            zip.file(`${run.id}.json`, res.data)
+          })
+          .catch((e: Error) =>
+            makeToast(e.message, ERROR_TOAST, { closeButton: true })
+          )
+      )
+    )
+      .then(() =>
+        zip
+          .generateAsync({ type: 'blob' })
+          .then(blob => {
+            saveAs(blob, `${robotName}-run-records.zip`)
+          })
+          .catch((e: Error) => {
+            eatToast(toastId)
+            makeToast(e.message, ERROR_TOAST, { closeButton: true })
+            if (isMounted.current) setIsDownloading(false)
+          })
+      )
+      .then(() => {
+        eatToast(toastId)
+        if (isMounted.current) setIsDownloading(false)
+      })
+      .catch((e: Error) => {
+        eatToast(toastId)
+        makeToast(e.message, ERROR_TOAST, { closeButton: true })
+        if (isMounted.current) setIsDownloading(false)
+      })
+  }
+
+  return { downloadSelectedRuns, isDownloading }
+}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/index.tsx
@@ -15,14 +15,25 @@ import { DeleteRecordsModal } from '../../../DeleteRecordsModal'
 import { FileManagementSectionHeader } from '../FileManagementSectionHeader'
 import { useRecordSelection } from '../hooks/useRecordSelection'
 import fileManagerStyles from '../robotsettingsfilemanager.module.css'
+import { useDeleteSelectedRuns } from './hooks/useDeleteSelectedRuns'
+import { useDownloadSelectedRuns } from './hooks/useDownloadSelectedRuns'
 import protocolRunRecordsStyles from './protocolrunrecords.module.css'
 import { RunRecord } from './RunRecord'
 
-export function ProtocolRunRecords(): JSX.Element {
+interface ProtocolRunRecordsProps {
+  robotName: string
+}
+
+export function ProtocolRunRecords({
+  robotName,
+}: ProtocolRunRecordsProps): JSX.Element {
   const { t } = useTranslation('device_details')
   const { makeToast } = useToaster()
   const { data: runData } = useNotifyAllRunsQuery()
   const runs = [...(runData?.data ?? [])]
+  const { downloadSelectedRuns, isDownloading: isDownloadingRuns } =
+    useDownloadSelectedRuns(robotName)
+  const { deleteSelectedRuns, deletingIds } = useDeleteSelectedRuns()
 
   const {
     selectedIds,
@@ -40,10 +51,13 @@ export function ProtocolRunRecords(): JSX.Element {
     })
   }
 
-  // no-op: download not yet implemented
   const handleDownloadSelected = (): void => {
     if (selectedIds.size === 0) {
       handleNoRunsSelected('download')
+      return
+    }
+    if (!isDownloadingRuns) {
+      downloadSelectedRuns(runs.filter(run => selectedIds.has(run.id)))
     }
   }
 
@@ -63,6 +77,7 @@ export function ProtocolRunRecords(): JSX.Element {
             setShowDeleteRecordsModal(false)
           }}
           onConfirm={() => {
+            deleteSelectedRuns(runs.filter(run => selectedIds.has(run.id)))
             setShowDeleteRecordsModal(false)
           }}
           type="selectedRuns"
@@ -71,6 +86,7 @@ export function ProtocolRunRecords(): JSX.Element {
       <div className={fileManagerStyles.file_management_group}>
         <FileManagementSectionHeader
           titleText={t('protocol_run_records')}
+          showButtons={isSomeSelected || isAllSelected}
           onDownloadSelected={handleDownloadSelected}
           onDeleteSelected={handleDeleteSelected}
         />
@@ -113,6 +129,7 @@ export function ProtocolRunRecords(): JSX.Element {
                 key={run.id}
                 run={run}
                 isSelected={selectedIds.has(run.id)}
+                isDeleting={deletingIds.has(run.id)}
                 onToggle={() => {
                   handleToggleRun(run.id)
                 }}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import {
@@ -30,7 +30,7 @@ export function ProtocolRunRecords({
   const { t } = useTranslation('device_details')
   const { makeToast } = useToaster()
   const { data: runData } = useNotifyAllRunsQuery()
-  const runs = [...(runData?.data ?? [])]
+  const runs = useMemo(() => [...(runData?.data ?? [])], [runData?.data])
   const { downloadSelectedRuns, isDownloading: isDownloadingRuns } =
     useDownloadSelectedRuns(robotName)
   const { deleteSelectedRuns, deletingIds } = useDeleteSelectedRuns()

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/index.tsx
@@ -21,8 +21,10 @@ export function RobotSettingsFileManager({
     <div className={styles.container}>
       <RobotStorage />
       <DiagnosticsFiles robotName={robotName} />
-      {isComplianceReady ? <ComplianceReadySoftwareFiles /> : null}
-      <ProtocolRunRecords />
+      {isComplianceReady ? (
+        <ComplianceReadySoftwareFiles robotName={robotName} />
+      ) : null}
+      <ProtocolRunRecords robotName={robotName} />
     </div>
   )
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/robotsettingsfilemanager.module.css
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/robotsettingsfilemanager.module.css
@@ -15,6 +15,7 @@
 
 .file_management_header {
   display: flex;
+  min-height: 1.75rem;
   align-items: center;
   justify-content: space-between;
 }

--- a/app/src/organisms/Desktop/Devices/hooks/useDownloadCalibrationData.ts
+++ b/app/src/organisms/Desktop/Devices/hooks/useDownloadCalibrationData.ts
@@ -13,14 +13,17 @@ import {
 
 interface UseDownloadCalibrationDataResult {
   downloadCalibration: () => void
+  isLoading: boolean
 }
 
 export function useDownloadCalibrationData(
   robotName: string
 ): UseDownloadCalibrationDataResult {
   const doTrackEvent = useTrackEvent()
-  const { data: attachedInstruments } = useInstrumentsQuery()
-  const { data: attachedModules } = useModulesQuery()
+  const { data: attachedInstruments, isLoading: isLoadingInstruments } =
+    useInstrumentsQuery()
+  const { data: attachedModules, isLoading: isLoadingModules } =
+    useModulesQuery()
 
   const downloadCalibration = (): void => {
     doTrackEvent({
@@ -38,5 +41,8 @@ export function useDownloadCalibrationData(
     )
   }
 
-  return { downloadCalibration }
+  return {
+    downloadCalibration,
+    isLoading: isLoadingInstruments || isLoadingModules,
+  }
 }

--- a/app/src/organisms/Desktop/RobotSettingsCalibration/__tests__/CalibrationDataDownload.test.tsx
+++ b/app/src/organisms/Desktop/RobotSettingsCalibration/__tests__/CalibrationDataDownload.test.tsx
@@ -56,6 +56,7 @@ describe('CalibrationDataDownload', () => {
     mockDownloadCalibration.mockClear()
     when(useDownloadCalibrationData).calledWith(ROBOT_NAME).thenReturn({
       downloadCalibration: mockDownloadCalibration,
+      isLoading: false,
     })
     when(useIsEstopNotDisengaged).calledWith(ROBOT_NAME).thenReturn(false)
   })

--- a/app/src/redux/audit/slice.ts
+++ b/app/src/redux/audit/slice.ts
@@ -15,7 +15,7 @@ export interface AuditState {
    * able to replay an old deletion key after a reload.
    */
   logPeriodDeletionKeysById: {
-    [logPeriodId: string]: string | undefined
+    [logPeriodId: string]: string
   }
 }
 


### PR DESCRIPTION
# Overview

Wires the download/delete UI up for all three FileManager sections: Diagnostic Files, Compliance Ready Software Files, and Protocol Run Records (note: diagnostic files only support download, not delete). Adds bulk download/delete hooks for log periods and run records and a per-row spinner that replaces the checkbox while that row's delete is loading.

Also, makes some UI improvements, including section headers hiding their download/delete buttons entirely when nothing is selected, and rendering spinners on individual file records during deletion.

Closes EXEC-2792

## Test Plan and Hands on Testing

Live testing is limited, since bundle download behavior for runs and audit logs, and delete behavior for audit logs is not yet built on the robot-server side. In light of that, the api-client fn's are subject to minor changes, so please mainly inspect the new file manager download/delete hooks. Bulk run deletion is wired up properly, so you should be able to correctly delete multiple selected runs.

## UI checks
- confirmed that for each file manager section, if no records are selected, the section's download/delete header buttons do _not_ render
- confirmed that for the sole wired-up bulk download/delete behavior (bulk deleting runs), a spinner renders in place of the deleting record's checkmark

## Changelog

- Added `useDownloadSelectedLogPeriods` / `useDeleteSelectedLogPeriods` hooks (`ComplianceReadySoftwareFiles/hooks`) wiring bulk zip download and bulk delete, with deletion-key enforcement, for audit log periods
- Added `useDownloadSelectedRuns` / `useDeleteSelectedRuns` hooks (`ProtocolRunRecords/hooks`) wiring bulk zip download and bulk delete for protocol run records
- `LogPeriodRow` and `RunRecord` now show a spinner in place of their checkbox while that row is being deleted
- `FileManagementSectionHeader` now takes a `showButtons` prop and hides its download/delete buttons entirely when nothing is selected, instead of always rendering them
- `DiagnosticFiles`'s calibration download now waits for the underlying instrument/module queries to finish loading before firing (`useDownloadCalibrationData` now exposes `isLoading`)

## Review requests

Nothing in particular, mainly review new hooks. See test plan above.

## Risk assessment

Low. Server not wired up yet.