### PR TITLE
feat(app): Prompt for documentation when homing the robot

### DIFF
--- a/api-client/src/robot/home.ts
+++ b/api-client/src/robot/home.ts
@@ -6,9 +6,11 @@ import type { HomeData, HomeResponse } from './types'
 
 export function home(
   config: HostConfig,
-  data: HomeData
+  data: HomeData,
+  userNotes?: string
 ): ResponsePromise<HomeResponse> {
   return request<HomeResponse, HomeData>(POST, '/robot/home', config, {
     body: data,
+    userNotes,
   })
 }

--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -4,6 +4,7 @@
   "place_plate_reader_lid": "Placing plate reader lid",
   "end_plate_reader_lid": "Finishing place plate reader lid",
   "home_pipettes": "Homing pipettes",
+  "home_robot": "Homing gantry",
   "end_home_pipettes": "Finishing home pipettes",
   "attach_gripper": "Attaching gripper",
   "detach_gripper": "Detaching gripper",

--- a/app/src/organisms/Desktop/Devices/RobotOverviewOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOverviewOverflowMenu.tsx
@@ -28,6 +28,7 @@ import {
 
 import { getTopPortalEl } from '/app/App/portal'
 import { Divider } from '/app/atoms/structure'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { ChooseProtocolSlideout } from '/app/organisms/Desktop/ChooseProtocolSlideout'
 import { RobotCertImportModal } from '/app/organisms/Desktop/RobotCertImport/RobotCertImportModal'
 import { useIsFlex, useIsRobotBusy } from '/app/redux-resources/robots'
@@ -68,6 +69,7 @@ export const RobotOverviewOverflowMenu = (
     setShowOverflowMenu,
   } = useMenuHandleClickOutside()
   const navigate = useNavigate()
+  const documentationState = useDocumentationState()
   const isRobotBusy = useIsRobotBusy()
   const runId = useCurrentRunId()
   const [targetProps, tooltipProps] = useHoverTooltip()
@@ -77,7 +79,7 @@ export const RobotOverviewOverflowMenu = (
   const isFlex = useIsFlex(robot.name)
   const { setLights } = useSetLightsMutation()
   const { createLiveCommand } = useCreateLiveCommandMutation()
-  const { home } = useHomeMutation()
+  const { home } = useHomeMutation(documentationState)
 
   const handleClickRestart: MouseEventHandler<HTMLButtonElement> = () => {
     dispatch(restartRobot(robot.name))

--- a/app/src/organisms/Desktop/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
+++ b/app/src/organisms/Desktop/Devices/__tests__/RobotOverviewOverflowMenu.test.tsx
@@ -9,6 +9,7 @@ import { useHomeMutation } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { ChooseProtocolSlideout } from '/app/organisms/Desktop/ChooseProtocolSlideout'
 import { useIsRobotBusy } from '/app/redux-resources/robots'
 import {
@@ -46,6 +47,9 @@ vi.mock('/app/resources/runs')
 vi.mock('../RobotSettings/UpdateBuildroot')
 vi.mock('/app/resources/devices/hooks/useIsEstopNotDisengaged')
 vi.mock('/app/redux-resources/robots')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 
 const render = (props: ComponentProps<typeof RobotOverviewOverflowMenu>) => {
   return renderWithProviders(

--- a/app/src/organisms/ODD/Navigation/NavigationMenu.tsx
+++ b/app/src/organisms/ODD/Navigation/NavigationMenu.tsx
@@ -17,6 +17,7 @@ import {
 import { useHomeMutation } from '@opentrons/react-api-client'
 
 import { getTopPortalEl } from '/app/App/portal'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useIsFlex } from '/app/redux-resources/robots'
 import { useLights } from '/app/resources/devices'
 
@@ -34,8 +35,9 @@ interface NavigationMenuProps {
 export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
   const { onClick, robotName, setShowNavMenu } = props
   const { t, i18n } = useTranslation(['devices_landing', 'robot_controls'])
+  const documentationState = useDocumentationState()
   const { lightsOn, toggleLights } = useLights()
-  const { home } = useHomeMutation()
+  const { home } = useHomeMutation(documentationState)
   const [
     showRestartRobotConfirmationModal,
     setShowRestartRobotConfirmationModal,

--- a/app/src/organisms/ODD/Navigation/__tests__/NavigationMenu.test.tsx
+++ b/app/src/organisms/ODD/Navigation/__tests__/NavigationMenu.test.tsx
@@ -5,6 +5,7 @@ import { useHomeMutation } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useIsFlex } from '/app/redux-resources/robots'
 import { useLights } from '/app/resources/devices'
 
@@ -21,6 +22,9 @@ vi.mock('/app/resources/devices')
 vi.mock('/app/redux-resources/robots')
 vi.mock('../RestartRobotConfirmationModal')
 vi.mock('../ShutdownRobotConfirmationModal')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 
 const mockNavigate = vi.fn()
 vi.mock('react-router-dom', async importOriginal => {

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -124,6 +124,7 @@ type AuditLogAction =
   | 'place_plate_reader_lid'
   | 'end_plate_reader_lid'
   | 'home_pipettes'
+  | 'home_robot'
   | 'end_home_pipettes'
   | 'attach_gripper'
   | 'detach_gripper'

--- a/react-api-client/src/robot/useHomeMutation.ts
+++ b/react-api-client/src/robot/useHomeMutation.ts
@@ -1,7 +1,6 @@
-import { useMutation } from 'react-query'
-
 import { home } from '@opentrons/api-client'
 
+import { useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
 import type { AxiosError } from 'axios'
@@ -11,6 +10,7 @@ import type {
   UseMutationResult,
 } from 'react-query'
 import type { HomeData, HomeResponse, HostConfig } from '@opentrons/api-client'
+import type { DocumentationState } from '../accessControl'
 
 export type UseHomeMutationResult = UseMutationResult<
   HomeResponse,
@@ -27,15 +27,19 @@ export type UseHomeMutationOptions = UseMutationOptions<
 >
 
 export function useHomeMutation(
+  documentationState: DocumentationState,
   options: UseHomeMutationOptions = {},
   hostOverride?: HostConfig | null
 ): UseHomeMutationResult {
   const contextHost = useHost()
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
-  const mutation = useMutation<HomeResponse, AxiosError, HomeData>(
+  const mutation = useDocumentedMutation<HomeResponse, AxiosError, HomeData>(
+    documentationState,
+    ['home_robot'],
     getQueryKey(host, 'robot', 'home'),
-    homeData => home(host!, homeData).then(response => response.data),
+    ({ variables: homeData, userNotes }) =>
+      home(host!, homeData, userNotes).then(response => response.data),
     options
   )
   return {


### PR DESCRIPTION
# Overview

This adds Compliance Ready Software support to the "Home robot" buttons. One small step to EXEC-2641.

## Test Plan and Hands on Testing

* [x] Homing from the ODD's navigation menu prompts for documentation and sends it along with the request.
* [x] Homing from the desktop app's device details page prompts for documentation and sends it along with the request.

## Review requests

Is there anything I'm missing, or is this all there is to it?

## Risk assessment

Low?
