### PR TITLE
feat(app,odd): documentation for pause run mutation

### DIFF
--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -30,6 +30,7 @@
   "launching_error_recovery": "Launching error recovery",
   "left_mount": "left mount",
   "lpc_flow": "Launching labware position check",
+  "pause_run": "Pausing protocol run",
   "pipette_wizard_flow": "{{flowtype}} {{pipette}} pipette on {{mount}}",
   "place_plate_reader_lid": "Placing plate reader lid",
   "play_run": "Playing protocol",

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -152,6 +152,7 @@ type AuditLogAction =
   | 'retry_action'
   | 'shutdown_robot'
   | 'update_robot_name'
+  | 'pause_run'
 
 /**
  * Type used for DocumentedActions - keys and info to enable correct rendering of actions in the 'list actions' popup in the Documentation Required Modal.

--- a/react-api-client/src/runs/__tests__/usePauseRunMutation.test.tsx
+++ b/react-api-client/src/runs/__tests__/usePauseRunMutation.test.tsx
@@ -6,6 +6,7 @@ import { createRunAction } from '@opentrons/api-client'
 
 import { usePauseRunMutation } from '..'
 import { mockPauseRunAction, RUN_ID_1 } from '../__fixtures__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../accessControl/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -36,9 +37,12 @@ describe('usePauseRunMutation hook', () => {
     vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
     vi.mocked(createRunAction).mockRejectedValue('uh oh')
 
-    const { result } = renderHook(usePauseRunMutation, {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => usePauseRunMutation(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+      {
+        wrapper,
+      }
+    )
 
     expect(result.current.data).toBeUndefined()
     act(() => result.current.pauseRun(RUN_ID_1))
@@ -53,9 +57,12 @@ describe('usePauseRunMutation hook', () => {
       data: mockPauseRunAction,
     } as Response<RunAction>)
 
-    const { result } = renderHook(usePauseRunMutation, {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => usePauseRunMutation(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+      {
+        wrapper,
+      }
+    )
     act(() => result.current.pauseRun(RUN_ID_1))
 
     await waitFor(() => {

--- a/react-api-client/src/runs/usePauseRunMutation.ts
+++ b/react-api-client/src/runs/usePauseRunMutation.ts
@@ -1,7 +1,6 @@
-import { useMutation } from 'react-query'
-
 import { createRunAction, RUN_ACTION_TYPE_PAUSE } from '@opentrons/api-client'
 
+import { useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
 import type { AxiosError } from 'axios'
@@ -11,6 +10,7 @@ import type {
   UseMutationResult,
 } from 'react-query'
 import type { RunAction } from '@opentrons/api-client'
+import type { DocumentationState } from '../accessControl'
 
 export type UsePauseRunMutationResult = UseMutationResult<
   RunAction,
@@ -27,15 +27,23 @@ export type UsePauseRunMutationOptions = UseMutationOptions<
 >
 
 export const usePauseRunMutation = (
+  documentationState: DocumentationState,
   options: UsePauseRunMutationOptions = {}
 ): UsePauseRunMutationResult => {
   const host = useHost()
-  const mutation = useMutation<RunAction, AxiosError, string>(
+  const mutation = useDocumentedMutation<RunAction, AxiosError, string>(
+    documentationState,
+    ['pause_run'],
     getQueryKey(host, 'runs', RUN_ACTION_TYPE_PAUSE),
-    (runId: string) =>
-      createRunAction(host!, runId, {
-        actionType: RUN_ACTION_TYPE_PAUSE,
-      })
+    ({ variables: runId, userNotes }) =>
+      createRunAction(
+        host!,
+        runId,
+        {
+          actionType: RUN_ACTION_TYPE_PAUSE,
+        },
+        userNotes
+      )
         .then(response => response.data)
         .catch(e => {
           throw e

--- a/react-api-client/src/runs/useRunActionMutations.ts
+++ b/react-api-client/src/runs/useRunActionMutations.ts
@@ -48,9 +48,12 @@ export function useRunActionMutations(
     }
   )
 
-  const { pauseRun, isLoading: isPauseRunActionLoading } = usePauseRunMutation({
-    onSuccess,
-  })
+  const { pauseRun, isLoading: isPauseRunActionLoading } = usePauseRunMutation(
+    documentationState,
+    {
+      onSuccess,
+    }
+  )
 
   const { stopRun, isLoading: isStopRunActionLoading } =
     useStopRunMutation(documentationState)


### PR DESCRIPTION
# Overview

Documentation state for the pause run mutation.


## Test Plan and Hands on Testing

1. Run a protocol on a CRS bot
2. Pause it, the documentation modal should pop up
3. Dismissing the documentation modal should not change the run. Submitting it should pause the run

## Review requests

Hey uh so when you go to pause a run you have to type a reason before you pause it? should we change this to after?

## Risk assessment

Low