### PR TITLE
fix(api): implement deactivate function for vacuum module to handle e-stop.

### DIFF
--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -404,7 +404,13 @@ class VacuumModule(mod_abc.AbstractModule):
         return update.upload_via_dfu
 
     async def deactivate(self, must_be_running: bool = True) -> None:
-        pass
+        """Stop the pump, and open the vent."""
+        if must_be_running:
+            await self.wait_for_is_running()
+        await self._driver.set_vacuum_state(False)
+        await self._driver.set_vent_state(VentState.OPENED)
+        self._reader.reset_pressure_target()
+        self._reader.reset_power_target()
 
     async def set_led_state(
         self,

--- a/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
@@ -975,6 +975,23 @@ async def test_execute_profile(
     )
 
 
+async def test_deactivate_stops_vacuum_and_opens_vent(
+    subject: modules.VacuumModule,
+    mock_driver: SimulatingDriver,
+    decoy: Decoy,
+) -> None:
+    """Deactivate should stop vacuum control, open the vent, and clear targets."""
+    subject._reader.set_target_pressure(-100.0)
+    subject._reader.set_target_power(50.0)
+
+    await subject.deactivate(must_be_running=False)
+
+    decoy.verify(await mock_driver.set_vacuum_state(False))
+    decoy.verify(await mock_driver.set_vent_state(VentState.OPENED))
+    assert subject._reader.target_pressure is None
+    assert subject._reader.get_target_power() is None
+
+
 async def test_move_port_updates_port_and_calls_driver(
     subject: modules.VacuumModule,
     mock_driver: SimulatingDriver,

--- a/api/tests/opentrons/hardware_control/test_ot3_api.py
+++ b/api/tests/opentrons/hardware_control/test_ot3_api.py
@@ -82,6 +82,7 @@ from opentrons.hardware_control.modules import (
     SpeedStatus,
     TempDeck,
     Thermocycler,
+    VacuumModule,
 )
 from opentrons.hardware_control.motion_utilities import target_position_from_plunger
 from opentrons.hardware_control.ot3api import OT3API
@@ -2592,11 +2593,12 @@ async def test_estop_event_deactivate_module(
     hs = decoy.mock(cls=HeaterShaker)
     md = decoy.mock(cls=MagDeck)
     td = decoy.mock(cls=TempDeck)
+    vm = decoy.mock(cls=VacuumModule)
 
     decoy.when(hs.speed_status).then_return(SpeedStatus.HOLDING)
 
     decoy.when(api._backend.module_controls.available_modules).then_return(
-        [tc, hs, md, td]
+        [tc, hs, md, td, vm]
     )
 
     estop_event = EstopStateNotification(old_state=old_state, new_state=new_state)
@@ -2615,6 +2617,7 @@ async def test_estop_event_deactivate_module(
             await hs.deactivate_shaker(must_be_running=False),
             await md.deactivate(must_be_running=False),
             await td.deactivate(must_be_running=False),
+            await vm.deactivate(must_be_running=False),
         )
     else:
         assert len(futures) == 0

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_qc_protocol.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_qc_protocol.py
@@ -69,7 +69,7 @@ def add_parameters(parameters: ParameterContext) -> None:
         variable_name="collar",
         display_name="Vacuum Collar",
         description="The kind of Collar (Opentrons or Millipore)",
-        default="millipore_vacuum_manifold_collar_short",
+        default="opentrons_vacuum_manifold_collar_short",
         choices=[
             {
                 "display_name": "Opentrons: Short",
@@ -94,6 +94,7 @@ def add_parameters(parameters: ParameterContext) -> None:
         variable_name="target_pressure",
         description="The target gauge pressure in mbar.",
         default=-200,
+        minimum=-800,
         maximum=0,
     )
     parameters.add_int(
@@ -179,11 +180,6 @@ def run(ctx: ProtocolContext) -> None:
         "opentrons_flex_96_tiprack_50ul",
         "D2",
         adapter=adapter,
-    )
-    tiprack_50 = ctx.load_labware(
-        "opentrons_flex_96_tiprack_50ul",
-        "D2",
-        adapter="opentrons_flex_96_tiprack_adapter",
     )
 
     # Load Labware


### PR DESCRIPTION
# Overview

The deactivate function was not implemented for the vacuum module, which is called when the e-stop is pressed. This meant the vacuum module would continue to be under vacuum when the e-stop was pressed, which is not correct.

Closes: [RQA-5763](https://opentrons.atlassian.net/browse/RQA-5763)

## Test Plan and Hands on Testing

- [ ] Make sure the vacuum module stops when the e-stop is pressed

## Changelog

- Implement the `VacuumModule.deactivate` function to handle the e-stop being pressed
- Update QC script syntax issue

## Review requests
## Risk assessment


[RQA-5763]: https://opentrons.atlassian.net/browse/RQA-5763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ