### PR TITLE
refactor(ci): Deduplicate trigger paths via YAML anchors

### DIFF
--- a/.github/workflows/abr-testing-lint-test.yaml
+++ b/.github/workflows/abr-testing-lint-test.yaml
@@ -4,7 +4,7 @@
 name: 'abr-testing lint/test'
 on:
   push:
-    paths:
+    paths: &paths
       - 'Makefile'
       - 'abr-testing/**'
       - 'scripts/**.mk'
@@ -16,11 +16,7 @@ on:
     tags-ignore:
       - '**'
   pull_request:
-    paths:
-      - 'abr-testing/**'
-      - 'scripts/**.mk'
-      - 'scripts/**.py'
-      - '.github/workflows/abr-testing-lint-test.yaml'
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/api-test-lint-deploy.yaml
+++ b/.github/workflows/api-test-lint-deploy.yaml
@@ -6,7 +6,7 @@ name: 'API test/lint/deploy'
 on:
   # Most of the time, we run on pull requests, which lets us handle external PRs
   pull_request:
-    paths:
+    paths: &paths
       - 'api/**'
       - 'Makefile'
       - 'shared-data/**'
@@ -19,17 +19,7 @@ on:
       - '.github/workflows/utils.js'
       - 'package-testing/**'
   push:
-    paths:
-      - 'api/**'
-      - 'Makefile'
-      - 'shared-data/**'
-      - '!shared-data/js/**'
-      - 'hardware/**'
-      - 'scripts/**.mk'
-      - 'scripts/**.py'
-      - '.github/workflows/api-test-lint-deploy.yaml'
-      - '.github/actions/python/**'
-      - '.github/workflows/utils.js'
+    paths: *paths
     branches:
       - 'edge'
       - 'release'

--- a/.github/workflows/app-test-build-deploy.yaml
+++ b/.github/workflows/app-test-build-deploy.yaml
@@ -4,7 +4,7 @@ name: 'App test, build, and deploy'
 
 on:
   push:
-    paths:
+    paths: &paths
       - 'Makefile'
       - 'app/**'
       - 'app-shell/**'
@@ -27,19 +27,7 @@ on:
       - 'v[0-9]*.[0-9]*'
       - 'ot3@*'
   pull_request:
-    paths:
-      - 'Makefile'
-      - 'app/**'
-      - 'app-shell/**'
-      - 'app-shell-odd/**'
-      - 'components/**'
-      - 'shared-data/**'
-      - 'discovery-client/**'
-      - '*.js'
-      - '*.json'
-      - 'pnpm-lock.yaml'
-      - 'scripts/**'
-      - '.vitest.config.*'
+    paths: *paths
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.ref_name != 'edge' || github.run_id}}-${{ github.ref_type != 'tag' || github.run_id }}

--- a/.github/workflows/audit-server-lint-test.yaml
+++ b/.github/workflows/audit-server-lint-test.yaml
@@ -5,7 +5,7 @@ name: 'audit-server test/lint'
 
 on:
   push:
-    paths:
+    paths: &paths
       - 'audit-server/**'
       - 'Makefile'
       - 'scripts/**.mk'
@@ -21,16 +21,7 @@ on:
       - '*'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'audit-server/**'
-      - 'Makefile'
-      - 'scripts/**.mk'
-      - 'scripts/**.py'
-      - '.github/workflows/audit-server-lint-test.yaml'
-      - '.github/actions/python/**'
-      - 'server-utils/**'
-      - 'shared-data/**'
-      - '!shared-data/js/**'
+    paths: *paths
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/auth-server-lint-test.yaml
+++ b/.github/workflows/auth-server-lint-test.yaml
@@ -5,7 +5,7 @@ name: 'auth-server test/lint'
 
 on:
   push:
-    paths:
+    paths: &paths
       - 'auth-server/**'
       - 'Makefile'
       - 'scripts/**.mk'
@@ -19,14 +19,7 @@ on:
       - '*'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'auth-server/**'
-      - 'Makefile'
-      - 'scripts/**.mk'
-      - 'scripts/**.py'
-      - '.github/workflows/auth-server-lint-test.yaml'
-      - '.github/actions/python/**'
-      - 'server-utils/**'
+    paths: *paths
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/g-code-confirm-tests.yaml
+++ b/.github/workflows/g-code-confirm-tests.yaml
@@ -3,16 +3,13 @@ name: 'G-Code-Confirm'
 on:
   # Run on any change to the api directory
   pull_request:
-    paths:
-      - 'api/**'
-      - 'g-code-testing/**'
-      - 'Makefile'
-  push:
-    paths:
+    paths: &paths
       - 'api/**'
       - 'g-code-testing/**'
       - 'Makefile'
       - '.github/workflows/g-code-confirm-tests.yaml'
+  push:
+    paths: *paths
     branches:
       - 'edge'
       - 'release'

--- a/.github/workflows/g-code-testing-lint-test.yaml
+++ b/.github/workflows/g-code-testing-lint-test.yaml
@@ -6,7 +6,7 @@ name: 'G-Code Testing Lint & Test'
 on:
   # Most of the time, we run on pull requests, which lets us handle external PRs
   push:
-    paths:
+    paths: &paths
       - 'Makefile'
       - 'api/**'
       - 'g-code-testing/**'
@@ -19,14 +19,7 @@ on:
       - 'release'
       - '*hotfix*'
   pull_request:
-    paths:
-      - 'Makefile'
-      - 'g-code-testing/**'
-      - 'api/**'
-      - 'scripts/**.mk'
-      - 'scripts/**.py'
-      - '.github/workflows/g-code-testing-lint-test.yaml'
-      - '.github/actions/python/**'
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/gh-actions-security-zizmor.yaml
+++ b/.github/workflows/gh-actions-security-zizmor.yaml
@@ -2,11 +2,10 @@ name: GitHub Actions security checks
 
 on:
   push:
-    paths:
+    paths: &paths
       - .github/**
   pull_request:
-    paths:
-      - .github/**
+    paths: *paths
   workflow_dispatch: {}
 
 permissions: {}

--- a/.github/workflows/hardware-lint-test.yaml
+++ b/.github/workflows/hardware-lint-test.yaml
@@ -6,7 +6,7 @@ name: 'hardware lint/test'
 on:
   # Most of the time, we run on pull requests, which lets us handle external PRs
   push:
-    paths:
+    paths: &paths
       - 'Makefile'
       - 'hardware/**'
       - 'scripts/**.mk'
@@ -21,15 +21,7 @@ on:
     tags-ignore:
       - '*'
   pull_request:
-    paths:
-      - 'Makefile'
-      - 'hardware/**'
-      - 'scripts/**.mk'
-      - 'scripts/**.py'
-      - '.github/workflows/hardware-lint-test.yaml'
-      - '.github/actions/python/**'
-      - 'shared-data/**'
-      - '!shared-data/js/**'
+    paths: *paths
 
   workflow_dispatch:
 

--- a/.github/workflows/hardware-testing-protocols.yaml
+++ b/.github/workflows/hardware-testing-protocols.yaml
@@ -3,16 +3,13 @@ name: 'hardware-testing testing protocols'
 on:
   # Run on any change to the api directory
   pull_request:
-    paths:
-      - 'api/**'
-      - 'hardware-testing/**'
-      - 'Makefile'
-  push:
-    paths:
+    paths: &paths
       - 'api/**'
       - 'hardware-testing/**'
       - 'Makefile'
       - '.github/workflows/hardware-testing-protocols.yaml'
+  push:
+    paths: *paths
     branches:
       - 'edge'
       - 'release'

--- a/.github/workflows/hardware-testing.yaml
+++ b/.github/workflows/hardware-testing.yaml
@@ -6,7 +6,7 @@ name: 'hardware-testing testing lint/test'
 on:
   # Most of the time, we run on pull requests, which lets us handle external PRs
   push:
-    paths:
+    paths: &paths
       - 'Makefile'
       - 'hardware-testing/**'
       - 'api/**'
@@ -20,14 +20,7 @@ on:
     tags-ignore:
       - '*'
   pull_request:
-    paths:
-      - 'Makefile'
-      - 'hardware-testing/**'
-      - 'api/**'
-      - 'hardware/**'
-      - 'shared-data/**'
-      - '.github/workflows/hardware-testing.yaml'
-      - '.github/actions/python/**'
+    paths: *paths
 
   workflow_dispatch:
 

--- a/.github/workflows/js-check.yaml
+++ b/.github/workflows/js-check.yaml
@@ -5,7 +5,7 @@ name: 'JS checks'
 
 on:
   pull_request:
-    paths:
+    paths: &paths
       - '**.js'
       - '**.cjs'
       - '**.mjs'
@@ -18,18 +18,7 @@ on:
       - '**.md'
       - '.github/workflows/js-check.yaml'
   push:
-    paths:
-      - '**.js'
-      - '**.cjs'
-      - '**.mjs'
-      - '**.ts'
-      - '**.cts'
-      - '**.mts'
-      - '**.tsx'
-      - '**.json'
-      - '**.css'
-      - '**.md'
-      - '.github/workflows/js-check.yaml'
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/key-server-lint-test.yaml
+++ b/.github/workflows/key-server-lint-test.yaml
@@ -5,7 +5,7 @@ name: 'key-server test/lint'
 
 on:
   push:
-    paths:
+    paths: &paths
       - 'key-server/**'
       - 'Makefile'
       - 'scripts/**.mk'
@@ -19,14 +19,7 @@ on:
       - '*'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'key-server/**'
-      - 'Makefile'
-      - 'scripts/**.mk'
-      - 'scripts/**.py'
-      - '.github/workflows/key-server-lint-test.yaml'
-      - '.github/actions/python/**'
-      - 'server-utils/**'
+    paths: *paths
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/react-api-client-test.yaml
+++ b/.github/workflows/react-api-client-test.yaml
@@ -4,19 +4,14 @@ name: 'JS API Clients test'
 
 on:
   pull_request:
-    paths:
+    paths: &paths
       - 'react-api-client/**'
       - 'api-client/**'
       - 'package.json'
       - '.github/workflows/react-api-client-test.yaml'
       - 'vitest.config.*'
   push:
-    paths:
-      - 'react-api-client/**'
-      - 'api-client/**'
-      - 'package.json'
-      - '.github/workflows/react-api-client-test.yaml'
-      - 'vitest.config.*'
+    paths: *paths
     branches:
       - '*'
   workflow_dispatch:

--- a/.github/workflows/robot-server-lint-test.yaml
+++ b/.github/workflows/robot-server-lint-test.yaml
@@ -6,7 +6,7 @@ name: 'Robot server lint/test'
 on:
   # Most of the time, we run on pull requests, which lets us handle external PRs
   push:
-    paths:
+    paths: &paths
       - 'api/**/*'
       - 'hardware/**/*'
       - 'hardware-testing/**/*'
@@ -26,19 +26,7 @@ on:
     tags-ignore:
       - '*'
   pull_request:
-    paths:
-      - 'api/**/*'
-      - 'hardware/**/*'
-      - 'hardware-testing/**/*'
-      - 'Makefile'
-      - 'shared-data/**/*'
-      - 'server-utils/**/*'
-      - '!shared-data/js/**/*'
-      - 'robot-server/**/*'
-      - 'scripts/**/*.mk'
-      - 'scripts/**/*.py'
-      - '.github/workflows/robot-server-lint-test.yaml'
-      - '.github/actions/python/**'
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/server-utils-lint-test.yaml
+++ b/.github/workflows/server-utils-lint-test.yaml
@@ -5,7 +5,7 @@ name: 'server-utils test/lint'
 
 on:
   push:
-    paths:
+    paths: &paths
       - 'server-utils/**/*'
       - 'Makefile'
       - 'scripts/**/*.mk'
@@ -18,13 +18,7 @@ on:
       - '*'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'server-utils/**/*'
-      - 'Makefile'
-      - 'scripts/**/*.mk'
-      - 'scripts/**/*.py'
-      - '.github/workflows/server-utils-lint-test.yaml'
-      - '.github/actions/python/**'
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/shared-data-test-lint-deploy.yaml
+++ b/.github/workflows/shared-data-test-lint-deploy.yaml
@@ -5,7 +5,7 @@ name: 'shared-data test/lint/deploy'
 
 on:
   push:
-    paths:
+    paths: &paths
       - 'Makefile'
       - 'shared-data/*/**'
       - 'scripts/**/*.mk'
@@ -23,15 +23,7 @@ on:
       - 'shared-data*'
       - 'components*'
   pull_request:
-    paths:
-      - 'Makefile'
-      - 'shared-data/*/**'
-      - 'scripts/**/*.mk'
-      - 'scripts/**/*.py'
-      - '.github/workflows/shared-data-test-lint-deploy.yaml'
-      - '.github/actions/python/**/*'
-      - '.github/workflows/utils.js'
-      - 'vitest.config.*'
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/step-generation-test.yaml
+++ b/.github/workflows/step-generation-test.yaml
@@ -4,7 +4,7 @@ name: 'Step generation test'
 
 on:
   pull_request:
-    paths:
+    paths: &paths
       - 'step-generation/**'
       - 'shared-data/**'
       - 'package.json'
@@ -14,15 +14,7 @@ on:
       - '.github/actions/environment/complex-variables/action.yml'
       - 'vitest.config.*'
   push:
-    paths:
-      - 'step-generation/**'
-      - 'shared-data/**'
-      - 'package.json'
-      - '.github/workflows/step-generation-test.yaml'
-      - '.github/actions/js/setup/action.yml'
-      - '.github/actions/git/resolve-tag/action.yml'
-      - '.github/actions/environment/complex-variables/action.yml'
-      - 'vitest.config.*'
+    paths: *paths
     branches:
       - '*'
 

--- a/.github/workflows/system-server-lint-test.yaml
+++ b/.github/workflows/system-server-lint-test.yaml
@@ -5,7 +5,7 @@ name: 'system-server test/lint'
 
 on:
   push:
-    paths:
+    paths: &paths
       - 'system-server/**/*'
       - 'Makefile'
       - 'scripts/**/*.mk'
@@ -19,14 +19,7 @@ on:
       - '*'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'system-server/**/*'
-      - 'Makefile'
-      - 'scripts/**/*.mk'
-      - 'scripts/**/*.py'
-      - '.github/workflows/system-server-lint-test.yaml'
-      - '.github/actions/python/**'
-      - 'server-utils/**'
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/update-server-lint-test.yaml
+++ b/.github/workflows/update-server-lint-test.yaml
@@ -5,7 +5,7 @@ name: 'Update Server test/lint'
 
 on:
   push:
-    paths:
+    paths: &paths
       - 'update-server/**'
       - 'server-utils/**'
       - 'Makefile'
@@ -19,14 +19,7 @@ on:
       - '*'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'update-server/**'
-      - 'server-utils/**'
-      - 'Makefile'
-      - 'scripts/**/*.mk'
-      - 'scripts/**/*.py'
-      - '.github/workflows/update-server-lint-test.yaml'
-      - '.github/actions/python/**'
+    paths: *paths
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/usb-bridge-lint-test.yaml
+++ b/.github/workflows/usb-bridge-lint-test.yaml
@@ -5,7 +5,7 @@ name: 'USB-Bridge test/lint'
 
 on:
   push:
-    paths:
+    paths: &paths
       - 'usb-bridge/**/*'
       - 'Makefile'
       - 'scripts/**/*.mk'
@@ -18,13 +18,7 @@ on:
       - '*'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - 'usb-bridge/**/*'
-      - 'Makefile'
-      - 'scripts/**/*.mk'
-      - 'scripts/**/*.py'
-      - '.github/workflows/usb-bridge-lint-test.yaml'
-      - '.github/actions/python/**'
+    paths: *paths
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Overview

Our GitHub Actions workflows each have a hard-coded list of file paths to watch. Some workflows have *two* hard-coded lists that need to stay in sync with each other—one for `push` events, which run on the branch tip, and one for `pull_request` events, which run on the merge commit.

[As of last year](https://github.blog/changelog/2025-09-18-actions-yaml-anchors-and-non-public-workflow-templates/), we can use YAML anchors to deduplicate them.

## Test Plan and Hands on Testing

None, just CI.

## Changelog

03cd9e794b58228256d7185858f413fcd2f33d0b merges identical lists. This is pretty straightforward and there's not much to review about it.

ddcb1ab79144664b02db97c178bbac276c14b948 merges some lists that seem to have accidentally drifted. For example, app-test-build-deploy.yaml had a `vitest.config.*`/`.vitest.config.*` typo.

## Review requests

None.

## Risk assessment

Low.