### PR TITLE
chore: add 9.1.2 alpha release notes

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -6,6 +6,20 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 By installing and using Opentrons software, you agree to the Opentrons End-User License Agreement (EULA). You can view the EULA at [opentrons.com/eula](https://opentrons.com/eula).
 
+## Opentrons Robot Software Changes in 9.1.2
+
+Welcome to the v9.1.2 release of the Opentrons Flex robot software! This release includes bug fixes and improvements.
+
+### Feature Improvements
+
+- Opentrons Flex 96 Filter Tip Racks (20 µL) are compatible with the Opentrons Flex Tip Rack Lid.
+
+### Bug Fixes
+
+- Flex 96-channel pipettes properly align over 12 well reservoirs for liquid handling with a single row of tips.
+
+---
+
 ## Opentrons Robot Software Changes in 9.1.1
 
 Welcome to the v9.1.1 release of the Opentrons Flex robot software! This release enables step grouping to better visualize and organize Python protocols, along with other new features, improvements, and bug fixes.

--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -16,7 +16,7 @@ Welcome to the v9.1.2 release of the Opentrons Flex robot software! This release
 
 ### Bug Fixes
 
-- Flex 96-channel pipettes properly align over 12 well reservoirs for liquid handling with a single row of tips.
+- Flex 96-channel pipettes properly align over 8-well reservoirs for liquid handling with a single row of tips.
 
 ---
 

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -6,6 +6,12 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 By installing and using Opentrons software, you agree to the Opentrons End-User License Agreement (EULA). You can view the EULA at [opentrons.com/eula](https://opentrons.com/eula).
 
+## Opentrons App Changes in 9.1.2
+
+Welcome to the v9.1.2 release of the Opentrons App! This release resolves a bug to prevent the Flex touchscreen from freezing while selecting runtime parameters for a protocol run.
+
+---
+
 ## Opentrons App Changes in 9.1.1
 
 Welcome to the v9.1.1 release of the Opentrons App! This release is designed specifically for use with Opentrons Flex and includes other new features, improvements, and bug fixes.


### PR DESCRIPTION
# Overview

Adds release notes for a 9.1.2 alpha. See changelog for bugs mentioned (and left out). 

## Test Plan and Hands on Testing


## Changelog

included: 
- [EXEC-2737](https://opentrons.atlassian.net/browse/EXEC-2737): I was specific about the 12 well reservoir here, but could be a little more vague. 
- [20 uL filter tips compatible with Flex tip rack lid](https://github.com/Opentrons/opentrons/pull/21940): listed as an improvement
- [AUTH-3041](https://opentrons.atlassian.net/browse/AUTH-3041): mentioned in app release notes

not included:
- [AUTH-3042](https://opentrons.atlassian.net/browse/AUTH-3042): Jethary just listed as _not_ a bug and closed, so no mention here
- [AUTH-3043](https://opentrons.atlassian.net/browse/AUTH-3043) looks like it's still in progress (and Nus thinks it may be a bigger hardware issue). can come back and add a description of this as needed
- [AUTH-3063](https://opentrons.atlassian.net/browse/AUTH-3063) this fix is bringing us to expected behavior, so no mention here


## Review requests


## Risk assessment

low.

[EXEC-2737]: https://opentrons.atlassian.net/browse/EXEC-2737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AUTH-3041]: https://opentrons.atlassian.net/browse/AUTH-3041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AUTH-3042]: https://opentrons.atlassian.net/browse/AUTH-3042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AUTH-3043]: https://opentrons.atlassian.net/browse/AUTH-3043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AUTH-3063]: https://opentrons.atlassian.net/browse/AUTH-3063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ