### PR TITLE
fix(shared-data, app): use getSortedStartingDeckEntries to reduce warnings

### DIFF
--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
@@ -33,8 +33,8 @@ import {
   getLabwareInfoByLiquidId,
   getLabwareLiquidRenderInfoFromStack,
   getModuleFromStack,
+  getSortedStartingDeckEntries,
   getStackedItemsOnStartingDeck,
-  getStacksWithLabware,
   HEATERSHAKER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
@@ -105,13 +105,10 @@ export function ProtocolSetupLabware({
     () => getLabwareInfoByLiquidId(mostRecentAnalysis?.commands ?? []),
     [mostRecentAnalysis]
   )
-  const stacksWithLaware = useMemo(
-    () => getStacksWithLabware(startingDeck),
+  const sortedStartingDeckEntries = useMemo(
+    () => getSortedStartingDeckEntries(startingDeck),
     [startingDeck]
   )
-  const sortedStartingDeckEntries = Object.entries(stacksWithLaware)
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .filter(([key, value]) => key !== 'offDeck')
   const offDeckItems = useMemo(
     () =>
       mostRecentAnalysis != null
@@ -287,8 +284,7 @@ function LabwareLatch({
   let icon: 'latch-open' | 'latch-closed' | null = null
 
   const latchCommand:
-    | HeaterShakerOpenLatchCreateCommand
-    | HeaterShakerCloseLatchCreateCommand = {
+    HeaterShakerOpenLatchCreateCommand | HeaterShakerCloseLatchCreateCommand = {
     commandType: isLatchClosed
       ? 'heaterShaker/openLabwareLatch'
       : 'heaterShaker/closeLabwareLatch',

--- a/shared-data/js/helpers/getStackedItemsOnStartingDeck.ts
+++ b/shared-data/js/helpers/getStackedItemsOnStartingDeck.ts
@@ -563,3 +563,24 @@ export function getModuleFromStack(
   )
   return moduleInStack ?? null
 }
+
+export const getSortedStartingDeckEntries = (
+  startingDeck: StackedItemsOnDeck
+): Array<{
+  location: string
+  stack: StackItem[]
+}> => {
+  const entriesOnDeck = Object.entries(startingDeck).filter(
+    ([location]) => location !== 'offDeck'
+  )
+  const stacksWithLabware = entriesOnDeck.flatMap(([location, stacks]) => {
+    const labwareStacks = stacks.filter(stack =>
+      stack.some(item => 'labwareId' in item)
+    )
+    return labwareStacks.map(stack => ({ location, stack }))
+  })
+  const sortedStartingDeckEntries = stacksWithLabware.sort((a, b) =>
+    a.location.localeCompare(b.location)
+  )
+  return sortedStartingDeckEntries
+}

--- a/shared-data/js/helpers/getStackedItemsOnStartingDeck.ts
+++ b/shared-data/js/helpers/getStackedItemsOnStartingDeck.ts
@@ -45,7 +45,7 @@ export interface ModuleInStack {
 export type StackItem = LabwareInStack | ModuleInStack
 
 export interface StackedItemsOnDeck {
-  [location: string]: StackItem[]
+  [location: string]: StackItem[][]
 }
 
 interface LoadLidOnLabwareParams extends Omit<LoadLidParams, 'location'> {


### PR DESCRIPTION


# Overview
use getSortedStartingDeckEntries to reduce warnings to remove warnings

closes AUTH-3041

## Test Plan and Hands on Testing
- push this branch to a Flex (QAPV1) `make make -C app-shell-odd push-ot3 host=robot_ip`
- set up the protocol that is attached to the ticket

## Changelog
- add `getSortedStartingDeckEntries` to shared-data to align with https://github.com/Opentrons/opentrons/pull/21905

## Review requests


## Risk assessment
low
