### PR TITLE
chore(react-api-client): add eslint rule to deprecate direct 'useMutation' calls

### DIFF
--- a/.cursor/skills/documented-mutations/SKILL.md
+++ b/.cursor/skills/documented-mutations/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: documented-mutations
+description: >-
+  Migrate react-api-client useMutation hooks to useDocumentedMutation and update
+  app callsites, tests, api-client userNotes, and audit_log keys. Use when
+  converting mutations to documented mutations, wiring documentationState, or
+  adding audit log actions for access control.
+---
+
+# Documented Mutations
+
+Migrate a `useMutation` hook to `useDocumentedMutation`. Copy shape from a migrated example (e.g. `react-api-client/src/runs/usePlayRunMutation.ts`).
+
+## Before coding
+
+**Prompt the user for an audit log key and text.** Do not invent either. Then add:
+
+1. Key to `AuditLogAction` in `react-api-client/src/accessControl/types.ts`
+2. `"key": "text"` in `app/src/assets/localization/en/audit_log.json` only (never `zh/`)
+
+## Hook (`react-api-client`)
+
+1. Replace `useMutation` with `useDocumentedMutation` from `../accessControl`.
+2. Require `documentationState: DocumentationState` as the first arg.
+3. Pass `actionsToDocument` as `['audit_log_key']`.
+4. Mutation fn must take `{ variables, userNotes }` (`DocumentedMutationParameters`) and forward `userNotes` to the api-client call.
+5. Ensure the api-client function accepts/sends `userNotes` if it does not already.
+
+## Callsites (`app/`)
+
+- Flex / shared / ODD: pass `useDocumentationState()` (or an existing docs state).
+- **OT-2 only callsites do not need to be updated and should be passed** `ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE` from `app/src/local-resources/access-control/utils.ts`.
+- **Docs modal cancel:** on isDocumentedMutationError, stay on the screen that launched the mutation (confirm modal, wizard step, etc.). Reset any in-flight UI; do not toast, navigate away, or apply mutation success side effects.
+
+## Tests — update with proper mocks
+
+- Hook tests: pass `ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE` from `react-api-client/src/accessControl/__fixtures__/documentationState`.
+- App tests: mock `useDocumentationState` (or pass the fixture) using `ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE` from `app/src/local-resources/access-control/__fixtures__/documentationState`.
+- Keep api-client / `useHost` mocks; assert `userNotes` is forwarded when relevant.
+- Do not add any new test files.
+
+## Checklist
+
+- [ ] User supplied audit log key + English text
+- [ ] `AuditLogAction` + `en/audit_log.json` updated
+- [ ] Hook uses `useDocumentedMutation` + `userNotes`
+- [ ] api-client accepts `userNotes`
+- [ ] Non-OT2 callsites get real docs state; OT2-only get disabled constant
+- [ ] Docs cancel restores prior screen with no changes / no user-facing error
+- [ ] Hook + app tests updated with proper mocks/fixtures

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,6 +47,7 @@ module.exports = {
     '@typescript-eslint/default-param-last': 'off',
     '@typescript-eslint/consistent-indexed-object-style': 'off',
     '@typescript-eslint/no-non-null-assertion': 'warn',
+    'opentrons/no-direct-use-mutation': 'error',
 
     // TODO(mc, 2021-01-29): fix these and remove warning overrides
     'lines-between-class-members': 'warn',

--- a/app/src/organisms/Desktop/RobotCertImport/useHandleRobotCertImport.ts
+++ b/app/src/organisms/Desktop/RobotCertImport/useHandleRobotCertImport.ts
@@ -44,6 +44,8 @@ export function useHandleRobotCertImport(
       }
     }
 
+  // Auth endpoint, does not require documentation.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
   const { status, mutate } = useMutation<boolean>({
     mutationFn: async () => {
       if (host == null) {

--- a/react-api-client/src/accessControl/GUIDE.md
+++ b/react-api-client/src/accessControl/GUIDE.md
@@ -1,0 +1,176 @@
+# Implementing Documented Mutation Hooks
+
+To maintain Compliance Ready Software, all mutations (POST, PUT, PATCH requests to the robot server) must go through `useDocumentedMutation` instead of calling `useMutation` directly. This wrapper prompts for login and user documentation when Compliance Ready Software mode is enabled, and forwards `userNotes` to the robot API.
+
+This guide walks through adding a **new** documented mutation end to end. You can use an existing hook such as [`usePlayRunMutation`](../../../react-api-client/src/runs/usePlayRunMutation.ts) as a template.
+
+Direct `useMutation` calls are blocked by the `opentrons/no-direct-use-mutation` ESLint rule. Exceptions are rare, and only for endpoints where authorization and documentation are not required. If you think your feature is an exception, check in with Janie, Seth, or Nick Ritso before proceeding.
+
+## Why do we need to do this?
+
+Maintaining Compliance Ready Software means that every action taken on a robot needs to be tracked and added to an auditable list. This list needs to include what action was taken, who took the action, and why they took the action. `useDocumentedMutation` handles collecting the 'who' and 'why' and passes that information to the backend to be stored in the audit log.
+
+## Glossary
+
+- [`DocumentationState`](../../../react-api-client/src/accessControl/types.ts): An object that holds all the information needed to run a documented mutation, i.e. if access control is enabled, if user documentation is required, a documentation report if one has been provided in advance, and callbacks to pop up the login modal or the documentation required modal as needed. As `react-api-client` functions cannot generate UI, these must be generated at callsites in `/app` and passed into the `useTKTKMutation` hooks separately.
+
+## Overview
+
+You will typically touch:
+
+1. **Audit log key + copy** — add copy for the 'Documentation Required' modal to list under 'Actions to Document'
+2. **`api-client`** — accept and send `userNotes` on the HTTP request
+3. **`react-api-client` hook** — wrap the api-client function call with `useDocumentedMutation`
+4. **`app/` callsites** — generate and pass documentation state into the hook, handle documentation modal cancel
+5. **Existing tests** — pass disabled documentation fixtures / mocks
+
+## 1. Choose an audit log key and English text
+
+You need a stable snake_case key and a short English phrase capitalized and in gerund form for the Documentation Required modal (e.g. `play_run` → `"Playing protocol"`). These should clearly describe the action being taken to the end user.
+
+Add these here:
+
+1. The key to the `AuditLogAction` union in [`react-api-client/src/accessControl/types.ts`](../../../react-api-client/src/accessControl/types.ts)
+2. Matching `"key": "text"` in [`app/src/assets/localization/en/audit_log.json`](../../../app/src/assets/localization/en/audit_log.json)
+
+The key in `AuditLogAction`, the string you pass in `actionsToDocument`, and the `audit_log.json` entry must all match.
+
+If you need to pass more information than a simple string, look at the other types in the DocumentedAction union. These encode commands, wizard flow steps, etc. as actions readable by the modal. See [Action List](../../../app/src/organisms/ActionItems/ActionList.tsx) for more information.
+
+## 2. Pass userNotes through the api-client function
+
+The mutation function must accept `userNotes` and pass it into the call to `request` as part of the request config object.
+
+Example shape:
+
+```ts
+export function createThing(
+  config: HostConfig,
+  data: CreateThingData,
+  userNotes?: string
+): ResponsePromise<Thing> {
+  return request<Thing, { data: CreateThingData }>(POST, '/things', config, {
+    body: { data },
+    userNotes,
+  })
+}
+```
+
+Request will take userNotes and pass it to the backend as part of a special header.
+
+If the function already exists without `userNotes`, add the parameter and thread it through the same way other documented endpoints do (see `createRunAction`, `deleteRun`, etc.).
+
+## 3. Write the react-api-client hook
+
+`useDocumentedMutation` calls can take the same form as 'useMutation' calls, but with some adjustments to their shape.
+
+You must take in and pass through a 'DocumentationState' object that will be generated in /app callsites. You must also pass in a list of 'actions to document'. In most cases this will be an array with a single entry - the action you defined in step 1.
+
+You can then pass in mutation keys and a mutation function as you would with `useMutation`. The mutation function must take have its parameters in the form `({ variables: TVariables, userNotes: string })`, and pass userNotes to the api-client function as you defined in step 2.
+
+### Required shape
+
+| Piece            | Requirement                                                                                           |
+| ---------------- | ----------------------------------------------------------------------------------------------------- |
+| First argument   | `documentationState: DocumentationState`                                                              |
+| Second Argument  | Pass `actionsToDocument` as `['your_audit_log_key']` (or merge with an optional caller-supplied list) |
+| Mutation fn args | Destructure `{ variables, userNotes }` (`DocumentedMutationParameters`)                               |
+| api-client call  | Forward `userNotes` into the api-client function                                                      |
+
+### Example
+
+```ts
+import { createThing } from '@opentrons/api-client'
+
+import { useDocumentedMutation } from '../accessControl'
+import { getQueryKey, useHost } from '../api'
+
+import type { DocumentationState } from '../accessControl'
+import type { DocumentedMutationParameters } from '../accessControl/types'
+
+export const useCreateThingMutation = (
+  documentationState: DocumentationState,
+  options = {}
+) => {
+  const host = useHost()
+  const mutation = useDocumentedMutation(
+    documentationState,
+    ['create_thing'], // must match AuditLogAction + audit_log.json
+    getQueryKey(host, 'things', 'create'),
+    ({
+      variables: data,
+      userNotes,
+    }: DocumentedMutationParameters<CreateThingData>) =>
+      createThing(host!, data, userNotes).then(response => response.data),
+    options
+  )
+
+  return {
+    ...mutation,
+    createThing: mutation.mutate,
+  }
+}
+```
+
+`useDocumentedMutation` mirrors the `useMutation` call shapes used in this repo: with or without a mutation key, plus options last.
+
+## 4. Wire app callsites
+
+### Documentation state
+
+In the app, we must generate a `DocumentationState` to pass into our new mutation hook. There are a few ways to do this:
+
+1. `useDocumentationState` - the most common case. Default to using this. The behavior is very simple - each mutation passed in the `DocumentationState `this generates will prompt for documentation when the mutation runs. The userNote this prompting generates is not stored, and just passed to the mutation directly.
+2. `useLinkedDocumentationState` - use this when two mutations run back to back and prompting for both would be disruptive to the user experience. For instance, sending a protocol to a robot and immediately running it. The first mutation will prompt for documentation, and the collected userNote will be stored and given to any other mutations passed the `DocumentationState`
+3. `useMaintenanceRunDocumentation` - use this for new maintenance runs. Pass the `commandDocState` into the `useCreateTargetedMaintenanceRunMutation` and `useChainMaintenanceCommands` calls, and `deletionDocState` into `useDeleteMaintenanceRunMutation`. This will prompt for documentation once at the beginning, track all the commands sent to the robot during the maintenance run, and prompt again listing all the actions at the end.
+4. `usePromptForDocumentation` - use this to synchronously prompt for documentation, capture the userNote, and pass it to a mutation. Its for when you need to prompt at a very specific time before a mutation runs. See [ChoosePipette](../../../app/src/organisms/PipetteWizardFlows/ChoosePipette.tsx) for an example.
+
+### Docs modal cancel
+
+When the user dismisses the documentation (or login) modal, `useDocumentedMutation` rejects with a `DocumentedMutationError`. Detect it with `isDocumentedMutationError` from `@opentrons/react-api-client`.
+
+On that error:
+
+- Stay on the screen that launched the mutation (confirm modal, wizard step, etc.)
+- Reset any in-flight UI (loading flags, disabled buttons)
+- Do **not** toast, navigate away, or run success side effects
+
+```ts
+onError: error => {
+  if (isDocumentedMutationError(error)) {
+    setIsSubmitting(false)
+    return
+  }
+  // real request failures…
+}
+```
+
+## 5. Update tests
+
+To test the new hook directly you can pass in `ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE`.
+
+Tests for functions that call `useDocumentationState` will fail without it being mocked like so:
+
+```ts
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
+```
+
+## Checklist
+
+- [ ] `AuditLogAction` and `en/audit_log.json` updated with new key
+- [ ] api-client accepts and sends `userNotes`
+- [ ] Hook uses `useDocumentedMutation` with `documentationState`, `actionsToDocument`, and correctly formed `DocumentedMutationFunction`
+- [ ] All callsites pass in generated `DocumentationState`
+- [ ] Docs / login cancel restores prior UI with no success side effects and no user-facing error toast
+- [ ] Existing hook and app tests updated with the disabled documentation fixture / mocks
+
+## Reference files
+
+- Wrapper: `react-api-client/src/accessControl/useDocumentedMutation.ts`
+- Types: `react-api-client/src/accessControl/types.ts`
+- Example hooks: `react-api-client/src/runs/usePlayRunMutation.ts`, `react-api-client/src/auth/users/useCreateUserMutation.ts`
+- App docs state: `app/src/local-resources/access-control/useDocumentationState.ts`
+- Disabled constant (runtime): `app/src/local-resources/access-control/utils.ts`
+- Cancel handling example: `app/src/organisms/EmergencyStop/EstopPressedModal.tsx`

--- a/react-api-client/src/auth/oauth2/useGetOAuth2TokenMutation.ts
+++ b/react-api-client/src/auth/oauth2/useGetOAuth2TokenMutation.ts
@@ -43,6 +43,8 @@ export function useGetOAuth2TokenMutation(
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
 
+  // Auth endpoint, does not require documentation.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation -- directly calling useMutation is deprecated in the codebase. Update this to useDocumentedMutation before using this function.
   const mutation = useMutation(
     getQueryKey(host, 'auth/oauth2/token'),
     body => getOAuth2Token(host!, body),

--- a/react-api-client/src/auth/settings/useAccessControlEnabledMutation.ts
+++ b/react-api-client/src/auth/settings/useAccessControlEnabledMutation.ts
@@ -35,6 +35,10 @@ export function useAccessControlEnabledMutation(
   > = {}
 ): UseAccessControlEnabledMutationResult {
   const host = useHost()
+  // Fun case. When turning on CRS, no documentation is required, obviously.
+  // If we ever add a way to turn off CRS, this will need documentation.
+  // Until then, this is fine.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation -- directly calling useMutation is deprecated in the codebase. Update this to useDocumentedMutation before using this function.
   const mutation = useMutation(
     getQueryKey(host, 'auth', 'settings', 'accessControlEnabled'),
     (body: PatchAccessControlEnabledSettingsRequest) =>

--- a/react-api-client/src/calibration/useDeleteCalibrationMutation.ts
+++ b/react-api-client/src/calibration/useDeleteCalibrationMutation.ts
@@ -37,6 +37,8 @@ export function useDeleteCalibrationMutation(
 ): UseDeleteCalibrationMutationResult {
   const host = useHost()
 
+  // OT-2 only.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
   const mutation = useMutation<EmptyResponse, unknown, DeleteCalRequestParams>(
     (requestParams: DeleteCalRequestParams) =>
       deleteCalibration(host!, requestParams).then(response => response.data),

--- a/react-api-client/src/client_data/useReadModifyWriteClientData.ts
+++ b/react-api-client/src/client_data/useReadModifyWriteClientData.ts
@@ -37,6 +37,8 @@ export function useReadModifyWriteClientData<T = DefaultClientData>(
 ): UseReadModifyWriteClientDataMutationResult<T> {
   const host = useHost()
 
+  // Client data endpoint, does not require documentation.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
   const mutation = useMutation<
     ClientDataResponse<T>,
     AxiosError,

--- a/react-api-client/src/client_data/useUpdateClientData.ts
+++ b/react-api-client/src/client_data/useUpdateClientData.ts
@@ -29,6 +29,8 @@ export function useUpdateClientData<T = DefaultClientData>(
 ): UseUpdateClientDataMutationResult<T> {
   const host = useHost()
 
+  // Client data endpoint, does not require documentation.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
   const mutation = useMutation<ClientDataResponse<T>, AxiosError, T>(
     getQueryKey(host, 'client_data', key),
     (clientData: T) =>

--- a/react-api-client/src/labwareOffsets/useDeleteAllLabwareOffsets.ts
+++ b/react-api-client/src/labwareOffsets/useDeleteAllLabwareOffsets.ts
@@ -18,6 +18,8 @@ export function useDeleteAllLabwareOffsetsMutation(): UseDeleteAllLabwareOffsets
   const host = useHost()
   const queryClient = useQueryClient()
 
+  // Directly calling useMutation is deprecated in the codebase. Update this to useDocumentedMutation before using this hook.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
   const mutation = useMutation<null, unknown>(() =>
     deleteAllLabwareOffsets(host!).then(response => {
       queryClient

--- a/react-api-client/src/pipettes/useUpdatePipetteSettingsMutation.ts
+++ b/react-api-client/src/pipettes/useUpdatePipetteSettingsMutation.ts
@@ -45,6 +45,8 @@ export function useUpdatePipetteSettingsMutation(
   const queryClient = useQueryClient()
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
+  // Directly calling useMutation is deprecated in the codebase. Update this to useDocumentedMutation before using this hook.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
   const mutation = useMutation<
     IndividualPipetteSettings,
     AxiosError,

--- a/react-api-client/src/protocols/useCreateProtocolAnalysisMutation.ts
+++ b/react-api-client/src/protocols/useCreateProtocolAnalysisMutation.ts
@@ -51,7 +51,8 @@ export function useCreateProtocolAnalysisMutation(
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
   const queryClient = useQueryClient()
-
+  // Protocol analysis endpoint, does not require documentation.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
   const mutation = useMutation<
     ProtocolAnalysisSummaryResult,
     AxiosError<ErrorResponse>,

--- a/react-api-client/src/protocols/useDeleteProtocolMutation.ts
+++ b/react-api-client/src/protocols/useDeleteProtocolMutation.ts
@@ -21,6 +21,8 @@ export function useDeleteProtocolMutation(
   const host = useHost()
   const queryClient = useQueryClient()
 
+  // Directly calling useMutation is deprecated in the codebase. Update this to useDocumentedMutation before using this hook.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
   const mutation = useMutation<EmptyResponse, unknown>(() =>
     deleteProtocol(host!, protocolId).then(response => {
       queryClient.invalidateQueries(getQueryKey(host, 'protocols'))

--- a/react-api-client/src/runs/useCreateLabwareDefinitionMutation.ts
+++ b/react-api-client/src/runs/useCreateLabwareDefinitionMutation.ts
@@ -28,7 +28,8 @@ export type UseCreateLabwareDefinitionMutationResult = UseMutationResult<
 export function useCreateLabwareDefinitionMutation(): UseCreateLabwareDefinitionMutationResult {
   const host = useHost()
   const queryClient = useQueryClient()
-
+  // Directly calling useMutation is deprecated in the codebase. Update this to useDocumentedMutation before using this hook.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
   const mutation = useMutation<
     CreateLabwareDefinitionResponsePayload,
     unknown,

--- a/react-api-client/src/sessions/useCreateSessionMutation.ts
+++ b/react-api-client/src/sessions/useCreateSessionMutation.ts
@@ -19,6 +19,8 @@ export function useCreateSessionMutation(
   createSessionData: CreateSessionData
 ): UseCreateSessionMutationResult {
   const host = useHost()
+  // Directly calling useMutation is deprecated in the codebase. Update this to useDocumentedMutation before using this hook.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
   const mutation = useMutation<Session, Error>(
     getQueryKey(host, 'session'),
     () =>

--- a/react-api-client/src/system/useCreateSplashMutation.ts
+++ b/react-api-client/src/system/useCreateSplashMutation.ts
@@ -40,7 +40,8 @@ export function useCreateSplashMutation(
   const contextHost = useHost()
   const host =
     hostOverride != null ? { ...contextHost, ...hostOverride } : contextHost
-
+  // For factory use only, does not require documentation.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
   const mutation = useMutation<
     AxiosResponse<void>,
     AxiosError<ErrorResponse>,

--- a/scripts/eslint-plugin-opentrons/lib/index.js
+++ b/scripts/eslint-plugin-opentrons/lib/index.js
@@ -6,4 +6,5 @@ module.exports.rules = {
   'no-imports-across-applications': require('./rules/no-imports-across-applications'),
   'no-margins-in-css': require('./rules/no-margins-in-css'),
   'no-margins-inline': require('./rules/no-margins-inline'),
+  'no-direct-use-mutation': require('./rules/no-direct-use-mutation'),
 }

--- a/scripts/eslint-plugin-opentrons/lib/rules/no-direct-use-mutation.js
+++ b/scripts/eslint-plugin-opentrons/lib/rules/no-direct-use-mutation.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const ALLOWLISTED_SUFFIX =
+  'react-api-client/src/accessControl/useDocumentedMutation.ts'
+
+function isAllowlisted(filename) {
+  return filename.replace(/\\/g, '/').endsWith(ALLOWLISTED_SUFFIX)
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow direct useMutation calls; use useDocumentedMutation instead',
+      recommended: false,
+    },
+    messages: {
+      noDirectUseMutation:
+        'Directly calling useMutation is deprecated. Use useDocumentedMutation instead to maintain Compliance Ready Software standards.',
+    },
+    schema: [],
+  },
+  create(context) {
+    if (isAllowlisted(context.physicalFilename)) {
+      return {}
+    }
+
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'useMutation'
+        ) {
+          context.report({
+            node: node.callee,
+            messageId: 'noDirectUseMutation',
+          })
+        }
+      },
+    }
+  },
+}

--- a/scripts/eslint-plugin-opentrons/lib/rules/no-direct-use-mutation.js
+++ b/scripts/eslint-plugin-opentrons/lib/rules/no-direct-use-mutation.js
@@ -12,12 +12,12 @@ module.exports = {
     type: 'problem',
     docs: {
       description:
-        'Disallow direct useMutation calls; use useDocumentedMutation instead',
+        'Disallow direct useMutation calls; use useDocumentedMutation instead.',
       recommended: false,
     },
     messages: {
       noDirectUseMutation:
-        'Directly calling useMutation is deprecated. Use useDocumentedMutation instead to maintain Compliance Ready Software standards.',
+        'Directly calling useMutation is deprecated. Use useDocumentedMutation instead to maintain Compliance Ready Software standards. See react-api-client/src/accessControl/GUIDE.md for more information.',
     },
     schema: [],
   },

--- a/scripts/eslint-plugin-opentrons/tests/lib/rules/no-direct-use-mutation.js
+++ b/scripts/eslint-plugin-opentrons/tests/lib/rules/no-direct-use-mutation.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const { RuleTester } = require('eslint')
+const rule = require('../../../lib/rules/no-direct-use-mutation')
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+  },
+})
+
+ruleTester.run('no-direct-use-mutation', rule, {
+  valid: [
+    {
+      code: 'useMutation(() => {})',
+      filename:
+        '/repo/react-api-client/src/accessControl/useDocumentedMutation.ts',
+    },
+    {
+      code: 'useQuery(() => {})',
+      filename: '/repo/react-api-client/src/runs/usePlayRunMutation.ts',
+    },
+    {
+      code: 'const useMutation = () => {}; const x = useMutation',
+      filename: '/repo/react-api-client/src/runs/usePlayRunMutation.ts',
+    },
+    {
+      code: 'foo.useMutation(() => {})',
+      filename: '/repo/react-api-client/src/runs/usePlayRunMutation.ts',
+    },
+  ],
+  invalid: [
+    {
+      code: 'useMutation(() => {})',
+      filename: '/repo/react-api-client/src/runs/usePlayRunMutation.ts',
+      errors: [{ messageId: 'noDirectUseMutation' }],
+    },
+    {
+      code: 'const result = useMutation({ mutationFn: async () => {} })',
+      filename:
+        '/repo/app/src/organisms/Desktop/RobotCertImport/useHandleRobotCertImport.ts',
+      errors: [{ messageId: 'noDirectUseMutation' }],
+    },
+  ],
+})


### PR DESCRIPTION
# Overview
<img width="885" height="314" alt="Screenshot 2026-07-21 at 1 18 13 PM" src="https://github.com/user-attachments/assets/9fa46df3-2429-439a-ab89-03294598f354" />

Adds an eslint rule to cause an error when someone attempts to call `useMutation` directly instead of using `useDocumentedMutation`. Also adds a guide for ICs attempting to implement new documented mutations, and a cursor skill to turn `useMutation` calls into `useDocumentedMutation` calls.

## Review requests

Does this guide make sense to you? Do you feel like you have everything you would need to implement your own documented mutations?

## Risk assessment

Low