### PR TITLE
fix(odd): fix homing documentation popping up from nav menu automatically

### DIFF
--- a/app/src/organisms/ODD/Navigation/NavigationMenu.tsx
+++ b/app/src/organisms/ODD/Navigation/NavigationMenu.tsx
@@ -38,11 +38,15 @@ export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
   const { t, i18n } = useTranslation(['devices_landing', 'robot_controls'])
   const { lightsOn, toggleLights } = useLights()
   const { makeSnackbar } = useToaster()
-  const { homeGantry } = useHomeGantry({
+  const { homeGantry, isHoming } = useHomeGantry({
     onError: error => {
       if (isMaintenanceDoorOpenError(error)) {
         makeSnackbar(t('close_door_to_home') as string)
       }
+      setShowNavMenu(false)
+    },
+    onSuccess: () => {
+      setShowNavMenu(false)
     },
   })
   const [
@@ -67,7 +71,6 @@ export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
 
   const handleHomeGantry = (): void => {
     void homeGantry()
-    setShowNavMenu(false)
   }
 
   return createPortal(
@@ -89,13 +92,21 @@ export function NavigationMenu(props: NavigationMenuProps): JSX.Element {
         />
       ) : null}
       <MenuList onClick={onClick} isOnDevice={true}>
-        <MenuItem key="reset-position" onClick={handleHomeGantry}>
+        <MenuItem
+          key="reset-position"
+          onClick={handleHomeGantry}
+          disabled={isHoming}
+        >
           <Flex alignItems={ALIGN_CENTER}>
-            <Icon
-              name="reset-position"
-              aria-label="reset-position_icon"
-              size="2.5rem"
-            />
+            {isHoming ? (
+              <Icon name="ot-spinner" aria-label="spinner" size="2.5rem" spin />
+            ) : (
+              <Icon
+                name="reset-position"
+                aria-label="reset-position_icon"
+                size="2.5rem"
+              />
+            )}
             <LegacyStyledText
               forwardedAs="h4"
               fontWeight={TYPOGRAPHY.fontWeightSemiBold}

--- a/app/src/organisms/ODD/Navigation/__tests__/NavigationMenu.test.tsx
+++ b/app/src/organisms/ODD/Navigation/__tests__/NavigationMenu.test.tsx
@@ -94,7 +94,23 @@ describe('NavigationMenu', () => {
     screen.getByLabelText('reset-position_icon')
     fireEvent.click(screen.getByText('Home gantry'))
     expect(mockHomeGantry).toHaveBeenCalled()
+    expect(props.setShowNavMenu).not.toHaveBeenCalled()
+    capturedHomeGantryProps.onSuccess?.()
     expect(props.setShowNavMenu).toHaveBeenCalled()
+  })
+
+  it('should disable the home menu item and show a spinner while homing', () => {
+    vi.mocked(useHomeGantry).mockReturnValue({
+      homeGantry: mockHomeGantry,
+      isHoming: true,
+    })
+    render(props)
+
+    expect(screen.getByRole('button', { name: /Home gantry/ })).toBeDisabled()
+    screen.getByLabelText('spinner')
+    expect(
+      screen.queryByLabelText('reset-position_icon')
+    ).not.toBeInTheDocument()
   })
 
   it('should show a close-door snackbar when homing the gantry fails because the door is open', () => {

--- a/app/src/resources/maintenance_runs/hooks/useRobotControlCommands.ts
+++ b/app/src/resources/maintenance_runs/hooks/useRobotControlCommands.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useDeleteMaintenanceRunMutation } from '@opentrons/react-api-client'
 
 import { useMaintenanceRunDocumentation } from '/app/local-resources/access-control/useMaintenanceRunDocumentation'
+import { isDocumentationProvided } from '/app/local-resources/access-control/utils'
 
 import { useCreateTargetedMaintenanceRunMutation } from '../../runs'
 import { useChainMaintenanceCommands } from './useChainMaintenanceCommands'
@@ -75,8 +76,14 @@ export function useRobotControlCommands({
     isLoading: isDocumentationLoading,
   } = useMaintenanceRunDocumentation(
     runStartedAction,
-    handleDocumentationCancel
+    handleDocumentationCancel,
+    undefined,
+    isExecuting // block prompting until execution begins
   )
+
+  // wait until documentation is ready before executing commands
+  const isExecutionBlocked =
+    isDocumentationLoading || !isDocumentationProvided(commandDocState)
 
   const { chainRunCommands } = useChainMaintenanceCommands(
     commandDocState,
@@ -136,7 +143,7 @@ export function useRobotControlCommands({
   // If documentation state is loading, we queue the execution, and run it in the useEffect when the documentation is ready.
   // If documentation state is not loading, we can execute the commands immediately.
   useEffect(() => {
-    if (isDocumentationLoading || pendingExecutionRef.current == null) {
+    if (isExecutionBlocked || pendingExecutionRef.current == null) {
       return
     }
 
@@ -144,12 +151,12 @@ export function useRobotControlCommands({
     pendingExecutionRef.current = null
 
     void createTargetedMaintenanceRun({}).then(resolve).catch(reject)
-  }, [createTargetedMaintenanceRun, isDocumentationLoading])
+  }, [createTargetedMaintenanceRun, isExecutionBlocked])
 
   const executeCommands = (): Promise<MaintenanceRun> => {
     setIsExecuting(true)
 
-    if (isDocumentationLoading) {
+    if (isExecutionBlocked) {
       return new Promise((resolve, reject) => {
         pendingExecutionRef.current = { resolve, reject }
       })


### PR DESCRIPTION
# Overview

Before, whenever you opened the nav menu on a compliance ready flex, a documentation required screen would pop up for homing gantry automatically. Now, it only pops up when you click 'home gantry'. This PR also adds a loading spinner to the menu to indicate that homing is proceeding. 

https://github.com/user-attachments/assets/140690f1-b8f2-435b-8e7d-697614241e30

## Test Plan and Hands on Testing

On a CRS bot, try to home the gantry from the navigation menu. A documentation required modal should pop up. After clicking submit, the nav menu should remain open with a loading spinner until homing completes. Then another documentation required modal should pop up. Submitting that one should close the menu.

## Review requests

Is this use of the spinner kosher?

## Risk assessment

Low