### PR TITLE
fix(app, odd): pass maintenance run documentation to sendIdentifyModule commands

### DIFF
--- a/app/src/local-resources/access-control/useActionsToDocumentList.ts
+++ b/app/src/local-resources/access-control/useActionsToDocumentList.ts
@@ -2,13 +2,12 @@ import { useCallback, useState } from 'react'
 
 import type { DocumentedAction } from '@opentrons/react-api-client'
 
-export const useActionsToDocumentList = (): [
-  DocumentedAction[],
-  (action: DocumentedAction) => void,
-] => {
+export const useActionsToDocumentList = (
+  initialActions?: DocumentedAction[]
+): [DocumentedAction[], (action: DocumentedAction) => void] => {
   const [actionsToDocument, setActionsToDocument] = useState<
     DocumentedAction[]
-  >([])
+  >(initialActions ?? [])
   const addActionToDocument = useCallback((action: DocumentedAction) => {
     setActionsToDocument(prev => [...prev, action])
   }, [])

--- a/app/src/local-resources/access-control/useMaintenanceRunDocumentation.ts
+++ b/app/src/local-resources/access-control/useMaintenanceRunDocumentation.ts
@@ -34,9 +34,11 @@ export const useMaintenanceRunDocumentation = (
   addActionToDocument: (action: DocumentedAction) => void
   isLoading: boolean
 } => {
-  const [actionsToDocument, addActionToDocument] = useActionsToDocumentList()
+  const [actionsToDocument, addActionToDocument] = useActionsToDocumentList([
+    maintenanceRunName,
+  ])
   const commandDocState = usePromptForDocumentation(
-    [maintenanceRunName],
+    actionsToDocument,
     onCancelStart,
     initialDocstate,
     promptEnabled

--- a/app/src/organisms/ModuleWizardFlows/CheckStackerInstall.tsx
+++ b/app/src/organisms/ModuleWizardFlows/CheckStackerInstall.tsx
@@ -7,8 +7,6 @@ import { FLEX_STACKER_MODULE_TYPE } from '@opentrons/shared-data'
 import { SmallButton } from '/app/atoms/buttons'
 import { SimpleWizardBody } from '/app/molecules/SimpleWizardBody'
 
-import { useSendIdentifyModule } from './hooks'
-
 import type { AttachedModule } from '@opentrons/api-client'
 import type { DeckConfiguration } from '@opentrons/shared-data'
 import type { ModuleSetupWizardMaybePipetteStepProps } from './types'
@@ -22,7 +20,13 @@ interface CheckStackerInstallProps extends ModuleSetupWizardMaybePipetteStepProp
 export function CheckStackerInstall(
   props: CheckStackerInstallProps
 ): JSX.Element {
-  const { proceed, isOnDevice, doorOpenStatus, attachedModules } = props
+  const {
+    proceed,
+    isOnDevice,
+    doorOpenStatus,
+    attachedModules,
+    sendIdentifyModule,
+  } = props
   const { t, i18n } = useTranslation([
     'module_wizard_flows',
     'shared',
@@ -55,7 +59,6 @@ export function CheckStackerInstall(
     }
   }
 
-  const sendIdentifyModule = useSendIdentifyModule()
   const handleTryAgain = (): void => {
     if (attachedStacker != null) {
       // Set the stacker to red

--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -28,9 +28,8 @@ import {
   SimpleWizardBodyContainer,
 } from '/app/molecules/SimpleWizardBody'
 
-import { useSendIdentifyModule } from './hooks'
-
 import type { AttachedModule } from '@opentrons/api-client'
+import type { SendIdentifyModule } from './types'
 
 interface SelectModuleProps {
   buildFlowForSelectedModule: (module: AttachedModule) => void
@@ -39,6 +38,7 @@ interface SelectModuleProps {
   setSelectedModule: (module: AttachedModule | null) => void
   setShowLaunchSetup: (show: boolean) => void
   attachedModuleOnLaunch?: AttachedModule | null
+  sendIdentifyModule: SendIdentifyModule
 }
 
 interface ModuleNameAndPort {
@@ -54,6 +54,7 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
     setSelectedModule,
     setShowLaunchSetup,
     attachedModuleOnLaunch = null,
+    sendIdentifyModule,
   } = props
   const { t } = useTranslation('module_wizard_flows')
 
@@ -75,7 +76,6 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
   const isSingleModule = newModules.length === 1 && !hasUnsetupabbleModules
   // Unless, of course, we're being invoked by a caller giving us a specific module
   const shortCircuitFlow = attachedModuleOnLaunch != null || isSingleModule
-  const sendIdentifyModule = useSendIdentifyModule()
 
   const getModuleNameAndPort = (module: AttachedModule): ModuleNameAndPort => {
     const name = getModuleDisplayName(module.moduleModel)

--- a/app/src/organisms/ModuleWizardFlows/Success.tsx
+++ b/app/src/organisms/ModuleWizardFlows/Success.tsx
@@ -18,8 +18,6 @@ import { useGetModulesNeedingSetupThatCanCurrentlyBeSetUp } from '/app/App/hooks
 import { SmallButton } from '/app/atoms/buttons'
 import { SimpleWizardBody } from '/app/molecules/SimpleWizardBody'
 
-import { useSendIdentifyModule } from './hooks'
-
 import type { AttachedModule } from '@opentrons/api-client'
 import type { ModuleSetupWizardMaybePipetteStepProps } from './types'
 
@@ -46,9 +44,9 @@ export function Success(props: SuccessProps): JSX.Element {
     isOnDevice,
     restartSetup,
     setSelectedModule,
+    sendIdentifyModule,
   } = props
   const { t } = useTranslation('module_wizard_flows')
-  const sendIdentifyModule = useSendIdentifyModule()
   const moduleDisplayName = getModuleDisplayName(attachedModule.moduleModel)
   const newModules = useGetModulesNeedingSetupThatCanCurrentlyBeSetUp()
 

--- a/app/src/organisms/ModuleWizardFlows/UpdateFirmware.tsx
+++ b/app/src/organisms/ModuleWizardFlows/UpdateFirmware.tsx
@@ -20,8 +20,6 @@ import {
   SUCCESS,
 } from '/app/redux/robot-api'
 
-import { useSendIdentifyModule } from './hooks'
-
 import type { AttachedModule } from '@opentrons/api-client'
 import type { Dispatch, State } from '/app/redux/types'
 import type { ModuleSetupWizardMaybePipetteStepProps } from './types'
@@ -44,11 +42,11 @@ export function UpdateFirmware(props: UpdateFirmwareProps): JSX.Element {
     patchModuleAfterUpdate,
     setIsModuleUpdating,
     isOnDevice,
+    sendIdentifyModule,
   } = props
   const { t } = useTranslation('module_wizard_flows')
 
   const dispatch = useDispatch<Dispatch>()
-  const sendIdentifyModule = useSendIdentifyModule()
   const [getLatestRequestId, handleModuleApiRequests] = useModuleApiRequests()
   const moduleSerialNumber = props.attachedModule.serialNumber
   const [moduleRequestTimeoutId, setModuleRequestTimeoutId] =

--- a/app/src/organisms/ModuleWizardFlows/__tests__/InstallShuttle.test.tsx
+++ b/app/src/organisms/ModuleWizardFlows/__tests__/InstallShuttle.test.tsx
@@ -70,6 +70,7 @@ describe('CloseDoorInstallShuttle', () => {
       setIsDoorOpenError: vi.fn(),
       dismissDoorOpenError: vi.fn(),
       isOnDevice: false,
+      sendIdentifyModule: vi.fn(),
       deckConfig: mockDeckConfig,
       maintenanceRunId: null,
     }
@@ -117,6 +118,7 @@ describe('CloseDoorInstallShuttle', () => {
       setIsDoorOpenError: vi.fn(),
       dismissDoorOpenError: vi.fn(),
       isOnDevice: false,
+      sendIdentifyModule: vi.fn(),
       deckConfig: mockDeckConfig,
       maintenanceRunId: null,
     }
@@ -138,6 +140,7 @@ describe('CloseDoorInstallShuttle', () => {
       setIsDoorOpenError: vi.fn(),
       dismissDoorOpenError: vi.fn(),
       isOnDevice: false,
+      sendIdentifyModule: vi.fn(),
       deckConfig: mockDeckConfig,
       maintenanceRunId: null,
       restartSetup: vi.fn(),

--- a/app/src/organisms/ModuleWizardFlows/__tests__/SelectLocation.test.tsx
+++ b/app/src/organisms/ModuleWizardFlows/__tests__/SelectLocation.test.tsx
@@ -120,6 +120,7 @@ describe('SelectLocation', () => {
       maintenanceRunId: RUN_ID_1,
       isLoadedInRun: false,
       isOnDevice: false,
+      sendIdentifyModule: vi.fn(),
       errorMessage: '',
       attachedPipette: {} as PipetteInformation,
     }
@@ -186,6 +187,7 @@ describe('handleAddFixture', () => {
       maintenanceRunId: RUN_ID_1,
       isLoadedInRun: false,
       isOnDevice: false,
+      sendIdentifyModule: vi.fn(),
       errorMessage: '',
       attachedPipette: {} as PipetteInformation,
     }
@@ -278,6 +280,7 @@ describe('handleRemoveFixture', () => {
       maintenanceRunId: RUN_ID_1,
       isLoadedInRun: false,
       isOnDevice: false,
+      sendIdentifyModule: vi.fn(),
       errorMessage: '',
       attachedPipette: {} as PipetteInformation,
     }
@@ -327,6 +330,7 @@ describe('door open error handling', () => {
       maintenanceRunId: null,
       isLoadedInRun: false,
       isOnDevice: false,
+      sendIdentifyModule: vi.fn(),
       errorMessage: '',
       attachedPipette: {} as PipetteInformation,
     }

--- a/app/src/organisms/ModuleWizardFlows/__tests__/UpdateFirmware.test.tsx
+++ b/app/src/organisms/ModuleWizardFlows/__tests__/UpdateFirmware.test.tsx
@@ -18,7 +18,6 @@ import {
 } from '/app/redux/robot-api'
 import { mockAttachedPipetteInformation } from '/app/resources/instruments/__fixtures__'
 
-import { useSendIdentifyModule } from '../hooks'
 import { UpdateFirmware } from '../UpdateFirmware'
 
 import type { ComponentProps } from 'react'
@@ -30,7 +29,6 @@ import type { State } from '/app/redux/types'
 
 vi.mock('/app/redux/robot-api')
 vi.mock('/app/organisms/ModuleCard/utils')
-vi.mock('/app/organisms/ModuleWizardFlows/hooks.tsx')
 vi.mock('@opentrons/react-api-client')
 
 const LAST_ID = 'lastRequestId'
@@ -75,6 +73,7 @@ describe('UpdateFirmware', () => {
       robotName: ROBOT_NAME,
       maintenanceRunId: '123',
       patchModuleAfterUpdate: vi.fn(),
+      sendIdentifyModule,
     }
     vi.mocked(useModuleApiRequests).mockReturnValue([
       () => LAST_ID,
@@ -87,7 +86,6 @@ describe('UpdateFirmware', () => {
       dispatchApiRequest,
       [LAST_ID],
     ])
-    vi.mocked(useSendIdentifyModule).mockReturnValue(sendIdentifyModule)
   })
 
   afterEach(() => {

--- a/app/src/organisms/ModuleWizardFlows/hooks.tsx
+++ b/app/src/organisms/ModuleWizardFlows/hooks.tsx
@@ -5,17 +5,24 @@ import { useCreateLiveCommandMutation } from '@opentrons/react-api-client'
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 
 import type { AttachedModule } from '@opentrons/api-client'
+import type {
+  DocumentationState,
+  DocumentedAction,
+} from '@opentrons/react-api-client'
 import type { IdentifyColor } from '@opentrons/shared-data'
+import type { SendIdentifyModule } from './types'
 
-type sendIdentifyModuleType = (
-  module: AttachedModule,
-  start: boolean,
-  color?: IdentifyColor
-) => void
-
-export function useSendIdentifyModule(): sendIdentifyModuleType {
-  const documentationState = useDocumentationState()
-  const { createLiveCommand } = useCreateLiveCommandMutation(documentationState)
+export function useSendIdentifyModule(
+  documentationState?: DocumentationState,
+  actionsToDocument?: DocumentedAction[],
+  addActionToDocument?: (action: DocumentedAction) => void
+): SendIdentifyModule {
+  const newDocState = useDocumentationState()
+  const { createLiveCommand } = useCreateLiveCommandMutation(
+    documentationState ?? newDocState,
+    actionsToDocument,
+    addActionToDocument
+  )
 
   const sendIdentifyModule = useCallback(
     (

--- a/app/src/organisms/ModuleWizardFlows/index.tsx
+++ b/app/src/organisms/ModuleWizardFlows/index.tsx
@@ -31,7 +31,6 @@ import { CheckStackerInstall } from './CheckStackerInstall'
 import { CloseDoor } from './CloseStackerDoor'
 import { SECTIONS } from './constants'
 import { DetachProbe } from './DetachProbe'
-import { useSendIdentifyModule } from './hooks'
 import { InstallShuttle } from './InstallShuttle'
 import { ModuleWizardScreen } from './ModuleWizardScreen'
 import { PlaceAdapter } from './PlaceAdapter'
@@ -78,7 +77,7 @@ export function ModuleWizardFlows(
     deckConfig,
   } = useModuleSetupWizard({ closeFlow, attachedModuleOnLaunch, onComplete })
 
-  const sendIdentifyModule = useSendIdentifyModule()
+  const sendIdentifyModule = wizardFlowBaseProps.sendIdentifyModule
   const [selectedModule, setSelectedModule] = useState<AttachedModule | null>(
     null
   )

--- a/app/src/organisms/ModuleWizardFlows/types.ts
+++ b/app/src/organisms/ModuleWizardFlows/types.ts
@@ -1,5 +1,5 @@
 import type { AttachedModule } from '@opentrons/api-client'
-import type { CreateCommand } from '@opentrons/shared-data'
+import type { CreateCommand, IdentifyColor } from '@opentrons/shared-data'
 import type { PipetteInformation } from '/app/resources/instruments/types'
 import type { ACTIONS, FLOWS, SECTIONS } from './constants'
 
@@ -66,6 +66,7 @@ export interface ModuleSetupWizardBaseStepProps {
   setIsDoorOpenError: (isDoorOpenError: boolean) => void
   dismissDoorOpenError: () => void
   isOnDevice: boolean
+  sendIdentifyModule: SendIdentifyModule
 }
 
 export interface ModuleSetupWizardRequiresPipetteStepProps extends ModuleSetupWizardBaseStepProps {
@@ -81,6 +82,12 @@ export type ModuleSetupWizardStepProps =
   | ModuleSetupWizardRequiresPipetteStepProps
 
 export type ModuleWizardFlow = typeof FLOWS.SETUP
+
+export type SendIdentifyModule = (
+  module: AttachedModule,
+  start: boolean,
+  color?: IdentifyColor
+) => void
 
 export interface BeforeBeginningStep {
   section: typeof SECTIONS.BEFORE_BEGINNING

--- a/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
+++ b/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
@@ -24,7 +24,7 @@ import type { AttachedModule, CommandData } from '@opentrons/api-client'
 import type { CreateMaintenanceRunType } from '@opentrons/react-api-client'
 import type { CreateCommand, DeckConfiguration } from '@opentrons/shared-data'
 import type { PipetteInformation } from '/app/resources/instruments/types'
-import type { ModuleSetupWizardStep } from './types'
+import type { ModuleSetupWizardStep, SendIdentifyModule } from './types'
 
 const RUN_REFETCH_INTERVAL = 5000
 
@@ -56,6 +56,7 @@ export interface UseModuleSetupWizardResult {
     isOnDevice: boolean
     attachedModule: AttachedModule | null
     isExiting: boolean
+    sendIdentifyModule: SendIdentifyModule
   }
   buildFlowForSelectedModule: (module: AttachedModule) => void
   patchModuleAfterUpdate: (module: AttachedModule) => void
@@ -74,7 +75,7 @@ export function useModuleSetupWizard(
   const { closeFlow, attachedModuleOnLaunch, onComplete } = params
   const isOnDevice = useSelector(getIsOnDevice)
   const { t } = useTranslation('module_wizard_flows')
-  const sendIdentifyModule = useSendIdentifyModule()
+
   const [state, dispatch] = useReducer(moduleSetupWizardReducer, {
     currentStepIndex: 0,
     currentStep: null,
@@ -112,6 +113,12 @@ export function useModuleSetupWizard(
       actionsToDocument,
       addActionToDocument
     )
+
+  const sendIdentifyModule = useSendIdentifyModule(
+    commandDocState,
+    actionsToDocument,
+    addActionToDocument
+  )
 
   const { createTargetedMaintenanceRun, isLoading: isCreateLoading } =
     useCreateTargetedMaintenanceRunMutation(
@@ -250,6 +257,7 @@ export function useModuleSetupWizard(
     isOnDevice,
     attachedModule,
     isExiting,
+    sendIdentifyModule,
   }
 
   const buildFlowForSelectedModule = (


### PR DESCRIPTION
# Overview

A bit in the weeds. A continutation from [this pr on live commands](https://github.com/Opentrons/opentrons/pull/21942). Module Setup Wizard was getting a new documentation state and calling `useSendIdentifyModule` in a bunch of places. This changes it so that `useSendIdentifyModule` uses the main maintenance command documentation, and adds its actions to the full list, instead of reprompting in the middle of the maintenance run. I decided to break this out into another PR to save you the reader from having to read 13 more changed files.

## Test Plan and Hands on Testing

In module setup, clicking 'identify' module should not trigger documentation, but should pop up in the actions list of the doc modal that pops at the end of the flow.

## Risk assessment

Low