### PR TITLE
refactor(app): Don't use <button> tags for the on-screen keyboard

### DIFF
--- a/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/index.tsx
@@ -8,6 +8,7 @@ import {
   alphanumericKeyboardLayout,
   customDisplay,
   layoutCandidates,
+  softwareKeyboardButtonAttributes,
 } from '../constants'
 
 import type { MutableRefObject } from 'react'
@@ -88,6 +89,7 @@ export function AlphanumericKeyboard({
       display={customDisplay}
       mergeDisplay={true}
       useButtonTag={false}
+      buttonAttributes={softwareKeyboardButtonAttributes}
       width="100%"
       debug={debug} // If true, <ENTER> will input a \n
     />

--- a/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/index.tsx
@@ -87,7 +87,7 @@ export function AlphanumericKeyboard({
       }
       display={customDisplay}
       mergeDisplay={true}
-      useButtonTag={true}
+      useButtonTag={false}
       width="100%"
       debug={debug} // If true, <ENTER> will input a \n
     />

--- a/app/src/atoms/SoftwareKeyboard/FullKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/FullKeyboard/index.tsx
@@ -8,6 +8,7 @@ import {
   customDisplay,
   fullKeyboardLayout,
   layoutCandidates,
+  softwareKeyboardButtonAttributes,
 } from '../constants'
 
 import type { MutableRefObject } from 'react'
@@ -154,6 +155,7 @@ export function FullKeyboard({
       display={display}
       mergeDisplay={true}
       useButtonTag={false}
+      buttonAttributes={softwareKeyboardButtonAttributes}
       debug={debug} // If true, <ENTER> will input a \n
       baseClass="fullKeyboard"
       buttonTheme={[

--- a/app/src/atoms/SoftwareKeyboard/FullKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/FullKeyboard/index.tsx
@@ -153,7 +153,7 @@ export function FullKeyboard({
       }
       display={display}
       mergeDisplay={true}
-      useButtonTag={true}
+      useButtonTag={false}
       debug={debug} // If true, <ENTER> will input a \n
       baseClass="fullKeyboard"
       buttonTheme={[

--- a/app/src/atoms/SoftwareKeyboard/IndividualKey/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/IndividualKey/index.tsx
@@ -31,10 +31,6 @@ export function IndividualKey({
     },
   }
   return (
-    /*
-     *  autoUseTouchEvents: for Flex on-device app
-     *  useButtonTag: this is for testing purpose that each key renders as a button
-     */
     <Keyboard
       keyboardRef={r => {
         keyboardRef.current = r

--- a/app/src/atoms/SoftwareKeyboard/IndividualKey/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/IndividualKey/index.tsx
@@ -40,7 +40,7 @@ export function IndividualKey({
       onChange={onChange}
       layoutName="default"
       display={customDisplayForIndividual}
-      useButtonTag={true}
+      useButtonTag={false}
       {...numericalKeyboard}
       width="100%"
       debug={debug} // If true, <ENTER> will input a \n

--- a/app/src/atoms/SoftwareKeyboard/IndividualKey/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/IndividualKey/index.tsx
@@ -1,6 +1,9 @@
 import { KeyboardReact as Keyboard } from 'react-simple-keyboard'
 
-import { customDisplayForIndividual } from '../constants'
+import {
+  customDisplayForIndividual,
+  softwareKeyboardButtonAttributes,
+} from '../constants'
 
 import type { MutableRefObject } from 'react'
 import type { KeyboardReactInterface } from 'react-simple-keyboard'
@@ -41,6 +44,7 @@ export function IndividualKey({
       layoutName="default"
       display={customDisplayForIndividual}
       useButtonTag={false}
+      buttonAttributes={softwareKeyboardButtonAttributes}
       {...numericalKeyboard}
       width="100%"
       debug={debug} // If true, <ENTER> will input a \n

--- a/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/StatelessNumericalKeyboard.tsx
+++ b/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/StatelessNumericalKeyboard.tsx
@@ -1,7 +1,11 @@
 import { useRef } from 'react'
 import { KeyboardReact as Keyboard } from 'react-simple-keyboard'
 
-import { numericalCustom, numericalKeyboardLayout } from '../constants'
+import {
+  numericalCustom,
+  numericalKeyboardLayout,
+  softwareKeyboardButtonAttributes,
+} from '../constants'
 import { applyNumericalKeyboardKey } from '../utils/applyNumericalKeyboardKey'
 import { toNumericalKeyboardKey } from '../utils/toNumericalKeyboardKey'
 
@@ -54,6 +58,7 @@ export function StatelessNumericalKeyboard({
       }}
       display={numericalCustom}
       useButtonTag={false}
+      buttonAttributes={softwareKeyboardButtonAttributes}
       layoutName={layoutName}
       layout={numericalKeyboardLayout}
       debug={debug}

--- a/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/StatelessNumericalKeyboard.tsx
+++ b/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/StatelessNumericalKeyboard.tsx
@@ -53,7 +53,7 @@ export function StatelessNumericalKeyboard({
         )
       }}
       display={numericalCustom}
-      useButtonTag={true}
+      useButtonTag={false}
       layoutName={layoutName}
       layout={numericalKeyboardLayout}
       debug={debug}

--- a/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
@@ -1,6 +1,10 @@
 import { KeyboardReact as Keyboard } from 'react-simple-keyboard'
 
-import { numericalCustom, numericalKeyboardLayout } from '../constants'
+import {
+  numericalCustom,
+  numericalKeyboardLayout,
+  softwareKeyboardButtonAttributes,
+} from '../constants'
 
 import type { MutableRefObject } from 'react'
 import type { KeyboardReactInterface } from 'react-simple-keyboard'
@@ -43,6 +47,7 @@ export function NumericalKeyboard({
       onChange={onChange}
       display={numericalCustom}
       useButtonTag={false}
+      buttonAttributes={softwareKeyboardButtonAttributes}
       layoutName={layoutName}
       layout={numericalKeyboardLayout}
       debug={debug} // If true, <ENTER> will input a \n

--- a/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
@@ -32,10 +32,6 @@ export function NumericalKeyboard({
   }`
 
   return (
-    /*
-     *  autoUseTouchEvents: for Flex on-device app
-     *  useButtonTag: this is for testing purpose that each key renders as a button
-     */
     <Keyboard
       keyboardRef={r => {
         keyboardRef.current = r
@@ -46,7 +42,7 @@ export function NumericalKeyboard({
       }}
       onChange={onChange}
       display={numericalCustom}
-      useButtonTag={true}
+      useButtonTag={false}
       layoutName={layoutName}
       layout={numericalKeyboardLayout}
       debug={debug} // If true, <ENTER> will input a \n

--- a/app/src/atoms/SoftwareKeyboard/constants.ts
+++ b/app/src/atoms/SoftwareKeyboard/constants.ts
@@ -6,6 +6,23 @@ type LayoutCandidates =
     }
   | undefined
 
+/**
+ * Hack:
+ *
+ * Software keyboard buttons render as non-focusable <div>s (`useButtonTag={false}`) so
+ * they stay out of tab order and don't steal focus from inputs. This is OK. However,
+ * we have a lot of preexisting tests that were expecting real <button>s and looking
+ * for `role="button"`. This restores the role for the tests' sake.
+ *
+ * This is a half-measure and a lie to accessibility tech. We could use real
+ * <button>s and fix the focusability issues in some other way (but beware of
+ * issues like https://github.com/hodgef/react-simple-keyboard/issues/44).
+ * Or we could rewrite the tests to not rely on `role`.
+ */
+export const softwareKeyboardButtonAttributes = [
+  { attribute: 'role', value: 'button' },
+]
+
 export const customDisplay = {
   '{numbers}': '123',
   '{shift}': 'ABC',


### PR DESCRIPTION
## Overview

By default, `react-simple-keyboard` renders our on-screen keyboard as a bunch of `<div>` tags with `onclick` handlers. We were overriding that to make it render as `<button>` tags. That turns out to be problematic, so this PR restores the `<div>` default.

I've seen two problems with the `<button>` tags:

* The on-screen keyboard buttons take space in the page's tab order. This means, when you have an external keyboard plugged in, the on-screen keyboard will get in the way of using the external keyboard to navigate to "real" inputs like submit buttons.
* Tapping an on-screen keyboard button steals focus away from "real" inputs like text fields. We have a habit of working around this by overriding `onBlur()` on all our text fields. But that causes other problems, especially when there are multiple fields on screen at once.

So although it is *normally* a good idea for buttons to be real `<button>`s, in this case it does more harm than good.

This closes EXEC-2822.

## Test Plan and Hands on Testing

* [x] The on-screen keyboard still works.
  * [x] Smoke-tested on the login screen.
* [x] The on-screen keyboard buttons cannot be focused anymore by pressing the Tab key on an external keyboard. (You need to use Chrome dev tools to see this—the focus state is invisible.)

## Review requests

* Agreed in principle?
* Is my testing hack acceptable for now?

## Risk assessment

Low. As far as I can tell, this should be pretty harmless?