### PR TITLE
feat(app, odd): document robot settings 

### DIFF
--- a/api-client/src/robot/updateRobotSetting.ts
+++ b/api-client/src/robot/updateRobotSetting.ts
@@ -7,12 +7,13 @@ import type { RobotSettingsResponse, UpdateRobotSettingRequest } from './types'
 export function updateRobotSetting(
   config: HostConfig,
   id: string,
-  value: boolean
+  value: boolean,
+  userNotes: string
 ): ResponsePromise<RobotSettingsResponse> {
   return request<RobotSettingsResponse, UpdateRobotSettingRequest>(
     POST,
     '/settings',
     config,
-    { body: { id, value } }
+    { body: { id, value }, userNotes }
   )
 }

--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -58,5 +58,6 @@
   "update_error_recovery_policy": "Updating error recovery policy",
   "update_error_recovery_settings": "Updating error recovery settings",
   "update_robot_name": "Updating robot name",
+  "update_settings": "Updating robot settings",
   "update_subsystem": "Updating subsystem firmware"
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/FactoryModeSlideout.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/AdvancedTabSlideouts/FactoryModeSlideout.tsx
@@ -24,6 +24,7 @@ import {
 
 import { ToggleButton } from '/app/atoms/buttons'
 import { MultiSlideout } from '/app/atoms/Slideout/MultiSlideout'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { FileUpload } from '/app/molecules/FileUpload'
 import { UploadInput } from '/app/molecules/UploadInput'
 import { restartRobot } from '/app/redux/robot-admin'
@@ -82,15 +83,19 @@ export function FactoryModeSlideout({
     },
   })
 
-  const { updateRobotSetting } = useUpdateRobotSettingMutation({
-    onSuccess: () => {
-      if (toggleValue && file != null) {
-        createSplash({ file })
-      } else {
-        onFinishCompleteClick()
-      }
-    },
-  })
+  const documentationState = useDocumentationState()
+  const { updateRobotSetting } = useUpdateRobotSettingMutation(
+    documentationState,
+    {
+      onSuccess: () => {
+        if (toggleValue && file != null) {
+          createSplash({ file })
+        } else {
+          onFinishCompleteClick()
+        }
+      },
+    }
+  )
 
   const validate = (
     data: FormValues,

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/GantryHoming.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/GantryHoming.tsx
@@ -12,6 +12,7 @@ import {
 import { useUpdateRobotSettingMutation } from '@opentrons/react-api-client'
 
 import { ToggleButton } from '/app/atoms/buttons'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 
 import type { MouseEventHandler } from 'react'
 import type { RobotSettingsField } from '@opentrons/api-client'
@@ -26,7 +27,9 @@ export function GantryHoming({
   isRobotBusy,
 }: GantryHomingProps): JSX.Element {
   const { t } = useTranslation('device_settings')
-  const { updateRobotSetting } = useUpdateRobotSettingMutation()
+  const documentationState = useDocumentationState()
+  const { updateRobotSetting } =
+    useUpdateRobotSettingMutation(documentationState)
   const value = settings?.value ? settings.value : false
   const id = settings?.id ? settings.id : 'disableHomeOnBoot'
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/LegacySettings.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/LegacySettings.tsx
@@ -12,6 +12,7 @@ import {
 import { useUpdateRobotSettingMutation } from '@opentrons/react-api-client'
 
 import { ToggleButton } from '/app/atoms/buttons'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/utils'
 
 import type { MouseEventHandler } from 'react'
 import type { RobotSettingsField } from '@opentrons/api-client'
@@ -26,7 +27,9 @@ export function LegacySettings({
   isRobotBusy,
 }: LegacySettingsProps): JSX.Element {
   const { t } = useTranslation('device_settings')
-  const { updateRobotSetting } = useUpdateRobotSettingMutation()
+  const { updateRobotSetting } = useUpdateRobotSettingMutation(
+    ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+  )
   const value = settings?.value ? settings.value : false
   const id = settings?.id ? settings.id : 'deckCalibrationDots'
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/ShortTrashBin.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/ShortTrashBin.tsx
@@ -12,6 +12,7 @@ import {
 import { useUpdateRobotSettingMutation } from '@opentrons/react-api-client'
 
 import { ToggleButton } from '/app/atoms/buttons'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/utils'
 
 import type { MouseEventHandler } from 'react'
 import type { RobotSettingsField } from '@opentrons/api-client'
@@ -26,7 +27,9 @@ export function ShortTrashBin({
   isRobotBusy,
 }: ShortTrashBinProps): JSX.Element {
   const { t } = useTranslation('device_settings')
-  const { updateRobotSetting } = useUpdateRobotSettingMutation()
+  const { updateRobotSetting } = useUpdateRobotSettingMutation(
+    ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+  )
   const value = settings?.value ? settings.value : false
   const id = settings?.id ? settings.id : 'shortTrashBin'
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/UsageSettings.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/UsageSettings.tsx
@@ -12,6 +12,7 @@ import {
 import { useUpdateRobotSettingMutation } from '@opentrons/react-api-client'
 
 import { ToggleButton } from '/app/atoms/buttons'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/utils'
 
 import type { MouseEventHandler } from 'react'
 import type { RobotSettingsField } from '@opentrons/api-client'
@@ -26,7 +27,9 @@ export function UsageSettings({
   isRobotBusy,
 }: UsageSettingsProps): JSX.Element {
   const { t } = useTranslation('device_settings')
-  const { updateRobotSetting } = useUpdateRobotSettingMutation()
+  const { updateRobotSetting } = useUpdateRobotSettingMutation(
+    ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+  )
   const value = settings?.value ? settings.value : false
   const id = settings?.id ? settings.id : 'enableDoorSafetySwitch'
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/UseOlderAspirateBehavior.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/UseOlderAspirateBehavior.tsx
@@ -12,6 +12,7 @@ import {
 import { useUpdateRobotSettingMutation } from '@opentrons/react-api-client'
 
 import { ToggleButton } from '/app/atoms/buttons'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/utils'
 
 import type { MouseEventHandler } from 'react'
 import type { RobotSettingsField } from '@opentrons/api-client'
@@ -26,7 +27,9 @@ export function UseOlderAspirateBehavior({
   isRobotBusy,
 }: UseOlderAspirateBehaviorProps): JSX.Element {
   const { t } = useTranslation('device_settings')
-  const { updateRobotSetting } = useUpdateRobotSettingMutation()
+  const { updateRobotSetting } = useUpdateRobotSettingMutation(
+    ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+  )
   const value = settings?.value ? settings.value : false
   const id = settings?.id ? settings.id : 'useOldAspirationFunctions'
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/GantryHoming.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/GantryHoming.test.tsx
@@ -6,10 +6,18 @@ import '@testing-library/jest-dom/vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 
 import { GantryHoming } from '../GantryHoming'
 
-vi.mock('../../../hooks')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
+vi.mock('@opentrons/react-api-client', () => ({
+  useUpdateRobotSettingMutation: () => ({
+    updateRobotSetting: vi.fn(),
+  }),
+}))
 
 const mockSettings = {
   id: 'homing-test',

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/LegacySettings.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/LegacySettings.test.tsx
@@ -1,6 +1,6 @@
 import { MemoryRouter } from 'react-router-dom'
 import { fireEvent, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
 
@@ -8,6 +8,12 @@ import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 
 import { LegacySettings } from '../LegacySettings'
+
+vi.mock('@opentrons/react-api-client', () => ({
+  useUpdateRobotSettingMutation: () => ({
+    updateRobotSetting: vi.fn(),
+  }),
+}))
 
 const mockSettings = {
   id: 'deckCalibrationDots',

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/ShortTrashBin.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/ShortTrashBin.test.tsx
@@ -1,6 +1,6 @@
 import { MemoryRouter } from 'react-router-dom'
 import { fireEvent, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
 
@@ -8,6 +8,12 @@ import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 
 import { ShortTrashBin } from '../ShortTrashBin'
+
+vi.mock('@opentrons/react-api-client', () => ({
+  useUpdateRobotSettingMutation: () => ({
+    updateRobotSetting: vi.fn(),
+  }),
+}))
 
 const mockSettings = {
   id: 'shortFixedTrash',

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/UsageSettings.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/UsageSettings.test.tsx
@@ -1,6 +1,6 @@
 import { MemoryRouter } from 'react-router-dom'
 import { fireEvent, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
 
@@ -8,6 +8,12 @@ import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 
 import { UsageSettings } from '../UsageSettings'
+
+vi.mock('@opentrons/react-api-client', () => ({
+  useUpdateRobotSettingMutation: () => ({
+    updateRobotSetting: vi.fn(),
+  }),
+}))
 
 const mockSettings = {
   id: 'enableDoorSafetySwitch',

--- a/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/UseOlderAspirateBehavior.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/AdvancedTab/__tests__/UseOlderAspirateBehavior.test.tsx
@@ -1,6 +1,6 @@
 import { MemoryRouter } from 'react-router-dom'
 import { fireEvent, screen } from '@testing-library/react'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
 
@@ -8,6 +8,12 @@ import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 
 import { UseOlderAspirateBehavior } from '../UseOlderAspirateBehavior'
+
+vi.mock('@opentrons/react-api-client', () => ({
+  useUpdateRobotSettingMutation: () => ({
+    updateRobotSetting: vi.fn(),
+  }),
+}))
 
 const mockSettings = {
   id: 'useOldAspirationFunctions',

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsAdvanced.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsAdvanced.tsx
@@ -19,6 +19,7 @@ import {
 import { getTopPortalEl } from '/app/App/portal'
 import { ToggleButton } from '/app/atoms/buttons'
 import { Divider } from '/app/atoms/structure'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useIsFlex, useRobot } from '/app/redux-resources/robots'
 import { getFeatureFlags } from '/app/redux/config'
 import { getRobotSerialNumber, UNREACHABLE } from '/app/redux/discovery'
@@ -274,7 +275,9 @@ export function FeatureFlagToggle({
   settingField,
   isRobotBusy,
 }: FeatureFlagToggleProps): JSX.Element | null {
-  const { updateRobotSetting } = useUpdateRobotSettingMutation()
+  const documentationState = useDocumentationState()
+  const { updateRobotSetting } =
+    useUpdateRobotSettingMutation(documentationState)
   const { value, id, title, description } = settingField
 
   if (id == null) return null

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFeatureFlags.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFeatureFlags.tsx
@@ -13,6 +13,7 @@ import {
 } from '@opentrons/react-api-client'
 
 import { ToggleButton } from '/app/atoms/buttons'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 
 import type { MouseEventHandler } from 'react'
 import type { RobotSettingsField } from '@opentrons/api-client'
@@ -51,7 +52,9 @@ interface FeatureFlagToggleProps {
 export function FeatureFlagToggle({
   settingField,
 }: FeatureFlagToggleProps): JSX.Element | null {
-  const { updateRobotSetting } = useUpdateRobotSettingMutation()
+  const documentationState = useDocumentationState()
+  const { updateRobotSetting } =
+    useUpdateRobotSettingMutation(documentationState)
   const { value, id, title, description } = settingField
 
   if (id == null) return null

--- a/app/src/organisms/Desktop/Devices/RobotSettings/SettingToggle.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/SettingToggle.tsx
@@ -10,6 +10,7 @@ import {
 import { useUpdateRobotSettingMutation } from '@opentrons/react-api-client'
 
 import { ToggleButton } from '/app/atoms/buttons'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 
 import type { MouseEventHandler } from 'react'
 import type { RobotSettingsField } from '@opentrons/api-client'
@@ -30,7 +31,9 @@ export function SettingToggle({
   description,
   invert = false,
 }: SettingToggleProps): JSX.Element | null {
-  const { updateRobotSetting } = useUpdateRobotSettingMutation()
+  const documentationState = useDocumentationState()
+  const { updateRobotSetting } =
+    useUpdateRobotSettingMutation(documentationState)
 
   if (id == null) return null
 

--- a/app/src/organisms/Desktop/Devices/RobotSettings/__tests__/RobotSettingsFeatureFlags.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/__tests__/RobotSettingsFeatureFlags.test.tsx
@@ -9,6 +9,7 @@ import {
 } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 
 import { RobotSettingsFeatureFlags } from '../RobotSettingsFeatureFlags'
 
@@ -16,6 +17,9 @@ import type { UseQueryResult } from 'react-query'
 import type { RobotSettingsResponse } from '@opentrons/api-client'
 
 vi.mock('@opentrons/react-api-client')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 
 const MOCK_FF_FIELD = {
   id: 'ff_1',

--- a/app/src/pages/ODD/RobotSettingsDashboard/RobotSettingsList.tsx
+++ b/app/src/pages/ODD/RobotSettingsDashboard/RobotSettingsList.tsx
@@ -13,6 +13,7 @@ import {
 } from '@opentrons/react-api-client'
 
 import { LANGUAGES, US_ENGLISH_DISPLAY_NAME } from '/app/i18n'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { Navigation } from '/app/organisms/ODD/Navigation'
 import {
   OnOffToggle,
@@ -56,7 +57,9 @@ export function RobotSettingsList(props: RobotSettingsListProps): JSX.Element {
     'branded',
   ])
   const dispatch = useDispatch<Dispatch>()
-  const { updateRobotSetting } = useUpdateRobotSettingMutation()
+  const documentationState = useDocumentationState()
+  const { updateRobotSetting } =
+    useUpdateRobotSettingMutation(documentationState)
   const localRobot = useSelector(getLocalRobot)
   const robotName = localRobot?.name != null ? localRobot.name : 'no name'
   const networkConnection = useNetworkConnection(robotName)

--- a/app/src/pages/ODD/RobotSettingsDashboard/__tests__/RobotSettingsDashboard.test.tsx
+++ b/app/src/pages/ODD/RobotSettingsDashboard/__tests__/RobotSettingsDashboard.test.tsx
@@ -10,6 +10,7 @@ import {
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { Navigation } from '/app/organisms/ODD/Navigation'
 import {
   DeviceReset,
@@ -56,6 +57,9 @@ vi.mock('react-redux', async () => {
   }
 })
 vi.mock('@opentrons/react-api-client')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 vi.mock('/app/resources/networking', async () => {
   const actual = await vi.importActual('/app/resources/networking')
   return {

--- a/app/src/resources/errorRecovery/__tests__/useErrorRecoverySettingsToggle.test.ts
+++ b/app/src/resources/errorRecovery/__tests__/useErrorRecoverySettingsToggle.test.ts
@@ -64,9 +64,12 @@ describe('useErrorRecoverySettingsToggle', () => {
     })
 
     expect(result.current.isEREnabled).toBe(false)
-    expect(mockUpdateSettings).toHaveBeenCalledWith({
-      data: { enabled: false },
-    })
+    expect(mockUpdateSettings).toHaveBeenCalledWith(
+      {
+        data: { enabled: false },
+      },
+      { onError: expect.any(Function) }
+    )
     expect(useUpdateErrorRecoverySettings).toHaveBeenCalledWith(
       ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
     )
@@ -76,6 +79,9 @@ describe('useErrorRecoverySettingsToggle', () => {
     })
 
     expect(result.current.isEREnabled).toBe(true)
-    expect(mockUpdateSettings).toHaveBeenCalledWith({ data: { enabled: true } })
+    expect(mockUpdateSettings).toHaveBeenCalledWith(
+      { data: { enabled: true } },
+      { onError: expect.any(Function) }
+    )
   })
 })

--- a/app/src/resources/errorRecovery/useErrorRecoverySettingsToggle.ts
+++ b/app/src/resources/errorRecovery/useErrorRecoverySettingsToggle.ts
@@ -28,10 +28,16 @@ export function useErrorRecoverySettingsToggle(): UseERSettingsToggleResult {
   }, [isEREnabledData])
 
   const toggleERSettings = (): void => {
-    setIsEREnabled(isEREnabled => {
-      updateErrorRecoverySettings({ data: { enabled: !isEREnabled } })
-      return !isEREnabled
-    })
+    const newIsEREnabled = !isEREnabled
+    setIsEREnabled(newIsEREnabled)
+    updateErrorRecoverySettings(
+      { data: { enabled: newIsEREnabled } },
+      {
+        onError: () => {
+          setIsEREnabled(isEREnabled)
+        },
+      }
+    )
   }
 
   return { isEREnabled, toggleERSettings }

--- a/app/src/resources/robot-settings/useDisableStackerSensors.ts
+++ b/app/src/resources/robot-settings/useDisableStackerSensors.ts
@@ -31,11 +31,19 @@ export function useDisableStackerSensors(): {
   }, [sensorsDisabledFromSettings])
 
   const toggleSensors = (): void => {
-    setSensorsDisabledCache(!sensorDisabledCache)
-    updateRobotSetting({
-      id: 'disableFlexStackerLabwareDetection',
-      value: !sensorDisabledCache,
-    })
+    const newSensorsDisabled = !sensorDisabledCache
+    setSensorsDisabledCache(newSensorsDisabled)
+    updateRobotSetting(
+      {
+        id: 'disableFlexStackerLabwareDetection',
+        value: newSensorsDisabled,
+      },
+      {
+        onError: () => {
+          setSensorsDisabledCache(sensorDisabledCache)
+        },
+      }
+    )
   }
 
   return { sensorsDisabled: sensorDisabledCache, toggleSensors }

--- a/app/src/resources/robot-settings/useDisableStackerSensors.ts
+++ b/app/src/resources/robot-settings/useDisableStackerSensors.ts
@@ -5,6 +5,8 @@ import {
   useUpdateRobotSettingMutation,
 } from '@opentrons/react-api-client'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+
 // not releveant to the OT-2, this controls the front LED lights on the Flex
 export function useDisableStackerSensors(): {
   sensorsDisabled: boolean
@@ -12,8 +14,10 @@ export function useDisableStackerSensors(): {
 } {
   const [sensorDisabledCache, setSensorsDisabledCache] =
     useState<boolean>(false)
+  const documentationState = useDocumentationState()
 
-  const { updateRobotSetting } = useUpdateRobotSettingMutation()
+  const { updateRobotSetting } =
+    useUpdateRobotSettingMutation(documentationState)
 
   const robotSettingsQuery = useRobotSettingsQuery()
   const settings = robotSettingsQuery.data?.settings ?? []

--- a/app/src/resources/robot-settings/useLEDLights.ts
+++ b/app/src/resources/robot-settings/useLEDLights.ts
@@ -28,8 +28,16 @@ export function useLEDLights(): {
   }, [isStatusBarEnabled])
 
   const toggleLights = (): void => {
-    updateRobotSetting({ id: 'disableStatusBar', value: lightsEnabledCache })
-    setLightsEnabledCache(!lightsEnabledCache)
+    const newLightsEnabled = !lightsEnabledCache
+    setLightsEnabledCache(newLightsEnabled)
+    updateRobotSetting(
+      { id: 'disableStatusBar', value: lightsEnabledCache },
+      {
+        onError: () => {
+          setLightsEnabledCache(lightsEnabledCache)
+        },
+      }
+    )
   }
 
   return { lightsEnabled: lightsEnabledCache, toggleLights }

--- a/app/src/resources/robot-settings/useLEDLights.ts
+++ b/app/src/resources/robot-settings/useLEDLights.ts
@@ -5,14 +5,18 @@ import {
   useUpdateRobotSettingMutation,
 } from '@opentrons/react-api-client'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+
 // not releveant to the OT-2, this controls the front LED lights on the Flex
 export function useLEDLights(): {
   lightsEnabled: boolean
   toggleLights: () => void
 } {
   const [lightsEnabledCache, setLightsEnabledCache] = useState<boolean>(true)
+  const documentationState = useDocumentationState()
 
-  const { updateRobotSetting } = useUpdateRobotSettingMutation()
+  const { updateRobotSetting } =
+    useUpdateRobotSettingMutation(documentationState)
 
   const robotSettingsQuery = useRobotSettingsQuery()
   const settings = robotSettingsQuery.data?.settings ?? []

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -170,6 +170,7 @@ type AuditLogAction =
   | 'set_lights'
   | 'apply_offsets'
   | 'update_subsystem'
+  | 'update_settings'
 
 /**
  * Type used for DocumentedActions - keys and info to enable correct rendering of actions in the 'list actions' popup in the Documentation Required Modal.

--- a/react-api-client/src/robot/__tests__/useUpdateRobotSettingMutation.test.tsx
+++ b/react-api-client/src/robot/__tests__/useUpdateRobotSettingMutation.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { updateRobotSetting } from '@opentrons/api-client'
 
 import { useUpdateRobotSettingMutation } from '..'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../accessControl/__fixtures__/documentationState'
 import { useHost } from '../../api'
 import { robotSettingsQueryKey } from '../useRobotSettingsQuery'
 
@@ -55,9 +56,15 @@ describe('useUpdateRobotSettingMutation hook', () => {
       data: ROBOT_SETTINGS_RESPONSE,
     } as Response<RobotSettingsResponse>)
 
-    const { result } = renderHook(() => useUpdateRobotSettingMutation(), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () =>
+        useUpdateRobotSettingMutation(
+          ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+        ),
+      {
+        wrapper,
+      }
+    )
 
     result.current.updateRobotSetting({
       id: 'disableHomeOnBoot',
@@ -68,6 +75,12 @@ describe('useUpdateRobotSettingMutation hook', () => {
       expect(result.current.isSuccess).toBe(true)
     })
 
+    expect(updateRobotSetting).toHaveBeenCalledWith(
+      HOST_CONFIG,
+      'disableHomeOnBoot',
+      true,
+      ''
+    )
     expect(
       queryClient.getQueryData(robotSettingsQueryKey(HOST_CONFIG))
     ).toEqual(ROBOT_SETTINGS_RESPONSE)

--- a/react-api-client/src/robot/useUpdateRobotSettingMutation.ts
+++ b/react-api-client/src/robot/useUpdateRobotSettingMutation.ts
@@ -1,7 +1,8 @@
-import { useMutation, useQueryClient } from 'react-query'
+import { useQueryClient } from 'react-query'
 
 import { updateRobotSetting } from '@opentrons/api-client'
 
+import { useDocumentedMutation } from '../accessControl'
 import { useHost } from '../api'
 import { robotSettingsQueryKey } from './useRobotSettingsQuery'
 
@@ -16,6 +17,8 @@ import type {
   HostConfig,
   RobotSettingsResponse,
 } from '@opentrons/api-client'
+import type { DocumentationState } from '../accessControl'
+import type { DocumentedMutationParameters } from '../accessControl/types'
 
 export interface UpdateRobotSettingVariables {
   id: string
@@ -41,6 +44,7 @@ export type UseUpdateRobotSettingMutationOptions = UseMutationOptions<
 >
 
 export function useUpdateRobotSettingMutation(
+  documentationState: DocumentationState,
   options: UseUpdateRobotSettingMutationOptions = {},
   hostOverride?: HostConfig | null
 ): UseUpdateRobotSettingMutationResult {
@@ -49,14 +53,19 @@ export function useUpdateRobotSettingMutation(
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
   const queryClient = useQueryClient()
 
-  const mutation = useMutation<
+  const mutation = useDocumentedMutation<
     RobotSettingsResponse,
     AxiosError<ErrorResponse>,
     UpdateRobotSettingVariables
   >(
+    documentationState,
+    ['update_settings'],
     robotSettingsQueryKey(host),
-    ({ id, value }) =>
-      updateRobotSetting(host!, id, value).then(response => {
+    ({
+      variables: { id, value },
+      userNotes,
+    }: DocumentedMutationParameters<UpdateRobotSettingVariables>) =>
+      updateRobotSetting(host!, id, value, userNotes).then(response => {
         queryClient.setQueryData(robotSettingsQueryKey(host), response.data)
         return response.data
       }),


### PR DESCRIPTION
# Overview

https://github.com/user-attachments/assets/650edd4c-98a8-4d66-910b-5b6dc06a2f2e

documentation for updating robot settings

## Test Plan and Hands on Testing

Updating all robot settings should require login and documentation. Backing out of the documentation modal should reset the toggle switch

## Risk assessment

Low