### PR TITLE
feat(api-client,react-api-client): Add support for `POST /auth/users`

### DIFF
--- a/api-client/src/auth/users/createUser.ts
+++ b/api-client/src/auth/users/createUser.ts
@@ -1,0 +1,22 @@
+import { POST, request } from '../../request'
+
+import type { ResponsePromise } from '../../request'
+import type { HostConfig } from '../../types'
+import type { AuthUserResponse, CreateUserRequest } from './types'
+
+export function createUser(
+  config: HostConfig,
+  body: CreateUserRequest,
+  userNotes?: string
+): ResponsePromise<AuthUserResponse> {
+  return request<AuthUserResponse, CreateUserRequest>(
+    POST,
+    '/auth/users',
+    config,
+    {
+      body,
+      requiresSecureTransport: true,
+      userNotes,
+    }
+  )
+}

--- a/api-client/src/auth/users/index.ts
+++ b/api-client/src/auth/users/index.ts
@@ -1,3 +1,4 @@
+export * from './createUser'
 export * from './getSelf'
 export * from './types'
 export * from './updateSelf'

--- a/api-client/src/auth/users/types.ts
+++ b/api-client/src/auth/users/types.ts
@@ -12,6 +12,15 @@ export interface AuthUserResponse {
   data: AuthUser
 }
 
+export interface CreateUserRequest {
+  data: {
+    username: string
+    fullName: string
+    password: string
+    accountType: AuthUserAccountType
+  }
+}
+
 export interface UpdateSelfRequest {
   data: {
     username?: string

--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -13,6 +13,7 @@
   "create_camera_image_settings": "Updating camera image settings",
   "create_offsets": "Saving new labware offsets",
   "create_protocol": "Creating protocol",
+  "create_user": "Creating user",
   "delete_offsets": "Deleting old labware offsets",
   "delete_run": "Deleting protocol run record",
   "delete_runs": "Deleting protocol run records",

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -169,6 +169,7 @@ type AuditLogAction =
   | 'set_lights'
   | 'apply_offsets'
   | 'update_subsystem'
+  | 'create_user'
 
 /**
  * Type used for DocumentedActions - keys and info to enable correct rendering of actions in the 'list actions' popup in the Documentation Required Modal.

--- a/react-api-client/src/auth/users/index.ts
+++ b/react-api-client/src/auth/users/index.ts
@@ -1,2 +1,3 @@
+export * from './useCreateUserMutation'
 export * from './useSelfQuery'
 export * from './useUpdateSelfMutation'

--- a/react-api-client/src/auth/users/useCreateUserMutation.ts
+++ b/react-api-client/src/auth/users/useCreateUserMutation.ts
@@ -1,0 +1,49 @@
+import { createUser } from '@opentrons/api-client'
+
+import { useDocumentedMutation } from '../../accessControl'
+import { getQueryKey, useHost } from '../../api'
+
+import type { AxiosError } from 'axios'
+import type {
+  UseMutateAsyncFunction,
+  UseMutationOptions,
+  UseMutationResult,
+} from 'react-query'
+import type { AuthUserResponse, CreateUserRequest } from '@opentrons/api-client'
+import type { DocumentationState } from '../../accessControl'
+
+export type UseCreateUserMutationResult = UseMutationResult<
+  AuthUserResponse,
+  AxiosError,
+  CreateUserRequest
+> & {
+  createUser: UseMutateAsyncFunction<
+    AuthUserResponse,
+    AxiosError,
+    CreateUserRequest
+  >
+}
+
+export function useCreateUserMutation(
+  options: UseMutationOptions<
+    AuthUserResponse,
+    AxiosError,
+    CreateUserRequest
+  > = {},
+  documentationState: DocumentationState
+): UseCreateUserMutationResult {
+  const host = useHost()
+  const mutation = useDocumentedMutation(
+    documentationState,
+    [],
+    getQueryKey(host, 'auth', 'users'),
+    ({ variables: data, userNotes }) =>
+      createUser(host!, data).then(response => response.data),
+    options
+  )
+
+  return {
+    ...mutation,
+    createUser: mutation.mutateAsync,
+  }
+}

--- a/react-api-client/src/auth/users/useCreateUserMutation.ts
+++ b/react-api-client/src/auth/users/useCreateUserMutation.ts
@@ -35,10 +35,10 @@ export function useCreateUserMutation(
   const host = useHost()
   const mutation = useDocumentedMutation(
     documentationState,
-    [],
+    ['create_user'],
     getQueryKey(host, 'auth', 'users'),
     ({ variables: data, userNotes }) =>
-      createUser(host!, data).then(response => response.data),
+      createUser(host!, data, userNotes).then(response => response.data),
     options
   )
 

--- a/react-api-client/src/auth/users/useCreateUserMutation.ts
+++ b/react-api-client/src/auth/users/useCreateUserMutation.ts
@@ -25,12 +25,12 @@ export type UseCreateUserMutationResult = UseMutationResult<
 }
 
 export function useCreateUserMutation(
+  documentationState: DocumentationState,
   options: UseMutationOptions<
     AuthUserResponse,
     AxiosError,
     CreateUserRequest
-  > = {},
-  documentationState: DocumentationState
+  > = {}
 ): UseCreateUserMutationResult {
   const host = useHost()
   const mutation = useDocumentedMutation(


### PR DESCRIPTION
## Overview

This adds the `POST /auth/users` endpoint to api-client and react-api-client, following the usual pattern, and using our new `useDocumentedMutation()` helper. Part of EXEC-2810.

## Test Plan and Hands on Testing

None. This will be tested as part of feature work.

## Review requests

None.

## Risk assessment

No risk.