### PR TITLE
refactor(robot-server, server-utils, audit-server): Stage download zips under `/root/temp/`

### DIFF
--- a/audit-server/audit_server/app.py
+++ b/audit-server/audit_server/app.py
@@ -5,6 +5,7 @@ from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator, Optional, override
 
+from anyio import to_thread
 from fastapi import FastAPI, Request, Response
 from opentrons_shared_data.errors.exceptions import AuditLoggingError
 
@@ -24,6 +25,9 @@ from server_utils.keys.key_server import (
     PublicKeyAndHash,
     SignedMessageData,
     SignMessageData,
+)
+from server_utils.persistence.persistence_directory import (
+    cleanup_persistence_temp_directory,
 )
 
 from audit_server.log_export.router import router as log_export_router
@@ -75,6 +79,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     configuration = get_configuration()
     persistence_directory_root = _get_persistence_directory_root(configuration)
     prepared_root = await prepare_root(persistence_directory_root)
+    await to_thread.run_sync(cleanup_persistence_temp_directory, prepared_root)
     set_persistence_directory(app.state, prepared_root)
 
     active_subdirectory = await prepare_active_subdirectory(prepared_root)

--- a/audit-server/audit_server/log_export/router.py
+++ b/audit-server/audit_server/log_export/router.py
@@ -3,7 +3,7 @@
 import tempfile
 import zipfile
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Final
 
 import fastapi
 from fastapi.responses import FileResponse
@@ -12,6 +12,9 @@ from starlette.background import BackgroundTask
 from server_utils.fastapi_utils.models.json_api import MultiBodyMeta, SimpleMultiBody
 from server_utils.keys.fastapi import get_key_client
 from server_utils.keys.key_server import Client as KeyClient
+from server_utils.persistence.persistence_directory import (
+    ensure_persistence_temp_directory,
+)
 
 from audit_server.log_storage.dependency import get_log_data_manager
 from audit_server.log_storage.log_data_manager import LogDataManager
@@ -20,6 +23,8 @@ from audit_server.log_storage.store import NoPeriodById
 from audit_server.persistence.fastapi_dependencies import get_persistence_directory_root
 
 router = fastapi.APIRouter()
+
+_DOWNLOAD_STAGING_PREFIX: Final = "temp-download-staging-"
 
 
 @router.get(
@@ -53,9 +58,11 @@ async def download_log_period(
     periodId: str,
     log_data_manager: Annotated[LogDataManager, fastapi.Depends(get_log_data_manager)],
     key_client: Annotated[KeyClient, fastapi.Depends(get_key_client)],
-    persistence_dir: Annotated[Path, fastapi.Depends(get_persistence_directory_root)],
+    persistence_directory_root: Annotated[
+        Path, fastapi.Depends(get_persistence_directory_root)
+    ],
 ) -> FileResponse:
-    """Get all audit log periods."""
+    """Download a zipped verifiable audit log period."""
     try:
         periods = log_data_manager.get_period_entries(period_id=periodId)
     except NoPeriodById as exc:
@@ -65,8 +72,9 @@ async def download_log_period(
         ) from exc
     signing_key = await key_client.get_key_and_hash()
 
+    temp_root = ensure_persistence_temp_directory(persistence_directory_root)
     temp_dir = tempfile.TemporaryDirectory(
-        prefix="temp-download-staging", dir=persistence_dir
+        prefix=_DOWNLOAD_STAGING_PREFIX, dir=str(temp_root)
     )
 
     zip_file_path = Path(temp_dir.name) / "log_period.zip"

--- a/audit-server/tests/log_export/test_router.py
+++ b/audit-server/tests/log_export/test_router.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import Path
 
 from decoy import Decoy
 
-from audit_server.log_export.router import get_log_periods
+from server_utils.keys.key_server import Client as KeyClient
+from server_utils.keys.key_server import PublicKeyAndHash
+from server_utils.persistence.persistence_directory import PERSISTENCE_TEMP_SUBDIRECTORY
+
+from audit_server.log_export.router import download_log_period, get_log_periods
 from audit_server.log_storage.log_data_manager import LogDataManager
-from audit_server.log_storage.models import LogPeriodSummary
+from audit_server.log_storage.models import LogPeriodSummary, UserLogForExport
+from audit_server.log_storage.types import LogPeriodEntries
 
 _OLDER_PERIOD = LogPeriodSummary(
     id=1,
@@ -63,3 +69,41 @@ async def test_get_log_periods_preserves_store_order(
     assert result.data[0].startedAt > result.data[1].startedAt
     assert result.data[0].endedAt is None
     assert result.data[1].endedAt is not None
+
+
+async def test_download_log_period_stages_under_persistence_temp(
+    decoy: Decoy,
+    mock_log_data_manager: LogDataManager,
+    mock_key_client: KeyClient,
+    tmp_path: Path,
+) -> None:
+    """It should stage the zip under persistence_root/temp/."""
+    period_entries = LogPeriodEntries(
+        user_log=UserLogForExport(
+            userLogEntries=[],
+            startedAt=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            endedAt=None,
+        ),
+        robot_log_entries=[],
+    )
+    decoy.when(mock_log_data_manager.get_period_entries(period_id="1")).then_return(
+        period_entries
+    )
+    decoy.when(await mock_key_client.get_key_and_hash()).then_return(
+        PublicKeyAndHash(publicKey="public-key", publicHash="public-hash")
+    )
+
+    result = await download_log_period(
+        periodId="1",
+        log_data_manager=mock_log_data_manager,
+        key_client=mock_key_client,
+        persistence_directory_root=tmp_path,
+    )
+
+    zip_path = Path(result.path)
+    assert zip_path.is_relative_to(tmp_path / PERSISTENCE_TEMP_SUBDIRECTORY)
+    assert zip_path.exists()
+
+    assert result.background is not None
+    await result.background()
+    assert not zip_path.exists()

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -52,7 +52,7 @@ from .zip_utils import (
 )
 from robot_server.errors.error_responses import ErrorBody, ErrorDetails
 from robot_server.persistence.fastapi_dependencies import (
-    get_active_persistence_directory,
+    get_persistence_directory_root,
 )
 from robot_server.protocols.protocol_store import ProtocolStore
 from robot_server.runs.dependencies import get_run_data_manager, get_run_store
@@ -576,7 +576,9 @@ async def download_run_images(
     data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
     run_store: Annotated[RunStore, Depends(get_run_store)],
     protocol_store: Annotated[ProtocolStore, Depends(get_protocol_store)],
-    persistence_directory: Annotated[Path, Depends(get_active_persistence_directory)],
+    persistence_directory_root: Annotated[
+        Path, Depends(get_persistence_directory_root)
+    ],
 ) -> FileResponse:
     """Download all camera images for a run as a zip file.
 
@@ -585,7 +587,7 @@ async def download_run_images(
         data_files_store: Store for data files database access.
         run_store: Store for run data management.
         protocol_store: Store for protocol storage access.
-        persistence_directory: Persistence directory used for zip staging.
+        persistence_directory_root: Persistence directory used for zip staging.
     """
     existing_files = collect_existing_run_images(runId, data_files_store)
 
@@ -601,7 +603,7 @@ async def download_run_images(
         fallback_filename=f"{runId}_images.zip",
     )
     zip_path, cleanup = await create_zip_for_download(
-        existing_files, persistence_directory
+        existing_files, persistence_directory_root
     )
 
     return FileResponse(

--- a/robot-server/robot_server/data_files/zip_utils.py
+++ b/robot-server/robot_server/data_files/zip_utils.py
@@ -1,8 +1,6 @@
 """Shared helpers for building and streaming zip downloads."""
 
 import asyncio
-import logging
-import shutil
 import tempfile
 import zipfile
 from pathlib import Path
@@ -10,12 +8,13 @@ from typing import Callable, Final, List, Optional, Tuple, Union
 
 from opentrons import config
 from opentrons_shared_data.data_files import MimeType
+from server_utils.persistence.persistence_directory import (
+    ensure_persistence_temp_directory,
+)
 
 from .data_files_store import DataFilesStore
 from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
 from robot_server.runs.run_store import BadRunResource, RunResource
-
-_log = logging.getLogger(__name__)
 
 _DOWNLOAD_STAGING_PREFIX: Final = "temp-download-staging-"
 _DOWNLOAD_ZIP_NAME: Final = "download.zip"
@@ -93,33 +92,14 @@ def collect_existing_run_output_csvs(
     return entries
 
 
-def create_download_staging_dir(staging_root: Path) -> tempfile.TemporaryDirectory[str]:
-    """Create a unique request-scoped staging directory under ``staging_root``."""
-    staging_root.mkdir(parents=True, exist_ok=True)
+def create_download_staging_dir(
+    persistence_root: Path,
+) -> tempfile.TemporaryDirectory[str]:
+    """Create a unique request-scoped staging directory under ``persistence_root/temp``."""
+    temp_directory = ensure_persistence_temp_directory(persistence_root)
     return tempfile.TemporaryDirectory(
-        prefix=_DOWNLOAD_STAGING_PREFIX, dir=str(staging_root)
+        prefix=_DOWNLOAD_STAGING_PREFIX, dir=str(temp_directory)
     )
-
-
-def cleanup_orphaned_download_staging_dirs(staging_root: Path) -> None:
-    """Delete abandoned ``temp-download-staging-*`` entries under ``staging_root``."""
-    if not staging_root.is_dir():
-        return
-
-    to_clean = (
-        entry
-        for entry in staging_root.iterdir()
-        if entry.name.startswith(_DOWNLOAD_STAGING_PREFIX)
-    )
-
-    for item in to_clean:
-        try:
-            if item.is_dir():
-                shutil.rmtree(item)
-            else:
-                item.unlink()
-        except Exception:
-            _log.warning(f"Error deleting {item.resolve()}.", exc_info=True)
 
 
 def _write_zip_file(entries: List[Tuple[Path, str]], zip_path: Path) -> None:
@@ -151,14 +131,14 @@ async def write_zip_for_download(
 
 async def create_zip_for_download(
     entries: List[Tuple[Path, str]],
-    staging_root: Path,
+    persistence_root: Path,
 ) -> Tuple[Path, Callable[[], None]]:
     """Create a staging directory, build a zip inside it, and return cleanup.
 
     Convenience wrapper for callers that do not need the scratch directory for
     anything other than the zip itself.
     """
-    temp_dir = create_download_staging_dir(staging_root)
+    temp_dir = create_download_staging_dir(persistence_root)
     try:
         zip_path = await write_zip_for_download(entries, Path(temp_dir.name))
     except Exception:

--- a/robot-server/robot_server/persistence/fastapi_dependencies.py
+++ b/robot-server/robot_server/persistence/fastapi_dependencies.py
@@ -71,7 +71,7 @@ def start_initializing_persistence(  # noqa: C901
         try:
             prepared_root = await prepare_root(persistence_directory_root)
             await to_thread.run_sync(cleanup_persistence_temp_directory, prepared_root)
-            
+
             return prepared_root
         except Exception:
             _log.exception(

--- a/robot-server/robot_server/persistence/fastapi_dependencies.py
+++ b/robot-server/robot_server/persistence/fastapi_dependencies.py
@@ -17,13 +17,13 @@ from server_utils.fastapi_utils.app_state import (
 )
 from server_utils.persistence.persistence_directory import (
     PersistenceResetter,
+    cleanup_persistence_temp_directory,
 )
 
 from .database import create_sql_engine
 from .file_and_directory_names import DB_FILE
 from .images_directory import ImagesResetter, prepare_images_directory
 from .manage_persistence_directory import prepare_active_subdirectory, prepare_root
-from robot_server.data_files.zip_utils import cleanup_orphaned_download_staging_dirs
 from robot_server.errors.error_responses import ErrorDetails
 
 _log = logging.getLogger(__name__)
@@ -69,7 +69,10 @@ def start_initializing_persistence(  # noqa: C901
 
     async def init_root_persistence_directory() -> Path:
         try:
-            return await prepare_root(persistence_directory_root)
+            prepared_root = await prepare_root(persistence_directory_root)
+            await to_thread.run_sync(cleanup_persistence_temp_directory, prepared_root)
+            
+            return prepared_root
         except Exception:
             _log.exception(
                 "Exception initializing persistence directory root in the background."
@@ -84,11 +87,7 @@ def start_initializing_persistence(  # noqa: C901
             assert root_prep_task is not None
             prepared_root = await root_prep_task
 
-            active_subdirectory = await prepare_active_subdirectory(prepared_root)
-            await to_thread.run_sync(
-                cleanup_orphaned_download_staging_dirs, active_subdirectory
-            )
-            return active_subdirectory
+            return await prepare_active_subdirectory(prepared_root)
 
         except Exception:
             _log.exception(
@@ -271,7 +270,7 @@ async def get_active_persistence_directory_failsafe(
         return None
 
 
-async def _get_persistence_directory_root(
+async def get_persistence_directory_root(
     app_state: Annotated[AppState, Depends(get_app_state)],
 ) -> Path:
     """Return the root persistence directory.
@@ -287,7 +286,7 @@ async def _get_persistence_directory_root(
 
 async def get_persistence_resetter(
     # We want to reset everything, not only the *active* persistence directory.
-    directory_to_reset: Annotated[Path, Depends(_get_persistence_directory_root)],
+    directory_to_reset: Annotated[Path, Depends(get_persistence_directory_root)],
 ) -> PersistenceResetter:
     """Get a `PersistenceResetter` to reset the robot-server's stored data."""
     return PersistenceResetter(directory_to_reset)

--- a/robot-server/robot_server/runs/router/file_download_router.py
+++ b/robot-server/robot_server/runs/router/file_download_router.py
@@ -25,7 +25,7 @@ from robot_server.data_files.zip_utils import (
 )
 from robot_server.errors.error_responses import ErrorBody, ErrorDetails
 from robot_server.persistence.fastapi_dependencies import (
-    get_active_persistence_directory,
+    get_persistence_directory_root,
 )
 from robot_server.protocols.dependencies import get_protocol_store
 from robot_server.protocols.protocol_store import ProtocolNotFoundError, ProtocolStore
@@ -77,7 +77,9 @@ async def download_run_files(
     run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
     data_files_store: Annotated[DataFilesStore, Depends(get_data_files_store)],
     protocol_store: Annotated[ProtocolStore, Depends(get_protocol_store)],
-    persistence_directory: Annotated[Path, Depends(get_active_persistence_directory)],
+    persistence_directory_root: Annotated[
+        Path, Depends(get_persistence_directory_root)
+    ],
 ) -> FileResponse:
     """Download files associated with a run as a zip archive.
 
@@ -87,14 +89,14 @@ async def download_run_files(
         run_data_manager: Run data retrieval interface.
         data_files_store: Store for data files database access.
         protocol_store: Store for protocol storage access.
-        persistence_directory: Persistence directory used for download staging.
+        persistence_directory_root: Persistence directory used for download staging.
     """
     try:
         run = run_store.get(runId)
     except RunNotFoundError as e:
         raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
 
-    staging_dir = create_download_staging_dir(persistence_directory)
+    staging_dir = create_download_staging_dir(persistence_directory_root)
     staging_path = Path(staging_dir.name)
 
     try:

--- a/robot-server/tests/data_files/test_router.py
+++ b/robot-server/tests/data_files/test_router.py
@@ -779,7 +779,7 @@ async def test_download_run_images_success(
         data_files_store=data_files_store,
         run_store=run_store,
         protocol_store=protocol_store,
-        persistence_directory=tmp_path,
+        persistence_directory_root=tmp_path,
     )
 
     assert result.media_type == "application/zip"
@@ -816,7 +816,7 @@ async def test_download_run_images_no_images_found(
             data_files_store=data_files_store,
             run_store=run_store,
             protocol_store=protocol_store,
-            persistence_directory=tmp_path,
+            persistence_directory_root=tmp_path,
         )
 
     assert exc_info.value.status_code == 404

--- a/robot-server/tests/data_files/test_zip_utils.py
+++ b/robot-server/tests/data_files/test_zip_utils.py
@@ -13,6 +13,9 @@ from opentrons_shared_data.data_files import (
     DataFileInfoWithCommands,
     MimeType,
 )
+from server_utils.persistence.persistence_directory import (
+    PERSISTENCE_TEMP_SUBDIRECTORY,
+)
 
 from robot_server.data_files.data_files_store import (
     DataFilesByRunInfo,
@@ -21,7 +24,6 @@ from robot_server.data_files.data_files_store import (
 )
 from robot_server.data_files.zip_utils import (
     build_run_zip_filename,
-    cleanup_orphaned_download_staging_dirs,
     collect_existing_run_images,
     collect_existing_run_output_csvs,
     create_download_staging_dir,
@@ -185,17 +187,17 @@ async def test_create_zip_for_download_preserves_archive_paths(tmp_path: Path) -
     """It should put files under the provided archive paths on disk staging."""
     image = tmp_path / "photo.jpeg"
     protocol = tmp_path / "protocol.py"
-    staging_root = tmp_path / "persistence"
+    persistence_root = tmp_path / "persistence"
     image.write_bytes(b"image-bytes")
     protocol.write_text("print('hi')")
 
     zip_path, cleanup = await create_zip_for_download(
         [(image, "images/photo.jpeg"), (protocol, "protocol.py")],
-        staging_root,
+        persistence_root,
     )
 
     try:
-        assert zip_path.is_relative_to(staging_root)
+        assert zip_path.is_relative_to(persistence_root / PERSISTENCE_TEMP_SUBDIRECTORY)
         with zipfile.ZipFile(zip_path) as zf:
             names = set(zf.namelist())
             assert "images/photo.jpeg" in names
@@ -212,11 +214,13 @@ async def test_write_zip_for_download_uses_existing_scratch_dir(tmp_path: Path) 
     """It should write the zip into a caller-owned scratch directory."""
     image = tmp_path / "photo.jpeg"
     image.write_bytes(b"image-bytes")
-    staging_root = tmp_path / "persistence"
-    staging_dir = create_download_staging_dir(staging_root)
+    persistence_root = tmp_path / "persistence"
+    staging_dir = create_download_staging_dir(persistence_root)
     staging_path = Path(staging_dir.name)
     scratch_file = staging_path / "notes.json"
     scratch_file.write_text('{"ok": true}')
+
+    assert staging_path.parent == persistence_root / PERSISTENCE_TEMP_SUBDIRECTORY
 
     try:
         zip_path = await write_zip_for_download(
@@ -238,10 +242,10 @@ async def test_create_zip_for_download_raises_for_missing_file(
 ) -> None:
     """It should let filesystem errors from zip creation propagate."""
     missing = tmp_path / "missing.jpeg"
-    staging_root = tmp_path / "persistence"
+    persistence_root = tmp_path / "persistence"
 
     with pytest.raises(FileNotFoundError):
-        await create_zip_for_download([(missing, "missing.jpeg")], staging_root)
+        await create_zip_for_download([(missing, "missing.jpeg")], persistence_root)
 
 
 def test_build_run_zip_filename_with_protocol(decoy: Decoy) -> None:
@@ -290,36 +294,3 @@ def test_build_run_zip_filename_missing_protocol_uses_fallback(
 def test_sanitize_filename_component() -> None:
     """It should replace unsafe characters."""
     assert sanitize_filename_component("Test Protocol!") == "Test_Protocol_"
-
-
-def test_cleanup_orphaned_download_staging_dirs(tmp_path: Path) -> None:
-    """It should remove only abandoned download staging entries."""
-    staging_root = tmp_path / "persistence"
-    staging_root.mkdir()
-
-    orphan_dir = staging_root / "temp-download-staging-abc123"
-    orphan_dir.mkdir()
-    (orphan_dir / "download.zip").write_bytes(b"zip")
-
-    orphan_file = staging_root / "temp-download-staging-orphan.file"
-    orphan_file.write_text("leftover")
-
-    keep_dir = staging_root / "protocols"
-    keep_dir.mkdir()
-    (keep_dir / "protocol.py").write_text("print('hi')")
-
-    keep_file = staging_root / "robot_server.db"
-    keep_file.write_bytes(b"db")
-
-    cleanup_orphaned_download_staging_dirs(staging_root)
-
-    assert not orphan_dir.exists()
-    assert not orphan_file.exists()
-    assert keep_dir.exists()
-    assert (keep_dir / "protocol.py").exists()
-    assert keep_file.exists()
-
-
-def test_cleanup_orphaned_download_staging_dirs_missing_root(tmp_path: Path) -> None:
-    """It should no-op when the staging root does not exist."""
-    cleanup_orphaned_download_staging_dirs(tmp_path / "does-not-exist")

--- a/robot-server/tests/runs/router/test_file_download_router.py
+++ b/robot-server/tests/runs/router/test_file_download_router.py
@@ -238,7 +238,7 @@ async def test_download_run_files_with_images_protocol_run_log_and_offsets(
         run_data_manager=mock_run_data_manager,
         data_files_store=data_files_store,
         protocol_store=mock_protocol_store,
-        persistence_directory=tmp_path,
+        persistence_directory_root=tmp_path,
     )
 
     assert result.media_type == "application/zip"
@@ -338,7 +338,7 @@ async def test_download_run_files_protocol_json_keeps_extension(
         run_data_manager=mock_run_data_manager,
         data_files_store=data_files_store,
         protocol_store=mock_protocol_store,
-        persistence_directory=tmp_path,
+        persistence_directory_root=tmp_path,
     )
 
     with await _read_and_cleanup_zip(result) as zf:
@@ -402,7 +402,7 @@ async def test_download_run_files_skips_missing_protocol_silently(
         run_data_manager=mock_run_data_manager,
         data_files_store=data_files_store,
         protocol_store=mock_protocol_store,
-        persistence_directory=tmp_path,
+        persistence_directory_root=tmp_path,
     )
 
     with await _read_and_cleanup_zip(result) as zf:
@@ -466,7 +466,7 @@ async def test_download_run_files_skips_missing_run_log_and_offsets_silently(
         run_data_manager=mock_run_data_manager,
         data_files_store=data_files_store,
         protocol_store=mock_protocol_store,
-        persistence_directory=tmp_path,
+        persistence_directory_root=tmp_path,
     )
 
     with await _read_and_cleanup_zip(result) as zf:
@@ -494,7 +494,7 @@ async def test_download_run_files_run_not_found(
             run_data_manager=mock_run_data_manager,
             data_files_store=data_files_store,
             protocol_store=mock_protocol_store,
-            persistence_directory=tmp_path,
+            persistence_directory_root=tmp_path,
         )
 
     assert exc_info.value.status_code == 404
@@ -537,7 +537,7 @@ async def test_download_run_files_no_content(
             run_data_manager=mock_run_data_manager,
             data_files_store=data_files_store,
             protocol_store=mock_protocol_store,
-            persistence_directory=tmp_path,
+            persistence_directory_root=tmp_path,
         )
 
     assert exc_info.value.status_code == 404

--- a/server-utils/server_utils/persistence/persistence_directory.py
+++ b/server-utils/server_utils/persistence/persistence_directory.py
@@ -1,6 +1,6 @@
 """Create or reset a server's persistence directory.
 
-Shared utilities used by both robot-server and auth-server.
+Shared utilities used by robot-server, auth-server, and audit-server.
 Each server has its own thin wrapper module that supplies server-specific
 configuration (migration list, temp-dir prefix, etc.) and delegates here.
 """
@@ -24,7 +24,34 @@ It tells the server to clear this directory on the next boot,
 after which it will delete this file.
 """
 
+# Scratch space for request-scoped work (e.g. zip download staging).
+PERSISTENCE_TEMP_SUBDIRECTORY: Final = "temp"
+
 _log = getLogger(__name__)
+
+
+def get_persistence_temp_directory(persistence_root: Path) -> Path:
+    """Return the path to ``persistence_root/temp``."""
+    return persistence_root / PERSISTENCE_TEMP_SUBDIRECTORY
+
+
+def ensure_persistence_temp_directory(persistence_root: Path) -> Path:
+    """Create and return ``persistence_root/temp`` for request-scoped scratch."""
+    temp_directory = get_persistence_temp_directory(persistence_root)
+    temp_directory.mkdir(parents=True, exist_ok=True)
+    return temp_directory
+
+
+def cleanup_persistence_temp_directory(persistence_root: Path) -> None:
+    """Delete ``persistence_root/temp`` if it exists."""
+    temp_directory = get_persistence_temp_directory(persistence_root)
+    if not temp_directory.exists():
+        return
+
+    try:
+        rmtree(temp_directory)
+    except Exception:
+        _log.warning(f"Error deleting {temp_directory.resolve()}.", exc_info=True)
 
 
 class PersistenceResetter:

--- a/server-utils/tests/persistence/test_persistence_temp_directory.py
+++ b/server-utils/tests/persistence/test_persistence_temp_directory.py
@@ -1,0 +1,50 @@
+"""Tests for persistence root temp/ scratch helpers."""
+
+from pathlib import Path
+
+from server_utils.persistence.persistence_directory import (
+    PERSISTENCE_TEMP_SUBDIRECTORY,
+    cleanup_persistence_temp_directory,
+    ensure_persistence_temp_directory,
+    get_persistence_temp_directory,
+)
+
+
+def test_get_persistence_temp_directory(tmp_path: Path) -> None:
+    """It should return the temp subdirectory path without creating it."""
+    result = get_persistence_temp_directory(tmp_path)
+
+    assert result == tmp_path / PERSISTENCE_TEMP_SUBDIRECTORY
+    assert not result.exists()
+
+
+def test_ensure_persistence_temp_directory_creates_directory(tmp_path: Path) -> None:
+    """It should create persistence_root/temp when missing."""
+    result = ensure_persistence_temp_directory(tmp_path)
+
+    assert result == tmp_path / "temp"
+    assert result.is_dir()
+
+
+def test_cleanup_persistence_temp_directory_removes_temp_tree(tmp_path: Path) -> None:
+    """It should delete the entire temp/ tree and leave siblings alone."""
+    version_dir = tmp_path / "13"
+    version_dir.mkdir()
+    (version_dir / "robot_server.db").write_bytes(b"db")
+
+    temp_dir = ensure_persistence_temp_directory(tmp_path)
+    staging = temp_dir / "temp-download-staging-abc"
+    staging.mkdir()
+    (staging / "download.zip").write_bytes(b"zip")
+
+    cleanup_persistence_temp_directory(tmp_path)
+
+    assert not temp_dir.exists()
+    assert version_dir.exists()
+    assert (version_dir / "robot_server.db").exists()
+
+
+def test_cleanup_persistence_temp_directory_missing_is_noop(tmp_path: Path) -> None:
+    """It should no-op when persistence_root/temp does not exist."""
+    cleanup_persistence_temp_directory(tmp_path)
+    assert not (tmp_path / "temp").exists()


### PR DESCRIPTION
# Overview

For the sake of functional uniformity, moves zip download scratch files into a shared `persistence_root/temp/` tree structure for both `robot-server` and `audit-server`. `audit-server` already functionally did this, but with a slightly different naming convention, and `robot-server` used versioned persistence subdirs (ex, …/13/…). 

Shared temp file lifecycle code is moved into `server-utils`. 

## Test Plan and Hands on Testing

- Verified that downloading related zip files for the two servers still works as expected.

## Risk assessment

- low-ish, just shuffling around some code and changing the exact path for writing temp zip files.