### PR TITLE
fix(protocol-designer): prevent drag selection whitescreen

### DIFF
--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -247,7 +247,7 @@ CUSTOM_LABWARE = json.loads("""{"fixture/fixture_trash/1":{"ordering":[["A1"]],"
             },
           },
         },
-        version: '9.0.1',
+        version: '9.0.0',
         name: 'opentrons/protocol-designer',
       },
       robot: { model: OT2_ROBOT_TYPE },

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -247,7 +247,7 @@ CUSTOM_LABWARE = json.loads("""{"fixture/fixture_trash/1":{"ordering":[["A1"]],"
             },
           },
         },
-        version: '9.0.0',
+        version: '9.0.1',
         name: 'opentrons/protocol-designer',
       },
       robot: { model: OT2_ROBOT_TYPE },

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/utils.ts
@@ -175,7 +175,9 @@ export const getEntireWellSelection = (
   const columnIndex = wellOrdering.findIndex(column =>
     column.includes(wellName)
   )
-  if (columnIndex === -1) return []
+  if (columnIndex === -1) {
+    return []
+  }
   const rowIndex = wellOrdering[columnIndex].indexOf(wellName)
   const is384Plate = wellOrdering.flat().length === 384
 

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/utils.ts
@@ -175,9 +175,6 @@ export const getEntireWellSelection = (
   const columnIndex = wellOrdering.findIndex(column =>
     column.includes(wellName)
   )
-  const indexInColumn = wellOrdering[columnIndex].findIndex(
-    well => well === wellName
-  )
   if (columnIndex === -1) return []
   const rowIndex = wellOrdering[columnIndex].indexOf(wellName)
   const is384Plate = wellOrdering.flat().length === 384
@@ -226,9 +223,9 @@ export const getEntireWellSelection = (
       return is384Plate
         ? skipEveryOtherWell(
             wellName,
-            column.slice(indexInColumn, Math.min(end, column.length))
+            column.slice(rowIndex, Math.min(end, column.length))
           )
-        : column.slice(indexInColumn, Math.min(end, column.length))
+        : column.slice(rowIndex, Math.min(end, column.length))
     }
     default:
       return [wellName]


### PR DESCRIPTION
closes AUTH-3078

# Overview

lolz the `wellOrdering[columnIndex]` was causing a crash when the mouse was out of bounds. so i literally just deleted that util

## Test Plan and Hands on Testing

upload protocol attached to the ticket and try dragging your mouse out of bounds when selecting the wells for the transfer step

## Changelog

remove the unnecessary util

## Risk assessment

low, pretty isolated fix, contained in the tip selection wizard