### PR TITLE
fix(components): flex trash tag rotated 180 degrees

### DIFF
--- a/components/src/hardware-sim/Deck/FlexTrash.tsx
+++ b/components/src/hardware-sim/Deck/FlexTrash.tsx
@@ -99,9 +99,7 @@ export const FlexTrash = ({
   // DeckLabelSet must stay outside the SVG rotate so its text stays rotated correctly
   // for column 1, place it relative to the trash AABB after the 180degree rotation
   const isRotated = rotateDegrees === '180'
-  const labelX = isRotated
-    ? 2 * rotateXCoord - trashX - xDimension
-    : trashX
+  const labelX = isRotated ? 2 * rotateXCoord - trashX - xDimension : trashX
   const labelY = isRotated
     ? 2 * rotateYCoord - trashY - yDimension - HEIGHT_OF_TAG
     : trashY - HEIGHT_OF_TAG

--- a/components/src/hardware-sim/Deck/FlexTrash.tsx
+++ b/components/src/hardware-sim/Deck/FlexTrash.tsx
@@ -93,73 +93,89 @@ export const FlexTrash = ({
   // rotate trash around x,y midpoint of standard slot bounding box
   const rotateXCoord = x + slotXDimension / 2
   const rotateYCoord = y + slotYDimension / 2
+  const trashX = x + xAdjustment
+  const trashY = y + yAdjustment
+
+  // DeckLabelSet must stay outside the SVG rotate so its text stays rotated correctly
+  // for column 1, place it relative to the trash AABB after the 180degree rotation
+  const isRotated = rotateDegrees === '180'
+  const labelX = isRotated
+    ? 2 * rotateXCoord - trashX - xDimension
+    : trashX
+  const labelY = isRotated
+    ? 2 * rotateYCoord - trashY - yDimension - HEIGHT_OF_TAG
+    : trashY - HEIGHT_OF_TAG
 
   return x != null && y != null && xDimension != null && yDimension != null ? (
-    <g transform={`rotate(${rotateDegrees}, ${rotateXCoord}, ${rotateYCoord})`}>
-      <RobotCoordsForeignObject
-        width={xDimension}
-        height={yDimension}
-        x={x + xAdjustment}
-        y={y + yAdjustment}
-        flexProps={{
-          flex: '1',
-        }}
-        flexEvents={{
-          onClick: onClick,
-          onMouseEnter: onMouseEnter,
-          onMouseLeave: onMouseLeave,
-        }}
-        foreignObjectProps={{
-          flex: '1',
-          cursor: onClick != null ? 'pointer' : 'default',
-        }}
+    <>
+      <g
+        transform={`rotate(${rotateDegrees}, ${rotateXCoord}, ${rotateYCoord})`}
       >
-        <div
-          className={clsx(styles.trash_container, {
-            [styles.trash_container_highlight]: showHighlight,
-          })}
-          style={{ backgroundColor }}
+        <RobotCoordsForeignObject
+          width={xDimension}
+          height={yDimension}
+          x={trashX}
+          y={trashY}
+          flexProps={{
+            flex: '1',
+          }}
+          flexEvents={{
+            onClick: onClick,
+            onMouseEnter: onMouseEnter,
+            onMouseLeave: onMouseLeave,
+          }}
+          foreignObjectProps={{
+            flex: '1',
+            cursor: onClick != null ? 'pointer' : 'default',
+          }}
         >
-          {rotateDegrees === '180' ? (
-            <div
-              className={styles.trash_container_rotate_copy}
-              style={{ transform: `rotate(${rotateDegrees}deg)` }}
-            >
+          <div
+            className={clsx(styles.trash_container, {
+              [styles.trash_container_highlight]: showHighlight,
+            })}
+            style={{ backgroundColor }}
+          >
+            {isRotated ? (
+              <div
+                className={styles.trash_container_rotate_copy}
+                style={{ transform: `rotate(${rotateDegrees}deg)` }}
+              >
+                <PlaceholderStyledText
+                  color={COLORS.white}
+                  desktopStyle="bodyDefaultSemiBold"
+                >
+                  Trash bin
+                </PlaceholderStyledText>
+              </div>
+            ) : null}
+            <Icon
+              name="trash"
+              color={trashIconColor}
+              height="2rem"
+              // rotate icon back 180 degrees
+              transform={`rotate(${rotateDegrees}deg)`}
+              transformOrigin="center"
+            />
+            {!isRotated ? (
               <PlaceholderStyledText
                 color={COLORS.white}
                 desktopStyle="bodyDefaultSemiBold"
               >
                 Trash bin
               </PlaceholderStyledText>
-            </div>
-          ) : null}
-          <Icon
-            name="trash"
-            color={trashIconColor}
-            height="2rem"
-            // rotate icon back 180 degrees
-            transform={`rotate(${rotateDegrees}deg)`}
-            transformOrigin="center"
-          />
-          {rotateDegrees === '0' ? (
-            <PlaceholderStyledText
-              color={COLORS.white}
-              desktopStyle="bodyDefaultSemiBold"
-            >
-              Trash bin
-            </PlaceholderStyledText>
-          ) : null}
-        </div>
-      </RobotCoordsForeignObject>
+            ) : null}
+          </div>
+        </RobotCoordsForeignObject>
+      </g>
       {tagInfo != null && tagInfo.length > 0 ? (
         <DeckLabelSet
           width={xDimension}
           height={yDimension}
-          x={x + xAdjustment}
-          y={y + yAdjustment - HEIGHT_OF_TAG}
+          x={labelX}
+          y={labelY}
           deckLabels={tagInfo}
         />
       ) : null}
-    </g>
+    </>
   ) : null
 }


### PR DESCRIPTION
# Overview
closes https://opentrons.atlassian.net/browse/AUTH-3063

<img width="351" height="286" alt="Screenshot 2026-07-15 at 09 10 33" src="https://github.com/user-attachments/assets/bde91b6c-4db5-4ee4-8ef7-b029a71ae42c" />

rotate the tag over the flexTrash 180 degrees

## Test Plan and Hands on Testing

Test the protocol attached to the ticket. the deck label set should be the correct direction for trash bins on the left slots

## Changelog

add logic to rotate the `DeckLabelSet` if the trash bin is on a left most slot

## Risk assessment

medium - `Flextrash` is used in every flex render with a trash bin but shouldn't affect the render itself, just the tag that is only used in PV
