### PR TITLE
fix(shared-data): add 20uL filtertiprack as compatible in tiprack lid…

### DIFF
--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13cc2361a9][Flex_S_v2_25_P50_P200_stacker_all_parts].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[13cc2361a9][Flex_S_v2_25_P50_P200_stacker_all_parts].json
@@ -3847,6 +3847,7 @@
           "compatibleParentLabware": [
             "opentrons_flex_96_filtertiprack_1000ul",
             "opentrons_flex_96_filtertiprack_200ul",
+            "opentrons_flex_96_filtertiprack_20ul",
             "opentrons_flex_96_filtertiprack_50ul",
             "opentrons_flex_96_tiprack_1000ul",
             "opentrons_flex_96_tiprack_200ul",
@@ -3927,6 +3928,11 @@
               "z": 14.25
             },
             "opentrons_flex_96_filtertiprack_200ul": {
+              "x": 0,
+              "y": 0,
+              "z": 14.25
+            },
+            "opentrons_flex_96_filtertiprack_20ul": {
               "x": 0,
               "y": 0,
               "z": 14.25
@@ -11464,6 +11470,7 @@
           "compatibleParentLabware": [
             "opentrons_flex_96_filtertiprack_1000ul",
             "opentrons_flex_96_filtertiprack_200ul",
+            "opentrons_flex_96_filtertiprack_20ul",
             "opentrons_flex_96_filtertiprack_50ul",
             "opentrons_flex_96_tiprack_1000ul",
             "opentrons_flex_96_tiprack_200ul",
@@ -11544,6 +11551,11 @@
               "z": 14.25
             },
             "opentrons_flex_96_filtertiprack_200ul": {
+              "x": 0,
+              "y": 0,
+              "z": 14.25
+            },
+            "opentrons_flex_96_filtertiprack_20ul": {
               "x": 0,
               "y": 0,
               "z": 14.25
@@ -13406,6 +13418,7 @@
           "compatibleParentLabware": [
             "opentrons_flex_96_filtertiprack_1000ul",
             "opentrons_flex_96_filtertiprack_200ul",
+            "opentrons_flex_96_filtertiprack_20ul",
             "opentrons_flex_96_filtertiprack_50ul",
             "opentrons_flex_96_tiprack_1000ul",
             "opentrons_flex_96_tiprack_200ul",
@@ -13486,6 +13499,11 @@
               "z": 14.25
             },
             "opentrons_flex_96_filtertiprack_200ul": {
+              "x": 0,
+              "y": 0,
+              "z": 14.25
+            },
+            "opentrons_flex_96_filtertiprack_20ul": {
               "x": 0,
               "y": 0,
               "z": 14.25
@@ -22376,6 +22394,7 @@
           "compatibleParentLabware": [
             "opentrons_flex_96_filtertiprack_1000ul",
             "opentrons_flex_96_filtertiprack_200ul",
+            "opentrons_flex_96_filtertiprack_20ul",
             "opentrons_flex_96_filtertiprack_50ul",
             "opentrons_flex_96_tiprack_1000ul",
             "opentrons_flex_96_tiprack_200ul",
@@ -22456,6 +22475,11 @@
               "z": 14.25
             },
             "opentrons_flex_96_filtertiprack_200ul": {
+              "x": 0,
+              "y": 0,
+              "z": 14.25
+            },
+            "opentrons_flex_96_filtertiprack_20ul": {
               "x": 0,
               "y": 0,
               "z": 14.25

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5ffae6e5c1][Flex_S_2_28_P200_96_GRIP_20uLLCPartial].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[5ffae6e5c1][Flex_S_2_28_P200_96_GRIP_20uLLCPartial].json
@@ -1621,6 +1621,7 @@
           "compatibleParentLabware": [
             "opentrons_flex_96_filtertiprack_1000ul",
             "opentrons_flex_96_filtertiprack_200ul",
+            "opentrons_flex_96_filtertiprack_20ul",
             "opentrons_flex_96_filtertiprack_50ul",
             "opentrons_flex_96_tiprack_1000ul",
             "opentrons_flex_96_tiprack_200ul",
@@ -1701,6 +1702,11 @@
               "z": 14.25
             },
             "opentrons_flex_96_filtertiprack_200ul": {
+              "x": 0,
+              "y": 0,
+              "z": 14.25
+            },
+            "opentrons_flex_96_filtertiprack_20ul": {
               "x": 0,
               "y": 0,
               "z": 14.25

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6aedceab7a][Flex_S_2_7_P200_96_GRIP_HS_MB_TC_TM_Overrides_SmokeTestWith2Stackers].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[6aedceab7a][Flex_S_2_7_P200_96_GRIP_HS_MB_TC_TM_Overrides_SmokeTestWith2Stackers].json
@@ -1260,6 +1260,7 @@
           "compatibleParentLabware": [
             "opentrons_flex_96_filtertiprack_1000ul",
             "opentrons_flex_96_filtertiprack_200ul",
+            "opentrons_flex_96_filtertiprack_20ul",
             "opentrons_flex_96_filtertiprack_50ul",
             "opentrons_flex_96_tiprack_1000ul",
             "opentrons_flex_96_tiprack_200ul",
@@ -1340,6 +1341,11 @@
               "z": 14.25
             },
             "opentrons_flex_96_filtertiprack_200ul": {
+              "x": 0,
+              "y": 0,
+              "z": 14.25
+            },
+            "opentrons_flex_96_filtertiprack_20ul": {
               "x": 0,
               "y": 0,
               "z": 14.25

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b2b1925b81][Flex_S_2_7_P200_96_GRIP_HS_MB_TC_TM_SmokeTestWith2Stackers].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[b2b1925b81][Flex_S_2_7_P200_96_GRIP_HS_MB_TC_TM_SmokeTestWith2Stackers].json
@@ -1265,6 +1265,7 @@
           "compatibleParentLabware": [
             "opentrons_flex_96_filtertiprack_1000ul",
             "opentrons_flex_96_filtertiprack_200ul",
+            "opentrons_flex_96_filtertiprack_20ul",
             "opentrons_flex_96_filtertiprack_50ul",
             "opentrons_flex_96_tiprack_1000ul",
             "opentrons_flex_96_tiprack_200ul",
@@ -1345,6 +1346,11 @@
               "z": 14.25
             },
             "opentrons_flex_96_filtertiprack_200ul": {
+              "x": 0,
+              "y": 0,
+              "z": 14.25
+            },
+            "opentrons_flex_96_filtertiprack_20ul": {
               "x": 0,
               "y": 0,
               "z": 14.25

--- a/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3b37eae0f][Flex_S_v2_25_P200_stacker_2].json
+++ b/analyses-snapshot-testing/tests/__snapshots__/analyses_snapshot_test/test_analysis_snapshot[c3b37eae0f][Flex_S_v2_25_P200_stacker_2].json
@@ -2560,6 +2560,7 @@
           "compatibleParentLabware": [
             "opentrons_flex_96_filtertiprack_1000ul",
             "opentrons_flex_96_filtertiprack_200ul",
+            "opentrons_flex_96_filtertiprack_20ul",
             "opentrons_flex_96_filtertiprack_50ul",
             "opentrons_flex_96_tiprack_1000ul",
             "opentrons_flex_96_tiprack_200ul",
@@ -2640,6 +2641,11 @@
               "z": 14.25
             },
             "opentrons_flex_96_filtertiprack_200ul": {
+              "x": 0,
+              "y": 0,
+              "z": 14.25
+            },
+            "opentrons_flex_96_filtertiprack_20ul": {
               "x": 0,
               "y": 0,
               "z": 14.25
@@ -4116,6 +4122,7 @@
           "compatibleParentLabware": [
             "opentrons_flex_96_filtertiprack_1000ul",
             "opentrons_flex_96_filtertiprack_200ul",
+            "opentrons_flex_96_filtertiprack_20ul",
             "opentrons_flex_96_filtertiprack_50ul",
             "opentrons_flex_96_tiprack_1000ul",
             "opentrons_flex_96_tiprack_200ul",
@@ -4196,6 +4203,11 @@
               "z": 14.25
             },
             "opentrons_flex_96_filtertiprack_200ul": {
+              "x": 0,
+              "y": 0,
+              "z": 14.25
+            },
+            "opentrons_flex_96_filtertiprack_20ul": {
               "x": 0,
               "y": 0,
               "z": 14.25

--- a/shared-data/labware/definitions/2/opentrons_flex_tiprack_lid/1.json
+++ b/shared-data/labware/definitions/2/opentrons_flex_tiprack_lid/1.json
@@ -45,6 +45,11 @@
       "y": 0,
       "z": 14.25
     },
+    "opentrons_flex_96_filtertiprack_20ul": {
+      "x": 0,
+      "y": 0,
+      "z": 14.25
+    },
     "opentrons_flex_96_filtertiprack_50ul": {
       "x": 0,
       "y": 0,
@@ -87,6 +92,7 @@
     "opentrons_flex_96_tiprack_50ul",
     "opentrons_flex_96_tiprack_200ul",
     "opentrons_flex_96_tiprack_1000ul",
+    "opentrons_flex_96_filtertiprack_20ul",
     "opentrons_flex_96_filtertiprack_50ul",
     "opentrons_flex_96_filtertiprack_200ul",
     "opentrons_flex_96_filtertiprack_1000ul"


### PR DESCRIPTION
… def

# Overview

This pr adds `opentrons_flex_96_filtertiprack_20ul` as compatible labware for the `opentrons_flex_tiprack_lid`

## Test Plan and Hands on Testing

Nothing to smoke test actually, just look at the code. This is something that we will be able to smoke test in PD later

## Changelog

add the filter tiprack load name as a compatible labware

## Risk assessment

low, adds adds a compatible labware