### PR TITLE
feat(api-client,server-utils): Support special characters in user-provided documentation

### DIFF
--- a/api-client/src/__tests__/request.test.ts
+++ b/api-client/src/__tests__/request.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { POST, request } from '../request'
+
+import type { AxiosRequestConfig } from 'axios'
+import type { HostConfig } from '../types'
+
+describe('request', () => {
+  const requestor = vi.fn()
+
+  const hostConfig: HostConfig = {
+    hostname: '127.0.0.1',
+    requestor,
+  }
+
+  beforeEach(() => {
+    requestor.mockReset()
+    requestor.mockResolvedValue({ data: null })
+  })
+
+  it('percent-encodes userNotes with newlines and Unicode for the header', async () => {
+    const userNotes = 'line 1\nline 2\n🥟'
+
+    await request(POST, '/runs', hostConfig, { userNotes })
+
+    expect(requestor).toHaveBeenCalledTimes(1)
+    const config = requestor.mock.calls[0][0] as AxiosRequestConfig
+    expect(config.headers).toMatchObject({
+      'Opentrons-User-Notes': encodeURI(userNotes),
+    })
+    expect(config.headers?.['Opentrons-User-Notes']).toStrictEqual(
+      'line%201%0Aline%202%0A%F0%9F%A5%9F'
+    )
+  })
+
+  it('omits Opentrons-User-Notes when userNotes is undefined', async () => {
+    await request(POST, '/runs', hostConfig)
+
+    expect(requestor).toHaveBeenCalledTimes(1)
+    const config = requestor.mock.calls[0][0] as AxiosRequestConfig
+    expect(config.headers).not.toHaveProperty('Opentrons-User-Notes')
+  })
+})

--- a/api-client/src/request.ts
+++ b/api-client/src/request.ts
@@ -94,7 +94,10 @@ export function request<
   const tokenHeader = token != null ? { Authorization: `Bearer ${token}` } : {}
   const userNotesHeader =
     requestConfig?.userNotes != null
-      ? { 'Opentrons-User-Notes': requestConfig.userNotes }
+      ? // encodeURI() is nominally for URIs, and this is a header, not a URI.
+        // But encodeURI() is sufficient for percent-encoding all the characters
+        // that would be invalid in a header.
+        { 'Opentrons-User-Notes': encodeURI(requestConfig.userNotes) }
       : {}
   const extraHeaders = requestConfig?.headers ?? {}
   const headers = {

--- a/server-utils/server_utils/fastapi_utils/documented_interaction.py
+++ b/server-utils/server_utils/fastapi_utils/documented_interaction.py
@@ -1,5 +1,6 @@
 """FastAPI helpers for audit notes supplied on mutating HTTP requests."""
 
+import urllib.parse
 from typing import Final
 
 from fastapi import Request
@@ -7,24 +8,25 @@ from fastapi import Request
 _MUTATING_METHODS: Final = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
 USER_NOTES_HEADER: Final[str] = "Opentrons-User-Notes"
-"""Audit reason when ``requireReasonForInteraction`` is enabled."""
-
-# TODO(TZ, 5-26-26): Support encoded header values (e.g. ``b64:`` prefix + base64) so clients can
-# send arbitrary Unicode and control characters, not only printable ASCII.
-# https://opentrons.atlassian.net/browse/EXEC-2727
 
 
+# todo(mm, 2026-07-13): Move this documentation into OpenAPI somehow.
 async def get_supplied_user_notes(request: Request) -> str | None:
-    """Return normalized audit notes from the ``Opentrons-User-Notes`` request header."""
+    """Extract the value of the `Opentrons-User-Notes` request header.
+
+    When `requireReasonForInteraction` is enabled, this header carries the user-provided
+    reason for interaction.
+
+    HTTP headers have strict charset limits; this header should be percent-encoded UTF-8
+    (see: https://www.rfc-editor.org/rfc/rfc3986.html#section-2.1).
+
+    If the value only contains whitespace (after decoding), it's treated the same
+    as if it's not present.
+    """
     if request.method not in _MUTATING_METHODS:
         return None
 
-    return _parse_supplied_user_notes(request.headers.get(USER_NOTES_HEADER))
-
-
-def _parse_supplied_user_notes(user_notes: str | None) -> str | None:
-    """Return non-empty audit notes, or ``None`` if absent or whitespace-only."""
-    if user_notes is None:
-        return None
-    stripped = user_notes.strip()
+    raw = request.headers.get(USER_NOTES_HEADER, "")
+    decoded = urllib.parse.unquote(raw)
+    stripped = decoded.strip()
     return stripped if stripped else None

--- a/server-utils/tests/fastapi_utils/test_documented_interaction.py
+++ b/server-utils/tests/fastapi_utils/test_documented_interaction.py
@@ -72,3 +72,14 @@ def test_get_supplied_user_notes_returns_none_without_header() -> None:
     response = client.put("/notes", json={"data": "ignored"})
     assert response.status_code == 200
     assert response.json() == {"userNotes": None}
+
+
+def test_get_supplied_user_notes_percent_encoding() -> None:
+    """Clients percent-encode the header; the server must decode it."""
+    client = _build_client()
+    response = client.post(
+        "/notes",
+        headers={USER_NOTES_HEADER: "line%201%0Aline%202%0A%F0%9F%A5%9F"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"userNotes": "line 1\nline 2\n🥟"}


### PR DESCRIPTION
## Overview

This closes EXEC-2727.

## Changelog

When the user enters documentation for the audit log, we now percent-encode it before sending it to the server. So `Feed me an éclair` gets encoded as `Feed%20me%20an%20%C3%A9clair`.

## Test Plan and Hands on Testing

I don't think we have any way to do real-world testing of this yet, but it's easy enough to cover with unit tests.

## Review requests

Does percent encoding seem like a good solution here?

I picked it over base64 because it keeps the contents mostly human-readable, e.g. in Chrome devtools. The downside is that it's less obviously correct. We're sort of repurposing the URL encoding algorithm for header encoding purposes.

Specifically, we're relying on the following assumptions:

* If the client unnecessarily encodes a character, like sending `%61` when it could have just sent `a`, it's safe—the server will process it the same either way.
* The characters that URL-encoding will leave alone are all valid in an HTTP header value.

I am pretty sure both of those assumptions are true, but it was surprisingly difficult to find straight answers.

## Risk assessment

Low.