### PR TITLE
Add LL production deploy gate and fix CloudFront IDs

### DIFF
--- a/.github/workflows/ll-test-build-deploy.yaml
+++ b/.github/workflows/ll-test-build-deploy.yaml
@@ -49,7 +49,7 @@ jobs:
       relative_artifact_dir: ${{ steps.deploy-config.outputs.RELATIVE_ARTIFACT_DIR }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/git/resolve-tag
       - name: Setup UV
         uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
@@ -70,7 +70,7 @@ jobs:
     runs-on: 'ubuntu-24.04'
     if: ${{ !startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: ./.github/actions/js/setup
       - name: 'run labware library unit tests'
         run: make -C labware-library test-cov
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 10
     runs-on: 'ubuntu-24.04'
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - uses: ./.github/actions/js/setup
@@ -101,13 +101,17 @@ jobs:
     runs-on: 'ubuntu-24.04'
     needs: ['determine-deploy-config', 'build-ll']
     timeout-minutes: 5
+    # Uses GitHub Environments to require manual approval in the UI before production deploys.
+    # Configure required reviewers on the `ll-prod` environment.
+    environment:
+      name: ${{ needs.determine-deploy-config.outputs.environment == 'production' && 'll-prod' || 'll-non-prod' }}
     if: always() && needs.build-ll.result == 'success' && needs.determine-deploy-config.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       id-token: write
       contents: read
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
       - uses: ./.github/actions/git/resolve-tag
@@ -149,7 +153,7 @@ jobs:
     if: always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && (needs.js-unit-test.result == 'success' || needs.js-unit-test.result == 'skipped') && needs.build-ll.result == 'success' && needs.deploy-ll.result == 'success'
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: 'Send success alert'
         uses: ./.github/actions/simple-build-alert
         with:
@@ -164,7 +168,7 @@ jobs:
     if: always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && (needs.js-unit-test.result == 'failure' || needs.build-ll.result == 'failure' || needs.deploy-ll.result == 'failure')
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: 'Determine failed jobs'
         id: failed-jobs
         shell: bash
@@ -198,7 +202,7 @@ jobs:
     if: always() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && (needs.js-unit-test.result == 'cancelled' || needs.build-ll.result == 'cancelled' || needs.deploy-ll.result == 'cancelled')
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: 'Send cancelled alert'
         uses: ./.github/actions/simple-build-alert
         with:

--- a/labware-library/RELEASE.md
+++ b/labware-library/RELEASE.md
@@ -6,6 +6,21 @@ This document describes the release process for Labware Library.
 
 Releases are intended to run from the Github Actions workflow: `.github/workflows/ll-test-build-deploy.yaml`. All process and configuration for release is contained in `scripts/static-release`. With the correct AWS credential and profile, the script to release may be run locally for testing, debugging, or in an emergency for actual release if GitHub Actions is down.
 
+## Builds and deployments
+
+**Source of truth:** what runs in CI and where artifacts go is defined in [`.github/workflows/ll-test-build-deploy.yaml`](https://github.com/Opentrons/opentrons/blob/edge/.github/workflows/ll-test-build-deploy.yaml) on `edge`.
+
+| Trigger | Where it deploys |
+| --- | --- |
+| Open PR (when workflow path filters match) | Sandbox: `https://sandbox.labware.opentrons.com/{branch}` |
+| Push to `edge` or `chore_release*` | Sandbox: `https://sandbox.labware.opentrons.com/{branch}` |
+| Push tag `staging-labware-library@*` | Staging: <https://staging.labware.opentrons.com/> |
+| Push tag `labware-library@*` | Production: <https://labware.opentrons.com/> |
+
+Tagged **production** builds need an **LL release team** member to approve the deployment in GitHub Actions before they go live. Staging and sandbox deploys (PRs, branch pushes, `staging-labware-library@*` tags) do not use that approval gate.
+
+**Common mistake:** alpha and prerelease builds must use the `staging-labware-library@` prefix (for example `staging-labware-library@3.8.1-alpha.0`). A tag like `labware-library@3.8.1-alpha.0` is treated as a **production** deploy and will pause for approval before going live.
+
 ## Tags
 
 Tags should be annotated and pushed one at a time. Please do not push all your tags at once with `git push --tags`. Push the individual tag like so:
@@ -36,7 +51,7 @@ git push origin staging-labware-library@8.6.0-alpha.1
 
 ### Production
 
-To deploy a build to production, create an annotated tag with the prefix `labware-library` and push it to GitHub. The tag name should be of the form `labware-library@X.Y.Z` where `X.Y.Z` is a [semver](https://semver.org/) version number matching the release cycle. This tag goes on the same commit as the staging tag for the final alpha build of the release cycle.
+To deploy a build to production, create an annotated tag with the prefix `labware-library` and push it to GitHub. The tag name should be of the form `labware-library@X.Y.Z` where `X.Y.Z` is a [semver](https://semver.org/) version number matching the release cycle (no `-alpha`, `-beta`, or `-rc` suffix). This tag goes on the same commit as the staging tag for the final alpha build of the release cycle. CI will pause for approval on the `ll-prod` GitHub Environment before deploying.
 
 ```shell
 git tag -a labware-library@8.6.0 -m "production release for 8.6.0"

--- a/labware-library/RELEASE.md
+++ b/labware-library/RELEASE.md
@@ -10,12 +10,12 @@ Releases are intended to run from the Github Actions workflow: `.github/workflow
 
 **Source of truth:** what runs in CI and where artifacts go is defined in [`.github/workflows/ll-test-build-deploy.yaml`](https://github.com/Opentrons/opentrons/blob/edge/.github/workflows/ll-test-build-deploy.yaml) on `edge`.
 
-| Trigger | Where it deploys |
-| --- | --- |
+| Trigger                                    | Where it deploys                                          |
+| ------------------------------------------ | --------------------------------------------------------- |
 | Open PR (when workflow path filters match) | Sandbox: `https://sandbox.labware.opentrons.com/{branch}` |
-| Push to `edge` or `chore_release*` | Sandbox: `https://sandbox.labware.opentrons.com/{branch}` |
-| Push tag `staging-labware-library@*` | Staging: <https://staging.labware.opentrons.com/> |
-| Push tag `labware-library@*` | Production: <https://labware.opentrons.com/> |
+| Push to `edge` or `chore_release*`         | Sandbox: `https://sandbox.labware.opentrons.com/{branch}` |
+| Push tag `staging-labware-library@*`       | Staging: <https://staging.labware.opentrons.com/>         |
+| Push tag `labware-library@*`               | Production: <https://labware.opentrons.com/>              |
 
 Tagged **production** builds need an **LL release team** member to approve the deployment in GitHub Actions before they go live. Staging and sandbox deploys (PRs, branch pushes, `staging-labware-library@*` tags) do not use that approval gate.
 

--- a/scripts/static-deploy/deploy_config.py
+++ b/scripts/static-deploy/deploy_config.py
@@ -147,7 +147,7 @@ def get_deploy_config() -> DeployConfig:
         labware_library=ApplicationConfig(
             name="labware_library",
             s3_bucket="opentrons.staging.labware",
-            cloudfront_id="E8IWASMDOWHYP",
+            cloudfront_id="E2IRNVL4J3NTI3",
             url="https://staging.labware.opentrons.com/",
         ),
         protocol_designer=ApplicationConfig(
@@ -181,7 +181,7 @@ def get_deploy_config() -> DeployConfig:
         labware_library=ApplicationConfig(
             name="labware_library",
             s3_bucket="opentrons.production.labware",
-            cloudfront_id="E16BZZXDTINN0S",
+            cloudfront_id="E1KMXWBD4WUZ4P",
             url="https://labware.opentrons.com/",
         ),
         protocol_designer=ApplicationConfig(


### PR DESCRIPTION
## Overview

Labware Library production deploys had no approval gate and stale CloudFront distribution IDs caused cache invalidation to fail after deploys. This PR aligns LL with Protocol Designer's production protection pattern and fixes the verified CloudFront IDs for staging and production.

**Acceptance criteria:**
- Production `labware-library@*` deploys pause on the `ll-prod` GitHub Environment until approved
- Staging and sandbox deploys use `ll-non-prod` and do not require approval
- Staging and production CloudFront invalidation uses live distribution IDs
- Release docs describe the deployment table, approval gate, and common alpha-tag mistake

**GitHub setup (already done):** `ll-prod` and `ll-non-prod` environments must exist with required reviewers on `ll-prod`.

**Important:** Tag pushes use the workflow from the tagged commit. Merge this PR into `chore_release-ll-3.8.1` before cutting `staging-labware-library@*` or `labware-library@*` tags for 3.8.1.

## Test Plan and Hands on Testing

- [x] `make test` in `scripts/static-deploy` (60 tests passed)
- [x] `uvx zizmor==1.23.1 --gh-token "$(gh auth token)" .github/workflows/ll-test-build-deploy.yaml` (no findings)
- [x] Verify CloudFront IDs against AWS:
  ```bash
  AWS_PROFILE=robotics-protocol-library-prod aws cloudfront get-distribution --id E2IRNVL4J3NTI3 --query "Distribution.{Aliases:DistributionConfig.Aliases.Items,Origin:DistributionConfig.Origins.Items[0].DomainName}" --output table
  AWS_PROFILE=robotics-protocol-library-prod aws cloudfront get-distribution --id E1KMXWBD4WUZ4P --query "Distribution.{Aliases:DistributionConfig.Aliases.Items,Origin:DistributionConfig.Origins.Items[0].DomainName}" --output table
  ```

## Changelog

- **CI:** Labware Library production deploys now require approval via the `ll-prod` GitHub Environment (same pattern as PD `pd-prod`)
- **CI:** Upgrade `actions/checkout` to v7.0.0 in the LL workflow
- **Deploy:** Fix stale Labware Library CloudFront distribution IDs for staging (`E2IRNVL4J3NTI3`) and production (`E1KMXWBD4WUZ4P`)
- **Docs:** Expand `labware-library/RELEASE.md` with deployment table, approval note, and alpha-tag guidance

## Review requests

- Confirm `ll-prod` / `ll-non-prod` environment names match what was created in GitHub repo settings
- Sanity-check CloudFront IDs against AWS if you have prod deploy access
- Confirm this should merge to `chore_release-ll-3.8.1` before 3.8.1 release tags are pushed

## Risk assessment

- **Attention level:** medium
- **Blast radius:** Labware Library CI deploys only (workflow + static-deploy config + release docs)
- **Trade-off:** Production LL tags will fail deploy until someone approves in GitHub Actions; this is intentional
- **Mitigation:** zizmor clean, static-deploy tests pass, sandbox/staging unaffected by approval gate