### PR TITLE
feat(app, odd): document estop disengage

### DIFF
--- a/api-client/src/robot/acknowledgeEstopDisengage.ts
+++ b/api-client/src/robot/acknowledgeEstopDisengage.ts
@@ -5,11 +5,13 @@ import type { HostConfig } from '../types'
 import type { EstopStatus } from './types'
 
 export function acknowledgeEstopDisengage(
-  config: HostConfig
+  config: HostConfig,
+  userNotes: string
 ): ResponsePromise<EstopStatus> {
   return request<EstopStatus>(
     PUT,
     '/robot/control/acknowledgeEstopDisengage',
-    config
+    config,
+    { userNotes }
   )
 }

--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -1,5 +1,6 @@
 {
   "96_channel": "96 channel",
+  "acknowledge_estop": "Acknowledging emergency stop disengage",
   "add_module": "Launching module setup flow",
   "attach": "Attaching",
   "attach_gripper": "Attaching gripper",

--- a/app/src/organisms/EmergencyStop/EstopPressedModal.tsx
+++ b/app/src/organisms/EmergencyStop/EstopPressedModal.tsx
@@ -22,10 +22,14 @@ import {
   SPACING,
   TYPOGRAPHY,
 } from '@opentrons/components'
-import { useAcknowledgeEstopDisengageMutation } from '@opentrons/react-api-client'
+import {
+  isDocumentedMutationError,
+  useAcknowledgeEstopDisengageMutation,
+} from '@opentrons/react-api-client'
 
 import { getTopPortalEl } from '/app/App/portal'
 import { SmallButton } from '/app/atoms/buttons'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
 import { getIsOnDevice } from '/app/redux/config'
 import { usePlacePlateReaderLid } from '/app/resources/modules'
@@ -83,7 +87,9 @@ function TouchscreenModal({
 }: EstopPressedModalProps): JSX.Element {
   const { t } = useTranslation(['device_settings', 'branded'])
   const [isResuming, setIsResuming] = useState<boolean>(false)
-  const { acknowledgeEstopDisengage } = useAcknowledgeEstopDisengageMutation()
+  const documentationState = useDocumentationState()
+  const { acknowledgeEstopDisengage } =
+    useAcknowledgeEstopDisengageMutation(documentationState)
 
   const { handlePlaceReaderLid, isValidPlateReaderMove } =
     usePlacePlateReaderLid({
@@ -100,12 +106,20 @@ function TouchscreenModal({
   }
   const handleClick = (): void => {
     setIsResuming(true)
-    setIsWaitingForResumeOperation()
-    acknowledgeEstopDisengage(null)
-    handlePlaceReaderLid()
-    if (!isValidPlateReaderMove) {
-      closeModal()
-    }
+    acknowledgeEstopDisengage(undefined, {
+      onSuccess: () => {
+        setIsWaitingForResumeOperation()
+        handlePlaceReaderLid()
+        if (!isValidPlateReaderMove) {
+          closeModal()
+        }
+      },
+      onError: error => {
+        if (isDocumentedMutationError(error)) {
+          setIsResuming(false)
+        }
+      },
+    })
   }
   return (
     <OddModal {...modalProps}>
@@ -162,7 +176,9 @@ function DesktopModal({
 }: EstopPressedModalProps): JSX.Element {
   const { t } = useTranslation('device_settings')
   const [isResuming, setIsResuming] = useState<boolean>(false)
-  const { acknowledgeEstopDisengage } = useAcknowledgeEstopDisengageMutation()
+  const documentationState = useDocumentationState()
+  const { acknowledgeEstopDisengage } =
+    useAcknowledgeEstopDisengageMutation(documentationState)
   const { handlePlaceReaderLid, isValidPlateReaderMove } =
     usePlacePlateReaderLid({
       onSuccess: closeModal,
@@ -180,12 +196,20 @@ function DesktopModal({
   const handleClick: MouseEventHandler<HTMLButtonElement> = (e): void => {
     e.preventDefault()
     setIsResuming(true)
-    setIsWaitingForResumeOperation()
-    acknowledgeEstopDisengage(null)
-    handlePlaceReaderLid()
-    if (!isValidPlateReaderMove) {
-      closeModal()
-    }
+    acknowledgeEstopDisengage(undefined, {
+      onSuccess: () => {
+        setIsWaitingForResumeOperation()
+        handlePlaceReaderLid()
+        if (!isValidPlateReaderMove) {
+          closeModal()
+        }
+      },
+      onError: error => {
+        if (isDocumentedMutationError(error)) {
+          setIsResuming(false)
+        }
+      },
+    })
   }
 
   return (

--- a/app/src/organisms/EmergencyStop/__tests__/EstopPressedModal.test.tsx
+++ b/app/src/organisms/EmergencyStop/__tests__/EstopPressedModal.test.tsx
@@ -8,6 +8,7 @@ import { useAcknowledgeEstopDisengageMutation } from '@opentrons/react-api-clien
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { getIsOnDevice } from '/app/redux/config'
 import { usePlacePlateReaderLid } from '/app/resources/modules'
 
@@ -19,6 +20,10 @@ vi.mock('@opentrons/react-api-client')
 vi.mock('/app/redux/config')
 vi.mock('/app/resources/modules')
 
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
+
 const render = (props: ComponentProps<typeof EstopPressedModal>) => {
   return renderWithProviders(<EstopPressedModal {...props} />, {
     i18nInstance: i18n,
@@ -27,6 +32,7 @@ const render = (props: ComponentProps<typeof EstopPressedModal>) => {
 
 describe('EstopPressedModal - Touchscreen', () => {
   let props: ComponentProps<typeof EstopPressedModal>
+  const mockAcknowledgeEstopDisengage = vi.fn()
 
   beforeEach(() => {
     props = {
@@ -36,8 +42,9 @@ describe('EstopPressedModal - Touchscreen', () => {
       setIsWaitingForResumeOperation: vi.fn(),
     }
     vi.mocked(getIsOnDevice).mockReturnValue(true)
+    mockAcknowledgeEstopDisengage.mockReset()
     vi.mocked(useAcknowledgeEstopDisengageMutation).mockReturnValue({
-      setEstopPhysicalStatus: vi.fn(),
+      acknowledgeEstopDisengage: mockAcknowledgeEstopDisengage,
     } as any)
 
     vi.mocked(usePlacePlateReaderLid).mockReturnValue({
@@ -69,28 +76,39 @@ describe('EstopPressedModal - Touchscreen', () => {
   })
 
   it('should call a mock function when clicking resume robot operations', () => {
+    props.isEngaged = false
     render(props)
     fireEvent.click(screen.getByText('Resume robot operations'))
-    expect(useAcknowledgeEstopDisengageMutation).toHaveBeenCalled()
-    expect(usePlacePlateReaderLid).toHaveBeenCalled()
+    expect(useAcknowledgeEstopDisengageMutation).toHaveBeenCalledWith(
+      ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+    )
+    expect(mockAcknowledgeEstopDisengage).toHaveBeenCalled()
   })
 
   it('should call a mock function to place the labware to a slot', () => {
+    props.isEngaged = false
+    const handlePlaceReaderLid = vi.fn()
     vi.mocked(usePlacePlateReaderLid).mockReturnValue({
-      handlePlaceReaderLid: vi.fn(),
+      handlePlaceReaderLid,
       isValidPlateReaderMove: true,
       isExecuting: true,
+    })
+    mockAcknowledgeEstopDisengage.mockImplementation((_vars, options) => {
+      options?.onSuccess?.({} as any, undefined, undefined)
     })
 
     render(props)
     fireEvent.click(screen.getByText('Resume robot operations'))
-    expect(useAcknowledgeEstopDisengageMutation).toHaveBeenCalled()
-    expect(usePlacePlateReaderLid).toHaveBeenCalled()
+    expect(useAcknowledgeEstopDisengageMutation).toHaveBeenCalledWith(
+      ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+    )
+    expect(handlePlaceReaderLid).toHaveBeenCalled()
   })
 })
 
 describe('EstopPressedModal - Desktop', () => {
   let props: ComponentProps<typeof EstopPressedModal>
+  const mockAcknowledgeEstopDisengage = vi.fn()
 
   beforeEach(() => {
     props = {
@@ -100,8 +118,9 @@ describe('EstopPressedModal - Desktop', () => {
       setIsWaitingForResumeOperation: vi.fn(),
     }
     vi.mocked(getIsOnDevice).mockReturnValue(false)
+    mockAcknowledgeEstopDisengage.mockReset()
     vi.mocked(useAcknowledgeEstopDisengageMutation).mockReturnValue({
-      setEstopPhysicalStatus: vi.fn(),
+      acknowledgeEstopDisengage: mockAcknowledgeEstopDisengage,
     } as any)
 
     vi.mocked(usePlacePlateReaderLid).mockReturnValue({
@@ -146,10 +165,14 @@ describe('EstopPressedModal - Desktop', () => {
   })
 
   it('should call a mock function when clicking resume robot operations', () => {
+    props.isEngaged = false
     render(props)
     fireEvent.click(
       screen.getByRole('button', { name: 'Resume robot operations' })
     )
-    expect(useAcknowledgeEstopDisengageMutation).toHaveBeenCalled()
+    expect(useAcknowledgeEstopDisengageMutation).toHaveBeenCalledWith(
+      ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+    )
+    expect(mockAcknowledgeEstopDisengage).toHaveBeenCalled()
   })
 })

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -121,6 +121,7 @@ export interface AttachingModuleAction {
  * These should match keys in audit_log.json
  */
 type AuditLogAction =
+  | 'acknowledge_estop'
   | 'stop_run'
   | 'play_run'
   | 'place_plate_reader_lid'

--- a/react-api-client/src/robot/__tests__/useAcknowledgeEstopDisengageMutation.test.tsx
+++ b/react-api-client/src/robot/__tests__/useAcknowledgeEstopDisengageMutation.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { acknowledgeEstopDisengage } from '@opentrons/api-client'
 
 import { useAcknowledgeEstopDisengageMutation } from '..'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../accessControl/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -39,11 +40,14 @@ describe('useAcknowledgeEstopDisengageMutation hook', () => {
     vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
     vi.mocked(acknowledgeEstopDisengage).mockRejectedValue('oh no')
     const { result } = renderHook(
-      () => useAcknowledgeEstopDisengageMutation(),
+      () =>
+        useAcknowledgeEstopDisengageMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+        ),
       { wrapper }
     )
     expect(result.current.data).toBeUndefined()
-    result.current.acknowledgeEstopDisengage(null)
+    result.current.acknowledgeEstopDisengage()
     await waitFor(() => {
       expect(result.current.data).toBeUndefined()
     })
@@ -56,10 +60,13 @@ describe('useAcknowledgeEstopDisengageMutation hook', () => {
     } as Response<EstopStatus>)
 
     const { result } = renderHook(
-      () => useAcknowledgeEstopDisengageMutation(),
+      () =>
+        useAcknowledgeEstopDisengageMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+        ),
       { wrapper }
     )
-    act(() => result.current.acknowledgeEstopDisengage(null))
+    act(() => result.current.acknowledgeEstopDisengage())
     await waitFor(() => {
       expect(result.current.data).toEqual(updatedEstopPhysicalStatus)
     })

--- a/react-api-client/src/robot/useAcknowledgeEstopDisengageMutation.ts
+++ b/react-api-client/src/robot/useAcknowledgeEstopDisengageMutation.ts
@@ -1,7 +1,8 @@
-import { useMutation, useQueryClient } from 'react-query'
+import { useQueryClient } from 'react-query'
 
 import { acknowledgeEstopDisengage } from '@opentrons/api-client'
 
+import { useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
 import type { AxiosError, AxiosResponse } from 'axios'
@@ -11,21 +12,27 @@ import type {
   UseMutationResult,
 } from 'react-query'
 import type { EstopStatus, HostConfig } from '@opentrons/api-client'
+import type {
+  DocumentationState,
+  DocumentedMutationParameters,
+} from '../accessControl/types'
 
 export type UseAcknowledgeEstopDisengageMutationResult = UseMutationResult<
   EstopStatus,
-  AxiosError
+  AxiosError,
+  void
 > & {
-  acknowledgeEstopDisengage: UseMutateFunction<EstopStatus, AxiosError, unknown>
+  acknowledgeEstopDisengage: UseMutateFunction<EstopStatus, AxiosError, void>
 }
 
 export type UseAcknowledgeEstopDisengageMutationOptions = UseMutationOptions<
   EstopStatus,
   AxiosError,
-  unknown
+  void
 >
 
 export function useAcknowledgeEstopDisengageMutation(
+  documentationState: DocumentationState,
   options: UseAcknowledgeEstopDisengageMutationOptions = {},
   hostOverride?: HostConfig | null
 ): UseAcknowledgeEstopDisengageMutationResult {
@@ -33,10 +40,12 @@ export function useAcknowledgeEstopDisengageMutation(
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
   const queryClient = useQueryClient()
-  const mutation = useMutation<EstopStatus, AxiosError, unknown>(
+  const mutation = useDocumentedMutation<EstopStatus, AxiosError>(
+    documentationState,
+    ['acknowledge_estop'],
     getQueryKey(host, 'robot/control/acknowledgeEstopDisengage'),
-    () => {
-      return acknowledgeEstopDisengage(host!)
+    ({ userNotes }: DocumentedMutationParameters<void>) => {
+      return acknowledgeEstopDisengage(host!, userNotes)
         .then((response: AxiosResponse<EstopStatus>) => {
           queryClient.setQueryData(
             getQueryKey(host, 'robot/control/estopStatus'),

--- a/react-api-client/src/runs/useRunQuery.ts
+++ b/react-api-client/src/runs/useRunQuery.ts
@@ -45,7 +45,9 @@ export function useRunQuery<TError = Error>(
           ((query.data?.data?.errors ?? []) as RunError[]).map(estopInErrorTree)
         )
       ) {
-        queryClient.invalidateQueries(getQueryKey(host, '/robot/control'))
+        queryClient.invalidateQueries(
+          getQueryKey(host, 'robot/control/estopStatus')
+        )
       }
     },
     // FIXME(2026-03-03): Supply all missing dependencies, if it's safe. If it's unsafe, explain why.


### PR DESCRIPTION
# Overview

https://github.com/user-attachments/assets/eb42fc56-70aa-4bde-be25-17fcda7bf95b


Documentation for disengaging the EStop


## Test Plan and Hands on Testing

Disengaging the estop should require documentation

## Risk assessment

Low