### PR TITLE
fix(robot-server): Allow unauthenticated access to POST /robot/lights and POST /identify

### DIFF
--- a/robot-server/robot_server/service/legacy/routers/control.py
+++ b/robot-server/robot_server/service/legacy/routers/control.py
@@ -27,7 +27,6 @@ router = APIRouter()
     "/identify",
     summary="Blink the lights",
     description="Blink the gantry lights so you can pick it out of a crowd",
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
 )
 async def post_identify(
     seconds: Annotated[int, Query(..., description="Time to blink the lights for")],
@@ -161,7 +160,6 @@ async def get_robot_light_state(
     summary="Turn the lights on or off",
     description="Turn the rail lights on or off",
     response_model=control.RobotLightState,
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
 )
 async def post_robot_light_state(
     robot_light_state: control.RobotLightState,

--- a/robot-server/tests/test_access_control_coverage.py
+++ b/robot-server/tests/test_access_control_coverage.py
@@ -20,6 +20,12 @@ IGNORED_ENDPOINTS: set[tuple[str, str]] = {
     ("post", "/labwareOffsets/searches"),
     # Protocol analyses are just disposable simulations.
     ("post", "/protocols/{protocolId}/analyses"),
+    # Light control is intentionally unauthenticated. The client uses these implicitly
+    # without a login at certain times, e.g. during ODD startup (?).
+    # If a user is doing science where lights need to be well-controlled, they probably
+    # need hardware modifications anyway.
+    ("post", "/identify"),
+    ("post", "/robot/lights"),
 }
 
 


### PR DESCRIPTION
## Overview

The frontend wants to toggle the lights implicitly in a couple places, e.g. during robot startup and robot update, where we can't prompt the user to log in and enter documentation. From speaking with Product, we're OK to just allow unauthenticated access to these, even though they're "changing something on the robot."

## Changelog

This removes authentication from `POST /robot/lights` and `POST /robot/identify`.

This does **not** remove authentication from any other endpoint that can control the lights, in particular `POST /commands`, `POST /maintenance_runs/{id}/commands`, etc.

## Test Plan and Hands on Testing

None needed.

## Review requests

Keeping in mind that endpoints like `POST /commands` and `POST /maintenance_runs/{id}/commands` will still require authentication, does this help?

## Risk assessment

Low.