### PR TITLE
feat(app,odd): add minimum length requirement to Documentation Required modal

### DIFF
--- a/app/src/assets/localization/en/access_control.json
+++ b/app/src/assets/localization/en/access_control.json
@@ -25,6 +25,7 @@
   "login_error_unknown_with_message": "An unknown error occurred while trying to log in: {{message}}",
   "login_form_password_field": "Password",
   "login_form_username_field": "Username",
+  "must_be_at_least_characters": "Must be at least {{minLength}} characters long",
   "on_device_login": "Login",
   "on_device_login_confirm_password": "Confirm password",
   "on_device_login_new_password": "New password",

--- a/app/src/local-resources/access-control/DocumentationRequiredModalContext.tsx
+++ b/app/src/local-resources/access-control/DocumentationRequiredModalContext.tsx
@@ -9,6 +9,7 @@ export interface DocumentationRequiredModalContextType {
   showDocumentationRequiredModal: (
     username: string,
     actionsToDocument: DocumentedAction[],
+    minReportLength: number,
     onCancel?: () => void,
     initialDocreport?: DocumentationReport
   ) => Promise<DocumentationReport>
@@ -27,6 +28,7 @@ export const DocumentationRequiredModalContext =
     showDocumentationRequiredModal: (
       username: string,
       actionsToDocument: DocumentedAction[],
+      minReportLength: number,
       onCancel?: () => void,
       initialDocreport?: DocumentationReport
     ) => {

--- a/app/src/local-resources/access-control/__tests__/useDocumentationState.test.ts
+++ b/app/src/local-resources/access-control/__tests__/useDocumentationState.test.ts
@@ -220,6 +220,7 @@ describe('useDocumentationState', () => {
     expect(mockShowDocumentationRequiredModal).toHaveBeenCalledWith(
       'alice',
       ['play_run'],
+      10,
       undefined,
       initialDocreport
     )

--- a/app/src/local-resources/access-control/useDocumentationState.ts
+++ b/app/src/local-resources/access-control/useDocumentationState.ts
@@ -51,9 +51,8 @@ export function useDocumentationState(
   const requireReasonForInteraction =
     auditSettingsQuery?.data?.data?.requireReasonForInteraction ?? false
 
-  // TODO(jj): add length check for documentation report
-  // const minLengthOfReasonForInteraction =
-  //   auditSettingsQuery?.data?.data?.minLengthOfReasonForInteraction ?? 0
+  const minLengthOfReasonForInteraction =
+    auditSettingsQuery?.data?.data?.minLengthOfReasonForInteraction ?? 0
 
   const reasonForInteractionLoading = useMemo(
     () => auditSettingsQuery?.isLoading || accessControlEnabledQuery?.isLoading,
@@ -93,6 +92,7 @@ export function useDocumentationState(
       const docResult = await requireDocumentation(
         username ?? '',
         providedActionsToDocument ?? actionsToDocument,
+        minLengthOfReasonForInteraction,
         handleCancel,
         initialDocreport
       )
@@ -103,6 +103,7 @@ export function useDocumentationState(
       currentRobotName,
       currentUsername,
       onPromptForDocumentation,
+      minLengthOfReasonForInteraction,
       providedActionsToDocument,
       requireDocumentation,
       requireLogin,

--- a/app/src/molecules/TouchTextAreaField/index.tsx
+++ b/app/src/molecules/TouchTextAreaField/index.tsx
@@ -74,7 +74,7 @@ export const TouchTextAreaField = forwardRef<
 
   const wrapperClasses = clsx(
     styles.wrapper,
-    error != null ? styles.warning_color : styles.default_color,
+    hasError ? styles.error_color : styles.default_color,
     rawDisabled === true && styles.disabled,
     multiline && styles.wrapper_multiline
   )
@@ -88,6 +88,7 @@ export const TouchTextAreaField = forwardRef<
 
   const labelClasses = clsx(
     styles.label_text,
+    hasError && styles.label_text_error,
     textAlign === 'center' ? styles.label_text_center : styles.label_text_left
   )
 

--- a/app/src/molecules/TouchTextAreaField/touchtextareafield.module.css
+++ b/app/src/molecules/TouchTextAreaField/touchtextareafield.module.css
@@ -4,8 +4,8 @@
   align-items: center;
 }
 
-.warning_color {
-  color: var(--yellow-60);
+.error_color {
+  color: var(--red-50);
 }
 
 .default_color {
@@ -83,6 +83,10 @@
   font-size: var(--font-size-h3);
   font-weight: var(--font-weight-regular);
   line-height: var(--line-height-20);
+}
+
+.label_text_error {
+  color: var(--red-50);
 }
 
 .label_text_left {

--- a/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequired.tsx
+++ b/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequired.tsx
@@ -23,6 +23,7 @@ interface DocumentationRequiredProps {
   actionsToDocument: DocumentedAction[]
   onConfirm: (note: string) => void
   onClose: () => void
+  minReportLength: number
   initialDocreport?: DocumentationReport
 }
 
@@ -31,15 +32,25 @@ export function DocumentationRequired({
   actionsToDocument,
   onConfirm,
   onClose,
+  minReportLength,
   initialDocreport,
 }: DocumentationRequiredProps): JSX.Element {
   const { t } = useTranslation(['access_control', 'shared'])
   const [inputText, setInputText] = useState<string>(initialDocreport ?? '')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleInputChange = (value: string): void => {
+    setInputText(value)
+    setError(null)
+  }
 
   const trimmedNote = inputText.trim()
-  // TODO(jj): check against min length
   const handleConfirm = (): void => {
     if (trimmedNote === '') return
+    if (trimmedNote.length < minReportLength) {
+      setError(t('must_be_at_least_characters', { minLength: minReportLength }))
+      return
+    }
     onConfirm(trimmedNote)
   }
 
@@ -69,8 +80,12 @@ export function DocumentationRequired({
             <TextAreaField
               multiline
               value={inputText}
+              error={error}
+              // reserve space for the error line so the textarea height
+              // doesn't shift when an error appears; text only shows on error
+              caption={minReportLength > 0 ? '\u00A0' : undefined}
               onChange={e => {
-                setInputText(e.target.value)
+                handleInputChange(e.target.value)
               }}
               label={t('access_control_note', { user: username })}
             />

--- a/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequired.tsx
+++ b/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequired.tsx
@@ -48,7 +48,9 @@ export function DocumentationRequired({
   const handleConfirm = (): void => {
     if (trimmedNote === '') return
     if (trimmedNote.length < minReportLength) {
-      setError(t('must_be_at_least_characters', { minLength: minReportLength }))
+      setError(
+        '' + t('must_be_at_least_characters', { minLength: minReportLength })
+      )
       return
     }
     onConfirm(trimmedNote)

--- a/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequiredModal.tsx
+++ b/app/src/organisms/Desktop/DocumentationRequired/DocumentationRequiredModal.tsx
@@ -16,11 +16,13 @@ const DocumentationRequiredModalImpl = NiceModal.create(
   ({
     username,
     actionsToDocument,
+    minReportLength,
     onCancel,
     initialDocreport,
   }: {
     username: string
     actionsToDocument: DocumentedAction[]
+    minReportLength: number
     onCancel?: () => void
     initialDocreport?: DocumentationReport
   }): JSX.Element => {
@@ -46,6 +48,7 @@ const DocumentationRequiredModalImpl = NiceModal.create(
           actionsToDocument={actionsToDocument}
           onConfirm={handleConfirm}
           onClose={handleBack}
+          minReportLength={minReportLength}
           initialDocreport={initialDocreport}
         />
       </ApiHostProvider>,
@@ -57,12 +60,14 @@ const DocumentationRequiredModalImpl = NiceModal.create(
 export const showDocumentationRequiredModal = (
   username: string,
   actionsToDocument: DocumentedAction[],
+  minReportLength: number,
   onCancel?: () => void,
   initialDocreport?: DocumentationReport
 ): Promise<DocumentationReport> =>
   NiceModal.show(DocumentationRequiredModalImpl, {
     username,
     actionsToDocument,
+    minReportLength,
     onCancel,
     initialDocreport,
   })

--- a/app/src/organisms/Desktop/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
+++ b/app/src/organisms/Desktop/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
@@ -26,6 +26,7 @@ describe('DocumentationRequired', () => {
       actionsToDocument: [],
       onConfirm: vi.fn(),
       onClose: vi.fn(),
+      minReportLength: 10,
     }
   })
 
@@ -71,6 +72,28 @@ describe('DocumentationRequired', () => {
     render(props)
     fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
     expect(props.onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('shows a min-length error and does not confirm when the note is too short', () => {
+    render(props)
+    editNote('too short')
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+
+    expect(props.onConfirm).not.toHaveBeenCalled()
+    screen.getByText('Must be at least 10 characters long')
+  })
+
+  it('clears the min-length error when the user edits the note', () => {
+    render(props)
+    editNote('too short')
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    screen.getByText('Must be at least 10 characters long')
+
+    editNote('long enough note')
+
+    expect(
+      screen.queryByText('Must be at least 10 characters long')
+    ).not.toBeInTheDocument()
   })
 
   it('calls onClose when the cancel button is clicked', () => {

--- a/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.stories.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.stories.tsx
@@ -47,5 +47,7 @@ export const DocumentationRequired: Story = {
     username: 'John Doe',
     onBack: action('onBack'),
     onConfirm: action('onConfirm'),
+    minReportLength: 10,
+    actionsToDocument: [],
   },
 }

--- a/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.tsx
@@ -53,7 +53,9 @@ export function DocumentationRequired({
   const handleConfirm = (): void => {
     if (trimmedNote === '') return
     if (trimmedNote.length < minReportLength) {
-      setError(t('must_be_at_least_characters', { minLength: minReportLength }))
+      setError(
+        '' + t('must_be_at_least_characters', { minLength: minReportLength })
+      )
       return
     }
     onConfirm(trimmedNote)

--- a/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/DocumentationRequired.tsx
@@ -21,6 +21,7 @@ interface DocumentationRequiredProps {
   actionsToDocument: DocumentedAction[]
   onConfirm: (note: string) => void
   onBack: () => void
+  minReportLength: number
   initialDocreport?: DocumentationReport
 }
 
@@ -29,10 +30,12 @@ export function DocumentationRequired({
   actionsToDocument,
   onConfirm,
   onBack,
+  minReportLength,
   initialDocreport,
 }: DocumentationRequiredProps): JSX.Element {
   const { t } = useTranslation(['access_control', 'shared'])
   const [inputText, setInputText] = useState<string>(initialDocreport ?? '')
+  const [error, setError] = useState<string | null>(null)
   const [keyboardExpanded, setKeyboardExpanded] = useState(true)
   const keyboardRef = useRef(null)
   const textAreaRef = useRef<HTMLTextAreaElement>(null)
@@ -41,9 +44,18 @@ export function DocumentationRequired({
     setKeyboardExpanded(prev => !prev)
   }
 
+  const handleInputChange = (value: string): void => {
+    setInputText(value)
+    setError(null)
+  }
+
   const trimmedNote = inputText.trim()
   const handleConfirm = (): void => {
     if (trimmedNote === '') return
+    if (trimmedNote.length < minReportLength) {
+      setError(t('must_be_at_least_characters', { minLength: minReportLength }))
+      return
+    }
     onConfirm(trimmedNote)
   }
 
@@ -86,8 +98,9 @@ export function DocumentationRequired({
                 value={inputText}
                 ref={textAreaRef}
                 label={t('access_control_note', { user: username })}
+                error={error}
                 onChange={e => {
-                  setInputText(e.target.value)
+                  handleInputChange(e.target.value)
                 }}
               />
             </div>
@@ -101,7 +114,7 @@ export function DocumentationRequired({
         >
           <FullKeyboard
             onChange={(input: string) => {
-              setInputText(input)
+              handleInputChange(input)
               textAreaRef.current?.focus()
             }}
             keyboardRef={keyboardRef}

--- a/app/src/organisms/ODD/DocumentationRequired/DocumentationRequiredModal.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/DocumentationRequiredModal.tsx
@@ -12,11 +12,13 @@ const DocumentationRequiredModalImpl = NiceModal.create(
   ({
     username,
     actionsToDocument,
+    minReportLength,
     onCancel,
     initialDocreport,
   }: {
     username: string
     actionsToDocument: DocumentedAction[]
+    minReportLength: number
     onCancel?: () => void
     initialDocreport?: DocumentationReport
   }): JSX.Element => {
@@ -42,6 +44,7 @@ const DocumentationRequiredModalImpl = NiceModal.create(
           onConfirm={handleConfirm}
           onBack={handleBack}
           initialDocreport={initialDocreport}
+          minReportLength={minReportLength}
         />
       </div>
     )
@@ -51,12 +54,14 @@ const DocumentationRequiredModalImpl = NiceModal.create(
 export const showDocumentationRequiredModal = (
   username: string,
   actionsToDocument: DocumentedAction[],
+  minReportLength: number,
   onCancel?: () => void,
   initialDocreport?: DocumentationReport
 ): Promise<DocumentationReport> =>
   NiceModal.show(DocumentationRequiredModalImpl, {
     username,
     actionsToDocument,
+    minReportLength,
     onCancel,
     initialDocreport,
   })

--- a/app/src/organisms/ODD/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
+++ b/app/src/organisms/ODD/DocumentationRequired/__tests__/DocumentationRequired.test.tsx
@@ -32,6 +32,7 @@ describe('DocumentationRequired', () => {
       actionsToDocument: [],
       onConfirm: vi.fn(),
       onBack: vi.fn(),
+      minReportLength: 10,
     }
   })
 
@@ -76,6 +77,28 @@ describe('DocumentationRequired', () => {
     render(props)
     fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
     expect(props.onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('shows a min-length error and does not confirm when the note is too short', () => {
+    render(props)
+    editNote('too short')
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+
+    expect(props.onConfirm).not.toHaveBeenCalled()
+    screen.getByText('Must be at least 10 characters long')
+  })
+
+  it('clears the min-length error when the user edits the note', () => {
+    render(props)
+    editNote('too short')
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    screen.getByText('Must be at least 10 characters long')
+
+    editNote('long enough note')
+
+    expect(
+      screen.queryByText('Must be at least 10 characters long')
+    ).not.toBeInTheDocument()
   })
 
   it('calls onBack when the back button is clicked', () => {

--- a/app/src/organisms/ODD/DocumentationRequired/__tests__/requireDocumentation.test.ts
+++ b/app/src/organisms/ODD/DocumentationRequired/__tests__/requireDocumentation.test.ts
@@ -19,7 +19,7 @@ describe('requireDocumentation', () => {
       'starting calibration' as DocumentationReport
     )
 
-    const result = await requireDocumentation('alice', [])
+    const result = await requireDocumentation('alice', [], 0)
 
     expect(result).toEqual('starting calibration' as DocumentationReport)
     expect(showDocumentationRequiredModal).toHaveBeenCalledWith(

--- a/app/src/organisms/ODD/DocumentationRequired/__tests__/requireDocumentation.test.ts
+++ b/app/src/organisms/ODD/DocumentationRequired/__tests__/requireDocumentation.test.ts
@@ -25,6 +25,7 @@ describe('requireDocumentation', () => {
     expect(showDocumentationRequiredModal).toHaveBeenCalledWith(
       'alice',
       [],
+      0,
       undefined
     )
   })

--- a/app/src/organisms/ODD/DocumentationRequired/requireDocumentation.ts
+++ b/app/src/organisms/ODD/DocumentationRequired/requireDocumentation.ts
@@ -12,11 +12,13 @@ import type {
 export async function requireDocumentation(
   username: string,
   actionsToDocument: DocumentedAction[],
+  minReportLength: number,
   onCancel?: () => void
 ): Promise<DocumentationReport> {
   const modalResult = await showDocumentationRequiredModal(
     username,
     actionsToDocument,
+    minReportLength,
     onCancel
   )
 


### PR DESCRIPTION
# Overview

Documentation Required modal now enforces minimum character length requirements

https://github.com/user-attachments/assets/933ba2be-98e2-4e47-bb60-adb8b631baad

https://github.com/user-attachments/assets/a8cf1d11-18cd-4d2e-ac49-0d38d1a57354


## Test Plan and Hands on Testing

1. In Compliance Ready settings in the desktop app, set a minimum character requirement for "Edit minimum length for documentation for robot actions"
2. Trigger a documentation modal on desktop or ODD
3. Attempt to submit the modal with only 1 character, an error state should occur
4. Keep typing, the error state should be dismissed
5. Submitting a long enough documentation report should work normally

## Risk assessment

Low