### PR TITLE
chore(components): move redux from dependencies to devDependencies

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -51,10 +51,10 @@
     "react-remove-scroll": "2.4.3",
     "react-select": "5.4.0",
     "react-viewport-list": "6.3.0",
-    "redux": "5.0.1",
     "styled-components": "5.3.6"
   },
   "devDependencies": {
+    "redux": "5.0.1",
     "react-redux": "8.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -870,9 +870,6 @@ importers:
       react-viewport-list:
         specifier: 6.3.0
         version: 6.3.0(react@18.2.0)
-      redux:
-        specifier: 5.0.1
-        version: 5.0.1
       styled-components:
         specifier: 5.3.6
         version: 5.3.6(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
@@ -880,6 +877,9 @@ importers:
       react-redux:
         specifier: 8.1.2
         version: 8.1.2(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(redux@5.0.1)
+      redux:
+        specifier: 5.0.1
+        version: 5.0.1
 
   discovery-client:
     dependencies:


### PR DESCRIPTION


# Overview
move redux from dependencies to devDependencies
redux is for `renderWithProviders` (test) so redux doesn't need to be in `dependencies`.

close AUTH-3099

## Test Plan and Hands on Testing
none


## Changelog
- move redux

## Review requests


## Risk assessment
low
