### PR TITLE
feat(app, odd): remove direct protocol deletion calls in app

### DIFF
--- a/api-client/src/protocols/deleteProtocol.ts
+++ b/api-client/src/protocols/deleteProtocol.ts
@@ -5,7 +5,10 @@ import type { EmptyResponse, HostConfig } from '../types'
 
 export function deleteProtocol(
   config: HostConfig,
-  protocolId: string
+  protocolId: string,
+  userNotes?: string
 ): ResponsePromise<EmptyResponse> {
-  return request<EmptyResponse>(DELETE, `/protocols/${protocolId}`, config)
+  return request<EmptyResponse>(DELETE, `/protocols/${protocolId}`, config, {
+    userNotes,
+  })
 }

--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -17,6 +17,7 @@
   "create_user": "Creating user",
   "delete_log_period": "Deleting log period",
   "delete_offsets": "Deleting old labware offsets",
+  "delete_protocol": "Deleting protocol",
   "delete_run": "Deleting protocol run record",
   "delete_run_images": "Deleting run images",
   "delete_runs": "Deleting protocol run records",

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRunOverflowMenu.tsx
@@ -190,7 +190,7 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
   const handleDeleteClick: MouseEventHandler<HTMLButtonElement> = e => {
     e.preventDefault()
     e.stopPropagation()
-    deleteRun({ runId })
+    void deleteRun({ runId })
     closeOverflowMenu(e)
   }
 

--- a/app/src/pages/ODD/ProtocolDashboard/DeleteProtocolConfirmationModal.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/DeleteProtocolConfirmationModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
 
-import { deleteRun, getProtocol } from '@opentrons/api-client'
+import { getProtocol } from '@opentrons/api-client'
 import {
   ALIGN_CENTER,
   Box,
@@ -17,6 +17,7 @@ import {
 import {
   isDocumentedMutationError,
   useDeleteProtocolMutation,
+  useDeleteRunMutation,
   useHost,
   useProtocolQuery,
 } from '@opentrons/react-api-client'
@@ -48,6 +49,7 @@ export function DeleteProtocolConfirmationModal({
   const host = useHost()
   const documentationState = useDocumentationState()
   const { deleteProtocol } = useDeleteProtocolMutation(documentationState)
+  const { deleteRun } = useDeleteRunMutation(documentationState)
   const { data: protocolRecord } = useProtocolQuery(protocolId)
   const protocolName =
     protocolRecord?.data.metadata.protocolName ??
@@ -66,11 +68,12 @@ export function DeleteProtocolConfirmationModal({
         )
         .then(referencingRunIds => {
           return Promise.all(
-            // eslint-disable-next-line opentrons/no-direct-mutating -- TODO(jj, 07-21-26): no direct mutations
-            referencingRunIds?.map(runId => deleteRun(host, runId))
+            referencingRunIds?.map(runId => deleteRun({ runId }))
           )
         })
-        .then(() => deleteProtocol(protocolId))
+        .then(() => {
+          return deleteProtocol(protocolId)
+        })
         .then(() => {
           setShowIcon(false)
           setShowDeleteConfirmationModal(false)

--- a/app/src/pages/ODD/ProtocolDashboard/DeleteProtocolConfirmationModal.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/DeleteProtocolConfirmationModal.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useQueryClient } from 'react-query'
 import styled from 'styled-components'
 
-import { deleteProtocol, deleteRun, getProtocol } from '@opentrons/api-client'
+import { deleteRun, getProtocol } from '@opentrons/api-client'
 import {
   ALIGN_CENTER,
   Box,
@@ -16,12 +15,14 @@ import {
   TYPOGRAPHY,
 } from '@opentrons/components'
 import {
-  getQueryKey,
+  isDocumentedMutationError,
+  useDeleteProtocolMutation,
   useHost,
   useProtocolQuery,
 } from '@opentrons/react-api-client'
 
 import { SmallButton } from '/app/atoms/buttons'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
 import { useToaster } from '/app/organisms/ToasterOven'
 
@@ -45,7 +46,8 @@ export function DeleteProtocolConfirmationModal({
     iconColor: COLORS.yellow50,
   }
   const host = useHost()
-  const queryClient = useQueryClient()
+  const documentationState = useDocumentationState()
+  const { deleteProtocol } = useDeleteProtocolMutation(documentationState)
   const { data: protocolRecord } = useProtocolQuery(protocolId)
   const protocolName =
     protocolRecord?.data.metadata.protocolName ??
@@ -68,21 +70,17 @@ export function DeleteProtocolConfirmationModal({
             referencingRunIds?.map(runId => deleteRun(host, runId))
           )
         })
-        // eslint-disable-next-line opentrons/no-direct-mutating -- TODO(jj, 07-21-26): no direct mutations
-        .then(() => deleteProtocol(host, protocolId))
-        .then(() =>
-          queryClient
-            .invalidateQueries(getQueryKey(host, 'protocols'))
-            .catch((e: Error) => {
-              console.error(`error invalidating runs query: ${e.message}`)
-            })
-        )
+        .then(() => deleteProtocol(protocolId))
         .then(() => {
           setShowIcon(false)
           setShowDeleteConfirmationModal(false)
           makeSnackbar(t('protocol_deleted') as string)
         })
         .catch((e: Error) => {
+          if (isDocumentedMutationError(e)) {
+            setShowIcon(false)
+            return
+          }
           console.error(`error deleting resources: ${e.message}`)
         })
     } else {

--- a/app/src/pages/ODD/ProtocolDashboard/DeleteProtocolConfirmationModal.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/DeleteProtocolConfirmationModal.tsx
@@ -23,7 +23,7 @@ import {
 } from '@opentrons/react-api-client'
 
 import { SmallButton } from '/app/atoms/buttons'
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
 import { useToaster } from '/app/organisms/ToasterOven'
 
@@ -47,7 +47,10 @@ export function DeleteProtocolConfirmationModal({
     iconColor: COLORS.yellow50,
   }
   const host = useHost()
-  const documentationState = useDocumentationState()
+  const { documentationState } = useLinkedDocumentationState(
+    ['delete_protocol', 'delete_runs'],
+    protocolId
+  )
   const { deleteProtocol } = useDeleteProtocolMutation(documentationState)
   const { deleteRun } = useDeleteRunMutation(documentationState)
   const { data: protocolRecord } = useProtocolQuery(protocolId)

--- a/app/src/pages/ODD/ProtocolDashboard/ProtocolCard.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/ProtocolCard.tsx
@@ -1,11 +1,10 @@
 import { useEffect, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { useQueryClient } from 'react-query'
 import { useNavigate } from 'react-router-dom'
 import last from 'lodash/last'
 import { css } from 'styled-components'
 
-import { deleteProtocol, deleteRun, getProtocol } from '@opentrons/api-client'
+import { deleteRun, getProtocol } from '@opentrons/api-client'
 import {
   ALIGN_CENTER,
   ALIGN_END,
@@ -24,13 +23,15 @@ import {
   useLongPress,
 } from '@opentrons/components'
 import {
-  getQueryKey,
+  isDocumentedMutationError,
+  useDeleteProtocolMutation,
   useHost,
   useMostRecentSuccessfulAnalysisAsDocumentQuery,
   useProtocolAnalysisAsDocumentQuery,
 } from '@opentrons/react-api-client'
 
 import { SmallButton } from '/app/atoms/buttons'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
 import { useUpdatedLastRunTime } from '/app/pages/ODD/ProtocolDashboard/hooks'
 import { formatTimeWithUtcLabel } from '/app/resources/runs'
@@ -69,8 +70,9 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element {
   const { t, i18n } = useTranslation(['protocol_info', 'branded'])
   const protocolName = protocol.metadata.protocolName ?? protocol.files[0].name
   const longpress = useLongPress()
-  const queryClient = useQueryClient()
   const host = useHost()
+  const documentationState = useDocumentationState()
+  const { deleteProtocol } = useDeleteProtocolMutation(documentationState)
   const updatedLastRun = useUpdatedLastRunTime(lastRun)
 
   const { id: protocolId, analysisSummaries } = protocol
@@ -159,19 +161,15 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element {
             referencingRunIds?.map(runId => deleteRun(host, runId))
           )
         })
-        // eslint-disable-next-line opentrons/no-direct-mutating -- TODO(jj, 07-21-26): no direct mutations
-        .then(() => deleteProtocol(host, protocol.id))
-        .then(() =>
-          queryClient
-            .invalidateQueries(getQueryKey(host, 'protocols'))
-            .catch((e: Error) => {
-              console.error(`error invalidating runs query: ${e.message}`)
-            })
-        )
+        .then(() => deleteProtocol(protocol.id))
         .then(() => {
           setShowIcon(false)
         })
         .catch((e: Error) => {
+          if (isDocumentedMutationError(e)) {
+            setShowIcon(false)
+            return
+          }
           console.error(`error deleting resources: ${e.message}`)
         })
     } else {

--- a/app/src/pages/ODD/ProtocolDashboard/ProtocolCard.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/ProtocolCard.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom'
 import last from 'lodash/last'
 import { css } from 'styled-components'
 
-import { deleteRun, getProtocol } from '@opentrons/api-client'
+import { getProtocol } from '@opentrons/api-client'
 import {
   ALIGN_CENTER,
   ALIGN_END,
@@ -25,6 +25,7 @@ import {
 import {
   isDocumentedMutationError,
   useDeleteProtocolMutation,
+  useDeleteRunMutation,
   useHost,
   useMostRecentSuccessfulAnalysisAsDocumentQuery,
   useProtocolAnalysisAsDocumentQuery,
@@ -73,6 +74,7 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element {
   const host = useHost()
   const documentationState = useDocumentationState()
   const { deleteProtocol } = useDeleteProtocolMutation(documentationState)
+  const { deleteRun } = useDeleteRunMutation(documentationState)
   const updatedLastRun = useUpdatedLastRunTime(lastRun)
 
   const { id: protocolId, analysisSummaries } = protocol
@@ -157,11 +159,12 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element {
         )
         .then(referencingRunIds => {
           return Promise.all(
-            // eslint-disable-next-line opentrons/no-direct-mutating -- TODO(jj, 07-21-26): no direct mutations
-            referencingRunIds?.map(runId => deleteRun(host, runId))
+            referencingRunIds?.map(runId => deleteRun({ runId }))
           )
         })
-        .then(() => deleteProtocol(protocol.id))
+        .then(() => {
+          return deleteProtocol(protocol.id)
+        })
         .then(() => {
           setShowIcon(false)
         })

--- a/app/src/pages/ODD/ProtocolDashboard/ProtocolCard.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/ProtocolCard.tsx
@@ -32,7 +32,7 @@ import {
 } from '@opentrons/react-api-client'
 
 import { SmallButton } from '/app/atoms/buttons'
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
 import { useUpdatedLastRunTime } from '/app/pages/ODD/ProtocolDashboard/hooks'
 import { formatTimeWithUtcLabel } from '/app/resources/runs'
@@ -72,7 +72,10 @@ export function ProtocolCard(props: ProtocolCardProps): JSX.Element {
   const protocolName = protocol.metadata.protocolName ?? protocol.files[0].name
   const longpress = useLongPress()
   const host = useHost()
-  const documentationState = useDocumentationState()
+  const { documentationState } = useLinkedDocumentationState(
+    ['delete_protocol', 'delete_runs'],
+    protocol.id
+  )
   const { deleteProtocol } = useDeleteProtocolMutation(documentationState)
   const { deleteRun } = useDeleteRunMutation(documentationState)
   const updatedLastRun = useUpdatedLastRunTime(lastRun)

--- a/app/src/pages/ODD/ProtocolDashboard/__tests__/DeleteProtocolConfirmationModal.test.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/__tests__/DeleteProtocolConfirmationModal.test.tsx
@@ -2,9 +2,10 @@ import { act, fireEvent, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
 
-import { deleteRun, getProtocol } from '@opentrons/api-client'
+import { getProtocol } from '@opentrons/api-client'
 import {
   useDeleteProtocolMutation,
+  useDeleteRunMutation,
   useHost,
   useProtocolQuery,
 } from '@opentrons/react-api-client'
@@ -30,6 +31,7 @@ const mockFunc = vi.fn()
 const PROTOCOL_ID = 'mockProtocolId'
 const mockMakeSnackbar = vi.fn()
 const mockDeleteProtocol = vi.fn()
+const mockDeleteRun = vi.fn()
 const MOCK_HOST_CONFIG = {} as HostConfig
 
 const render = (
@@ -66,7 +68,11 @@ describe('DeleteProtocolConfirmationModal', () => {
     vi.mocked(useDeleteProtocolMutation).mockReturnValue({
       deleteProtocol: mockDeleteProtocol,
     } as any)
+    vi.mocked(useDeleteRunMutation).mockReturnValue({
+      deleteRun: mockDeleteRun,
+    } as any)
     mockDeleteProtocol.mockResolvedValue(undefined)
+    mockDeleteRun.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -99,8 +105,8 @@ describe('DeleteProtocolConfirmationModal', () => {
       screen.getByText('Delete').click()
     })
     await new Promise(setImmediate)
-    expect(vi.mocked(deleteRun)).toHaveBeenCalledWith(MOCK_HOST_CONFIG, '1')
-    expect(vi.mocked(deleteRun)).toHaveBeenCalledWith(MOCK_HOST_CONFIG, '2')
+    expect(mockDeleteRun).toHaveBeenCalledWith({ runId: '1' })
+    expect(mockDeleteRun).toHaveBeenCalledWith({ runId: '2' })
     expect(mockDeleteProtocol).toHaveBeenCalledWith(PROTOCOL_ID)
     expect(mockMakeSnackbar).toHaveBeenCalledWith('Protocol deleted')
   })

--- a/app/src/pages/ODD/ProtocolDashboard/__tests__/DeleteProtocolConfirmationModal.test.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/__tests__/DeleteProtocolConfirmationModal.test.tsx
@@ -2,11 +2,16 @@ import { act, fireEvent, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
 
-import { deleteProtocol, deleteRun, getProtocol } from '@opentrons/api-client'
-import { useHost, useProtocolQuery } from '@opentrons/react-api-client'
+import { deleteRun, getProtocol } from '@opentrons/api-client'
+import {
+  useDeleteProtocolMutation,
+  useHost,
+  useProtocolQuery,
+} from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { useToaster } from '/app/organisms/ToasterOven'
 
 import { DeleteProtocolConfirmationModal } from '../DeleteProtocolConfirmationModal'
@@ -17,10 +22,14 @@ import type { HostConfig } from '@opentrons/api-client'
 vi.mock('@opentrons/api-client')
 vi.mock('@opentrons/react-api-client')
 vi.mock('/app/organisms/ToasterOven')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 
 const mockFunc = vi.fn()
 const PROTOCOL_ID = 'mockProtocolId'
 const mockMakeSnackbar = vi.fn()
+const mockDeleteProtocol = vi.fn()
 const MOCK_HOST_CONFIG = {} as HostConfig
 
 const render = (
@@ -54,6 +63,10 @@ describe('DeleteProtocolConfirmationModal', () => {
       makeToast: vi.fn(),
       eatToast: vi.fn(),
     })
+    vi.mocked(useDeleteProtocolMutation).mockReturnValue({
+      deleteProtocol: mockDeleteProtocol,
+    } as any)
+    mockDeleteProtocol.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -88,10 +101,7 @@ describe('DeleteProtocolConfirmationModal', () => {
     await new Promise(setImmediate)
     expect(vi.mocked(deleteRun)).toHaveBeenCalledWith(MOCK_HOST_CONFIG, '1')
     expect(vi.mocked(deleteRun)).toHaveBeenCalledWith(MOCK_HOST_CONFIG, '2')
-    expect(vi.mocked(deleteProtocol)).toHaveBeenCalledWith(
-      MOCK_HOST_CONFIG,
-      PROTOCOL_ID
-    )
+    expect(mockDeleteProtocol).toHaveBeenCalledWith(PROTOCOL_ID)
     expect(mockMakeSnackbar).toHaveBeenCalledWith('Protocol deleted')
   })
 })

--- a/app/src/pages/ODD/ProtocolDashboard/__tests__/DeleteProtocolConfirmationModal.test.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/__tests__/DeleteProtocolConfirmationModal.test.tsx
@@ -23,9 +23,15 @@ import type { HostConfig } from '@opentrons/api-client'
 vi.mock('@opentrons/api-client')
 vi.mock('@opentrons/react-api-client')
 vi.mock('/app/organisms/ToasterOven')
-vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
-  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
-}))
+vi.mock(
+  '/app/local-resources/access-control/useLinkedDocumentationState',
+  () => ({
+    useLinkedDocumentationState: () => ({
+      documentationState: ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+      clearDocreport: vi.fn(),
+    }),
+  })
+)
 
 const mockFunc = vi.fn()
 const PROTOCOL_ID = 'mockProtocolId'

--- a/app/src/pages/ODD/ProtocolDashboard/__tests__/ProtocolCard.test.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/__tests__/ProtocolCard.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  useDeleteProtocolMutation,
   useMostRecentSuccessfulAnalysisAsDocumentQuery,
   useProtocolAnalysisAsDocumentQuery,
 } from '@opentrons/react-api-client'
@@ -126,6 +127,9 @@ describe('ProtocolCard', () => {
     vi.mocked(useMostRecentSuccessfulAnalysisAsDocumentQuery).mockReturnValue({
       data: { result: 'ok' } as any,
     } as UseQueryResult<CompletedProtocolAnalysis>)
+    vi.mocked(useDeleteProtocolMutation).mockReturnValue({
+      deleteProtocol: vi.fn(),
+    } as any)
     vi.mocked(useFeatureFlag).mockReturnValue(false)
   })
 

--- a/app/src/pages/ODD/ProtocolDashboard/__tests__/ProtocolCard.test.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/__tests__/ProtocolCard.test.tsx
@@ -40,6 +40,15 @@ vi.mock('/app/redux/config')
 vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
   useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
 }))
+vi.mock(
+  '/app/local-resources/access-control/useLinkedDocumentationState',
+  () => ({
+    useLinkedDocumentationState: () => ({
+      documentationState: ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+      clearDocreport: vi.fn(),
+    }),
+  })
+)
 vi.mock('@opentrons/components', async importOriginal => {
   const actual = await importOriginal<typeof Chip>()
   return {

--- a/app/src/pages/ODD/ProtocolDashboard/__tests__/ProtocolCard.test.tsx
+++ b/app/src/pages/ODD/ProtocolDashboard/__tests__/ProtocolCard.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   useDeleteProtocolMutation,
+  useDeleteRunMutation,
   useMostRecentSuccessfulAnalysisAsDocumentQuery,
   useProtocolAnalysisAsDocumentQuery,
 } from '@opentrons/react-api-client'
@@ -129,6 +130,9 @@ describe('ProtocolCard', () => {
     } as UseQueryResult<CompletedProtocolAnalysis>)
     vi.mocked(useDeleteProtocolMutation).mockReturnValue({
       deleteProtocol: vi.fn(),
+    } as any)
+    vi.mocked(useDeleteRunMutation).mockReturnValue({
+      deleteRun: vi.fn(),
     } as any)
     vi.mocked(useFeatureFlag).mockReturnValue(false)
   })

--- a/app/src/pages/ODD/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -5,9 +5,10 @@ import { when } from 'vitest-when'
 
 import '@testing-library/jest-dom/vitest'
 
-import { deleteProtocol, deleteRun, getProtocol } from '@opentrons/api-client'
+import { deleteRun, getProtocol } from '@opentrons/api-client'
 import {
   useCreateRunMutation,
+  useDeleteProtocolMutation,
   useHost,
   useProtocolAnalysisAsDocumentQuery,
   useProtocolQuery,
@@ -56,6 +57,7 @@ vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
 
 const MOCK_HOST_CONFIG = {} as HostConfig
 const mockCreateRun = vi.fn((id: string) => {})
+const mockDeleteProtocol = vi.fn()
 const MOCK_DATA = {
   data: {
     id: 'mockProtocol1',
@@ -94,6 +96,10 @@ describe('ODDProtocolDetails', () => {
     vi.mocked(useCreateRunMutation).mockReturnValue({
       createRun: mockCreateRun,
     } as any)
+    vi.mocked(useDeleteProtocolMutation).mockReturnValue({
+      deleteProtocol: mockDeleteProtocol,
+    } as any)
+    mockDeleteProtocol.mockResolvedValue(undefined)
     vi.mocked(useHardwareStatusText).mockReturnValue(
       'mock missing hardware chip text'
     )
@@ -184,10 +190,7 @@ describe('ODDProtocolDetails', () => {
       expect(vi.mocked(deleteRun)).toHaveBeenCalledWith(MOCK_HOST_CONFIG, '2')
     )
     await waitFor(() =>
-      expect(vi.mocked(deleteProtocol)).toHaveBeenCalledWith(
-        MOCK_HOST_CONFIG,
-        'fakeProtocolId'
-      )
+      expect(mockDeleteProtocol).toHaveBeenCalledWith('fakeProtocolId')
     )
   })
 

--- a/app/src/pages/ODD/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -55,6 +55,15 @@ vi.mock('/app/local-resources/dom-utils')
 vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
   useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
 }))
+vi.mock(
+  '/app/local-resources/access-control/useLinkedDocumentationState',
+  () => ({
+    useLinkedDocumentationState: () => ({
+      documentationState: ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+      clearDocreport: vi.fn(),
+    }),
+  })
+)
 
 const MOCK_HOST_CONFIG = {} as HostConfig
 const mockCreateRun = vi.fn((id: string) => {})

--- a/app/src/pages/ODD/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/__tests__/ProtocolDetails.test.tsx
@@ -5,10 +5,11 @@ import { when } from 'vitest-when'
 
 import '@testing-library/jest-dom/vitest'
 
-import { deleteRun, getProtocol } from '@opentrons/api-client'
+import { getProtocol } from '@opentrons/api-client'
 import {
   useCreateRunMutation,
   useDeleteProtocolMutation,
+  useDeleteRunMutation,
   useHost,
   useProtocolAnalysisAsDocumentQuery,
   useProtocolQuery,
@@ -58,6 +59,7 @@ vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
 const MOCK_HOST_CONFIG = {} as HostConfig
 const mockCreateRun = vi.fn((id: string) => {})
 const mockDeleteProtocol = vi.fn()
+const mockDeleteRun = vi.fn()
 const MOCK_DATA = {
   data: {
     id: 'mockProtocol1',
@@ -99,7 +101,11 @@ describe('ODDProtocolDetails', () => {
     vi.mocked(useDeleteProtocolMutation).mockReturnValue({
       deleteProtocol: mockDeleteProtocol,
     } as any)
+    vi.mocked(useDeleteRunMutation).mockReturnValue({
+      deleteRun: mockDeleteRun,
+    } as any)
     mockDeleteProtocol.mockResolvedValue(undefined)
+    mockDeleteRun.mockResolvedValue(undefined)
     vi.mocked(useHardwareStatusText).mockReturnValue(
       'mock missing hardware chip text'
     )
@@ -184,10 +190,10 @@ describe('ODDProtocolDetails', () => {
     const confirmDeleteButton = screen.getByText('Delete')
     fireEvent.click(confirmDeleteButton)
     await waitFor(() =>
-      expect(vi.mocked(deleteRun)).toHaveBeenCalledWith(MOCK_HOST_CONFIG, '1')
+      expect(mockDeleteRun).toHaveBeenCalledWith({ runId: '1' })
     )
     await waitFor(() =>
-      expect(vi.mocked(deleteRun)).toHaveBeenCalledWith(MOCK_HOST_CONFIG, '2')
+      expect(mockDeleteRun).toHaveBeenCalledWith({ runId: '2' })
     )
     await waitFor(() =>
       expect(mockDeleteProtocol).toHaveBeenCalledWith('fakeProtocolId')

--- a/app/src/pages/ODD/ProtocolDetails/index.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/index.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate, useParams } from 'react-router-dom'
 import last from 'lodash/last'
 
-import { deleteProtocol, deleteRun, getProtocol } from '@opentrons/api-client'
+import { deleteRun, getProtocol } from '@opentrons/api-client'
 import {
   ALIGN_CENTER,
   BORDERS,
@@ -28,7 +28,9 @@ import {
 } from '@opentrons/components'
 import {
   getQueryKey,
+  isDocumentedMutationError,
   useCreateRunMutation,
+  useDeleteProtocolMutation,
   useHost,
   useProtocolAnalysisAsDocumentQuery,
   useProtocolQuery,
@@ -346,6 +348,7 @@ export function ProtocolDetails(): JSX.Element | null {
     { enabled: protocolRecord != null }
   )
   const documentationState = useDocumentationState()
+  const { deleteProtocol } = useDeleteProtocolMutation(documentationState)
   const { createRun } = useCreateRunMutation(documentationState, {
     onSuccess: data => {
       queryClient
@@ -391,7 +394,6 @@ export function ProtocolDetails(): JSX.Element | null {
     useState<boolean>(false)
 
   const handleDeleteClick = (): void => {
-    setShowConfirmationDeleteProtocol(false)
     if (host != null) {
       getProtocol(host, protocolId)
         .then(
@@ -402,13 +404,17 @@ export function ProtocolDetails(): JSX.Element | null {
           // eslint-disable-next-line opentrons/no-direct-mutating -- TODO(jj, 07-21-26): no direct mutations
           Promise.all(referencingRunIds?.map(runId => deleteRun(host, runId)))
         )
-        // eslint-disable-next-line opentrons/no-direct-mutating -- TODO(jj, 07-21-26): no direct mutations
-        .then(() => deleteProtocol(host, protocolId))
+        .then(() => deleteProtocol(protocolId))
         .then(() => {
+          setShowConfirmationDeleteProtocol(false)
           navigate('/protocols')
         })
         .catch((e: Error) => {
+          if (isDocumentedMutationError(e)) {
+            return
+          }
           console.error(`error deleting resources: ${e.message}`)
+          setShowConfirmationDeleteProtocol(false)
           navigate('/protocols')
         })
     } else {

--- a/app/src/pages/ODD/ProtocolDetails/index.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/index.tsx
@@ -40,6 +40,7 @@ import {
 import { MAXIMUM_PINNED_PROTOCOLS } from '/app/App/constants'
 import { MediumButton, SmallButton } from '/app/atoms/buttons'
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { useScrollPosition } from '/app/local-resources/dom-utils'
 import { OddModal, SmallModalChildren } from '/app/molecules/OddModal'
 import {
@@ -348,9 +349,11 @@ export function ProtocolDetails(): JSX.Element | null {
     last(protocolRecord?.data.analysisSummaries)?.id ?? null,
     { enabled: protocolRecord != null }
   )
+  const { documentationState: deleteDocumentationState } =
+    useLinkedDocumentationState(['delete_protocol', 'delete_runs'], protocolId)
+  const { deleteProtocol } = useDeleteProtocolMutation(deleteDocumentationState)
+  const { deleteRun } = useDeleteRunMutation(deleteDocumentationState)
   const documentationState = useDocumentationState()
-  const { deleteProtocol } = useDeleteProtocolMutation(documentationState)
-  const { deleteRun } = useDeleteRunMutation(documentationState)
   const { createRun } = useCreateRunMutation(documentationState, {
     onSuccess: data => {
       queryClient

--- a/app/src/pages/ODD/ProtocolDetails/index.tsx
+++ b/app/src/pages/ODD/ProtocolDetails/index.tsx
@@ -5,7 +5,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate, useParams } from 'react-router-dom'
 import last from 'lodash/last'
 
-import { deleteRun, getProtocol } from '@opentrons/api-client'
+import { getProtocol } from '@opentrons/api-client'
 import {
   ALIGN_CENTER,
   BORDERS,
@@ -31,6 +31,7 @@ import {
   isDocumentedMutationError,
   useCreateRunMutation,
   useDeleteProtocolMutation,
+  useDeleteRunMutation,
   useHost,
   useProtocolAnalysisAsDocumentQuery,
   useProtocolQuery,
@@ -349,6 +350,7 @@ export function ProtocolDetails(): JSX.Element | null {
   )
   const documentationState = useDocumentationState()
   const { deleteProtocol } = useDeleteProtocolMutation(documentationState)
+  const { deleteRun } = useDeleteRunMutation(documentationState)
   const { createRun } = useCreateRunMutation(documentationState, {
     onSuccess: data => {
       queryClient
@@ -401,10 +403,11 @@ export function ProtocolDetails(): JSX.Element | null {
             response.data.links?.referencingRuns.map(({ id }) => id) ?? []
         )
         .then(referencingRunIds =>
-          // eslint-disable-next-line opentrons/no-direct-mutating -- TODO(jj, 07-21-26): no direct mutations
-          Promise.all(referencingRunIds?.map(runId => deleteRun(host, runId)))
+          Promise.all(referencingRunIds?.map(runId => deleteRun({ runId })))
         )
-        .then(() => deleteProtocol(protocolId))
+        .then(() => {
+          return deleteProtocol(protocolId)
+        })
         .then(() => {
           setShowConfirmationDeleteProtocol(false)
           navigate('/protocols')

--- a/app/src/pages/ODD/QuickTransferDetails/DeleteTransferConfirmationModal.tsx
+++ b/app/src/pages/ODD/QuickTransferDetails/DeleteTransferConfirmationModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 
-import { deleteRun, getProtocol } from '@opentrons/api-client'
+import { getProtocol } from '@opentrons/api-client'
 import {
   ALIGN_CENTER,
   COLORS,
@@ -15,6 +15,7 @@ import {
 import {
   isDocumentedMutationError,
   useDeleteProtocolMutation,
+  useDeleteRunMutation,
   useHost,
   useProtocolQuery,
 } from '@opentrons/react-api-client'
@@ -47,6 +48,7 @@ export function DeleteTransferConfirmationModal({
   const host = useHost()
   const documentationState = useDocumentationState()
   const { deleteProtocol } = useDeleteProtocolMutation(documentationState)
+  const { deleteRun } = useDeleteRunMutation(documentationState)
   const { data: protocolRecord } = useProtocolQuery(transferId)
   const transferName =
     protocolRecord?.data.metadata.protocolName ??
@@ -65,11 +67,12 @@ export function DeleteTransferConfirmationModal({
         )
         .then(referencingRunIds => {
           return Promise.all(
-            // eslint-disable-next-line opentrons/no-direct-mutating -- TODO(jj, 07-21-26): no direct mutations
-            referencingRunIds?.map(runId => deleteRun(host, runId))
+            referencingRunIds?.map(runId => deleteRun({ runId }))
           )
         })
-        .then(() => deleteProtocol(transferId))
+        .then(() => {
+          return deleteProtocol(transferId)
+        })
         .then(() => {
           setShowIcon(false)
           setShowDeleteConfirmationModal(false)

--- a/app/src/pages/ODD/QuickTransferDetails/DeleteTransferConfirmationModal.tsx
+++ b/app/src/pages/ODD/QuickTransferDetails/DeleteTransferConfirmationModal.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
-import { useQueryClient } from 'react-query'
 import { useNavigate } from 'react-router-dom'
 
-import { deleteProtocol, deleteRun, getProtocol } from '@opentrons/api-client'
+import { deleteRun, getProtocol } from '@opentrons/api-client'
 import {
   ALIGN_CENTER,
   COLORS,
@@ -14,12 +13,14 @@ import {
   StyledText,
 } from '@opentrons/components'
 import {
-  getQueryKey,
+  isDocumentedMutationError,
+  useDeleteProtocolMutation,
   useHost,
   useProtocolQuery,
 } from '@opentrons/react-api-client'
 
 import { SmallButton } from '/app/atoms/buttons'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
 import { useToaster } from '/app/organisms/ToasterOven'
 
@@ -44,7 +45,8 @@ export function DeleteTransferConfirmationModal({
     iconColor: COLORS.yellow50,
   }
   const host = useHost()
-  const queryClient = useQueryClient()
+  const documentationState = useDocumentationState()
+  const { deleteProtocol } = useDeleteProtocolMutation(documentationState)
   const { data: protocolRecord } = useProtocolQuery(transferId)
   const transferName =
     protocolRecord?.data.metadata.protocolName ??
@@ -67,15 +69,7 @@ export function DeleteTransferConfirmationModal({
             referencingRunIds?.map(runId => deleteRun(host, runId))
           )
         })
-        // eslint-disable-next-line opentrons/no-direct-mutating -- TODO(jj, 07-21-26): no direct mutations
-        .then(() => deleteProtocol(host, transferId))
-        .then(() =>
-          queryClient
-            .invalidateQueries(getQueryKey(host, 'protocols'))
-            .catch((e: Error) => {
-              console.error(`error invalidating runs query: ${e.message}`)
-            })
-        )
+        .then(() => deleteProtocol(transferId))
         .then(() => {
           setShowIcon(false)
           setShowDeleteConfirmationModal(false)
@@ -83,6 +77,10 @@ export function DeleteTransferConfirmationModal({
           makeSnackbar(t('deleted_transfer') as string)
         })
         .catch((e: Error) => {
+          if (isDocumentedMutationError(e)) {
+            setShowIcon(false)
+            return
+          }
           navigate('/protocols')
           console.error(`error deleting resources: ${e.message}`)
         })

--- a/app/src/pages/ODD/QuickTransferDetails/DeleteTransferConfirmationModal.tsx
+++ b/app/src/pages/ODD/QuickTransferDetails/DeleteTransferConfirmationModal.tsx
@@ -21,7 +21,7 @@ import {
 } from '@opentrons/react-api-client'
 
 import { SmallButton } from '/app/atoms/buttons'
-import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useLinkedDocumentationState } from '/app/local-resources/access-control/useLinkedDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
 import { useToaster } from '/app/organisms/ToasterOven'
 
@@ -46,7 +46,10 @@ export function DeleteTransferConfirmationModal({
     iconColor: COLORS.yellow50,
   }
   const host = useHost()
-  const documentationState = useDocumentationState()
+  const { documentationState } = useLinkedDocumentationState(
+    ['delete_protocol', 'delete_runs'],
+    transferId
+  )
   const { deleteProtocol } = useDeleteProtocolMutation(documentationState)
   const { deleteRun } = useDeleteRunMutation(documentationState)
   const { data: protocolRecord } = useProtocolQuery(transferId)

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -163,6 +163,7 @@ type AuditLogAction =
   | 'pause_run'
   | 'disconnect_wifi'
   | 'connect_wifi'
+  | 'delete_protocol'
   | 'delete_run'
   | 'delete_run_images'
   | 'delete_runs'

--- a/react-api-client/src/protocols/__tests__/useDeleteProtocol.test.tsx
+++ b/react-api-client/src/protocols/__tests__/useDeleteProtocol.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { deleteProtocol } from '@opentrons/api-client'
 
 import { useDeleteProtocolMutation } from '..'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '../../accessControl/__fixtures__/documentationState'
 import { useHost } from '../../api'
 
 import type * as React from 'react'
@@ -37,12 +38,16 @@ describe('useDeleteProtocolMutation hook', () => {
     vi.mocked(useHost).mockReturnValue(HOST_CONFIG)
     vi.mocked(deleteProtocol).mockRejectedValue('oh no')
 
-    const { result } = renderHook(() => useDeleteProtocolMutation(protocolId), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () =>
+        useDeleteProtocolMutation(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+      {
+        wrapper,
+      }
+    )
 
     expect(result.current.data).toBeUndefined()
-    result.current.deleteProtocol()
+    result.current.deleteProtocol(protocolId)
     await waitFor(() => {
       expect(result.current.data).toBeUndefined()
     })
@@ -54,10 +59,14 @@ describe('useDeleteProtocolMutation hook', () => {
       data: DELETE_PROTOCOL_RESPONSE,
     } as Response<EmptyResponse>)
 
-    const { result } = renderHook(() => useDeleteProtocolMutation(protocolId), {
-      wrapper,
-    })
-    act(() => result.current.deleteProtocol())
+    const { result } = renderHook(
+      () =>
+        useDeleteProtocolMutation(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE),
+      {
+        wrapper,
+      }
+    )
+    act(() => result.current.deleteProtocol(protocolId))
 
     await waitFor(() => {
       expect(result.current.data).toEqual(DELETE_PROTOCOL_RESPONSE)

--- a/react-api-client/src/protocols/__tests__/useDeleteProtocol.test.tsx
+++ b/react-api-client/src/protocols/__tests__/useDeleteProtocol.test.tsx
@@ -47,7 +47,9 @@ describe('useDeleteProtocolMutation hook', () => {
     )
 
     expect(result.current.data).toBeUndefined()
-    result.current.deleteProtocol(protocolId)
+    await expect(
+      result.current.deleteProtocol(protocolId)
+    ).rejects.toBeDefined()
     await waitFor(() => {
       expect(result.current.data).toBeUndefined()
     })
@@ -66,7 +68,9 @@ describe('useDeleteProtocolMutation hook', () => {
         wrapper,
       }
     )
-    act(() => result.current.deleteProtocol(protocolId))
+    await act(async () => {
+      await result.current.deleteProtocol(protocolId)
+    })
 
     await waitFor(() => {
       expect(result.current.data).toEqual(DELETE_PROTOCOL_RESPONSE)

--- a/react-api-client/src/protocols/useDeleteProtocolMutation.ts
+++ b/react-api-client/src/protocols/useDeleteProtocolMutation.ts
@@ -1,33 +1,52 @@
-import { useMutation, useQueryClient } from 'react-query'
+import { useQueryClient } from 'react-query'
 
 import { deleteProtocol } from '@opentrons/api-client'
 
+import { useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
-import type { UseMutateFunction, UseMutationResult } from 'react-query'
+import type {
+  UseMutateFunction,
+  UseMutationOptions,
+  UseMutationResult,
+} from 'react-query'
 import type { EmptyResponse } from '@opentrons/api-client'
+import type { DocumentationState } from '../accessControl'
+import type { DocumentedMutationParameters } from '../accessControl/types'
 
 export type UseDeleteProtocolMutationResult = UseMutationResult<
   EmptyResponse,
   unknown,
-  void
+  string
 > & {
-  deleteProtocol: UseMutateFunction<EmptyResponse, unknown, void>
+  deleteProtocol: UseMutateFunction<EmptyResponse, unknown, string>
 }
 
+export type UseDeleteProtocolMutationOptions = UseMutationOptions<
+  EmptyResponse,
+  unknown,
+  string
+>
+
 export function useDeleteProtocolMutation(
-  protocolId: string
+  documentationState: DocumentationState,
+  options: UseDeleteProtocolMutationOptions = {}
 ): UseDeleteProtocolMutationResult {
   const host = useHost()
   const queryClient = useQueryClient()
 
-  // Directly calling useMutation is deprecated in the codebase. Update this to useDocumentedMutation before using this hook.
-  // eslint-disable-next-line opentrons/no-direct-use-mutation
-  const mutation = useMutation<EmptyResponse, unknown>(() =>
-    deleteProtocol(host!, protocolId).then(response => {
-      queryClient.invalidateQueries(getQueryKey(host, 'protocols'))
-      return response.data
-    })
+  const mutation = useDocumentedMutation<EmptyResponse, unknown, string>(
+    documentationState,
+    ['delete_protocol'],
+    ({
+      variables: protocolId,
+      userNotes,
+    }: DocumentedMutationParameters<string>) =>
+      deleteProtocol(host!, protocolId, userNotes).then(response => {
+        queryClient.invalidateQueries(getQueryKey(host, 'protocols'))
+        return response.data
+      }),
+    options
   )
 
   return {

--- a/react-api-client/src/protocols/useDeleteProtocolMutation.ts
+++ b/react-api-client/src/protocols/useDeleteProtocolMutation.ts
@@ -6,7 +6,7 @@ import { useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
 import type {
-  UseMutateFunction,
+  UseMutateAsyncFunction,
   UseMutationOptions,
   UseMutationResult,
 } from 'react-query'
@@ -19,7 +19,7 @@ export type UseDeleteProtocolMutationResult = UseMutationResult<
   unknown,
   string
 > & {
-  deleteProtocol: UseMutateFunction<EmptyResponse, unknown, string>
+  deleteProtocol: UseMutateAsyncFunction<EmptyResponse, unknown, string>
 }
 
 export type UseDeleteProtocolMutationOptions = UseMutationOptions<
@@ -51,6 +51,6 @@ export function useDeleteProtocolMutation(
 
   return {
     ...mutation,
-    deleteProtocol: mutation.mutate,
+    deleteProtocol: mutation.mutateAsync,
   }
 }

--- a/react-api-client/src/runs/useDeleteRunMutation.ts
+++ b/react-api-client/src/runs/useDeleteRunMutation.ts
@@ -6,12 +6,13 @@ import { useDocumentedMutation } from '../accessControl'
 import { getQueryKey, useHost } from '../api'
 
 import type {
-  UseMutateFunction,
+  UseMutateAsyncFunction,
   UseMutationOptions,
   UseMutationResult,
 } from 'react-query'
 import type { EmptyResponse } from '@opentrons/api-client'
 import type { DocumentationState } from '../accessControl'
+import type { DocumentedMutationParameters } from '../accessControl/types'
 
 export interface DeleteRunParams {
   runId: string
@@ -22,7 +23,7 @@ export type UseDeleteRunMutationResult = UseMutationResult<
   unknown,
   DeleteRunParams
 > & {
-  deleteRun: UseMutateFunction<EmptyResponse, unknown, DeleteRunParams>
+  deleteRun: UseMutateAsyncFunction<EmptyResponse, unknown, DeleteRunParams>
 }
 
 export type UseDeleteRunMutationOptions = UseMutationOptions<
@@ -45,7 +46,10 @@ export function useDeleteRunMutation(
   >(
     documentationState,
     ['delete_run'],
-    ({ variables: { runId }, userNotes }) =>
+    ({
+      variables: { runId },
+      userNotes,
+    }: DocumentedMutationParameters<DeleteRunParams>) =>
       deleteRun(host!, runId, userNotes).then(response => {
         queryClient.removeQueries(getQueryKey(host, 'runs', runId))
         queryClient
@@ -60,6 +64,6 @@ export function useDeleteRunMutation(
 
   return {
     ...mutation,
-    deleteRun: mutation.mutate,
+    deleteRun: mutation.mutateAsync,
   }
 }


### PR DESCRIPTION
# Overview

Replaces direct calls to `deleteProtocol` and `deleteRun` in app with calls to the newly documented `useDeleteProtocolMutation` and `useDeleteRunMutation`. 

https://github.com/user-attachments/assets/05ba7f48-b31e-4ed1-a913-e2065c23b246

<img width="953" height="552" alt="Screenshot 2026-07-22 at 1 36 43 PM" src="https://github.com/user-attachments/assets/bfe65858-a5fc-476d-a933-86644cb8bd9a" />



## Test Plan and Hands on Testing

Deleting protocols and run records should ask for documentation.

## Risk assessment

Low