### PR TITLE
fix(protocol-designer, shared-data): add x-axis and 20ul filter tip s…

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -247,7 +247,7 @@ CUSTOM_LABWARE = json.loads("""{"fixture/fixture_trash/1":{"ordering":[["A1"]],"
             },
           },
         },
-        version: '9.0.0',
+        version: '9.0.1',
         name: 'opentrons/protocol-designer',
       },
       robot: { model: OT2_ROBOT_TYPE },

--- a/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
@@ -122,6 +122,7 @@ export const RECOMMENDED_LABWARE_BY_MODULE: {
     'opentrons_flex_96_filtertiprack_1000ul',
     'opentrons_flex_96_filtertiprack_200ul',
     'opentrons_flex_96_filtertiprack_50ul',
+    'opentrons_flex_96_filtertiprack_20ul',
     'opentrons_flex_96_tiprack_1000ul',
     'opentrons_flex_96_tiprack_200ul',
     'opentrons_flex_96_tiprack_50ul',

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -16,7 +16,7 @@ import { cssModuleSideEffect } from './cssModuleSideEffect'
 
 import type { UserConfig } from 'vite'
 
-const REQUIRED_APP_VERSION = '9.0.0' // PD requires this robot stack version or higher
+const REQUIRED_APP_VERSION = '9.1.2' // PD requires this robot stack version or higher
 const { getVersion, generateBuildInfoHtml } = createGitVersionToolkit({
   project: 'protocol-designer',
 })

--- a/shared-data/js/__tests__/getWellNamePerMultiTip.test.ts
+++ b/shared-data/js/__tests__/getWellNamePerMultiTip.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
+import nest_8_reservoir_22ml from '../../labware/definitions/2/nest_8_reservoir_22ml/2.json'
 import fixture_12_trough from '../../labware/fixtures/2/fixture_12_trough.json'
 import fixture_24_tuberack from '../../labware/fixtures/2/fixture_24_tuberack.json'
 import fixture_96_plate from '../../labware/fixtures/2/fixture_96_plate.json'
 import fixture_384_plate from '../../labware/fixtures/2/fixture_384_plate.json'
 import fixture_trash from '../../labware/fixtures/2/fixture_trash.json'
-import { getWellNamePerMultiTip } from '../helpers/getWellNamePerMultiTip'
+import {
+  getWellNamePerMultiTip,
+  getWellNamePerRowMultiTip,
+} from '../helpers/getWellNamePerMultiTip'
 
 import type { LabwareDefinition } from '../types'
 
@@ -14,6 +18,7 @@ const fixture96Plate = fixture_96_plate as LabwareDefinition
 const fixture384Plate = fixture_384_plate as LabwareDefinition
 const fixture12Trough = fixture_12_trough as LabwareDefinition
 const fixture24Tuberack = fixture_24_tuberack as LabwareDefinition
+const nest8Reservoir = nest_8_reservoir_22ml as LabwareDefinition
 const EIGHT_CHANNEL = 8
 
 describe('96 plate', () => {
@@ -159,5 +164,58 @@ describe('12 channel trough', () => {
 
   it('B1 => null (well does not exist)', () => {
     expect(getWellNamePerMultiTip(labware, 'B1', EIGHT_CHANNEL)).toEqual(null)
+  })
+})
+
+describe('getWellNamePerRowMultiTip', () => {
+  it('96 plate A1 => full row A', () => {
+    expect(getWellNamePerRowMultiTip(fixture96Plate, 'A1')).toEqual([
+      'A1',
+      'A2',
+      'A3',
+      'A4',
+      'A5',
+      'A6',
+      'A7',
+      'A8',
+      'A9',
+      'A10',
+      'A11',
+      'A12',
+    ])
+  })
+
+  it('12 trough A1 => one tip per column trough', () => {
+    expect(getWellNamePerRowMultiTip(fixture12Trough, 'A1')).toEqual([
+      'A1',
+      'A2',
+      'A3',
+      'A4',
+      'A5',
+      'A6',
+      'A7',
+      'A8',
+      'A9',
+      'A10',
+      'A11',
+      'A12',
+    ])
+  })
+
+  it('8-well row reservoir centers all tips in one trough', () => {
+    expect(getWellNamePerRowMultiTip(nest8Reservoir, 'A1')).toEqual([
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+    ])
   })
 })

--- a/shared-data/js/helpers/__tests__/wellSets.test.ts
+++ b/shared-data/js/helpers/__tests__/wellSets.test.ts
@@ -2,11 +2,11 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { get96Channel384WellPlateWells, orderWells } from '..'
 import { ALL, COLUMN, ROW, SINGLE } from '../../../command/types'
+import nest_8_reservoir_22ml from '../../../labware/definitions/2/nest_8_reservoir_22ml/2.json'
 import fixture_12_trough from '../../../labware/fixtures/2/fixture_12_trough.json'
 import fixture_96_plate from '../../../labware/fixtures/2/fixture_96_plate.json'
 import fixture_384_plate from '../../../labware/fixtures/2/fixture_384_plate.json'
 import fixture_overlappy_wellplate from '../../../labware/fixtures/2/fixture_overlappy_wellplate.json'
-import nest_8_reservoir_22ml from '../../../labware/definitions/2/nest_8_reservoir_22ml/2.json'
 import {
   fixtureP10MultiV2Specs,
   fixtureP10SingleV2Specs,

--- a/shared-data/js/helpers/__tests__/wellSets.test.ts
+++ b/shared-data/js/helpers/__tests__/wellSets.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { get96Channel384WellPlateWells, orderWells } from '..'
-import { ALL, SINGLE } from '../../../command/types'
+import { ALL, COLUMN, ROW, SINGLE } from '../../../command/types'
 import fixture_12_trough from '../../../labware/fixtures/2/fixture_12_trough.json'
 import fixture_96_plate from '../../../labware/fixtures/2/fixture_96_plate.json'
 import fixture_384_plate from '../../../labware/fixtures/2/fixture_384_plate.json'
 import fixture_overlappy_wellplate from '../../../labware/fixtures/2/fixture_overlappy_wellplate.json'
+import nest_8_reservoir_22ml from '../../../labware/definitions/2/nest_8_reservoir_22ml/2.json'
 import {
   fixtureP10MultiV2Specs,
   fixtureP10SingleV2Specs,
@@ -22,6 +23,7 @@ const fixture96Plate = fixture_96_plate as LabwareDefinition
 const fixture384Plate = fixture_384_plate as LabwareDefinition
 const fixtureOverlappyWellplate =
   fixture_overlappy_wellplate as LabwareDefinition
+const nest8Reservoir = nest_8_reservoir_22ml as LabwareDefinition
 const EIGHT_CHANNEL = 8
 const NINETY_SIX_CHANNEL = 96
 const wellsForReservoir = [
@@ -222,6 +224,30 @@ describe('canPipetteUseLabware', () => {
     const pipette = fixtureP10MultiV2Specs
     const nozzles = SINGLE
     expect(canPipetteUseLabware(pipette, nozzles, labwareDef)).toBe(true)
+  })
+
+  it('allows 96-channel ROW on row trough reservoirs with centerMultichannelOnWells', () => {
+    const pipette96 = fixtureP100096V2Specs
+
+    // y-axis column probe fails for this def because the quirk centers tips on
+    // narrow row troughs, but X-axis row geometry succeeds.
+    expect(canPipetteUseLabware(pipette96, ALL, nest8Reservoir)).toBe(false)
+    expect(canPipetteUseLabware(pipette96, COLUMN, nest8Reservoir)).toBe(false)
+    expect(canPipetteUseLabware(pipette96, ROW, nest8Reservoir)).toBe(true)
+  })
+
+  it('allows 96-channel ROW on standard 96 plates and 12-trough reservoirs', () => {
+    const pipette96 = fixtureP100096V2Specs
+
+    expect(canPipetteUseLabware(pipette96, ROW, fixture96Plate)).toBe(true)
+    expect(canPipetteUseLabware(pipette96, ROW, fixture12Trough)).toBe(true)
+  })
+
+  it('returns false for 96-channel ROW when wells are too close together', () => {
+    const pipette96 = fixtureP100096V2Specs
+    expect(
+      canPipetteUseLabware(pipette96, ROW, fixtureOverlappyWellplate)
+    ).toBe(false)
   })
 })
 

--- a/shared-data/js/helpers/getWellNamePerMultiTip.ts
+++ b/shared-data/js/helpers/getWellNamePerMultiTip.ts
@@ -8,7 +8,37 @@ import type { ActiveNozzleNumber, LabwareDefinition } from '../types'
 // TODO Ian 2018-03-13 pull pipette offsets/positions from some pipette definitions data
 const OFFSET_8_CHANNEL = 9 // offset in mm between tips
 
-const MULTICHANNEL_TIP_SPAN = OFFSET_8_CHANNEL * (8 - 1) // length in mm from first to last tip of multichannel
+const COLUMN_TIP_COUNT = 8
+const ROW_TIP_COUNT = 12
+
+const MULTICHANNEL_COLUMN_TIP_SPAN =
+  OFFSET_8_CHANNEL * (COLUMN_TIP_COUNT - 1)
+const MULTICHANNEL_ROW_TIP_SPAN = OFFSET_8_CHANNEL * (ROW_TIP_COUNT - 1)
+
+/** returns true when labware is a series of row-length wells (ex: 8-well reservoir). */
+export function isRowLabware(labwareDef: LabwareDefinition): boolean {
+  return (
+    Object.keys(labwareDef.wells).length > 1 && labwareDef.ordering.length === 1
+  )
+}
+
+/** returns true when labware is a series of column-length wells (ex: 12-well reservoir). */
+export function isColumnLabware(labwareDef: LabwareDefinition): boolean {
+  return (
+    Object.keys(labwareDef.wells).length > 1 &&
+    labwareDef.ordering.every(column => column.length === 1)
+  )
+}
+
+function shouldCenterRowTipsOnWell(labwareDef: LabwareDefinition): boolean {
+  if (!getLabwareHasQuirk(labwareDef, 'centerMultichannelOnWells')) {
+    return false
+  }
+  const wellCount = Object.keys(labwareDef.wells).length
+  // single-well reservoirs and row troughs: center the row of tips in X
+  // column troughs keep SBS X spacing so each tip lands in its own trough
+  return wellCount === 1 || isRowLabware(labwareDef)
+}
 
 export function findWellAt(
   labwareDef: LabwareDefinition,
@@ -34,6 +64,45 @@ export function findWellAt(
         Math.abs(y - well.y) < well.yDimension / 2
       )
     })
+}
+
+/**
+ * Given a well, return the wells contacted by a 12-tip row (9 mm pitch -- see const above),
+ * or null if any tip misses a well.
+ *
+ * With centerMultichannelOnWells on row troughs / 1-well reservoirs, the tip
+ * span is centered on the well in X so all tips share one wide trough.
+ */
+export function getWellNamePerRowMultiTip(
+  labwareDef: LabwareDefinition,
+  wellName: string
+): string[] | null {
+  const well = labwareDef.wells[wellName]
+  if (!well) {
+    console.warn(
+      `well "${wellName}" does not exist in labware ${labwareDef?.namespace}/${labwareDef?.parameters?.loadName}, cannot getWellNamePerRowMultiTip`
+    )
+    return null
+  }
+
+  const { x, y } = well
+  let offsetXTipPositions: number[] = range(0, ROW_TIP_COUNT).map(
+    tipNo => x + tipNo * OFFSET_8_CHANNEL
+  )
+
+  if (shouldCenterRowTipsOnWell(labwareDef)) {
+    offsetXTipPositions = offsetXTipPositions.map(
+      tipPosX => tipPosX - MULTICHANNEL_ROW_TIP_SPAN / 2
+    )
+  }
+
+  return offsetXTipPositions.reduce((acc: string[] | null, tipPosX) => {
+    const wellForTip = findWellAt(labwareDef, tipPosX, y)
+    if (acc === null || !wellForTip) {
+      return null
+    }
+    return acc.concat(wellForTip)
+  }, [])
 }
 
 // "topWellName" means well at the "top" of the column we're accessing: usually A row, or B row for 384-format
@@ -65,14 +134,14 @@ export function getWellNamePerMultiTip(
     return test
   }
   const { x, y } = topWell
-  let offsetYTipPositions: number[] = range(0, 8).map(
+  let offsetYTipPositions: number[] = range(0, COLUMN_TIP_COUNT).map(
     tipNo => y - tipNo * OFFSET_8_CHANNEL
   )
 
   if (getLabwareHasQuirk(labwareDef, 'centerMultichannelOnWells')) {
     // move multichannel up in Y by half the pipette's tip span to center it in the well
     offsetYTipPositions = offsetYTipPositions.map(
-      tipPosY => tipPosY + MULTICHANNEL_TIP_SPAN / 2
+      tipPosY => tipPosY + MULTICHANNEL_COLUMN_TIP_SPAN / 2
     )
   }
   // Return null for containers with any undefined wells

--- a/shared-data/js/helpers/getWellNamePerMultiTip.ts
+++ b/shared-data/js/helpers/getWellNamePerMultiTip.ts
@@ -11,8 +11,7 @@ const OFFSET_8_CHANNEL = 9 // offset in mm between tips
 const COLUMN_TIP_COUNT = 8
 const ROW_TIP_COUNT = 12
 
-const MULTICHANNEL_COLUMN_TIP_SPAN =
-  OFFSET_8_CHANNEL * (COLUMN_TIP_COUNT - 1)
+const MULTICHANNEL_COLUMN_TIP_SPAN = OFFSET_8_CHANNEL * (COLUMN_TIP_COUNT - 1)
 const MULTICHANNEL_ROW_TIP_SPAN = OFFSET_8_CHANNEL * (ROW_TIP_COUNT - 1)
 
 /** returns true when labware is a series of row-length wells (ex: 8-well reservoir). */

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -19,13 +19,19 @@ import type {
   ThermalAdapterName,
 } from '../types'
 
-export { getWellNamePerMultiTip } from './getWellNamePerMultiTip'
+export {
+  findWellAt,
+  getWellNamePerMultiTip,
+  getWellNamePerRowMultiTip,
+  isColumnLabware,
+  isRowLabware,
+  skipEveryOtherWell,
+} from './getWellNamePerMultiTip'
 export { getWellTotalVolume } from './getWellTotalVolume'
 export { wellIsRect } from './wellIsRect'
 export { orderWells } from './orderWells'
 export { get96Channel384WellPlateWells } from './get96Channel384WellPlateWells'
 export { getTipTypeFromTipRackDefinition } from './getTipTypeFromTipRackDefinition'
-export { skipEveryOtherWell } from './getWellNamePerMultiTip'
 export * from './__fixtures__'
 export * from './parseProtocolCommands'
 export * from './parseProtocolData'

--- a/shared-data/js/helpers/wellSets.ts
+++ b/shared-data/js/helpers/wellSets.ts
@@ -14,8 +14,11 @@
 import uniq from 'lodash/uniq'
 
 import { get96Channel384WellPlateWells, getLabwareDefURI, orderWells } from '.'
-import { SINGLE } from '../../command/types'
-import { getWellNamePerMultiTip } from './getWellNamePerMultiTip'
+import { ROW, SINGLE } from '../../command/types'
+import {
+  getWellNamePerMultiTip,
+  getWellNamePerRowMultiTip,
+} from './getWellNamePerMultiTip'
 
 import type { NozzleConfigurationStyle } from '../../command/types'
 import type {
@@ -27,6 +30,20 @@ import type {
 
 type WellSetByPrimaryWell = string[][]
 
+const VALID_COLUMN_WELL_SET_SIZES = [1, 8] as const
+const VALID_ROW_WELL_SET_SIZES = [1, 12] as const
+
+function isValidWellSet(
+  wellSet: string[],
+  validUniqueCounts: readonly number[]
+): boolean {
+  const uniqueWells = uniq(wellSet)
+  return (
+    uniqueWells.every(well => well != null) &&
+    validUniqueCounts.includes(uniqueWells.length)
+  )
+}
+
 // Compute all well sets for a labware def (non-memoized)
 function _getAllWellSetsForLabware(
   labwareDef: LabwareDefinition
@@ -36,6 +53,22 @@ function _getAllWellSetsForLabware(
 
   for (const well of allWells) {
     const wellSet = getWellNamePerMultiTip(labwareDef, well, 8)
+    if (wellSet != null) {
+      wellSets.push(wellSet)
+    }
+  }
+
+  return wellSets
+}
+
+function _getAllRowWellSetsForLabware(
+  labwareDef: LabwareDefinition
+): WellSetByPrimaryWell {
+  const allWells: string[] = Object.keys(labwareDef.wells)
+  const wellSets: WellSetByPrimaryWell = []
+
+  for (const well of allWells) {
+    const wellSet = getWellNamePerRowMultiTip(labwareDef, well)
     if (wellSet != null) {
       wellSets.push(wellSet)
     }
@@ -226,6 +259,20 @@ export const makeWellSetHelpers = (): WellSetHelpers => {
     }
   }
 
+  const hasValidColumnWellSets = (labwareDef: LabwareDefinition): boolean => {
+    const allWellSets = getAllWellSetsForLabware(labwareDef)
+    return allWellSets.some(wellSet =>
+      isValidWellSet(wellSet, VALID_COLUMN_WELL_SET_SIZES)
+    )
+  }
+
+  const hasValidRowWellSets = (labwareDef: LabwareDefinition): boolean => {
+    const allRowWellSets = _getAllRowWellSetsForLabware(labwareDef)
+    return allRowWellSets.some(wellSet =>
+      isValidWellSet(wellSet, VALID_ROW_WELL_SET_SIZES)
+    )
+  }
+
   const canPipetteUseLabware = (
     pipetteSpec: PipetteV2Specs,
     nozzleConfiguration: NozzleConfigurationStyle,
@@ -238,21 +285,19 @@ export const makeWellSetHelpers = (): WellSetHelpers => {
       // assume all labware can be used by single-channel
       return true
     }
-    if (labwareDef != null) {
-      const allWellSets = getAllWellSetsForLabware(labwareDef)
-      return allWellSets.some(wellSet => {
-        const uniqueWells = uniq(wellSet)
-        // if all wells are non-null, and there are either 1 (reservoir-like)
-        // or 8 (well plate-like) unique wells in the set,
-        // then assume both 8 and 96 channel pipettes will work
-        return (
-          uniqueWells.every(well => well != null) &&
-          [1, 8].includes(uniqueWells.length)
-        )
-      })
-    } else {
+    if (labwareDef == null) {
       return false
     }
+
+    // row tips span X. Use row geometry so row troughs (ex 8-well reservoirs
+    // with centerMultichannelOnWells) are not judged by column Y spacing.
+    if (nozzleConfiguration === ROW) {
+      return hasValidRowWellSets(labwareDef)
+    }
+
+    // column/partial column/full multi: tips span Y.
+    // full 96 nozzles still need Y-aligned wells... row-only troughs stay incompatible.
+    return hasValidColumnWellSets(labwareDef)
   }
   return {
     getAllWellSetsForLabware,

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -50,7 +50,7 @@ import type {
 } from '../types'
 
 export const PAPI_VERSION = '2.29' // oldest version that we need from api/src/opentrons/protocols/api_support/definitions.py, might not be the actual latest version
-export const PD_APPLICATION_VERSION = '9.0.0' // latest PD version to insert into DESIGNER_APPLICATION blob
+export const PD_APPLICATION_VERSION = '9.0.1' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {
   return ['import json', 'from opentrons import protocol_api, types'].join('\n')


### PR DESCRIPTION
…upport

# Overview

address AUTH-3066, AUTH-3067, AUTH-3069

PR does 3 things... sorry.

1. updates the require robot app version to `9.1.2`
2. add the 20ul filter tips as compatible with the flex stacker
3. extends logic to well partial tip selection so y-axis geometry is included

## Test Plan and Hands on Testing

Upload attached protocol

[untitled (4).py](https://github.com/user-attachments/files/30134598/untitled.4.py)

see that:
1. the filter 20uL tips are selectable to add to the flex stacker
2. examine the transfer step. see that you can select the first 6 rows for row pick up

## Changelog

- update required app and pd version
- add 20uL filter tips as compatible with flex stacker
- `canPipetteUseLabware` used to decide multi-channel compatibility with only an 8-channel column (y-axis) geometry check. That broke 96channel row pickup on row troughs like `nest_8_reservoir_22ml`, because `centerMultichannelOnWells` shifts tips in y and makes that column probe fail incorrectly. so `getWellNamePerRowMultiTip` was added so same idea as the column tip probe, but for 12 tips along x.

so to conclude

- 96channel `ROW` on `nest_8_reservoir_22ml` is allowed
- 96channel `COLUMN` and `ALL` on that labware still blocked - y centering on narrow row troughs is still wrong
- normal 96 plates and 12 trough reservoirs still work for `ROW`

## Risk assessment

medium, this shouldn't affect any partial tip pick up besides row pick up for a 96-channel... but good to smoke test every partial tip<>labware configuration with QA before release