### PR TITLE
chore(mono): Cherry-pick select commits for `chore_release-9.1.2`

### DIFF
--- a/api/src/opentrons/drivers/temp_deck/driver.py
+++ b/api/src/opentrons/drivers/temp_deck/driver.py
@@ -13,6 +13,8 @@ import asyncio
 import logging
 from typing import Dict, Optional
 
+from serial import PortNotOpenError  # type: ignore[import-untyped]
+
 from opentrons_shared_data.util import StrEnum
 
 from opentrons.drivers import utils
@@ -192,7 +194,13 @@ class TempDeckDriver(AbstractTempDeckDriver):
         Returns:
             command response
         """
-        response = await self._connection.send_command(
-            command=command, retries=DEFAULT_COMMAND_RETRIES
-        )
-        return response
+        try:
+            return await self._connection.send_command(
+                command=command, retries=DEFAULT_COMMAND_RETRIES
+            )
+        except PortNotOpenError:
+            log.warning("Temp-Deck port was closed; reopening and retrying once.")
+            await self._connection.open()
+            return await self._connection.send_command(
+                command=command, retries=DEFAULT_COMMAND_RETRIES
+            )

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -136,6 +136,22 @@ class AttachedModulesControl:
     def available_peripherals(self) -> List[peripherals.AbstractPeripheral]:
         return self._available_peripherals
 
+    def _dedupe_available_modules(self, new_mod: modules.AbstractModule) -> None:
+        """
+        Remove any existing entry in _available_modules that shares new_mod's
+        serial, then append new_mod and re-sort.
+        """
+        if not self._api.is_simulator:
+            serial = new_mod.serial_number
+            if serial is not None:
+                self._available_modules = [
+                    m for m in self._available_modules if m.serial_number != serial
+                ]
+        self._available_modules.append(new_mod)
+        self._available_modules = sorted(
+            self._available_modules, key=modules.AbstractModule.sort_key
+        )
+
     async def clean_up(self) -> None:
         """Clean up all registered modules and emulator scanning tasks (if any)."""
         for module in self._available_modules:
@@ -163,10 +179,7 @@ class AttachedModulesControl:
         )
         if isinstance(type, modules.ModuleType):
             assert isinstance(device, modules.AbstractModule)
-            self._available_modules.append(device)
-            self._available_modules = sorted(
-                self._available_modules, key=modules.AbstractModule.sort_key
-            )
+            self._dedupe_available_modules(device)
         else:
             assert isinstance(device, peripherals.AbstractPeripheral)
             self._available_peripherals.append(device)
@@ -257,43 +270,38 @@ class AttachedModulesControl:
 
     async def _clear_old_modules(self) -> None:
         async with self._use_reconnect_lock():
-            for old_mod in self._recently_removed_modules:
+            for old_mod in list(self._recently_removed_modules):
                 # Important: this wants to be after the remove because this may trigger
                 # recursion back to here; we therefore want the module to already be
                 # removed so that the recursion terminates next loop
                 old_mod.disconnected_callback()
                 log.info(f"did not find {old_mod.serial_number}")
-                self._recently_removed_modules.remove(old_mod)
+                if old_mod in self._recently_removed_modules:
+                    self._recently_removed_modules.remove(old_mod)
                 await old_mod.cleanup()
+
+    async def _reconnect_single_module(self, old_mod: modules.AbstractModule) -> None:
+        """Find an attached module matching old_mod's serial and swap it in."""
+        for attached_mod in list(self._available_modules):
+            if attached_mod.serial_number != old_mod.serial_number:
+                continue
+            log.info(f"Found {old_mod.serial_number} was reconnected")
+            if attached_mod.port != old_mod.port:
+                log.info(f"module moved from {old_mod.port} to {attached_mod.port}")
+                await old_mod.move_port(attached_mod.port, attached_mod.usb_port)
+            await attached_mod.soft_cleanup()
+            await old_mod.soft_cleanup()
+            await old_mod.attempt_reconnect()
+            if old_mod in self._recently_removed_modules:
+                self._recently_removed_modules.remove(old_mod)
+            self._dedupe_available_modules(old_mod)
+            break
 
     async def _reconnect_patch(self) -> None:
         try:
-            for old_mod in self._recently_removed_modules:
+            for old_mod in list(self._recently_removed_modules):
                 log.info(f"Attempting to find and reconect {old_mod.serial_number}")
-                for attached_mod in self._available_modules:
-                    if attached_mod.serial_number == old_mod.serial_number:
-                        log.info(f"Found {old_mod.serial_number} was reconnected")
-                        # Move the port before cleaning up the old instance.
-                        # this will give it a chance to successfully retry sending whatever command
-                        # if it was disconnected in the middle of sending a command.
-                        # if it was in the middle of sending a command, it cant cleanup until that retry loop
-                        # succeeds or hits its limit
-                        if attached_mod.port != old_mod.port:
-                            log.info(
-                                f"module moved from {old_mod.port} to {attached_mod.port}"
-                            )
-                            await old_mod.move_port(
-                                attached_mod.port, attached_mod.usb_port
-                            )
-                        await attached_mod.soft_cleanup()
-                        await old_mod.soft_cleanup()
-                        await old_mod.attempt_reconnect()
-                        self._available_modules.remove(attached_mod)
-                        self._available_modules.append(old_mod)
-                        self._recently_removed_modules.remove(old_mod)
-                        self._available_modules = sorted(
-                            self._available_modules, key=modules.AbstractModule.sort_key
-                        )
+                await self._reconnect_single_module(old_mod)
         except BaseException:
             log.exception("Encountered an error during reconnect attempt.")
 
@@ -393,7 +401,7 @@ class AttachedModulesControl:
                     )
                 else:
                     assert isinstance(new_instance, modules.AbstractModule)
-                    self._available_modules.append(new_instance)
+                    self._dedupe_available_modules(new_instance)
                     log.info(
                         f"Module {device.name} discovered and attached"
                         f" at port {device.port}, new_instance: {new_instance}"

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -18,6 +18,7 @@ from opentrons.drivers.rpi_drivers.types import USBPort
 from opentrons.drivers.types import RPM, HeaterShakerLabwareLatchStatus, Temperature
 from opentrons.hardware_control.execution_manager import ExecutionManager
 from opentrons.hardware_control.modules import mod_abc, update
+from opentrons.hardware_control.modules.retry import retry_module_init
 from opentrons.hardware_control.modules.types import (
     HeaterShakerData,
     HeaterShakerStatus,
@@ -86,11 +87,24 @@ class HeaterShaker(mod_abc.AbstractModule):
         """
         driver: AbstractHeaterShakerDriver
         if not simulating:
-            driver = await HeaterShakerDriver.create(port=port, loop=hw_control_loop)
             poll_interval_seconds = poll_interval_seconds or POLL_PERIOD
+
+            async def _init_driver() -> tuple[
+                AbstractHeaterShakerDriver, Mapping[str, str]
+            ]:
+                d = await HeaterShakerDriver.create(port=port, loop=hw_control_loop)
+                try:
+                    info = await d.get_device_info()
+                    return d, info
+                except BaseException:
+                    await d.disconnect()
+                    raise
+
+            driver, device_info = await retry_module_init(_init_driver, port=port)
         else:
             driver = SimulatingDriver(serial_number=sim_serial_number)
             poll_interval_seconds = poll_interval_seconds or SIMULATING_POLL_PERIOD
+            device_info = await driver.get_device_info()
 
         reader = HeaterShakerReader(driver=driver)
         poller = Poller(reader=reader, interval=poll_interval_seconds)
@@ -100,7 +114,7 @@ class HeaterShaker(mod_abc.AbstractModule):
             driver=driver,
             reader=reader,
             poller=poller,
-            device_info=await driver.get_device_info(),
+            device_info=device_info,
             hw_control_loop=hw_control_loop,
             execution_manager=execution_manager,
             disconnected_callback=disconnected_callback,

--- a/api/src/opentrons/hardware_control/modules/magdeck.py
+++ b/api/src/opentrons/hardware_control/modules/magdeck.py
@@ -10,6 +10,7 @@ from opentrons.drivers.mag_deck import (
     SimulatingDriver,
 )
 from opentrons.drivers.rpi_drivers.types import USBPort
+from opentrons.hardware_control.modules.retry import retry_module_init
 
 log = logging.getLogger(__name__)
 
@@ -61,18 +62,29 @@ class MagDeck(mod_abc.AbstractModule):
         """Factory function."""
         driver: AbstractMagDeckDriver
         if not simulating:
-            driver = await MagDeckDriver.create(port=port, loop=hw_control_loop)
+
+            async def _init_driver() -> tuple[AbstractMagDeckDriver, Dict[str, str]]:
+                d = await MagDeckDriver.create(port=port, loop=hw_control_loop)
+                try:
+                    info = await d.get_device_info()
+                    return d, info
+                except BaseException:
+                    await d.disconnect()
+                    raise
+
+            driver, device_info = await retry_module_init(_init_driver, port=port)
         else:
             driver = SimulatingDriver(
                 sim_model=sim_model, serial_number=sim_serial_number
             )
+            device_info = await driver.get_device_info()
 
         mod = cls(
             port=port,
             usb_port=usb_port,
             execution_manager=execution_manager,
             hw_control_loop=hw_control_loop,
-            device_info=await driver.get_device_info(),
+            device_info=device_info,
             driver=driver,
             disconnected_callback=disconnected_callback,
             error_callback=error_callback,

--- a/api/src/opentrons/hardware_control/modules/retry.py
+++ b/api/src/opentrons/hardware_control/modules/retry.py
@@ -1,0 +1,58 @@
+"""Retry/backoff helper for module initialization."""
+
+import asyncio
+import logging
+from typing import Awaitable, Callable, Optional, Tuple, Type, TypeVar
+
+from opentrons.drivers.asyncio.communication.errors import NoResponse
+from opentrons.drivers.utils import ParseError
+
+log = logging.getLogger(__name__)
+
+MODULE_BUILD_RETRIES = 5
+MODULE_BUILD_INITIAL_BACKOFF_S = 0.5
+MODULE_BUILD_MAX_BACKOFF_S = 2.0
+
+# Exceptions that indicate the module is not ready yet and a retry is worthwhile.
+MODULE_BUILD_RETRYABLE_ERRORS: Tuple[Type[BaseException], ...] = (
+    ParseError,
+    NoResponse,
+)
+
+_T = TypeVar("_T")
+
+
+async def retry_module_init(
+    factory: Callable[[], Awaitable[_T]],
+    port: str = "",
+) -> _T:
+    """Run `factory` with retry/backoff on retryable module-init errors.
+
+    Args:
+        factory: A coroutine factory performing the operation that may fail with
+            a retryable error.
+        port: Port string used only for logging context.
+
+    Returns: The result of a successful `factory` call.
+
+    Raises: The last retryable error if all attempts fail, or any non-retryable
+        error raised by `factory`.
+    """
+    backoff = MODULE_BUILD_INITIAL_BACKOFF_S
+    last_exc: Optional[BaseException] = None
+
+    for attempt in range(0, MODULE_BUILD_RETRIES):
+        try:
+            return await factory()
+        except MODULE_BUILD_RETRYABLE_ERRORS as e:
+            last_exc = e
+            log.warning(
+                f"Module build attempt {attempt}/{MODULE_BUILD_RETRIES} on port "
+                f"{port!r} failed with {type(e).__name__}: {e}"
+            )
+            if attempt < MODULE_BUILD_RETRIES:
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, MODULE_BUILD_MAX_BACKOFF_S)
+
+    assert last_exc is not None
+    raise last_exc

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -362,9 +362,10 @@ class TempDeckReader(Reader):
     def on_error(self, exception: Exception) -> None:
         self._debounce_count -= 1
         if self._error_callback:
-            if self._debounce_count != 0:
+            if self._debounce_count > 0:
                 log.error(
                     f"Reader encountered error {exception} but has {self._debounce_count} tries left"
                 )
             else:
                 self._error_callback(exception)
+                self._debounce_count = DEFAULT_COMMAND_RETRIES

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -17,6 +17,7 @@ from opentrons.drivers.temp_deck import (
 from opentrons.drivers.types import Temperature
 from opentrons.hardware_control.execution_manager import ExecutionManager
 from opentrons.hardware_control.modules import errors, mod_abc, types, update
+from opentrons.hardware_control.modules.retry import retry_module_init
 from opentrons.hardware_control.modules.types import (
     ModuleDisconnectedCallback,
     ModuleErrorCallback,
@@ -72,13 +73,24 @@ class TempDeck(mod_abc.AbstractModule):
         """
         driver: AbstractTempDeckDriver
         if not simulating:
-            driver = await TempDeckDriver.create(port=port, loop=hw_control_loop)
             poll_interval_seconds = poll_interval_seconds or TEMP_POLL_INTERVAL_SECS
+
+            async def _init_driver() -> tuple[AbstractTempDeckDriver, Dict[str, str]]:
+                d = await TempDeckDriver.create(port=port, loop=hw_control_loop)
+                try:
+                    info = await d.get_device_info()
+                    return d, info
+                except BaseException:
+                    await d.disconnect()
+                    raise
+
+            driver, device_info = await retry_module_init(_init_driver, port=port)
         else:
             driver = SimulatingDriver(
                 sim_model=sim_model, serial_number=sim_serial_number
             )
             poll_interval_seconds = poll_interval_seconds or SIM_TEMP_POLL_INTERVAL_SECS
+            device_info = await driver.get_device_info()
 
         reader = TempDeckReader(driver=driver)
         poller = Poller(reader=reader, interval=poll_interval_seconds)
@@ -89,7 +101,7 @@ class TempDeck(mod_abc.AbstractModule):
             driver=driver,
             reader=reader,
             poller=poller,
-            device_info=await driver.get_device_info(),
+            device_info=device_info,
             hw_control_loop=hw_control_loop,
             disconnected_callback=disconnected_callback,
             error_callback=error_callback,

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -19,6 +19,7 @@ from opentrons.drivers.thermocycler import (
 from opentrons.drivers.types import PlateTemperature, Temperature, ThermocyclerLidStatus
 from opentrons.hardware_control.modules.lid_temp_status import LidTemperatureStatus
 from opentrons.hardware_control.modules.plate_temp_status import PlateTemperatureStatus
+from opentrons.hardware_control.modules.retry import retry_module_init
 from opentrons.hardware_control.modules.types import (
     ModuleDisconnectedCallback,
     ModuleErrorCallback,
@@ -98,13 +99,26 @@ class Thermocycler(mod_abc.AbstractModule):
         """
         driver: AbstractThermocyclerDriver
         if not simulating:
-            driver = await ThermocyclerDriverFactory.create(
-                port=port, loop=hw_control_loop
-            )
             poll_interval_seconds = poll_interval_seconds or POLLING_FREQUENCY_SEC
+
+            async def _init_driver() -> tuple[
+                AbstractThermocyclerDriver, Dict[str, str]
+            ]:
+                d = await ThermocyclerDriverFactory.create(
+                    port=port, loop=hw_control_loop
+                )
+                try:
+                    info = await d.get_device_info()
+                    return d, info
+                except BaseException:
+                    await d.disconnect()
+                    raise
+
+            driver, device_info = await retry_module_init(_init_driver, port=port)
         else:
             driver = SimulatingDriver(model=sim_model, serial_number=sim_serial_number)
             poll_interval_seconds = poll_interval_seconds or SIM_POLLING_FREQUENCY_SEC
+            device_info = await driver.get_device_info()
 
         reader = ThermocyclerReader(driver=driver)
         poller = Poller(reader=reader, interval=poll_interval_seconds)
@@ -114,7 +128,7 @@ class Thermocycler(mod_abc.AbstractModule):
             driver=driver,
             reader=reader,
             poller=poller,
-            device_info=await driver.get_device_info(),
+            device_info=device_info,
             hw_control_loop=hw_control_loop,
             execution_manager=execution_manager,
             disconnected_callback=disconnected_callback,

--- a/api/src/opentrons/hardware_control/nozzle_manager.py
+++ b/api/src/opentrons/hardware_control/nozzle_manager.py
@@ -173,6 +173,13 @@ class NozzleMap(BaseModel):
         )
 
     @property
+    def x_center_offset(self) -> Point:
+        """The position in the center of the primary row of the map."""
+        back_right = next(reversed(list(self.columns.values())))[0]
+        difference = self.map_store[back_right] - self.map_store[self.back_left]
+        return self.map_store[self.back_left] + Point(difference[0] / 2, 0, 0)
+
+    @property
     def y_center_offset(self) -> Point:
         """The position in the center of the primary column of the map."""
         front_left = next(reversed(list(self.rows.values())))[0]
@@ -417,6 +424,8 @@ class NozzleConfigurationManager:
             )
         elif cp_override == CriticalPoint.XY_CENTER:
             current_nozzle = self._current_nozzle_configuration.xy_center_offset
+        elif cp_override == CriticalPoint.X_CENTER:
+            current_nozzle = self._current_nozzle_configuration.x_center_offset
         elif cp_override == CriticalPoint.Y_CENTER:
             current_nozzle = self._current_nozzle_configuration.y_center_offset
         elif cp_override == CriticalPoint.FRONT_NOZZLE:

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -8,6 +8,7 @@ from opentrons_shared_data.errors.exceptions import ModuleCommunicationError
 
 from opentrons.drivers.asyncio.communication.errors import SerialException
 from opentrons.hardware_control.modules.errors import AbsorbanceReaderDisconnectedError
+from serial.serialutil import SerialException as PySerialSerialException  # type: ignore[import-untyped]
 
 log = logging.getLogger(__name__)
 
@@ -116,7 +117,7 @@ class Poller:
         except AbsorbanceReaderDisconnectedError as e:
             self._error_callback(e)
             self._complete_all(e, previous_waiters)
-        except SerialException as se:
+        except (SerialException, PySerialSerialException) as se:
             log.error(f"Polling gcode error: {se}")
             self._error_callback(se)
             self._complete_all(se, previous_waiters)

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -4,11 +4,14 @@ import logging
 from abc import ABC, abstractmethod
 from typing import AsyncGenerator, List, Optional
 
+from serial.serialutil import (  # type: ignore[import-untyped]
+    SerialException as PySerialSerialException,
+)
+
 from opentrons_shared_data.errors.exceptions import ModuleCommunicationError
 
 from opentrons.drivers.asyncio.communication.errors import SerialException
 from opentrons.hardware_control.modules.errors import AbsorbanceReaderDisconnectedError
-from serial.serialutil import SerialException as PySerialSerialException  # type: ignore[import-untyped]
 
 log = logging.getLogger(__name__)
 

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -566,6 +566,16 @@ class CriticalPoint(enum.Enum):
     channel pipette.
     """
 
+    X_CENTER = enum.auto()
+    """
+    Similar to Y_CENTER, but here the X_CENTER critical point that is the same
+    Y coordinate as the default nozzle point, but halfway in between the X axis
+    bounding box of the pipette. In other words it is the XY center of the first
+    row of the pipette. This is only relevant for the 96 channel when interfacing
+    with labware with rows. On an eight or one channel this will be the same as the
+    starting nozzle.
+    """
+
 
 class ExecutionState(enum.Enum):
     RUNNING = enum.auto()

--- a/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
+++ b/api/src/opentrons/protocol_api/core/engine/_default_labware_versions.py
@@ -160,6 +160,7 @@ DEFAULT_LABWARE_VERSIONS: DefaultLabwareVersions = {
         "opentrons_tough_12_reservoir_22ml": 3,
         "opentrons_tough_1_reservoir_300ml": 3,
         "opentrons_tough_4_reservoir_72ml": 2,
+        "nest_8_reservoir_22ml": 2,
     },
 }
 

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -685,16 +685,13 @@ class LabwareView:
         definition = self.get_definition(labware_id)
         return definition.parameters.quirks or []
 
-    def get_should_center_column_on_target_well(self, labware_id: str) -> bool:
-        """True if a pipette moving to this labware should center its active column on the target.
+    def get_should_center_column_or_row_on_target_well(self, labware_id: str) -> bool:
+        """True if a pipette moving to this labware should center its active column or row on the target.
 
-        This is true for labware that have wells spanning entire columns.
+        This is true for labware that have wells spanning entire columns or rows.
         """
         has_quirk = self.get_has_quirk(labware_id, "centerMultichannelOnWells")
-        return has_quirk and (
-            len(self.get_definition(labware_id).wells) > 1
-            and len(self.get_definition(labware_id).wells) < 96
-        )
+        return has_quirk and 1 < len(self.get_definition(labware_id).wells) < 96
 
     def get_labware_stacking_maximum(self, labware: LabwareDefinition) -> int:
         """Returns the maximum number of labware allowed in a stack for a given labware definition.
@@ -721,6 +718,18 @@ class LabwareView:
     def get_has_12_subwells(self, labware_id: str) -> bool:
         """True if a labware is a reservoir with a 12-grid of sub-wells."""
         return self.get_has_quirk(labware_id, "offsetPipetteFor12GridSubwells")
+
+    def get_is_column_labware(self, labware_id: str) -> bool:
+        """True if a labware is a series of column-length wells. One well reservoirs do not count."""
+        definition = self.get_definition(labware_id)
+        return len(definition.wells) > 1 and all(
+            len(column) == 1 for column in definition.ordering
+        )
+
+    def get_is_row_labware(self, labware_id: str) -> bool:
+        """True if a labware is a series of row-length wells. One well reservoirs do not count."""
+        definition = self.get_definition(labware_id)
+        return len(definition.wells) > 1 and len(definition.ordering) == 1
 
     def get_well_definition(
         self,

--- a/api/src/opentrons/protocol_engine/state/motion.py
+++ b/api/src/opentrons/protocol_engine/state/motion.py
@@ -123,8 +123,13 @@ class MotionView:
         self, labware_id: str
     ) -> CriticalPoint | None:
         """Get the appropriate critical point override for this labware."""
-        if self._labware.get_should_center_column_on_target_well(labware_id):
-            return CriticalPoint.Y_CENTER
+        if self._labware.get_should_center_column_or_row_on_target_well(labware_id):
+            if self._labware.get_is_column_labware(labware_id):
+                return CriticalPoint.Y_CENTER
+            elif self._labware.get_is_row_labware(labware_id):
+                return CriticalPoint.X_CENTER
+            else:
+                return None
         elif self._labware.get_should_center_pipette_on_target_well(labware_id):
             return CriticalPoint.XY_CENTER
         else:

--- a/api/src/opentrons/protocol_engine/state/pipettes.py
+++ b/api/src/opentrons/protocol_engine/state/pipettes.py
@@ -777,6 +777,8 @@ class PipetteView:
                 return nozzle_map.instrument_xy_center_offset
             case CriticalPoint.XY_CENTER:
                 return nozzle_map.xy_center_offset
+            case CriticalPoint.X_CENTER:
+                return nozzle_map.x_center_offset
             case CriticalPoint.Y_CENTER:
                 return nozzle_map.y_center_offset
             case CriticalPoint.FRONT_NOZZLE:

--- a/api/tests/opentrons/hardware_control/instruments/test_nozzle_manager.py
+++ b/api/tests/opentrons/hardware_control/instruments/test_nozzle_manager.py
@@ -344,6 +344,7 @@ def test_single_pipette_map_geometry(
 
     def test_map_geometry(nozzlemap: nozzle_manager.NozzleMap) -> None:
         assert nozzlemap.xy_center_offset == Point(*config.nozzle_map["A1"])
+        assert nozzlemap.x_center_offset == Point(*config.nozzle_map["A1"])
         assert nozzlemap.y_center_offset == Point(*config.nozzle_map["A1"])
         assert nozzlemap.front_nozzle_offset == Point(*config.nozzle_map["A1"])
         assert nozzlemap.starting_nozzle_offset == Point(*config.nozzle_map["A1"])
@@ -516,10 +517,14 @@ def test_multi_config_geometry(
         front_nozzle: str,
         starting_nozzle: str,
         xy_center_in_center_of: Union[Tuple[str, str], str],
+        x_center_in_center_of: Union[Tuple[str, str], str],
         y_center_in_center_of: Union[Tuple[str, str], str],
     ) -> None:
         assert_offset_in_center_of(
             nozzlemap.xy_center_offset, xy_center_in_center_of, config
+        )
+        assert_offset_in_center_of(
+            nozzlemap.x_center_offset, x_center_in_center_of, config
         )
         assert_offset_in_center_of(
             nozzlemap.y_center_offset, y_center_in_center_of, config
@@ -531,20 +536,20 @@ def test_multi_config_geometry(
         )
 
     test_map_geometry(
-        subject.current_configuration, "H1", "A1", ("A1", "H1"), ("A1", "H1")
+        subject.current_configuration, "H1", "A1", ("A1", "H1"), "A1", ("A1", "H1")
     )
 
     subject.update_nozzle_configuration("A1", "A1", "A1")
-    test_map_geometry(subject.current_configuration, "A1", "A1", "A1", "A1")
+    test_map_geometry(subject.current_configuration, "A1", "A1", "A1", "A1", "A1")
 
     subject.update_nozzle_configuration("E1", "H1", "E1")
     test_map_geometry(
-        subject.current_configuration, "H1", "E1", ("E1", "H1"), ("E1", "H1")
+        subject.current_configuration, "H1", "E1", ("E1", "H1"), "E1", ("E1", "H1")
     )
 
     subject.reset_to_default_configuration()
     test_map_geometry(
-        subject.current_configuration, "H1", "A1", ("A1", "H1"), ("A1", "H1")
+        subject.current_configuration, "H1", "A1", ("A1", "H1"), "A1", ("A1", "H1")
     )
 
 
@@ -1042,11 +1047,13 @@ def test_96_config_geometry(
         starting_nozzle: str,
         front_nozzle: str,
         xy_center_between: Union[str, Tuple[str, str]],
+        x_center_between: Union[str, Tuple[str, str]],
         y_center_between: Union[str, Tuple[str, str]],
     ) -> None:
         assert_offset_in_center_of(
             nozzlemap.xy_center_offset, xy_center_between, config
         )
+        assert_offset_in_center_of(nozzlemap.x_center_offset, x_center_between, config)
         assert_offset_in_center_of(nozzlemap.y_center_offset, y_center_between, config)
 
         assert nozzlemap.front_nozzle_offset == Point(*config.nozzle_map[front_nozzle])
@@ -1055,12 +1062,23 @@ def test_96_config_geometry(
         )
 
     test_map_geometry(
-        config, subject.current_configuration, "A1", "H1", ("A1", "H12"), ("A1", "H1")
+        config,
+        subject.current_configuration,
+        "A1",
+        "H1",
+        ("A1", "H12"),
+        ("A1", "A12"),
+        ("A1", "H1"),
     )
-
     subject.update_nozzle_configuration("A1", "H1")
     test_map_geometry(
-        config, subject.current_configuration, "A1", "H1", ("A1", "H1"), ("A1", "H1")
+        config,
+        subject.current_configuration,
+        "A1",
+        "H1",
+        ("A1", "H1"),
+        "A1",
+        ("A1", "H1"),
     )
 
     subject.update_nozzle_configuration("A12", "H12")
@@ -1070,25 +1088,39 @@ def test_96_config_geometry(
         "A12",
         "H12",
         ("A12", "H12"),
+        "A12",
         ("A12", "H12"),
     )
 
     subject.update_nozzle_configuration("A1", "A12")
     test_map_geometry(
-        config, subject.current_configuration, "A1", "A1", ("A1", "A12"), "A1"
+        config,
+        subject.current_configuration,
+        "A1",
+        "A1",
+        ("A1", "A12"),
+        ("A1", "A12"),
+        "A1",
     )
 
     subject.update_nozzle_configuration("H1", "H12")
     test_map_geometry(
-        config, subject.current_configuration, "H1", "H1", ("H1", "H12"), "H1"
+        config,
+        subject.current_configuration,
+        "H1",
+        "H1",
+        ("H1", "H12"),
+        ("H1", "H12"),
+        "H1",
     )
 
     subject.update_nozzle_configuration("A1", "D6")
     test_map_geometry(
-        config, subject.current_configuration, "A1", "D1", ("A1", "D6"), ("A1", "D1")
-    )
-
-    subject.update_nozzle_configuration("E7", "H12")
-    test_map_geometry(
-        config, subject.current_configuration, "E7", "H7", ("E7", "H12"), ("E7", "H7")
+        config,
+        subject.current_configuration,
+        "A1",
+        "D1",
+        ("A1", "D6"),
+        ("A1", "A6"),
+        ("A1", "D1"),
     )

--- a/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_tempdeck.py
@@ -5,8 +5,9 @@ import pytest
 from decoy import Decoy, matchers
 
 from opentrons.drivers.rpi_drivers.types import USBPort
+from opentrons.drivers.temp_deck import DEFAULT_COMMAND_RETRIES
 from opentrons.hardware_control import ExecutionManager, modules
-from opentrons.hardware_control.modules.tempdeck import TempDeck
+from opentrons.hardware_control.modules.tempdeck import TempDeck, TempDeckReader
 from opentrons.hardware_control.modules.types import (
     ModuleDisconnectedCallback,
     ModuleErrorCallback,
@@ -141,3 +142,60 @@ async def test_error_callback(
             exc, "temperatureModuleV1", "/dev/ot_module_sim_tempdeck0", "dummySerialTD"
         )
     )
+
+
+def test_tempdeck_reader_on_error_fires_callback_after_retries_exhausted(
+    decoy: Decoy,
+) -> None:
+    """TempDeckReader.on_error should invoke the error callback exactly once
+    after DEFAULT_COMMAND_RETRIES consecutive errors."""
+    driver = decoy.mock(name="driver")
+    reader = TempDeckReader(driver=driver)
+    cb = decoy.mock(name="error_callback")
+    reader.set_error_callback(cb)
+
+    exc = Exception("boom")
+    for _ in range(DEFAULT_COMMAND_RETRIES):
+        reader.on_error(exc)
+
+    decoy.verify(cb(exc), times=1)
+
+
+def test_tempdeck_reader_on_error_recovers_after_firing(decoy: Decoy) -> None:
+    """After the callback fires and resets the debounce counter, a fresh burst
+    of errors should fire the callback again rather than running the counter
+    negative and never recovering.
+    """
+    driver = decoy.mock(name="driver")
+    reader = TempDeckReader(driver=driver)
+    cb = decoy.mock(name="error_callback")
+    reader.set_error_callback(cb)
+
+    exc = Exception("boom")
+    for _ in range(DEFAULT_COMMAND_RETRIES):
+        reader.on_error(exc)
+    for _ in range(DEFAULT_COMMAND_RETRIES):
+        reader.on_error(exc)
+
+    decoy.verify(cb(exc), times=2)
+
+
+def test_tempdeck_reader_on_error_resets_on_successful_read(decoy: Decoy) -> None:
+    """A successful read resets the debounce counter, so the next error burst
+    must again exhaust all retries before firing."""
+    driver = decoy.mock(name="driver")
+    reader = TempDeckReader(driver=driver)
+    cb = decoy.mock(name="error_callback")
+    reader.set_error_callback(cb)
+
+    exc = Exception("boom")
+    # One error short of firing.
+    for _ in range(DEFAULT_COMMAND_RETRIES - 1):
+        reader.on_error(exc)
+    decoy.verify(cb(matchers.Anything()), times=0)
+
+    reader._debounce_count = DEFAULT_COMMAND_RETRIES
+
+    for _ in range(DEFAULT_COMMAND_RETRIES - 1):
+        reader.on_error(exc)
+    decoy.verify(cb(matchers.Anything()), times=0)

--- a/api/tests/opentrons/hardware_control/modules/test_retry.py
+++ b/api/tests/opentrons/hardware_control/modules/test_retry.py
@@ -1,0 +1,126 @@
+"""Tests for the module build retry/backoff helper."""
+
+import asyncio
+import pytest
+
+from opentrons.drivers.asyncio.communication.errors import NoResponse
+from opentrons.drivers.utils import ParseError
+from opentrons.hardware_control.modules import retry as retry_module
+from opentrons.hardware_control.modules.retry import (
+    MODULE_BUILD_RETRIES,
+    retry_module_init,
+)
+
+
+@pytest.fixture
+def fast_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch the retry backoff to be effectively instant."""
+    monkeypatch.setattr(retry_module, "MODULE_BUILD_INITIAL_BACKOFF_S", 0)
+    monkeypatch.setattr(retry_module, "MODULE_BUILD_MAX_BACKOFF_S", 0)
+    monkeypatch.setattr(asyncio, "sleep", lambda _: _noop())
+
+
+async def _noop() -> None:
+    return None
+
+
+async def test_returns_on_first_success(fast_backoff: None) -> None:
+    """It should return the factory result when it succeeds immediately."""
+
+    async def factory() -> str:
+        return "ok"
+
+    result = await retry_module_init(factory, port="/dev/test")
+
+    assert result == "ok"
+
+
+async def test_retries_on_parse_error_then_succeeds(
+    fast_backoff: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """It should retry on ParseError and return once the factory succeeds."""
+    call_count = 0
+
+    async def factory() -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise ParseError(error_message="Missing key 'model'", parse_source="")
+        return "ok"
+
+    result = await retry_module_init(factory, port="/dev/test")
+
+    assert result == "ok"
+    assert call_count == 3
+
+
+async def test_retries_on_no_response_then_succeeds(
+    fast_backoff: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """It should retry on NoResponse (ack timeout) and return on success."""
+    call_count = 0
+
+    async def factory() -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise NoResponse(port="/dev/test", command="M115")
+        return "ok"
+
+    result = await retry_module_init(factory, port="/dev/test")
+
+    assert result == "ok"
+    assert call_count == 2
+
+
+async def test_raises_after_exhausting_retries(fast_backoff: None) -> None:
+    """It should re-raise the last retryable error after all attempts fail."""
+    call_count = 0
+
+    async def factory() -> str:
+        nonlocal call_count
+        call_count += 1
+        raise ParseError(error_message="always fails", parse_source="")
+
+    with pytest.raises(ParseError, match="always fails"):
+        await retry_module_init(factory, port="/dev/test")
+
+    assert call_count == MODULE_BUILD_RETRIES
+
+
+async def test_does_not_retry_non_retryable_error(fast_backoff: None) -> None:
+    """It should not retry on exceptions outside the retryable set."""
+    call_count = 0
+
+    async def factory() -> str:
+        nonlocal call_count
+        call_count += 1
+        raise ValueError("not retryable")
+
+    with pytest.raises(ValueError, match="not retryable"):
+        await retry_module_init(factory, port="/dev/test")
+
+    assert call_count == 1
+
+
+async def test_factory_cleanup_called_between_attempts(
+    fast_backoff: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The factory is responsible for cleaning up on failure.
+
+    This documents the contract: the factory's own except block runs before
+    the retry sleep, so partially-constructed drivers get torn down each time.
+    """
+    cleanup_calls: list[BaseException] = []
+
+    async def factory() -> str:
+        try:
+            raise ParseError(error_message="boom", parse_source="")
+        except ParseError as e:
+            cleanup_calls.append(e)
+            raise
+
+    with pytest.raises(ParseError):
+        await retry_module_init(factory, port="/dev/test")
+
+    assert len(cleanup_calls) == MODULE_BUILD_RETRIES

--- a/api/tests/opentrons/hardware_control/modules/test_retry.py
+++ b/api/tests/opentrons/hardware_control/modules/test_retry.py
@@ -1,6 +1,7 @@
 """Tests for the module build retry/backoff helper."""
 
 import asyncio
+
 import pytest
 
 from opentrons.drivers.asyncio.communication.errors import NoResponse

--- a/api/tests/opentrons/hardware_control/test_module_control.py
+++ b/api/tests/opentrons/hardware_control/test_module_control.py
@@ -24,6 +24,21 @@ from opentrons.hardware_control.peripherals import AbstractPeripheral
 from opentrons.hardware_control.peripherals.types import PeripheralType
 
 
+def _make_module(
+    decoy: Decoy,
+    *,
+    serial: str = "serial-1",
+    port: str = "/dev/ot_module_tempdeck0",
+    usb_port: USBPort = USBPort(name="a", port_number=1),
+) -> AbstractModule:
+    """Build a decoy AbstractModule."""
+    module = decoy.mock(cls=AbstractModule)
+    decoy.when(module.serial_number).then_return(serial)
+    decoy.when(module.usb_port).then_return(usb_port)
+    decoy.when(module.port).then_return(port)
+    return module
+
+
 @pytest.fixture()
 def hardware_api(decoy: Decoy) -> HardwareAPI:
     """Get a mocked out HardwareAPI."""
@@ -324,3 +339,264 @@ async def test_unregister_modules(
     decoy.verify(
         await module_1.move_port(port="/dev/bar", usb_port=module_2.usb_port), times=1
     )
+
+
+async def test_dedupe_available_modules_replaces_stale_entry(
+    decoy: Decoy,
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """_dedupe_available_modules should replace an existing entry with the same serial."""
+    decoy.when(hardware_api.is_simulator).then_return(False)
+    stale = _make_module(decoy, serial="ABC", port="/dev/ot_module_tempdeck0")
+    fresh = _make_module(decoy, serial="ABC", port="/dev/ot_module_tempdeck0")
+
+    subject._available_modules.append(stale)
+
+    subject._dedupe_available_modules(fresh)
+
+    assert subject._available_modules == [fresh]
+
+
+async def test_dedupe_available_modules_keeps_other_serials(
+    decoy: Decoy,
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """_dedupe_available_modules should only remove entries sharing the serial."""
+    decoy.when(hardware_api.is_simulator).then_return(False)
+    other = _make_module(
+        decoy,
+        serial="OTHER",
+        port="/dev/ot_module_tempdeck1",
+        usb_port=USBPort(name="b", port_number=2),
+    )
+    stale_same = _make_module(decoy, serial="ABC", port="/dev/ot_module_tempdeck0")
+    fresh_same = _make_module(
+        decoy,
+        serial="ABC",
+        port="/dev/ot_module_tempdeck0",
+        usb_port=USBPort(name="c", port_number=3),
+    )
+
+    subject._available_modules = [other, stale_same]
+
+    subject._dedupe_available_modules(fresh_same)
+
+    assert subject._available_modules == [other, fresh_same]
+
+
+async def test_dedupe_available_modules_appends_when_no_existing(
+    decoy: Decoy,
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """_dedupe_available_modules should append when no matching serial exists."""
+    decoy.when(hardware_api.is_simulator).then_return(False)
+    mod = _make_module(decoy, serial="NEW")
+
+    subject._dedupe_available_modules(mod)
+
+    assert subject._available_modules == [mod]
+
+
+async def test_dedupe_available_modules_evicts_parked_entry_same_serial(
+    decoy: Decoy,
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """A fresh attach should not duplicate a parked entry in available_modules
+    once reconnect completes.
+    """
+    decoy.when(hardware_api.is_simulator).then_return(False)
+    parked = _make_module(decoy, serial="DUP", port="/dev/ot_module_tempdeck0")
+    fresh = _make_module(decoy, serial="DUP", port="/dev/ot_module_tempdeck0")
+
+    subject._recently_removed_modules = [parked]
+    subject._available_modules = []
+
+    subject._dedupe_available_modules(fresh)
+
+    assert subject._available_modules == [fresh]
+    assert subject._recently_removed_modules == [parked]
+    assert subject.available_modules == [fresh, parked]
+
+    decoy.when(await fresh.soft_cleanup())
+    decoy.when(await parked.soft_cleanup())
+    decoy.when(await parked.attempt_reconnect())
+
+    await subject._reconnect_patch()
+
+    assert subject._available_modules == [parked]
+    assert subject._recently_removed_modules == []
+    assert subject.available_modules == [parked]
+
+
+async def test_register_devices_dedupes_on_attach(
+    decoy: Decoy,
+    usb_bus: USBDriverInterface,
+    build_device: Callable[..., Awaitable[AbstractDevice]],
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """register_devices should not create a duplicate when a stale entry exists."""
+    decoy.when(hardware_api.is_simulator).then_return(False)
+    stale = _make_module(decoy, serial="DUP", port="/dev/foo")
+    fresh = _make_module(
+        decoy,
+        serial="DUP",
+        port="/dev/foo",
+        usb_port=USBPort(name="baz", port_number=0),
+    )
+
+    subject._available_modules.append(stale)
+
+    mods_at_port = [ModuleAtPort(port="/dev/foo", name="tempdeck")]
+    decoy.when(usb_bus.match_virtual_ports(mods_at_port)).then_return(
+        [
+            ModuleAtPort(
+                port="/dev/foo",
+                name="tempdeck",
+                usb_port=USBPort(name="baz", port_number=0),
+            )
+        ]
+    )
+    decoy.when(
+        await build_device(
+            port="/dev/foo",
+            usb_port=USBPort(name="baz", port_number=0),
+            type=matchers.Anything(),
+            sim_serial_number=None,
+            sim_model=None,
+        )
+    ).then_return(fresh)
+
+    await subject.register_devices(new_devices_at_ports=mods_at_port)
+
+    assert subject.available_modules == [fresh]
+
+
+async def test_reconnect_patch_breaks_after_first_match(
+    decoy: Decoy,
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """_reconnect_patch should process a reconnected module exactly once."""
+    old_mod = _make_module(
+        decoy,
+        serial="XYZ",
+        port="/dev/ot_module_tempdeck0",
+        usb_port=USBPort(name="a", port_number=1),
+    )
+    attached_mod = _make_module(
+        decoy,
+        serial="XYZ",
+        port="/dev/ot_module_tempdeck0",
+        usb_port=USBPort(name="a", port_number=1),
+    )
+
+    subject._recently_removed_modules = [old_mod]
+    subject._available_modules = [attached_mod]
+
+    decoy.when(hardware_api.is_simulator).then_return(False)
+    decoy.when(await attached_mod.soft_cleanup())
+    decoy.when(await old_mod.soft_cleanup())
+    decoy.when(await old_mod.attempt_reconnect())
+
+    await subject._reconnect_patch()
+
+    assert subject._available_modules == [old_mod]
+    assert subject._recently_removed_modules == []
+
+
+async def test_reconnect_patch_dedupes_when_fresh_already_present(
+    decoy: Decoy,
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """_reconnect_patch should not leave two entries for one serial."""
+    old_mod = _make_module(
+        decoy,
+        serial="RACE",
+        port="/dev/ot_module_tempdeck0",
+        usb_port=USBPort(name="a", port_number=1),
+    )
+    fresh = _make_module(
+        decoy,
+        serial="RACE",
+        port="/dev/ot_module_tempdeck0",
+        usb_port=USBPort(name="a", port_number=1),
+    )
+
+    subject._recently_removed_modules = [old_mod]
+    # fresh already registered by the concurrent CREATE path
+    subject._available_modules = [fresh]
+
+    decoy.when(hardware_api.is_simulator).then_return(False)
+    decoy.when(await fresh.soft_cleanup())
+    decoy.when(await old_mod.soft_cleanup())
+    decoy.when(await old_mod.attempt_reconnect())
+
+    await subject._reconnect_patch()
+
+    assert subject._available_modules == [old_mod]
+    assert len(subject._available_modules) == 1
+
+
+async def test_clear_old_modules_guarded_remove(
+    decoy: Decoy,
+    subject: AttachedModulesControl,
+) -> None:
+    """_clear_old_modules should not raise if the entry was already removed."""
+    old_mod = _make_module(decoy, serial="GONE")
+    subject._recently_removed_modules = [old_mod]
+
+    decoy.when(old_mod.disconnected_callback())
+    decoy.when(await old_mod.cleanup())
+
+    # First call removes it normally.
+    await subject._clear_old_modules()
+    assert subject._recently_removed_modules == []
+
+    # Second call must not raise ValueError on the now-empty list.
+    await subject._clear_old_modules()
+    assert subject._recently_removed_modules == []
+
+
+async def test_reconnect_patch_guarded_remove(
+    decoy: Decoy,
+    hardware_api: HardwareAPI,
+    subject: AttachedModulesControl,
+) -> None:
+    """_reconnect_patch should not raise if old_mod was concurrently removed."""
+    old_mod = _make_module(
+        decoy,
+        serial="CONCURRENT",
+        port="/dev/ot_module_tempdeck0",
+        usb_port=USBPort(name="a", port_number=1),
+    )
+    attached_mod = _make_module(
+        decoy,
+        serial="CONCURRENT",
+        port="/dev/ot_module_tempdeck0",
+        usb_port=USBPort(name="a", port_number=1),
+    )
+
+    subject._recently_removed_modules = [old_mod]
+    subject._available_modules = [attached_mod]
+
+    decoy.when(hardware_api.is_simulator).then_return(False)
+    decoy.when(await attached_mod.soft_cleanup())
+    decoy.when(await old_mod.soft_cleanup())
+
+    async def _clear_concurrently() -> None:
+        subject._recently_removed_modules.clear()
+
+    decoy.when(await old_mod.attempt_reconnect()).then_do(  # type: ignore[func-returns-value]
+        _clear_concurrently
+    )
+
+    # Must not raise ValueError.
+    await subject._reconnect_patch()
+
+    assert subject._available_modules == [old_mod]

--- a/api/tests/opentrons/protocol_engine/state/test_labware_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_state.py
@@ -152,3 +152,151 @@ def test_raise_if_wells_are_invalid(ot3_standard_deck_def: DeckDefinitionV5) -> 
         )
     with pytest.raises(errors.WellDoesNotExistError):
         subject_view.raise_if_wells_are_invalid("labware-id", ["well-5"])
+
+
+def test_get_is_column_labware(ot3_standard_deck_def: DeckDefinitionV5) -> None:
+    """It should return True if the labware is made up of multiple column wide wells, and False otherwise."""
+    subject = LabwareStore(deck_definition=ot3_standard_deck_def, deck_fixed_labware=[])
+    subject_view = LabwareView(subject.state)
+
+    def _load_labware(labware_id: str, definition: LabwareDefinition3) -> None:
+        load_labware_update = update_types.LoadedLabwareUpdate(
+            labware_id=labware_id,
+            new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),
+            offset_id=None,
+            display_name="Display Name",
+            definition=definition,
+        )
+        subject.handle_action(
+            actions.SucceedCommandAction(
+                state_update=update_types.StateUpdate(
+                    loaded_labware=load_labware_update
+                ),
+                command=_dummy_command(),
+            )
+        )
+
+    column_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+            "well-2": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123"], ["456"]],
+    )
+    _load_labware("column-id", column_labware_def)
+    assert subject_view.get_is_column_labware("column-id")
+
+    row_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+            "well-2": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123", "456"]],
+    )
+    _load_labware("row-id", row_labware_def)
+    assert not subject_view.get_is_column_labware("row-id")
+
+    reservoir_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123"]],
+    )
+    _load_labware("reservoir-id", reservoir_labware_def)
+    assert not subject_view.get_is_column_labware("reservoir-id")
+
+    multi_well_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+            "well-2": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123", "456"], ["654", "321"]],
+    )
+    _load_labware("multi-well-id", multi_well_labware_def)
+    assert not subject_view.get_is_column_labware("multi-well-id")
+
+
+def test_get_is_row_labware(ot3_standard_deck_def: DeckDefinitionV5) -> None:
+    """It should return True if the labware is made up of multiple row wide wells, and False otherwise."""
+    subject = LabwareStore(deck_definition=ot3_standard_deck_def, deck_fixed_labware=[])
+    subject_view = LabwareView(subject.state)
+
+    def _load_labware(labware_id: str, definition: LabwareDefinition3) -> None:
+        load_labware_update = update_types.LoadedLabwareUpdate(
+            labware_id=labware_id,
+            new_location=DeckSlotLocation(slotName=DeckSlotName.SLOT_A1),
+            offset_id=None,
+            display_name="Display Name",
+            definition=definition,
+        )
+        subject.handle_action(
+            actions.SucceedCommandAction(
+                state_update=update_types.StateUpdate(
+                    loaded_labware=load_labware_update
+                ),
+                command=_dummy_command(),
+            )
+        )
+
+    row_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+            "well-2": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123", "456"]],
+    )
+    _load_labware("row-id", row_labware_def)
+    assert subject_view.get_is_row_labware("row-id")
+
+    column_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+            "well-2": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123"], ["456"]],
+    )
+    _load_labware("column-id", column_labware_def)
+    assert not subject_view.get_is_row_labware("column-id")
+
+    reservoir_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123"]],
+    )
+    _load_labware("reservoir-id", reservoir_labware_def)
+    assert not subject_view.get_is_row_labware("reservoir-id")
+
+    multi_well_labware_def = LabwareDefinition3.model_construct(  # type: ignore[call-arg]
+        namespace="foo",
+        parameters=Parameters3.model_construct(loadName="load_name"),  # type: ignore[call-arg]
+        version=123,
+        wells={
+            "well-1": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+            "well-2": RectangularWellDefinition3.model_construct(),  # type: ignore[call-arg]
+        },
+        ordering=[["123", "456"], ["654", "321"]],
+    )
+    _load_labware("multi-well-id", multi_well_labware_def)
+    assert not subject_view.get_is_row_labware("multi-well-id")

--- a/api/tests/opentrons/protocol_engine/state/test_motion_view.py
+++ b/api/tests/opentrons/protocol_engine/state/test_motion_view.py
@@ -158,6 +158,41 @@ def test_get_pipette_location_with_no_current_location(
     assert result == PipetteLocationData(mount=MountType.LEFT, critical_point=None)
 
 
+def test_get_pipette_location_with_current_location_with_x_center(
+    decoy: Decoy,
+    labware_view: LabwareView,
+    pipette_view: PipetteView,
+    subject: MotionView,
+) -> None:
+    """It should return cp=X_CENTER if location labware requests."""
+    decoy.when(pipette_view.get_current_location()).then_return(
+        CurrentWell(pipette_id="pipette-id", labware_id="reservoir-id", well_name="A1")
+    )
+
+    decoy.when(pipette_view.get("pipette-id")).then_return(
+        LoadedPipette(
+            id="pipette-id",
+            mount=MountType.RIGHT,
+            pipetteName=PipetteNameType.P300_SINGLE,
+        )
+    )
+
+    decoy.when(
+        labware_view.get_should_center_column_or_row_on_target_well(
+            "reservoir-id",
+        )
+    ).then_return(True)
+
+    decoy.when(labware_view.get_is_row_labware("reservoir-id")).then_return(True)
+
+    result = subject.get_pipette_location("pipette-id")
+
+    assert result == PipetteLocationData(
+        mount=MountType.RIGHT,
+        critical_point=CriticalPoint.X_CENTER,
+    )
+
+
 def test_get_pipette_location_with_current_location_with_y_center(
     decoy: Decoy,
     labware_view: LabwareView,
@@ -178,10 +213,12 @@ def test_get_pipette_location_with_current_location_with_y_center(
     )
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "reservoir-id",
         )
     ).then_return(True)
+
+    decoy.when(labware_view.get_is_column_labware("reservoir-id")).then_return(True)
 
     result = subject.get_pipette_location("pipette-id")
 
@@ -248,7 +285,7 @@ def test_get_pipette_location_with_current_location_different_pipette(
     )
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "reservoir-id",
         )
     ).then_return(False)
@@ -305,13 +342,13 @@ def test_get_pipette_location_override_current_location_xy_center(
     )
 
 
-def test_get_pipette_location_override_current_location_y_center(
+def test_get_pipette_location_override_current_location_x_center(
     decoy: Decoy,
     labware_view: LabwareView,
     pipette_view: PipetteView,
     subject: MotionView,
 ) -> None:
-    """It should calculate pipette location from a passed in deck location with xy override."""
+    """It should calculate pipette location from a passed in deck location with x override."""
     current_well = CurrentWell(
         pipette_id="pipette-id",
         labware_id="reservoir-id",
@@ -327,10 +364,52 @@ def test_get_pipette_location_override_current_location_y_center(
     )
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "reservoir-id",
         )
     ).then_return(True)
+
+    decoy.when(labware_view.get_is_row_labware("reservoir-id")).then_return(True)
+
+    result = subject.get_pipette_location(
+        pipette_id="pipette-id",
+        current_location=current_well,
+    )
+
+    assert result == PipetteLocationData(
+        mount=MountType.RIGHT,
+        critical_point=CriticalPoint.X_CENTER,
+    )
+
+
+def test_get_pipette_location_override_current_location_y_center(
+    decoy: Decoy,
+    labware_view: LabwareView,
+    pipette_view: PipetteView,
+    subject: MotionView,
+) -> None:
+    """It should calculate pipette location from a passed in deck location with y override."""
+    current_well = CurrentWell(
+        pipette_id="pipette-id",
+        labware_id="reservoir-id",
+        well_name="A1",
+    )
+
+    decoy.when(pipette_view.get("pipette-id")).then_return(
+        LoadedPipette(
+            id="pipette-id",
+            mount=MountType.RIGHT,
+            pipetteName=PipetteNameType.P300_SINGLE,
+        )
+    )
+
+    decoy.when(
+        labware_view.get_should_center_column_or_row_on_target_well(
+            "reservoir-id",
+        )
+    ).then_return(True)
+
+    decoy.when(labware_view.get_is_column_labware("reservoir-id")).then_return(True)
 
     result = subject.get_pipette_location(
         pipette_id="pipette-id",
@@ -382,7 +461,7 @@ def test_get_pipette_offset_for_reservoirs(
     decoy.when(labware_view.get_has_12_subwells("labware-id")).then_return(has_12_grid)
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "labware-id",
         )
     ).then_return(True)
@@ -391,6 +470,7 @@ def test_get_pipette_offset_for_reservoirs(
             "labware-id",
         )
     ).then_return(False)
+    decoy.when(labware_view.get_is_column_labware("labware-id")).then_return(True)
 
     fake_well_position = Point(x=4, y=5, z=6)
     decoy.when(
@@ -461,6 +541,94 @@ def test_get_pipette_offset_for_reservoirs(
     assert result is sentinel.waypoints
 
 
+def test_get_movement_waypoints_to_well_for_x_center(
+    decoy: Decoy,
+    labware_view: LabwareView,
+    pipette_view: PipetteView,
+    geometry_view: GeometryView,
+    mock_module_view: ModuleView,
+    subject: MotionView,
+) -> None:
+    """It should call get_waypoints() with the correct args to move to a well."""
+    location = CurrentWell(pipette_id="123", labware_id="456", well_name="abc")
+
+    decoy.when(pipette_view.get_current_location()).then_return(location)
+
+    decoy.when(
+        labware_view.get_should_center_column_or_row_on_target_well(
+            "labware-id",
+        )
+    ).then_return(True)
+    decoy.when(
+        labware_view.get_should_center_pipette_on_target_well(
+            "labware-id",
+        )
+    ).then_return(False)
+    decoy.when(labware_view.get_is_row_labware("labware-id")).then_return(True)
+
+    decoy.when(
+        geometry_view.get_well_position(
+            "labware-id", "well-name", WellLocation(), None, "pipette-id"
+        )
+    ).then_return(Point(x=4, y=5, z=6))
+
+    decoy.when(
+        _move_types.get_move_type_to_well(
+            "pipette-id", "labware-id", "well-name", location, True
+        )
+    ).then_return(motion_planning.MoveType.GENERAL_ARC)
+    decoy.when(
+        geometry_view.get_min_travel_z("pipette-id", "labware-id", location, 123)
+    ).then_return(42.0)
+
+    decoy.when(geometry_view.get_ancestor_slot_name("labware-id")).then_return(
+        DeckSlotName.SLOT_2
+    )
+    decoy.when(pipette_view.get_config("pipette-id")).then_return(
+        _fake_static_pipette_config(1)
+    )
+
+    decoy.when(
+        geometry_view.get_extra_waypoints(location, DeckSlotName.SLOT_2)
+    ).then_return([(456, 789)])
+
+    waypoints = [
+        motion_planning.Waypoint(
+            position=Point(1, 2, 3), critical_point=CriticalPoint.X_CENTER
+        ),
+        motion_planning.Waypoint(
+            position=Point(4, 5, 6), critical_point=CriticalPoint.MOUNT
+        ),
+    ]
+
+    decoy.when(
+        motion_planning.get_waypoints(
+            move_type=motion_planning.MoveType.GENERAL_ARC,
+            origin=Point(x=1, y=2, z=3),
+            origin_cp=CriticalPoint.MOUNT,
+            max_travel_z=1337,
+            min_travel_z=42,
+            dest=Point(x=4, y=5, z=6),
+            dest_cp=CriticalPoint.X_CENTER,
+            xy_waypoints=[(456, 789)],
+        )
+    ).then_return(waypoints)
+
+    result = subject.get_movement_waypoints_to_well(
+        pipette_id="pipette-id",
+        labware_id="labware-id",
+        well_name="well-name",
+        well_location=WellLocation(),
+        origin=Point(x=1, y=2, z=3),
+        origin_cp=CriticalPoint.MOUNT,
+        max_travel_z=1337,
+        force_direct=True,
+        minimum_z_height=123,
+    )
+
+    assert result == waypoints
+
+
 def test_get_movement_waypoints_to_well_for_y_center(
     decoy: Decoy,
     labware_view: LabwareView,
@@ -475,7 +643,7 @@ def test_get_movement_waypoints_to_well_for_y_center(
     decoy.when(pipette_view.get_current_location()).then_return(location)
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "labware-id",
         )
     ).then_return(True)
@@ -484,6 +652,7 @@ def test_get_movement_waypoints_to_well_for_y_center(
             "labware-id",
         )
     ).then_return(False)
+    decoy.when(labware_view.get_is_column_labware("labware-id")).then_return(True)
 
     decoy.when(
         geometry_view.get_well_position(
@@ -562,7 +731,7 @@ def test_get_movement_waypoints_to_well_for_xy_center(
     decoy.when(pipette_view.get_current_location()).then_return(location)
 
     decoy.when(
-        labware_view.get_should_center_column_on_target_well(
+        labware_view.get_should_center_column_or_row_on_target_well(
             "labware-id",
         )
     ).then_return(False)
@@ -1082,7 +1251,7 @@ def test_get_touch_tip_waypoints(
         labware_view.get_should_center_pipette_on_target_well("labware-id")
     ).then_return(True)
     decoy.when(
-        labware_view.get_should_center_column_on_target_well("labware-id")
+        labware_view.get_should_center_column_or_row_on_target_well("labware-id")
     ).then_return(False)
 
     decoy.when(pipette_view.get_mount("pipette-id")).then_return(MountType.LEFT)

--- a/shared-data/labware/definitions/2/nest_8_reservoir_22ml/2.json
+++ b/shared-data/labware/definitions/2/nest_8_reservoir_22ml/2.json
@@ -1,0 +1,162 @@
+{
+  "ordering": [["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"]],
+  "brand": {
+    "brand": "NEST",
+    "brandId": ["360111"]
+  },
+  "metadata": {
+    "displayName": "NEST 8 Well Reservoir 22 mL",
+    "displayCategory": "reservoir",
+    "displayVolumeUnits": "mL",
+    "tags": []
+  },
+  "dimensions": {
+    "xDimension": 127.76,
+    "yDimension": 85.48,
+    "zDimension": 31.4
+  },
+  "wells": {
+    "A1": {
+      "depth": 26.85,
+      "totalLiquidVolume": 22000,
+      "shape": "rectangular",
+      "xDimension": 107.5,
+      "yDimension": 8.2,
+      "x": 63.88,
+      "y": 74.24,
+      "z": 4.55,
+      "geometryDefinitionId": "cuboidalWell"
+    },
+    "B1": {
+      "depth": 26.85,
+      "totalLiquidVolume": 22000,
+      "shape": "rectangular",
+      "xDimension": 107.5,
+      "yDimension": 8.2,
+      "x": 63.88,
+      "y": 65.24,
+      "z": 4.55,
+      "geometryDefinitionId": "cuboidalWell"
+    },
+    "C1": {
+      "depth": 26.85,
+      "totalLiquidVolume": 22000,
+      "shape": "rectangular",
+      "xDimension": 107.5,
+      "yDimension": 8.2,
+      "x": 63.88,
+      "y": 56.24,
+      "z": 4.55,
+      "geometryDefinitionId": "cuboidalWell"
+    },
+    "D1": {
+      "depth": 26.85,
+      "totalLiquidVolume": 22000,
+      "shape": "rectangular",
+      "xDimension": 107.5,
+      "yDimension": 8.2,
+      "x": 63.88,
+      "y": 47.24,
+      "z": 4.55,
+      "geometryDefinitionId": "cuboidalWell"
+    },
+    "E1": {
+      "depth": 26.85,
+      "totalLiquidVolume": 22000,
+      "shape": "rectangular",
+      "xDimension": 107.5,
+      "yDimension": 8.2,
+      "x": 63.88,
+      "y": 38.24,
+      "z": 4.55,
+      "geometryDefinitionId": "cuboidalWell"
+    },
+    "F1": {
+      "depth": 26.85,
+      "totalLiquidVolume": 22000,
+      "shape": "rectangular",
+      "xDimension": 107.5,
+      "yDimension": 8.2,
+      "x": 63.88,
+      "y": 29.24,
+      "z": 4.55,
+      "geometryDefinitionId": "cuboidalWell"
+    },
+    "G1": {
+      "depth": 26.85,
+      "totalLiquidVolume": 22000,
+      "shape": "rectangular",
+      "xDimension": 107.5,
+      "yDimension": 8.2,
+      "x": 63.88,
+      "y": 20.24,
+      "z": 4.55,
+      "geometryDefinitionId": "cuboidalWell"
+    },
+    "H1": {
+      "depth": 26.85,
+      "totalLiquidVolume": 22000,
+      "shape": "rectangular",
+      "xDimension": 107.5,
+      "yDimension": 8.2,
+      "x": 63.88,
+      "y": 11.24,
+      "z": 4.55,
+      "geometryDefinitionId": "cuboidalWell"
+    }
+  },
+  "groups": [
+    {
+      "metadata": {
+        "wellBottomShape": "v"
+      },
+      "wells": ["A1", "B1", "C1", "D1", "E1", "F1", "G1", "H1"]
+    }
+  ],
+  "parameters": {
+    "format": "trough",
+    "quirks": ["centerMultichannelOnWells", "touchTipDisabled"],
+    "isTiprack": false,
+    "isMagneticModuleCompatible": false,
+    "loadName": "nest_8_reservoir_22ml"
+  },
+  "namespace": "opentrons",
+  "version": 2,
+  "schemaVersion": 2,
+  "cornerOffsetFromSlot": {
+    "x": 0,
+    "y": 0,
+    "z": 0
+  },
+  "stackingOffsetWithLabware": {
+    "opentrons_universal_flat_adapter": {
+      "x": 0,
+      "y": 0,
+      "z": 10.22
+    }
+  },
+  "innerLabwareGeometry": {
+    "cuboidalWell": {
+      "sections": [
+        {
+          "shape": "cuboidal",
+          "topXDimension": 107.5,
+          "topYDimension": 8.2,
+          "bottomXDimension": 107.5,
+          "bottomYDimension": 6.88,
+          "topHeight": 26.85,
+          "bottomHeight": 1.68
+        },
+        {
+          "shape": "cuboidal",
+          "topXDimension": 107.5,
+          "topYDimension": 6.88,
+          "bottomXDimension": 102.52,
+          "bottomYDimension": 1.9,
+          "topHeight": 1.68,
+          "bottomHeight": 0
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Overview

Incorporates the select commits from various branches that we'd like to include in `9.1.2`. This includes work items related to the following:

- Centering pipettes properly over labware with rows
- Various module disconnect tolerance improvements

The only non-trivial fix is `_dedupe_available_modules` no longer clears `_recently_removed_modules` as it does in 8.8.2.

In 8.8.2 that was fine: reconnect was a separate scheduled task, and `register_modules` did not call it. In 9.1.2, `register_devices` calls `_reconnect_patch()` immediately after attach. Evicting the parked module during dedupe would remove the instance reconnect needs to restore. Now we keep parked modules until reconnect swaps them in.