### PR TITLE
feat(app,odd): document update deck configuration

### DIFF
--- a/api-client/src/deck_configuration/updateDeckConfiguration.ts
+++ b/api-client/src/deck_configuration/updateDeckConfiguration.ts
@@ -10,12 +10,13 @@ import type {
 
 export function updateDeckConfiguration(
   config: HostConfig,
-  deckConfig: DeckConfiguration
+  deckConfig: DeckConfiguration,
+  userNotes: string
 ): ResponsePromise<DeckConfigurationResponse> {
   return request<DeckConfigurationResponse, UpdateDeckConfigurationRequest>(
     PUT,
     '/deck_configuration',
     config,
-    { body: { data: { cutoutFixtures: deckConfig } } }
+    { body: { data: { cutoutFixtures: deckConfig } }, userNotes }
   )
 }

--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -1,6 +1,6 @@
 {
   "96_channel": "96 channel",
-  "add_module": "Adding module to deck configuration",
+  "add_module": "Launching module setup flow",
   "attach": "Attaching",
   "attach_gripper": "Attaching gripper",
   "attach_module": "Launching setup flow for {{module}}",
@@ -41,5 +41,6 @@
   "shutdown_robot": "Shutting down robot",
   "single_channel_and_8_channel": "single channel or 8 channel",
   "stop_run": "Stopping protocol run",
+  "update_deck_configuration": "Updating deck configuration",
   "update_robot_name": "Updating robot name"
 }

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal.tsx
@@ -10,10 +10,7 @@ import {
   SPACING,
   StyledText,
 } from '@opentrons/components'
-import {
-  useModulesQuery,
-  useUpdateDeckConfigurationMutation,
-} from '@opentrons/react-api-client'
+import { useModulesQuery } from '@opentrons/react-api-client'
 import {
   getAADisplayName,
   getFixtureDisplayName,
@@ -45,6 +42,7 @@ import type {
   CutoutConfigMap,
   CutoutFixtureId,
   CutoutId,
+  DeckConfiguration,
   DeckDefinition,
 } from '@opentrons/shared-data'
 import type { OddModalHeaderBaseProps } from '/app/molecules/OddModal/types'
@@ -59,6 +57,7 @@ interface AddFixtureModalProps {
   deckDef: DeckDefinition
   isOnDevice?: boolean
   existingCutoutFixtureId?: CutoutFixtureId
+  updateDeckConfiguration: (deckConfig: DeckConfiguration) => void
 }
 type OptionStage =
   | 'modulesOrFixtures'
@@ -74,13 +73,13 @@ export function AddFixtureModal({
   isOnDevice = false,
   deckDef,
   existingCutoutFixtureId,
+  updateDeckConfiguration,
 }: AddFixtureModalProps): JSX.Element {
   const { t } = useTranslation([
     'device_details',
     'shared',
     'deck_configuration',
   ])
-  const { updateDeckConfiguration } = useUpdateDeckConfigurationMutation()
   const { data: modulesData } = useModulesQuery()
   const deckConfig = useNotifyDeckConfigurationQuery()?.data ?? []
 

--- a/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/AddFixtureModal.test.tsx
+++ b/app/src/organisms/DeviceDetailsDeckConfiguration/__tests__/AddFixtureModal.test.tsx
@@ -12,6 +12,7 @@ import {
 } from '@opentrons/shared-data'
 
 import { renderWithProviders } from '/app/__testing-utils__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 
 import { useSendIdentifyModule } from '../../ModuleWizardFlows/hooks'
@@ -46,6 +47,12 @@ vi.mock('i18next', () => {
   }
 })
 
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: vi
+    .fn()
+    .mockReturnValue(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+}))
+
 const mockCloseModal = vi.fn()
 const mockUpdateDeckConfiguration = vi.fn()
 const deckDef = getDeckDefFromRobotType('OT-3 Standard')
@@ -77,6 +84,7 @@ describe('Touchscreen AddFixtureModal', () => {
       addressableAreaId: 'D3',
       closeModal: mockCloseModal,
       deckDef,
+      updateDeckConfiguration: mockUpdateDeckConfiguration,
     }
     vi.mocked(useUpdateDeckConfigurationMutation).mockReturnValue({
       updateDeckConfiguration: mockUpdateDeckConfiguration,
@@ -130,6 +138,7 @@ describe('Desktop AddFixtureModal', () => {
       addressableAreaId: 'D3',
       closeModal: mockCloseModal,
       deckDef,
+      updateDeckConfiguration: mockUpdateDeckConfiguration,
     }
     vi.mocked(useUpdateDeckConfigurationMutation).mockReturnValue({
       updateDeckConfiguration: mockUpdateDeckConfiguration,

--- a/app/src/organisms/LocationConflictModal/LocationConflictModal.tsx
+++ b/app/src/organisms/LocationConflictModal/LocationConflictModal.tsx
@@ -46,6 +46,7 @@ import {
 
 import { getTopPortalEl } from '/app/App/portal'
 import { SmallButton } from '/app/atoms/buttons/SmallButton'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 
@@ -93,7 +94,9 @@ export const LocationConflictModal = (
 
   const [showModuleSelect, setShowModuleSelect] = useState(false)
   const deckConfig = useNotifyDeckConfigurationQuery().data ?? []
-  const { updateDeckConfiguration } = useUpdateDeckConfigurationMutation()
+  const documentationState = useDocumentationState()
+  const { updateDeckConfiguration } =
+    useUpdateDeckConfigurationMutation(documentationState)
   const deckConfigurationAtLocationFixtureId = deckConfig.find(
     (deckFixture: CutoutConfig) => deckFixture.cutoutId === cutoutId
   )?.cutoutFixtureId

--- a/app/src/organisms/LocationConflictModal/NotConfiguredModal.tsx
+++ b/app/src/organisms/LocationConflictModal/NotConfiguredModal.tsx
@@ -17,6 +17,7 @@ import {
 } from '@opentrons/shared-data'
 
 import { getTopPortalEl } from '/app/App/portal'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { ODDFixtureOption } from '/app/molecules/ODDFixtureOption'
 import { OddModal } from '/app/molecules/OddModal'
 import { patchDeckConfigForRequiredFixture } from '/app/organisms/LocationConflictModal/patchDeckConfigForRequiredFixture'
@@ -41,7 +42,9 @@ export const NotConfiguredModal = (
     'shared',
     'deck_configuration',
   ])
-  const { updateDeckConfiguration } = useUpdateDeckConfigurationMutation()
+  const documentationState = useDocumentationState()
+  const { updateDeckConfiguration } =
+    useUpdateDeckConfigurationMutation(documentationState)
   const deckConfig = useNotifyDeckConfigurationQuery()?.data ?? []
 
   const handleUpdateDeck = (): void => {

--- a/app/src/organisms/LocationConflictModal/__tests__/LocationConflictModal.test.tsx
+++ b/app/src/organisms/LocationConflictModal/__tests__/LocationConflictModal.test.tsx
@@ -18,6 +18,7 @@ import {
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import {
   mockFlexStacker,
   mockHeaterShaker,
@@ -38,6 +39,12 @@ vi.mock('/app/resources/deck_configuration')
 vi.mock('/app/resources/runs')
 vi.mock('/app/organisms/ModuleCard/utils')
 vi.mock('/app/organisms/ModuleWizardFlows/hooks.tsx')
+
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: vi
+    .fn()
+    .mockReturnValue(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+}))
 
 const mockFixture = {
   cutoutId: 'cutoutB3',

--- a/app/src/organisms/LocationConflictModal/__tests__/NotConfiguredModal.test.tsx
+++ b/app/src/organisms/LocationConflictModal/__tests__/NotConfiguredModal.test.tsx
@@ -6,6 +6,7 @@ import { TRASH_BIN_ADAPTER_FIXTURE } from '@opentrons/shared-data'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 
 import { NotConfiguredModal } from '../NotConfiguredModal'
@@ -16,6 +17,12 @@ import type { DeckConfiguration } from '@opentrons/shared-data'
 
 vi.mock('@opentrons/react-api-client')
 vi.mock('/app/resources/deck_configuration')
+
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: vi
+    .fn()
+    .mockReturnValue(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+}))
 
 const render = (props: ComponentProps<typeof NotConfiguredModal>) => {
   return renderWithProviders(<NotConfiguredModal {...props} />, {

--- a/app/src/organisms/ModuleWizardFlows/SelectLocation.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectLocation.tsx
@@ -9,7 +9,6 @@ import {
   StyledText,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { useUpdateDeckConfigurationMutation } from '@opentrons/react-api-client'
 import {
   COMBO_FIXTURES,
   FAKE_FIXTURE_IDS,
@@ -64,6 +63,7 @@ export interface SelectLocationProps extends ModuleSetupWizardMaybePipetteStepPr
   deckConfig: DeckConfiguration
   createMaintenanceRun: CreateMaintenanceRunType
   isLoadedInRun: boolean
+  updateDeckConfiguration: (deckConfig: DeckConfiguration) => void
 }
 export function SelectLocation(props: SelectLocationProps): JSX.Element {
   const {
@@ -75,6 +75,7 @@ export function SelectLocation(props: SelectLocationProps): JSX.Element {
     maintenanceRunId,
     setErrorMessage,
     setIsDoorOpenError,
+    updateDeckConfiguration,
   } = props
 
   const configuredFixtureIdByCutoutId = getFixtureIdByCutoutIdForModule(
@@ -108,7 +109,6 @@ export function SelectLocation(props: SelectLocationProps): JSX.Element {
       proceed()
     }
   }
-  const { updateDeckConfiguration } = useUpdateDeckConfigurationMutation()
   const deckDef = getDeckDefFromRobotType(FLEX_ROBOT_TYPE)
   const cutoutConfig = deckConfig.find(
     cc => cc.opentronsModuleSerialNumber === attachedModule.serialNumber

--- a/app/src/organisms/ModuleWizardFlows/__tests__/SelectLocation.test.tsx
+++ b/app/src/organisms/ModuleWizardFlows/__tests__/SelectLocation.test.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { useUpdateDeckConfigurationMutation } from '@opentrons/react-api-client'
 import {
   FLEX_STACKER_MODULE_V1,
   FLEX_STACKER_WITH_MAG_BLOCK_FIXTURE,
@@ -14,18 +13,14 @@ import {
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
-import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 
 import { SelectLocation } from '../SelectLocation'
 
 import type { ComponentProps } from 'react'
-import type { UseQueryResult } from 'react-query'
 import type { AttachedModule } from '@opentrons/api-client'
-import type { CutoutConfig, DeckConfiguration } from '@opentrons/shared-data'
+import type { CutoutConfig } from '@opentrons/shared-data'
 import type { PipetteInformation } from '/app/resources/instruments/types'
 
-vi.mock('@opentrons/react-api-client')
-vi.mock('/app/resources/deck_configuration')
 vi.mock('/app/organisms/ModuleCard/utils')
 vi.mock('/app/organisms/ModuleWizardFlows/hooks.tsx')
 
@@ -99,41 +94,36 @@ const attachedModule: Partial<AttachedModule> = {
 const RUN_ID_1: string = 'mock_run_1'
 const mockUpdateDeckConfiguration = vi.fn()
 
+const getBaseProps = (): ComponentProps<typeof SelectLocation> => ({
+  proceed: vi.fn(),
+  goBack: vi.fn(),
+  restartSetup: vi.fn(),
+  isRobotMoving: false,
+  isModuleUpdating: false,
+  setIsModuleUpdating: vi.fn(),
+  attachedModule: attachedModule as AttachedModule,
+  deckConfig: mockSimpleDeckConfig,
+  createMaintenanceRun: vi.fn(),
+  setErrorMessage: vi.fn(),
+  isDoorOpenError: false,
+  setIsDoorOpenError: vi.fn(),
+  dismissDoorOpenError: vi.fn(),
+  maintenanceRunId: RUN_ID_1,
+  isLoadedInRun: false,
+  isOnDevice: false,
+  sendIdentifyModule: vi.fn(),
+  errorMessage: '',
+  attachedPipette: {} as PipetteInformation,
+  updateDeckConfiguration: mockUpdateDeckConfiguration,
+})
+
 describe('SelectLocation', () => {
   let props: ComponentProps<typeof SelectLocation>
 
   beforeEach(() => {
-    props = {
-      proceed: vi.fn(),
-      goBack: vi.fn,
-      restartSetup: vi.fn(),
-      isRobotMoving: false,
-      isModuleUpdating: false,
-      setIsModuleUpdating: vi.fn(),
-      attachedModule: attachedModule as AttachedModule,
-      deckConfig: mockSimpleDeckConfig,
-      createMaintenanceRun: vi.fn(),
-      setErrorMessage: vi.fn(),
-      isDoorOpenError: false,
-      setIsDoorOpenError: vi.fn(),
-      dismissDoorOpenError: vi.fn(),
-      maintenanceRunId: RUN_ID_1,
-      isLoadedInRun: false,
-      isOnDevice: false,
-      sendIdentifyModule: vi.fn(),
-      errorMessage: '',
-      attachedPipette: {} as PipetteInformation,
-      updateDeckConfiguration: vi.fn(),
-    }
-    vi.mocked(useUpdateDeckConfigurationMutation).mockReturnValue({
-      updateDeckConfiguration: mockUpdateDeckConfiguration,
-    } as any)
-    vi.mocked(useNotifyDeckConfigurationQuery).mockReturnValue({
-      data: [],
-    } as unknown as UseQueryResult<DeckConfiguration>)
+    vi.clearAllMocks()
+    props = getBaseProps()
   })
-
-  vi.restoreAllMocks()
 
   it('should render text and buttons slot D3', async () => {
     props.deckConfig = mockSimpleDeckConfig.map(dc => {
@@ -171,37 +161,9 @@ describe('handleAddFixture', () => {
   let props: ComponentProps<typeof SelectLocation>
 
   beforeEach(() => {
-    props = {
-      proceed: vi.fn(),
-      goBack: vi.fn,
-      restartSetup: vi.fn(),
-      isRobotMoving: false,
-      isModuleUpdating: false,
-      setIsModuleUpdating: vi.fn(),
-      attachedModule: attachedModule as AttachedModule,
-      deckConfig: mockSimpleDeckConfig,
-      createMaintenanceRun: vi.fn(),
-      setErrorMessage: vi.fn(),
-      isDoorOpenError: false,
-      setIsDoorOpenError: vi.fn(),
-      dismissDoorOpenError: vi.fn(),
-      maintenanceRunId: RUN_ID_1,
-      isLoadedInRun: false,
-      isOnDevice: false,
-      sendIdentifyModule: vi.fn(),
-      errorMessage: '',
-      attachedPipette: {} as PipetteInformation,
-      updateDeckConfiguration: vi.fn(),
-    }
-    vi.mocked(useUpdateDeckConfigurationMutation).mockReturnValue({
-      updateDeckConfiguration: mockUpdateDeckConfiguration,
-    } as any)
-    vi.mocked(useNotifyDeckConfigurationQuery).mockReturnValue({
-      data: [],
-    } as unknown as UseQueryResult<DeckConfiguration>)
+    vi.clearAllMocks()
+    props = getBaseProps()
   })
-
-  vi.restoreAllMocks()
 
   it('should call updateDeckConfig with mag block and temp module', async () => {
     const mockDeckConfigWithMagBlock = mockSimpleDeckConfig.map(dc => {
@@ -219,7 +181,7 @@ describe('handleAddFixture', () => {
     const mockUpdatedDeckConfig = mockDeckConfigWithMagBlock.map(config => {
       const cd = { ...config }
       if (cd.cutoutId === 'cutoutC1') {
-        cd.cutoutFixtureId = 'temperatureModuleV2'
+        cd.cutoutFixtureId = TEMPERATURE_MODULE_V2_FIXTURE
         cd.opentronsModuleSerialNumber = 'test123'
       }
       return cd
@@ -265,34 +227,9 @@ describe('handleRemoveFixture', () => {
   let props: ComponentProps<typeof SelectLocation>
 
   beforeEach(() => {
-    props = {
-      proceed: vi.fn(),
-      goBack: vi.fn,
-      restartSetup: vi.fn(),
-      isRobotMoving: false,
-      isModuleUpdating: false,
-      setIsModuleUpdating: vi.fn(),
-      attachedModule: attachedModule as AttachedModule,
-      deckConfig: mockSimpleDeckConfig,
-      createMaintenanceRun: vi.fn(),
-      setErrorMessage: vi.fn(),
-      isDoorOpenError: false,
-      setIsDoorOpenError: vi.fn(),
-      dismissDoorOpenError: vi.fn(),
-      maintenanceRunId: RUN_ID_1,
-      isLoadedInRun: false,
-      isOnDevice: false,
-      sendIdentifyModule: vi.fn(),
-      errorMessage: '',
-      attachedPipette: {} as PipetteInformation,
-      updateDeckConfiguration: vi.fn(),
-    }
-    vi.mocked(useUpdateDeckConfigurationMutation).mockReturnValue({
-      updateDeckConfiguration: mockUpdateDeckConfiguration,
-    } as any)
+    vi.clearAllMocks()
+    props = getBaseProps()
   })
-
-  vi.restoreAllMocks()
 
   it('should call updateDeckConfig without tempDeck', async () => {
     const mockUpdatedDeckConfig = mockSimpleDeckConfig.map(config => {
@@ -316,34 +253,11 @@ describe('door open error handling', () => {
   let props: ComponentProps<typeof SelectLocation>
 
   beforeEach(() => {
+    vi.clearAllMocks()
     props = {
-      proceed: vi.fn(),
-      goBack: vi.fn(),
-      restartSetup: vi.fn(),
-      isRobotMoving: false,
-      isModuleUpdating: false,
-      setIsModuleUpdating: vi.fn(),
-      attachedModule: attachedModule as AttachedModule,
-      deckConfig: mockSimpleDeckConfig,
-      createMaintenanceRun: vi.fn(),
-      setErrorMessage: vi.fn(),
-      isDoorOpenError: false,
-      setIsDoorOpenError: vi.fn(),
-      dismissDoorOpenError: vi.fn(),
+      ...getBaseProps(),
       maintenanceRunId: null,
-      isLoadedInRun: false,
-      isOnDevice: false,
-      sendIdentifyModule: vi.fn(),
-      errorMessage: '',
-      attachedPipette: {} as PipetteInformation,
-      updateDeckConfiguration: vi.fn(),
     }
-    vi.mocked(useUpdateDeckConfigurationMutation).mockReturnValue({
-      updateDeckConfiguration: mockUpdateDeckConfiguration,
-    } as any)
-    vi.mocked(useNotifyDeckConfigurationQuery).mockReturnValue({
-      data: [],
-    } as unknown as UseQueryResult<DeckConfiguration>)
   })
 
   it('sets door open error state when createMaintenanceRun rejects with a door-open error', async () => {

--- a/app/src/organisms/ModuleWizardFlows/__tests__/SelectLocation.test.tsx
+++ b/app/src/organisms/ModuleWizardFlows/__tests__/SelectLocation.test.tsx
@@ -123,6 +123,7 @@ describe('SelectLocation', () => {
       sendIdentifyModule: vi.fn(),
       errorMessage: '',
       attachedPipette: {} as PipetteInformation,
+      updateDeckConfiguration: vi.fn(),
     }
     vi.mocked(useUpdateDeckConfigurationMutation).mockReturnValue({
       updateDeckConfiguration: mockUpdateDeckConfiguration,
@@ -190,6 +191,7 @@ describe('handleAddFixture', () => {
       sendIdentifyModule: vi.fn(),
       errorMessage: '',
       attachedPipette: {} as PipetteInformation,
+      updateDeckConfiguration: vi.fn(),
     }
     vi.mocked(useUpdateDeckConfigurationMutation).mockReturnValue({
       updateDeckConfiguration: mockUpdateDeckConfiguration,
@@ -283,6 +285,7 @@ describe('handleRemoveFixture', () => {
       sendIdentifyModule: vi.fn(),
       errorMessage: '',
       attachedPipette: {} as PipetteInformation,
+      updateDeckConfiguration: vi.fn(),
     }
     vi.mocked(useUpdateDeckConfigurationMutation).mockReturnValue({
       updateDeckConfiguration: mockUpdateDeckConfiguration,
@@ -333,6 +336,7 @@ describe('door open error handling', () => {
       sendIdentifyModule: vi.fn(),
       errorMessage: '',
       attachedPipette: {} as PipetteInformation,
+      updateDeckConfiguration: vi.fn(),
     }
     vi.mocked(useUpdateDeckConfigurationMutation).mockReturnValue({
       updateDeckConfiguration: mockUpdateDeckConfiguration,

--- a/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
+++ b/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
@@ -2,7 +2,10 @@ import { useEffect, useReducer, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 
-import { useDeleteMaintenanceRunMutation } from '@opentrons/react-api-client'
+import {
+  useDeleteMaintenanceRunMutation,
+  useUpdateDeckConfigurationMutation,
+} from '@opentrons/react-api-client'
 
 import { useMaintenanceRunDocumentation } from '/app/local-resources/access-control/useMaintenanceRunDocumentation'
 import { isMaintenanceDoorOpenError } from '/app/local-resources/maintenance_runs/utils/isDoorOpenError'
@@ -57,6 +60,7 @@ export interface UseModuleSetupWizardResult {
     attachedModule: AttachedModule | null
     isExiting: boolean
     sendIdentifyModule: SendIdentifyModule
+    updateDeckConfiguration: (deckConfig: DeckConfiguration) => void
   }
   buildFlowForSelectedModule: (module: AttachedModule) => void
   patchModuleAfterUpdate: (module: AttachedModule) => void
@@ -118,6 +122,15 @@ export function useModuleSetupWizard(
     commandDocState,
     actionsToDocument,
     addActionToDocument
+  )
+
+  const { updateDeckConfiguration } = useUpdateDeckConfigurationMutation(
+    commandDocState,
+    {
+      onSuccess: () => {
+        addActionToDocument('update_deck_configuration')
+      },
+    }
   )
 
   const { createTargetedMaintenanceRun, isLoading: isCreateLoading } =
@@ -258,6 +271,7 @@ export function useModuleSetupWizard(
     attachedModule,
     isExiting,
     sendIdentifyModule,
+    updateDeckConfiguration,
   }
 
   const buildFlowForSelectedModule = (

--- a/app/src/resources/deck_configuration/hooks/useDeckConfigurationEditingTools.tsx
+++ b/app/src/resources/deck_configuration/hooks/useDeckConfigurationEditingTools.tsx
@@ -8,6 +8,7 @@ import {
   getReplacementFixtureForFixtureRemoval,
 } from '@opentrons/shared-data'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 // TODO: return the arguments or something - don't instantiate ui in helper code like this
 /* eslint-disable-next-line opentrons/no-imports-across-applications */
 import { AddFixtureModal } from '/app/organisms/DeviceDetailsDeckConfiguration/AddFixtureModal'
@@ -44,7 +45,9 @@ export function useDeckConfigurationEditingTools(
     useNotifyDeckConfigurationQuery({
       refetchInterval: DECK_CONFIG_REFETCH_INTERVAL,
     }).data ?? []
-  const { updateDeckConfiguration } = useUpdateDeckConfigurationMutation()
+  const documentationState = useDocumentationState()
+  const { updateDeckConfiguration } =
+    useUpdateDeckConfigurationMutation(documentationState)
   const [targetCutoutId, setTargetCutoutId] = useState<CutoutId | null>(null)
   const [addressableAreaId, setAddressableAreaId] =
     useState<AddressableAreaNamesWithFakes | null>(null)
@@ -92,6 +95,7 @@ export function useDeckConfigurationEditingTools(
     addFixtureModal:
       targetCutoutId != null && addressableAreaId != null ? (
         <AddFixtureModal
+          updateDeckConfiguration={updateDeckConfiguration}
           cutoutId={targetCutoutId}
           addressableAreaId={addressableAreaId}
           closeModal={() => {

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -153,6 +153,7 @@ type AuditLogAction =
   | 'shutdown_robot'
   | 'update_robot_name'
   | 'pause_run'
+  | 'update_deck_configuration'
 
 /**
  * Type used for DocumentedActions - keys and info to enable correct rendering of actions in the 'list actions' popup in the Documentation Required Modal.

--- a/react-api-client/src/deck_configuration/useUpdateDeckConfigurationMutation.ts
+++ b/react-api-client/src/deck_configuration/useUpdateDeckConfigurationMutation.ts
@@ -1,7 +1,8 @@
-import { useMutation, useQueryClient } from 'react-query'
+import { useQueryClient } from 'react-query'
 
 import { updateDeckConfiguration } from '@opentrons/api-client'
 
+import { useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
 import type { AxiosError } from 'axios'
@@ -12,6 +13,7 @@ import type {
 } from 'react-query'
 import type { ErrorResponse } from '@opentrons/api-client'
 import type { DeckConfiguration } from '@opentrons/shared-data'
+import type { DocumentationState } from '../accessControl'
 
 export type UseUpdateDeckConfigurationMutationResult = UseMutationResult<
   DeckConfiguration,
@@ -32,19 +34,22 @@ export type UseUpdateDeckConfigurationMutationOptions = UseMutationOptions<
 >
 
 export function useUpdateDeckConfigurationMutation(
+  documentationState: DocumentationState,
   options: UseUpdateDeckConfigurationMutationOptions = {}
 ): UseUpdateDeckConfigurationMutationResult {
   const host = useHost()
   const queryClient = useQueryClient()
 
-  const mutation = useMutation<
+  const mutation = useDocumentedMutation<
     DeckConfiguration,
     AxiosError<ErrorResponse>,
     DeckConfiguration
   >(
+    documentationState,
+    ['update_deck_configuration'],
     getQueryKey(host, 'deck_configuration'),
-    (deckConfig: DeckConfiguration) =>
-      updateDeckConfiguration(host!, deckConfig).then(response => {
+    ({ variables: deckConfig, userNotes }) =>
+      updateDeckConfiguration(host!, deckConfig, userNotes).then(response => {
         queryClient
           .invalidateQueries(getQueryKey(host, 'deck_configuration'))
           .catch((e: Error) => {


### PR DESCRIPTION
# Overview

https://github.com/user-attachments/assets/6dc18bc3-3ea0-49b3-ab9f-fd2f43995a91

## Test Plan and Hands on Testing

1. Updating the deck configuration in the desktop app or on the ODD should prompt for documentation
2. During module setup, updating the deck configuration should not prompt for documentation, but should appear in the list of actions to document at the end of the flow. 

## Risk assessment

Low