### PR TITLE
feat(app): wire up bulk run actions in Recent Protocol Runs

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -195,6 +195,8 @@
   "no_protocols_found": "No protocols found",
   "no_recent_runs": "No recent runs",
   "no_recent_runs_description": "After you run some protocols, they will appear here.",
+  "no_recent_runs_to_delete": "No recent runs to delete.",
+  "no_recent_runs_to_download": "No recent runs to download.",
   "no_usb_connected": "No external memory drives detected",
   "no_user_action_logs": "No user action logs",
   "num_units": "{{num}} mm",

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRun.tsx
@@ -3,6 +3,7 @@ import {
   BORDERS,
   COLORS,
   Flex,
+  Icon,
   JUSTIFY_SPACE_BETWEEN,
   SPACING,
   StyledText,
@@ -28,6 +29,7 @@ interface HistoricalProtocolRunProps {
   protocolName: string
   robotName: string
   robotIsBusy: boolean
+  isDeleting: boolean
   protocolKey?: string
 }
 
@@ -36,7 +38,8 @@ interface HistoricalProtocolRunProps {
 export function HistoricalProtocolRun(
   props: HistoricalProtocolRunProps
 ): JSX.Element | null {
-  const { run, protocolName, robotIsBusy, robotName, protocolKey } = props
+  const { run, protocolName, robotIsBusy, robotName, isDeleting, protocolKey } =
+    props
   const outputFileIds = useRunGeneratedDataFiles(run.id)
   const imageFileCount = outputFileIds.jpeg.length > 0 ? 1 : 0
   const totalOutputFiles = outputFileIds.csv.length + imageFileCount
@@ -105,12 +108,16 @@ export function HistoricalProtocolRun(
             <Tag type="default" text={duration} shrinkToContent />
           </Flex>
         </Flex>
-        <OverflowMenu
-          run={run}
-          robotName={robotName}
-          robotIsBusy={robotIsBusy}
-          runHasImages={imageFileCount > 0}
-        />
+        {isDeleting ? (
+          <Icon name="ot-spinner" spin size="1rem" color={COLORS.grey60} />
+        ) : (
+          <OverflowMenu
+            run={run}
+            robotName={robotName}
+            robotIsBusy={robotIsBusy}
+            runHasImages={imageFileCount > 0}
+          />
+        )}
       </Flex>
     </>
   )

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRun.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRun.tsx
@@ -29,7 +29,7 @@ interface HistoricalProtocolRunProps {
   protocolName: string
   robotName: string
   robotIsBusy: boolean
-  isDeleting: boolean
+  isDeleting?: boolean
   protocolKey?: string
 }
 
@@ -38,8 +38,14 @@ interface HistoricalProtocolRunProps {
 export function HistoricalProtocolRun(
   props: HistoricalProtocolRunProps
 ): JSX.Element | null {
-  const { run, protocolName, robotIsBusy, robotName, isDeleting, protocolKey } =
-    props
+  const {
+    run,
+    protocolName,
+    robotIsBusy,
+    robotName,
+    isDeleting = false,
+    protocolKey,
+  } = props
   const outputFileIds = useRunGeneratedDataFiles(run.id)
   const imageFileCount = outputFileIds.jpeg.length > 0 ? 1 : 0
   const totalOutputFiles = outputFileIds.csv.length + imageFileCount

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/__tests__/RecentProtocolRuns.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/__tests__/RecentProtocolRuns.test.tsx
@@ -8,6 +8,10 @@ import { useAllProtocolsQuery } from '@opentrons/react-api-client'
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useIsRobotViewable } from '/app/redux-resources/robots'
+import {
+  useDeleteSelectedRuns,
+  useDownloadSelectedRuns,
+} from '/app/resources/devices'
 import { useNotifyAllRunsQuery, useRunStatuses } from '/app/resources/runs'
 
 import { RecentProtocolRuns } from '../../RecentProtocolRuns'
@@ -18,7 +22,9 @@ import type { UseQueryResult } from 'react-query'
 import type { Protocols, Runs } from '@opentrons/api-client'
 
 vi.mock('@opentrons/react-api-client')
+vi.mock('/app/local-resources/access-control/useDocumentationState')
 vi.mock('/app/redux-resources/robots')
+vi.mock('/app/resources/devices')
 vi.mock('/app/resources/runs')
 vi.mock('../HistoricalProtocolRun')
 
@@ -27,6 +33,8 @@ const render = () => {
     i18nInstance: i18n,
   })
 }
+const mockDownloadRuns = vi.fn()
+const mockDeleteRuns = vi.fn()
 
 describe('RecentProtocolRuns', () => {
   beforeEach(() => {
@@ -39,6 +47,15 @@ describe('RecentProtocolRuns', () => {
     vi.mocked(HistoricalProtocolRun).mockReturnValue(
       <div>mock HistoricalProtocolRun</div>
     )
+    vi.mocked(useDownloadSelectedRuns).mockReturnValue({
+      downloadRuns: mockDownloadRuns,
+      isDownloading: false,
+      hasError: false,
+    })
+    vi.mocked(useDeleteSelectedRuns).mockReturnValue({
+      deleteSelectedRuns: mockDeleteRuns,
+      deletingIds: new Set(),
+    })
   })
 
   it('renders an empty state message when robot is not on the network', () => {

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/index.tsx
@@ -69,7 +69,7 @@ export function RecentProtocolRuns({
       const toastId = makeToast(
         t('downloading_run_records') as string,
         INFO_TOAST,
-        { disableTimeout: true, icon: toastIcon }
+        { icon: toastIcon }
       )
       void downloadRuns(runs)
         .catch((e: Error) => {

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/index.tsx
@@ -54,7 +54,7 @@ export function RecentProtocolRuns({
     useDeleteSelectedRuns(documentationState)
 
   const handleNoRuns = (type: 'delete' | 'download'): void => {
-    makeToast(t(`select_entry_to_${type}`) as string, WARNING_TOAST, {
+    makeToast(t(`no_recent_runs_to_${type}`) as string, WARNING_TOAST, {
       closeButton: true,
     })
   }

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/index.tsx
@@ -1,10 +1,23 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { BasicButton, InfoScreen, StyledText } from '@opentrons/components'
+import {
+  BasicButton,
+  ERROR_TOAST,
+  INFO_TOAST,
+  InfoScreen,
+  StyledText,
+  WARNING_TOAST,
+} from '@opentrons/components'
 import { useAllProtocolsQuery } from '@opentrons/react-api-client'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
+import { useToaster } from '/app/organisms/ToasterOven'
 import { useIsRobotViewable } from '/app/redux-resources/robots'
+import {
+  useDeleteSelectedRuns,
+  useDownloadSelectedRuns,
+} from '/app/resources/devices'
 import {
   useCurrentRunId,
   useNotifyAllRunsQuery,
@@ -14,6 +27,8 @@ import {
 import { DeleteRecordsModal } from '../DeleteRecordsModal'
 import { HistoricalProtocolRun } from './HistoricalProtocolRun'
 import styles from './recentprotocolruns.module.css'
+
+import type { IconProps } from '@opentrons/components'
 
 interface RecentProtocolRunsProps {
   robotName: string
@@ -25,15 +40,59 @@ export function RecentProtocolRuns({
   const { t } = useTranslation(['device_details', 'shared'])
   const isRobotViewable = useIsRobotViewable(robotName)
   const runsQueryResponse = useNotifyAllRunsQuery()
-  const runs = runsQueryResponse?.data?.data
+  const runs = runsQueryResponse?.data?.data ?? []
   const protocols = useAllProtocolsQuery()
   const currentRunId = useCurrentRunId()
   const { isRunTerminal } = useRunStatuses()
+  const { makeToast, eatToast } = useToaster()
   const [showDeleteRecordsModal, setShowDeleteRecordsModal] =
     useState<boolean>(false)
+  const documentationState = useDocumentationState()
+  const { downloadRuns, isDownloading: isDownloadingRuns } =
+    useDownloadSelectedRuns(robotName)
+  const { deleteSelectedRuns, deletingIds } =
+    useDeleteSelectedRuns(documentationState)
 
-  // TODO: wire up delete runs handler
-  const handleConfirmDeleteRuns = (): void => {
+  const handleNoRuns = (type: 'delete' | 'download'): void => {
+    makeToast(t(`select_entry_to_${type}`) as string, WARNING_TOAST, {
+      closeButton: true,
+    })
+  }
+
+  const handleDownloadSelected = (): void => {
+    if (runs.length === 0) {
+      handleNoRuns('download')
+      return
+    }
+    if (!isDownloadingRuns) {
+      const toastIcon: IconProps = { name: 'ot-spinner', spin: true }
+      const toastId = makeToast(
+        t('downloading_run_records') as string,
+        INFO_TOAST,
+        { disableTimeout: true, icon: toastIcon }
+      )
+      void downloadRuns(runs)
+        .catch((e: Error) => {
+          makeToast(e.message, ERROR_TOAST, { closeButton: true })
+        })
+        .finally(() => {
+          eatToast(toastId)
+        })
+    }
+  }
+
+  const handleClickDeleteAll = (): void => {
+    if (runs.length === 0) {
+      handleNoRuns('delete')
+      return
+    }
+    setShowDeleteRecordsModal(true)
+  }
+
+  const handleConfirmDeleteAll = (): void => {
+    void deleteSelectedRuns(runs).catch(() => {
+      makeToast('Error deleting records', ERROR_TOAST)
+    })
     setShowDeleteRecordsModal(false)
   }
 
@@ -50,7 +109,7 @@ export function RecentProtocolRuns({
           onClose={() => {
             setShowDeleteRecordsModal(false)
           }}
-          onConfirm={handleConfirmDeleteRuns}
+          onConfirm={handleConfirmDeleteAll}
         />
       ) : null}
       <div className={styles.container}>
@@ -59,20 +118,10 @@ export function RecentProtocolRuns({
             {t('run_history')}
           </StyledText>
           <div className={styles.header_actions}>
-            <BasicButton
-              // TODO: wire up actions for downloading all
-              onClick={() => {
-                setShowDeleteRecordsModal(true)
-              }}
-              iconName="download"
-            >
+            <BasicButton onClick={handleDownloadSelected} iconName="download">
               {t('download_all')}
             </BasicButton>
-            <BasicButton
-              onClick={() => {
-                setShowDeleteRecordsModal(true)
-              }}
-            >
+            <BasicButton onClick={handleClickDeleteAll}>
               {t('delete_all')}
             </BasicButton>
           </div>
@@ -136,6 +185,7 @@ export function RecentProtocolRuns({
                         protocolKey={protocol?.key}
                         robotName={robotName}
                         robotIsBusy={robotIsBusy}
+                        isDeleting={deletingIds.has(run.id)}
                         key={index}
                       />
                     )


### PR DESCRIPTION
# Overview

This PR wires up bulk deletion and download of all recent protocol runs in the device details > Recent Protocol Runs tab. This behavior should exactly mirror the behavior of bulk delete/download in the File Manager, without exposing selectability of individual records.

## Test Plan and Hands on Testing

On desktop app, navigate to the device details page of any bot with some protocol runs, and select "Recent Protocol Runs" tab

#### Download all

- click "Download all" in the section header
- verify toast is made to specify download
- verify zip file downloads and contains all run record folders

#### Delete all

- click "Delete all" in the section header
- verify that modal pops up to ask confirmation for deleting the runs
- confirm
- verify that all entries show a spinner instead of overflow menu button. They will be removed when deletion completes.

https://github.com/user-attachments/assets/7eab3a74-581a-4d1b-b8c0-d7c77dc63b1f

## Changelog

- wire up download and delete all behavior in Recent Protocol Runs
- pass loading deletion state to Historical Protocol Run 
- fix tests

## Review requests

see test plan

## Risk assessment

low