### PR TITLE
refactor(app): Delete a duplicated call to storeLoginState()

### DIFF
--- a/app/src/organisms/Desktop/LoginModal/index.tsx
+++ b/app/src/organisms/Desktop/LoginModal/index.tsx
@@ -147,12 +147,10 @@ function LoginModalImpl(props: LoginModalImplProps): JSX.Element {
           kind: 'setNewPassword',
           formData: setNewPasswordStateForm(successfulUsername),
         })
-        return
+      } else {
+        modal.resolve({ username: successfulUsername })
+        modal.remove()
       }
-
-      storeLoginState(robotName, successfulUsername, response)
-      modal.resolve({ username: successfulUsername })
-      modal.remove()
     },
     onError: handleError,
   })


### PR DESCRIPTION
## Overview

This function was accidentally calling `storeLoginState()` twice, once on line 143 and once on line 153. A merge mishap, maybe. This was harmless, but it caused confusing duplicate Redux actions to be dispatched.

## Test Plan and Hands on Testing

* [x] The login modal still dispatches the `robotAuth/logIn` action.
* [x] Now it only dispatches it once.

## Review requests

None.

## Risk assessment

Low.