### PR TITLE
feat(audit-server): include robot identity file in log period download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,7 @@ dev-backend:
 dev-backend-flex:
 	$(python) scripts/run_concurrently.py \
 		$(MAKE) -C auth-server dev OT_AUTH_SERVER_audit_server_url=http://localhost:33970 ';' \
-		$(MAKE) -C audit-server dev OT_AUDIT_SERVER_key_server_url=http://localhost:33960 OT_AUDIT_SERVER_auth_server_url=http://localhost:31950 ';' \
+		$(MAKE) -C audit-server dev OT_AUDIT_SERVER_key_server_url=http://localhost:33960 OT_AUDIT_SERVER_auth_server_url=http://localhost:31950 OT_AUDIT_SERVER_robot_server_url=http://localhost:31951 ';' \
 		$(MAKE) -C robot-server dev-flex OT_ROBOT_SERVER_auth_server_url=http://localhost:31950 OT_ROBOT_SERVER_audit_server_url=http://localhost:33970 BEHIND_DEV_PROXY=1 ';' \
 		$(MAKE) -C system-server dev OT_SYSTEM_SERVER_auth_server_url=http://localhost:31950 OT_SYSTEM_SERVER_audit_server_url=http://localhost:33970 ';' \
 		$(MAKE) -C key-server dev-mitmproxy ';' \

--- a/audit-server/audit_server/app.py
+++ b/audit-server/audit_server/app.py
@@ -19,13 +19,17 @@ from server_utils.auth.resource_server.fastapi import (
     install_authorization_checker,
 )
 from server_utils.keys.fastapi import build_key_client, install_key_client
-from server_utils.keys.key_server import Client as KeyClientABC
+from server_utils.keys.key_server import (
+    Client as KeyClientABC,
+)
 from server_utils.keys.key_server import (
     PublicKeyAndHash,
     SignedMessageData,
     SignMessageData,
 )
 from server_utils.robot.fastapi import build_robot_client, install_robot_server_client
+from server_utils.robot.robot_server import Client as RobotClientABC
+from server_utils.robot.robot_server import RobotNameandSerial
 
 from audit_server.log_export.router import router as log_export_router
 from audit_server.log_ingest.router import router as ingest_router
@@ -69,6 +73,17 @@ class _NoOpFailKeyClient(KeyClientABC):
     @override
     async def get_key_and_hash(self) -> PublicKeyAndHash:
         raise AuditLoggingError(message="Key server unavailable (not configured)")
+
+
+class _StubRobotServerClient(RobotClientABC):
+    """A local robot server client when no robot server url/uds has been provided."""
+
+    @override
+    async def get_name_and_serial(self) -> RobotNameandSerial:
+        return RobotNameandSerial(
+            name="localrobot",
+            serial=None,
+        )
 
 
 @asynccontextmanager
@@ -117,7 +132,13 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
                 )
             )
         else:
-            raise RuntimeError("Cannot establish robot server client.")
+            _log.warning(
+                "robot-server is not configured."
+                " robot identity file in log period download"
+                " will return stub data."
+            )
+            robot_server_client = _StubRobotServerClient()
+
         install_robot_server_client(app.state, robot_server_client)
         log_store = build_log_store(app.state, engine)
         log_data_manager = build_log_data_manager(

--- a/audit-server/audit_server/app.py
+++ b/audit-server/audit_server/app.py
@@ -25,6 +25,7 @@ from server_utils.keys.key_server import (
     SignedMessageData,
     SignMessageData,
 )
+from server_utils.robot.fastapi import build_robot_client, install_robot_server_client
 
 from audit_server.log_export.router import router as log_export_router
 from audit_server.log_ingest.router import router as ingest_router
@@ -105,6 +106,19 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             )
             key_client = _NoOpFailKeyClient()
         install_key_client(app.state, key_client)
+        if (
+            configuration.robot_server_uds is not None
+            or configuration.robot_server_url is not None
+        ):
+            robot_server_client = await exit_stack.enter_async_context(
+                build_robot_client(
+                    robot_server_uds=configuration.robot_server_uds,
+                    robot_server_url=configuration.robot_server_url,
+                )
+            )
+        else:
+            raise RuntimeError("Cannot establish robot server client.")
+        install_robot_server_client(app.state, robot_server_client)
         log_store = build_log_store(app.state, engine)
         log_data_manager = build_log_data_manager(
             app.state, log_store, settings_store, key_client

--- a/audit-server/audit_server/log_export/router.py
+++ b/audit-server/audit_server/log_export/router.py
@@ -1,5 +1,6 @@
 """Route handlers for audit log export endpoints."""
 
+import json
 import tempfile
 import zipfile
 from pathlib import Path
@@ -12,6 +13,9 @@ from starlette.background import BackgroundTask
 from server_utils.fastapi_utils.models.json_api import MultiBodyMeta, SimpleMultiBody
 from server_utils.keys.fastapi import get_key_client
 from server_utils.keys.key_server import Client as KeyClient
+from server_utils.keys.key_server import SignMessageData
+from server_utils.robot.fastapi import get_robot_client
+from server_utils.robot.robot_server import Client as RobotServerClient
 
 from audit_server.log_storage.dependency import get_log_data_manager
 from audit_server.log_storage.log_data_manager import LogDataManager
@@ -53,6 +57,9 @@ async def download_log_period(
     periodId: str,
     log_data_manager: Annotated[LogDataManager, fastapi.Depends(get_log_data_manager)],
     key_client: Annotated[KeyClient, fastapi.Depends(get_key_client)],
+    robot_server_client: Annotated[
+        RobotServerClient, fastapi.Depends(get_robot_client)
+    ],
     persistence_dir: Annotated[Path, fastapi.Depends(get_persistence_directory_root)],
 ) -> FileResponse:
     """Get all audit log periods."""
@@ -61,9 +68,24 @@ async def download_log_period(
     except NoPeriodById as exc:
         raise fastapi.HTTPException(
             status_code=fastapi.status.HTTP_404_NOT_FOUND,
-            detail=(f"No log period found with ID {periodId}"),
+            detail=f"No log period found with ID {periodId}",
         ) from exc
+
     signing_key = await key_client.get_key_and_hash()
+    robot_info = await robot_server_client.get_name_and_serial()
+
+    signed_robot_identity = await key_client.sign_message(
+        SignMessageData(
+            message=json.dumps(
+                {
+                    "robot_name": robot_info.name,
+                    "robot_serial": robot_info.serial,
+                    "public_hash": signing_key.publicHash,
+                }
+            ),
+            previousHash=None,
+        )
+    )
 
     temp_dir = tempfile.TemporaryDirectory(
         prefix="temp-download-staging", dir=persistence_dir
@@ -73,6 +95,7 @@ async def download_log_period(
     with zipfile.ZipFile(zip_file_path, mode="w") as zh:
         zh.writestr("log_period.json", periods.user_log.model_dump_json())
         zh.writestr("signing_key.pem", signing_key.publicKey)
+        zh.writestr("robot_identity.json", signed_robot_identity.model_dump_json())
         for robot_log in periods.robot_log_entries:
             robot_log_path = Path(robot_log.file_path)
             zh.write(robot_log_path, arcname=robot_log_path.name)

--- a/audit-server/audit_server/server_configuration.py
+++ b/audit-server/audit_server/server_configuration.py
@@ -79,3 +79,19 @@ class AuditServerConfiguration(BaseSettings):
             " If both are unset, authentication cannot be checked and modification requests will fail."
         ),
     )
+    robot_server_uds: str | None = Field(
+        default=None,
+        description=(
+            "The path to the Unix domain socket where robot-server is listening."
+            " This is mutually exclusive with robot_server_url."
+            " If both are unset, robot name and serial name can not be obtained and log period download will fail."
+        ),
+    )
+    robot_server_url: str | None = Field(
+        default=None,
+        description=(
+            "The base URL (e.g. `http://localhost:33960`) where robot-server is listening."
+            " This is mutually exclusive with robot_server_uds."
+            " If both are unset, robot name and serial name can not be obtained and log period download will fail.."
+        ),
+    )

--- a/audit-server/tests/conftest.py
+++ b/audit-server/tests/conftest.py
@@ -160,8 +160,51 @@ def fake_key_server(
 
 
 @pytest.fixture
+def fake_robot_server(
+    unused_tcp_port_factory: Callable[[], int],
+) -> Generator[str, None, None]:
+    """Run a minimal in-process standin for robot-server on a TCP port.
+
+    Yields the base URL.
+    """
+    port = unused_tcp_port_factory()
+
+    async def fake_stub_health(request: aiohttp.web.Request) -> aiohttp.web.Response:
+        return aiohttp.web.json_response(
+            data={"name": "my robot", "robot_serial": "123abc"}
+        )
+
+    app = aiohttp.web.Application()
+    app.router.add_get("/health", fake_stub_health)
+    loop = asyncio.new_event_loop()
+    runner = aiohttp.web.AppRunner(app)
+
+    def serve() -> None:
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(runner.setup())
+        site = aiohttp.web.TCPSite(runner, host="127.0.0.1", port=port)
+        loop.run_until_complete(site.start())
+        loop.run_forever()
+
+    thread = threading.Thread(target=serve, name="fake-robot-server", daemon=True)
+    thread.start()
+
+    base_url = f"http://127.0.0.1:{port}"
+    _wait_for_tcp(base_url)
+    try:
+        yield base_url
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
+        asyncio.run(runner.cleanup())
+
+
+@pytest.fixture
 def run_server(
-    unused_tcp_port: int, fake_key_server: str, fake_auth_server: str
+    unused_tcp_port: int,
+    fake_key_server: str,
+    fake_auth_server: str,
+    fake_robot_server: str,
 ) -> Generator[DevServer, None, None]:
     """Run a dev server as a fixture scoped to the test.
 
@@ -171,6 +214,7 @@ def run_server(
     extra_env = {
         "OT_AUDIT_SERVER_key_server_url": fake_key_server,
         "OT_AUDIT_SERVER_auth_server_url": fake_auth_server,
+        "OT_AUDIT_SERVER_robot_server_url": fake_robot_server,
     }
     with DevServer(port=unused_tcp_port, extra_env=extra_env) as dev_server:
         dev_server.start()

--- a/audit-server/tests/integration/test_download_log_period.py
+++ b/audit-server/tests/integration/test_download_log_period.py
@@ -48,4 +48,8 @@ async def test_download_log_period(run_server: DevServer) -> None:
 
         with zipfile.ZipFile(io.BytesIO(log_zip), mode="r") as zf:
             file_list = zf.namelist()
-            assert file_list == ["log_period.json", "signing_key.pem"]
+            assert file_list == [
+                "log_period.json",
+                "signing_key.pem",
+                "robot_identity.json",
+            ]

--- a/server-utils/server_utils/robot/__init__.py
+++ b/server-utils/server_utils/robot/__init__.py
@@ -1,0 +1,1 @@
+"""server_utils.robot: Shared code for talking to robot-server."""

--- a/server-utils/server_utils/robot/fastapi.py
+++ b/server-utils/server_utils/robot/fastapi.py
@@ -1,0 +1,52 @@
+"""FastAPI-specific helpers for talking to robot-server."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import Annotated, AsyncGenerator
+
+import fastapi
+
+from .robot_server import Client, LocalHTTPClient
+from server_utils.fastapi_utils.app_state import (
+    AppState,
+    AppStateAccessor,
+    get_app_state,
+)
+
+_robot_server_client_accessor = AppStateAccessor[Client]("robot_server_client")
+
+
+def install_robot_server_client(app_state: AppState, client: Client) -> None:
+    """Store a singleton robot_server `Client` in global server state for later retrieval.
+
+    This should be called once during server initialization.
+    """
+    _robot_server_client_accessor.set_on(app_state, client)
+
+
+def get_robot_client(
+    app_state: Annotated[AppState, fastapi.Depends(get_app_state)],
+) -> Client:
+    """A FastAPI dependency to retrieve the server's singleton robot-server `Client`.
+
+    Endpoints can take this as a dependency to get robot health information.
+    """
+    client = _robot_server_client_accessor.get_from(app_state)
+    assert client is not None, (
+        "Forgot to initialize robot-server client as part of server startup?"
+    )
+    return client
+
+
+@asynccontextmanager
+async def build_robot_client(
+    *,
+    robot_server_uds: str | None = None,
+    robot_server_url: str | None = None,
+) -> AsyncGenerator[Client, None]:
+    """Build a robot-server `Client` appropriately configured for most servers. """
+    async with LocalHTTPClient(
+        robot_server_uds=robot_server_uds, robot_server_url=robot_server_url
+    ) as client:
+        yield client

--- a/server-utils/server_utils/robot/fastapi.py
+++ b/server-utils/server_utils/robot/fastapi.py
@@ -45,7 +45,7 @@ async def build_robot_client(
     robot_server_uds: str | None = None,
     robot_server_url: str | None = None,
 ) -> AsyncGenerator[Client, None]:
-    """Build a robot-server `Client` appropriately configured for most servers. """
+    """Build a robot-server `Client` appropriately configured for most servers."""
     async with LocalHTTPClient(
         robot_server_uds=robot_server_uds, robot_server_url=robot_server_url
     ) as client:

--- a/server-utils/server_utils/robot/robot_server.py
+++ b/server-utils/server_utils/robot/robot_server.py
@@ -42,7 +42,9 @@ class LocalHTTPClient(Client):
                 via TCP.
         """
         if robot_server_uds is not None and robot_server_url is not None:
-            raise ValueError("Specify only one of robot_server_uds or robot_server_url.")
+            raise ValueError(
+                "Specify only one of robot_server_uds or robot_server_url."
+            )
 
         if robot_server_uds is not None:
             connector = aiohttp.UnixConnector(path=robot_server_uds)
@@ -55,7 +57,9 @@ class LocalHTTPClient(Client):
                 headers={"Opentrons-Version": "2"},
             )
         elif robot_server_url is not None:
-            session = aiohttp.ClientSession(base_url=robot_server_url, headers={"Opentrons-Version": "2"})
+            session = aiohttp.ClientSession(
+                base_url=robot_server_url, headers={"Opentrons-Version": "2"}
+            )
         else:
             raise ValueError("Specify robot_server_uds or robot_server_url.")
 
@@ -77,19 +81,19 @@ class LocalHTTPClient(Client):
     async def get_name_and_serial(self) -> RobotNameandSerial:
         async with self._session.get(HEALTH_ENDPOINT_PATH) as response:
             response_json = await response.json()
-        #raise ValueError(f"JEREMY NOTE {response_json}")
         response.raise_for_status()
         return RobotNameandSerial(
             name=response_json["name"],
             serial=response_json["robot_serial"],
         )
 
+
 class _StrictBaseModel(pydantic.BaseModel):
     model_config = {"strict": True}
 
 
 class RobotNameandSerial(_StrictBaseModel):
-    """Robot name and serial number received via the health endpoint"""
+    """Robot name and serial number received via the health endpoint."""
 
     name: str
     serial: typing.Optional[str]

--- a/server-utils/server_utils/robot/robot_server.py
+++ b/server-utils/server_utils/robot/robot_server.py
@@ -1,0 +1,95 @@
+"""Bindings to robot server's HTTP API."""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import typing
+from abc import ABC, abstractmethod
+
+import aiohttp
+import pydantic
+
+HEALTH_ENDPOINT_PATH = "health"
+
+_log = logging.getLogger(__name__)
+
+
+class Client(ABC):
+    """An interface for a dependent server to get health information via robot-server."""
+
+    @abstractmethod
+    async def get_name_and_serial(self) -> RobotNameandSerial:
+        """Get the name and serial number of the robot via the health endpoint."""
+        pass
+
+
+class LocalHTTPClient(Client):
+    """A client implementation that talks to robot-server over a local HTTP connection."""
+
+    def __init__(
+        self,
+        *,
+        robot_server_uds: str | None = None,
+        robot_server_url: str | None = None,
+    ) -> None:
+        """Construct the client.
+
+        Params:
+            robot_server_uds: e.g. `/path/to/socket`, to connect to robot-server via
+                a Unix domain socket.
+            robot_server_url: e.g. `http://localhost:1234`, to connect to robot-server
+                via TCP.
+        """
+        if robot_server_uds is not None and robot_server_url is not None:
+            raise ValueError("Specify only one of robot_server_uds or robot_server_url.")
+
+        if robot_server_uds is not None:
+            connector = aiohttp.UnixConnector(path=robot_server_uds)
+            session = aiohttp.ClientSession(
+                connector=connector,
+                # We're connecting over a Unix socket, so this URL is nonsensical,
+                # but aiohttp seems to require it as a placeholder.
+                # https://github.com/aio-libs/aiohttp/issues/11324.
+                base_url="http://localhost",
+                headers={"Opentrons-Version": "2"},
+            )
+        elif robot_server_url is not None:
+            session = aiohttp.ClientSession(base_url=robot_server_url, headers={"Opentrons-Version": "2"})
+        else:
+            raise ValueError("Specify robot_server_uds or robot_server_url.")
+
+        self._session = session
+        self._exit_stack = contextlib.AsyncExitStack()
+
+    async def __aenter__(self) -> typing.Self:
+        """When entered as a context manager, open the underlying connection."""
+        await self._exit_stack.enter_async_context(self._session)
+        return self
+
+    async def __aexit__(
+        self, exc_type: object, exc_value: object, traceback: object
+    ) -> None:
+        """When exited as a context manager, close the underlying connection."""
+        await self._exit_stack.aclose()
+
+    @typing.override
+    async def get_name_and_serial(self) -> RobotNameandSerial:
+        async with self._session.get(HEALTH_ENDPOINT_PATH) as response:
+            response_json = await response.json()
+        #raise ValueError(f"JEREMY NOTE {response_json}")
+        response.raise_for_status()
+        return RobotNameandSerial(
+            name=response_json["name"],
+            serial=response_json["robot_serial"],
+        )
+
+class _StrictBaseModel(pydantic.BaseModel):
+    model_config = {"strict": True}
+
+
+class RobotNameandSerial(_StrictBaseModel):
+    """Robot name and serial number received via the health endpoint"""
+
+    name: str
+    serial: typing.Optional[str]

--- a/server-utils/tests/robot/test_fastapi.py
+++ b/server-utils/tests/robot/test_fastapi.py
@@ -1,0 +1,92 @@
+"""Tests for the robot-server FastAPI integration."""
+
+from __future__ import annotations
+
+import fastapi
+import pytest
+from starlette.testclient import TestClient
+
+from server_utils.robot.fastapi import (
+    build_robot_client,
+    get_robot_client,
+    install_robot_server_client,
+)
+from server_utils.robot.robot_server import Client, LocalHTTPClient, RobotNameandSerial
+
+
+async def test_build_robot_client_with_uds_yields_local_http_client(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """With a UDS configured, `build_robot_client` should yield a `LocalHTTPClient`."""
+    socket_path = tmp_path_factory.mktemp("robot") / "sock"
+    async with build_robot_client(robot_server_uds=str(socket_path)) as client:
+        assert isinstance(client, LocalHTTPClient)
+
+
+async def test_build_robot_client_with_url_yields_local_http_client() -> None:
+    """With a URL configured, `build_robot_client` should yield a `LocalHTTPClient`."""
+    async with build_robot_client(robot_server_url="http://localhost:1234") as client:
+        assert isinstance(client, LocalHTTPClient)
+
+
+async def test_build_robot_client_rejects_both_uds_and_url(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Passing both UDS and URL to `build_robot_client` should raise `ValueError`."""
+    socket_path = tmp_path_factory.mktemp("robot") / "sock"
+    with pytest.raises(ValueError):
+        async with build_robot_client(
+            robot_server_uds=str(socket_path),
+            robot_server_url="http://localhost:1234",
+        ):
+            pass
+
+
+async def test_build_robot_client_rejects_no_args() -> None:
+    """Passing neither UDS nor URL to `build_robot_client` should raise `ValueError`."""
+    with pytest.raises(ValueError):
+        async with build_robot_client():
+            pass
+
+
+def test_install_and_get_robot_client_via_dependency() -> None:
+    """`install_robot_client` + `get_robot_client` should round-trip through FastAPI."""
+
+    class StubClient(Client):
+        async def get_name_and_serial(self) -> RobotNameandSerial:
+            raise NotImplementedError
+
+    stub_client = StubClient()
+
+    app = fastapi.FastAPI()
+    install_robot_server_client(app.state, stub_client)
+
+    seen: dict[str, Client] = {}
+
+    @app.get("/check")
+    def check(
+        client: Client = fastapi.Depends(get_robot_client),  # noqa: B008
+    ) -> dict[str, str]:
+        seen["client"] = client
+        return {"ok": "ok"}
+
+    with TestClient(app) as test_client:
+        response = test_client.get("/check")
+        assert response.status_code == 200
+
+    assert seen["client"] is stub_client
+
+
+def test_get_robot_client_without_install_raises() -> None:
+    """`get_robot_client` should assert if no client has been installed."""
+    app = fastapi.FastAPI()
+
+    @app.get("/check")
+    def check(
+        client: Client = fastapi.Depends(get_robot_client),  # noqa: B008
+    ) -> dict[str, str]:  # pragma: no cover - dependency assertion fires first
+        return {"ok": "ok"}
+
+    with TestClient(app, raise_server_exceptions=True) as test_client:
+        with pytest.raises(AssertionError):
+            test_client.get("/check")

--- a/server-utils/tests/robot/test_robot_server.py
+++ b/server-utils/tests/robot/test_robot_server.py
@@ -1,0 +1,168 @@
+"""Tests for our client of robot-server's HTTP API."""
+
+from __future__ import annotations
+
+from contextlib import AsyncExitStack
+from pathlib import Path
+from typing import AsyncGenerator, Final
+
+import aiohttp
+import aiohttp.web
+import pytest
+
+from server_utils.robot.robot_server import (
+    HEALTH_ENDPOINT_PATH,
+    LocalHTTPClient,
+    RobotNameandSerial,
+)
+
+
+class AppMock:
+    """A fake AIOHTTP app to test the client against.
+
+    This should mirror the HTTP API of our real robot-server.
+    """
+
+    get_name_and_serial_response: object
+    """The JSON body the server should respond with to a get_name_and_serial request."""
+
+    get_name_and_serial_response_status: int
+    """The HTTP status code the server should respond with to a get_name_and_serialrequest."""
+
+    app: Final[aiohttp.web.Application]
+
+    def __init__(self) -> None:
+        self.get_name_and_serial_response = {}
+        self.get_name_and_serial_response_status = 200
+
+        app = aiohttp.web.Application()
+        app.router.add_get(
+            f"/{HEALTH_ENDPOINT_PATH}", self._get_name_and_serial_request_content_types
+        )
+        self.app = app
+
+    async def _get_name_and_serial_request_content_types(
+        self, request: aiohttp.web.Request
+    ) -> aiohttp.web.Response:
+        return aiohttp.web.json_response(
+            data=self.get_name_and_serial_response,
+            status=self.get_name_and_serial_response_status,
+        )
+
+
+@pytest.fixture(params=["unix_domain_socket", "tcp"])
+async def mock_server(
+    request: pytest.FixtureRequest,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> AsyncGenerator[tuple[AppMock, LocalHTTPClient], None]:
+    """Return a fake server, and a real client pointed at that fake server.
+
+    Parametrized over two connection types: Unix domain socket, and TCP.
+    """
+    async with AsyncExitStack() as exit_stack:
+        app_mock = AppMock()
+
+        runner = aiohttp.web.AppRunner(app_mock.app)
+
+        await runner.setup()
+        exit_stack.push_async_callback(runner.cleanup)
+
+        mock_server_type = request.param
+
+        if mock_server_type == "unix_domain_socket":
+            socket_path = tmp_path_factory.mktemp("mock") / "sock"
+
+            unix_site = aiohttp.web.UnixSite(runner, socket_path)
+            await unix_site.start()
+            exit_stack.push_async_callback(unix_site.stop)
+
+            client = await exit_stack.enter_async_context(
+                LocalHTTPClient(robot_server_uds=str(socket_path))
+            )
+
+            yield (app_mock, client)
+
+        else:  # mock_server_type == "tcp"
+            tcp_site = aiohttp.web.TCPSite(runner, host="localhost", port=0)
+            await tcp_site.start()
+            exit_stack.push_async_callback(tcp_site.stop)
+
+            port = runner.addresses[0][1]
+            url = f"http://localhost:{port}"
+
+            client = await exit_stack.enter_async_context(
+                LocalHTTPClient(robot_server_url=url)
+            )
+
+            yield (app_mock, client)
+
+
+async def test_get_name_and_serial(
+    mock_server: tuple[AppMock, LocalHTTPClient],
+) -> None:
+    """Test that the client can send a well-formed get_name_and_serial and parse the response."""
+    app_mock, client = mock_server
+
+    app_mock.get_name_and_serial_response = {
+        "name": "my cool robot",
+        "robot_serial": "987-zyx",
+    }
+
+    result = await client.get_name_and_serial()
+
+    assert result == RobotNameandSerial(
+        name="my cool robot",
+        serial="987-zyx",
+    )
+
+
+async def test_get_name_and_serial_http_error(
+    mock_server: tuple[AppMock, LocalHTTPClient],
+) -> None:
+    """A non-2xx response from robot-server should be raised as an exception."""
+    app_mock, client = mock_server
+
+    app_mock.get_name_and_serial_response = {"errors": [{"detail": "oops"}]}
+    app_mock.get_name_and_serial_response_status = 500
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.get_name_and_serial()
+
+
+async def test_get_name_and_serial_raises_when_uds_server_unreachable(
+    tmp_path: Path,
+) -> None:
+    """If the UDS server can't be contacted, the client must raise.
+
+    No socket file exists at the configured path, so aiohttp should raise a
+    connection-related error rather than returning a synthesized success.
+    """
+    socket_path = str(tmp_path / "does-not-exist.sock")
+
+    async with LocalHTTPClient(robot_server_uds=socket_path) as client:
+        with pytest.raises(aiohttp.ClientConnectionError):
+            await client.get_name_and_serial()
+
+
+async def test_get_name_and_serial_raises_when_tcp_server_unreachable() -> None:
+    """If the TCP server can't be contacted, the client must raise."""
+    # Port 1 is privileged and almost certainly not listening; the connection
+    # should be refused (or otherwise fail), surfacing as a connection error.
+    async with LocalHTTPClient(robot_server_url="http://127.0.0.1:1") as client:
+        with pytest.raises(aiohttp.ClientConnectionError):
+            await client.get_name_and_serial()
+
+
+def test_invalid_constructor_args_both_specified() -> None:
+    """Passing both `robot_server_uds` and `robot_server_url` should raise."""
+    with pytest.raises(ValueError):
+        LocalHTTPClient(
+            robot_server_uds="/tmp/sock",
+            robot_server_url="http://localhost:1234",
+        )
+
+
+def test_invalid_constructor_args_neither_specified() -> None:
+    """Passing neither `robot_server_uds` nor `robot_server_url` should raise."""
+    with pytest.raises(ValueError):
+        LocalHTTPClient()


### PR DESCRIPTION
# Overview

Completes EXEC-2779.

This PR adds the robot identity file to the log period download endpoint added in #21963. The robot identity file is a JSON encoded message containing the robot's name, the robot's serial number, and the hash of the public signing certificate, formatted like a log message with a hash and signature and saved as a JSON file.

In the previous PR, the hash of the public signing key was included in changes to the key server, but getting the robot's name and serial number was not there. In order to get this information, we're pinging the `/health` endpoint of the robot-server to get the name and serial number. Doing this required adding a robot server client to server-utils, with a similar HTTP client and accessors/installers as the key-server, auth-server, and audit-server in server-utils. The robot-server-client as it exists in this PR only accesses the `/health` endpoint and only returns the robot name and serial number from it.

In order to actually talk with the robot server, a `robot_server_url` and `robot_server_uds` settings were added to the `AuditServerConfiguration`. Unlike the auth-server and audit-server which use a unit domain socket, here we are expecting a url to `http://localhost:31950`. This exists in the opentrons-audit-server service file, and a separate OE-core PR adds that to our build. If a robot-server cannot be found or connected to, we set up a stub client which will return dummy data. This is hooked up in the `make dev-backend-flex` as well.

## Test Plan and Hands on Testing

Integration tests, running this locally with `make dev-backend-flex`, and running this on a CRS enabled Flex to ensure that the log period download still works and contains the robot identity file with the expected information.

## Changelog

- `GET /audit/external/logPeriods/{periodId}/download` now includes robot identity file
- added a robot-server client to server-utils
- audit-server will now attempt to initialize a connection with the robot server via the client, else use a stub client

## Review requests

I used a lot of copy and paste for the boilerplate for the robot server client, I removed what seemed extraneous or unnecessary for the robot-server, but if I left out or included anything I should not have I can change that. The names of the files in the log period remain hardcoded, but that can change too if required in this PR or a follow-up.

## Risk assessment

Low-medium, code for a new feature that does have a dependency on an OE-core change, but the addition is small in scale and the server changes will not prevent the audit server from running if the build doesn't contain this change.