### PR TITLE
fix(app) cherry picking for ODD rendering issue when using a loop with RTP

### DIFF
--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
@@ -102,9 +102,9 @@ export function ProtocolSetupLabware({
     [mostRecentAnalysis]
   )
   const labwareByLiquidId = useMemo(
-      () => getLabwareInfoByLiquidId(mostRecentAnalysis?.commands ?? []),
-      [mostRecentAnalysis]
-    )
+    () => getLabwareInfoByLiquidId(mostRecentAnalysis?.commands ?? []),
+    [mostRecentAnalysis]
+  )
   const stacksWithLaware = useMemo(
     () => getStacksWithLabware(startingDeck),
     [startingDeck]
@@ -140,13 +140,13 @@ export function ProtocolSetupLabware({
   )
 
   const attachedProtocolModuleMatches = useMemo(
-      () =>
-        getAttachedProtocolModuleMatches(
-          attachedModules,
-          protocolModulesInfo,
-          deckConfig
-        ),
-      [attachedModules, protocolModulesInfo, deckConfig]
+    () =>
+      getAttachedProtocolModuleMatches(
+        attachedModules,
+        protocolModulesInfo,
+        deckConfig
+      ),
+    [attachedModules, protocolModulesInfo, deckConfig]
   )
 
   return (

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
@@ -123,11 +123,17 @@ export function ProtocolSetupLabware({
   const moduleQuery = useModulesQuery({
     refetchInterval: MODULE_REFETCH_INTERVAL_MS,
   })
-  const attachedModules = moduleQuery?.data?.data ?? []
-  const protocolModulesInfo =
-    mostRecentAnalysis != null
-      ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-      : []
+  const attachedModules = useMemo(
+    () => moduleQuery?.data?.data ?? [],
+    [moduleQuery?.data?.data]
+  )
+  const protocolModulesInfo = useMemo(
+    () =>
+      mostRecentAnalysis != null
+        ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+        : [],
+    [mostRecentAnalysis, deckDef]
+  )
 
   const attachedProtocolModuleMatches = getAttachedProtocolModuleMatches(
     attachedModules,

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
@@ -101,10 +101,14 @@ export function ProtocolSetupLabware({
       ),
     [mostRecentAnalysis]
   )
-  const labwareByLiquidId = getLabwareInfoByLiquidId(
-    mostRecentAnalysis?.commands ?? []
+  const labwareByLiquidId = useMemo(
+      () => getLabwareInfoByLiquidId(mostRecentAnalysis?.commands ?? []),
+      [mostRecentAnalysis]
+    )
+  const stacksWithLaware = useMemo(
+    () => getStacksWithLabware(startingDeck),
+    [startingDeck]
   )
-  const stacksWithLaware = getStacksWithLabware(startingDeck)
   const sortedStartingDeckEntries = Object.entries(stacksWithLaware)
     .sort((a, b) => a[0].localeCompare(b[0]))
     .filter(([key, value]) => key !== 'offDeck')
@@ -135,10 +139,14 @@ export function ProtocolSetupLabware({
     [mostRecentAnalysis, deckDef]
   )
 
-  const attachedProtocolModuleMatches = getAttachedProtocolModuleMatches(
-    attachedModules,
-    protocolModulesInfo,
-    deckConfig
+  const attachedProtocolModuleMatches = useMemo(
+      () =>
+        getAttachedProtocolModuleMatches(
+          attachedModules,
+          protocolModulesInfo,
+          deckConfig
+        ),
+      [attachedModules, protocolModulesInfo, deckConfig]
   )
 
   return (

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ProtocolSetupModulesAndDeck.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ProtocolSetupModulesAndDeck.tsx
@@ -84,10 +84,13 @@ export function ProtocolSetupModulesAndDeck({
   const { data: deckConfig = [] } = useNotifyDeckConfigurationQuery({
     refetchInterval: DECK_CONFIG_POLL_MS,
   })
-  const attachedModules =
-    useAttachedModules({
-      refetchInterval: ATTACHED_MODULE_POLL_MS,
-    }) ?? []
+  const attachedModulesData = useAttachedModules({
+    refetchInterval: ATTACHED_MODULE_POLL_MS,
+  })
+  const attachedModules = useMemo(
+    () => attachedModulesData ?? [],
+    [attachedModulesData]
+  )
 
   const protocolModulesInfo =
     mostRecentAnalysis != null

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ProtocolSetupModulesAndDeck.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ProtocolSetupModulesAndDeck.tsx
@@ -92,15 +92,22 @@ export function ProtocolSetupModulesAndDeck({
     [attachedModulesData]
   )
 
-  const protocolModulesInfo =
-    mostRecentAnalysis != null
-      ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-      : []
+  const protocolModulesInfo = useMemo(
+      () =>
+        mostRecentAnalysis != null
+          ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+          : [],
+      [mostRecentAnalysis, deckDef]
+    )
 
-  const attachedProtocolModuleMatches = getAttachedProtocolModuleMatches(
-    attachedModules,
-    protocolModulesInfo,
-    deckConfig
+  const attachedProtocolModuleMatches = useMemo(
+      () =>
+        getAttachedProtocolModuleMatches(
+          attachedModules,
+          protocolModulesInfo,
+          deckConfig
+        ),
+    [attachedModules, protocolModulesInfo, deckConfig]
   )
 
   const hasModules = attachedProtocolModuleMatches.length > 0

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ProtocolSetupModulesAndDeck.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ProtocolSetupModulesAndDeck.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ProtocolSetupModulesAndDeck.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ProtocolSetupModulesAndDeck.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
@@ -93,20 +93,20 @@ export function ProtocolSetupModulesAndDeck({
   )
 
   const protocolModulesInfo = useMemo(
-      () =>
-        mostRecentAnalysis != null
-          ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-          : [],
-      [mostRecentAnalysis, deckDef]
-    )
+    () =>
+      mostRecentAnalysis != null
+        ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+        : [],
+    [mostRecentAnalysis, deckDef]
+  )
 
   const attachedProtocolModuleMatches = useMemo(
-      () =>
-        getAttachedProtocolModuleMatches(
-          attachedModules,
-          protocolModulesInfo,
-          deckConfig
-        ),
+    () =>
+      getAttachedProtocolModuleMatches(
+        attachedModules,
+        protocolModulesInfo,
+        deckConfig
+      ),
     [attachedModules, protocolModulesInfo, deckConfig]
   )
 

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -262,10 +262,13 @@ function PrepareToRun({
 
   const deckDef = getDeckDefFromRobotType(robotType)
 
-  const protocolModulesInfo =
-    mostRecentAnalysis != null
-      ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-      : []
+  const protocolModulesInfo = useMemo(
+      () =>
+        mostRecentAnalysis != null
+          ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+          : [],
+      [mostRecentAnalysis, deckDef]
+    )
 
   const { missingModuleIds } = getUnmatchedModulesForProtocol(
     attachedModules,
@@ -554,9 +557,11 @@ function PrepareToRun({
   }
 
   // Labware information
-  const { offDeckItems, onDeckItems } = getLabwareSetupItemGroups(
-    mostRecentAnalysis?.commands ?? []
-  )
+  const { offDeckItems, onDeckItems } = useMemo(
+      () => getLabwareSetupItemGroups(mostRecentAnalysis?.commands ?? []),
+      [mostRecentAnalysis]
+    )
+
   const onDeckLabwareCount = onDeckItems.length
   const additionalLabwareCount = offDeckItems.length
 
@@ -829,10 +834,13 @@ export function ProtocolSetup(): JSX.Element {
   }, [mostRecentAnalysis?.status])
   const deckDef = getDeckDefFromRobotType(robotType)
 
-  const protocolModulesInfo =
-    mostRecentAnalysis != null
-      ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-      : []
+  const protocolModulesInfo = useMemo(
+      () =>
+        mostRecentAnalysis != null
+          ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+          : [],
+      [mostRecentAnalysis, deckDef]
+    )
 
   const { missingModuleIds } = getUnmatchedModulesForProtocol(
     attachedModules,

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -263,12 +263,12 @@ function PrepareToRun({
   const deckDef = getDeckDefFromRobotType(robotType)
 
   const protocolModulesInfo = useMemo(
-      () =>
-        mostRecentAnalysis != null
-          ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-          : [],
-      [mostRecentAnalysis, deckDef]
-    )
+    () =>
+      mostRecentAnalysis != null
+        ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+        : [],
+    [mostRecentAnalysis, deckDef]
+  )
 
   const { missingModuleIds } = getUnmatchedModulesForProtocol(
     attachedModules,
@@ -558,9 +558,9 @@ function PrepareToRun({
 
   // Labware information
   const { offDeckItems, onDeckItems } = useMemo(
-      () => getLabwareSetupItemGroups(mostRecentAnalysis?.commands ?? []),
-      [mostRecentAnalysis]
-    )
+    () => getLabwareSetupItemGroups(mostRecentAnalysis?.commands ?? []),
+    [mostRecentAnalysis]
+  )
 
   const onDeckLabwareCount = onDeckItems.length
   const additionalLabwareCount = offDeckItems.length
@@ -835,12 +835,12 @@ export function ProtocolSetup(): JSX.Element {
   const deckDef = getDeckDefFromRobotType(robotType)
 
   const protocolModulesInfo = useMemo(
-      () =>
-        mostRecentAnalysis != null
-          ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-          : [],
-      [mostRecentAnalysis, deckDef]
-    )
+    () =>
+      mostRecentAnalysis != null
+        ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+        : [],
+    [mostRecentAnalysis, deckDef]
+  )
 
   const { missingModuleIds } = getUnmatchedModulesForProtocol(
     attachedModules,


### PR DESCRIPTION
# Overview

cherry pick for odd rendering issue: https://github.com/Opentrons/opentrons/pull/21905

`getSortedStartingDeckEntries` isn't used in 9.1.2 branch so keep using the existing sort function.


## Test Plan and Hands on Testing
the test is in the above pr


## Changelog
- add useMemo to avoid unnecessary rendering

## Review requests


## Risk assessment
low
