### PR TITLE
fix(app-shell): Fix robot cert filenames using invalid characters on Windows

### DIFF
--- a/app-shell/src/__tests__/certs.test.ts
+++ b/app-shell/src/__tests__/certs.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   decryptFromOTDetails,
+  getCertificateFilename,
   validateCert,
   validateCertShouldLoad,
   validateCertShouldVerify,
@@ -25,6 +26,18 @@ vi.mock('../log', () => {
 })
 
 const promisifiedPBKDF = promisify(pbkdf2)
+
+describe('getCertificateFilename', () => {
+  it('strips colons from fingerprint256 so filenames are Windows-safe', () => {
+    const certificate = {
+      fingerprint256:
+        '02:5E:62:C9:4B:61:1A:1E:3E:28:37:D6:64:81:34:C4:4E:BB:30:81:18:E9:01:D7:84:B4:C9:AA:6B:2A:65:0B',
+    } as X509Certificate
+    expect(getCertificateFilename(certificate)).toBe(
+      '025E62C94B611A1E3E2837D6648134C44EBB308118E901D784B4C9AA6B2A650B.cer'
+    )
+  })
+})
 
 describe('fernet decryption', () => {
   it('should decrypt some data given the password', async () => {

--- a/app-shell/src/certs.ts
+++ b/app-shell/src/certs.ts
@@ -24,6 +24,19 @@ const CERT_SUBDIR = 'robot-certificates'
 
 const log = createLogger('certs')
 
+/**
+ * Convert a Node.js certificate fingerprint into a safe filename.
+ *
+ * `X509Certificate.fingerprint256` is colon-separated hex, e.g. `AB:CD:...`.
+ * Colons are illegal in Windows filenames and display oddly in macOS Finder,
+ * so strip them and keep only the hex digits.
+ *
+ * Exported for tests.
+ */
+export function getCertificateFilename(certificate: X509Certificate): string {
+  return `${certificate.fingerprint256.replaceAll(':', '')}.cer`
+}
+
 async function wrappedStat(
   path: string
 ): Promise<Awaited<ReturnType<typeof stat>> | null> {
@@ -66,7 +79,7 @@ async function saveCertificateToDisk(
   certificate: X509Certificate
 ): Promise<void> {
   const certDir = await getCertDir()
-  const certPath = join(certDir, `${certificate.fingerprint256}.cer`)
+  const certPath = join(certDir, getCertificateFilename(certificate))
   await writeFile(certPath, certificate.raw)
   log.info(`Saved certificate to ${certPath}`)
   addCertificateToMap(certificate)


### PR DESCRIPTION
## Overview

We were storing filenames like:

```
02:5E:62:C9:4B:61:1A:1E:3E:28:37:D6:64:81:34:C4:4E:BB:30:81:18:E9:01:D7:84:B4:C9:AA:6B:2A:65:0B.cer
7C:E1:4A:A5:55:77:99:C5:38:60:F0:88:75:D5:09:89:AF:9F:8C:55:E7:BE:93:7A:82:EC:2D:A5:0C:D4:16:5D.cer
```

This happens to work on macOS and Linux, but it would have broken on Windows, where `:` is a reserved character.

This fixes it by stripping `:` out of the filenames before we save them.

The read side already appears to be insensitive to the exact filename, so we don't need to update it:

https://github.com/Opentrons/opentrons/blob/f1adba30fdc6f951cfb9a3d4cf04bb0e651c616e/app-shell/src/certs.ts#L128-L148

## Test Plan and Hands on Testing

* [x] Set up HTTPS through the UI and make sure that the new file gets saved without colons and that it gets used for TLS.

## Review requests

None in particular.

## Risk assessment

Low.
