### PR TITLE
require wider offset from atm to determine under_vacuum

### DIFF
--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -57,6 +57,7 @@ TARGET_REACHED_POLL_PERIOD = 0.5
 PRESSURE_COMPARISON_WINDOW_SIZE = 5
 POWER_COMPARISON_WINDOW_SIZE = 5
 PRESSURE_TOL = 5.0
+UNDER_VACUUM_PRESSURE_OFFSET = 100
 POWER_TOL = 1.0
 
 
@@ -270,7 +271,9 @@ class VacuumModule(mod_abc.AbstractModule):
         avg_pressure = (state.pressure_abs_a + state.pressure_abs_b) / 2
         return math.isclose(
             state.pressure_abs_a, state.pressure_abs_b, abs_tol=PRESSURE_TOL
-        ) and not math.isclose(avg_pressure, atm_pressure, abs_tol=PRESSURE_TOL)
+        ) and not math.isclose(
+            avg_pressure, atm_pressure, abs_tol=UNDER_VACUUM_PRESSURE_OFFSET
+        )
 
     @property
     def total_cycle_count(self) -> Optional[int]:


### PR DESCRIPTION
# Overview

This fix is for [this issue where the app throws a vacuumModuleStillUnderVacuumError](https://opentrons.atlassian.net/browse/RQA-5652) , despite not yet having turned on the pump. 

Need to verify this with testing and I may end up changing the number, but all this branch does is require the difference between atmospheric pressure and the pressure sensors to be greater than 100 before determining that we’re under vacuum.