### PR TITLE
fix(api-client, app, react-api-client): pass userNotes to deleteRun calls

### DIFF
--- a/api-client/src/runs/deleteRun.ts
+++ b/api-client/src/runs/deleteRun.ts
@@ -2,17 +2,11 @@ import { DELETE, request } from '../request'
 
 import type { ResponsePromise } from '../request'
 import type { EmptyResponse, HostConfig } from '../types'
-import type { DeleteRunData } from './types'
 
 export function deleteRun(
   config: HostConfig,
   runId: string,
-  data: DeleteRunData = {}
+  userNotes?: string
 ): ResponsePromise<EmptyResponse> {
-  return request<EmptyResponse, { data: DeleteRunData }>(
-    DELETE,
-    `/runs/${runId}`,
-    config,
-    { body: { data } }
-  )
+  return request<EmptyResponse>(DELETE, `/runs/${runId}`, config, { userNotes })
 }

--- a/api-client/src/runs/types.ts
+++ b/api-client/src/runs/types.ts
@@ -251,7 +251,3 @@ export interface FlexStackerState {
   count: number
   maxCount: number
 }
-
-export interface DeleteRunData {
-  shouldDeleteAllRunFiles?: boolean
-}

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/hooks/useDeleteSelectedRuns.ts
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/hooks/useDeleteSelectedRuns.ts
@@ -30,7 +30,7 @@ export function useDeleteSelectedRuns(
   const mutation = useDocumentedMutation<unknown, unknown, RunData[]>(
     documentationState,
     ['delete_runs'],
-    ({ variables: runs }) => {
+    ({ variables: runs, userNotes }) => {
       const currentHost = host
       if (currentHost == null || runs.length === 0) {
         return Promise.resolve()
@@ -38,7 +38,7 @@ export function useDeleteSelectedRuns(
 
       return Promise.all(
         runs.map(run =>
-          deleteRun(currentHost, run.id).catch((e: Error) =>
+          deleteRun(currentHost, run.id, userNotes).catch((e: Error) =>
             makeToast(e.message, ERROR_TOAST, { closeButton: true })
           )
         )

--- a/react-api-client/src/runs/useDeleteRunMutation.ts
+++ b/react-api-client/src/runs/useDeleteRunMutation.ts
@@ -10,12 +10,11 @@ import type {
   UseMutationOptions,
   UseMutationResult,
 } from 'react-query'
-import type { DeleteRunData, EmptyResponse } from '@opentrons/api-client'
+import type { EmptyResponse } from '@opentrons/api-client'
 import type { DocumentationState } from '../accessControl'
 
 export interface DeleteRunParams {
   runId: string
-  settings?: DeleteRunData
 }
 
 export type UseDeleteRunMutationResult = UseMutationResult<
@@ -46,8 +45,8 @@ export function useDeleteRunMutation(
   >(
     documentationState,
     ['delete_run'],
-    ({ variables: { runId, settings } }) =>
-      deleteRun(host!, runId, settings).then(response => {
+    ({ variables: { runId }, userNotes }) =>
+      deleteRun(host!, runId, userNotes).then(response => {
         queryClient.removeQueries(getQueryKey(host, 'runs', runId))
         queryClient
           .invalidateQueries(getQueryKey(host, 'runs'))


### PR DESCRIPTION
# Overview

This PR ensures user notes are passed down to the api-client `deleteRun` function. Call sites for now include the mutation hooks `useDeleteRunMutation` and `useDeleteSelectedRuns`.

This behavior was accidentally omitted from #21982

## Test Plan and Hands on Testing

Inspect `deleteRun` API client mutation fn and implementation in 2 hooks mentioned above

## Changelog

- add optional `userNotes` param to `deleteRun`
- pass down `userNotes` from documented mutations calling `deleteRun`

## Review requests

see test plan

## Risk assessment

low