### PR TITLE
refactor(components): remove redux from renderWithProviders

### DIFF
--- a/components/package.json
+++ b/components/package.json
@@ -52,9 +52,5 @@
     "react-select": "5.4.0",
     "react-viewport-list": "6.3.0",
     "styled-components": "5.3.6"
-  },
-  "devDependencies": {
-    "redux": "5.0.1",
-    "react-redux": "8.1.2"
   }
 }

--- a/components/src/testing/utils/renderWithProviders.tsx
+++ b/components/src/testing/utils/renderWithProviders.tsx
@@ -1,17 +1,11 @@
-// render using targeted component using @testing-library/react
-// with wrapping providers for i18next and react-query
+// render using targetted component using @testing-library/react
+// with wrapping provider for i18next when needed
 
 import { I18nextProvider } from 'react-i18next'
-import { QueryClient, QueryClientProvider } from 'react-query'
 import { render } from '@testing-library/react'
 
 import type { RenderOptions, RenderResult } from '@testing-library/react'
-import type {
-  ComponentProps,
-  ComponentType,
-  PropsWithChildren,
-  ReactElement,
-} from 'react'
+import type { ComponentProps, ReactElement } from 'react'
 
 export interface RenderWithProvidersOptions extends RenderOptions {
   i18nInstance?: ComponentProps<typeof I18nextProvider>['i18n']
@@ -21,23 +15,14 @@ export function renderWithProviders(
   Component: ReactElement,
   options?: RenderWithProvidersOptions
 ): [RenderResult] {
-  const { i18nInstance = null, ...renderOptions } = options || {}
+  const { i18nInstance = null, ...renderOptions } = options ?? {}
 
-  const queryClient = new QueryClient()
-
-  const ProviderWrapper: ComponentType<PropsWithChildren<{}>> = ({
-    children,
-  }) => {
-    const BaseWrapper = (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  const componentToRender =
+    i18nInstance != null ? (
+      <I18nextProvider i18n={i18nInstance}>{Component}</I18nextProvider>
+    ) : (
+      Component
     )
-    if (i18nInstance != null) {
-      return (
-        <I18nextProvider i18n={i18nInstance}>{BaseWrapper}</I18nextProvider>
-      )
-    }
-    return BaseWrapper
-  }
 
-  return [render(Component, { wrapper: ProviderWrapper, ...renderOptions })]
+  return [render(componentToRender, renderOptions)]
 }

--- a/components/src/testing/utils/renderWithProviders.tsx
+++ b/components/src/testing/utils/renderWithProviders.tsx
@@ -1,15 +1,11 @@
-// render using targetted component using @testing-library/react
-// with wrapping providers for i18next and redux
+// render using targeted component using @testing-library/react
+// with wrapping providers for i18next and react-query
 
 import { I18nextProvider } from 'react-i18next'
 import { QueryClient, QueryClientProvider } from 'react-query'
-import { Provider } from 'react-redux'
 import { render } from '@testing-library/react'
-import { legacy_createStore } from 'redux'
-import { vi } from 'vitest'
 
 import type { RenderOptions, RenderResult } from '@testing-library/react'
-import type { Store } from 'redux'
 import type {
   ComponentProps,
   ComponentType,
@@ -17,20 +13,15 @@ import type {
   ReactElement,
 } from 'react'
 
-export interface RenderWithProvidersOptions<State> extends RenderOptions {
-  initialState?: State
-  i18nInstance: ComponentProps<typeof I18nextProvider>['i18n']
+export interface RenderWithProvidersOptions extends RenderOptions {
+  i18nInstance?: ComponentProps<typeof I18nextProvider>['i18n']
 }
 
-export function renderWithProviders<State>(
+export function renderWithProviders(
   Component: ReactElement,
-  options?: RenderWithProvidersOptions<State>
-): [RenderResult, Store<State>] {
-  const { initialState = {}, i18nInstance = null } = options || {}
-
-  const store: Store<State> = legacy_createStore(vi.fn(), initialState)
-  store.dispatch = vi.fn()
-  store.getState = vi.fn(() => initialState) as () => State
+  options?: RenderWithProvidersOptions
+): [RenderResult] {
+  const { i18nInstance = null, ...renderOptions } = options || {}
 
   const queryClient = new QueryClient()
 
@@ -38,18 +29,15 @@ export function renderWithProviders<State>(
     children,
   }) => {
     const BaseWrapper = (
-      <QueryClientProvider client={queryClient}>
-        <Provider store={store}>{children}</Provider>
-      </QueryClientProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     )
     if (i18nInstance != null) {
       return (
         <I18nextProvider i18n={i18nInstance}>{BaseWrapper}</I18nextProvider>
       )
-    } else {
-      return BaseWrapper
     }
+    return BaseWrapper
   }
 
-  return [render(Component, { wrapper: ProviderWrapper }), store]
+  return [render(Component, { wrapper: ProviderWrapper, ...renderOptions })]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -873,13 +873,6 @@ importers:
       styled-components:
         specifier: 5.3.6
         version: 5.3.6(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0)
-    devDependencies:
-      react-redux:
-        specifier: 8.1.2
-        version: 8.1.2(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(redux@5.0.1)
-      redux:
-        specifier: 5.0.1
-        version: 5.0.1
 
   discovery-client:
     dependencies:


### PR DESCRIPTION
# Overview
remove redux from renderWithProviders

closes AUTH-3101

## Test Plan and Hands on Testing
`make -C components test` doesn't have any error

## Changelog
- remove redux from renderWithProviders
- remove redux and react-redux from package.json

## Review requests


## Risk assessment
low