### PR TITLE
fix(api, robot-server): unblock LPC for protocols with vacuum module + simulator changes to enable LPC

### DIFF
--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -2378,6 +2378,11 @@ class OT3API(
         follow_singular_sensor: Optional[InstrumentProbeType] = None,
     ) -> None:
         real_mount = OT3Mount.from_mount(mount)
+        if isinstance(self._backend, OT3Simulator) and expected == TipStateType.PRESENT:
+            # The simulator has no physical tip/probe sensors. LPC and other
+            # calibration flows call verify_tip_presence after the user attaches
+            # a probe; simulate that attachment here.
+            self._backend._update_tip_state(real_mount, True)
         status = await self.get_tip_presence_status(real_mount, follow_singular_sensor)
         if status != expected:
             raise FailedTipStateCheck(

--- a/api/src/opentrons/protocol_engine/state/labware.py
+++ b/api/src/opentrons/protocol_engine/state/labware.py
@@ -1189,6 +1189,13 @@ class LabwareView:
             return False
 
         labware_definition = self.get_definition(labware_id)
+
+        # Labware staged off-deck for maintenance runs are not physically stacked.
+        # Skip containedSpace checks so unrelated off-deck labware (e.g. a collar and
+        # a plate loaded separately for LPC) can be moved independently.
+        if labware.location == OFF_DECK_LOCATION:
+            return True
+
         # Check every other loaded labware to see if any contains this one
         for container in self.get_all():
             if container.id == labware_id:

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -620,6 +620,32 @@ def mock_backend_get_tip_status(hardware_backend: OT3Simulator) -> Iterator[Asyn
         yield mock_tip_status
 
 
+async def test_verify_tip_presence_simulates_probe_attachment_on_simulator(
+    ot3_hardware: ThreadManager[OT3API],
+    managed_obj: OT3API,
+    hardware_backend: OT3Simulator,
+) -> None:
+    """Simulator tip sensors are absent; verifying PRESENT should succeed."""
+    pipette_config = load_pipette_data.load_definition(
+        PipetteModelType("p1000"),
+        PipetteChannelType(8),
+        PipetteVersionType(3, 4),
+        PipetteOEMType.OT,
+    )
+    instr_data = AttachedPipette(config=pipette_config, id="fakepip")
+    await ot3_hardware.cache_pipette(OT3Mount.RIGHT, instr_data, None)
+
+    assert hardware_backend.current_tip_state(OT3Mount.RIGHT) is False
+
+    await managed_obj.verify_tip_presence(
+        OT3Mount.RIGHT,
+        TipStateType.PRESENT,
+        InstrumentProbeType.PRIMARY,
+    )
+
+    assert hardware_backend.current_tip_state(OT3Mount.RIGHT) is True
+
+
 @pytest.fixture
 def mock_verify_tip_presence(
     managed_obj: OT3API,

--- a/api/tests/opentrons/protocol_engine/state/test_labware_state.py
+++ b/api/tests/opentrons/protocol_engine/state/test_labware_state.py
@@ -8,9 +8,15 @@ import pytest
 
 from opentrons_shared_data.deck.types import DeckDefinitionV5
 from opentrons_shared_data.labware.labware_definition import (
+    ContainedSpace,
+    ContainmentShape,
+    Dimensions,
+    LabwareDefinition2,
     LabwareDefinition3,
+    Parameters2,
     Parameters3,
     RectangularWellDefinition3,
+    Vector3D,
 )
 
 from opentrons.protocol_engine import actions, commands, errors
@@ -19,7 +25,11 @@ from opentrons.protocol_engine.state.labware import (
     LabwareStore,
     LabwareView,
 )
-from opentrons.protocol_engine.types import DeckSlotLocation, LoadedLabware
+from opentrons.protocol_engine.types import (
+    OFF_DECK_LOCATION,
+    DeckSlotLocation,
+    LoadedLabware,
+)
 from opentrons.types import DeckSlotName
 
 
@@ -152,3 +162,53 @@ def test_raise_if_wells_are_invalid(ot3_standard_deck_def: DeckDefinitionV5) -> 
         )
     with pytest.raises(errors.WellDoesNotExistError):
         subject_view.raise_if_wells_are_invalid("labware-id", ["well-5"])
+
+
+def test_raise_if_labware_is_contained_ignores_off_deck_labware(
+    ot3_standard_deck_def: DeckDefinitionV5,
+) -> None:
+    """Unrelated labware staged off-deck should not block each other's moves."""
+    subject = LabwareStore(deck_definition=ot3_standard_deck_def, deck_fixed_labware=[])
+    subject_view = LabwareView(subject.state)
+
+    collar_definition = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+        namespace="opentrons",
+        version=1,
+        schemaVersion=2,
+        parameters=Parameters2.model_construct(loadName="vacuum_collar"),  # type: ignore[call-arg]
+        containedSpace=ContainedSpace(
+            shape=ContainmentShape.rectangular,
+            origin=Vector3D(x=0, y=0, z=0),
+            dimensions=Dimensions(xDimension=127.76, yDimension=85.48, zDimension=45.0),
+        ),
+    )
+    plate_definition = LabwareDefinition2.model_construct(  # type: ignore[call-arg]
+        namespace="opentrons",
+        version=5,
+        schemaVersion=2,
+        parameters=Parameters2.model_construct(  # type: ignore[call-arg]
+            loadName="corning_96_wellplate_360ul_flat"
+        ),
+        dimensions=Dimensions(xDimension=127.76, yDimension=85.48, zDimension=14.22),
+    )
+
+    for labware_id, definition in (
+        ("collar-id", collar_definition),
+        ("plate-id", plate_definition),
+    ):
+        subject.handle_action(
+            actions.SucceedCommandAction(
+                state_update=update_types.StateUpdate(
+                    loaded_labware=update_types.LoadedLabwareUpdate(
+                        labware_id=labware_id,
+                        new_location=OFF_DECK_LOCATION,
+                        offset_id=None,
+                        display_name=None,
+                        definition=definition,
+                    )
+                ),
+                command=_dummy_command(),
+            )
+        )
+
+    assert subject_view.raise_if_labware_is_contained("plate-id") is True

--- a/robot-server/robot_server/hardware.py
+++ b/robot-server/robot_server/hardware.py
@@ -61,6 +61,7 @@ from .errors.robot_errors import (
 from .robot.control.estop_handler import EstopHandler
 from .service.task_runner import TaskRunner, get_task_runner
 from .settings import RobotServerSettings, get_settings
+from .simulator_calibration_seed import seed_simulator_calibration
 from .subsystems.firmware_update_manager import (
     FirmwareUpdateManager,
     UpdateProcessHandle,
@@ -484,9 +485,12 @@ async def _postinit_ot3_tasks(
     )
 
     hardware = cast("OT3API", hardware_resource)
+    settings = get_settings()
 
     try:
         await _do_updates(hardware, update_manager)
+        if settings.simulator_configuration_file_path is not None:
+            seed_simulator_calibration(Path(settings.simulator_configuration_file_path))
         await hardware.cache_instruments()
         await _home_on_boot(hardware)
         await hardware.set_status_bar_state(StatusBarState.ACTIVATION)

--- a/robot-server/robot_server/simulator_calibration_seed.py
+++ b/robot-server/robot_server/simulator_calibration_seed.py
@@ -1,0 +1,128 @@
+r"""Seed fake calibration data for OT-3 hardware simulators.
+
+Dev simulators attach instruments with default (uncalibrated) offsets. The desktop
+app requires calibratedOffset.last_modified and moduleOffset.last_modified before
+LPC can proceed. This module writes zero-offset user calibrations for every
+instrument and module declared in a simulator configuration file.
+
+Robot-server auto-seeds on startup when `simulator_configuration_file_path` is set.
+To seed manually:
+
+    uv run python -m robot_server.simulator_calibration_seed \\
+        simulators/test-flex-vm-combos.json
+"""
+
+import argparse
+import logging
+from pathlib import Path
+
+from opentrons.calibration_storage.ot3 import (
+    save_module_calibration,
+    save_pipette_calibration,
+)
+from opentrons.calibration_storage.ot3.gripper_offset import save_gripper_calibration
+from opentrons.hardware_control.modules.types import ModuleType
+from opentrons.hardware_control.simulator_setup import (
+    OT3SimulatorSetup,
+    load_simulator_setup,
+)
+from opentrons.hardware_control.types import OT3Mount
+from opentrons.types import Point
+
+log = logging.getLogger(__name__)
+
+# Keys match simulator JSON `attached_modules` entries and SimulatingModule.name().
+_MODULE_KEY_TO_TYPE: dict[str, ModuleType] = {
+    "thermocycler": ModuleType.THERMOCYCLER,
+    "tempdeck": ModuleType.TEMPERATURE,
+    "heatershaker": ModuleType.HEATER_SHAKER,
+    "magdeck": ModuleType.MAGNETIC,
+    "flexstacker": ModuleType.FLEX_STACKER,
+    "vacuummodule": ModuleType.VACUUM_MODULE,
+}
+
+_DEFAULT_MODULE_SLOT = "B1"
+_DEFAULT_MODULE_MOUNT = OT3Mount.LEFT
+
+
+def _get_calibration_instrument_id(setup: OT3SimulatorSetup) -> str:
+    for mount, instrument in setup.attached_instruments.items():
+        if mount != OT3Mount.GRIPPER:
+            instrument_id = instrument.get("id")
+            if instrument_id is not None:
+                return instrument_id
+    return "simulator-calibration-instrument"
+
+
+def seed_simulator_calibration(simulator_config_path: Path) -> None:
+    """Write fake calibration files for a simulator configuration."""
+    setup = load_simulator_setup(simulator_config_path)
+    if not isinstance(setup, OT3SimulatorSetup):
+        log.info(
+            "Skipping simulator calibration seed for non-OT-3 machine: %s",
+            setup.machine,
+        )
+        return
+
+    zero_offset = Point(0, 0, 0)
+    calibration_instrument_id = _get_calibration_instrument_id(setup)
+
+    for mount, instrument in setup.attached_instruments.items():
+        instrument_id = instrument.get("id")
+        if instrument_id is None:
+            continue
+        if mount == OT3Mount.GRIPPER:
+            save_gripper_calibration(zero_offset, instrument_id)
+            log.info("Seeded gripper calibration for %s", instrument_id)
+        else:
+            save_pipette_calibration(zero_offset, instrument_id, mount.to_mount())
+            log.info(
+                "Seeded pipette calibration for %s on %s",
+                instrument_id,
+                mount.name,
+            )
+
+    for module_key, modules in setup.attached_modules.items():
+        module_type = _MODULE_KEY_TO_TYPE.get(module_key)
+        if module_type is None:
+            log.warning(
+                "Skipping module calibration seed for unknown module key: %s",
+                module_key,
+            )
+            continue
+        for module in modules:
+            save_module_calibration(
+                zero_offset,
+                _DEFAULT_MODULE_MOUNT,
+                _DEFAULT_MODULE_SLOT,
+                module_type,
+                module.serial_number,
+                calibration_instrument_id,
+            )
+            log.info(
+                "Seeded module calibration for %s (%s)",
+                module.serial_number,
+                module_key,
+            )
+
+
+def main() -> int:
+    """Parse arguments and seed simulator calibration data."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "simulator_config",
+        type=Path,
+        help="Path to simulator JSON configuration file",
+    )
+    args = parser.parse_args()
+    if not args.simulator_config.is_file():
+        log.error("Simulator config not found: %s", args.simulator_config)
+        return 1
+    seed_simulator_calibration(args.simulator_config)
+    log.info("Seeded calibration data for %s", args.simulator_config)
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    raise SystemExit(main())

--- a/robot-server/tests/integration/conftest.py
+++ b/robot-server/tests/integration/conftest.py
@@ -79,17 +79,17 @@ def _ot2_session_server(
 
 @pytest.fixture(scope="session")
 def _ot3_session_server(
-    server_temp_directory: str,
     # We need unused_tcp_port_factory instead of unused_tcp_port to avoid a ScopeMismatch
     # error, since it's function-scoped and we're session-scoped.
     unused_tcp_port_factory: Callable[[], int],
 ) -> Generator[str, None, None]:
+    # Use a dedicated OT_API_CONFIG_DIR so Flex simulator calibration seeding
+    # cannot leak module offsets into the shared OT-2 session server.
     port = unused_tcp_port_factory()
     base_url = f"{_SESSION_SERVER_SCHEME}{_SESSION_SERVER_HOST}:{port}"
     with DevServer(
         port=str(port),
         is_ot3=True,
-        ot_api_config_dir=Path(server_temp_directory),
     ) as dev_server:
         dev_server.start()
         _wait_until_ready(base_url)

--- a/robot-server/tests/integration/test_modules.tavern.yaml
+++ b/robot-server/tests/integration/test_modules.tavern.yaml
@@ -225,6 +225,7 @@ stages:
             compatibleWithRobot: true
             moduleType: thermocyclerModuleType
             moduleModel: thermocyclerModuleV2
+            moduleOffset: !anydict
             usbPort:
               port: !anyint
               hub: !anybool
@@ -247,6 +248,7 @@ stages:
             compatibleWithRobot: true
             moduleType: heaterShakerModuleType
             moduleModel: heaterShakerModuleV1
+            moduleOffset: !anydict
             usbPort:
               port: !anyint
               hub: !anybool
@@ -267,6 +269,7 @@ stages:
             compatibleWithRobot: true
             moduleType: flexStackerModuleType
             moduleModel: flexStackerModuleV1
+            moduleOffset: !anydict
             usbPort:
               port: !anyint
               hub: !anybool
@@ -286,6 +289,7 @@ stages:
             compatibleWithRobot: true
             moduleType: flexStackerModuleType
             moduleModel: flexStackerModuleV1
+            moduleOffset: !anydict
             usbPort:
               port: !anyint
               hub: !anybool
@@ -305,6 +309,7 @@ stages:
             compatibleWithRobot: true
             moduleType: temperatureModuleType
             moduleModel: temperatureModuleV2
+            moduleOffset: !anydict
             usbPort:
               port: !anyint
               hub: !anybool
@@ -322,6 +327,7 @@ stages:
             compatibleWithRobot: true
             moduleType: temperatureModuleType
             moduleModel: temperatureModuleV2
+            moduleOffset: !anydict
             usbPort:
               port: !anyint
               hub: !anybool


### PR DESCRIPTION
# Overview

Unblocks Labware Position Check (LPC) when running the Flex hardware, + lets make changes to make it easier to simulate LPC and seed a dev robot-server with calibration data.

Three issues prevented LPC from completing:

1. Off-deck labware staged for maintenance runs was incorrectly blocked by `containedSpace` overlap checks.
2. The simulator has no physical probe sensors, so `verify_tip_presence` failed after the attach-probe step.
3. The desktop app requires calibrated offsets before LPC, but simulators start uncalibrated.

Closes: [RQA-5645](https://opentrons.atlassian.net/browse/RQA-5645)

# Test Plan and Hands on Testing

- Verified LPC end-to-end with `make dev-flex` using `simulators/test-flex-vm-combos.json` and the desktop app connected via `127.0.0.1:31950`. I'm able to correctly get through LPC, assign offsets to all labware, and run the protocol.

# Changelog

- Skip `containedSpace` checks for labware staged off-deck during maintenance runs.
- Simulate probe attachment in the OT-3 simulator when verifying tip presence during LPC.
- Seed zero-offset pipette, gripper, and module calibrations on simulator startup.

# Review requests

- Confirm the off-deck containment skip is scoped narrowly enough for maintenance-run flows.
- Sanity-check that auto-seeding calibrations on simulator startup are acceptable for dev workflows.

# Risk assessment

Low risk.

[RQA-5645]: https://opentrons.atlassian.net/browse/RQA-5645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ