### PR TITLE
fix(docs): update cover dates for 2026 Q3

### DIFF
--- a/docs/flex/docs/cover.tpl
+++ b/docs/flex/docs/cover.tpl
@@ -7,5 +7,5 @@
 
 <p><strong>Opentrons Labworks Inc.</strong></p>
 
-<p>June 2026</p>
+<p>July 2026</p>
 </div>

--- a/docs/flex/docs/index.md
+++ b/docs/flex/docs/index.md
@@ -18,5 +18,5 @@ div.cover {
 
 **Opentrons Labworks Inc.**
 
-June 2026
+July 2026
 </div>

--- a/docs/ot-2/docs/cover.tpl
+++ b/docs/ot-2/docs/cover.tpl
@@ -8,5 +8,5 @@
 
 <p><strong>Opentrons Labworks Inc.</strong></p>
 
-<p>April 2026</p>
+<p>June 2026</p>
 </div>

--- a/docs/ot-2/docs/index.md
+++ b/docs/ot-2/docs/index.md
@@ -12,4 +12,4 @@ description: "Official instruction manual for the Opentrons OT-2 liquid handling
 ![OT-2 rendered cover image](images/OT2-render-HERO.png)
 
 **Opentrons Labworks Inc.**<br>
-April 2026
+June 2026

--- a/docs/protocol-designer/docs/cover.tpl
+++ b/docs/protocol-designer/docs/cover.tpl
@@ -8,5 +8,5 @@
 
 <p><strong>Opentrons Labworks Inc.</strong></p>
 
-<p>April 2026</p>
+<p>July 2026</p>
 </div>


### PR DESCRIPTION
# Overview

Updates the dates on manual cover pages to match when their content was last changed.

## Test Plan and Hands on Testing

Sandbox and successful PDF export with new dates.

## Changelog

- 3 `cover.tpl` changes
- 2 `index.md` changes (PD manual doesn't have date there)

## Review requests

Should we add the date to PD `index.md`?

## Risk assessment

lowest