### PR TITLE
fix(react-api-client): Fix Makefile syntax

### DIFF
--- a/react-api-client/Makefile
+++ b/react-api-client/Makefile
@@ -20,7 +20,7 @@ all: clean build
 
 .PHONY: clean
 clean:
-  pnpm shx rm -rf dist
+	pnpm shx rm -rf dist
 
 .PHONY: build
 build: export NODE_ENV := production


### PR DESCRIPTION
## Overview

This fixes a syntax error that was preventing commands like `make -C react-api-client test`. In Makefiles, there's a significant difference between spaces and tabs. 

## Test Plan and Hands on Testing

* [x] `make -C react-api-client test` works now.

## Risk assessment

Very low.