### PR TITLE
fix(protocol-designer): add 20uL non filter tips as compatible for stacker

### DIFF
--- a/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
@@ -122,9 +122,11 @@ export const RECOMMENDED_LABWARE_BY_MODULE: {
     'opentrons_flex_96_filtertiprack_1000ul',
     'opentrons_flex_96_filtertiprack_200ul',
     'opentrons_flex_96_filtertiprack_50ul',
+    'opentrons_flex_96_filtertiprack_20ul',
     'opentrons_flex_96_tiprack_1000ul',
     'opentrons_flex_96_tiprack_200ul',
     'opentrons_flex_96_tiprack_50ul',
+    'opentrons_flex_96_tiprack_20ul',
     // tested and verified well plates
     'opentrons_96_wellplate_200ul_pcr_full_skirt',
     'biorad_96_wellplate_200ul_pcr',

--- a/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
@@ -122,7 +122,6 @@ export const RECOMMENDED_LABWARE_BY_MODULE: {
     'opentrons_flex_96_filtertiprack_1000ul',
     'opentrons_flex_96_filtertiprack_200ul',
     'opentrons_flex_96_filtertiprack_50ul',
-    'opentrons_flex_96_filtertiprack_20ul',
     'opentrons_flex_96_tiprack_1000ul',
     'opentrons_flex_96_tiprack_200ul',
     'opentrons_flex_96_tiprack_50ul',


### PR DESCRIPTION
# Overview

Add 20uL non filter tip as compatible for the flex stacker

## Test Plan and Hands on Testing

test that the 20uL tips (non filter) are selectable to add to the flex stacker

## Changelog

add the 1 load name to the compatible list

## Risk assessment

low, minimal change
