### PR TITLE
feat(robot-server): Support downloading select files related to a protocol run

### DIFF
--- a/robot-server/robot_server/data_files/models.py
+++ b/robot-server/robot_server/data_files/models.py
@@ -85,13 +85,6 @@ class NoImagesFound(ErrorDetails):
     title: str = "No images found for run"
 
 
-class ZipCreationFailed(ErrorDetails):
-    """An error returned when zip file creation fails during image download."""
-
-    id: Literal["ZipCreationFailed"] = "ZipCreationFailed"
-    title: str = "Failed to create zip file"
-
-
 class ImageFileMetadata(BaseModel):
     """Metadata associated with a particular image file captured by a camera during a run."""
 

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -1,15 +1,13 @@
 """Router for /dataFiles endpoints."""
 
-import asyncio
 from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
-from typing import Annotated, AsyncIterator, Final, Literal, Optional, Union
+from typing import Annotated, Final, Literal, Optional, Union
 
 from fastapi import Depends, File, Form, Query, Response, UploadFile, status
 from fastapi.responses import FileResponse, StreamingResponse
 
-from opentrons import config
 from opentrons.protocol_reader import FileHasher, FileReaderWriter
 from opentrons_shared_data.data_files import DataFileInfo, DataFileSource, MimeType
 from server_utils.auth.resource_server.fastapi import require_scopes
@@ -46,6 +44,11 @@ from .models import (
     ImageFileMetadata,
     NoImagesFound,
     ZipCreationFailed,
+)
+from .zip_utils import (
+    build_run_zip_filename,
+    collect_existing_run_images,
+    stream_zip,
 )
 from robot_server.errors.error_responses import ErrorBody, ErrorDetails
 from robot_server.protocols.protocol_store import ProtocolStore
@@ -582,115 +585,22 @@ async def download_run_images(
         run_store: Store for run data management.
         protocol_store: Store for protocol storage access.
     """
-    info_slice = data_files_store.get_files_info_by_run_mime_type(
-        run_id=runId,
-        mime_type=MimeType.IMAGE_JPEG,
-        offset=0,
-        limit=None,
-    )
-
-    if not info_slice.file_info:
-        raise NoImagesFound(detail=f"No images found for run '{runId}'").as_error(
-            status.HTTP_404_NOT_FOUND
-        )
-
-    existing_files = []
-    for file_info in info_slice.file_info:
-        image_path = Path(file_info.path)
-        if image_path.exists() and image_path.is_file():
-            existing_files.append((image_path, file_info.name))
+    existing_files = collect_existing_run_images(runId, data_files_store)
 
     if not existing_files:
         raise NoImagesFound(
             detail=f"No accessible images found for run '{runId}'"
         ).as_error(status.HTTP_404_NOT_FOUND)
 
-    zip_filename = _build_zip_filename(
-        run_id=runId, run_store=run_store, protocol_store=protocol_store
+    run = run_store.get(runId)
+    zip_filename = build_run_zip_filename(
+        run=run,
+        protocol_store=protocol_store,
+        fallback_filename=f"{runId}_images.zip",
     )
 
     return StreamingResponse(
-        _stream_zip_from_subprocess(existing_files),
+        stream_zip(existing_files),
         media_type="application/zip",
         headers={"Content-Disposition": f"attachment; filename={zip_filename}"},
     )
-
-
-async def _stream_zip_from_subprocess(
-    files: list[tuple[Path, str]],
-    chunk_size: int = 65536,
-) -> AsyncIterator[bytes]:
-    """Offload zipping to a subprocess, yielding the final zip file chunks, `chunk_size` bytes in size."""
-    process = None
-
-    try:
-        file_paths = [str(file_path) for file_path, _ in files]
-
-        process = await asyncio.create_subprocess_exec(
-            "zip",
-            "-q",  # quiet
-            "-j",  # junk paths (store only filenames)
-            "-",  # write zip output to stdout
-            *file_paths,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-
-        if process.stdout is None:
-            raise RuntimeError("stdout was not captured")
-        if process.stderr is None:
-            raise RuntimeError("stderr was not captured")
-
-        while True:
-            chunk = await process.stdout.read(chunk_size)
-            if not chunk:
-                break
-            yield chunk
-
-        await process.wait()
-
-        if process.returncode != 0:
-            stderr_output = await process.stderr.read()
-            error_msg = stderr_output.decode() if stderr_output else "Unknown error"
-            raise Exception(
-                f"zip command failed with code {process.returncode}: {error_msg}"
-            )
-
-    except Exception as e:
-        # Clean up process if still running
-        if process is not None and process.returncode is None:
-            process.kill()
-            await process.wait()
-
-        raise ZipCreationFailed(
-            detail=f"Unexpected error during zip creation: {str(e)}"
-        ).as_error(status.HTTP_500_INTERNAL_SERVER_ERROR) from e
-
-
-def _build_zip_filename(
-    run_id: str, run_store: RunStore, protocol_store: ProtocolStore
-) -> str:
-    run_info = run_store.get(run_id)
-    protocol_id = run_info.protocol_id if run_info else None
-
-    if protocol_id is not None:
-        protocol = protocol_store.get(protocol_id)
-        protocol_name = (
-            protocol.source.metadata.get(
-                "protocolName", protocol.source.files[0].path.name
-            )
-            if protocol is not None
-            else None
-        )
-        robot_name = config.name()
-        timestamp = run_info.created_at.strftime("%Y%m%d_%H%M%S")
-        final_str = f"{robot_name}_{_sanitize_str(protocol_name)}_{timestamp}.zip"
-
-        return final_str
-
-    return f"{run_id}_images.zip"
-
-
-def _sanitize_str(input_str: str) -> str:
-    """Ensure that the input string contains only alphanumeric characters."""
-    return "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in input_str)

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -576,9 +576,7 @@ async def download_run_images(
     data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
     run_store: Annotated[RunStore, Depends(get_run_store)],
     protocol_store: Annotated[ProtocolStore, Depends(get_protocol_store)],
-    persistence_directory: Annotated[
-        Path, Depends(get_active_persistence_directory)
-    ],
+    persistence_directory: Annotated[Path, Depends(get_active_persistence_directory)],
 ) -> FileResponse:
     """Download all camera images for a run as a zip file.
 

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -6,7 +6,8 @@ from textwrap import dedent
 from typing import Annotated, Final, Literal, Optional, Union
 
 from fastapi import Depends, File, Form, Query, Response, UploadFile, status
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse
+from starlette.background import BackgroundTask
 
 from opentrons.protocol_reader import FileHasher, FileReaderWriter
 from opentrons_shared_data.data_files import DataFileInfo, DataFileSource, MimeType
@@ -48,9 +49,12 @@ from .models import (
 from .zip_utils import (
     build_run_zip_filename,
     collect_existing_run_images,
-    stream_zip,
+    create_zip_for_download,
 )
 from robot_server.errors.error_responses import ErrorBody, ErrorDetails
+from robot_server.persistence.fastapi_dependencies import (
+    get_active_persistence_directory,
+)
 from robot_server.protocols.protocol_store import ProtocolStore
 from robot_server.runs.dependencies import get_run_data_manager, get_run_store
 from robot_server.runs.router.base_router import RunNotFound
@@ -574,7 +578,10 @@ async def download_run_images(
     data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
     run_store: Annotated[RunStore, Depends(get_run_store)],
     protocol_store: Annotated[ProtocolStore, Depends(get_protocol_store)],
-) -> StreamingResponse:
+    persistence_directory: Annotated[
+        Path, Depends(get_active_persistence_directory)
+    ],
+) -> FileResponse:
     """Download all camera images for a run as a zip file.
 
     Arguments:
@@ -582,6 +589,7 @@ async def download_run_images(
         data_files_store: Store for data files database access.
         run_store: Store for run data management.
         protocol_store: Store for protocol storage access.
+        persistence_directory: Persistence directory used for zip staging.
     """
     existing_files = collect_existing_run_images(runId, data_files_store)
 
@@ -596,9 +604,13 @@ async def download_run_images(
         protocol_store=protocol_store,
         fallback_filename=f"{runId}_images.zip",
     )
+    zip_path, cleanup = await create_zip_for_download(
+        existing_files, persistence_directory
+    )
 
-    return StreamingResponse(
-        stream_zip(existing_files),
+    return FileResponse(
+        path=zip_path,
         media_type="application/zip",
-        headers={"Content-Disposition": f"attachment; filename={zip_filename}"},
+        filename=zip_filename,
+        background=BackgroundTask(cleanup),
     )

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -577,8 +577,6 @@ async def download_run_images(
 ) -> StreamingResponse:
     """Download all camera images for a run as a zip file.
 
-    Streams the resultant zip file via a spawned subprocess.
-
     Arguments:
         runId: The run ID associated with the camera image files.
         data_files_store: Store for data files database access.

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -44,7 +44,6 @@ from .models import (
     FileNotFound,
     ImageFileMetadata,
     NoImagesFound,
-    ZipCreationFailed,
 )
 from .zip_utils import (
     build_run_zip_filename,
@@ -570,7 +569,6 @@ async def delete_run_images(
             "description": "A zip file containing all camera images for the run",
         },
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[NoImagesFound]},
-        status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": ErrorBody[ZipCreationFailed]},
     },
 )
 async def download_run_images(

--- a/robot-server/robot_server/data_files/zip_utils.py
+++ b/robot-server/robot_server/data_files/zip_utils.py
@@ -1,8 +1,9 @@
 """Shared helpers for building and streaming zip downloads."""
 
 import asyncio
+import io
+import zipfile
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import AsyncIterator, List, Optional, Tuple, Union
 
 from fastapi import status
@@ -88,62 +89,32 @@ def collect_existing_run_output_csvs(
     return entries
 
 
+def _build_zip_bytes(entries: List[Tuple[Path, str]]) -> bytes:
+    """Build a zip archive in memory from filesystem/archive path pairs."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(
+        buffer, mode="w", compression=zipfile.ZIP_DEFLATED
+    ) as zip_file:
+        for source_path, archive_name in entries:
+            zip_file.write(source_path, arcname=archive_name)
+    return buffer.getvalue()
+
+
 async def stream_zip(
     entries: List[Tuple[Path, str]],
     chunk_size: int = 65536,
 ) -> AsyncIterator[bytes]:
-    """Stage files into a temp tree and stream a zip with preserved archive paths.
+    """Build a zip archive off the event loop and stream it in chunks.
 
     Args:
         entries: ``(filesystem_path, archive_path)`` pairs to include.
         chunk_size: Number of bytes to yield per chunk.
     """
-    process = None
-
     try:
-        with TemporaryDirectory() as staging_dir:
-            staging_path = Path(staging_dir)
-            for source_path, archive_name in entries:
-                destination = staging_path / archive_name
-                destination.parent.mkdir(parents=True, exist_ok=True)
-                destination.symlink_to(source_path.resolve())
-
-            process = await asyncio.create_subprocess_exec(
-                "zip",
-                "-q",  # quiet
-                "-r",  # recurse into directories
-                "-",  # write zip output to stdout
-                ".",
-                cwd=str(staging_path),
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-
-            if process.stdout is None:
-                raise RuntimeError("stdout was not captured")
-            if process.stderr is None:
-                raise RuntimeError("stderr was not captured")
-
-            while True:
-                chunk = await process.stdout.read(chunk_size)
-                if not chunk:
-                    break
-                yield chunk
-
-            await process.wait()
-
-            if process.returncode != 0:
-                stderr_output = await process.stderr.read()
-                error_msg = stderr_output.decode() if stderr_output else "Unknown error"
-                raise Exception(
-                    f"zip command failed with code {process.returncode}: {error_msg}"
-                )
-
+        zip_bytes = await asyncio.to_thread(_build_zip_bytes, entries)
+        for offset in range(0, len(zip_bytes), chunk_size):
+            yield zip_bytes[offset : offset + chunk_size]
     except Exception as e:
-        if process is not None and process.returncode is None:
-            process.kill()
-            await process.wait()
-
         raise ZipCreationFailed(
             detail=f"Unexpected error during zip creation: {str(e)}"
         ).as_error(status.HTTP_500_INTERNAL_SERVER_ERROR) from e

--- a/robot-server/robot_server/data_files/zip_utils.py
+++ b/robot-server/robot_server/data_files/zip_utils.py
@@ -29,7 +29,7 @@ def collect_existing_run_images(
         data_files_store: Store for data files database access.
         archive_prefix: Optional directory prefix inside the zip
             (e.g. ``"images"`` -> ``images/foo.jpeg``). When ``None``,
-            files are stored at the zip root using their basename.
+            files are stored using their basename.
 
     Returns:
         A list of ``(filesystem_path, archive_path)`` tuples for files
@@ -63,14 +63,13 @@ def collect_existing_run_output_csvs(
 ) -> List[Tuple[Path, str]]:
     """Collect existing CSV output files for a run under ``archive_prefix``.
 
-    Camera images are excluded (they belong in the images folder). File names
-    are prefixed with the data file id because ``data_files.name`` is not unique.
+    File names are prefixed with the data file id because ``data_files.name`` is not unique.
 
     Args:
         run_id: The run to collect output CSVs for.
         data_files_store: Store for data files database access.
         archive_prefix: Directory prefix inside the zip
-            (e.g. ``"my_protocol_2024-06-20T10_30_15.354Z_output"``).
+            (e.x. ``"my_protocol_2024-06-20T10_30_15.354Z_output"``).
 
     Returns:
         A list of ``(filesystem_path, archive_path)`` tuples for files
@@ -182,8 +181,8 @@ def build_run_zip_filename(
                 f"{robot_name}_{sanitize_filename_component(str(protocol_name))}"
                 f"_{timestamp}.zip"
             )
-
-    return fallback_filename
+    else:
+        return fallback_filename
 
 
 def sanitize_filename_component(input_str: str) -> str:

--- a/robot-server/robot_server/data_files/zip_utils.py
+++ b/robot-server/robot_server/data_files/zip_utils.py
@@ -1,10 +1,10 @@
 """Shared helpers for building and streaming zip downloads."""
 
 import asyncio
-import io
+import tempfile
 import zipfile
 from pathlib import Path
-from typing import AsyncIterator, List, Optional, Tuple, Union
+from typing import Callable, Final, List, Optional, Tuple, Union
 
 from fastapi import status
 
@@ -15,6 +15,8 @@ from .data_files_store import DataFilesStore
 from .models import ZipCreationFailed
 from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
 from robot_server.runs.run_store import BadRunResource, RunResource
+
+_DOWNLOAD_STAGING_PREFIX: Final = "temp-download-staging-"
 
 
 def collect_existing_run_images(
@@ -89,31 +91,48 @@ def collect_existing_run_output_csvs(
     return entries
 
 
-def _build_zip_bytes(entries: List[Tuple[Path, str]]) -> bytes:
-    """Build a zip archive in memory from filesystem/archive path pairs."""
-    buffer = io.BytesIO()
-    with zipfile.ZipFile(
-        buffer, mode="w", compression=zipfile.ZIP_DEFLATED
-    ) as zip_file:
-        for source_path, archive_name in entries:
-            zip_file.write(source_path, arcname=archive_name)
-    return buffer.getvalue()
-
-
-async def stream_zip(
+def _create_zip_for_download(
     entries: List[Tuple[Path, str]],
-    chunk_size: int = 65536,
-) -> AsyncIterator[bytes]:
-    """Build a zip archive off the event loop and stream it in chunks.
+    staging_root: Path,
+) -> Tuple[Path, Callable[[], None]]:
+    """Write a zip under ``staging_root`` and return ``(zip_path, cleanup)``."""
+    staging_root.mkdir(parents=True, exist_ok=True)
+    temp_dir = tempfile.TemporaryDirectory(
+        prefix=_DOWNLOAD_STAGING_PREFIX, dir=str(staging_root)
+    )
+    zip_path = Path(temp_dir.name) / "download.zip"
+    try:
+        with zipfile.ZipFile(
+            zip_path, mode="w", compression=zipfile.ZIP_DEFLATED
+        ) as zip_file:
+            for source_path, archive_name in entries:
+                zip_file.write(source_path, arcname=archive_name)
+    except Exception:
+        temp_dir.cleanup()
+        raise
+
+    def cleanup() -> None:
+        try:
+            zip_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        temp_dir.cleanup()
+
+    return zip_path, cleanup
+
+
+async def create_zip_for_download(
+    entries: List[Tuple[Path, str]],
+    staging_root: Path,
+) -> Tuple[Path, Callable[[], None]]:
+    """Build a zip archive off the event loop under ``staging_root``.
 
     Args:
         entries: ``(filesystem_path, archive_path)`` pairs to include.
-        chunk_size: Number of bytes to yield per chunk.
+        staging_root: Directory that should hold the staging temp dir.
     """
     try:
-        zip_bytes = await asyncio.to_thread(_build_zip_bytes, entries)
-        for offset in range(0, len(zip_bytes), chunk_size):
-            yield zip_bytes[offset : offset + chunk_size]
+        return await asyncio.to_thread(_create_zip_for_download, entries, staging_root)
     except Exception as e:
         raise ZipCreationFailed(
             detail=f"Unexpected error during zip creation: {str(e)}"

--- a/robot-server/robot_server/data_files/zip_utils.py
+++ b/robot-server/robot_server/data_files/zip_utils.py
@@ -1,0 +1,157 @@
+"""Shared helpers for building and streaming zip downloads."""
+
+import asyncio
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import AsyncIterator, List, Optional, Tuple, Union
+
+from fastapi import status
+
+from opentrons import config
+from opentrons_shared_data.data_files import MimeType
+
+from .data_files_store import DataFilesStore
+from .models import ZipCreationFailed
+from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
+from robot_server.runs.run_store import BadRunResource, RunResource
+
+
+def collect_existing_run_images(
+    run_id: str,
+    data_files_store: DataFilesStore,
+    *,
+    archive_prefix: Optional[str] = None,
+) -> List[Tuple[Path, str]]:
+    """Collect existing JPEG image files for a run.
+
+    Args:
+        run_id: The run to collect images for.
+        data_files_store: Store for data files database access.
+        archive_prefix: Optional directory prefix inside the zip
+            (e.g. ``"images"`` -> ``images/foo.jpeg``). When ``None``,
+            files are stored at the zip root using their basename.
+
+    Returns:
+        A list of ``(filesystem_path, archive_path)`` tuples for files
+        that exist on disk.
+    """
+    info_slice = data_files_store.get_files_info_by_run_mime_type(
+        run_id=run_id,
+        mime_type=MimeType.IMAGE_JPEG,
+        offset=0,
+        limit=None,
+    )
+
+    entries: List[Tuple[Path, str]] = []
+    for file_info in info_slice.file_info:
+        image_path = Path(file_info.path)
+        if image_path.exists() and image_path.is_file():
+            archive_name = (
+                f"{archive_prefix}/{file_info.name}"
+                if archive_prefix is not None
+                else file_info.name
+            )
+            entries.append((image_path, archive_name))
+    return entries
+
+
+async def stream_zip(
+    entries: List[Tuple[Path, str]],
+    chunk_size: int = 65536,
+) -> AsyncIterator[bytes]:
+    """Stage files into a temp tree and stream a zip with preserved archive paths.
+
+    Args:
+        entries: ``(filesystem_path, archive_path)`` pairs to include.
+        chunk_size: Number of bytes to yield per chunk.
+    """
+    process = None
+
+    try:
+        with TemporaryDirectory() as staging_dir:
+            staging_path = Path(staging_dir)
+            for source_path, archive_name in entries:
+                destination = staging_path / archive_name
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.symlink_to(source_path.resolve())
+
+            process = await asyncio.create_subprocess_exec(
+                "zip",
+                "-q",  # quiet
+                "-r",  # recurse into directories
+                "-",  # write zip output to stdout
+                ".",
+                cwd=str(staging_path),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+
+            if process.stdout is None:
+                raise RuntimeError("stdout was not captured")
+            if process.stderr is None:
+                raise RuntimeError("stderr was not captured")
+
+            while True:
+                chunk = await process.stdout.read(chunk_size)
+                if not chunk:
+                    break
+                yield chunk
+
+            await process.wait()
+
+            if process.returncode != 0:
+                stderr_output = await process.stderr.read()
+                error_msg = stderr_output.decode() if stderr_output else "Unknown error"
+                raise Exception(
+                    f"zip command failed with code {process.returncode}: {error_msg}"
+                )
+
+    except Exception as e:
+        if process is not None and process.returncode is None:
+            process.kill()
+            await process.wait()
+
+        raise ZipCreationFailed(
+            detail=f"Unexpected error during zip creation: {str(e)}"
+        ).as_error(status.HTTP_500_INTERNAL_SERVER_ERROR) from e
+
+
+def build_run_zip_filename(
+    run: Union[RunResource, BadRunResource],
+    protocol_store: ProtocolStore,
+    *,
+    fallback_filename: str,
+) -> str:
+    """Build a download zip filename from run/protocol metadata.
+
+    Prefers ``{robot}_{protocolName}_{timestamp}.zip`` when a protocol
+    name is available; otherwise returns ``fallback_filename``.
+    """
+    protocol_id = run.protocol_id
+
+    if protocol_id is not None:
+        try:
+            protocol = protocol_store.get(protocol_id)
+        except ProtocolNotFoundError:
+            protocol = None
+
+        protocol_name = None
+        if protocol is not None:
+            protocol_name = protocol.source.metadata.get("protocolName")
+            if protocol_name is None:
+                protocol_name = protocol.source.files[0].path.name
+
+        if protocol_name is not None:
+            robot_name = config.name()
+            timestamp = run.created_at.strftime("%Y%m%d_%H%M%S")
+            return (
+                f"{robot_name}_{sanitize_filename_component(str(protocol_name))}"
+                f"_{timestamp}.zip"
+            )
+
+    return fallback_filename
+
+
+def sanitize_filename_component(input_str: str) -> str:
+    """Ensure that the input string contains only filesystem-safe characters."""
+    return "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in input_str)

--- a/robot-server/robot_server/data_files/zip_utils.py
+++ b/robot-server/robot_server/data_files/zip_utils.py
@@ -181,8 +181,8 @@ def build_run_zip_filename(
                 f"{robot_name}_{sanitize_filename_component(str(protocol_name))}"
                 f"_{timestamp}.zip"
             )
-    else:
-        return fallback_filename
+
+    return fallback_filename
 
 
 def sanitize_filename_component(input_str: str) -> str:

--- a/robot-server/robot_server/data_files/zip_utils.py
+++ b/robot-server/robot_server/data_files/zip_utils.py
@@ -6,13 +6,10 @@ import zipfile
 from pathlib import Path
 from typing import Callable, Final, List, Optional, Tuple, Union
 
-from fastapi import status
-
 from opentrons import config
 from opentrons_shared_data.data_files import MimeType
 
 from .data_files_store import DataFilesStore
-from .models import ZipCreationFailed
 from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
 from robot_server.runs.run_store import BadRunResource, RunResource
 
@@ -131,12 +128,7 @@ async def create_zip_for_download(
         entries: ``(filesystem_path, archive_path)`` pairs to include.
         staging_root: Directory that should hold the staging temp dir.
     """
-    try:
-        return await asyncio.to_thread(_create_zip_for_download, entries, staging_root)
-    except Exception as e:
-        raise ZipCreationFailed(
-            detail=f"Unexpected error during zip creation: {str(e)}"
-        ).as_error(status.HTTP_500_INTERNAL_SERVER_ERROR) from e
+    return await asyncio.to_thread(_create_zip_for_download, entries, staging_root)
 
 
 def build_run_zip_filename(

--- a/robot-server/robot_server/data_files/zip_utils.py
+++ b/robot-server/robot_server/data_files/zip_utils.py
@@ -55,6 +55,40 @@ def collect_existing_run_images(
     return entries
 
 
+def collect_existing_run_output_csvs(
+    run_id: str,
+    data_files_store: DataFilesStore,
+    *,
+    archive_prefix: str,
+) -> List[Tuple[Path, str]]:
+    """Collect existing CSV output files for a run under ``archive_prefix``.
+
+    Camera images are excluded (they belong in the images folder). File names
+    are prefixed with the data file id because ``data_files.name`` is not unique.
+
+    Args:
+        run_id: The run to collect output CSVs for.
+        data_files_store: Store for data files database access.
+        archive_prefix: Directory prefix inside the zip
+            (e.g. ``"my_protocol_2024-06-20T10_30_15.354Z_output"``).
+
+    Returns:
+        A list of ``(filesystem_path, archive_path)`` tuples for files
+        that exist on disk.
+    """
+    files_by_run = data_files_store.get_data_files_by_run_id(run_id)
+
+    entries: List[Tuple[Path, str]] = []
+    for file_info in files_by_run.output_files:
+        if file_info.mime_type != MimeType.TEXT_CSV:
+            continue
+        file_path = Path(file_info.path)
+        if file_path.exists() and file_path.is_file():
+            archive_name = f"{archive_prefix}/{file_info.id}_{file_info.name}"
+            entries.append((file_path, archive_name))
+    return entries
+
+
 async def stream_zip(
     entries: List[Tuple[Path, str]],
     chunk_size: int = 65536,

--- a/robot-server/robot_server/data_files/zip_utils.py
+++ b/robot-server/robot_server/data_files/zip_utils.py
@@ -14,6 +14,7 @@ from robot_server.protocols.protocol_store import ProtocolNotFoundError, Protoco
 from robot_server.runs.run_store import BadRunResource, RunResource
 
 _DOWNLOAD_STAGING_PREFIX: Final = "temp-download-staging-"
+_DOWNLOAD_ZIP_NAME: Final = "download.zip"
 
 
 def collect_existing_run_images(
@@ -88,47 +89,57 @@ def collect_existing_run_output_csvs(
     return entries
 
 
-def _create_zip_for_download(
-    entries: List[Tuple[Path, str]],
-    staging_root: Path,
-) -> Tuple[Path, Callable[[], None]]:
-    """Write a zip under ``staging_root`` and return ``(zip_path, cleanup)``."""
+def create_download_staging_dir(staging_root: Path) -> tempfile.TemporaryDirectory[str]:
+    """Create a unique request-scoped staging directory under ``staging_root``."""
     staging_root.mkdir(parents=True, exist_ok=True)
-    temp_dir = tempfile.TemporaryDirectory(
+    return tempfile.TemporaryDirectory(
         prefix=_DOWNLOAD_STAGING_PREFIX, dir=str(staging_root)
     )
-    zip_path = Path(temp_dir.name) / "download.zip"
-    try:
-        with zipfile.ZipFile(
-            zip_path, mode="w", compression=zipfile.ZIP_DEFLATED
-        ) as zip_file:
-            for source_path, archive_name in entries:
-                zip_file.write(source_path, arcname=archive_name)
-    except Exception:
-        temp_dir.cleanup()
-        raise
 
-    def cleanup() -> None:
-        try:
-            zip_path.unlink(missing_ok=True)
-        except OSError:
-            pass
-        temp_dir.cleanup()
 
-    return zip_path, cleanup
+def _write_zip_file(entries: List[Tuple[Path, str]], zip_path: Path) -> None:
+    """Write ``entries`` into ``zip_path``."""
+    with zipfile.ZipFile(
+        zip_path, mode="w", compression=zipfile.ZIP_DEFLATED
+    ) as zip_file:
+        for source_path, archive_name in entries:
+            zip_file.write(source_path, arcname=archive_name)
+
+
+async def write_zip_for_download(
+    entries: List[Tuple[Path, str]],
+    staging_dir: Path,
+) -> Path:
+    """Build ``download.zip`` inside an existing staging directory.
+
+    Args:
+        entries: ``(filesystem_path, archive_path)`` pairs to include.
+        staging_dir: Already-created request scratch directory.
+
+    Returns:
+        Path to the created zip file inside ``staging_dir``.
+    """
+    zip_path = staging_dir / _DOWNLOAD_ZIP_NAME
+    await asyncio.to_thread(_write_zip_file, entries, zip_path)
+    return zip_path
 
 
 async def create_zip_for_download(
     entries: List[Tuple[Path, str]],
     staging_root: Path,
 ) -> Tuple[Path, Callable[[], None]]:
-    """Build a zip archive off the event loop under ``staging_root``.
+    """Create a staging directory, build a zip inside it, and return cleanup.
 
-    Args:
-        entries: ``(filesystem_path, archive_path)`` pairs to include.
-        staging_root: Directory that should hold the staging temp dir.
+    Convenience wrapper for callers that do not need the scratch directory for
+    anything other than the zip itself.
     """
-    return await asyncio.to_thread(_create_zip_for_download, entries, staging_root)
+    temp_dir = create_download_staging_dir(staging_root)
+    try:
+        zip_path = await write_zip_for_download(entries, Path(temp_dir.name))
+    except Exception:
+        temp_dir.cleanup()
+        raise
+    return zip_path, temp_dir.cleanup
 
 
 def build_run_zip_filename(

--- a/robot-server/robot_server/runs/router/__init__.py
+++ b/robot-server/robot_server/runs/router/__init__.py
@@ -8,6 +8,7 @@ from .camera_router import camera_router
 from .command_annotations_router import command_annotations_router
 from .commands_router import commands_router
 from .error_recovery_policy_router import error_recovery_policy_router
+from .file_download_router import file_download_router
 from .labware_router import labware_router
 
 runs_router = LightRouter()
@@ -19,5 +20,6 @@ runs_router.include_router(actions_router)
 runs_router.include_router(labware_router)
 runs_router.include_router(camera_router)
 runs_router.include_router(error_recovery_policy_router)
+runs_router.include_router(file_download_router)
 
 __all__ = ["runs_router"]

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -52,6 +52,7 @@ class NoDownloadContent(ErrorDetails):
         - Camera images under an `images/` directory
         - The protocol source file
         - The run log
+        - Labware offset data
         """
     ),
     responses={
@@ -106,6 +107,16 @@ async def download_run_files(
     if run_log_entry is not None:
         zip_entries.append(run_log_entry)
         temp_paths.append(run_log_entry[0])
+
+    offsets_entry = _collect_labware_offsets(
+        run_id=runId,
+        run=run,
+        run_data_manager=run_data_manager,
+        protocol_store=protocol_store,
+    )
+    if offsets_entry is not None:
+        zip_entries.append(offsets_entry)
+        temp_paths.append(offsets_entry[0])
 
     if not zip_entries:
         raise NoDownloadContent(
@@ -198,18 +209,42 @@ def _collect_run_log(
         }
 
         archive_name = _build_run_log_filename(run=run, protocol_store=protocol_store)
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            suffix=".json",
-            delete=False,
-            encoding="utf-8",
-        ) as temp_file:
-            json.dump(run_details, temp_file)
-            temp_path = Path(temp_file.name)
-
-        return (temp_path, archive_name)
+        return _write_temp_json(run_details, archive_name)
     except Exception:
         return None
+
+
+def _collect_labware_offsets(
+    run_id: str,
+    run: Union[RunResource, BadRunResource],
+    run_data_manager: RunDataManager,
+    protocol_store: ProtocolStore,
+) -> Optional[Tuple[Path, str]]:
+    """Build a labware offsets JSON file from the run record, or None if unavailable."""
+    try:
+        run_record = run_data_manager.get(run_id)
+        offsets_payload = [
+            offset.model_dump(mode="json", by_alias=True)
+            for offset in run_record.labwareOffsets
+        ]
+        archive_name = _build_labware_offsets_filename(
+            run=run, protocol_store=protocol_store
+        )
+        return _write_temp_json(offsets_payload, archive_name)
+    except Exception:
+        return None
+
+
+def _write_temp_json(payload: object, archive_name: str) -> Tuple[Path, str]:
+    """Write JSON payload to a temp file for inclusion in the zip."""
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".json",
+        delete=False,
+        encoding="utf-8",
+    ) as temp_file:
+        json.dump(payload, temp_file)
+        return (Path(temp_file.name), archive_name)
 
 
 def _build_run_log_filename(
@@ -221,6 +256,22 @@ def _build_run_log_filename(
     name_stem = _protocol_display_name_stem(run=run, protocol_store=protocol_store)
     return f"{name_stem}_{created_at}.json"
 
+
+def _build_labware_offsets_filename(
+    run: Union[RunResource, BadRunResource],
+    protocol_store: ProtocolStore,
+) -> str:
+    """Build `{protocolFileName}_{ISO-timestamp}_offsetdata.json`."""
+    created_at = _format_download_timestamp(run.created_at)
+    name_stem = _protocol_file_name_stem(run=run, protocol_store=protocol_store)
+    return f"{name_stem}_{created_at}_offsetdata.json"
+
+
+def _protocol_display_name_stem(
+    run: Union[RunResource, BadRunResource],
+    protocol_store: ProtocolStore,
+) -> str:
+    """Prefer protocolName metadata, then protocol file name, then ids."""
     if run.protocol_id is not None:
         try:
             protocol = protocol_store.get(run.protocol_id)
@@ -239,7 +290,28 @@ def _build_run_log_filename(
         return sanitize_filename_component(run.run_id)
 
 
-def _format_run_log_timestamp(created_at: datetime) -> str:
+def _protocol_file_name_stem(
+    run: Union[RunResource, BadRunResource],
+    protocol_store: ProtocolStore,
+) -> str:
+    """Prefer the protocol main file stem, then ids."""
+    if run.protocol_id is not None:
+        try:
+            protocol = protocol_store.get(run.protocol_id)
+        except ProtocolNotFoundError:
+            protocol = None
+
+        if protocol is not None:
+            return sanitize_filename_component(protocol.source.main_file.stem)
+
+        else:
+            return sanitize_filename_component(run.protocol_id)
+
+    else:
+        return sanitize_filename_component(run.run_id)
+
+
+def _format_download_timestamp(created_at: datetime) -> str:
     """Format a run createdAt timestamp like JS toISOString, with ':' -> '_'."""
     if created_at.tzinfo is None:
         created_at = created_at.replace(tzinfo=timezone.utc)

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -5,10 +5,11 @@ import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from textwrap import dedent
-from typing import Annotated, AsyncIterator, List, Literal, Optional, Tuple, Union
+from typing import Annotated, List, Literal, Optional, Tuple, Union
 
 from fastapi import Depends, status
-from fastapi.responses import StreamingResponse
+from fastapi.responses import FileResponse
+from starlette.background import BackgroundTask
 
 from server_utils.fastapi_utils.light_router import LightRouter
 
@@ -20,10 +21,13 @@ from robot_server.data_files.zip_utils import (
     build_run_zip_filename,
     collect_existing_run_images,
     collect_existing_run_output_csvs,
+    create_zip_for_download,
     sanitize_filename_component,
-    stream_zip,
 )
 from robot_server.errors.error_responses import ErrorBody, ErrorDetails
+from robot_server.persistence.fastapi_dependencies import (
+    get_active_persistence_directory,
+)
 from robot_server.protocols.dependencies import get_protocol_store
 from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
 from robot_server.runs.dependencies import get_run_data_manager, get_run_store
@@ -75,7 +79,10 @@ async def download_run_files(
     run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
     data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
     protocol_store: Annotated[ProtocolStore, Depends(get_protocol_store)],
-) -> StreamingResponse:
+    persistence_directory: Annotated[
+        Path, Depends(get_active_persistence_directory)
+    ],
+) -> FileResponse:
     """Download files associated with a run as a zip archive.
 
     Arguments:
@@ -84,6 +91,7 @@ async def download_run_files(
         run_data_manager: Run data retrieval interface.
         data_files_store: Store for data files database access.
         protocol_store: Store for protocol storage access.
+        persistence_directory: Persistence directory used for zip staging.
     """
     try:
         run = run_store.get(runId)
@@ -149,11 +157,23 @@ async def download_run_files(
         protocol_store=protocol_store,
         fallback_filename=f"{runId}.zip",
     )
+    zip_path, cleanup_zip = await create_zip_for_download(
+        zip_entries, persistence_directory
+    )
 
-    return StreamingResponse(
-        _stream_zip_cleaning_temps(zip_entries, temp_paths),
+    def cleanup() -> None:
+        cleanup_zip()
+        for path in temp_paths:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+    return FileResponse(
+        path=zip_path,
         media_type="application/zip",
-        headers={"Content-Disposition": f"attachment; filename={zip_filename}"},
+        filename=zip_filename,
+        background=BackgroundTask(cleanup),
     )
 
 
@@ -371,18 +391,3 @@ def _format_download_timestamp(created_at: datetime) -> str:
     iso = created_at.isoformat(timespec="milliseconds").replace("+00:00", "Z")
     return iso.replace(":", "_")
 
-
-async def _stream_zip_cleaning_temps(
-    entries: List[Tuple[Path, str]],
-    temp_paths: List[Path],
-) -> AsyncIterator[bytes]:
-    """Stream a zip archive, then delete any temporary files used as entries."""
-    try:
-        async for chunk in stream_zip(entries):
-            yield chunk
-    finally:
-        for path in temp_paths:
-            try:
-                path.unlink(missing_ok=True)
-            except OSError:
-                pass

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -55,6 +55,7 @@ class NoDownloadContent(ErrorDetails):
         - The run log
         - Labware offset data
         - CSV output files
+        - The CSV runtime parameter input file
         """
     ),
     responses={
@@ -99,6 +100,14 @@ async def download_run_files(
     protocol_entry = _collect_protocol_file(run.protocol_id, protocol_store)
     if protocol_entry is not None:
         zip_entries.append(protocol_entry)
+
+    rtp_csv_entry = _collect_rtp_csv(
+        run_id=runId,
+        run_data_manager=run_data_manager,
+        data_files_store=data_files_store,
+    )
+    if rtp_csv_entry is not None:
+        zip_entries.append(rtp_csv_entry)
 
     run_log_entry = _collect_run_log(
         run_id=runId,
@@ -165,6 +174,25 @@ def _collect_protocol_file(
         return None
 
     return (main_file, main_file.name)
+
+
+def _collect_rtp_csv(
+    run_id: str,
+    run_data_manager: RunDataManager,
+    data_files_store: DataFilesStore,
+) -> Optional[Tuple[Path, str]]:
+    """Return the CSV runtime parameter input file, or None if unavailable."""
+    try:
+        run_record = run_data_manager.get(run_id)
+        for param in run_record.runTimeParameters:
+            if param.type == "csv_file" and param.file is not None:
+                file_info = data_files_store.get(param.file.id)
+                file_path = Path(file_info.path)
+                if file_path.exists() and file_path.is_file():
+                    return (file_path, file_info.name)
+        return None
+    except Exception:
+        return None
 
 
 def _collect_run_log(

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -77,9 +77,7 @@ async def download_run_files(
     run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
     data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
     protocol_store: Annotated[ProtocolStore, Depends(get_protocol_store)],
-    persistence_directory: Annotated[
-        Path, Depends(get_active_persistence_directory)
-    ],
+    persistence_directory: Annotated[Path, Depends(get_active_persistence_directory)],
 ) -> FileResponse:
     """Download files associated with a run as a zip archive.
 
@@ -387,4 +385,3 @@ def _format_download_timestamp(created_at: datetime) -> str:
 
     iso = created_at.isoformat(timespec="milliseconds").replace("+00:00", "Z")
     return iso.replace(":", "_")
-

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -16,7 +16,6 @@ from server_utils.fastapi_utils.light_router import LightRouter
 from .base_router import RunNotFound
 from robot_server.data_files.data_files_store import DataFilesStore
 from robot_server.data_files.dependencies import get_data_files_store
-from robot_server.data_files.models import ZipCreationFailed
 from robot_server.data_files.zip_utils import (
     build_run_zip_filename,
     collect_existing_run_images,
@@ -54,7 +53,7 @@ class NoDownloadContent(ErrorDetails):
 
         The archive includes, when available:
 
-        - Camera images under an `images/` directory
+        - Camera images
         - The protocol source file
         - The run log
         - Labware offset data
@@ -70,7 +69,6 @@ class NoDownloadContent(ErrorDetails):
         status.HTTP_404_NOT_FOUND: {
             "model": ErrorBody[Union[RunNotFound, NoDownloadContent]]
         },
-        status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": ErrorBody[ZipCreationFailed]},
     },
 )
 async def download_run_files(

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -1,7 +1,8 @@
 """Router for /runs/{runId}/download file bundle endpoints."""
 
+from pathlib import Path
 from textwrap import dedent
-from typing import Annotated, Literal, Union
+from typing import Annotated, List, Literal, Optional, Tuple, Union
 
 from fastapi import Depends, status
 from fastapi.responses import StreamingResponse
@@ -19,7 +20,7 @@ from robot_server.data_files.zip_utils import (
 )
 from robot_server.errors.error_responses import ErrorBody, ErrorDetails
 from robot_server.protocols.dependencies import get_protocol_store
-from robot_server.protocols.protocol_store import ProtocolStore
+from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
 from robot_server.runs.dependencies import get_run_store
 from robot_server.runs.run_models import RunNotFoundError
 from robot_server.runs.run_store import RunStore
@@ -44,6 +45,7 @@ class NoDownloadContent(ErrorDetails):
         The archive includes, when available:
 
         - Camera images under an `images/` directory
+        - The protocol source file
         """
     ),
     responses={
@@ -76,9 +78,15 @@ async def download_run_files(
     except RunNotFoundError as e:
         raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
 
-    zip_entries = collect_existing_run_images(
-        runId, data_files_store, archive_prefix="images"
+    # (filesystem path, archive path within the zip)
+    zip_entries: List[Tuple[Path, str]] = []
+
+    zip_entries.extend(
+        collect_existing_run_images(runId, data_files_store, archive_prefix="images")
     )
+    protocol_entry = _collect_protocol_file(run.protocol_id, protocol_store)
+    if protocol_entry is not None:
+        zip_entries.append(protocol_entry)
 
     if not zip_entries:
         raise NoDownloadContent(
@@ -96,3 +104,22 @@ async def download_run_files(
         media_type="application/zip",
         headers={"Content-Disposition": f"attachment; filename={zip_filename}"},
     )
+
+
+def _collect_protocol_file(
+    protocol_id: Optional[str], protocol_store: ProtocolStore
+) -> Optional[Tuple[Path, str]]:
+    """Return the protocol main file for the zip, or None if unavailable."""
+    if protocol_id is None:
+        return None
+
+    try:
+        protocol = protocol_store.get(protocol_id)
+    except ProtocolNotFoundError:
+        return None
+
+    main_file = protocol.source.main_file
+    if not main_file.exists() or not main_file.is_file():
+        return None
+
+    return (main_file, main_file.name)

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -1,8 +1,11 @@
 """Router for /runs/{runId}/download file bundle endpoints."""
 
+import json
+import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from textwrap import dedent
-from typing import Annotated, List, Literal, Optional, Tuple, Union
+from typing import Annotated, AsyncIterator, List, Literal, Optional, Tuple, Union
 
 from fastapi import Depends, status
 from fastapi.responses import StreamingResponse
@@ -16,14 +19,16 @@ from robot_server.data_files.models import ZipCreationFailed
 from robot_server.data_files.zip_utils import (
     build_run_zip_filename,
     collect_existing_run_images,
+    sanitize_filename_component,
     stream_zip,
 )
 from robot_server.errors.error_responses import ErrorBody, ErrorDetails
 from robot_server.protocols.dependencies import get_protocol_store
 from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
-from robot_server.runs.dependencies import get_run_store
-from robot_server.runs.run_models import RunNotFoundError
-from robot_server.runs.run_store import RunStore
+from robot_server.runs.dependencies import get_run_data_manager, get_run_store
+from robot_server.runs.run_data_manager import RunDataManager
+from robot_server.runs.run_models import RunCommandSummary, RunNotFoundError
+from robot_server.runs.run_store import BadRunResource, RunResource, RunStore
 
 file_download_router = LightRouter()
 
@@ -46,6 +51,7 @@ class NoDownloadContent(ErrorDetails):
 
         - Camera images under an `images/` directory
         - The protocol source file
+        - The run log
         """
     ),
     responses={
@@ -62,6 +68,7 @@ class NoDownloadContent(ErrorDetails):
 async def download_run_files(
     runId: str,
     run_store: Annotated[RunStore, Depends(get_run_store)],
+    run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
     data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
     protocol_store: Annotated[ProtocolStore, Depends(get_protocol_store)],
 ) -> StreamingResponse:
@@ -70,6 +77,7 @@ async def download_run_files(
     Arguments:
         runId: The run ID to download files for.
         run_store: Store for run data management.
+        run_data_manager: Run data retrieval interface.
         data_files_store: Store for data files database access.
         protocol_store: Store for protocol storage access.
     """
@@ -80,6 +88,7 @@ async def download_run_files(
 
     # (filesystem path, archive path within the zip)
     zip_entries: List[Tuple[Path, str]] = []
+    temp_paths: List[Path] = []
 
     zip_entries.extend(
         collect_existing_run_images(runId, data_files_store, archive_prefix="images")
@@ -87,6 +96,16 @@ async def download_run_files(
     protocol_entry = _collect_protocol_file(run.protocol_id, protocol_store)
     if protocol_entry is not None:
         zip_entries.append(protocol_entry)
+
+    run_log_entry = _collect_run_log(
+        run_id=runId,
+        run=run,
+        run_data_manager=run_data_manager,
+        protocol_store=protocol_store,
+    )
+    if run_log_entry is not None:
+        zip_entries.append(run_log_entry)
+        temp_paths.append(run_log_entry[0])
 
     if not zip_entries:
         raise NoDownloadContent(
@@ -100,7 +119,7 @@ async def download_run_files(
     )
 
     return StreamingResponse(
-        stream_zip(zip_entries),
+        _stream_zip_cleaning_temps(zip_entries, temp_paths),
         media_type="application/zip",
         headers={"Content-Disposition": f"attachment; filename={zip_filename}"},
     )
@@ -123,3 +142,125 @@ def _collect_protocol_file(
         return None
 
     return (main_file, main_file.name)
+
+
+def _collect_run_log(
+    run_id: str,
+    run: Union[RunResource, BadRunResource],
+    run_data_manager: RunDataManager,
+    protocol_store: ProtocolStore,
+) -> Optional[Tuple[Path, str]]:
+    """Build a run log JSON file, or None if unavailable."""
+    try:
+        run_record = run_data_manager.get(run_id)
+        length_probe = run_data_manager.get_commands_slice(
+            run_id=run_id,
+            cursor=0,
+            length=0,
+            include_fixit_commands=True,
+        )
+        command_slice = run_data_manager.get_commands_slice(
+            run_id=run_id,
+            cursor=0,
+            length=length_probe.total_length,
+            include_fixit_commands=True,
+        )
+        command_summaries = [
+            RunCommandSummary.model_construct(
+                id=c.id,
+                key=c.key,
+                commandType=c.commandType,
+                intent=c.intent,
+                status=c.status,
+                createdAt=c.createdAt,
+                startedAt=c.startedAt,
+                completedAt=c.completedAt,
+                params=c.params,
+                error=c.error,
+                notes=c.notes,
+                failedCommandId=c.failedCommandId,
+                commandAnnotationIds=c.commandAnnotationIds
+                if c.commandAnnotationIds
+                else None,
+            ).model_dump(mode="json", by_alias=True)
+            for c in command_slice.commands
+        ]
+
+        run_details = {
+            "data": run_record.model_dump(mode="json", by_alias=True),
+            "commands": {
+                "data": command_summaries,
+                "meta": {
+                    "cursor": command_slice.cursor,
+                    "totalLength": command_slice.total_length,
+                },
+            },
+        }
+
+        archive_name = _build_run_log_filename(run=run, protocol_store=protocol_store)
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".json",
+            delete=False,
+            encoding="utf-8",
+        ) as temp_file:
+            json.dump(run_details, temp_file)
+            temp_path = Path(temp_file.name)
+
+        return (temp_path, archive_name)
+    except Exception:
+        return None
+
+
+def _build_run_log_filename(
+    run: Union[RunResource, BadRunResource],
+    protocol_store: ProtocolStore,
+) -> str:
+    """Build `{protocolName}_{ISO-timestamp}.json`."""
+    created_at = _format_download_timestamp(run.created_at)
+    name_stem = _protocol_display_name_stem(run=run, protocol_store=protocol_store)
+    return f"{name_stem}_{created_at}.json"
+
+    if run.protocol_id is not None:
+        try:
+            protocol = protocol_store.get(run.protocol_id)
+        except ProtocolNotFoundError:
+            protocol = None
+
+        if protocol is not None:
+            protocol_name = protocol.source.metadata.get("protocolName")
+            if protocol_name is None:
+                protocol_name = protocol.source.main_file.name
+            return sanitize_filename_component(str(protocol_name))
+        else:
+            return sanitize_filename_component(run.protocol_id)
+
+    else:
+        return sanitize_filename_component(run.run_id)
+
+
+def _format_run_log_timestamp(created_at: datetime) -> str:
+    """Format a run createdAt timestamp like JS toISOString, with ':' -> '_'."""
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    else:
+        created_at = created_at.astimezone(timezone.utc)
+
+    iso = created_at.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+    return iso.replace(":", "_")
+
+
+async def _stream_zip_cleaning_temps(
+    entries: List[Tuple[Path, str]],
+    temp_paths: List[Path],
+) -> AsyncIterator[bytes]:
+    """Stream a zip archive, then delete any temporary files used as entries."""
+    try:
+        async for chunk in stream_zip(entries):
+            yield chunk
+    finally:
+        for path in temp_paths:
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                pass

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -1,7 +1,6 @@
 """Router for /runs/{runId}/download file bundle endpoints."""
 
 import json
-import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from textwrap import dedent
@@ -20,8 +19,9 @@ from robot_server.data_files.zip_utils import (
     build_run_zip_filename,
     collect_existing_run_images,
     collect_existing_run_output_csvs,
-    create_zip_for_download,
+    create_download_staging_dir,
     sanitize_filename_component,
+    write_zip_for_download,
 )
 from robot_server.errors.error_responses import ErrorBody, ErrorDetails
 from robot_server.persistence.fastapi_dependencies import (
@@ -89,89 +89,87 @@ async def download_run_files(
         run_data_manager: Run data retrieval interface.
         data_files_store: Store for data files database access.
         protocol_store: Store for protocol storage access.
-        persistence_directory: Persistence directory used for zip staging.
+        persistence_directory: Persistence directory used for download staging.
     """
     try:
         run = run_store.get(runId)
     except RunNotFoundError as e:
         raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
 
-    # (filesystem path, archive path within the zip)
-    zip_entries: List[Tuple[Path, str]] = []
-    temp_paths: List[Path] = []
+    staging_dir = create_download_staging_dir(persistence_directory)
+    staging_path = Path(staging_dir.name)
 
-    zip_entries.extend(
-        collect_existing_run_images(runId, data_files_store, archive_prefix="images")
-    )
-    protocol_entry = _collect_protocol_file(run.protocol_id, protocol_store)
-    if protocol_entry is not None:
-        zip_entries.append(protocol_entry)
+    try:
+        # (filesystem path, archive path within the zip)
+        zip_entries: List[Tuple[Path, str]] = []
 
-    rtp_csv_entry = _collect_rtp_csv(
-        run_id=runId,
-        run_data_manager=run_data_manager,
-        data_files_store=data_files_store,
-    )
-    if rtp_csv_entry is not None:
-        zip_entries.append(rtp_csv_entry)
-
-    run_log_entry = _collect_run_log(
-        run_id=runId,
-        run=run,
-        run_data_manager=run_data_manager,
-        protocol_store=protocol_store,
-    )
-    if run_log_entry is not None:
-        zip_entries.append(run_log_entry)
-        temp_paths.append(run_log_entry[0])
-
-    offsets_entry = _collect_labware_offsets(
-        run_id=runId,
-        run=run,
-        run_data_manager=run_data_manager,
-        protocol_store=protocol_store,
-    )
-    if offsets_entry is not None:
-        zip_entries.append(offsets_entry)
-        temp_paths.append(offsets_entry[0])
-
-    zip_entries.extend(
-        collect_existing_run_output_csvs(
-            runId,
-            data_files_store,
-            archive_prefix=_build_output_csvs_directory_name(
-                run=run, protocol_store=protocol_store
-            ),
+        zip_entries.extend(
+            collect_existing_run_images(
+                runId, data_files_store, archive_prefix="images"
+            )
         )
-    )
+        protocol_entry = _collect_protocol_file(run.protocol_id, protocol_store)
+        if protocol_entry is not None:
+            zip_entries.append(protocol_entry)
 
-    if not zip_entries:
-        raise NoDownloadContent(
-            detail=f"No downloadable content found for run '{runId}'"
-        ).as_error(status.HTTP_404_NOT_FOUND)
+        rtp_csv_entry = _collect_rtp_csv(
+            run_id=runId,
+            run_data_manager=run_data_manager,
+            data_files_store=data_files_store,
+        )
+        if rtp_csv_entry is not None:
+            zip_entries.append(rtp_csv_entry)
 
-    zip_filename = build_run_zip_filename(
-        run=run,
-        protocol_store=protocol_store,
-        fallback_filename=f"{runId}.zip",
-    )
-    zip_path, cleanup_zip = await create_zip_for_download(
-        zip_entries, persistence_directory
-    )
+        run_log_entry = _collect_run_log(
+            run_id=runId,
+            run=run,
+            run_data_manager=run_data_manager,
+            protocol_store=protocol_store,
+            staging_dir=staging_path,
+        )
+        if run_log_entry is not None:
+            zip_entries.append(run_log_entry)
 
-    def cleanup() -> None:
-        cleanup_zip()
-        for path in temp_paths:
-            try:
-                path.unlink(missing_ok=True)
-            except OSError:
-                pass
+        offsets_entry = _collect_labware_offsets(
+            run_id=runId,
+            run=run,
+            run_data_manager=run_data_manager,
+            protocol_store=protocol_store,
+            staging_dir=staging_path,
+        )
+        if offsets_entry is not None:
+            zip_entries.append(offsets_entry)
+
+        zip_entries.extend(
+            collect_existing_run_output_csvs(
+                runId,
+                data_files_store,
+                archive_prefix=_build_output_csvs_directory_name(
+                    run=run, protocol_store=protocol_store
+                ),
+            )
+        )
+
+        if not zip_entries:
+            raise NoDownloadContent(
+                detail=f"No downloadable content found for run '{runId}'"
+            ).as_error(status.HTTP_404_NOT_FOUND)
+
+        zip_filename = build_run_zip_filename(
+            run=run,
+            protocol_store=protocol_store,
+            fallback_filename=f"{runId}.zip",
+        )
+        zip_path = await write_zip_for_download(zip_entries, staging_path)
+    except Exception:
+        staging_dir.cleanup()
+        raise
 
     return FileResponse(
         path=zip_path,
         media_type="application/zip",
         filename=zip_filename,
-        background=BackgroundTask(cleanup),
+        background=BackgroundTask(staging_dir.cleanup),
     )
 
 
@@ -218,8 +216,9 @@ def _collect_run_log(
     run: Union[RunResource, BadRunResource],
     run_data_manager: RunDataManager,
     protocol_store: ProtocolStore,
+    staging_dir: Path,
 ) -> Optional[Tuple[Path, str]]:
-    """Build a run log JSON file, or None if unavailable."""
+    """Build a run log JSON file in ``staging_dir``, or None if unavailable."""
     try:
         run_record = run_data_manager.get(run_id)
         length_probe = run_data_manager.get_commands_slice(
@@ -267,7 +266,7 @@ def _collect_run_log(
         }
 
         archive_name = _build_run_log_filename(run=run, protocol_store=protocol_store)
-        return _write_temp_json(run_details, archive_name)
+        return _write_staging_json(run_details, archive_name, staging_dir)
     except Exception:
         return None
 
@@ -277,8 +276,9 @@ def _collect_labware_offsets(
     run: Union[RunResource, BadRunResource],
     run_data_manager: RunDataManager,
     protocol_store: ProtocolStore,
+    staging_dir: Path,
 ) -> Optional[Tuple[Path, str]]:
-    """Build a labware offsets JSON file from the run record, or None if unavailable."""
+    """Build labware offsets JSON in ``staging_dir``, or None if unavailable."""
     try:
         run_record = run_data_manager.get(run_id)
         offsets_payload = [
@@ -288,21 +288,20 @@ def _collect_labware_offsets(
         archive_name = _build_labware_offsets_filename(
             run=run, protocol_store=protocol_store
         )
-        return _write_temp_json(offsets_payload, archive_name)
+        return _write_staging_json(offsets_payload, archive_name, staging_dir)
     except Exception:
         return None
 
 
-def _write_temp_json(payload: object, archive_name: str) -> Tuple[Path, str]:
-    """Write JSON payload to a temp file for inclusion in the zip."""
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        suffix=".json",
-        delete=False,
-        encoding="utf-8",
-    ) as temp_file:
-        json.dump(payload, temp_file)
-        return (Path(temp_file.name), archive_name)
+def _write_staging_json(
+    payload: object, archive_name: str, staging_dir: Path
+) -> Tuple[Path, str]:
+    """Write JSON payload into the request scratch directory for zip inclusion."""
+    file_path = staging_dir / archive_name
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with file_path.open(mode="w", encoding="utf-8") as json_file:
+        json.dump(payload, json_file)
+    return (file_path, archive_name)
 
 
 def _build_run_log_filename(

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -19,6 +19,7 @@ from robot_server.data_files.models import ZipCreationFailed
 from robot_server.data_files.zip_utils import (
     build_run_zip_filename,
     collect_existing_run_images,
+    collect_existing_run_output_csvs,
     sanitize_filename_component,
     stream_zip,
 )
@@ -53,6 +54,7 @@ class NoDownloadContent(ErrorDetails):
         - The protocol source file
         - The run log
         - Labware offset data
+        - CSV output files
         """
     ),
     responses={
@@ -117,6 +119,16 @@ async def download_run_files(
     if offsets_entry is not None:
         zip_entries.append(offsets_entry)
         temp_paths.append(offsets_entry[0])
+
+    zip_entries.extend(
+        collect_existing_run_output_csvs(
+            runId,
+            data_files_store,
+            archive_prefix=_build_output_csvs_directory_name(
+                run=run, protocol_store=protocol_store
+            ),
+        )
+    )
 
     if not zip_entries:
         raise NoDownloadContent(
@@ -265,6 +277,16 @@ def _build_labware_offsets_filename(
     created_at = _format_download_timestamp(run.created_at)
     name_stem = _protocol_file_name_stem(run=run, protocol_store=protocol_store)
     return f"{name_stem}_{created_at}_offsetdata.json"
+
+
+def _build_output_csvs_directory_name(
+    run: Union[RunResource, BadRunResource],
+    protocol_store: ProtocolStore,
+) -> str:
+    """Build `{protocolFileStem}_{ISO-timestamp}_output` directory name."""
+    created_at = _format_download_timestamp(run.created_at)
+    name_stem = _protocol_file_name_stem(run=run, protocol_store=protocol_store)
+    return f"{name_stem}_{created_at}_output"
 
 
 def _protocol_display_name_stem(

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -103,7 +103,11 @@ async def download_run_files(
 
         zip_entries.extend(
             collect_existing_run_images(
-                runId, data_files_store, archive_prefix="images"
+                runId,
+                data_files_store,
+                archive_prefix=_build_download_artifact_name(
+                    run=run, protocol_store=protocol_store, suffix="_images"
+                ),
             )
         )
         protocol_entry = _collect_protocol_file(run=run, protocol_store=protocol_store)
@@ -142,8 +146,8 @@ async def download_run_files(
             collect_existing_run_output_csvs(
                 runId,
                 data_files_store,
-                archive_prefix=_build_output_csvs_directory_name(
-                    run=run, protocol_store=protocol_store
+                archive_prefix=_build_download_artifact_name(
+                    run=run, protocol_store=protocol_store, suffix="_output"
                 ),
             )
         )
@@ -304,14 +308,26 @@ def _write_staging_json(
     return (file_path, archive_name)
 
 
+def _build_download_artifact_name(
+    run: Union[RunResource, BadRunResource],
+    protocol_store: ProtocolStore,
+    *,
+    suffix: str,
+) -> str:
+    """Build `{protocolName}_{ISO-timestamp}{suffix}` for zip entries/directories."""
+    created_at = _format_download_timestamp(run.created_at)
+    name_stem = _protocol_download_name_stem(run=run, protocol_store=protocol_store)
+    return f"{name_stem}_{created_at}{suffix}"
+
+
 def _build_run_log_filename(
     run: Union[RunResource, BadRunResource],
     protocol_store: ProtocolStore,
 ) -> str:
     """Build `{protocolName}_{ISO-timestamp}.json`."""
-    created_at = _format_download_timestamp(run.created_at)
-    name_stem = _protocol_download_name_stem(run=run, protocol_store=protocol_store)
-    return f"{name_stem}_{created_at}.json"
+    return _build_download_artifact_name(
+        run=run, protocol_store=protocol_store, suffix=".json"
+    )
 
 
 def _build_labware_offsets_filename(
@@ -319,30 +335,16 @@ def _build_labware_offsets_filename(
     protocol_store: ProtocolStore,
 ) -> str:
     """Build `{protocolName}_{ISO-timestamp}_offsetdata.json`."""
-    created_at = _format_download_timestamp(run.created_at)
-    name_stem = _protocol_download_name_stem(run=run, protocol_store=protocol_store)
-    return f"{name_stem}_{created_at}_offsetdata.json"
-
-
-def _build_output_csvs_directory_name(
-    run: Union[RunResource, BadRunResource],
-    protocol_store: ProtocolStore,
-) -> str:
-    """Build `{protocolName}_{ISO-timestamp}_output` directory name."""
-    created_at = _format_download_timestamp(run.created_at)
-    name_stem = _protocol_download_name_stem(run=run, protocol_store=protocol_store)
-    return f"{name_stem}_{created_at}_output"
+    return _build_download_artifact_name(
+        run=run, protocol_store=protocol_store, suffix="_offsetdata.json"
+    )
 
 
 def _protocol_download_name_stem(
     run: Union[RunResource, BadRunResource],
     protocol_store: ProtocolStore,
 ) -> str:
-    """Shared name stem for download zip entries derived from the protocol.
-
-    Prefers metadata ``protocolName``, then the protocol main file stem, then
-    protocol/run ids. The result is filesystem-safe.
-    """
+    """Prefer protocolName metadata, then protocol file name, then ids."""
     if run.protocol_id is not None:
         try:
             protocol = protocol_store.get(run.protocol_id)

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -362,7 +362,7 @@ def _protocol_file_name_stem(
 
 
 def _format_download_timestamp(created_at: datetime) -> str:
-    """Format a run createdAt timestamp like JS toISOString, with ':' -> '_'."""
+    """Format a run createdAt timestamp like JS toISOString."""
     if created_at.tzinfo is None:
         created_at = created_at.replace(tzinfo=timezone.utc)
     else:

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -106,7 +106,7 @@ async def download_run_files(
                 runId, data_files_store, archive_prefix="images"
             )
         )
-        protocol_entry = _collect_protocol_file(run.protocol_id, protocol_store)
+        protocol_entry = _collect_protocol_file(run=run, protocol_store=protocol_store)
         if protocol_entry is not None:
             zip_entries.append(protocol_entry)
 
@@ -172,14 +172,15 @@ async def download_run_files(
 
 
 def _collect_protocol_file(
-    protocol_id: Optional[str], protocol_store: ProtocolStore
+    run: Union[RunResource, BadRunResource],
+    protocol_store: ProtocolStore,
 ) -> Optional[Tuple[Path, str]]:
     """Return the protocol main file for the zip, or None if unavailable."""
-    if protocol_id is None:
+    if run.protocol_id is None:
         return None
 
     try:
-        protocol = protocol_store.get(protocol_id)
+        protocol = protocol_store.get(run.protocol_id)
     except ProtocolNotFoundError:
         return None
 
@@ -187,7 +188,8 @@ def _collect_protocol_file(
     if not main_file.exists() or not main_file.is_file():
         return None
 
-    return (main_file, main_file.name)
+    name_stem = _protocol_download_name_stem(run=run, protocol_store=protocol_store)
+    return (main_file, f"{name_stem}{main_file.suffix}")
 
 
 def _collect_rtp_csv(
@@ -308,7 +310,7 @@ def _build_run_log_filename(
 ) -> str:
     """Build `{protocolName}_{ISO-timestamp}.json`."""
     created_at = _format_download_timestamp(run.created_at)
-    name_stem = _protocol_display_name_stem(run=run, protocol_store=protocol_store)
+    name_stem = _protocol_download_name_stem(run=run, protocol_store=protocol_store)
     return f"{name_stem}_{created_at}.json"
 
 
@@ -316,9 +318,9 @@ def _build_labware_offsets_filename(
     run: Union[RunResource, BadRunResource],
     protocol_store: ProtocolStore,
 ) -> str:
-    """Build `{protocolFileName}_{ISO-timestamp}_offsetdata.json`."""
+    """Build `{protocolName}_{ISO-timestamp}_offsetdata.json`."""
     created_at = _format_download_timestamp(run.created_at)
-    name_stem = _protocol_file_name_stem(run=run, protocol_store=protocol_store)
+    name_stem = _protocol_download_name_stem(run=run, protocol_store=protocol_store)
     return f"{name_stem}_{created_at}_offsetdata.json"
 
 
@@ -326,17 +328,21 @@ def _build_output_csvs_directory_name(
     run: Union[RunResource, BadRunResource],
     protocol_store: ProtocolStore,
 ) -> str:
-    """Build `{protocolFileStem}_{ISO-timestamp}_output` directory name."""
+    """Build `{protocolName}_{ISO-timestamp}_output` directory name."""
     created_at = _format_download_timestamp(run.created_at)
-    name_stem = _protocol_file_name_stem(run=run, protocol_store=protocol_store)
+    name_stem = _protocol_download_name_stem(run=run, protocol_store=protocol_store)
     return f"{name_stem}_{created_at}_output"
 
 
-def _protocol_display_name_stem(
+def _protocol_download_name_stem(
     run: Union[RunResource, BadRunResource],
     protocol_store: ProtocolStore,
 ) -> str:
-    """Prefer protocolName metadata, then protocol file name, then ids."""
+    """Shared name stem for download zip entries derived from the protocol.
+
+    Prefers metadata ``protocolName``, then the protocol main file stem, then
+    protocol/run ids. The result is filesystem-safe.
+    """
     if run.protocol_id is not None:
         try:
             protocol = protocol_store.get(run.protocol_id)
@@ -346,34 +352,12 @@ def _protocol_display_name_stem(
         if protocol is not None:
             protocol_name = protocol.source.metadata.get("protocolName")
             if protocol_name is None:
-                protocol_name = protocol.source.main_file.name
+                protocol_name = protocol.source.main_file.stem
             return sanitize_filename_component(str(protocol_name))
-        else:
-            return sanitize_filename_component(run.protocol_id)
 
-    else:
-        return sanitize_filename_component(run.run_id)
+        return sanitize_filename_component(run.protocol_id)
 
-
-def _protocol_file_name_stem(
-    run: Union[RunResource, BadRunResource],
-    protocol_store: ProtocolStore,
-) -> str:
-    """Prefer the protocol main file stem, then ids."""
-    if run.protocol_id is not None:
-        try:
-            protocol = protocol_store.get(run.protocol_id)
-        except ProtocolNotFoundError:
-            protocol = None
-
-        if protocol is not None:
-            return sanitize_filename_component(protocol.source.main_file.stem)
-
-        else:
-            return sanitize_filename_component(run.protocol_id)
-
-    else:
-        return sanitize_filename_component(run.run_id)
+    return sanitize_filename_component(run.run_id)
 
 
 def _format_download_timestamp(created_at: datetime) -> str:

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -1,0 +1,98 @@
+"""Router for /runs/{runId}/download file bundle endpoints."""
+
+from textwrap import dedent
+from typing import Annotated, Literal, Union
+
+from fastapi import Depends, status
+from fastapi.responses import StreamingResponse
+
+from server_utils.fastapi_utils.light_router import LightRouter
+
+from .base_router import RunNotFound
+from robot_server.data_files.data_files_store import DataFilesStore
+from robot_server.data_files.dependencies import get_data_files_store
+from robot_server.data_files.models import ZipCreationFailed
+from robot_server.data_files.zip_utils import (
+    build_run_zip_filename,
+    collect_existing_run_images,
+    stream_zip,
+)
+from robot_server.errors.error_responses import ErrorBody, ErrorDetails
+from robot_server.protocols.dependencies import get_protocol_store
+from robot_server.protocols.protocol_store import ProtocolStore
+from robot_server.runs.dependencies import get_run_store
+from robot_server.runs.run_models import RunNotFoundError
+from robot_server.runs.run_store import RunStore
+
+file_download_router = LightRouter()
+
+
+class NoDownloadContent(ErrorDetails):
+    """An error returned when a run has no downloadable content."""
+
+    id: Literal["NoDownloadContent"] = "NoDownloadContent"
+    title: str = "No downloadable content for run"
+
+
+@file_download_router.get(
+    path="/runs/{runId}/download",
+    summary="Download run files as a zip",
+    description=dedent(
+        """
+        Download a zip archive of files associated with a run.
+
+        The archive includes, when available:
+
+        - Camera images under an `images/` directory
+        """
+    ),
+    responses={
+        status.HTTP_200_OK: {
+            "content": {"application/zip": {}},
+            "description": "A zip file containing downloadable files for the run",
+        },
+        status.HTTP_404_NOT_FOUND: {
+            "model": ErrorBody[Union[RunNotFound, NoDownloadContent]]
+        },
+        status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": ErrorBody[ZipCreationFailed]},
+    },
+)
+async def download_run_files(
+    runId: str,
+    run_store: Annotated[RunStore, Depends(get_run_store)],
+    data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
+    protocol_store: Annotated[ProtocolStore, Depends(get_protocol_store)],
+) -> StreamingResponse:
+    """Download files associated with a run as a zip archive.
+
+    Arguments:
+        runId: The run ID to download files for.
+        run_store: Store for run data management.
+        data_files_store: Store for data files database access.
+        protocol_store: Store for protocol storage access.
+    """
+    try:
+        run = run_store.get(runId)
+    except RunNotFoundError as e:
+        raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
+
+    zip_entries = collect_existing_run_images(
+        runId, data_files_store, archive_prefix="images"
+    )
+
+    if not zip_entries:
+        raise NoDownloadContent(
+            detail=f"No downloadable content found for run '{runId}'"
+        ).as_error(status.HTTP_404_NOT_FOUND)
+
+    zip_filename = build_run_zip_filename(
+        run=run,
+        protocol_store=protocol_store,
+        fallback_filename=f"{runId}.zip",
+    )
+
+    return StreamingResponse(
+        stream_zip(zip_entries),
+        media_type="application/zip",
+        headers={"Content-Disposition": f"attachment; filename={zip_filename}"},
+    )

--- a/robot-server/tests/data_files/test_router.py
+++ b/robot-server/tests/data_files/test_router.py
@@ -779,19 +779,18 @@ async def test_download_run_images_success(
         data_files_store=data_files_store,
         run_store=run_store,
         protocol_store=protocol_store,
+        persistence_directory=tmp_path,
     )
 
     assert result.media_type == "application/zip"
     assert "attachment" in result.headers["Content-Disposition"]
     assert ".zip" in result.headers["Content-Disposition"]
+    assert Path(result.path).exists()
+    assert Path(result.path).stat().st_size > 0
 
-    chunks = []
-    async for chunk in result.body_iterator:
-        chunks.append(chunk)
-
-    assert len(chunks) > 0
-    total_size = sum(len(chunk) for chunk in chunks)
-    assert total_size > 0
+    if result.background is not None:
+        await result.background()
+    assert not Path(result.path).exists()
 
 
 async def test_download_run_images_no_images_found(
@@ -799,6 +798,7 @@ async def test_download_run_images_no_images_found(
     data_files_store: DataFilesStore,
     run_store: RunStore,
     protocol_store: ProtocolStore,
+    tmp_path: Path,
 ) -> None:
     """It should raise an error when no images are found for the run."""
     decoy.when(
@@ -816,6 +816,7 @@ async def test_download_run_images_no_images_found(
             data_files_store=data_files_store,
             run_store=run_store,
             protocol_store=protocol_store,
+            persistence_directory=tmp_path,
         )
 
     assert exc_info.value.status_code == 404

--- a/robot-server/tests/data_files/test_zip_utils.py
+++ b/robot-server/tests/data_files/test_zip_utils.py
@@ -23,8 +23,10 @@ from robot_server.data_files.zip_utils import (
     build_run_zip_filename,
     collect_existing_run_images,
     collect_existing_run_output_csvs,
+    create_download_staging_dir,
     create_zip_for_download,
     sanitize_filename_component,
+    write_zip_for_download,
 )
 from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
 
@@ -203,6 +205,31 @@ async def test_create_zip_for_download_preserves_archive_paths(tmp_path: Path) -
         cleanup()
 
     assert not zip_path.exists()
+
+
+async def test_write_zip_for_download_uses_existing_scratch_dir(tmp_path: Path) -> None:
+    """It should write the zip into a caller-owned scratch directory."""
+    image = tmp_path / "photo.jpeg"
+    image.write_bytes(b"image-bytes")
+    staging_root = tmp_path / "persistence"
+    staging_dir = create_download_staging_dir(staging_root)
+    staging_path = Path(staging_dir.name)
+    scratch_file = staging_path / "notes.json"
+    scratch_file.write_text('{"ok": true}')
+
+    try:
+        zip_path = await write_zip_for_download(
+            [(image, "images/photo.jpeg"), (scratch_file, "notes.json")],
+            staging_path,
+        )
+        assert zip_path.parent == staging_path
+        with zipfile.ZipFile(zip_path) as zf:
+            assert zf.read("notes.json") == b'{"ok": true}'
+            assert zf.read("images/photo.jpeg") == b"image-bytes"
+    finally:
+        staging_dir.cleanup()
+
+    assert not staging_path.exists()
 
 
 async def test_create_zip_for_download_raises_for_missing_file(

--- a/robot-server/tests/data_files/test_zip_utils.py
+++ b/robot-server/tests/data_files/test_zip_utils.py
@@ -1,6 +1,5 @@
 """Tests for data_files zip_utils."""
 
-import io
 import zipfile
 from datetime import datetime
 from pathlib import Path
@@ -24,8 +23,8 @@ from robot_server.data_files.zip_utils import (
     build_run_zip_filename,
     collect_existing_run_images,
     collect_existing_run_output_csvs,
+    create_zip_for_download,
     sanitize_filename_component,
-    stream_zip,
 )
 from robot_server.errors.error_responses import ApiError
 from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
@@ -180,40 +179,42 @@ def test_collect_existing_run_output_csvs(decoy: Decoy, tmp_path: Path) -> None:
     ]
 
 
-async def test_stream_zip_preserves_archive_paths(tmp_path: Path) -> None:
-    """It should put files under the provided archive paths."""
+async def test_create_zip_for_download_preserves_archive_paths(tmp_path: Path) -> None:
+    """It should put files under the provided archive paths on disk staging."""
     image = tmp_path / "photo.jpeg"
     protocol = tmp_path / "protocol.py"
+    staging_root = tmp_path / "persistence"
     image.write_bytes(b"image-bytes")
     protocol.write_text("print('hi')")
 
-    chunks = [
-        chunk
-        async for chunk in stream_zip(
-            [(image, "images/photo.jpeg"), (protocol, "protocol.py")],
-            chunk_size=8,
-        )
-    ]
+    zip_path, cleanup = await create_zip_for_download(
+        [(image, "images/photo.jpeg"), (protocol, "protocol.py")],
+        staging_root,
+    )
 
-    assert len(chunks) > 1
-    with zipfile.ZipFile(io.BytesIO(b"".join(chunks))) as zf:
-        names = set(zf.namelist())
-        assert "images/photo.jpeg" in names
-        assert "protocol.py" in names
-        assert zf.read("images/photo.jpeg") == b"image-bytes"
-        assert zf.read("protocol.py") == b"print('hi')"
+    try:
+        assert zip_path.is_relative_to(staging_root)
+        with zipfile.ZipFile(zip_path) as zf:
+            names = set(zf.namelist())
+            assert "images/photo.jpeg" in names
+            assert "protocol.py" in names
+            assert zf.read("images/photo.jpeg") == b"image-bytes"
+            assert zf.read("protocol.py") == b"print('hi')"
+    finally:
+        cleanup()
+
+    assert not zip_path.exists()
 
 
-async def test_stream_zip_raises_zip_creation_failed_for_missing_file(
+async def test_create_zip_for_download_raises_zip_creation_failed_for_missing_file(
     tmp_path: Path,
 ) -> None:
     """It should map zip build failures to ZipCreationFailed."""
     missing = tmp_path / "missing.jpeg"
-    chunks = stream_zip([(missing, "missing.jpeg")])
+    staging_root = tmp_path / "persistence"
 
     with pytest.raises(ApiError) as exc_info:
-        async for _ in chunks:
-            pass
+        await create_zip_for_download([(missing, "missing.jpeg")], staging_root)
 
     assert exc_info.value.status_code == 500
     assert exc_info.value.content["errors"][0]["id"] == "ZipCreationFailed"

--- a/robot-server/tests/data_files/test_zip_utils.py
+++ b/robot-server/tests/data_files/test_zip_utils.py
@@ -9,17 +9,20 @@ from decoy import Decoy
 
 from opentrons_shared_data.data_files import (
     CmdDataFileInfo,
+    DataFileInfo,
     DataFileInfoWithCommands,
     MimeType,
 )
 
 from robot_server.data_files.data_files_store import (
+    DataFilesByRunInfo,
     DataFilesStore,
     DataFileWithCommandsInfoSlice,
 )
 from robot_server.data_files.zip_utils import (
     build_run_zip_filename,
     collect_existing_run_images,
+    collect_existing_run_output_csvs,
     sanitize_filename_component,
     stream_zip,
 )
@@ -112,6 +115,67 @@ def test_collect_existing_run_images_flat(decoy: Decoy, tmp_path: Path) -> None:
     entries = collect_existing_run_images("run-id", data_files_store)
 
     assert entries == [(existing, "a.jpeg")]
+
+
+def test_collect_existing_run_output_csvs(decoy: Decoy, tmp_path: Path) -> None:
+    """It should include CSV outputs under the prefix, prefixed by file id."""
+    data_files_store = decoy.mock(cls=DataFilesStore)
+    csv_path = tmp_path / "plate_read450nm.csv"
+    jpeg_path = tmp_path / "photo.jpeg"
+    missing_path = tmp_path / "missing.csv"
+    csv_path.write_text("a,b,c\n")
+    jpeg_path.write_bytes(b"img")
+
+    decoy.when(data_files_store.get_data_files_by_run_id("run-id")).then_return(
+        DataFilesByRunInfo(
+            input_files=[],
+            output_files=[
+                DataFileInfo(
+                    id="csv-file-id",
+                    name="plate_read450nm.csv",
+                    file_hash="h1",
+                    created_at=datetime(2024, 6, 20),
+                    mime_type=MimeType.TEXT_CSV,
+                    path=str(csv_path),
+                    generated=True,
+                    stored=True,
+                ),
+                DataFileInfo(
+                    id="image-file-id",
+                    name="photo.jpeg",
+                    file_hash="h2",
+                    created_at=datetime(2024, 6, 20),
+                    mime_type=MimeType.IMAGE_JPEG,
+                    path=str(jpeg_path),
+                    generated=True,
+                    stored=True,
+                ),
+                DataFileInfo(
+                    id="missing-file-id",
+                    name="missing.csv",
+                    file_hash="h3",
+                    created_at=datetime(2024, 6, 20),
+                    mime_type=MimeType.TEXT_CSV,
+                    path=str(missing_path),
+                    generated=True,
+                    stored=False,
+                ),
+            ],
+        )
+    )
+
+    entries = collect_existing_run_output_csvs(
+        "run-id",
+        data_files_store,
+        archive_prefix="my_protocol_2024-06-20T10_30_15.354Z_output",
+    )
+
+    assert entries == [
+        (
+            csv_path,
+            "my_protocol_2024-06-20T10_30_15.354Z_output/csv-file-id_plate_read450nm.csv",
+        )
+    ]
 
 
 async def test_stream_zip_preserves_archive_paths(tmp_path: Path) -> None:

--- a/robot-server/tests/data_files/test_zip_utils.py
+++ b/robot-server/tests/data_files/test_zip_utils.py
@@ -26,7 +26,6 @@ from robot_server.data_files.zip_utils import (
     create_zip_for_download,
     sanitize_filename_component,
 )
-from robot_server.errors.error_responses import ApiError
 from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
 
 
@@ -206,18 +205,15 @@ async def test_create_zip_for_download_preserves_archive_paths(tmp_path: Path) -
     assert not zip_path.exists()
 
 
-async def test_create_zip_for_download_raises_zip_creation_failed_for_missing_file(
+async def test_create_zip_for_download_raises_for_missing_file(
     tmp_path: Path,
 ) -> None:
-    """It should map zip build failures to ZipCreationFailed."""
+    """It should let filesystem errors from zip creation propagate."""
     missing = tmp_path / "missing.jpeg"
     staging_root = tmp_path / "persistence"
 
-    with pytest.raises(ApiError) as exc_info:
+    with pytest.raises(FileNotFoundError):
         await create_zip_for_download([(missing, "missing.jpeg")], staging_root)
-
-    assert exc_info.value.status_code == 500
-    assert exc_info.value.content["errors"][0]["id"] == "ZipCreationFailed"
 
 
 def test_build_run_zip_filename_with_protocol(decoy: Decoy) -> None:

--- a/robot-server/tests/data_files/test_zip_utils.py
+++ b/robot-server/tests/data_files/test_zip_utils.py
@@ -5,6 +5,7 @@ import zipfile
 from datetime import datetime
 from pathlib import Path
 
+import pytest
 from decoy import Decoy
 
 from opentrons_shared_data.data_files import (
@@ -26,6 +27,7 @@ from robot_server.data_files.zip_utils import (
     sanitize_filename_component,
     stream_zip,
 )
+from robot_server.errors.error_responses import ApiError
 from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
 
 
@@ -188,15 +190,33 @@ async def test_stream_zip_preserves_archive_paths(tmp_path: Path) -> None:
     chunks = [
         chunk
         async for chunk in stream_zip(
-            [(image, "images/photo.jpeg"), (protocol, "protocol.py")]
+            [(image, "images/photo.jpeg"), (protocol, "protocol.py")],
+            chunk_size=8,
         )
     ]
 
+    assert len(chunks) > 1
     with zipfile.ZipFile(io.BytesIO(b"".join(chunks))) as zf:
         names = set(zf.namelist())
         assert "images/photo.jpeg" in names
         assert "protocol.py" in names
         assert zf.read("images/photo.jpeg") == b"image-bytes"
+        assert zf.read("protocol.py") == b"print('hi')"
+
+
+async def test_stream_zip_raises_zip_creation_failed_for_missing_file(
+    tmp_path: Path,
+) -> None:
+    """It should map zip build failures to ZipCreationFailed."""
+    missing = tmp_path / "missing.jpeg"
+    chunks = stream_zip([(missing, "missing.jpeg")])
+
+    with pytest.raises(ApiError) as exc_info:
+        async for _ in chunks:
+            pass
+
+    assert exc_info.value.status_code == 500
+    assert exc_info.value.content["errors"][0]["id"] == "ZipCreationFailed"
 
 
 def test_build_run_zip_filename_with_protocol(decoy: Decoy) -> None:

--- a/robot-server/tests/data_files/test_zip_utils.py
+++ b/robot-server/tests/data_files/test_zip_utils.py
@@ -1,0 +1,183 @@
+"""Tests for data_files zip_utils."""
+
+import io
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+from decoy import Decoy
+
+from opentrons_shared_data.data_files import (
+    CmdDataFileInfo,
+    DataFileInfoWithCommands,
+    MimeType,
+)
+
+from robot_server.data_files.data_files_store import (
+    DataFilesStore,
+    DataFileWithCommandsInfoSlice,
+)
+from robot_server.data_files.zip_utils import (
+    build_run_zip_filename,
+    collect_existing_run_images,
+    sanitize_filename_component,
+    stream_zip,
+)
+from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
+
+
+def test_collect_existing_run_images_with_prefix(decoy: Decoy, tmp_path: Path) -> None:
+    """It should include only existing files under the archive prefix."""
+    data_files_store = decoy.mock(cls=DataFilesStore)
+    existing = tmp_path / "a.jpeg"
+    missing = tmp_path / "missing.jpeg"
+    existing.write_bytes(b"img")
+
+    decoy.when(
+        data_files_store.get_files_info_by_run_mime_type(
+            run_id="run-id",
+            mime_type=MimeType.IMAGE_JPEG,
+            offset=0,
+            limit=None,
+        )
+    ).then_return(
+        DataFileWithCommandsInfoSlice(
+            file_info=[
+                DataFileInfoWithCommands.model_construct(
+                    id="file-1",
+                    name="a.jpeg",
+                    file_hash="h1",
+                    created_at=datetime(2024, 6, 20),
+                    mime_type=MimeType.IMAGE_JPEG,
+                    path=str(existing),
+                    generated=True,
+                    stored=True,
+                    command_info=CmdDataFileInfo(command_id="c1", prev_command_id="p1"),
+                ),
+                DataFileInfoWithCommands.model_construct(
+                    id="file-2",
+                    name="missing.jpeg",
+                    file_hash="h2",
+                    created_at=datetime(2024, 6, 21),
+                    mime_type=MimeType.IMAGE_JPEG,
+                    path=str(missing),
+                    generated=True,
+                    stored=True,
+                    command_info=CmdDataFileInfo(command_id="c2", prev_command_id="p2"),
+                ),
+            ],
+            total_length=2,
+        )
+    )
+
+    entries = collect_existing_run_images(
+        "run-id", data_files_store, archive_prefix="images"
+    )
+
+    assert entries == [(existing, "images/a.jpeg")]
+
+
+def test_collect_existing_run_images_flat(decoy: Decoy, tmp_path: Path) -> None:
+    """It should store files at the zip root when no prefix is given."""
+    data_files_store = decoy.mock(cls=DataFilesStore)
+    existing = tmp_path / "a.jpeg"
+    existing.write_bytes(b"img")
+
+    decoy.when(
+        data_files_store.get_files_info_by_run_mime_type(
+            run_id="run-id",
+            mime_type=MimeType.IMAGE_JPEG,
+            offset=0,
+            limit=None,
+        )
+    ).then_return(
+        DataFileWithCommandsInfoSlice(
+            file_info=[
+                DataFileInfoWithCommands.model_construct(
+                    id="file-1",
+                    name="a.jpeg",
+                    file_hash="h1",
+                    created_at=datetime(2024, 6, 20),
+                    mime_type=MimeType.IMAGE_JPEG,
+                    path=str(existing),
+                    generated=True,
+                    stored=True,
+                    command_info=CmdDataFileInfo(command_id="c1", prev_command_id="p1"),
+                ),
+            ],
+            total_length=1,
+        )
+    )
+
+    entries = collect_existing_run_images("run-id", data_files_store)
+
+    assert entries == [(existing, "a.jpeg")]
+
+
+async def test_stream_zip_preserves_archive_paths(tmp_path: Path) -> None:
+    """It should put files under the provided archive paths."""
+    image = tmp_path / "photo.jpeg"
+    protocol = tmp_path / "protocol.py"
+    image.write_bytes(b"image-bytes")
+    protocol.write_text("print('hi')")
+
+    chunks = [
+        chunk
+        async for chunk in stream_zip(
+            [(image, "images/photo.jpeg"), (protocol, "protocol.py")]
+        )
+    ]
+
+    with zipfile.ZipFile(io.BytesIO(b"".join(chunks))) as zf:
+        names = set(zf.namelist())
+        assert "images/photo.jpeg" in names
+        assert "protocol.py" in names
+        assert zf.read("images/photo.jpeg") == b"image-bytes"
+
+
+def test_build_run_zip_filename_with_protocol(decoy: Decoy) -> None:
+    """It should build a protocol-aware zip filename."""
+    protocol_store = decoy.mock(cls=ProtocolStore)
+    run = decoy.mock(name="run")
+    decoy.when(run.protocol_id).then_return("protocol-id")
+    decoy.when(run.created_at).then_return(datetime(2024, 6, 20, 10, 30, 15))
+
+    mock_protocol = decoy.mock(name="protocol")
+    mock_source = decoy.mock(name="source")
+    decoy.when(mock_source.metadata).then_return({"protocolName": "Test Protocol"})
+    decoy.when(mock_protocol.source).then_return(mock_source)
+    decoy.when(protocol_store.get("protocol-id")).then_return(mock_protocol)
+
+    filename = build_run_zip_filename(
+        run=run,
+        protocol_store=protocol_store,
+        fallback_filename="fallback.zip",
+    )
+
+    assert filename.endswith("_20240620_103015.zip")
+    assert "Test_Protocol" in filename
+
+
+def test_build_run_zip_filename_missing_protocol_uses_fallback(
+    decoy: Decoy,
+) -> None:
+    """It should use the fallback when the protocol cannot be loaded."""
+    protocol_store = decoy.mock(cls=ProtocolStore)
+    run = decoy.mock(name="run")
+    decoy.when(run.protocol_id).then_return("protocol-id")
+    decoy.when(protocol_store.get("protocol-id")).then_raise(
+        ProtocolNotFoundError("protocol-id")
+    )
+
+    filename = build_run_zip_filename(
+        run=run,
+        protocol_store=protocol_store,
+        fallback_filename="run-id.zip",
+    )
+
+    assert filename == "run-id.zip"
+
+
+def test_sanitize_filename_component() -> None:
+    """It should replace unsafe characters."""
+    assert sanitize_filename_component("Test Protocol!") == "Test_Protocol_"

--- a/robot-server/tests/runs/router/test_file_download_router.py
+++ b/robot-server/tests/runs/router/test_file_download_router.py
@@ -1,0 +1,172 @@
+"""Tests for runs download router."""
+
+import io
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from decoy import Decoy
+
+from opentrons_shared_data.data_files import (
+    CmdDataFileInfo,
+    DataFileInfoWithCommands,
+    MimeType,
+)
+
+from robot_server.data_files.data_files_store import (
+    DataFilesStore,
+    DataFileWithCommandsInfoSlice,
+)
+from robot_server.errors.error_responses import ApiError
+from robot_server.protocols.protocol_store import ProtocolStore
+from robot_server.runs.router.file_download_router import download_run_files
+from robot_server.runs.run_models import RunNotFoundError
+from robot_server.runs.run_store import RunStore
+
+
+async def test_download_run_files_with_images(
+    decoy: Decoy,
+    mock_run_store: RunStore,
+    mock_protocol_store: ProtocolStore,
+    tmp_path: Path,
+) -> None:
+    """It should zip images under images/."""
+    data_files_store = decoy.mock(cls=DataFilesStore)
+
+    image1_path = tmp_path / "image1.jpeg"
+    image2_path = tmp_path / "image2.jpeg"
+    image1_path.write_bytes(b"fake image data 1")
+    image2_path.write_bytes(b"fake image data 2")
+
+    file_info_1 = DataFileInfoWithCommands.model_construct(
+        id="file-id-1",
+        name="image1.jpeg",
+        file_hash="hash1",
+        created_at=datetime(year=2024, month=6, day=20),
+        mime_type=MimeType.IMAGE_JPEG,
+        path=str(image1_path),
+        generated=True,
+        stored=True,
+        command_info=CmdDataFileInfo(
+            command_id="command-1",
+            prev_command_id="prev-1",
+        ),
+    )
+    file_info_2 = DataFileInfoWithCommands.model_construct(
+        id="file-id-2",
+        name="image2.jpeg",
+        file_hash="hash2",
+        created_at=datetime(year=2024, month=6, day=21),
+        mime_type=MimeType.IMAGE_JPEG,
+        path=str(image2_path),
+        generated=True,
+        stored=True,
+        command_info=CmdDataFileInfo(
+            command_id="command-2",
+            prev_command_id="prev-2",
+        ),
+    )
+
+    decoy.when(
+        data_files_store.get_files_info_by_run_mime_type(
+            run_id="run-id",
+            mime_type=MimeType.IMAGE_JPEG,
+            offset=0,
+            limit=None,
+        )
+    ).then_return(
+        DataFileWithCommandsInfoSlice(
+            file_info=[file_info_1, file_info_2], total_length=2
+        )
+    )
+
+    mock_run = decoy.mock(name="run_data")
+    decoy.when(mock_run.run_id).then_return("run-id")
+    decoy.when(mock_run.protocol_id).then_return(None)
+    decoy.when(mock_run.created_at).then_return(
+        datetime(year=2024, month=6, day=20, hour=10, minute=30, second=15)
+    )
+    decoy.when(mock_run_store.get("run-id")).then_return(mock_run)
+
+    result = await download_run_files(
+        runId="run-id",
+        run_store=mock_run_store,
+        data_files_store=data_files_store,
+        protocol_store=mock_protocol_store,
+    )
+
+    assert result.media_type == "application/zip"
+    assert "attachment" in result.headers["Content-Disposition"]
+    assert ".zip" in result.headers["Content-Disposition"]
+
+    chunks = []
+    async for chunk in result.body_iterator:
+        chunks.append(chunk)
+
+    zip_bytes = b"".join(chunks)
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+        names = set(zf.namelist())
+        assert "images/image1.jpeg" in names
+        assert "images/image2.jpeg" in names
+        assert zf.read("images/image1.jpeg") == b"fake image data 1"
+
+
+async def test_download_run_files_run_not_found(
+    decoy: Decoy,
+    mock_run_store: RunStore,
+    mock_protocol_store: ProtocolStore,
+) -> None:
+    """It should 404 when the run does not exist."""
+    data_files_store = decoy.mock(cls=DataFilesStore)
+    decoy.when(mock_run_store.get("missing-run")).then_raise(
+        RunNotFoundError(run_id="missing-run")
+    )
+
+    with pytest.raises(ApiError) as exc_info:
+        await download_run_files(
+            runId="missing-run",
+            run_store=mock_run_store,
+            data_files_store=data_files_store,
+            protocol_store=mock_protocol_store,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.content["errors"][0]["id"] == "RunNotFound"
+
+
+async def test_download_run_files_no_content(
+    decoy: Decoy,
+    mock_run_store: RunStore,
+    mock_protocol_store: ProtocolStore,
+) -> None:
+    """It should 404 when the run exists but has nothing downloadable."""
+    data_files_store = decoy.mock(cls=DataFilesStore)
+
+    mock_run = decoy.mock(name="run_data")
+    decoy.when(mock_run.run_id).then_return("run-id")
+    decoy.when(mock_run.protocol_id).then_return(None)
+    decoy.when(mock_run.created_at).then_return(
+        datetime(year=2024, month=6, day=20, hour=10, minute=30, second=15)
+    )
+    decoy.when(mock_run_store.get("run-id")).then_return(mock_run)
+
+    decoy.when(
+        data_files_store.get_files_info_by_run_mime_type(
+            run_id="run-id",
+            mime_type=MimeType.IMAGE_JPEG,
+            offset=0,
+            limit=None,
+        )
+    ).then_return(DataFileWithCommandsInfoSlice(file_info=[], total_length=0))
+
+    with pytest.raises(ApiError) as exc_info:
+        await download_run_files(
+            runId="run-id",
+            run_store=mock_run_store,
+            data_files_store=data_files_store,
+            protocol_store=mock_protocol_store,
+        )
+
+    assert exc_info.value.status_code == 404
+    assert exc_info.value.content["errors"][0]["id"] == "NoDownloadContent"

--- a/robot-server/tests/runs/router/test_file_download_router.py
+++ b/robot-server/tests/runs/router/test_file_download_router.py
@@ -1,13 +1,16 @@
 """Tests for runs download router."""
 
 import io
+import json
 import zipfile
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 from decoy import Decoy
 
+from opentrons.protocol_engine import CommandSlice
+from opentrons.protocol_engine import commands as pe_commands
 from opentrons_shared_data.data_files import (
     CmdDataFileInfo,
     DataFileInfoWithCommands,
@@ -21,17 +24,66 @@ from robot_server.data_files.data_files_store import (
 from robot_server.errors.error_responses import ApiError
 from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
 from robot_server.runs.router.file_download_router import download_run_files
-from robot_server.runs.run_models import RunNotFoundError
+from robot_server.runs.run_data_manager import RunDataManager
+from robot_server.runs.run_models import Run, RunNotFoundError
 from robot_server.runs.run_store import RunStore
 
 
-async def test_download_run_files_with_images_and_protocol(
+def _make_home_command() -> pe_commands.Command:
+    return pe_commands.Home(
+        id="command-id",
+        key="command-key",
+        status=pe_commands.CommandStatus.SUCCEEDED,
+        createdAt=datetime(2024, 6, 20, 10, 30, 15, tzinfo=timezone.utc),
+        startedAt=datetime(2024, 6, 20, 10, 30, 16, tzinfo=timezone.utc),
+        completedAt=datetime(2024, 6, 20, 10, 30, 17, tzinfo=timezone.utc),
+        params=pe_commands.HomeParams(),
+        result=pe_commands.HomeResult(),
+    )
+
+
+def _stub_run_log(
+    decoy: Decoy,
+    run_data_manager: RunDataManager,
+    *,
+    run_id: str = "run-id",
+) -> Run:
+    mock_run_record = decoy.mock(cls=Run)
+    decoy.when(mock_run_record.model_dump(mode="json", by_alias=True)).then_return(
+        {"id": run_id, "protocolId": "protocol-id"}
+    )
+    decoy.when(run_data_manager.get(run_id)).then_return(mock_run_record)
+
+    command = _make_home_command()
+    empty_slice = CommandSlice(commands=[], cursor=0, total_length=1)
+    full_slice = CommandSlice(commands=[command], cursor=0, total_length=1)
+    decoy.when(
+        run_data_manager.get_commands_slice(
+            run_id=run_id,
+            cursor=0,
+            length=0,
+            include_fixit_commands=True,
+        )
+    ).then_return(empty_slice)
+    decoy.when(
+        run_data_manager.get_commands_slice(
+            run_id=run_id,
+            cursor=0,
+            length=1,
+            include_fixit_commands=True,
+        )
+    ).then_return(full_slice)
+    return mock_run_record
+
+
+async def test_download_run_files_with_images_protocol_and_run_log(
     decoy: Decoy,
     mock_run_store: RunStore,
+    mock_run_data_manager: RunDataManager,
     mock_protocol_store: ProtocolStore,
     tmp_path: Path,
 ) -> None:
-    """It should zip images under images/ and include the protocol file."""
+    """It should zip images, protocol file, and run log."""
     data_files_store = decoy.mock(cls=DataFilesStore)
 
     image1_path = tmp_path / "image1.jpeg"
@@ -88,7 +140,7 @@ async def test_download_run_files_with_images_and_protocol(
     decoy.when(mock_run.run_id).then_return("run-id")
     decoy.when(mock_run.protocol_id).then_return("protocol-id")
     decoy.when(mock_run.created_at).then_return(
-        datetime(year=2024, month=6, day=20, hour=10, minute=30, second=15)
+        datetime(2024, 6, 20, 10, 30, 15, 354000, tzinfo=timezone.utc)
     )
     decoy.when(mock_run_store.get("run-id")).then_return(mock_run)
 
@@ -99,14 +151,17 @@ async def test_download_run_files_with_images_and_protocol(
     decoy.when(mock_path.name).then_return("my_protocol.py")
     decoy.when(mock_files[0].path).then_return(mock_path)
     decoy.when(mock_source.files).then_return(mock_files)
-    decoy.when(mock_source.metadata).then_return({"protocolName": "Test Protocol"})
+    decoy.when(mock_source.metadata).then_return({"protocolName": "pcrprep-standard"})
     decoy.when(mock_source.main_file).then_return(protocol_path)
     decoy.when(mock_protocol.source).then_return(mock_source)
     decoy.when(mock_protocol_store.get("protocol-id")).then_return(mock_protocol)
 
+    _stub_run_log(decoy, mock_run_data_manager)
+
     result = await download_run_files(
         runId="run-id",
         run_store=mock_run_store,
+        run_data_manager=mock_run_data_manager,
         data_files_store=data_files_store,
         protocol_store=mock_protocol_store,
     )
@@ -125,13 +180,20 @@ async def test_download_run_files_with_images_and_protocol(
         assert "images/image1.jpeg" in names
         assert "images/image2.jpeg" in names
         assert "my_protocol.py" in names
+        assert "pcrprep-standard_2024-06-20T10_30_15.354Z.json" in names
         assert zf.read("images/image1.jpeg") == b"fake image data 1"
         assert zf.read("my_protocol.py") == protocol_path.read_bytes()
+
+        run_log = json.loads(zf.read("pcrprep-standard_2024-06-20T10_30_15.354Z.json"))
+        assert run_log["data"]["id"] == "run-id"
+        assert run_log["commands"]["meta"]["totalLength"] == 1
+        assert len(run_log["commands"]["data"]) == 1
 
 
 async def test_download_run_files_protocol_json_keeps_extension(
     decoy: Decoy,
     mock_run_store: RunStore,
+    mock_run_data_manager: RunDataManager,
     mock_protocol_store: ProtocolStore,
     tmp_path: Path,
 ) -> None:
@@ -154,7 +216,7 @@ async def test_download_run_files_protocol_json_keeps_extension(
     decoy.when(mock_run.run_id).then_return("run-id")
     decoy.when(mock_run.protocol_id).then_return("protocol-id")
     decoy.when(mock_run.created_at).then_return(
-        datetime(year=2024, month=6, day=20, hour=10, minute=30, second=15)
+        datetime(2024, 6, 20, 10, 30, 15, tzinfo=timezone.utc)
     )
     decoy.when(mock_run_store.get("run-id")).then_return(mock_run)
 
@@ -170,9 +232,13 @@ async def test_download_run_files_protocol_json_keeps_extension(
     decoy.when(mock_protocol.source).then_return(mock_source)
     decoy.when(mock_protocol_store.get("protocol-id")).then_return(mock_protocol)
 
+    # Skip run log so this test stays focused on protocol naming.
+    decoy.when(mock_run_data_manager.get("run-id")).then_raise(RuntimeError("skip"))
+
     result = await download_run_files(
         runId="run-id",
         run_store=mock_run_store,
+        run_data_manager=mock_run_data_manager,
         data_files_store=data_files_store,
         protocol_store=mock_protocol_store,
     )
@@ -188,6 +254,7 @@ async def test_download_run_files_protocol_json_keeps_extension(
 async def test_download_run_files_skips_missing_protocol_silently(
     decoy: Decoy,
     mock_run_store: RunStore,
+    mock_run_data_manager: RunDataManager,
     mock_protocol_store: ProtocolStore,
     tmp_path: Path,
 ) -> None:
@@ -225,16 +292,18 @@ async def test_download_run_files_skips_missing_protocol_silently(
     decoy.when(mock_run.run_id).then_return("run-id")
     decoy.when(mock_run.protocol_id).then_return("protocol-id")
     decoy.when(mock_run.created_at).then_return(
-        datetime(year=2024, month=6, day=20, hour=10, minute=30, second=15)
+        datetime(2024, 6, 20, 10, 30, 15, tzinfo=timezone.utc)
     )
     decoy.when(mock_run_store.get("run-id")).then_return(mock_run)
     decoy.when(mock_protocol_store.get("protocol-id")).then_raise(
         ProtocolNotFoundError("protocol-id")
     )
+    decoy.when(mock_run_data_manager.get("run-id")).then_raise(RuntimeError("skip"))
 
     result = await download_run_files(
         runId="run-id",
         run_store=mock_run_store,
+        run_data_manager=mock_run_data_manager,
         data_files_store=data_files_store,
         protocol_store=mock_protocol_store,
     )
@@ -246,12 +315,78 @@ async def test_download_run_files_skips_missing_protocol_silently(
     with zipfile.ZipFile(io.BytesIO(b"".join(chunks))) as zf:
         names = zf.namelist()
         assert "images/image1.jpeg" in names
-        assert not any(name.endswith(".py") or name.endswith(".json") for name in names)
+        assert not any(
+            name.endswith(".py") or (name.endswith(".json") and "/" not in name)
+            for name in names
+            if not name.startswith("images/")
+        )
+
+
+async def test_download_run_files_skips_missing_run_log_silently(
+    decoy: Decoy,
+    mock_run_store: RunStore,
+    mock_run_data_manager: RunDataManager,
+    mock_protocol_store: ProtocolStore,
+    tmp_path: Path,
+) -> None:
+    """It should omit a failed run log and still return other files."""
+    data_files_store = decoy.mock(cls=DataFilesStore)
+    image_path = tmp_path / "image1.jpeg"
+    image_path.write_bytes(b"fake image data")
+
+    file_info = DataFileInfoWithCommands.model_construct(
+        id="file-id-1",
+        name="image1.jpeg",
+        file_hash="hash1",
+        created_at=datetime(year=2024, month=6, day=20),
+        mime_type=MimeType.IMAGE_JPEG,
+        path=str(image_path),
+        generated=True,
+        stored=True,
+        command_info=CmdDataFileInfo(
+            command_id="command-1",
+            prev_command_id="prev-1",
+        ),
+    )
+    decoy.when(
+        data_files_store.get_files_info_by_run_mime_type(
+            run_id="run-id",
+            mime_type=MimeType.IMAGE_JPEG,
+            offset=0,
+            limit=None,
+        )
+    ).then_return(DataFileWithCommandsInfoSlice(file_info=[file_info], total_length=1))
+
+    mock_run = decoy.mock(name="run_data")
+    decoy.when(mock_run.run_id).then_return("run-id")
+    decoy.when(mock_run.protocol_id).then_return(None)
+    decoy.when(mock_run.created_at).then_return(
+        datetime(2024, 6, 20, 10, 30, 15, tzinfo=timezone.utc)
+    )
+    decoy.when(mock_run_store.get("run-id")).then_return(mock_run)
+    decoy.when(mock_run_data_manager.get("run-id")).then_raise(RuntimeError("boom"))
+
+    result = await download_run_files(
+        runId="run-id",
+        run_store=mock_run_store,
+        run_data_manager=mock_run_data_manager,
+        data_files_store=data_files_store,
+        protocol_store=mock_protocol_store,
+    )
+
+    chunks = []
+    async for chunk in result.body_iterator:
+        chunks.append(chunk)
+
+    with zipfile.ZipFile(io.BytesIO(b"".join(chunks))) as zf:
+        assert "images/image1.jpeg" in zf.namelist()
+        assert not any(name.endswith(".json") for name in zf.namelist())
 
 
 async def test_download_run_files_run_not_found(
     decoy: Decoy,
     mock_run_store: RunStore,
+    mock_run_data_manager: RunDataManager,
     mock_protocol_store: ProtocolStore,
 ) -> None:
     """It should 404 when the run does not exist."""
@@ -264,6 +399,7 @@ async def test_download_run_files_run_not_found(
         await download_run_files(
             runId="missing-run",
             run_store=mock_run_store,
+            run_data_manager=mock_run_data_manager,
             data_files_store=data_files_store,
             protocol_store=mock_protocol_store,
         )
@@ -275,6 +411,7 @@ async def test_download_run_files_run_not_found(
 async def test_download_run_files_no_content(
     decoy: Decoy,
     mock_run_store: RunStore,
+    mock_run_data_manager: RunDataManager,
     mock_protocol_store: ProtocolStore,
 ) -> None:
     """It should 404 when the run exists but has nothing downloadable."""
@@ -284,7 +421,7 @@ async def test_download_run_files_no_content(
     decoy.when(mock_run.run_id).then_return("run-id")
     decoy.when(mock_run.protocol_id).then_return(None)
     decoy.when(mock_run.created_at).then_return(
-        datetime(year=2024, month=6, day=20, hour=10, minute=30, second=15)
+        datetime(2024, 6, 20, 10, 30, 15, tzinfo=timezone.utc)
     )
     decoy.when(mock_run_store.get("run-id")).then_return(mock_run)
 
@@ -296,11 +433,13 @@ async def test_download_run_files_no_content(
             limit=None,
         )
     ).then_return(DataFileWithCommandsInfoSlice(file_info=[], total_length=0))
+    decoy.when(mock_run_data_manager.get("run-id")).then_raise(RuntimeError("skip"))
 
     with pytest.raises(ApiError) as exc_info:
         await download_run_files(
             runId="run-id",
             run_store=mock_run_store,
+            run_data_manager=mock_run_data_manager,
             data_files_store=data_files_store,
             protocol_store=mock_protocol_store,
         )

--- a/robot-server/tests/runs/router/test_file_download_router.py
+++ b/robot-server/tests/runs/router/test_file_download_router.py
@@ -3,6 +3,7 @@
 import io
 import json
 import zipfile
+from collections.abc import AsyncIterable
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -52,13 +53,21 @@ def _stub_empty_output_files(decoy: Decoy, data_files_store: DataFilesStore) -> 
     )
 
 
+async def _collect_zip_bytes(body_iterator: AsyncIterable[bytes | str]) -> bytes:
+    chunks: list[bytes] = []
+    async for chunk in body_iterator:
+        assert isinstance(chunk, bytes)
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 def _stub_run_record_for_download(
     decoy: Decoy,
     run_data_manager: RunDataManager,
     *,
     run_id: str = "run-id",
     labware_offsets: list[pe_types.LabwareOffset] | None = None,
-    run_time_parameters: list[object] | None = None,
+    run_time_parameters: list[pe_types.RunTimeParameter] | None = None,
 ) -> Run:
     mock_run_record = decoy.mock(cls=Run)
     decoy.when(mock_run_record.model_dump(mode="json", by_alias=True)).then_return(
@@ -234,11 +243,7 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
     assert "attachment" in result.headers["Content-Disposition"]
     assert ".zip" in result.headers["Content-Disposition"]
 
-    chunks = []
-    async for chunk in result.body_iterator:
-        chunks.append(chunk)
-
-    zip_bytes = b"".join(chunks)
+    zip_bytes = await _collect_zip_bytes(result.body_iterator)
     with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
         names = set(zf.namelist())
         assert "images/image1.jpeg" in names
@@ -331,11 +336,8 @@ async def test_download_run_files_protocol_json_keeps_extension(
         protocol_store=mock_protocol_store,
     )
 
-    chunks = []
-    async for chunk in result.body_iterator:
-        chunks.append(chunk)
-
-    with zipfile.ZipFile(io.BytesIO(b"".join(chunks))) as zf:
+    zip_bytes = await _collect_zip_bytes(result.body_iterator)
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
         assert "my_protocol.json" in zf.namelist()
 
 
@@ -397,11 +399,8 @@ async def test_download_run_files_skips_missing_protocol_silently(
         protocol_store=mock_protocol_store,
     )
 
-    chunks = []
-    async for chunk in result.body_iterator:
-        chunks.append(chunk)
-
-    with zipfile.ZipFile(io.BytesIO(b"".join(chunks))) as zf:
+    zip_bytes = await _collect_zip_bytes(result.body_iterator)
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
         names = zf.namelist()
         assert "images/image1.jpeg" in names
         assert not any(
@@ -464,11 +463,8 @@ async def test_download_run_files_skips_missing_run_log_and_offsets_silently(
         protocol_store=mock_protocol_store,
     )
 
-    chunks = []
-    async for chunk in result.body_iterator:
-        chunks.append(chunk)
-
-    with zipfile.ZipFile(io.BytesIO(b"".join(chunks))) as zf:
+    zip_bytes = await _collect_zip_bytes(result.body_iterator)
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
         assert "images/image1.jpeg" in zf.namelist()
         assert not any(name.endswith(".json") for name in zf.namelist())
 

--- a/robot-server/tests/runs/router/test_file_download_router.py
+++ b/robot-server/tests/runs/router/test_file_download_router.py
@@ -15,11 +15,13 @@ from opentrons.protocol_engine import types as pe_types
 from opentrons.types import DeckSlotName
 from opentrons_shared_data.data_files import (
     CmdDataFileInfo,
+    DataFileInfo,
     DataFileInfoWithCommands,
     MimeType,
 )
 
 from robot_server.data_files.data_files_store import (
+    DataFilesByRunInfo,
     DataFilesStore,
     DataFileWithCommandsInfoSlice,
 )
@@ -41,6 +43,12 @@ def _make_home_command() -> pe_commands.Command:
         completedAt=datetime(2024, 6, 20, 10, 30, 17, tzinfo=timezone.utc),
         params=pe_commands.HomeParams(),
         result=pe_commands.HomeResult(),
+    )
+
+
+def _stub_empty_output_files(decoy: Decoy, data_files_store: DataFilesStore) -> None:
+    decoy.when(data_files_store.get_data_files_by_run_id("run-id")).then_return(
+        DataFilesByRunInfo(input_files=[], output_files=[])
     )
 
 
@@ -97,6 +105,8 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
 
     protocol_path = tmp_path / "my_protocol.py"
     protocol_path.write_text("metadata = {'protocolName': 'Test'}\n")
+    csv_path = tmp_path / "plate_read450nm.csv"
+    csv_path.write_text("wl,a1\n450,0.12\n")
 
     file_info_1 = DataFileInfoWithCommands.model_construct(
         id="file-id-1",
@@ -137,6 +147,23 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
     ).then_return(
         DataFileWithCommandsInfoSlice(
             file_info=[file_info_1, file_info_2], total_length=2
+        )
+    )
+    decoy.when(data_files_store.get_data_files_by_run_id("run-id")).then_return(
+        DataFilesByRunInfo(
+            input_files=[],
+            output_files=[
+                DataFileInfo(
+                    id="csv-file-id",
+                    name="plate_read450nm.csv",
+                    file_hash="csv-hash",
+                    created_at=datetime(2024, 6, 20),
+                    mime_type=MimeType.TEXT_CSV,
+                    path=str(csv_path),
+                    generated=True,
+                    stored=True,
+                ),
+            ],
         )
     )
 
@@ -195,8 +222,19 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
         assert "my_protocol.py" in names
         assert "pcrprep-standard_2024-06-20T10_30_15.354Z.json" in names
         assert "my_protocol_2024-06-20T10_30_15.354Z_offsetdata.json" in names
+        assert (
+            "my_protocol_2024-06-20T10_30_15.354Z_output/"
+            "csv-file-id_plate_read450nm.csv"
+        ) in names
         assert zf.read("images/image1.jpeg") == b"fake image data 1"
         assert zf.read("my_protocol.py") == protocol_path.read_bytes()
+        assert (
+            zf.read(
+                "my_protocol_2024-06-20T10_30_15.354Z_output/"
+                "csv-file-id_plate_read450nm.csv"
+            )
+            == csv_path.read_bytes()
+        )
 
         run_log = json.loads(zf.read("pcrprep-standard_2024-06-20T10_30_15.354Z.json"))
         assert run_log["data"]["id"] == "run-id"
@@ -234,6 +272,7 @@ async def test_download_run_files_protocol_json_keeps_extension(
             limit=None,
         )
     ).then_return(DataFileWithCommandsInfoSlice(file_info=[], total_length=0))
+    _stub_empty_output_files(decoy, data_files_store)
 
     mock_run = decoy.mock(name="run_data")
     decoy.when(mock_run.run_id).then_return("run-id")
@@ -310,6 +349,7 @@ async def test_download_run_files_skips_missing_protocol_silently(
             limit=None,
         )
     ).then_return(DataFileWithCommandsInfoSlice(file_info=[file_info], total_length=1))
+    _stub_empty_output_files(decoy, data_files_store)
 
     mock_run = decoy.mock(name="run_data")
     decoy.when(mock_run.run_id).then_return("run-id")
@@ -379,6 +419,7 @@ async def test_download_run_files_skips_missing_run_log_and_offsets_silently(
             limit=None,
         )
     ).then_return(DataFileWithCommandsInfoSlice(file_info=[file_info], total_length=1))
+    _stub_empty_output_files(decoy, data_files_store)
 
     mock_run = decoy.mock(name="run_data")
     decoy.when(mock_run.run_id).then_return("run-id")
@@ -456,6 +497,7 @@ async def test_download_run_files_no_content(
             limit=None,
         )
     ).then_return(DataFileWithCommandsInfoSlice(file_info=[], total_length=0))
+    _stub_empty_output_files(decoy, data_files_store)
     decoy.when(mock_run_data_manager.get("run-id")).then_raise(RuntimeError("skip"))
 
     with pytest.raises(ApiError) as exc_info:

--- a/robot-server/tests/runs/router/test_file_download_router.py
+++ b/robot-server/tests/runs/router/test_file_download_router.py
@@ -11,6 +11,8 @@ from decoy import Decoy
 
 from opentrons.protocol_engine import CommandSlice
 from opentrons.protocol_engine import commands as pe_commands
+from opentrons.protocol_engine import types as pe_types
+from opentrons.types import DeckSlotName
 from opentrons_shared_data.data_files import (
     CmdDataFileInfo,
     DataFileInfoWithCommands,
@@ -42,16 +44,18 @@ def _make_home_command() -> pe_commands.Command:
     )
 
 
-def _stub_run_log(
+def _stub_run_record_for_download(
     decoy: Decoy,
     run_data_manager: RunDataManager,
     *,
     run_id: str = "run-id",
+    labware_offsets: list[pe_types.LabwareOffset] | None = None,
 ) -> Run:
     mock_run_record = decoy.mock(cls=Run)
     decoy.when(mock_run_record.model_dump(mode="json", by_alias=True)).then_return(
         {"id": run_id, "protocolId": "protocol-id"}
     )
+    decoy.when(mock_run_record.labwareOffsets).then_return(labware_offsets or [])
     decoy.when(run_data_manager.get(run_id)).then_return(mock_run_record)
 
     command = _make_home_command()
@@ -76,14 +80,14 @@ def _stub_run_log(
     return mock_run_record
 
 
-async def test_download_run_files_with_images_protocol_and_run_log(
+async def test_download_run_files_with_images_protocol_run_log_and_offsets(
     decoy: Decoy,
     mock_run_store: RunStore,
     mock_run_data_manager: RunDataManager,
     mock_protocol_store: ProtocolStore,
     tmp_path: Path,
 ) -> None:
-    """It should zip images, protocol file, and run log."""
+    """It should zip images, protocol file, run log, and labware offsets."""
     data_files_store = decoy.mock(cls=DataFilesStore)
 
     image1_path = tmp_path / "image1.jpeg"
@@ -156,7 +160,16 @@ async def test_download_run_files_with_images_protocol_and_run_log(
     decoy.when(mock_protocol.source).then_return(mock_source)
     decoy.when(mock_protocol_store.get("protocol-id")).then_return(mock_protocol)
 
-    _stub_run_log(decoy, mock_run_data_manager)
+    labware_offset = pe_types.LabwareOffset(
+        id="labware-offset-id",
+        createdAt=datetime(2024, 6, 20, 10, 30, 15, tzinfo=timezone.utc),
+        definitionUri="opentrons/biorad_96_wellplate_200ul_pcr/1",
+        location=pe_types.LegacyLabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
+        vector=pe_types.LabwareOffsetVector(x=1.11, y=2.22, z=3.33),
+    )
+    _stub_run_record_for_download(
+        decoy, mock_run_data_manager, labware_offsets=[labware_offset]
+    )
 
     result = await download_run_files(
         runId="run-id",
@@ -181,6 +194,7 @@ async def test_download_run_files_with_images_protocol_and_run_log(
         assert "images/image2.jpeg" in names
         assert "my_protocol.py" in names
         assert "pcrprep-standard_2024-06-20T10_30_15.354Z.json" in names
+        assert "my_protocol_2024-06-20T10_30_15.354Z_offsetdata.json" in names
         assert zf.read("images/image1.jpeg") == b"fake image data 1"
         assert zf.read("my_protocol.py") == protocol_path.read_bytes()
 
@@ -188,6 +202,15 @@ async def test_download_run_files_with_images_protocol_and_run_log(
         assert run_log["data"]["id"] == "run-id"
         assert run_log["commands"]["meta"]["totalLength"] == 1
         assert len(run_log["commands"]["data"]) == 1
+
+        offsets = json.loads(
+            zf.read("my_protocol_2024-06-20T10_30_15.354Z_offsetdata.json")
+        )
+        assert len(offsets) == 1
+        assert offsets[0]["definitionUri"] == (
+            "opentrons/biorad_96_wellplate_200ul_pcr/1"
+        )
+        assert offsets[0]["vector"] == {"x": 1.11, "y": 2.22, "z": 3.33}
 
 
 async def test_download_run_files_protocol_json_keeps_extension(
@@ -322,14 +345,14 @@ async def test_download_run_files_skips_missing_protocol_silently(
         )
 
 
-async def test_download_run_files_skips_missing_run_log_silently(
+async def test_download_run_files_skips_missing_run_log_and_offsets_silently(
     decoy: Decoy,
     mock_run_store: RunStore,
     mock_run_data_manager: RunDataManager,
     mock_protocol_store: ProtocolStore,
     tmp_path: Path,
 ) -> None:
-    """It should omit a failed run log and still return other files."""
+    """It should omit failed run log/offsets and still return other files."""
     data_files_store = decoy.mock(cls=DataFilesStore)
     image_path = tmp_path / "image1.jpeg"
     image_path.write_bytes(b"fake image data")

--- a/robot-server/tests/runs/router/test_file_download_router.py
+++ b/robot-server/tests/runs/router/test_file_download_router.py
@@ -58,12 +58,14 @@ def _stub_run_record_for_download(
     *,
     run_id: str = "run-id",
     labware_offsets: list[pe_types.LabwareOffset] | None = None,
+    run_time_parameters: list[object] | None = None,
 ) -> Run:
     mock_run_record = decoy.mock(cls=Run)
     decoy.when(mock_run_record.model_dump(mode="json", by_alias=True)).then_return(
         {"id": run_id, "protocolId": "protocol-id"}
     )
     decoy.when(mock_run_record.labwareOffsets).then_return(labware_offsets or [])
+    decoy.when(mock_run_record.runTimeParameters).then_return(run_time_parameters or [])
     decoy.when(run_data_manager.get(run_id)).then_return(mock_run_record)
 
     command = _make_home_command()
@@ -107,6 +109,8 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
     protocol_path.write_text("metadata = {'protocolName': 'Test'}\n")
     csv_path = tmp_path / "plate_read450nm.csv"
     csv_path.write_text("wl,a1\n450,0.12\n")
+    rtp_csv_path = tmp_path / "samples.csv"
+    rtp_csv_path.write_text("sample,well\nA,A1\n")
 
     file_info_1 = DataFileInfoWithCommands.model_construct(
         id="file-id-1",
@@ -194,8 +198,28 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
         location=pe_types.LegacyLabwareOffsetLocation(slotName=DeckSlotName.SLOT_1),
         vector=pe_types.LabwareOffsetVector(x=1.11, y=2.22, z=3.33),
     )
+    rtp_param = pe_types.CSVParameter(
+        variableName="csv_data",
+        displayName="CSV Data",
+        file=pe_types.FileInfo(id="rtp-file-id", name="samples.csv"),
+    )
+    decoy.when(data_files_store.get("rtp-file-id")).then_return(
+        DataFileInfo(
+            id="rtp-file-id",
+            name="samples.csv",
+            file_hash="rtp-hash",
+            created_at=datetime(2024, 6, 20),
+            mime_type=MimeType.TEXT_CSV,
+            path=str(rtp_csv_path),
+            generated=False,
+            stored=True,
+        )
+    )
     _stub_run_record_for_download(
-        decoy, mock_run_data_manager, labware_offsets=[labware_offset]
+        decoy,
+        mock_run_data_manager,
+        labware_offsets=[labware_offset],
+        run_time_parameters=[rtp_param],
     )
 
     result = await download_run_files(
@@ -220,6 +244,7 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
         assert "images/image1.jpeg" in names
         assert "images/image2.jpeg" in names
         assert "my_protocol.py" in names
+        assert "samples.csv" in names
         assert "pcrprep-standard_2024-06-20T10_30_15.354Z.json" in names
         assert "my_protocol_2024-06-20T10_30_15.354Z_offsetdata.json" in names
         assert (
@@ -228,6 +253,7 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
         ) in names
         assert zf.read("images/image1.jpeg") == b"fake image data 1"
         assert zf.read("my_protocol.py") == protocol_path.read_bytes()
+        assert zf.read("samples.csv") == rtp_csv_path.read_bytes()
         assert (
             zf.read(
                 "my_protocol_2024-06-20T10_30_15.354Z_output/"

--- a/robot-server/tests/runs/router/test_file_download_router.py
+++ b/robot-server/tests/runs/router/test_file_download_router.py
@@ -19,25 +19,28 @@ from robot_server.data_files.data_files_store import (
     DataFileWithCommandsInfoSlice,
 )
 from robot_server.errors.error_responses import ApiError
-from robot_server.protocols.protocol_store import ProtocolStore
+from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
 from robot_server.runs.router.file_download_router import download_run_files
 from robot_server.runs.run_models import RunNotFoundError
 from robot_server.runs.run_store import RunStore
 
 
-async def test_download_run_files_with_images(
+async def test_download_run_files_with_images_and_protocol(
     decoy: Decoy,
     mock_run_store: RunStore,
     mock_protocol_store: ProtocolStore,
     tmp_path: Path,
 ) -> None:
-    """It should zip images under images/."""
+    """It should zip images under images/ and include the protocol file."""
     data_files_store = decoy.mock(cls=DataFilesStore)
 
     image1_path = tmp_path / "image1.jpeg"
     image2_path = tmp_path / "image2.jpeg"
     image1_path.write_bytes(b"fake image data 1")
     image2_path.write_bytes(b"fake image data 2")
+
+    protocol_path = tmp_path / "my_protocol.py"
+    protocol_path.write_text("metadata = {'protocolName': 'Test'}\n")
 
     file_info_1 = DataFileInfoWithCommands.model_construct(
         id="file-id-1",
@@ -83,11 +86,23 @@ async def test_download_run_files_with_images(
 
     mock_run = decoy.mock(name="run_data")
     decoy.when(mock_run.run_id).then_return("run-id")
-    decoy.when(mock_run.protocol_id).then_return(None)
+    decoy.when(mock_run.protocol_id).then_return("protocol-id")
     decoy.when(mock_run.created_at).then_return(
         datetime(year=2024, month=6, day=20, hour=10, minute=30, second=15)
     )
     decoy.when(mock_run_store.get("run-id")).then_return(mock_run)
+
+    mock_protocol = decoy.mock(name="protocol")
+    mock_source = decoy.mock(name="source")
+    mock_files = [decoy.mock(name="file")]
+    mock_path = decoy.mock(name="path")
+    decoy.when(mock_path.name).then_return("my_protocol.py")
+    decoy.when(mock_files[0].path).then_return(mock_path)
+    decoy.when(mock_source.files).then_return(mock_files)
+    decoy.when(mock_source.metadata).then_return({"protocolName": "Test Protocol"})
+    decoy.when(mock_source.main_file).then_return(protocol_path)
+    decoy.when(mock_protocol.source).then_return(mock_source)
+    decoy.when(mock_protocol_store.get("protocol-id")).then_return(mock_protocol)
 
     result = await download_run_files(
         runId="run-id",
@@ -109,7 +124,129 @@ async def test_download_run_files_with_images(
         names = set(zf.namelist())
         assert "images/image1.jpeg" in names
         assert "images/image2.jpeg" in names
+        assert "my_protocol.py" in names
         assert zf.read("images/image1.jpeg") == b"fake image data 1"
+        assert zf.read("my_protocol.py") == protocol_path.read_bytes()
+
+
+async def test_download_run_files_protocol_json_keeps_extension(
+    decoy: Decoy,
+    mock_run_store: RunStore,
+    mock_protocol_store: ProtocolStore,
+    tmp_path: Path,
+) -> None:
+    """It should keep the .json extension for JSON protocol files."""
+    data_files_store = decoy.mock(cls=DataFilesStore)
+
+    protocol_path = tmp_path / "my_protocol.json"
+    protocol_path.write_text('{"metadata": {"protocolName": "JSON Proto"}}')
+
+    decoy.when(
+        data_files_store.get_files_info_by_run_mime_type(
+            run_id="run-id",
+            mime_type=MimeType.IMAGE_JPEG,
+            offset=0,
+            limit=None,
+        )
+    ).then_return(DataFileWithCommandsInfoSlice(file_info=[], total_length=0))
+
+    mock_run = decoy.mock(name="run_data")
+    decoy.when(mock_run.run_id).then_return("run-id")
+    decoy.when(mock_run.protocol_id).then_return("protocol-id")
+    decoy.when(mock_run.created_at).then_return(
+        datetime(year=2024, month=6, day=20, hour=10, minute=30, second=15)
+    )
+    decoy.when(mock_run_store.get("run-id")).then_return(mock_run)
+
+    mock_protocol = decoy.mock(name="protocol")
+    mock_source = decoy.mock(name="source")
+    mock_files = [decoy.mock(name="file")]
+    mock_path = decoy.mock(name="path")
+    decoy.when(mock_path.name).then_return("my_protocol.json")
+    decoy.when(mock_files[0].path).then_return(mock_path)
+    decoy.when(mock_source.files).then_return(mock_files)
+    decoy.when(mock_source.metadata).then_return({"protocolName": "JSON Proto"})
+    decoy.when(mock_source.main_file).then_return(protocol_path)
+    decoy.when(mock_protocol.source).then_return(mock_source)
+    decoy.when(mock_protocol_store.get("protocol-id")).then_return(mock_protocol)
+
+    result = await download_run_files(
+        runId="run-id",
+        run_store=mock_run_store,
+        data_files_store=data_files_store,
+        protocol_store=mock_protocol_store,
+    )
+
+    chunks = []
+    async for chunk in result.body_iterator:
+        chunks.append(chunk)
+
+    with zipfile.ZipFile(io.BytesIO(b"".join(chunks))) as zf:
+        assert "my_protocol.json" in zf.namelist()
+
+
+async def test_download_run_files_skips_missing_protocol_silently(
+    decoy: Decoy,
+    mock_run_store: RunStore,
+    mock_protocol_store: ProtocolStore,
+    tmp_path: Path,
+) -> None:
+    """It should omit a missing protocol file and still return images."""
+    data_files_store = decoy.mock(cls=DataFilesStore)
+
+    image_path = tmp_path / "image1.jpeg"
+    image_path.write_bytes(b"fake image data")
+
+    file_info = DataFileInfoWithCommands.model_construct(
+        id="file-id-1",
+        name="image1.jpeg",
+        file_hash="hash1",
+        created_at=datetime(year=2024, month=6, day=20),
+        mime_type=MimeType.IMAGE_JPEG,
+        path=str(image_path),
+        generated=True,
+        stored=True,
+        command_info=CmdDataFileInfo(
+            command_id="command-1",
+            prev_command_id="prev-1",
+        ),
+    )
+
+    decoy.when(
+        data_files_store.get_files_info_by_run_mime_type(
+            run_id="run-id",
+            mime_type=MimeType.IMAGE_JPEG,
+            offset=0,
+            limit=None,
+        )
+    ).then_return(DataFileWithCommandsInfoSlice(file_info=[file_info], total_length=1))
+
+    mock_run = decoy.mock(name="run_data")
+    decoy.when(mock_run.run_id).then_return("run-id")
+    decoy.when(mock_run.protocol_id).then_return("protocol-id")
+    decoy.when(mock_run.created_at).then_return(
+        datetime(year=2024, month=6, day=20, hour=10, minute=30, second=15)
+    )
+    decoy.when(mock_run_store.get("run-id")).then_return(mock_run)
+    decoy.when(mock_protocol_store.get("protocol-id")).then_raise(
+        ProtocolNotFoundError("protocol-id")
+    )
+
+    result = await download_run_files(
+        runId="run-id",
+        run_store=mock_run_store,
+        data_files_store=data_files_store,
+        protocol_store=mock_protocol_store,
+    )
+
+    chunks = []
+    async for chunk in result.body_iterator:
+        chunks.append(chunk)
+
+    with zipfile.ZipFile(io.BytesIO(b"".join(chunks))) as zf:
+        names = zf.namelist()
+        assert "images/image1.jpeg" in names
+        assert not any(name.endswith(".py") or name.endswith(".json") for name in names)
 
 
 async def test_download_run_files_run_not_found(

--- a/robot-server/tests/runs/router/test_file_download_router.py
+++ b/robot-server/tests/runs/router/test_file_download_router.py
@@ -249,20 +249,20 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
         names = set(zf.namelist())
         assert "images/image1.jpeg" in names
         assert "images/image2.jpeg" in names
-        assert "my_protocol.py" in names
+        assert "pcrprep-standard.py" in names
         assert "samples.csv" in names
         assert "pcrprep-standard_2024-06-20T10_30_15.354Z.json" in names
-        assert "my_protocol_2024-06-20T10_30_15.354Z_offsetdata.json" in names
+        assert "pcrprep-standard_2024-06-20T10_30_15.354Z_offsetdata.json" in names
         assert (
-            "my_protocol_2024-06-20T10_30_15.354Z_output/"
+            "pcrprep-standard_2024-06-20T10_30_15.354Z_output/"
             "csv-file-id_plate_read450nm.csv"
         ) in names
         assert zf.read("images/image1.jpeg") == b"fake image data 1"
-        assert zf.read("my_protocol.py") == protocol_path.read_bytes()
+        assert zf.read("pcrprep-standard.py") == protocol_path.read_bytes()
         assert zf.read("samples.csv") == rtp_csv_path.read_bytes()
         assert (
             zf.read(
-                "my_protocol_2024-06-20T10_30_15.354Z_output/"
+                "pcrprep-standard_2024-06-20T10_30_15.354Z_output/"
                 "csv-file-id_plate_read450nm.csv"
             )
             == csv_path.read_bytes()
@@ -274,7 +274,7 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
         assert len(run_log["commands"]["data"]) == 1
 
         offsets = json.loads(
-            zf.read("my_protocol_2024-06-20T10_30_15.354Z_offsetdata.json")
+            zf.read("pcrprep-standard_2024-06-20T10_30_15.354Z_offsetdata.json")
         )
         assert len(offsets) == 1
         assert offsets[0]["definitionUri"] == (
@@ -290,7 +290,7 @@ async def test_download_run_files_protocol_json_keeps_extension(
     mock_protocol_store: ProtocolStore,
     tmp_path: Path,
 ) -> None:
-    """It should keep the .json extension for JSON protocol files."""
+    """It should keep the .json extension on the protocolName-based archive name."""
     data_files_store = decoy.mock(cls=DataFilesStore)
 
     protocol_path = tmp_path / "my_protocol.json"
@@ -339,7 +339,8 @@ async def test_download_run_files_protocol_json_keeps_extension(
     )
 
     with await _read_and_cleanup_zip(result) as zf:
-        assert "my_protocol.json" in zf.namelist()
+        assert "JSON_Proto.json" in zf.namelist()
+        assert zf.read("JSON_Proto.json") == protocol_path.read_bytes()
 
 
 async def test_download_run_files_skips_missing_protocol_silently(

--- a/robot-server/tests/runs/router/test_file_download_router.py
+++ b/robot-server/tests/runs/router/test_file_download_router.py
@@ -3,12 +3,12 @@
 import io
 import json
 import zipfile
-from collections.abc import AsyncIterable
 from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 from decoy import Decoy
+from fastapi.responses import FileResponse
 
 from opentrons.protocol_engine import CommandSlice
 from opentrons.protocol_engine import commands as pe_commands
@@ -53,12 +53,13 @@ def _stub_empty_output_files(decoy: Decoy, data_files_store: DataFilesStore) -> 
     )
 
 
-async def _collect_zip_bytes(body_iterator: AsyncIterable[bytes | str]) -> bytes:
-    chunks: list[bytes] = []
-    async for chunk in body_iterator:
-        assert isinstance(chunk, bytes)
-        chunks.append(chunk)
-    return b"".join(chunks)
+async def _read_and_cleanup_zip(result: FileResponse) -> zipfile.ZipFile:
+    """Copy zip bytes, run background cleanup, then open an in-memory ZipFile."""
+    assert isinstance(result, FileResponse)
+    zip_bytes = Path(result.path).read_bytes()
+    if result.background is not None:
+        await result.background()
+    return zipfile.ZipFile(io.BytesIO(zip_bytes))
 
 
 def _stub_run_record_for_download(
@@ -237,14 +238,14 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
         run_data_manager=mock_run_data_manager,
         data_files_store=data_files_store,
         protocol_store=mock_protocol_store,
+        persistence_directory=tmp_path,
     )
 
     assert result.media_type == "application/zip"
     assert "attachment" in result.headers["Content-Disposition"]
     assert ".zip" in result.headers["Content-Disposition"]
 
-    zip_bytes = await _collect_zip_bytes(result.body_iterator)
-    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+    with await _read_and_cleanup_zip(result) as zf:
         names = set(zf.namelist())
         assert "images/image1.jpeg" in names
         assert "images/image2.jpeg" in names
@@ -334,10 +335,10 @@ async def test_download_run_files_protocol_json_keeps_extension(
         run_data_manager=mock_run_data_manager,
         data_files_store=data_files_store,
         protocol_store=mock_protocol_store,
+        persistence_directory=tmp_path,
     )
 
-    zip_bytes = await _collect_zip_bytes(result.body_iterator)
-    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+    with await _read_and_cleanup_zip(result) as zf:
         assert "my_protocol.json" in zf.namelist()
 
 
@@ -397,10 +398,10 @@ async def test_download_run_files_skips_missing_protocol_silently(
         run_data_manager=mock_run_data_manager,
         data_files_store=data_files_store,
         protocol_store=mock_protocol_store,
+        persistence_directory=tmp_path,
     )
 
-    zip_bytes = await _collect_zip_bytes(result.body_iterator)
-    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+    with await _read_and_cleanup_zip(result) as zf:
         names = zf.namelist()
         assert "images/image1.jpeg" in names
         assert not any(
@@ -461,10 +462,10 @@ async def test_download_run_files_skips_missing_run_log_and_offsets_silently(
         run_data_manager=mock_run_data_manager,
         data_files_store=data_files_store,
         protocol_store=mock_protocol_store,
+        persistence_directory=tmp_path,
     )
 
-    zip_bytes = await _collect_zip_bytes(result.body_iterator)
-    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+    with await _read_and_cleanup_zip(result) as zf:
         assert "images/image1.jpeg" in zf.namelist()
         assert not any(name.endswith(".json") for name in zf.namelist())
 
@@ -474,6 +475,7 @@ async def test_download_run_files_run_not_found(
     mock_run_store: RunStore,
     mock_run_data_manager: RunDataManager,
     mock_protocol_store: ProtocolStore,
+    tmp_path: Path,
 ) -> None:
     """It should 404 when the run does not exist."""
     data_files_store = decoy.mock(cls=DataFilesStore)
@@ -488,6 +490,7 @@ async def test_download_run_files_run_not_found(
             run_data_manager=mock_run_data_manager,
             data_files_store=data_files_store,
             protocol_store=mock_protocol_store,
+            persistence_directory=tmp_path,
         )
 
     assert exc_info.value.status_code == 404
@@ -499,6 +502,7 @@ async def test_download_run_files_no_content(
     mock_run_store: RunStore,
     mock_run_data_manager: RunDataManager,
     mock_protocol_store: ProtocolStore,
+    tmp_path: Path,
 ) -> None:
     """It should 404 when the run exists but has nothing downloadable."""
     data_files_store = decoy.mock(cls=DataFilesStore)
@@ -529,6 +533,7 @@ async def test_download_run_files_no_content(
             run_data_manager=mock_run_data_manager,
             data_files_store=data_files_store,
             protocol_store=mock_protocol_store,
+            persistence_directory=tmp_path,
         )
 
     assert exc_info.value.status_code == 404

--- a/robot-server/tests/runs/router/test_file_download_router.py
+++ b/robot-server/tests/runs/router/test_file_download_router.py
@@ -247,8 +247,8 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
 
     with await _read_and_cleanup_zip(result) as zf:
         names = set(zf.namelist())
-        assert "images/image1.jpeg" in names
-        assert "images/image2.jpeg" in names
+        assert "pcrprep-standard_2024-06-20T10_30_15.354Z_images/image1.jpeg" in names
+        assert "pcrprep-standard_2024-06-20T10_30_15.354Z_images/image2.jpeg" in names
         assert "pcrprep-standard.py" in names
         assert "samples.csv" in names
         assert "pcrprep-standard_2024-06-20T10_30_15.354Z.json" in names
@@ -257,7 +257,10 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
             "pcrprep-standard_2024-06-20T10_30_15.354Z_output/"
             "csv-file-id_plate_read450nm.csv"
         ) in names
-        assert zf.read("images/image1.jpeg") == b"fake image data 1"
+        assert (
+            zf.read("pcrprep-standard_2024-06-20T10_30_15.354Z_images/image1.jpeg")
+            == b"fake image data 1"
+        )
         assert zf.read("pcrprep-standard.py") == protocol_path.read_bytes()
         assert zf.read("samples.csv") == rtp_csv_path.read_bytes()
         assert (
@@ -404,11 +407,11 @@ async def test_download_run_files_skips_missing_protocol_silently(
 
     with await _read_and_cleanup_zip(result) as zf:
         names = zf.namelist()
-        assert "images/image1.jpeg" in names
+        assert "protocol-id_2024-06-20T10_30_15.000Z_images/image1.jpeg" in names
         assert not any(
             name.endswith(".py") or (name.endswith(".json") and "/" not in name)
             for name in names
-            if not name.startswith("images/")
+            if not name.startswith("protocol-id_2024-06-20T10_30_15.000Z_images/")
         )
 
 
@@ -467,7 +470,7 @@ async def test_download_run_files_skips_missing_run_log_and_offsets_silently(
     )
 
     with await _read_and_cleanup_zip(result) as zf:
-        assert "images/image1.jpeg" in zf.namelist()
+        assert "run-id_2024-06-20T10_30_15.000Z_images/image1.jpeg" in zf.namelist()
         assert not any(name.endswith(".json") for name in zf.namelist())
 
 


### PR DESCRIPTION
Closes [EXEC-2849](https://opentrons.atlassian.net/browse/EXEC-2849)

# Overview

Adds the `runs/:runId/download` endpoint for downloading all sorts of various files associated with a particular protocol run, if available:

- The protocol file.
- The images captured during the run.
- The labware offset data utilized in the protocol run.
- The run log.
- The input RTP file.
- Generic CSV output.
- Absorbance reader output. 

The endpoint aggregates all these files into one zip file, following the naming convention specified by [Design](https://www.figma.com/design/4AZqNTVC8eMt1aEDQvpITI/Feature--Compliance-Ready-Software?node-id=3133-151163&t=t0z4Q98TvVf7bs6d-4). The endpoint returns a `404` code only if the run was not found or exactly none of the above data files associated with a known run are found. So, for example, if the protocol associated with a particular run is not present, but the run log is present, the resultant zip file generated contains the run log and not the protocol file.

Given the sheer amount of code this entails, we add a new runs router, the `file_download_router`. Because so much of the zip logic and file download exists in the data files router, we refactor that code into `zip_utils.py`. 

This PR is most easily viewed commit by commit. All commits except the first commit, 38d0c5f3dc0cb30361b420b3493489dc8035700f, add more downloadble files to this new endpoint.

## Test Plan and Hands on Testing

- Ran the following protocol, verifying that a request to `runs/:runId/download` returned the expect files and file types.

```
from opentrons import protocol_api

metadata = {
    "protocolName": "Run Download Bundle Demo",
    "author": "Opentrons",
}

requirements = {"robotType": "Flex", "apiLevel": "2.29"}


def add_parameters(parameters: protocol_api.Parameters) -> None:
    parameters.add_csv_file(
        variable_name="sample_map",
        display_name="Sample Map",
        description="CSV with columns: well, note",
    )


def run(protocol: protocol_api.ProtocolContext) -> None:
    trash = protocol.load_trash_bin("A3")
    tiprack = protocol.load_labware(
        "opentrons_flex_96_tiprack_1000ul",
        "B1",
        adapter="opentrons_flex_96_tiprack_adapter",
    )
    plate = protocol.load_labware("corning_96_wellplate_360ul_flat", "D1")
    apr = protocol.load_module("absorbanceReaderV1", "D3")

    pipette = protocol.load_instrument(
        "flex_96channel_1000",
        tip_racks=[tiprack],
    )

    rows = protocol.params.sample_map.parse_as_csv()
    protocol.comment(f"RTP CSV rows (including header): {len(rows)}")

    pipette.pick_up_tip()
    pipette.aspirate(10, plate["A1"].top())
    pipette.dispense(10, plate["A1"].top())
    pipette.return_tip()

    protocol.capture_image(filename="download_demo")

    results_csv = protocol.create_csv(
        filename="user_results",
        title_row=["well", "note"],
    )
    results_csv.write_row(["A1", "from_rtp" if len(rows) > 1 else "demo"])

    apr.close_lid()
    apr.initialize("single", [450])
    apr.open_lid()
    protocol.move_labware(plate, apr, use_gripper=True)
    apr.close_lid()
    apr.read(export_filename="absorbance_read")
    apr.open_lid()
    protocol.move_labware(plate, "D1", use_gripper=True)
```


Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.

## Changelog

- Added `/runs/:runId/download` for downloading select files associated with a protocol run.

## Review requests

- I don't think we have some sort of shared utilities namespace for router-layer concerns, so I tossed the `zip_utils` into data files. I'm more than happy to make some sort of shared `service` directory elsewhere if we feel that's better?
- It seems totally fine to allow people to do this file download while a protocol is running, since this isn't the OT-2. Is that a fair assumption? 

## Risk assessment

- low, additive, and a lot of this functionality exists on various other endpoints. 


[EXEC-2849]: https://opentrons.atlassian.net/browse/EXEC-2849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ