### PR TITLE
docs(components): Update the public Storybook link

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -2,7 +2,7 @@
 
 React components for Opentrons' applications. Visit the [Opentrons Components Library][components-library] to see available components.
 
-[components-library]: https://s3-us-west-2.amazonaws.com/opentrons-components/edge/index.html
+[components-library]: https://sandbox.components.opentrons.com/edge/
 
 ## example usage
 


### PR DESCRIPTION
## Overview

Old: https://s3-us-west-2.amazonaws.com/opentrons-components/edge/index.html

New: https://sandbox.components.opentrons.com/edge/

The old link works, but it looks like it's pointing to an old deployment, running Storybook 7.6.17 instead of our current 10.3.5.

## Review requests

Is this right?

## Risk assessment

No risk.