### PR TITLE
feat(app, odd): Documentation required in error recovery flows 

### DIFF
--- a/api-client/src/runs/commands/createCommand.ts
+++ b/api-client/src/runs/commands/createCommand.ts
@@ -10,12 +10,13 @@ export function createCommand(
   config: HostConfig,
   runId: string,
   data: CreateCommand,
-  params?: CreateCommandParams
+  params?: CreateCommandParams,
+  userNotes?: string
 ): ResponsePromise<CommandData> {
   return request<CommandData, { data: CreateCommand }>(
     POST,
     `/runs/${runId}/commands`,
     config,
-    { queryParams: { ...params }, body: { data } }
+    { queryParams: { ...params }, body: { data }, userNotes }
   )
 }

--- a/api-client/src/runs/dismissCurrentRun.ts
+++ b/api-client/src/runs/dismissCurrentRun.ts
@@ -5,12 +5,13 @@ import type { EmptyResponse, HostConfig } from '../types'
 
 export function dismissCurrentRun(
   config: HostConfig,
-  runId: string
+  runId: string,
+  userNotes?: string
 ): ResponsePromise<EmptyResponse> {
   return request<EmptyResponse, { data: { current: false } }>(
     PATCH,
     `/runs/${runId}`,
     config,
-    { body: { data: { current: false } } }
+    { body: { data: { current: false } }, userNotes }
   )
 }

--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -2,6 +2,7 @@
   "stop_run": "Stopping protocol run",
   "play_run": "Playing protocol",
   "place_plate_reader_lid": "Placing plate reader lid",
+  "dismiss_run": "Dismissing protocol run",
   "end_plate_reader_lid": "Finishing place plate reader lid",
   "home_pipettes": "Homing pipettes",
   "end_home_pipettes": "Finishing home pipettes",

--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -34,5 +34,6 @@
   "finish_recalibrate_gripper": "Finishing recalibrate gripper flow",
   "create_protocol": "Creating protocol",
   "launching_error_recovery": "Launching error recovery",
-  "resume_run_from_recovery": "Resuming protocol run from recovery mode"
+  "resume_run_from_recovery": "Resuming protocol run from recovery mode",
+  "retry_action": "Retrying step"
 }

--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -31,5 +31,7 @@
   "finish_attach_gripper": "Finishing attach gripper flow",
   "finish_detach_gripper": "Finishing detach gripper flow",
   "finish_recalibrate_gripper": "Finishing recalibrate gripper flow",
-  "create_protocol": "Creating protocol"
+  "create_protocol": "Creating protocol",
+  "launching_error_recovery": "Launching error recovery",
+  "resume_run_from_recovery": "Resuming protocol run from recovery mode"
 }

--- a/app/src/local-resources/access-control/useErrorRecoveryDocumentation.ts
+++ b/app/src/local-resources/access-control/useErrorRecoveryDocumentation.ts
@@ -1,0 +1,25 @@
+import { useCallback, useState } from 'react'
+
+import { useDocumentationState } from './useDocumentationState'
+
+import type {
+  DocumentationState,
+  DocumentedAction,
+} from '@opentrons/react-api-client'
+
+export const useErrorRecoveryDocumentation = (): {
+  documentationState: DocumentationState
+  actionsToDocument: DocumentedAction[]
+  addActionToDocument: (action: DocumentedAction) => void
+} => {
+  const [actionsToDocument, setActionsToDocument] = useState<
+    DocumentedAction[]
+  >(['launching_error_recovery'])
+  const addActionToDocument = useCallback((action: DocumentedAction) => {
+    setActionsToDocument(prev => [...prev, action])
+  }, [])
+
+  const documentationState = useDocumentationState()
+
+  return { documentationState, actionsToDocument, addActionToDocument }
+}

--- a/app/src/organisms/ActionItems/ActionList.tsx
+++ b/app/src/organisms/ActionItems/ActionList.tsx
@@ -3,10 +3,17 @@ import clsx from 'clsx'
 import { getLabwareDefinitionsFromCommands } from '@opentrons/components'
 
 import { useNotifyCurrentMaintenanceRun } from '/app/resources/maintenance_runs'
+import {
+  useCurrentRunId,
+  useMostRecentCompletedAnalysis,
+  useNotifyRunQuery,
+  useRunLoadedLabwareDefinitionsByUri,
+} from '/app/resources/runs'
 
 import { ActionItem } from './ActionItem'
 import styles from './actionlist.module.css'
 
+import type { CommandTextData } from '@opentrons/components'
 import type { DocumentedAction } from '@opentrons/react-api-client'
 import type { RunTimeCommand } from '@opentrons/shared-data'
 
@@ -18,18 +25,28 @@ export const ActionList = ({
   className?: string
 }): JSX.Element => {
   const allRunTimeCommands = actionsToDocument.filter(isRunTimeCommand)
-  const allRunDefs = getLabwareDefinitionsFromCommands(allRunTimeCommands)
-  const { data } = useNotifyCurrentMaintenanceRun()
-  const commandTextData =
-    data != null
-      ? {
-          pipettes: data?.data.pipettes ?? [],
-          labware: data?.data.labware ?? [],
-          modules: data?.data.modules ?? [],
-          liquids: data?.data.liquids ?? [],
-          commands: allRunTimeCommands,
-        }
-      : null
+  const { data: maintenanceRun } = useNotifyCurrentMaintenanceRun()
+  const currentRunId = useCurrentRunId()
+  const { data: protocolRun } = useNotifyRunQuery(currentRunId)
+  const protocolAnalysis = useMostRecentCompletedAnalysis(currentRunId)
+  // Only needed for protocol-run fixit commands; skip while a maintenance run is active.
+  const runLwDefsByUri = useRunLoadedLabwareDefinitionsByUri(
+    maintenanceRun?.data != null ? null : currentRunId
+  )
+
+  const allRunDefs =
+    runLwDefsByUri != null
+      ? Object.values(runLwDefsByUri)
+      : getLabwareDefinitionsFromCommands(
+          protocolAnalysis?.commands ?? allRunTimeCommands
+        )
+
+  const commandTextData = getCommandTextData(
+    maintenanceRun,
+    protocolRun,
+    protocolAnalysis?.commands,
+    allRunTimeCommands
+  )
   return (
     <div className={clsx(styles.actions_list, className)}>
       {actionsToDocument.map((action, i) => (
@@ -47,4 +64,38 @@ export const ActionList = ({
 
 function isRunTimeCommand(action: DocumentedAction): action is RunTimeCommand {
   return typeof action === 'object' && 'commandType' in action
+}
+
+function getCommandTextData(
+  maintenanceRun: ReturnType<typeof useNotifyCurrentMaintenanceRun>['data'],
+  protocolRun: ReturnType<typeof useNotifyRunQuery>['data'],
+  analysisCommands: RunTimeCommand[] | undefined,
+  documentedCommands: RunTimeCommand[]
+): CommandTextData | null {
+  if (maintenanceRun?.data != null) {
+    return {
+      pipettes: maintenanceRun.data.pipettes ?? [],
+      labware: maintenanceRun.data.labware ?? [],
+      modules: maintenanceRun.data.modules ?? [],
+      liquids: maintenanceRun.data.liquids ?? [],
+      commands: documentedCommands,
+    }
+  }
+
+  if (protocolRun?.data != null) {
+    return {
+      pipettes: protocolRun.data.pipettes ?? [],
+      labware: protocolRun.data.labware ?? [],
+      modules: protocolRun.data.modules ?? [],
+      liquids: protocolRun.data.liquids ?? [],
+      // Analysis commands include loadLabware results needed for location/name
+      // lookup; append documented fixit commands so they can be found by id.
+      commands:
+        analysisCommands != null
+          ? [...analysisCommands, ...documentedCommands]
+          : documentedCommands,
+    }
+  }
+
+  return null
 }

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderBannerContainer/TerminalRunBannerContainer.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderBannerContainer/TerminalRunBannerContainer.tsx
@@ -12,6 +12,7 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import {
   useCloseCurrentRun,
   useIsRunCurrent,
@@ -92,7 +93,10 @@ export function TerminalRunBannerContainer(
 function ProtocolRunSuccessBanner(): JSX.Element {
   const { t } = useTranslation('run_details')
 
-  const { closeCurrentRun, isClosingCurrentRun } = useCloseCurrentRun()
+  const documentationState = useDocumentationState()
+
+  const { closeCurrentRun, isClosingCurrentRun } =
+    useCloseCurrentRun(documentationState)
 
   const handleRunSuccessClick = (): void => {
     closeCurrentRun()
@@ -119,7 +123,9 @@ function ProtocolRunErrorBanner({
 }: RunHeaderBannerContainerProps): JSX.Element {
   const { t } = useTranslation('run_details')
 
-  const { closeCurrentRun } = useCloseCurrentRun()
+  const documentationState = useDocumentationState()
+
+  const { closeCurrentRun } = useCloseCurrentRun(documentationState)
 
   const { highestPriorityError } = runErrors
 

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
@@ -211,7 +211,12 @@ export function useActionButtonProperties({
     buttonText = t('run_again')
     handleButtonClick = () => {
       isResetRunLoadingRef.current = true
-      reset()
+      reset({
+        onError: () => {
+          // e.g. user cancelled the documentation modal
+          isResetRunLoadingRef.current = false
+        },
+      })
       runHeaderModalContainerUtils.dropTipUtils.resetTipStatus()
       trackEvent({
         name: ANALYTICS_PROTOCOL_PROCEED_TO_RUN,

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/ProtocolRunHeader.test.tsx
@@ -7,6 +7,7 @@ import { useModulesQuery } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useIsRobotViewable } from '/app/redux-resources/robots'
 import { useRunGeneratedDataFiles } from '/app/resources/dataFiles/useRunGeneratedDataFiles'
 import {
@@ -42,6 +43,9 @@ vi.mock('../RunHeaderProtocolName')
 vi.mock('/app/resources/dataFiles/useRunGeneratedDataFiles')
 vi.mock('../hooks')
 vi.mock('/app/local-resources/images/hooks/useInitializeCameraState')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 
 const MOCK_PROTOCOL = 'MOCK_PROTOCOL'
 const MOCK_RUN_ID = 'MOCK_RUN_ID'

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '@opentrons/components'
 import { useModulesQuery } from '@opentrons/react-api-client'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useInitializeCameraState } from '/app/local-resources/images/hooks/useInitializeCameraState'
 import { isCancellableStatus } from '/app/local-resources/runs/utils'
 import { useIsRobotViewable } from '/app/redux-resources/robots'
@@ -68,7 +69,10 @@ export function ProtocolRunHeader(
     runStatus: runStatus,
     runId,
   })
-  const { closeCurrentRun, isClosingCurrentRun } = useCloseCurrentRun()
+
+  const documentationState = useDocumentationState()
+  const { closeCurrentRun, isClosingCurrentRun } =
+    useCloseCurrentRun(documentationState)
 
   const enteredER = runRecord?.data.hasEverEnteredErrorRecovery ?? false
   const protocolRunControls = useRunHeaderRunControls(runId, robotName)

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCreateCommands.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipCreateCommands.ts
@@ -67,7 +67,13 @@ export function useDropTipCreateCommands({
   const {
     chainRunCommands: chainRunFixitCommands,
     isCommandMutationLoading: isFixitCommandLoading,
-  } = useChainRunCommands(runId, failedCommandId)
+  } = useChainRunCommands(
+    runId,
+    commandDocState,
+    actionsToDocument,
+    addActionToDocument,
+    failedCommandId
+  )
 
   const { createMaintenanceCommand } = useCreateMaintenanceCommandMutation(
     commandDocState,
@@ -77,6 +83,9 @@ export function useDropTipCreateCommands({
 
   const { createRunCommand } = useCreateRunCommandMutation(
     runId,
+    commandDocState,
+    actionsToDocument,
+    addActionToDocument,
     failedCommandId
   )
 

--- a/app/src/organisms/DropTipWizardFlows/hooks/useDropTipWithType.ts
+++ b/app/src/organisms/DropTipWizardFlows/hooks/useDropTipWithType.ts
@@ -43,7 +43,12 @@ export function useDropTipWithType(
     deletionDocState,
     actionsToDocument,
     addActionToDocument,
-  } = useMaintenanceRunDocumentation('drop_tips', closeFlow)
+  } = useMaintenanceRunDocumentation(
+    'drop_tips',
+    // Prefer the fixit cancel handler so ER does not re-enter drop tip (and
+    // re-prompt) when the user backs out of documentation.
+    fixitCommandTypeUtils?.onDocumentationCancel ?? closeFlow
+  )
   const activeMaintenanceRunId = useDropTipMaintenanceRun({
     ...params,
     setErrorDetails,

--- a/app/src/organisms/DropTipWizardFlows/types.ts
+++ b/app/src/organisms/DropTipWizardFlows/types.ts
@@ -45,6 +45,8 @@ export interface FixitCommandTypeUtils {
   reportMap: (dropTipMap: DropTipWizardRouteOverride | null) => void
   /* If supplied, begin drop tip flows on the specified route & step. If no step is supplied, begin at the start of the route. */
   routeOverride?: DropTipWizardRouteOverride
+  /* Called when the user backs out of the initial documentation modal. */
+  onDocumentationCancel?: () => void
 }
 
 export type DropTipWizardContainerProps = DropTipWizardProps & {

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/ManageTips.tsx
@@ -345,6 +345,52 @@ export function useDropTipFlowUtils({
     }
   }
 
+  // Leaving the documentation modal must unmount the drop tip wizard. Using the
+  // normal closeFlow path re-checks tip status and re-enters this flow, which
+  // immediately re-prompts for documentation.
+  const onDocumentationCancel = (): void => {
+    switch (selectedRecoveryOption) {
+      case RETRY_NEW_TIPS.ROUTE:
+        void proceedToRouteAndStep(
+          RETRY_NEW_TIPS.ROUTE,
+          RETRY_NEW_TIPS.STEPS.REPLACE_TIPS
+        )
+        break
+      case SKIP_STEP_WITH_NEW_TIPS.ROUTE:
+        void proceedToRouteAndStep(
+          SKIP_STEP_WITH_NEW_TIPS.ROUTE,
+          SKIP_STEP_WITH_NEW_TIPS.STEPS.REPLACE_TIPS
+        )
+        break
+      case HOME_AND_RETRY.ROUTE:
+        void proceedToRouteAndStep(
+          HOME_AND_RETRY.ROUTE,
+          HOME_AND_RETRY.STEPS.HOME_BEFORE_RETRY
+        )
+        break
+      case MANUAL_FILL_AND_RETRY_NEW_TIPS.ROUTE:
+        void proceedToRouteAndStep(
+          MANUAL_FILL_AND_RETRY_NEW_TIPS.ROUTE,
+          MANUAL_FILL_AND_RETRY_NEW_TIPS.STEPS.REPLACE_TIPS
+        )
+        break
+      case RECOVERY_MAP.CANCEL_RUN.ROUTE:
+        void proceedToRouteAndStep(
+          RECOVERY_MAP.CANCEL_RUN.ROUTE,
+          RECOVERY_MAP.CANCEL_RUN.STEPS.CONFIRM_CANCEL
+        )
+        break
+      default:
+        // Splash cancel and other entry points: return to begin-removal so the
+        // wizard unmounts and documentation is not prompted again.
+        void proceedToRouteAndStep(
+          DROP_TIP_FLOWS.ROUTE,
+          DROP_TIP_FLOWS.STEPS.BEGIN_REMOVAL
+        )
+        break
+    }
+  }
+
   // If a specific step within the DROP_TIP_FLOWS route is selected, begin the Drop Tip Flows at its related route.
   //
   // NOTE: The substep is cleared by drop tip wizard after the completion of the wizard flow.
@@ -378,6 +424,7 @@ export function useDropTipFlowUtils({
     buttonOverrides: buildButtonOverrides(),
     routeOverride: buildRouteOverride(),
     reportMap: updateSubMap,
+    onDocumentationCancel,
   }
 }
 

--- a/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/ManageTips.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoveryOptions/__tests__/ManageTips.test.tsx
@@ -348,6 +348,35 @@ describe('useDropTipFlowUtils', () => {
     expect(mockUpdateSubMap).toHaveBeenCalledWith(currentMap)
   })
 
+  it('should route to begin removal when documentation is cancelled with no selected option', () => {
+    const { result } = renderHook(() => useDropTipFlowUtils(mockProps))
+
+    result.current.onDocumentationCancel?.()
+
+    expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
+      DROP_TIP_FLOWS.ROUTE,
+      DROP_TIP_FLOWS.STEPS.BEGIN_REMOVAL
+    )
+  })
+
+  it('should route to confirm cancel when documentation is cancelled during cancel run', () => {
+    const { result } = renderHook(() =>
+      useDropTipFlowUtils({
+        ...mockProps,
+        currentRecoveryOptionUtils: {
+          selectedRecoveryOption: RECOVERY_MAP.CANCEL_RUN.ROUTE,
+        },
+      } as any)
+    )
+
+    result.current.onDocumentationCancel?.()
+
+    expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
+      RECOVERY_MAP.CANCEL_RUN.ROUTE,
+      RECOVERY_MAP.CANCEL_RUN.STEPS.CONFIRM_CANCEL
+    )
+  })
+
   it('should return the correct error overrides', () => {
     const { result } = renderHook(() => useDropTipFlowUtils(mockProps))
 

--- a/app/src/organisms/ErrorRecoveryFlows/RecoverySplash.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/RecoverySplash.tsx
@@ -27,6 +27,7 @@ import {
   TYPOGRAPHY,
   WARNING_TOAST,
 } from '@opentrons/components'
+import { isDocumentedMutationError } from '@opentrons/react-api-client'
 
 import { useToaster } from '../ToasterOven'
 import {
@@ -161,6 +162,12 @@ export function RecoverySplash(props: RecoverySplashProps): JSX.Element | null {
             return recoveryCommands.homeExceptPlungers()
           } else {
             return recoveryCommands.homePipetteZAxes()
+          }
+        })
+        .catch((error: unknown) => {
+          // Cancelling the documentation modal should return to the splash unchanged.
+          if (isDocumentedMutationError(error)) {
+            return toggleERWizAsActiveUser(false, false)
           }
         })
         .finally(() => {

--- a/app/src/organisms/ErrorRecoveryFlows/__tests__/RecoverySplash.test.tsx
+++ b/app/src/organisms/ErrorRecoveryFlows/__tests__/RecoverySplash.test.tsx
@@ -10,6 +10,7 @@ import {
   RUN_STATUS_AWAITING_RECOVERY_BLOCKED_BY_OPEN_DOOR,
   RUN_STATUS_AWAITING_RECOVERY_PAUSED,
 } from '@opentrons/api-client'
+import { DocumentedMutationError } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
@@ -173,6 +174,27 @@ describe('RecoverySplash', () => {
 
     await waitFor(() => {
       expect(props.recoveryCommands.homePipetteZAxes).toHaveBeenCalled()
+    })
+  })
+
+  it('should return to the splash when documentation is cancelled during launch', async () => {
+    mockHomePipetteZAxes.mockRejectedValueOnce(
+      new DocumentedMutationError('no_documentation_report')
+    )
+
+    render(props)
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Launch recovery mode' })
+    )
+
+    await waitFor(() => {
+      expect(mockToggleERWiz).toHaveBeenCalledWith(true, true)
+    })
+    await waitFor(() => {
+      expect(mockToggleERWiz).toHaveBeenCalledWith(false, false)
+    })
+    await waitFor(() => {
+      expect(mockHandleMotionRouting).toHaveBeenCalledWith(false)
     })
   })
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryActionMutation.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryActionMutation.test.ts
@@ -1,7 +1,10 @@
 import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { usePlayRunMutation } from '@opentrons/react-api-client'
+import {
+  isDocumentedMutationError,
+  usePlayRunMutation,
+} from '@opentrons/react-api-client'
 
 import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 
@@ -12,6 +15,7 @@ import type { Mock } from 'vitest'
 
 vi.mock('@opentrons/react-api-client', () => ({
   usePlayRunMutation: vi.fn(),
+  isDocumentedMutationError: vi.fn(),
 }))
 
 describe('useRecoveryActionMutation', () => {
@@ -24,6 +28,7 @@ describe('useRecoveryActionMutation', () => {
     mockMutateAsync = vi.fn()
     mockIsLoading = false
     mockProceedToRouteAndStep = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(isDocumentedMutationError).mockReturnValue(false)
 
     vi.mocked(usePlayRunMutation).mockReturnValue({
       mutateAsync: mockMutateAsync,
@@ -109,5 +114,24 @@ describe('useRecoveryActionMutation', () => {
     expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
       RECOVERY_MAP.ERROR_WHILE_RECOVERING.ROUTE
     )
+  })
+
+  it('should not route to the error screen when documentation is cancelled', async () => {
+    const mockError = new Error('No documentation report provided')
+    vi.mocked(isDocumentedMutationError).mockReturnValue(true)
+    mockMutateAsync.mockRejectedValue(mockError)
+
+    const { result } = renderHook(() =>
+      useRecoveryActionMutation(
+        mockRunId,
+        {
+          proceedToRouteAndStep: mockProceedToRouteAndStep,
+        } as any,
+        ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+      )
+    )
+
+    await expect(result.current.resumeRecovery()).rejects.toBe(mockError)
+    expect(mockProceedToRouteAndStep).not.toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRecoveryCommands.test.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  isDocumentedMutationError,
   useErrorRecoveryPolicy,
   useResumeRunFromRecoveryAssumingFalsePositiveMutation,
   useResumeRunFromRecoveryMutation,
@@ -47,8 +48,10 @@ describe('useRecoveryCommands', () => {
     pickUpTipLabware: { id: 'MOCK_LW_ID' },
   } as any
   const mockProceedToRouteAndStep = vi.fn()
+  const mockStashedMapRef = { current: null as any }
   const mockRouteUpdateActions = {
     proceedToRouteAndStep: mockProceedToRouteAndStep,
+    stashedMapRef: mockStashedMapRef,
   } as any
   const mockMakeSuccessToast = vi.fn()
   const mockResumeRunFromRecovery = vi.fn(() =>
@@ -81,6 +84,7 @@ describe('useRecoveryCommands', () => {
   }
 
   beforeEach(() => {
+    vi.mocked(isDocumentedMutationError).mockReturnValue(false)
     vi.mocked(useResumeRunFromRecoveryMutation).mockReturnValue({
       mutateAsync: mockResumeRunFromRecovery,
     } as any)
@@ -116,6 +120,10 @@ describe('useRecoveryCommands', () => {
 
   it(`should call proceedToRouteAndStep with ${RECOVERY_MAP.ERROR_WHILE_RECOVERING.ROUTE} when chainRunCommands throws an error`, async () => {
     const mockError = new Error('Mock error')
+    mockStashedMapRef.current = {
+      route: RECOVERY_MAP.RETRY_STEP.ROUTE,
+      step: RECOVERY_MAP.RETRY_STEP.STEPS.CONFIRM_RETRY,
+    }
     vi.mocked(useChainRunCommands).mockReturnValue({
       chainRunCommands: vi.fn().mockRejectedValue(mockError),
     } as any)
@@ -128,9 +136,37 @@ describe('useRecoveryCommands', () => {
       )
     })
 
+    expect(mockStashedMapRef.current).toBeNull()
     expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
       RECOVERY_MAP.ERROR_WHILE_RECOVERING.ROUTE
     )
+  })
+
+  it('should rethrow DocumentedMutationError without routing to ERROR_WHILE_RECOVERING', async () => {
+    const mockError = new Error('No documentation report provided')
+    const mockHandleMotionRouting = vi.fn(() => Promise.resolve())
+    mockProceedToRouteAndStep.mockClear()
+    vi.mocked(isDocumentedMutationError).mockReturnValue(true)
+    vi.mocked(useChainRunCommands).mockReturnValue({
+      chainRunCommands: vi.fn().mockRejectedValue(mockError),
+    } as any)
+
+    const { result } = renderHook(() =>
+      useRecoveryCommands({
+        ...props,
+        routeUpdateActions: {
+          ...mockRouteUpdateActions,
+          handleMotionRouting: mockHandleMotionRouting,
+        },
+      })
+    )
+
+    await act(async () => {
+      await expect(result.current.homePipetteZAxes()).rejects.toBe(mockError)
+    })
+
+    expect(mockHandleMotionRouting).toHaveBeenCalledWith(false)
+    expect(mockProceedToRouteAndStep).not.toHaveBeenCalled()
   })
 
   it('should call retryFailedCommand with the failedCommand', async () => {
@@ -401,12 +437,69 @@ describe('useRecoveryCommands', () => {
     expect(mockMakeSuccessToast).toHaveBeenCalled()
   })
 
+  it('should restore the previous screen when resumeRun documentation is cancelled', async () => {
+    const mockHandleMotionRouting = vi.fn(() => Promise.resolve())
+    mockMakeSuccessToast.mockClear()
+    vi.mocked(isDocumentedMutationError).mockReturnValue(true)
+    mockResumeRunFromRecovery.mockRejectedValueOnce(
+      new Error('No documentation report provided')
+    )
+
+    const { result } = renderHook(() =>
+      useRecoveryCommands({
+        ...props,
+        routeUpdateActions: {
+          ...mockRouteUpdateActions,
+          handleMotionRouting: mockHandleMotionRouting,
+        },
+      })
+    )
+
+    await act(async () => {
+      result.current.resumeRun()
+    })
+
+    expect(mockHandleMotionRouting).toHaveBeenCalledWith(false)
+    expect(mockMakeSuccessToast).not.toHaveBeenCalled()
+  })
+
   it('should call cancelRun with runId', () => {
     const { result } = renderHook(() => useRecoveryCommands(props))
 
     result.current.cancelRun()
 
-    expect(mockStopRun).toHaveBeenCalledWith(mockRunId)
+    expect(mockStopRun).toHaveBeenCalledWith(
+      mockRunId,
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      })
+    )
+  })
+
+  it('should return to confirm cancel when cancelRun documentation is cancelled', async () => {
+    mockStopRun.mockClear()
+    mockProceedToRouteAndStep.mockClear()
+    mockStashedMapRef.current = {
+      route: RECOVERY_MAP.DROP_TIP_FLOWS.ROUTE,
+      step: RECOVERY_MAP.DROP_TIP_FLOWS.STEPS.BEFORE_BEGINNING,
+    }
+    vi.mocked(isDocumentedMutationError).mockReturnValue(true)
+
+    const { result } = renderHook(() => useRecoveryCommands(props))
+
+    result.current.cancelRun()
+
+    const onError = mockStopRun.mock.calls[0][1].onError as (
+      error: unknown
+    ) => void
+    onError(new Error('No documentation report provided'))
+
+    expect(mockStashedMapRef.current).toBeNull()
+    expect(mockProceedToRouteAndStep).toHaveBeenCalledWith(
+      RECOVERY_MAP.CANCEL_RUN.ROUTE,
+      RECOVERY_MAP.CANCEL_RUN.STEPS.CONFIRM_CANCEL
+    )
   })
 
   it('should call homePipetteZAxes with the appropriate command', async () => {
@@ -618,6 +711,32 @@ describe('useRecoveryCommands', () => {
 
     expect(mockResumeRunFromRecovery).toHaveBeenCalledWith(mockRunId)
     expect(mockMakeSuccessToast).toHaveBeenCalled()
+  })
+
+  it('should restore the previous screen when skipFailedCommand documentation is cancelled', async () => {
+    const mockHandleMotionRouting = vi.fn(() => Promise.resolve())
+    mockMakeSuccessToast.mockClear()
+    vi.mocked(isDocumentedMutationError).mockReturnValue(true)
+    mockResumeRunFromRecovery.mockRejectedValueOnce(
+      new Error('No documentation report provided')
+    )
+
+    const { result } = renderHook(() =>
+      useRecoveryCommands({
+        ...props,
+        routeUpdateActions: {
+          ...mockRouteUpdateActions,
+          handleMotionRouting: mockHandleMotionRouting,
+        },
+      })
+    )
+
+    await act(async () => {
+      result.current.skipFailedCommand()
+    })
+
+    expect(mockHandleMotionRouting).toHaveBeenCalledWith(false)
+    expect(mockMakeSuccessToast).not.toHaveBeenCalled()
   })
 
   it('should call updateErrorRecoveryPolicy with correct policy rules when failedCommand has an error', async () => {

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRouteUpdateActions.test.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/__tests__/useRouteUpdateActions.test.ts
@@ -200,6 +200,52 @@ describe('useRouteUpdateActions', () => {
     })
   })
 
+  it('does not overwrite the restored route when handleMotionRouting(false) is called twice', async () => {
+    const { result, rerender } = renderHook(
+      ({ recoveryMap }) =>
+        useRouteUpdateActions({
+          ...useRouteUpdateActionsParams,
+          recoveryMap,
+        }),
+      {
+        initialProps: {
+          recoveryMap: useRouteUpdateActionsParams.recoveryMap,
+        },
+      }
+    )
+
+    await result.current.handleMotionRouting(true)
+    await result.current.handleMotionRouting(false)
+    rerender({
+      recoveryMap: {
+        route: RECOVERY_MAP.RETRY_STEP.ROUTE,
+        step: RECOVERY_MAP.RETRY_STEP.STEPS.CONFIRM_RETRY,
+      },
+    })
+    mockSetRecoveryMap.mockClear()
+
+    await result.current.handleMotionRouting(false)
+    expect(mockSetRecoveryMap).not.toHaveBeenCalled()
+  })
+
+  it('falls back to option selection when ending motion with no stash while still on a motion route', async () => {
+    const { result } = renderHook(() =>
+      useRouteUpdateActions({
+        ...useRouteUpdateActionsParams,
+        recoveryMap: {
+          route: RECOVERY_MAP.ROBOT_IN_MOTION.ROUTE,
+          step: RECOVERY_MAP.ROBOT_IN_MOTION.STEPS.IN_MOTION,
+        },
+      })
+    )
+
+    await result.current.handleMotionRouting(false)
+    expect(mockSetRecoveryMap).toHaveBeenCalledWith({
+      route: OPTION_SELECTION.ROUTE,
+      step: OPTION_SELECTION.STEPS.SELECT,
+    })
+  })
+
   it('routes to the first step of the supplied route when proceedToRouteAndStep is called without a step', () => {
     const { result } = renderHook(() =>
       useRouteUpdateActions(useRouteUpdateActionsParams)

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryActionMutation.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryActionMutation.ts
@@ -1,4 +1,7 @@
-import { usePlayRunMutation } from '@opentrons/react-api-client'
+import {
+  isDocumentedMutationError,
+  usePlayRunMutation,
+} from '@opentrons/react-api-client'
 
 import { RECOVERY_MAP } from '../constants'
 
@@ -23,6 +26,10 @@ export function useRecoveryActionMutation(
 
   const resumeRecovery = (): Promise<RunAction> => {
     return mutateAsync(runId).catch(e => {
+      // User cancelled documentation/login — stay on the current screen.
+      if (isDocumentedMutationError(e)) {
+        return Promise.reject(e)
+      }
       return proceedToRouteAndStep(
         RECOVERY_MAP.ERROR_WHILE_RECOVERING.ROUTE
       ).then(() => {

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -20,6 +20,7 @@ import { DEFINED_ERROR_TYPES, ERROR_KINDS, RECOVERY_MAP } from '../constants'
 
 import type { CommandData, IfMatchType, RunAction } from '@opentrons/api-client'
 import type { WellGroup } from '@opentrons/components'
+import type { DocumentedAction } from '@opentrons/react-api-client'
 import type {
   AspDispWhileTrackingParams,
   AspirateInPlaceRunTimeCommand,
@@ -149,14 +150,19 @@ export function useRecoveryCommands({
   const chainRunRecoveryCommands = useCallback(
     (
       commands: CreateCommand[],
-      continuePastFailure: boolean = false
-    ): Promise<CommandData[]> =>
-      chainRunCommands(commands, continuePastFailure)
-        // the catch never occurs if continuePastCommandFailure is "true"
-        .catch((e: Error) => reportAndRouteFailedCmd(e)),
+      continuePastFailure: boolean = false,
+      recoveryAction?: DocumentedAction
+    ): Promise<CommandData[]> => {
+      if (!!recoveryAction) addActionToDocument(recoveryAction)
+      return (
+        chainRunCommands(commands, continuePastFailure)
+          // the catch never occurs if continuePastCommandFailure is "true"
+          .catch((e: Error) => reportAndRouteFailedCmd(e))
+      )
+    },
     // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [analytics, selectedRecoveryOption]
+    [analytics, selectedRecoveryOption, addActionToDocument]
   )
 
   const buildRetryPrepMove = ():
@@ -302,7 +308,9 @@ export function useRecoveryCommands({
           // move back to the location of the command if it is an in-place command
           buildRetryPrepMove(),
           { commandType, params }, // retry the command that failed
-        ].filter(c => c != null) as CreateCommand[]
+        ].filter(c => c != null) as CreateCommand[],
+        false,
+        'retry_action'
       ) // the created command is the same command that failed
     },
     // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -9,7 +9,7 @@ import {
 } from '@opentrons/react-api-client'
 import { WELL_ORIGIN_TOP } from '@opentrons/shared-data'
 
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useErrorRecoveryDocumentation } from '/app/local-resources/access-control/useErrorRecoveryDocumentation'
 import { getErrorKind } from '/app/organisms/ErrorRecoveryFlows/utils'
 import {
   useChainRunCommands,
@@ -116,19 +116,23 @@ export function useRecoveryCommands({
   selectedRecoveryOption,
 }: UseRecoveryCommandsParams): UseRecoveryCommandsResult {
   const [ignoreErrors, setIgnoreErrors] = useState(false)
+  const { documentationState, actionsToDocument, addActionToDocument } =
+    useErrorRecoveryDocumentation()
 
   const { proceedToRouteAndStep } = routeUpdateActions
   const { mutateAsync: resumeRunFromRecovery } =
-    useResumeRunFromRecoveryMutation()
+    useResumeRunFromRecoveryMutation(documentationState)
   const { mutateAsync: resumeRunFromRecoveryAssumingFalsePositive } =
-    useResumeRunFromRecoveryAssumingFalsePositiveMutation()
+    useResumeRunFromRecoveryAssumingFalsePositiveMutation(documentationState)
 
-  const documentationState = useDocumentationState()
   const { stopRun } = useStopRunMutation(documentationState)
   const updateErrorRecoveryPolicy = useUpdateRecoveryPolicyWithStrategy(runId)
   const currentRecoveryPolicy = useErrorRecoveryPolicy(runId)?.data?.data
   const { chainRunCommands } = useChainRunCommands(
     runId,
+    documentationState,
+    actionsToDocument,
+    addActionToDocument,
     unvalidatedFailedCommand?.id,
     currentRecoveryPolicy
   )

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 import head from 'lodash/head'
 
 import {
+  isDocumentedMutationError,
   useErrorRecoveryPolicy,
   useResumeRunFromRecoveryAssumingFalsePositiveMutation,
   useResumeRunFromRecoveryMutation,
@@ -120,7 +121,8 @@ export function useRecoveryCommands({
   const { documentationState, actionsToDocument, addActionToDocument } =
     useErrorRecoveryDocumentation()
 
-  const { proceedToRouteAndStep } = routeUpdateActions
+  const { proceedToRouteAndStep, handleMotionRouting, stashedMapRef } =
+    routeUpdateActions
   const { mutateAsync: resumeRunFromRecovery } =
     useResumeRunFromRecoveryMutation(documentationState)
   const { mutateAsync: resumeRunFromRecoveryAssumingFalsePositive } =
@@ -142,6 +144,10 @@ export function useRecoveryCommands({
   const reportAndRouteFailedCmd = (e: Error): Promise<never> => {
     console.warn(`Error executing "fixit" command: ${e}`)
     analytics.reportActionSelectedResult(selectedRecoveryOption, 'failed')
+    // Drop any in-motion stash so a later documentation cancel (e.g. from the
+    // recovery-failed "back to menu" home) restores this error screen, not the
+    // pre-retry step that was stashed when the failed action began.
+    stashedMapRef.current = null
     void proceedToRouteAndStep(RECOVERY_MAP.ERROR_WHILE_RECOVERING.ROUTE)
 
     return Promise.reject(new Error(`Could not execute command: ${e}`))
@@ -157,12 +163,25 @@ export function useRecoveryCommands({
       return (
         chainRunCommands(commands, continuePastFailure)
           // the catch never occurs if continuePastCommandFailure is "true"
-          .catch((e: Error) => reportAndRouteFailedCmd(e))
+          .catch((e: Error) => {
+            // User cancelled documentation/login — return to the screen from
+            // before this mutation (stashed by handleMotionRouting(true)).
+            // Callers such as launch may still close the wizard afterward.
+            if (isDocumentedMutationError(e)) {
+              return handleMotionRouting(false).then(() => Promise.reject(e))
+            }
+            return reportAndRouteFailedCmd(e)
+          })
       )
     },
     // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [analytics, selectedRecoveryOption, addActionToDocument]
+    [
+      analytics,
+      selectedRecoveryOption,
+      addActionToDocument,
+      handleMotionRouting,
+    ]
   )
 
   const buildRetryPrepMove = ():
@@ -407,6 +426,12 @@ export function useRecoveryCommands({
           )
           makeSuccessToast()
         })
+        .catch((error: unknown) => {
+          if (isDocumentedMutationError(error)) {
+            return handleMotionRouting(false)
+          }
+          return Promise.reject(error)
+        })
     },
     // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -417,18 +442,40 @@ export function useRecoveryCommands({
       handleIgnoringErrorKind,
       selectedRecoveryOption,
       makeSuccessToast,
+      handleMotionRouting,
     ]
   )
 
-  const cancelRun = useCallback(
-    (): void => {
-      analytics.reportActionSelectedResult(selectedRecoveryOption, 'succeeded')
-      stopRun(runId)
-    },
-    // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [runId]
-  )
+  const cancelRun = useCallback((): void => {
+    stopRun(runId, {
+      onSuccess: () => {
+        analytics.reportActionSelectedResult(
+          selectedRecoveryOption,
+          'succeeded'
+        )
+      },
+      onError: (error: unknown) => {
+        // stopRun is not routed through chainRunRecoveryCommands, so handle
+        // documentation cancel here. Always return to confirm-cancel rather than
+        // restoring a DROP_TIP_FLOWS stash — after tips are removed, that would
+        // re-enter the drop tip wizard from the start.
+        if (isDocumentedMutationError(error)) {
+          stashedMapRef.current = null
+          void proceedToRouteAndStep(
+            RECOVERY_MAP.CANCEL_RUN.ROUTE,
+            RECOVERY_MAP.CANCEL_RUN.STEPS.CONFIRM_CANCEL
+          )
+        }
+      },
+    })
+  }, [
+    runId,
+    stopRun,
+    proceedToRouteAndStep,
+    stashedMapRef,
+    selectedRecoveryOption,
+    analytics,
+  ])
 
   const handleResumeAction = (): Promise<RunAction> => {
     if (isAssumeFalsePositiveResumeKind(failedCommand)) {
@@ -440,15 +487,21 @@ export function useRecoveryCommands({
 
   const skipFailedCommand = useCallback(
     (): void => {
-      void handleIgnoringErrorKind().then(() =>
-        handleResumeAction().then(() => {
+      void handleIgnoringErrorKind()
+        .then(() => handleResumeAction())
+        .then(() => {
           analytics.reportActionSelectedResult(
             selectedRecoveryOption,
             'succeeded'
           )
           makeSuccessToast()
         })
-      )
+        .catch((error: unknown) => {
+          if (isDocumentedMutationError(error)) {
+            return handleMotionRouting(false)
+          }
+          return Promise.reject(error)
+        })
     },
     // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -458,6 +511,7 @@ export function useRecoveryCommands({
       handleIgnoringErrorKind,
       selectedRecoveryOption,
       makeSuccessToast,
+      handleMotionRouting,
     ]
   )
 

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRecoveryCommands.ts
@@ -21,7 +21,6 @@ import { DEFINED_ERROR_TYPES, ERROR_KINDS, RECOVERY_MAP } from '../constants'
 
 import type { CommandData, IfMatchType, RunAction } from '@opentrons/api-client'
 import type { WellGroup } from '@opentrons/components'
-import type { DocumentedAction } from '@opentrons/react-api-client'
 import type {
   AspDispWhileTrackingParams,
   AspirateInPlaceRunTimeCommand,
@@ -139,6 +138,15 @@ export function useRecoveryCommands({
     unvalidatedFailedCommand?.id,
     currentRecoveryPolicy
   )
+
+  const { chainRunCommands: chainRetryRunCommands } = useChainRunCommands(
+    runId,
+    documentationState,
+    [...actionsToDocument, 'retry_action'],
+    addActionToDocument,
+    unvalidatedFailedCommand?.id,
+    currentRecoveryPolicy
+  )
   const { makeSuccessToast } = recoveryToastUtils
 
   const reportAndRouteFailedCmd = (e: Error): Promise<never> => {
@@ -157,11 +165,10 @@ export function useRecoveryCommands({
     (
       commands: CreateCommand[],
       continuePastFailure: boolean = false,
-      recoveryAction?: DocumentedAction
+      chain: typeof chainRunCommands = chainRunCommands
     ): Promise<CommandData[]> => {
-      if (!!recoveryAction) addActionToDocument(recoveryAction)
       return (
-        chainRunCommands(commands, continuePastFailure)
+        chain(commands, continuePastFailure)
           // the catch never occurs if continuePastCommandFailure is "true"
           .catch((e: Error) => {
             // User cancelled documentation/login — return to the screen from
@@ -176,12 +183,7 @@ export function useRecoveryCommands({
     },
     // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      analytics,
-      selectedRecoveryOption,
-      addActionToDocument,
-      handleMotionRouting,
-    ]
+    [analytics, selectedRecoveryOption, chainRunCommands, handleMotionRouting]
   )
 
   const buildRetryPrepMove = ():
@@ -329,12 +331,16 @@ export function useRecoveryCommands({
           { commandType, params }, // retry the command that failed
         ].filter(c => c != null) as CreateCommand[],
         false,
-        'retry_action'
+        chainRetryRunCommands
       ) // the created command is the same command that failed
     },
     // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [chainRunRecoveryCommands, unvalidatedFailedCommand?.key]
+    [
+      chainRunRecoveryCommands,
+      chainRetryRunCommands,
+      unvalidatedFailedCommand?.key,
+    ]
   )
 
   // Homes the Z-axis of all attached pipettes.

--- a/app/src/organisms/ErrorRecoveryFlows/hooks/useRouteUpdateActions.ts
+++ b/app/src/organisms/ErrorRecoveryFlows/hooks/useRouteUpdateActions.ts
@@ -39,7 +39,7 @@ export interface UseRouteUpdateActionsResult {
     step?: RouteStep
   ) => Promise<void>
   /* Stashes the current map then sets the current map to robot in motion after validating the door is closed.
-  Restores the map after motion completes. */
+  Restores the stashed map when motion ends (including when the user cancels documentation for the mutation). */
   handleMotionRouting: (
     inMotion: boolean,
     movingRoute?: RobotMovingRoute
@@ -60,6 +60,20 @@ export function useRouteUpdateActions(
   const { OPTION_SELECTION, ROBOT_IN_MOTION, ROBOT_DOOR_OPEN } = RECOVERY_MAP
   const { isDoorOpen } = doorStatusUtils
   const stashedMapRef = useRef<IRecoveryMap | null>(null)
+
+  const isRobotMovingRoute = (route: RecoveryRoute): boolean => {
+    const movingRoutes: RecoveryRoute[] = [
+      RECOVERY_MAP.ROBOT_IN_MOTION.ROUTE,
+      RECOVERY_MAP.ROBOT_RESUMING.ROUTE,
+      RECOVERY_MAP.ROBOT_RETRYING_STEP.ROUTE,
+      RECOVERY_MAP.ROBOT_CANCELING.ROUTE,
+      RECOVERY_MAP.ROBOT_PICKING_UP_TIPS.ROUTE,
+      RECOVERY_MAP.ROBOT_SKIPPING_STEP.ROUTE,
+      RECOVERY_MAP.ROBOT_RELEASING_LABWARE.ROUTE,
+      RECOVERY_MAP.STACKER_RELEASING_LABWARE_LATCH.ROUTE,
+    ]
+    return movingRoutes.includes(route)
+  }
 
   const goBackPrevStep = useCallback((): Promise<void> => {
     return new Promise((resolve, reject) => {
@@ -154,17 +168,20 @@ export function useRouteUpdateActions(
               ? head(STEP_ORDER[robotMovingRoute])!
               : ROBOT_IN_MOTION.STEPS.IN_MOTION
           setRecoveryMap({ route, step })
-        } else {
-          if (stashedMapRef.current != null) {
-            setRecoveryMap(stashedMapRef.current)
-            stashedMapRef.current = null
-          } else {
-            setRecoveryMap({
-              route: OPTION_SELECTION.ROUTE,
-              step: OPTION_SELECTION.STEPS.SELECT,
-            })
-          }
+        } else if (stashedMapRef.current != null) {
+          // Return to the screen from before motion/mutation started.
+          setRecoveryMap(stashedMapRef.current)
+          stashedMapRef.current = null
+        } else if (isRobotMovingRoute(currentRoute)) {
+          // Stash was already cleared but we are still on a motion route — escape
+          // to option selection rather than remaining stuck on the motion screen.
+          setRecoveryMap({
+            route: OPTION_SELECTION.ROUTE,
+            step: OPTION_SELECTION.STEPS.SELECT,
+          })
         }
+        // else: motion already cleared and previous screen restored (e.g. a
+        // caller's .finally after documentation cancel). Leave the map alone.
 
         resolve()
       })

--- a/app/src/organisms/LocationConflictModal/ChooseModuleToConfigureModal.tsx
+++ b/app/src/organisms/LocationConflictModal/ChooseModuleToConfigureModal.tsx
@@ -29,6 +29,7 @@ import {
 
 import { getTopPortalEl } from '/app/App/portal'
 import { SmallButton } from '/app/atoms/buttons'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useModuleUSBPort } from '/app/local-resources/modules'
 import { ODDFixtureOption } from '/app/molecules/ODDFixtureOption'
 import { OddModal } from '/app/molecules/OddModal'
@@ -312,7 +313,8 @@ function NoUnconfiguredModules(props: NoUnconfiguredModulesProps): JSX.Element {
   } = props
   const { t } = useTranslation('protocol_setup')
   const navigate = useNavigate()
-  const { closeCurrentRun } = useCloseCurrentRun()
+  const documentationState = useDocumentationState()
+  const { closeCurrentRun } = useCloseCurrentRun(documentationState)
   const handleCancelRun = (): void => {
     closeCurrentRun()
   }

--- a/app/src/organisms/ODD/DocumentationRequired/__tests__/ActionsView.test.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/__tests__/ActionsView.test.tsx
@@ -7,6 +7,12 @@ import { useCommandTextString } from '@opentrons/components'
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useNotifyCurrentMaintenanceRun } from '/app/resources/maintenance_runs'
+import {
+  useCurrentRunId,
+  useMostRecentCompletedAnalysis,
+  useNotifyRunQuery,
+  useRunLoadedLabwareDefinitionsByUri,
+} from '/app/resources/runs'
 
 import { ActionsView } from '../ActionsView'
 
@@ -14,6 +20,12 @@ import type { DocumentedAction } from '@opentrons/react-api-client'
 import type { RunTimeCommand } from '@opentrons/shared-data'
 
 vi.mock('/app/resources/maintenance_runs')
+vi.mock('/app/resources/runs', () => ({
+  useCurrentRunId: vi.fn(),
+  useNotifyRunQuery: vi.fn(),
+  useMostRecentCompletedAnalysis: vi.fn(),
+  useRunLoadedLabwareDefinitionsByUri: vi.fn(),
+}))
 vi.mock('@opentrons/components', async () => {
   const actual = await vi.importActual('@opentrons/components')
   return {
@@ -48,6 +60,10 @@ const renderWithModal = (actionsToDocument: DocumentedAction[]) => {
 
 describe('ActionsView', () => {
   beforeEach(() => {
+    vi.mocked(useCurrentRunId).mockReturnValue(null)
+    vi.mocked(useNotifyRunQuery).mockReturnValue({ data: undefined } as any)
+    vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue(null)
+    vi.mocked(useRunLoadedLabwareDefinitionsByUri).mockReturnValue(null)
     vi.mocked(useNotifyCurrentMaintenanceRun).mockReturnValue({
       data: {
         data: {
@@ -150,7 +166,40 @@ describe('ActionsView', () => {
     )
   })
 
-  it('renders stringified runtime commands when maintenance run data is unavailable', () => {
+  it('renders command text for runtime commands when protocol run data is available', () => {
+    vi.mocked(useNotifyCurrentMaintenanceRun).mockReturnValue({
+      data: undefined,
+    } as any)
+    vi.mocked(useCurrentRunId).mockReturnValue('run-id')
+    vi.mocked(useNotifyRunQuery).mockReturnValue({
+      data: {
+        data: {
+          pipettes: [],
+          labware: [],
+          modules: [],
+          liquids: [],
+        },
+      },
+    } as any)
+    vi.mocked(useMostRecentCompletedAnalysis).mockReturnValue({
+      commands: [],
+    } as any)
+    vi.mocked(useRunLoadedLabwareDefinitionsByUri).mockReturnValue({})
+
+    renderWithModal([HOME_COMMAND])
+    screen.getByText('Mock command text')
+    expect(useCommandTextString).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: HOME_COMMAND,
+        robotType: 'OT-3 Standard',
+        commandTextData: expect.objectContaining({
+          commands: [HOME_COMMAND],
+        }),
+      })
+    )
+  })
+
+  it('renders stringified runtime commands when run data is unavailable', () => {
     vi.mocked(useNotifyCurrentMaintenanceRun).mockReturnValue({
       data: undefined,
     } as any)

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/AnalysisFailedModal.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/AnalysisFailedModal.tsx
@@ -12,6 +12,7 @@ import {
 import { useDismissCurrentRunMutation } from '@opentrons/react-api-client'
 
 import { SmallButton } from '/app/atoms/buttons'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
 
 import type { OddModalHeaderBaseProps } from '/app/molecules/OddModal/types'
@@ -38,8 +39,9 @@ export function AnalysisFailedModal({
     hasExitIcon: true,
   }
 
+  const documentationState = useDocumentationState()
   const { isLoading: isDismissing, mutateAsync: dismissCurrentRunAsync } =
-    useDismissCurrentRunMutation()
+    useDismissCurrentRunMutation(documentationState)
 
   const handleRestartSetup = (): void => {
     dismissCurrentRunAsync(runId).then(() => {

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/AnalysisFailedModal.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/AnalysisFailedModal.test.tsx
@@ -6,6 +6,7 @@ import { useDismissCurrentRunMutation } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 
 import { AnalysisFailedModal } from '../AnalysisFailedModal'
 
@@ -21,6 +22,9 @@ const mockDismissCurrentRunAsync = vi.fn(
 )
 
 vi.mock('@opentrons/react-api-client')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 vi.mock('react-router-dom', async importOriginal => {
   const reactRouterDom = await importOriginal<NavigateFunction>()
   return {
@@ -38,12 +42,13 @@ const render = (props: ComponentProps<typeof AnalysisFailedModal>) => {
 describe('AnalysisFailedModal', () => {
   let props: ComponentProps<typeof AnalysisFailedModal>
 
-  when(vi.mocked(useDismissCurrentRunMutation))
-    .calledWith()
-    .thenReturn({
-      mutateAsync: mockDismissCurrentRunAsync,
-    } as any)
   beforeEach(() => {
+    mockDismissCurrentRunAsync.mockClear()
+    when(vi.mocked(useDismissCurrentRunMutation))
+      .calledWith(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE)
+      .thenReturn({
+        mutateAsync: mockDismissCurrentRunAsync,
+      } as any)
     props = {
       errors: [
         'analysis failed reason message 1',
@@ -74,7 +79,6 @@ describe('AnalysisFailedModal', () => {
   it('should call mock dismiss current run function when tapping restart setup button', () => {
     render(props)
     fireEvent.click(screen.getByText('Restart setup'))
-    console.log(mockDismissCurrentRunAsync)
-    expect(mockDismissCurrentRunAsync).toBeCalled()
+    expect(mockDismissCurrentRunAsync).toHaveBeenCalledWith(RUN_ID)
   })
 })

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
@@ -41,7 +41,7 @@ export function ConfirmCancelRunModal({
   const documentationState = useDocumentationState()
   const { stopRun } = useStopRunMutation(documentationState)
   const { dismissCurrentRun, isLoading: isDismissing } =
-    useDismissCurrentRunMutation()
+    useDismissCurrentRunMutation(documentationState)
   const localRobot = useSelector(getLocalRobot)
   const { data, isError: isRunFetchError } = useNotifyRunQuery(runId)
   const { status: runStatus, current: isRunCurrent } = data?.data ?? {}

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
@@ -12,7 +12,7 @@ import {
 } from '@opentrons/react-api-client'
 
 import { SmallButton } from '/app/atoms/buttons'
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
 import { useTrackProtocolRunEvent } from '/app/redux-resources/analytics'
 import { ANALYTICS_PROTOCOL_RUN_ACTION } from '/app/redux/analytics'
@@ -38,7 +38,10 @@ export function ConfirmCancelRunModal({
   protocolId,
 }: ConfirmCancelRunModalProps): JSX.Element {
   const { t } = useTranslation(['run_details', 'shared'])
-  const documentationState = useDocumentationState()
+  const documentationState = useLinkedDocumentationState([
+    'stop_run',
+    'dismiss_run',
+  ])
   const { stopRun } = useStopRunMutation(documentationState)
   const { dismissCurrentRun, isLoading: isDismissing } =
     useDismissCurrentRunMutation(documentationState)

--- a/app/src/organisms/RunTimeControl/__tests__/hooks.test.tsx
+++ b/app/src/organisms/RunTimeControl/__tests__/hooks.test.tsx
@@ -33,6 +33,10 @@ vi.mock('@opentrons/react-api-client', async importOriginal => {
   }
 })
 
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
+
 vi.mock('/app/resources/protocols')
 vi.mock('/app/resources/runs')
 

--- a/app/src/organisms/RunTimeControl/hooks.ts
+++ b/app/src/organisms/RunTimeControl/hooks.ts
@@ -1,5 +1,6 @@
 import { useRunActionMutations } from '@opentrons/react-api-client'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import {
   DEFAULT_RUN_QUERY_REFETCH_INTERVAL,
   DEFAULT_STATUS_REFETCH_INTERVAL,
@@ -30,7 +31,8 @@ export function useRunControls(
   runId: string | null,
   onCloneRunSuccess?: (createRunResponse: Run) => unknown
 ): RunControls {
-  // TODO (jj): popup doc modal in desktop app
+  const documentationState = useDocumentationState()
+
   const {
     playRun,
     pauseRun,
@@ -40,10 +42,7 @@ export function useRunControls(
     isPauseRunActionLoading,
     isStopRunActionLoading,
     isResumeRunFromRecoveryActionLoading,
-  } = useRunActionMutations(runId!, {
-    isLoading: false,
-    accessControlEnabled: false,
-  })
+  } = useRunActionMutations(runId!, documentationState)
 
   const {
     cloneRun,

--- a/app/src/organisms/RunTimeControl/hooks.ts
+++ b/app/src/organisms/RunTimeControl/hooks.ts
@@ -17,7 +17,7 @@ export interface RunControls {
   play: () => void
   pause: () => void
   stop: () => void
-  reset: () => void
+  reset: (options?: { onError?: (error: unknown) => void }) => void
   resumeFromRecovery: () => void
   isPlayRunActionLoading: boolean
   isPauseRunActionLoading: boolean

--- a/app/src/pages/ODD/RunSummary/index.tsx
+++ b/app/src/pages/ODD/RunSummary/index.tsx
@@ -39,6 +39,7 @@ import {
   useRunCommandErrors,
 } from '@opentrons/react-api-client'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { lastRunCommandPromptedErrorRecovery } from '/app/local-resources/commands'
 import { isTerminalRunStatus } from '/app/local-resources/runs/utils'
 import { RunTimer } from '/app/molecules/RunTimer'
@@ -146,7 +147,8 @@ export function RunSummary(): JSX.Element {
   const trackEvent = useTrackEvent()
   const { trackEventWithRobotSerial } = useTrackEventWithRobotSerial()
 
-  const { closeCurrentRun } = useCloseCurrentRun()
+  const documentationState = useDocumentationState()
+  const { closeCurrentRun } = useCloseCurrentRun(documentationState)
   // Close the current run only if it's active and then execute the onSuccess callback. Prefer this wrapper over
   // closeCurrentRun directly, since the callback is swallowed if currentRun is null.
   const closeCurrentRunIfValid = (onSettled?: () => void): void => {

--- a/app/src/pages/ODD/RunSummary/index.tsx
+++ b/app/src/pages/ODD/RunSummary/index.tsx
@@ -257,7 +257,12 @@ export function RunSummary(): JSX.Element {
   // TODO(jh, 05-30-24): EXEC-487. Refactor reset() so we can redirect to the setup page, showing the shimmer skeleton instead.
   const runAgain = (): void => {
     setShowRunAgainSpinner(true)
-    reset()
+    reset({
+      onError: () => {
+        // e.g. user cancelled the documentation modal
+        setShowRunAgainSpinner(false)
+      },
+    })
     if (isQuickTransfer) {
       trackEventWithRobotSerial({
         name: ANALYTICS_QUICK_TRANSFER_RERUN,

--- a/app/src/resources/runs/__tests__/useCloneRun.test.tsx
+++ b/app/src/resources/runs/__tests__/useCloneRun.test.tsx
@@ -159,18 +159,21 @@ describe('useCloneRun hook', () => {
 
     const { result } = renderHook(() => useCloneRun(RUN_ID_NO_RTP), { wrapper })
     result.current && result.current.cloneRun()
-    expect(mockCreateRun).toHaveBeenCalledWith({
-      protocolId: 'protocolId',
-      labwareOffsets: [
-        {
-          definitionUri: 'uri1',
-          locationSequence: [1, 2],
-          offset: { x: 1, y: 1, z: 1 },
-        },
-      ],
-      runTimeParameterValues: {},
-      runTimeParameterFiles: {},
-    })
+    expect(mockCreateRun).toHaveBeenCalledWith(
+      {
+        protocolId: 'protocolId',
+        labwareOffsets: [
+          {
+            definitionUri: 'uri1',
+            locationSequence: [1, 2],
+            offset: { x: 1, y: 1, z: 1 },
+          },
+        ],
+        runTimeParameterValues: {},
+        runTimeParameterFiles: {},
+      },
+      { onError: expect.any(Function) }
+    )
   })
 
   it('should return a function that when called, calls createRun run with runTimeParameterValues overrides', async () => {
@@ -181,23 +184,26 @@ describe('useCloneRun hook', () => {
 
     const { result } = renderHook(() => useCloneRun(RUN_ID_RTP), { wrapper })
     result.current && result.current.cloneRun()
-    expect(mockCreateRun).toHaveBeenCalledWith({
-      protocolId: 'protocolId',
-      labwareOffsets: [
-        {
-          definitionUri: 'uri1',
-          locationSequence: [1, 2],
-          offset: { x: 1, y: 1, z: 1 },
+    expect(mockCreateRun).toHaveBeenCalledWith(
+      {
+        protocolId: 'protocolId',
+        labwareOffsets: [
+          {
+            definitionUri: 'uri1',
+            locationSequence: [1, 2],
+            offset: { x: 1, y: 1, z: 1 },
+          },
+        ],
+        runTimeParameterValues: {
+          number_param: 2,
+          boolean_param: false,
         },
-      ],
-      runTimeParameterValues: {
-        number_param: 2,
-        boolean_param: false,
+        runTimeParameterFiles: {
+          file_param: 'fileId_123',
+        },
       },
-      runTimeParameterFiles: {
-        file_param: 'fileId_123',
-      },
-    })
+      { onError: expect.any(Function) }
+    )
   })
 
   it('should filter duplicate labware offsets and keep only the most recent ones', async () => {
@@ -224,12 +230,32 @@ describe('useCloneRun hook', () => {
       },
     ]
 
-    expect(mockCreateRun).toHaveBeenCalledWith({
-      protocolId: 'protocolId',
-      labwareOffsets: expectedOffsets,
-      runTimeParameterValues: {},
-      runTimeParameterFiles: {},
+    expect(mockCreateRun).toHaveBeenCalledWith(
+      {
+        protocolId: 'protocolId',
+        labwareOffsets: expectedOffsets,
+        runTimeParameterValues: {},
+        runTimeParameterFiles: {},
+      },
+      { onError: expect.any(Function) }
+    )
+  })
+
+  it('should invoke onError when createRun fails', () => {
+    const mockCreateRun = vi.fn((_vars, options) => {
+      options?.onError?.(new Error('documentation cancelled'))
     })
+    const mockOnError = vi.fn()
+    vi.mocked(useCreateRunMutation).mockReturnValue({
+      createRun: mockCreateRun,
+    } as any)
+
+    const { result } = renderHook(() => useCloneRun(RUN_ID_NO_RTP), { wrapper })
+    result.current.cloneRun({ onError: mockOnError })
+
+    expect(mockOnError).toHaveBeenCalledWith(
+      new Error('documentation cancelled')
+    )
   })
 
   it('should handle analysis trigger when specified', async () => {

--- a/app/src/resources/runs/hooks.ts
+++ b/app/src/resources/runs/hooks.ts
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useSelector } from 'react-redux'
 
 import {
+  isDocumentedMutationError,
   useCreateCommandMutation,
   useCreateLiveCommandMutation,
   useCreateMaintenanceRunMutation,
@@ -48,9 +49,16 @@ type CreateRunCommandMutation = Omit<
 
 export function useCreateRunCommandMutation(
   runId: string,
+  documentationState: DocumentationState,
+  actionsToDocument: DocumentedAction[],
+  addActionToDocument: (action: DocumentedAction) => void,
   failedCommandId?: string
 ): CreateRunCommandMutation {
-  const createCommandMutation = useCreateCommandMutation()
+  const createCommandMutation = useCreateCommandMutation(
+    documentationState,
+    actionsToDocument,
+    addActionToDocument
+  )
 
   return {
     ...createCommandMutation,
@@ -68,6 +76,9 @@ export function useCreateRunCommandMutation(
 
 export function useChainRunCommands(
   runId: string,
+  documentationState: DocumentationState,
+  actionsToDocument: DocumentedAction[],
+  addActionToDocument: (action: DocumentedAction) => void,
   failedCommandId?: string,
   recoveryPolicy?: ErrorRecoveryPolicy
 ): {
@@ -81,6 +92,9 @@ export function useChainRunCommands(
 
   const { createRunCommand } = useCreateRunCommandMutation(
     runId,
+    documentationState,
+    actionsToDocument,
+    addActionToDocument,
     failedCommandId
   )
   return {
@@ -94,7 +108,12 @@ export function useChainRunCommands(
         continuePastCommandFailure,
         setIsLoading,
         recoveryPolicy
-      ),
+      ).catch(error => {
+        if (isDocumentedMutationError(error)) {
+          return new Promise(() => {})
+        }
+        return Promise.reject(error)
+      }),
     isCommandMutationLoading: isLoading,
   }
 }

--- a/app/src/resources/runs/hooks.ts
+++ b/app/src/resources/runs/hooks.ts
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import { useSelector } from 'react-redux'
 
 import {
-  isDocumentedMutationError,
   useCreateCommandMutation,
   useCreateLiveCommandMutation,
   useCreateMaintenanceRunMutation,
@@ -108,12 +107,7 @@ export function useChainRunCommands(
         continuePastCommandFailure,
         setIsLoading,
         recoveryPolicy
-      ).catch(error => {
-        if (isDocumentedMutationError(error)) {
-          return new Promise(() => {})
-        }
-        return Promise.reject(error)
-      }),
+      ),
     isCommandMutationLoading: isLoading,
   }
 }

--- a/app/src/resources/runs/useCloneRun.ts
+++ b/app/src/resources/runs/useCloneRun.ts
@@ -19,7 +19,7 @@ import { useNotifyRunQuery } from './useNotifyRunQuery'
 import type { LabwareOffset, Run } from '@opentrons/api-client'
 
 interface UseCloneRunResult {
-  cloneRun: () => void
+  cloneRun: (options?: { onError?: (error: unknown) => void }) => void
   isLoadingRun: boolean
   isCloning: boolean
 }
@@ -57,7 +57,7 @@ export function useCloneRun(
     protocolKey,
     host
   )
-  const cloneRun = (): void => {
+  const cloneRun = (options?: { onError?: (error: unknown) => void }): void => {
     if (runRecord != null) {
       const { protocolId, labwareOffsets } = runRecord.data
       const runTimeParameters =
@@ -75,12 +75,19 @@ export function useCloneRun(
           runTimeParameterFiles,
         })
       }
-      createRun({
-        protocolId,
-        labwareOffsets: mostRecentUniqueLabwareOffsets(labwareOffsets),
-        runTimeParameterValues,
-        runTimeParameterFiles,
-      })
+      createRun(
+        {
+          protocolId,
+          labwareOffsets: mostRecentUniqueLabwareOffsets(labwareOffsets),
+          runTimeParameterValues,
+          runTimeParameterFiles,
+        },
+        {
+          onError: error => {
+            options?.onError?.(error)
+          },
+        }
+      )
     } else {
       console.info('failed to clone run record, source run record not found')
     }

--- a/app/src/resources/runs/useCloseCurrentRun.ts
+++ b/app/src/resources/runs/useCloseCurrentRun.ts
@@ -4,18 +4,19 @@ import { useDismissCurrentRunMutation } from '@opentrons/react-api-client'
 
 import { useCurrentRunId } from '/app/resources/runs'
 
+import type { DocumentationState } from '@opentrons/react-api-client'
 import type { UseDismissCurrentRunMutationOptions } from '@opentrons/react-api-client/src/runs/useDismissCurrentRunMutation'
 
 type CloseCallback = (options?: UseDismissCurrentRunMutationOptions) => void
 
-export function useCloseCurrentRun(): {
+export function useCloseCurrentRun(documentationState: DocumentationState): {
   closeCurrentRun: CloseCallback
   isClosingCurrentRun: boolean
 } {
   const currentRunId = useCurrentRunId()
 
   const { dismissCurrentRun, isLoading: isDismissing } =
-    useDismissCurrentRunMutation()
+    useDismissCurrentRunMutation(documentationState)
 
   const closeCurrentRun = (
     options?: UseDismissCurrentRunMutationOptions

--- a/app/src/resources/runs/useRestartRun.ts
+++ b/app/src/resources/runs/useRestartRun.ts
@@ -2,10 +2,14 @@ import { useCloneRun } from './useCloneRun'
 import { useCloseCurrentRun } from './useCloseCurrentRun'
 import { useMostRecentRunId } from './useMostRecentRunId'
 
-export function useRestartRun(): () => void {
+import type { DocumentationState } from '@opentrons/react-api-client'
+
+export function useRestartRun(
+  documentationState: DocumentationState
+): () => void {
   const mostRecentRunId = useMostRecentRunId()
   const { cloneRun } = useCloneRun(mostRecentRunId!)
-  const { closeCurrentRun } = useCloseCurrentRun()
+  const { closeCurrentRun } = useCloseCurrentRun(documentationState)
 
   return () => {
     if (mostRecentRunId != null) {

--- a/app/src/resources/runs/useRestartRun.ts
+++ b/app/src/resources/runs/useRestartRun.ts
@@ -14,7 +14,9 @@ export function useRestartRun(
   return () => {
     if (mostRecentRunId != null) {
       closeCurrentRun({
-        onSuccess: cloneRun,
+        onSuccess: () => {
+          cloneRun()
+        },
       })
     }
   }

--- a/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getPipettingCommandText.ts
+++ b/components/src/organisms/CommandText/useCommandTextString/utils/commandText/getPipettingCommandText.ts
@@ -36,7 +36,7 @@ export const getPipettingCommandText = ({
     0,
     commandTextData.commands.findIndex(c => c.id === command?.id)
   )
-  const labwareLocation =
+  const labwareLocationFromCommands =
     allPreviousCommands != null
       ? getFinalLabwareLocation(
           labwareId,
@@ -44,9 +44,21 @@ export const getPipettingCommandText = ({
         )
       : null
 
+  const loadedLabware =
+    commandTextData != null
+      ? getLoadedLabware(commandTextData.labware ?? [], labwareId)
+      : null
+
+  // Prefer location derived from prior commands; fall back to the run's loaded
+  // labware location (needed when command history IDs don't match, e.g. fixit
+  // commands documented against protocol-analysis command lists).
   const displayLocation = getLabwareDisplayLocation({
     loadedLabwares: commandTextData?.labware ?? [],
-    location: labwareLocation?.locationSequence ?? labwareLocation?.location,
+    location:
+      labwareLocationFromCommands?.locationSequence ??
+      labwareLocationFromCommands?.location ??
+      loadedLabware?.location ??
+      null,
     robotType,
     allRunDefs,
     loadedModules: commandTextData?.modules ?? [],
@@ -146,10 +158,6 @@ export const getPipettingCommandText = ({
       })
     }
     case 'dropTip': {
-      const loadedLabware =
-        commandTextData != null
-          ? getLoadedLabware(commandTextData.labware ?? [], labwareId)
-          : null
       const labwareDefinitions =
         commandTextData != null
           ? getLabwareDefinitionsFromCommands(

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -141,6 +141,8 @@ type AuditLogAction =
   | 'attach_pipette_left'
   | 'attach_pipette_right'
   | 'create_protocol'
+  | 'launching_error_recovery'
+  | 'resume_run_from_recovery'
 
 /**
  * Type used for DocumentedActions - keys and info to enable correct rendering of actions in the 'list actions' popup in the Documentation Required Modal.

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -143,6 +143,7 @@ type AuditLogAction =
   | 'create_protocol'
   | 'launching_error_recovery'
   | 'resume_run_from_recovery'
+  | 'dismiss_run'
 
 /**
  * Type used for DocumentedActions - keys and info to enable correct rendering of actions in the 'list actions' popup in the Documentation Required Modal.

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -144,6 +144,7 @@ type AuditLogAction =
   | 'launching_error_recovery'
   | 'resume_run_from_recovery'
   | 'dismiss_run'
+  | 'retry_action'
 
 /**
  * Type used for DocumentedActions - keys and info to enable correct rendering of actions in the 'list actions' popup in the Documentation Required Modal.

--- a/react-api-client/src/runs/__tests__/useCreateCommandMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/useCreateCommandMutation.test.tsx
@@ -6,6 +6,7 @@ import { createCommand } from '@opentrons/api-client'
 
 import { useCreateCommandMutation } from '..'
 import { mockAnonLoadCommand, RUN_ID_1 } from '../__fixtures__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../accessControl/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -33,9 +34,17 @@ describe('useCreateCommandMutation hook', () => {
     vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
     vi.mocked(createCommand).mockResolvedValue({ data: 'something' } as any)
 
-    const { result } = renderHook(() => useCreateCommandMutation(), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () =>
+        useCreateCommandMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+          [],
+          () => {}
+        ),
+      {
+        wrapper,
+      }
+    )
 
     expect(result.current.data).toBeUndefined()
     act(() => {
@@ -54,9 +63,17 @@ describe('useCreateCommandMutation hook', () => {
     vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
     vi.mocked(createCommand).mockResolvedValue({ data: 'something' } as any)
 
-    const { result } = renderHook(() => useCreateCommandMutation(), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () =>
+        useCreateCommandMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+          [],
+          () => {}
+        ),
+      {
+        wrapper,
+      }
+    )
 
     expect(result.current.data).toBeUndefined()
     act(() => {

--- a/react-api-client/src/runs/__tests__/useDismissCurrentRunMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/useDismissCurrentRunMutation.test.tsx
@@ -6,6 +6,7 @@ import { dismissCurrentRun } from '@opentrons/api-client'
 
 import { useDismissCurrentRunMutation } from '..'
 import { RUN_ID_1 } from '../__fixtures__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../accessControl/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -33,9 +34,15 @@ describe('useDismissCurrentRunMutation hook', () => {
     vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
     vi.mocked(dismissCurrentRun).mockResolvedValue({ data: 'something' } as any)
 
-    const { result } = renderHook(() => useDismissCurrentRunMutation(), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () =>
+        useDismissCurrentRunMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+        ),
+      {
+        wrapper,
+      }
+    )
 
     expect(result.current.data).toBeUndefined()
     act(() => {

--- a/react-api-client/src/runs/__tests__/useResumeFromRecoveryAssumingFalsePositiveMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/useResumeFromRecoveryAssumingFalsePositiveMutation.test.tsx
@@ -6,6 +6,7 @@ import { createRunAction } from '@opentrons/api-client'
 
 import { useResumeRunFromRecoveryAssumingFalsePositiveMutation } from '..'
 import { mockResumeFromRecoveryAction, RUN_ID_1 } from '../__fixtures__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../accessControl/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -41,10 +42,11 @@ describe('useResumeRunFromRecoveryAssumingFalsePositiveMutation hook', () => {
     vi.mocked(createRunAction).mockRejectedValue('oh no')
 
     const { result } = renderHook(
-      useResumeRunFromRecoveryAssumingFalsePositiveMutation,
-      {
-        wrapper,
-      }
+      () =>
+        useResumeRunFromRecoveryAssumingFalsePositiveMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+        ),
+      { wrapper }
     )
 
     expect(result.current.data).toBeUndefined()
@@ -63,10 +65,11 @@ describe('useResumeRunFromRecoveryAssumingFalsePositiveMutation hook', () => {
     } as Response<RunAction>)
 
     const { result } = renderHook(
-      useResumeRunFromRecoveryAssumingFalsePositiveMutation,
-      {
-        wrapper,
-      }
+      () =>
+        useResumeRunFromRecoveryAssumingFalsePositiveMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+        ),
+      { wrapper }
     )
     act(() =>
       result.current.resumeRunFromRecoveryAssumingFalsePositive(RUN_ID_1)

--- a/react-api-client/src/runs/__tests__/useResumeRunFromRecoveryMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/useResumeRunFromRecoveryMutation.test.tsx
@@ -6,6 +6,7 @@ import { createRunAction } from '@opentrons/api-client'
 
 import { useResumeRunFromRecoveryMutation } from '..'
 import { mockResumeFromRecoveryAction, RUN_ID_1 } from '../__fixtures__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../accessControl/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -36,9 +37,13 @@ describe('useResumeRunFromRecoveryMutation hook', () => {
     vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
     vi.mocked(createRunAction).mockRejectedValue('oh no')
 
-    const { result } = renderHook(useResumeRunFromRecoveryMutation, {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () =>
+        useResumeRunFromRecoveryMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+        ),
+      { wrapper }
+    )
 
     expect(result.current.data).toBeUndefined()
     act(() => result.current.resumeRunFromRecovery(RUN_ID_1))
@@ -53,9 +58,13 @@ describe('useResumeRunFromRecoveryMutation hook', () => {
       data: mockResumeFromRecoveryAction,
     } as Response<RunAction>)
 
-    const { result } = renderHook(useResumeRunFromRecoveryMutation, {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () =>
+        useResumeRunFromRecoveryMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+        ),
+      { wrapper }
+    )
     act(() => result.current.resumeRunFromRecovery(RUN_ID_1))
 
     await waitFor(() => {

--- a/react-api-client/src/runs/useCreateCommandMutation.ts
+++ b/react-api-client/src/runs/useCreateCommandMutation.ts
@@ -1,12 +1,14 @@
-import { useMutation, useQueryClient } from 'react-query'
+import { useQueryClient } from 'react-query'
 
 import { createCommand } from '@opentrons/api-client'
 
+import { useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
 import type { UseMutateAsyncFunction, UseMutationResult } from 'react-query'
 import type { CommandData, CreateCommandParams } from '@opentrons/api-client'
 import type { CreateCommand } from '@opentrons/shared-data'
+import type { DocumentationState, DocumentedAction } from '../accessControl'
 
 interface CreateCommandMutateParams extends CreateCommandParams {
   runId: string
@@ -27,26 +29,39 @@ export type UseCreateCommandMutationResult = UseMutationResult<
   >
 }
 
-export function useCreateCommandMutation(): UseCreateCommandMutationResult {
+export function useCreateCommandMutation(
+  documentationState: DocumentationState,
+  actionsToDocument: DocumentedAction[],
+  addActionToDocument: (action: DocumentedAction) => void
+): UseCreateCommandMutationResult {
   const host = useHost()
   const queryClient = useQueryClient()
 
-  const mutation = useMutation<CommandData, unknown, CreateCommandMutateParams>(
-    params => {
-      const { runId, command, ...rest } = params
+  const mutation = useDocumentedMutation<
+    CommandData,
+    unknown,
+    CreateCommandMutateParams
+  >(documentationState, actionsToDocument, ({ variables, userNotes }) => {
+    const { runId, command, ...rest } = variables
 
-      return createCommand(host!, runId, command, {
+    return createCommand(
+      host!,
+      runId,
+      command,
+      {
         ...rest,
-      }).then(response => {
-        queryClient
-          .invalidateQueries(getQueryKey(host, 'runs'))
-          .catch((e: Error) => {
-            console.error(`error invalidating runs query: ${e.message}`)
-          })
-        return response.data
-      })
-    }
-  )
+      },
+      userNotes
+    ).then(response => {
+      queryClient
+        .invalidateQueries(getQueryKey(host, 'runs'))
+        .catch((e: Error) => {
+          console.error(`error invalidating runs query: ${e.message}`)
+        })
+      addActionToDocument(response.data.data)
+      return response.data
+    })
+  })
 
   return {
     ...mutation,

--- a/react-api-client/src/runs/useDismissCurrentRunMutation.ts
+++ b/react-api-client/src/runs/useDismissCurrentRunMutation.ts
@@ -1,7 +1,8 @@
-import { useMutation, useQueryClient } from 'react-query'
+import { useQueryClient } from 'react-query'
 
 import { dismissCurrentRun } from '@opentrons/api-client'
 
+import { useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
 import type {
@@ -10,6 +11,8 @@ import type {
   UseMutationResult,
 } from 'react-query'
 import type { EmptyResponse } from '@opentrons/api-client'
+import type { DocumentationState } from '../accessControl'
+import type { DocumentedMutationParameters } from '../accessControl/types'
 
 export type UseDismissCurrentRunMutationResult = UseMutationResult<
   EmptyResponse,
@@ -26,14 +29,17 @@ export type UseDismissCurrentRunMutationOptions = UseMutationOptions<
 >
 
 export function useDismissCurrentRunMutation(
+  documentationState: DocumentationState,
   options: UseDismissCurrentRunMutationOptions = {}
 ): UseDismissCurrentRunMutationResult {
   const host = useHost()
   const queryClient = useQueryClient()
 
-  const mutation = useMutation<EmptyResponse, unknown, string>(
-    (runId: string) =>
-      dismissCurrentRun(host!, runId).then(response => {
+  const mutation = useDocumentedMutation<EmptyResponse, unknown, string>(
+    documentationState,
+    ['dismiss_run'],
+    ({ userNotes, variables: runId }: DocumentedMutationParameters<string>) =>
+      dismissCurrentRun(host!, runId, userNotes).then(response => {
         queryClient.removeQueries(getQueryKey(host, 'runs', runId))
         queryClient
           .invalidateQueries(getQueryKey(host, 'runs'))

--- a/react-api-client/src/runs/useResumeFromRecoveryAssumingFalsePositiveMutation.ts
+++ b/react-api-client/src/runs/useResumeFromRecoveryAssumingFalsePositiveMutation.ts
@@ -1,10 +1,9 @@
-import { useMutation } from 'react-query'
-
 import {
   createRunAction,
   RUN_ACTION_TYPE_RESUME_FROM_RECOVERY_ASSUMING_FALSE_POSITIVE,
 } from '@opentrons/api-client'
 
+import { useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
 import type { AxiosError } from 'axios'
@@ -14,6 +13,7 @@ import type {
   UseMutationResult,
 } from 'react-query'
 import type { RunAction } from '@opentrons/api-client'
+import type { DocumentationState } from '../accessControl'
 
 export type UseResumeRunFromRecoveryAssumingFalsePositiveMutationResult =
   UseMutationResult<RunAction, AxiosError, string> & {
@@ -28,20 +28,28 @@ export type UseResumeRunFromRecoveryAssumingFalsePositiveMutationOptions =
   UseMutationOptions<RunAction, AxiosError, string>
 
 export const useResumeRunFromRecoveryAssumingFalsePositiveMutation = (
+  documentationState: DocumentationState,
   options: UseResumeRunFromRecoveryAssumingFalsePositiveMutationOptions = {}
 ): UseResumeRunFromRecoveryAssumingFalsePositiveMutationResult => {
   const host = useHost()
-  const mutation = useMutation<RunAction, AxiosError, string>(
+  const mutation = useDocumentedMutation<RunAction, AxiosError, string>(
+    documentationState,
+    ['resume_run_from_recovery'],
     getQueryKey(
       host,
       'runs',
       RUN_ACTION_TYPE_RESUME_FROM_RECOVERY_ASSUMING_FALSE_POSITIVE
     ),
-    (runId: string) =>
-      createRunAction(host!, runId, {
-        actionType:
-          RUN_ACTION_TYPE_RESUME_FROM_RECOVERY_ASSUMING_FALSE_POSITIVE,
-      })
+    ({ variables: runId, userNotes }) =>
+      createRunAction(
+        host!,
+        runId,
+        {
+          actionType:
+            RUN_ACTION_TYPE_RESUME_FROM_RECOVERY_ASSUMING_FALSE_POSITIVE,
+        },
+        userNotes
+      )
         .then(response => response.data)
         .catch(e => {
           throw e

--- a/react-api-client/src/runs/useResumeRunFromRecoveryMutation.ts
+++ b/react-api-client/src/runs/useResumeRunFromRecoveryMutation.ts
@@ -1,11 +1,10 @@
-import { useMutation } from 'react-query'
-
 import {
   createRunAction,
   RUN_ACTION_TYPE_RESUME_FROM_RECOVERY,
 } from '@opentrons/api-client'
 
-import { getQueryKey, useHost } from '../api'
+import { useDocumentedMutation } from '../accessControl'
+import { useHost } from '../api'
 
 import type { AxiosError } from 'axios'
 import type {
@@ -14,6 +13,7 @@ import type {
   UseMutationResult,
 } from 'react-query'
 import type { RunAction } from '@opentrons/api-client'
+import type { DocumentationState } from '../accessControl'
 
 export type UseResumeRunFromRecoveryMutationResult = UseMutationResult<
   RunAction,
@@ -30,15 +30,22 @@ export type UseResumeRunFromRecoveryMutationOptions = UseMutationOptions<
 >
 
 export const useResumeRunFromRecoveryMutation = (
+  documentationState: DocumentationState,
   options: UseResumeRunFromRecoveryMutationOptions = {}
 ): UseResumeRunFromRecoveryMutationResult => {
   const host = useHost()
-  const mutation = useMutation<RunAction, AxiosError, string>(
-    getQueryKey(host, 'runs', RUN_ACTION_TYPE_RESUME_FROM_RECOVERY),
-    (runId: string) =>
-      createRunAction(host!, runId, {
-        actionType: RUN_ACTION_TYPE_RESUME_FROM_RECOVERY,
-      })
+  const mutation = useDocumentedMutation<RunAction, AxiosError, string>(
+    documentationState,
+    ['resume_run_from_recovery'],
+    ({ variables: runId, userNotes }) =>
+      createRunAction(
+        host!,
+        runId,
+        {
+          actionType: RUN_ACTION_TYPE_RESUME_FROM_RECOVERY,
+        },
+        userNotes
+      )
         .then(response => response.data)
         .catch(e => {
           throw e

--- a/react-api-client/src/runs/useRunActionMutations.ts
+++ b/react-api-client/src/runs/useRunActionMutations.ts
@@ -58,12 +58,12 @@ export function useRunActionMutations(
   const {
     resumeRunFromRecovery,
     isLoading: isResumeRunFromRecoveryActionLoading,
-  } = useResumeRunFromRecoveryMutation()
+  } = useResumeRunFromRecoveryMutation(documentationState)
 
   const {
     resumeRunFromRecoveryAssumingFalsePositive,
     isLoading: isResumeRunFromRecoveryAssumingFalsePositiveActionLoading,
-  } = useResumeRunFromRecoveryAssumingFalsePositiveMutation()
+  } = useResumeRunFromRecoveryAssumingFalsePositiveMutation(documentationState)
 
   return {
     playRun: () => {


### PR DESCRIPTION
# Overview

Adds documentation required screens to error recovery flow. Each action taken by a user triggers the documentation required screen.

https://github.com/user-attachments/assets/aca5d1cb-c355-4fea-83ca-97848f2122fa

https://github.com/user-attachments/assets/4f40a01a-c50a-440f-8d53-8e3afa611b81

https://github.com/user-attachments/assets/b579f3e3-a9d6-47e1-8cc4-50164594da79

## Test Plan and Hands on Testing

1. Run a protocol that triggers an error on a robot
2. Launch error recovery or cancel the run, both should pop up a documentation required modal
3. Retrying the step should launch a documentation required modal
4. Dropping tips should launch a documentation required modal
5. Skipping the step and continuing the run should launch a documentation required modal
Backing out of all documentation required modals should return you to the screen you were on previously

## Review requests
Is there anywhere obvious that I missed adding documentation state?

## Risk assessment

Medium, touching lots of different parts of error recovery.