### PR TITLE
fix(shared-data): add 20uL filtertiprack as compatible in tiprack lid…

### DIFF
--- a/shared-data/labware/definitions/2/opentrons_flex_tiprack_lid/1.json
+++ b/shared-data/labware/definitions/2/opentrons_flex_tiprack_lid/1.json
@@ -45,6 +45,11 @@
       "y": 0,
       "z": 14.25
     },
+    "opentrons_flex_96_filtertiprack_20ul": {
+      "x": 0,
+      "y": 0,
+      "z": 14.25
+    },
     "opentrons_flex_96_filtertiprack_50ul": {
       "x": 0,
       "y": 0,
@@ -87,6 +92,7 @@
     "opentrons_flex_96_tiprack_50ul",
     "opentrons_flex_96_tiprack_200ul",
     "opentrons_flex_96_tiprack_1000ul",
+    "opentrons_flex_96_filtertiprack_20ul",
     "opentrons_flex_96_filtertiprack_50ul",
     "opentrons_flex_96_filtertiprack_200ul",
     "opentrons_flex_96_filtertiprack_1000ul"


### PR DESCRIPTION
… def

# Overview

This pr adds `opentrons_flex_96_filtertiprack_20ul` as compatible labware for the `opentrons_flex_tiprack_lid`

## Test Plan and Hands on Testing

Nothing to smoke test actually, just look at the code. This is something that we will be able to smoke test in PD later

## Changelog

add the filter tiprack load name as a compatible labware

## Risk assessment

low, adds adds a compatible labware