### PR TITLE
fix: Fix `make dev-backend-flex` leaving behind orphan processes

### DIFF
--- a/scripts/run_concurrently.py
+++ b/scripts/run_concurrently.py
@@ -9,6 +9,9 @@ Make sure it's appropriately quoted if you're running this in a shell.
 
 import asyncio
 import asyncio.subprocess
+import contextlib
+import os
+import signal
 import sys
 import typing
 
@@ -22,6 +25,7 @@ async def run_command(command: list[str]) -> None:
         command[0],
         *command[1:],
         stdin=asyncio.subprocess.DEVNULL,
+        start_new_session=True,  # For os.killpg().
     )
     try:
         await subprocess.wait()
@@ -51,12 +55,16 @@ async def terminate_process(
         return  # Already stopped.
 
     try:
+        # Polite termination: send SIGTERM to our direct child process.
+        # If it has its own children, let it terminate them on its own terms.
         async with asyncio.timeout(timeout_sec):
             process.terminate()
             await process.wait()
     except asyncio.TimeoutError:
-        process.kill()
-        await process.wait()
+        # Forceful termination after timeout: send SIGKILL to the entire process group.
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+
 
 def split(
     source: typing.Iterable[str], delimiter: str

--- a/scripts/run_concurrently.py
+++ b/scripts/run_concurrently.py
@@ -64,6 +64,7 @@ async def terminate_process(
         # Forceful termination after timeout: send SIGKILL to the entire process group.
         with contextlib.suppress(ProcessLookupError):
             os.killpg(process.pid, signal.SIGKILL)
+        await process.wait()
 
 
 def split(


### PR DESCRIPTION
## Overview

I've noticed that sometimes, when interrupting `make dev-backend-flex` with ^C, the servers hang during shutdown. I don't know exactly why this is, but I have a hunch it has to do with Git branch switching and Uvicorn hot reloading.

`run_concurrently.py` has [a timeout](https://github.com/Opentrons/opentrons/blob/e4cabae2fe384908aae6da8c22ab77557f55eb27/scripts/run_concurrently.py#L57-L59) in case the servers hang. It escalates `SIGTERM` to a more aggressive `SIGKILL`. This works, but it only kills the server's parent process. Child processes will remain running indefinitely in the background, potentially consuming TCP ports and interfering with later runs of `make dev-backend-flex`.

This tries to fix it so we don't leave behind orphan grandchildren. The way this works is that when we spawn a child, we create a process group for it. Then, when we send `SIGKILL`, we send it to the *entire subtree,* not just our direct child.

## Test Plan and Hands on Testing

I haven't figured out how to reproduce the shutdown hanging, so I'm not 100% sure this fixes it. But the normal, non-hanging case still works.

## Review requests

Does this seem like the right approach?

## Risk assessment

Low. Dev only.