### PR TITLE
feat(api): Update subprocess feature flags to default to On

### DIFF
--- a/api/src/opentrons/config/advanced_settings.py
+++ b/api/src/opentrons/config/advanced_settings.py
@@ -814,6 +814,17 @@ def _migrate41to42(previous: SettingsMap) -> SettingsMap:
     return newmap
 
 
+def _migrate42to43(previous: SettingsMap) -> SettingsMap:
+    """Migrate to version 43 of the feature flags file.
+
+    -  Ensure the subprocess flags default to True ensuring the hardware always runs with Pyro.
+    """
+    newmap = {k: v for k, v in previous.items()}
+    newmap["enableProtocolSubprocess"] = True
+    newmap["enableHardwareSubprocess"] = True
+    return newmap
+
+
 _MIGRATIONS = [
     _migrate0to1,
     _migrate1to2,
@@ -857,6 +868,7 @@ _MIGRATIONS = [
     _migrate39to40,
     _migrate40to41,
     _migrate41to42,
+    _migrate42to43,
 ]
 """
 List of all migrations to apply, indexed by (version - 1). See _migrate below

--- a/api/tests/opentrons/config/test_advanced_settings_migration.py
+++ b/api/tests/opentrons/config/test_advanced_settings_migration.py
@@ -9,7 +9,7 @@ from opentrons.config.advanced_settings import _ensure, _migrate
 
 @pytest.fixture
 def migrated_file_version() -> int:
-    return 42
+    return 43
 
 
 # make sure to set a boolean value in default_file_settings only if
@@ -32,8 +32,8 @@ def default_file_settings() -> Dict[str, Any]:
         "enableOEMMode": None,
         "enablePerformanceMetrics": None,
         "disableFlexStackerLabwareDetection": None,
-        "enableProtocolSubprocess": False,
-        "enableHardwareSubprocess": False,
+        "enableProtocolSubprocess": True,
+        "enableHardwareSubprocess": True,
         "alwaysRunProtocolAsUser": False,
     }
 
@@ -499,6 +499,19 @@ def v42_config(v41_config: Dict[str, Any]) -> Dict[str, Any]:
     return r
 
 
+@pytest.fixture
+def v43_config(v42_config: Dict[str, Any]) -> Dict[str, Any]:
+    r = v42_config.copy()
+    r.update(
+        {
+            "_version": 43,
+            "enableProtocolSubprocess": True,
+            "enableHardwareSubprocess": True,
+        }
+    )
+    return r
+
+
 @pytest.fixture(
     params=[
         lazy_fixture("empty_settings"),
@@ -545,6 +558,7 @@ def v42_config(v41_config: Dict[str, Any]) -> Dict[str, Any]:
         lazy_fixture("v40_config"),
         lazy_fixture("v41_config"),
         lazy_fixture("v42_config"),
+        lazy_fixture("v43_config"),
     ],
 )
 def old_settings(request: SubRequest) -> Dict[str, Any]:

--- a/robot-server/dev-flex.env
+++ b/robot-server/dev-flex.env
@@ -5,3 +5,5 @@ OT_ROBOT_SERVER_persistence_directory=automatically_make_temporary
 OT_ROBOT_SERVER_simulator_configuration_file_path=simulators/test-flex.json
 OT_API_FF_enableOT3HardwareController=true
 DEV_ROBOT_NAME=opentrons-dev
+OT_API_FF_enableHardwareSubprocess=false
+OT_API_FF_enableProtocolSubprocess=false

--- a/robot-server/dev.env
+++ b/robot-server/dev.env
@@ -4,3 +4,5 @@ ENABLE_VIRTUAL_SMOOTHIE=true
 OT_ROBOT_SERVER_persistence_directory=automatically_make_temporary
 OT_ROBOT_SERVER_simulator_configuration_file_path=simulators/test.json
 DEV_ROBOT_NAME=opentrons-dev
+OT_API_FF_enableHardwareSubprocess=false
+OT_API_FF_enableProtocolSubprocess=false

--- a/robot-server/tests/maintenance_runs/test_run_data_manager.py
+++ b/robot-server/tests/maintenance_runs/test_run_data_manager.py
@@ -1,10 +1,12 @@
 """Tests for RunDataManager."""
 
+import inspect
 from datetime import datetime
 
 import pytest
 from decoy import Decoy
 
+from opentrons.config import feature_flags
 from opentrons.protocol_engine import (
     CommandSlice,
     EngineStatus,
@@ -23,6 +25,7 @@ from opentrons.protocol_engine import (
 )
 from opentrons.protocol_engine.resources import CameraProvider
 from opentrons.types import DeckSlotName
+from opentrons_shared_data.robot.types import RobotTypeEnum
 
 from robot_server.camera.provider import CameraProviderWrapper
 from robot_server.maintenance_runs.maintenance_run_data_manager import (
@@ -123,14 +126,30 @@ def mock_camera_provider(
     return decoy.mock(cls=CameraProvider)
 
 
+@pytest.fixture
+def mock_feature_flags(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Get a mocked feature flags."""
+    for name, func in inspect.getmembers(feature_flags, inspect.isfunction):
+        params = inspect.getfullargspec(func)
+        mock_get_ff = decoy.mock(func=func)
+        if any("robot_type" in p for p in params.args):
+            decoy.when(mock_get_ff(RobotTypeEnum.FLEX)).then_return(False)
+        else:
+            decoy.when(mock_get_ff()).then_return(False)
+        monkeypatch.setattr(feature_flags, name, mock_get_ff)
+
+
 async def test_create(
     decoy: Decoy,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     subject: MaintenanceRunDataManager,
     engine_state_summary: StateSummary,
     mock_camera_provider: CameraProvider,
+    mock_feature_flags: None,
 ) -> None:
     """It should create an engine and a persisted run resource."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     run_id = "hello world"
     created_at = datetime(year=2021, month=1, day=1)
 
@@ -179,8 +198,11 @@ async def test_create_with_options(
     subject: MaintenanceRunDataManager,
     engine_state_summary: StateSummary,
     mock_camera_provider: CameraProvider,
+    mock_feature_flags: None,
 ) -> None:
     """It should handle creation with labware offsets."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     run_id = "hello world"
     created_at = datetime(year=2021, month=1, day=1)
 
@@ -235,8 +257,11 @@ async def test_create_engine_error(
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     subject: MaintenanceRunDataManager,
     mock_camera_provider: CameraProvider,
+    mock_feature_flags: None,
 ) -> None:
     """It should not create a resource if engine creation fails."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     run_id = "hello world"
     created_at = datetime(year=2021, month=1, day=1)
 
@@ -270,8 +295,11 @@ async def test_get_current_run(
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     subject: MaintenanceRunDataManager,
     engine_state_summary: StateSummary,
+    mock_feature_flags: None,
 ) -> None:
     """It should get the current run from the engine."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     run_id = "hello world"
 
     decoy.when(mock_maintenance_run_orchestrator_store.current_run_id).then_return(
@@ -309,8 +337,11 @@ async def test_get_run_not_current(
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     subject: MaintenanceRunDataManager,
     engine_state_summary: StateSummary,
+    mock_feature_flags: None,
 ) -> None:
     """It should raise a MaintenanceRunNotFoundError."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     run_id = "hello world"
 
     decoy.when(mock_maintenance_run_orchestrator_store.current_run_id).then_return(
@@ -325,8 +356,11 @@ async def test_delete_current_run(
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     mock_camera_provider: CameraProvider,
     subject: MaintenanceRunDataManager,
+    mock_feature_flags: None,
 ) -> None:
     """It should delete the current run from the engine."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     run_id = "hello world"
     decoy.when(mock_maintenance_run_orchestrator_store.current_run_id).then_return(
         run_id
@@ -346,8 +380,11 @@ def test_get_commands_slice_current_run(
     subject: MaintenanceRunDataManager,
     mock_maintenance_run_orchestrator_store: MaintenanceRunOrchestratorStore,
     run_command: commands.Command,
+    mock_feature_flags: None,
 ) -> None:
     """Should get a sliced command list from engine store."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     expected_commands_result = [
         commands.WaitForResume(
             id="command-id-2",

--- a/robot-server/tests/protocols/test_protocol_analyzer.py
+++ b/robot-server/tests/protocols/test_protocol_analyzer.py
@@ -1,5 +1,6 @@
 """Tests for the ProtocolAnalyzer."""
 
+import inspect
 from datetime import datetime
 from pathlib import Path
 
@@ -9,6 +10,7 @@ from decoy import Decoy
 import opentrons.protocol_runner as protocol_runner
 import opentrons.protocol_runner.create_simulating_orchestrator as simulating_runner
 import opentrons.util.helpers as datetime_helper
+from opentrons.config import feature_flags
 from opentrons.protocol_engine import (
     EngineStatus,
     StateSummary,
@@ -32,7 +34,7 @@ from opentrons.protocols.api_support.types import APIVersion
 from opentrons.types import DeckSlotName, MountType
 from opentrons_shared_data.errors import EnumeratedError, ErrorCodes
 from opentrons_shared_data.pipette.types import PipetteNameType
-from opentrons_shared_data.robot.types import RobotType
+from opentrons_shared_data.robot.types import RobotType, RobotTypeEnum
 
 import robot_server.errors.error_mappers as em
 from robot_server.protocols.analysis_store import AnalysisStore
@@ -79,12 +81,28 @@ def run_process_pyro_provider(decoy: Decoy) -> RunProcessPyroProvider:
     return decoy.mock(cls=RunProcessPyroProvider)
 
 
+@pytest.fixture
+def mock_feature_flags(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Get a mocked feature flags."""
+    for name, func in inspect.getmembers(feature_flags, inspect.isfunction):
+        params = inspect.getfullargspec(func)
+        mock_get_ff = decoy.mock(func=func)
+        if any("robot_type" in p for p in params.args):
+            decoy.when(mock_get_ff(RobotTypeEnum.FLEX)).then_return(False)
+        else:
+            decoy.when(mock_get_ff()).then_return(False)
+        monkeypatch.setattr(feature_flags, name, mock_get_ff)
+
+
 async def test_load_orchestrator(
     decoy: Decoy,
     analysis_store: AnalysisStore,
     run_process_pyro_provider: RunProcessPyroProvider,
+    mock_feature_flags: None,
 ) -> None:
     """It should load the appropriate run orchestrator."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     robot_type: RobotType = "OT-3 Standard"
     protocol_source = ProtocolSource(
         directory=Path("/dev/null"),
@@ -135,8 +153,11 @@ async def test_analyze(
     decoy: Decoy,
     analysis_store: AnalysisStore,
     run_process_pyro_provider: RunProcessPyroProvider,
+    mock_feature_flags: None,
 ) -> None:
     """It should be able to start a protocol analysis and update the analysis store when completed."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     robot_type: RobotType = "OT-3 Standard"
 
     protocol_resource = ProtocolResource(
@@ -271,8 +292,11 @@ async def test_analyze_updates_pending_on_error(
     decoy: Decoy,
     analysis_store: AnalysisStore,
     run_process_pyro_provider: RunProcessPyroProvider,
+    mock_feature_flags: None,
 ) -> None:
     """It should update pending analysis with an internal error."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     robot_type: RobotType = "OT-3 Standard"
 
     protocol_resource = ProtocolResource(

--- a/robot-server/tests/robot/control/test_estop_lockout.py
+++ b/robot-server/tests/robot/control/test_estop_lockout.py
@@ -1,11 +1,13 @@
 """Test the dependency for locking endpoints based on Estop."""
 
+import inspect
 from typing import TYPE_CHECKING, Optional
 
 import pytest
 from decoy import Decoy, matchers
 from fastapi import status
 
+from opentrons.config import feature_flags
 from opentrons.hardware_control import ThreadManagedHardware
 from opentrons.hardware_control.api import API
 from opentrons.hardware_control.types import (
@@ -13,6 +15,7 @@ from opentrons.hardware_control.types import (
     EstopPhysicalStatus,
     EstopState,
 )
+from opentrons_shared_data.robot.types import RobotTypeEnum
 
 if TYPE_CHECKING:
     from opentrons.hardware_control.ot3api import OT3API
@@ -53,8 +56,24 @@ async def thread_manager_ot3(
     return thread_manager
 
 
-async def test_estop_ignored_ot2(thread_manager_ot2: ThreadManagedHardware) -> None:
+@pytest.fixture
+def mock_feature_flags(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Get a mocked feature flags."""
+    for name, func in inspect.getmembers(feature_flags, inspect.isfunction):
+        params = inspect.getfullargspec(func)
+        mock_get_ff = decoy.mock(func=func)
+        if any("robot_type" in p for p in params.args):
+            decoy.when(mock_get_ff(RobotTypeEnum.FLEX)).then_return(False)
+        else:
+            decoy.when(mock_get_ff()).then_return(False)
+        monkeypatch.setattr(feature_flags, name, mock_get_ff)
+
+
+async def test_estop_ignored_ot2(
+    decoy: Decoy, thread_manager_ot2: ThreadManagedHardware, mock_feature_flags: None
+) -> None:
     """Test that we can use the dependency on OT-2."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
     assert await require_estop_in_good_state(hardware_resource=thread_manager_ot2)
 
 
@@ -74,9 +93,10 @@ async def test_estop_ot3(
     decoy: Decoy,
     estop_state: EstopState,
     error_code: Optional[ErrorCode],
+    mock_feature_flags: None,
 ) -> None:
     """Test that ot3 hardware will check estop state."""
-
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
     decoy.when(hardware_ot3.estop_status).then_return(
         EstopOverallStatus(
             state=estop_state,

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -1,5 +1,6 @@
 """Tests for RunDataManager."""
 
+import inspect
 from datetime import datetime
 from typing import Dict, List, Optional
 from unittest.mock import Mock, sentinel
@@ -8,6 +9,7 @@ import pytest
 from decoy import Decoy, matchers
 
 from opentrons import config
+from opentrons.config import feature_flags
 from opentrons.hardware_control.nozzle_manager import NozzleMap
 from opentrons.protocol_engine import (
     CommandErrorSlice,
@@ -40,6 +42,7 @@ from opentrons.protocol_runner import RunResult
 from opentrons_shared_data.data_files import RunFileNameMetadata
 from opentrons_shared_data.errors.exceptions import InvalidStoredData
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition2
+from opentrons_shared_data.robot.types import RobotTypeEnum
 
 from robot_server.camera.provider import CameraProviderWrapper
 from robot_server.camera.settings.store import CameraSettingStore
@@ -243,6 +246,19 @@ def run_command() -> commands.Command:
 
 
 @pytest.fixture
+def mock_feature_flags(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Get a mocked feature flags."""
+    for name, func in inspect.getmembers(feature_flags, inspect.isfunction):
+        params = inspect.getfullargspec(func)
+        mock_get_ff = decoy.mock(func=func)
+        if any("robot_type" in p for p in params.args):
+            decoy.when(mock_get_ff(RobotTypeEnum.FLEX)).then_return(False)
+        else:
+            decoy.when(mock_get_ff()).then_return(False)
+        monkeypatch.setattr(feature_flags, name, mock_get_ff)
+
+
+@pytest.fixture
 def subject(
     mock_run_orchestrator_store: RunOrchestratorStore,
     mock_run_store: RunStore,
@@ -274,8 +290,11 @@ async def test_create(
     subject: RunDataManager,
     engine_state_summary: StateSummary,
     run_resource: RunResource,
+    mock_feature_flags: None,
 ) -> None:
     """It should create an engine and a persisted run resource."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     run_id = "hello world"
     created_at = datetime(year=2021, month=1, day=1)
     protocol_source = ProtocolSource.model_construct(
@@ -397,8 +416,11 @@ async def test_create_engine_error(
     mock_file_provider: FileProvider,
     mock_camera_provider: CameraProvider,
     subject: RunDataManager,
+    mock_feature_flags: None,
 ) -> None:
     """It should not create a resource if engine creation fails."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     run_id = "hello world"
     created_at = datetime(year=2021, month=1, day=1)
 
@@ -915,8 +937,11 @@ async def test_create_archives_existing(
     mock_file_provider: FileProvider,
     mock_camera_provider: CameraProvider,
     subject: RunDataManager,
+    mock_feature_flags: None,
 ) -> None:
     """It should persist the previously current run when a new run is created."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     run_id_old = "hello world"
     run_id_new = "hello is it me you're looking for"
 

--- a/robot-server/tests/runs/test_run_orchestrator_store.py
+++ b/robot-server/tests/runs/test_run_orchestrator_store.py
@@ -1,5 +1,6 @@
 """Tests for the EngineStore interface."""
 
+import inspect
 from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
@@ -7,6 +8,7 @@ from textwrap import dedent
 import pytest
 from decoy import Decoy, matchers
 
+from opentrons.config import feature_flags
 from opentrons.hardware_control import API, HardwareControlAPI
 from opentrons.hardware_control.modules.types import TemperatureModuleModel
 from opentrons.hardware_control.types import (
@@ -27,7 +29,7 @@ from opentrons.protocol_reader import ProtocolReader
 from opentrons.protocol_runner import RunOrchestrator, RunResult
 from opentrons.types import DeckSlotName
 from opentrons_shared_data.errors.exceptions import ModuleCommunicationError
-from opentrons_shared_data.robot.types import RobotType
+from opentrons_shared_data.robot.types import RobotType, RobotTypeEnum
 
 from robot_server.protocols.protocol_models import ProtocolKind
 from robot_server.protocols.protocol_store import ProtocolResource
@@ -97,8 +99,24 @@ async def bad_python_protocol_source(tmp_path: Path) -> ProtocolResource:
     )
 
 
-async def test_create_engine(decoy: Decoy, subject: RunOrchestratorStore) -> None:
+@pytest.fixture
+def mock_feature_flags(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Get a mocked feature flags."""
+    for name, func in inspect.getmembers(feature_flags, inspect.isfunction):
+        params = inspect.getfullargspec(func)
+        mock_get_ff = decoy.mock(func=func)
+        if any("robot_type" in p for p in params.args):
+            decoy.when(mock_get_ff(RobotTypeEnum.FLEX)).then_return(False)
+        else:
+            decoy.when(mock_get_ff()).then_return(False)
+        monkeypatch.setattr(feature_flags, name, mock_get_ff)
+
+
+async def test_create_engine(
+    decoy: Decoy, subject: RunOrchestratorStore, mock_feature_flags: None
+) -> None:
     """It should create an engine for a run."""
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     result = await subject.create(
         run_id="run-id",
         labware_offsets=[],
@@ -125,8 +143,10 @@ async def test_create_engine_uses_robot_type(
     robot_type: RobotType,
     deck_type: pe_types.DeckType,
     mock_run_process_pyro_provider: RunProcessPyroProvider,
+    mock_feature_flags: None,
 ) -> None:
     """It should create ProtocolEngines with the given robot and deck type."""
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
     # should pass in some sort of actual, valid HardwareAPI instead of a mock
     hardware_api = decoy.mock(cls=API)
@@ -155,9 +175,12 @@ async def test_create_engine_uses_robot_type(
 
 
 async def test_create_engine_with_labware_offsets(
+    decoy: Decoy,
     subject: RunOrchestratorStore,
+    mock_feature_flags: None,
 ) -> None:
     """It should create an engine for a run with labware offsets."""
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     labware_offset = pe_types.LegacyLabwareOffsetCreate(
         definitionUri="namespace/load_name/version",
         location=pe_types.LegacyLabwareOffsetLocation(slotName=DeckSlotName.SLOT_5),
@@ -194,9 +217,12 @@ async def test_create_engine_with_labware_offsets(
 
 
 async def test_archives_state_if_engine_already_exists(
+    decoy: Decoy,
     subject: RunOrchestratorStore,
+    mock_feature_flags: None,
 ) -> None:
     """It should not create more than one engine / runner pair."""
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     await subject.create(
         run_id="run-id-1",
         labware_offsets=[],
@@ -228,9 +254,13 @@ async def test_archives_state_if_engine_already_exists(
 
 
 async def test_create_does_not_store_orchestrator_on_load_failure(
-    subject: RunOrchestratorStore, bad_python_protocol_source: ProtocolResource
+    decoy: Decoy,
+    subject: RunOrchestratorStore,
+    bad_python_protocol_source: ProtocolResource,
+    mock_feature_flags: None,
 ) -> None:
     """It should not store an orchestrator unless it could be loaded."""
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     with pytest.raises(ZeroDivisionError):
         await subject.create(
             run_id="run-id",
@@ -247,8 +277,13 @@ async def test_create_does_not_store_orchestrator_on_load_failure(
     assert subject.current_run_id is None
 
 
-async def test_clear_engine(subject: RunOrchestratorStore) -> None:
+async def test_clear_engine(
+    decoy: Decoy,
+    subject: RunOrchestratorStore,
+    mock_feature_flags: None,
+) -> None:
     """It should clear a stored engine entry."""
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     await subject.create(
         run_id="run-id",
         labware_offsets=[],
@@ -276,8 +311,13 @@ async def test_clear_engine(subject: RunOrchestratorStore) -> None:
         subject.run_coordinator
 
 
-async def test_clear_engine_not_stopped_or_idle(subject: RunOrchestratorStore) -> None:
+async def test_clear_engine_not_stopped_or_idle(
+    decoy: Decoy,
+    subject: RunOrchestratorStore,
+    mock_feature_flags: None,
+) -> None:
     """It should raise a conflict if the engine is not stopped."""
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     await subject.create(
         run_id="run-id",
         labware_offsets=[],
@@ -296,8 +336,13 @@ async def test_clear_engine_not_stopped_or_idle(subject: RunOrchestratorStore) -
         await subject.clear()
 
 
-async def test_clear_idle_engine(subject: RunOrchestratorStore) -> None:
+async def test_clear_idle_engine(
+    decoy: Decoy,
+    subject: RunOrchestratorStore,
+    mock_feature_flags: None,
+) -> None:
     """It should successfully clear engine if idle (not started)."""
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     await subject.create(
         run_id="run-id",
         labware_offsets=[],
@@ -320,9 +365,12 @@ async def test_clear_idle_engine(subject: RunOrchestratorStore) -> None:
 
 
 async def test_get_default_orchestrator_idempotent(
+    decoy: Decoy,
     subject: RunOrchestratorStore,
+    mock_feature_flags: None,
 ) -> None:
     """It should create and retrieve the same default ProtocolEngine."""
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     result = await subject.get_default_orchestrator()
     repeated_result = await subject.get_default_orchestrator()
 
@@ -337,8 +385,10 @@ async def test_get_default_orchestrator_robot_type(
     robot_type: RobotType,
     deck_type: pe_types.DeckType,
     mock_run_process_pyro_provider: RunProcessPyroProvider,
+    mock_feature_flags: None,
 ) -> None:
     """It should create default ProtocolEngines with the given robot and deck type."""
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     # TODO(mc, 2021-06-11): to make these test more effective and valuable, we
     # should pass in some sort of actual, valid HardwareAPI instead of a mock
     hardware_api = decoy.mock(cls=API)
@@ -356,9 +406,12 @@ async def test_get_default_orchestrator_robot_type(
 
 
 async def test_get_default_orchestrator_current_unstarted(
+    decoy: Decoy,
     subject: RunOrchestratorStore,
+    mock_feature_flags: None,
 ) -> None:
     """It should allow a default engine if another engine current but unstarted."""
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     await subject.create(
         run_id="run-id",
         labware_offsets=[],
@@ -376,8 +429,13 @@ async def test_get_default_orchestrator_current_unstarted(
     assert isinstance(result, RunOrchestrator)
 
 
-async def test_get_default_orchestrator_conflict(subject: RunOrchestratorStore) -> None:
+async def test_get_default_orchestrator_conflict(
+    decoy: Decoy,
+    subject: RunOrchestratorStore,
+    mock_feature_flags: None,
+) -> None:
     """It should not allow a default engine if another engine is executing commands."""
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     await subject.create(
         run_id="run-id",
         labware_offsets=[],
@@ -397,9 +455,12 @@ async def test_get_default_orchestrator_conflict(subject: RunOrchestratorStore) 
 
 
 async def test_get_default_orchestrator_run_stopped(
+    decoy: Decoy,
     subject: RunOrchestratorStore,
+    mock_feature_flags: None,
 ) -> None:
     """It allow a default engine if another engine is terminal."""
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(False)
     await subject.create(
         run_id="run-id",
         labware_offsets=[],

--- a/robot-server/tests/subsystems/test_router.py
+++ b/robot-server/tests/subsystems/test_router.py
@@ -1,5 +1,6 @@
 """Tests for /subsystems routes."""
 
+import inspect
 from datetime import datetime
 from typing import TYPE_CHECKING, Dict, Set
 
@@ -8,6 +9,7 @@ from decoy import Decoy
 from fastapi import Request, Response
 from starlette.datastructures import URL, MutableHeaders
 
+from opentrons.config import feature_flags
 from opentrons.hardware_control import ThreadManagedHardware
 from opentrons.hardware_control.types import (
     SubSystem as HWSubSystem,
@@ -18,6 +20,7 @@ from opentrons.hardware_control.types import (
 from opentrons.hardware_control.types import (
     UpdateState as HWUpdateState,
 )
+from opentrons_shared_data.robot.types import RobotTypeEnum
 
 from robot_server.errors.error_responses import ApiError
 from robot_server.subsystems.firmware_update_manager import (
@@ -91,6 +94,19 @@ def thread_manager(decoy: Decoy, ot3_hardware_api: "OT3API") -> ThreadManagedHar
     return manager
 
 
+@pytest.fixture
+def mock_feature_flags(decoy: Decoy, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Get a mocked feature flags."""
+    for name, func in inspect.getmembers(feature_flags, inspect.isfunction):
+        params = inspect.getfullargspec(func)
+        mock_get_ff = decoy.mock(func=func)
+        if any("robot_type" in p for p in params.args):
+            decoy.when(mock_get_ff(RobotTypeEnum.FLEX)).then_return(False)
+        else:
+            decoy.when(mock_get_ff()).then_return(False)
+        monkeypatch.setattr(feature_flags, name, mock_get_ff)
+
+
 def _build_attached_subsystem(
     subsystem: HWSubSystem,
     ok: bool = True,
@@ -140,8 +156,10 @@ async def test_get_attached_subsystems(
     thread_manager: ThreadManagedHardware,
     subsystems: Set[HWSubSystem],
     decoy: Decoy,
+    mock_feature_flags: None,
 ) -> None:
     """It should return all subsystems the hardware says are present."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
     subsystem_state = _build_attached_subsystems(subsystems)
     decoy.when(ot3_hardware_api.attached_subsystems).then_return(subsystem_state)
     resp = await get_attached_subsystems(thread_manager)

--- a/robot-server/tests/subsystems/test_router.py
+++ b/robot-server/tests/subsystems/test_router.py
@@ -185,8 +185,10 @@ async def test_get_attached_subsystem(
     thread_manager: ThreadManagedHardware,
     subsystem: SubSystem,
     decoy: Decoy,
+    mock_feature_flags: None,
 ) -> None:
     """It should return data for present subsystems."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(False)
     subsystems_dict = _build_attached_subsystems({subsystem.to_hw()})
     status = subsystems_dict[subsystem.to_hw()]
     decoy.when(ot3_hardware_api.attached_subsystems).then_return(subsystems_dict)


### PR DESCRIPTION
# Overview
Covers EXEC-2864

The enableHardwareSubprocess and enableProtocolSubprocess feature flags should be updated to default to True. This mean the Flex will always run in Pyro/Subprocess mode by default!

For the time being the dev environment does not spin up a name server or an OT3API daemon. To support tavern tests and running make dev locally these feature flags default to false.

## Test Plan and Hands on Testing
 - Ensure the feature flags properly update on the Flex and the system boots in subprocess mode by default.

## Changelog
Added migration to update the subprocess feature flags

## Review requests
Are there any concerns with running in subprocess mode on top of other ongoing edge work?

## Risk assessment
Medium-High! We're switching edge over to running in subprocess/pyro mode with this! Pyro is currently in QA and will continue to be so, but we should make sure this change over won't effect other in-flight work.