### PR TITLE
fix(api): clean up old attached module poller before creating replacement for disconnect tolerance.

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -321,6 +321,7 @@ class SerialConnection:
             reset_buffer_before_write=self._serial._reset_buffer_before_write,
         )
         self._port = new_port
+        self._name = new_port
 
     async def on_retry(self) -> None:
         """

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -286,11 +286,13 @@ class AttachedModulesControl:
             if attached_mod.serial_number != old_mod.serial_number:
                 continue
             log.info(f"Found {old_mod.serial_number} was reconnected")
+            # Stop the new instance's poller/connection before reopening on old_mod.
+            await attached_mod.soft_cleanup()
+            # Stop the parked instance on the old path before rebinding.
+            await old_mod.soft_cleanup()
             if attached_mod.port != old_mod.port:
                 log.info(f"module moved from {old_mod.port} to {attached_mod.port}")
                 await old_mod.move_port(attached_mod.port, attached_mod.usb_port)
-            await attached_mod.soft_cleanup()
-            await old_mod.soft_cleanup()
             await old_mod.attempt_reconnect()
             if old_mod in self._recently_removed_modules:
                 self._recently_removed_modules.remove(old_mod)

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -444,3 +444,31 @@ async def test_send_data_multiple_raises_unhandled(
     with pytest.raises(UnhandledGcode):
         await async_subject._send_data_multiack(data="M411", retries=0, acks=3)
     mock_serial_port.read_until.assert_called_once()
+
+
+async def test_update_port_updates_port_and_name(
+    mock_serial_port: AsyncMock, async_subject: AsyncResponseSerialConnection
+) -> None:
+    """update_port should rebind serial and keep log name aligned with the path."""
+    mock_serial_port.is_open = True
+    new_serial = AsyncMock(spec=AsyncSerial)
+    new_serial._baud_rate = 115200
+    new_serial.get_timeout.return_value = 5.0
+    new_serial._loop = mock_serial_port._loop
+    new_serial._reset_buffer_before_write = False
+    mock_serial_port._baud_rate = 115200
+    mock_serial_port.get_timeout.return_value = 5.0
+    mock_serial_port._loop = mock.sentinel.loop
+    mock_serial_port._reset_buffer_before_write = True
+
+    with patch.object(
+        AsyncResponseSerialConnection,
+        "_build_serial",
+        new=AsyncMock(return_value=new_serial),
+    ) as build_serial:
+        await async_subject.update_port("/dev/ot_module_vacuummodule5")
+
+    mock_serial_port.close.assert_awaited_once()
+    build_serial.assert_awaited_once()
+    assert async_subject.port == "/dev/ot_module_vacuummodule5"
+    assert async_subject.name == "/dev/ot_module_vacuummodule5"

--- a/hardware-testing/hardware_testing/modules/common/utils.py
+++ b/hardware-testing/hardware_testing/modules/common/utils.py
@@ -1,12 +1,44 @@
 """Common utils."""
 
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
 from serial.tools.list_ports import comports  # type: ignore[import]
 
 
+def resolve_ot_module_symlink(device_path: str) -> str:
+    """Map a raw serial device path to its Opentrons udev symlink, if any.
+
+    udev creates nodes like ``/dev/ot_module_vacuummodule5 -> ttyACM5``.
+    Given ``/dev/ttyACM5`` (as returned by pyserial ``comports()``), return the
+    matching ``/dev/ot_module_*`` path by comparing realpaths. Falls back to
+    ``device_path`` when no symlink is found.
+    """
+    try:
+        target_real = os.path.realpath(device_path)
+    except OSError:
+        return device_path
+
+    for link in Path("/dev").glob("ot_module_*"):
+        try:
+            if os.path.realpath(link) == target_real:
+                return str(link)
+        except OSError:
+            continue
+    return device_path
+
+
 def find_module_port(vid: int, pid: int) -> str:
-    """Finds the port of the module with given pid and vid."""
+    """Finds the port of the module with given pid and vid.
+
+    Prefers the ``/dev/ot_module_*`` udev symlink for the matched device when
+    present.
+    """
     for i in comports():
         if i.vid == vid and i.pid == pid:
-            print(f"Found module at port: {i.device}")
-            return i.device
+            port = resolve_ot_module_symlink(i.device)
+            print(f"Found module at port: {port}")
+            return port
     raise RuntimeError("could not find connected module.")

--- a/hardware-testing/hardware_testing/modules/vacuum_module/scripts/vacuum_manifold_stress_test.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/scripts/vacuum_manifold_stress_test.py
@@ -1,6 +1,6 @@
 """Vacuum manifold 400mbar stress test protocol for the Opentrons Flex."""
 import asyncio
-from typing import Any
+from typing import Any, Optional
 from datetime import datetime
 from pathlib import Path
 from opentrons import protocol_api  # type: ignore[import]
@@ -9,6 +9,7 @@ import serial.tools.list_ports  # type: ignore[import]
 from opentrons.drivers import vacuum_module
 from opentrons.drivers.vacuum_module.types import VentState
 from opentrons.hardware_control.ot3api import OT3API  # type: ignore[import]
+from hardware_testing.modules.common.utils import resolve_ot_module_symlink
 import dataclasses
 import time
 import traceback
@@ -119,14 +120,30 @@ def add_parameters(parameters: ParameterContext) -> None:
 
 
 def find_port_by_id(vendorId: int, productId: int) -> str:
-    """Find a serial port by USB vendor and product ID."""
+    """Find a serial port by USB vendor and product ID.
+
+    When an Opentrons udev symlink exists for that device
+    (``/dev/ttyACM5`` -> ``/dev/ot_module_vacuummodule5``), return the symlink
+    so scripts open the same path robot-server uses.
+    """
     ports = serial.tools.list_ports.comports()
     for port in ports:
         # ctx.comment(f"port_vid: {port.vid}, port_pid: {port.pid}")
         if port.vid == vendorId and port.pid == productId:
             # ctx.comment(f"port: {port.device}")
-            return port.device
+            return resolve_ot_module_symlink(port.device)
     return ""
+
+
+def _get_attached_module_driver(
+    api: OT3API,
+    port: str,
+) -> Optional[vacuum_module.VacuumModuleDriver]:
+    """Reuse api module driver when the module is already attached."""
+    for mod in api.attached_modules:
+        if mod.port == port and isinstance(mod, vacuum_module.VacuumModuleDriver):
+            return mod._driver
+    return None
 
 
 def _write_to_csv(
@@ -220,7 +237,11 @@ async def _setup_devices(
     loop = asyncio.get_event_loop()
     # Vacuum Manifold Driver
     port = find_port_by_id(VM_idVendor, VM_idProduct)
-    pump = await vacuum_module.VacuumModuleDriver.create(port=port, loop=self._loop)
+    # Prefer the already-attached module driver so we do not open a second one
+    pump = _get_attached_module_driver(
+        self, port
+    ) or await vacuum_module.VacuumModuleDriver.create(port=port, loop=self._loop)
+
     await pump.set_waste_configs(False)
     # Arduino Water pump Driver
     m_port = find_port_by_id(Ard_idVendor, Ard_idProduct)

--- a/hardware-testing/hardware_testing/modules/vacuum_module/scripts/vm_waste_test.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/scripts/vm_waste_test.py
@@ -7,6 +7,7 @@ from opentrons.drivers import vacuum_module
 from opentrons.drivers.vacuum_module.types import VentState
 from typing import Dict
 from hardware_testing.drivers.flowrate_sensor import driver
+from hardware_testing.modules.common.utils import resolve_ot_module_symlink
 import dataclasses
 import argparse
 import csv
@@ -49,8 +50,9 @@ async def find_port_by_id(vendorId: int, productId: int) -> str:
     for port in ports:
         print(f"port_vid: {port.vid}, port_pid: {port.pid}")
         if port.vid == vendorId and port.pid == productId:
-            print(f"port: {port.device}")
-            return port.device
+            resolved = resolve_ot_module_symlink(port.device)
+            print(f"port: {resolved}")
+            return resolved
     return ""
 
 


### PR DESCRIPTION
# Overview

The module disconnect logic had an issue that could cause both the old and new poller instances to run at the same time, which would cause us to double-send serial commands. We were also keeping the old self._name, which we use for logging, so let's fix that too. Lastly, the hardware-testing side needed to be updated to deal with the disconnect logic, so instead of looking for the module port as `/dev/ttyACM*`, let's resolve that path to the symlink `/dev/ot_module_vacuummodule*` which makes it easier to track.


## Test Plan and Hands on Testing

- [ ] Brief disconnects should not lead to double G-code sends on reconnects.

## Changelog

- Change `self._name` as well when we call `SerialConnection.update_port` function since we use that for logging.
- Stop the old and new pollers before calling `AbstractModule.move_port` so we don't double-poll briefly.
- Update hardware-testing to resolve device paths to their symlink equivalents

## Review requests
## Risk assessment