### PR TITLE
chore(audit-server): Fix formatting

### DIFF
--- a/key-server/tests/integration/test_signing_key.tavern.yml
+++ b/key-server/tests/integration/test_signing_key.tavern.yml
@@ -14,7 +14,7 @@ stages:
       json:
         data:
           publicKeyPem: "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAqvlF5UaVgYPvt/vNtirrzIWSlARPyf69ZVWpnSqpdB4=\n-----END PUBLIC KEY-----\n"
-          hashedKey: "sha256:7joao5sCagU94b_QvDskeDWJGikWPJJdsrlG6kSuWiI="
+          hashedKey: 'sha256:7joao5sCagU94b_QvDskeDWJGikWPJJdsrlG6kSuWiI='
   - name: Get message signature with a none hash
     request:
       method: POST


### PR DESCRIPTION
## Overview

This fixes formatting with `make format-js`. This snuck in because the relevant CI workflow didn't run because of some out-of-sync globs—that'll be fixed separately.

## Test plan

* [x] `make check-js` passes locally now.

## Risk assessment

No risk.