### PR TITLE
refactor(robot-server): Clean up orphaned download staging dirs on startup

### DIFF
--- a/robot-server/robot_server/data_files/zip_utils.py
+++ b/robot-server/robot_server/data_files/zip_utils.py
@@ -1,6 +1,8 @@
 """Shared helpers for building and streaming zip downloads."""
 
 import asyncio
+import logging
+import shutil
 import tempfile
 import zipfile
 from pathlib import Path
@@ -12,6 +14,8 @@ from opentrons_shared_data.data_files import MimeType
 from .data_files_store import DataFilesStore
 from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
 from robot_server.runs.run_store import BadRunResource, RunResource
+
+_log = logging.getLogger(__name__)
 
 _DOWNLOAD_STAGING_PREFIX: Final = "temp-download-staging-"
 _DOWNLOAD_ZIP_NAME: Final = "download.zip"
@@ -95,6 +99,27 @@ def create_download_staging_dir(staging_root: Path) -> tempfile.TemporaryDirecto
     return tempfile.TemporaryDirectory(
         prefix=_DOWNLOAD_STAGING_PREFIX, dir=str(staging_root)
     )
+
+
+def cleanup_orphaned_download_staging_dirs(staging_root: Path) -> None:
+    """Delete abandoned ``temp-download-staging-*`` entries under ``staging_root``."""
+    if not staging_root.is_dir():
+        return
+
+    to_clean = (
+        entry
+        for entry in staging_root.iterdir()
+        if entry.name.startswith(_DOWNLOAD_STAGING_PREFIX)
+    )
+
+    for item in to_clean:
+        try:
+            if item.is_dir():
+                shutil.rmtree(item)
+            else:
+                item.unlink()
+        except Exception:
+            _log.warning(f"Error deleting {item.resolve()}.", exc_info=True)
 
 
 def _write_zip_file(entries: List[Tuple[Path, str]], zip_path: Path) -> None:

--- a/robot-server/robot_server/persistence/fastapi_dependencies.py
+++ b/robot-server/robot_server/persistence/fastapi_dependencies.py
@@ -23,6 +23,7 @@ from .database import create_sql_engine
 from .file_and_directory_names import DB_FILE
 from .images_directory import ImagesResetter, prepare_images_directory
 from .manage_persistence_directory import prepare_active_subdirectory, prepare_root
+from robot_server.data_files.zip_utils import cleanup_orphaned_download_staging_dirs
 from robot_server.errors.error_responses import ErrorDetails
 
 _log = logging.getLogger(__name__)
@@ -84,6 +85,9 @@ def start_initializing_persistence(  # noqa: C901
             prepared_root = await root_prep_task
 
             active_subdirectory = await prepare_active_subdirectory(prepared_root)
+            await to_thread.run_sync(
+                cleanup_orphaned_download_staging_dirs, active_subdirectory
+            )
             return active_subdirectory
 
         except Exception:

--- a/robot-server/tests/data_files/test_zip_utils.py
+++ b/robot-server/tests/data_files/test_zip_utils.py
@@ -21,6 +21,7 @@ from robot_server.data_files.data_files_store import (
 )
 from robot_server.data_files.zip_utils import (
     build_run_zip_filename,
+    cleanup_orphaned_download_staging_dirs,
     collect_existing_run_images,
     collect_existing_run_output_csvs,
     create_download_staging_dir,
@@ -289,3 +290,36 @@ def test_build_run_zip_filename_missing_protocol_uses_fallback(
 def test_sanitize_filename_component() -> None:
     """It should replace unsafe characters."""
     assert sanitize_filename_component("Test Protocol!") == "Test_Protocol_"
+
+
+def test_cleanup_orphaned_download_staging_dirs(tmp_path: Path) -> None:
+    """It should remove only abandoned download staging entries."""
+    staging_root = tmp_path / "persistence"
+    staging_root.mkdir()
+
+    orphan_dir = staging_root / "temp-download-staging-abc123"
+    orphan_dir.mkdir()
+    (orphan_dir / "download.zip").write_bytes(b"zip")
+
+    orphan_file = staging_root / "temp-download-staging-orphan.file"
+    orphan_file.write_text("leftover")
+
+    keep_dir = staging_root / "protocols"
+    keep_dir.mkdir()
+    (keep_dir / "protocol.py").write_text("print('hi')")
+
+    keep_file = staging_root / "robot_server.db"
+    keep_file.write_bytes(b"db")
+
+    cleanup_orphaned_download_staging_dirs(staging_root)
+
+    assert not orphan_dir.exists()
+    assert not orphan_file.exists()
+    assert keep_dir.exists()
+    assert (keep_dir / "protocol.py").exists()
+    assert keep_file.exists()
+
+
+def test_cleanup_orphaned_download_staging_dirs_missing_root(tmp_path: Path) -> None:
+    """It should no-op when the staging root does not exist."""
+    cleanup_orphaned_download_staging_dirs(tmp_path / "does-not-exist")


### PR DESCRIPTION
# Overview

A followup to #22001, we want to ensure that any temp dirs present during the data files zip process are removed at robot startup. The pattern utilized in this PR is identical to how we manage cleaning up data migrations.

Note there was some discussion that we'd like to extend this same coverage to audit log zip files in this work, however, audit server already deletes its temp files at startup. 

In a subsequent followup PR, we'll harmonize the temp file structure between `audit-server` and `robot-server`.  These files are currently stored in slightly separate locations relative to their root directories and result in somewhat duplicative utilities.

## Test Plan and Hands on Testing

- Verified that stopping the robot server during temp file creation and then restarting it wipes 

## Changelog

- Temp files created during the run data file zip download process are now properly deleted on robot server startup. 

## Risk assessment

- low, just additive behavior