### PR TITLE
chore(api, hardware): Remove evt rear panel support

### DIFF
--- a/api/src/opentrons/__init__.py
+++ b/api/src/opentrons/__init__.py
@@ -127,7 +127,6 @@ async def _create_thread_manager() -> ThreadManagedHardware:
 
         thread_manager = ThreadManager(
             ThreadManager.nonblocking_builder(OT3API.build_hardware_controller),
-            use_usb_bus=ff.rear_panel_integration(),
             status_bar_enabled=ff.status_bar_enabled(),
             feature_flags=hw_types.HardwareFeatureFlags.build_from_ff(),
         )

--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -33,14 +33,6 @@ def enable_ot3_hardware_controller() -> bool:
     )
 
 
-def rear_panel_integration() -> bool:
-    """Whether to enable usb connected rear_panel for the OT-3."""
-
-    return advs.get_setting_with_env_overload(
-        "rearPanelIntegration", RobotTypeEnum.FLEX
-    )
-
-
 def stall_detection_enabled() -> bool:
     return not advs.get_setting_with_env_overload(
         "disableStallDetection", RobotTypeEnum.FLEX

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -293,7 +293,6 @@ class OT3Controller(FlexBackend):
     async def build(
         cls,
         config: OT3Config,
-        use_usb_bus: bool = False,
         check_updates: bool = True,
         feature_flags: Optional[HardwareFeatureFlags] = None,
     ) -> OT3Controller:
@@ -306,15 +305,13 @@ class OT3Controller(FlexBackend):
             Instance.
         """
         driver = await build_driver(DriverSettings())
-        usb_driver = None
-        if use_usb_bus:
-            try:
-                usb_driver = await build_rear_panel_driver()
-            except IOError as e:
-                log.error(
-                    "No rear panel device found, probably an EVT bot, disable rearPanelIntegration feature flag if it is"
-                )
-                raise e
+        try:
+            usb_driver = await build_rear_panel_driver()
+        except IOError as e:
+            log.error(
+                "No rear panel device found, probably an EVT bot, Downgrade to v9.1.2 or lower and disable rearPanelIntegration feature flag if it is"
+            )
+            raise e
         inst = cls(
             config,
             driver=driver,

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -282,7 +282,7 @@ class OT3Controller(FlexBackend):
 
     _initialized: bool
     _messenger: CanMessenger
-    _usb_messenger: Optional[BinaryMessenger]
+    _usb_messenger: BinaryMessenger
     _position: Dict[NodeId, float]
     _encoder_position: Dict[NodeId, float]
     _motor_status: Dict[NodeId, MotorStatus]
@@ -326,7 +326,7 @@ class OT3Controller(FlexBackend):
         self,
         config: OT3Config,
         driver: AbstractCanDriver,
-        usb_driver: Optional[SerialUsbDriver] = None,
+        usb_driver: SerialUsbDriver,
         eeprom_driver: Optional[EEPROMDriver] = None,
         check_updates: bool = True,
         feature_flags: Optional[HardwareFeatureFlags] = None,
@@ -477,18 +477,16 @@ class OT3Controller(FlexBackend):
     @staticmethod
     def _build_system_hardware(
         can_messenger: CanMessenger,
-        usb_driver: Optional[SerialUsbDriver],
+        usb_driver: SerialUsbDriver,
         eeprom_driver: Optional[EEPROMDriver],
     ) -> SystemDrivers:
         gpio = OT3GPIO("hardware_control")
         eeprom_driver = eeprom_driver or EEPROMDriver(gpio)
         eeprom_driver.setup()
         gpio_dev: Union[OT3GPIO, RemoteOT3GPIO] = gpio
-        usb_messenger: Optional[BinaryMessenger] = None
-        if usb_driver:
-            usb_messenger = BinaryMessenger(usb_driver)
-            usb_messenger.start()
-            gpio_dev = RemoteOT3GPIO(usb_messenger)
+        usb_messenger = BinaryMessenger(usb_driver)
+        usb_messenger.start()
+        gpio_dev = RemoteOT3GPIO(usb_messenger)
         return SystemDrivers(
             can_messenger,
             gpio_dev,
@@ -1721,18 +1719,15 @@ class OT3Controller(FlexBackend):
             )
             _module_door_listener(door_state)
 
-        if self._usb_messenger is not None:
-            self._usb_messenger.add_listener(
-                _door_listener,
-                lambda message_id: bool(
-                    message_id == BinaryMessageId.door_switch_state_info
-                ),
-            )
+        self._usb_messenger.add_listener(
+            _door_listener,
+            lambda message_id: bool(
+                message_id == BinaryMessageId.door_switch_state_info
+            ),
+        )
 
     async def build_estop_detector(self) -> bool:
         """Must be called to set up the estop detector & state machine."""
-        if self._drivers.usb_messenger is None:
-            return False
         self._estop_detector = await EstopDetector.build(
             usb_messenger=self._drivers.usb_messenger
         )

--- a/api/src/opentrons/hardware_control/backends/ot3controller.py
+++ b/api/src/opentrons/hardware_control/backends/ot3controller.py
@@ -22,7 +22,6 @@ from typing import (
     Set,
     Tuple,
     TypeVar,
-    Union,
     cast,
 )
 
@@ -72,7 +71,7 @@ from opentrons_hardware.drivers.can_bus import CanMessenger, DriverSettings
 from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
 from opentrons_hardware.drivers.can_bus.build import build_driver
 from opentrons_hardware.drivers.eeprom import EEPROMData, EEPROMDriver
-from opentrons_hardware.drivers.gpio import OT3GPIO, RemoteOT3GPIO
+from opentrons_hardware.drivers.gpio import RemoteOT3GPIO
 from opentrons_hardware.firmware_bindings.binary_constants import BinaryMessageId
 from opentrons_hardware.firmware_bindings.constants import (
     ErrorCode,
@@ -480,13 +479,11 @@ class OT3Controller(FlexBackend):
         usb_driver: SerialUsbDriver,
         eeprom_driver: Optional[EEPROMDriver],
     ) -> SystemDrivers:
-        gpio = OT3GPIO("hardware_control")
-        eeprom_driver = eeprom_driver or EEPROMDriver(gpio)
-        eeprom_driver.setup()
-        gpio_dev: Union[OT3GPIO, RemoteOT3GPIO] = gpio
         usb_messenger = BinaryMessenger(usb_driver)
         usb_messenger.start()
-        gpio_dev = RemoteOT3GPIO(usb_messenger)
+        gpio_dev = RemoteOT3GPIO(usb_messenger, "hardware_control")
+        eeprom_driver = eeprom_driver or EEPROMDriver(gpio_dev)
+        eeprom_driver.setup()
         return SystemDrivers(
             can_messenger,
             gpio_dev,
@@ -562,7 +559,7 @@ class OT3Controller(FlexBackend):
         return hold_currents
 
     @property
-    def gpio_chardev(self) -> Union[OT3GPIO, RemoteOT3GPIO]:
+    def gpio_chardev(self) -> RemoteOT3GPIO:
         """Get the GPIO device."""
         return self._gpio_dev
 
@@ -1660,37 +1657,29 @@ class OT3Controller(FlexBackend):
         if self._gpio_dev is None:
             log.error("no gpio control available")
             raise IOError("no gpio control")
-        elif isinstance(self._gpio_dev, RemoteOT3GPIO):
-            await self._gpio_dev.deactivate_estop()
         else:
-            self._gpio_dev.deactivate_estop()
+            await self._gpio_dev.deactivate_estop()
 
     async def engage_estop(self) -> None:
         if self._gpio_dev is None:
             log.error("no gpio control available")
             raise IOError("no gpio control")
-        elif isinstance(self._gpio_dev, RemoteOT3GPIO):
-            await self._gpio_dev.activate_estop()
         else:
-            self._gpio_dev.activate_estop()
+            await self._gpio_dev.activate_estop()
 
     async def release_sync(self) -> None:
         if self._gpio_dev is None:
             log.error("no gpio control available")
             raise IOError("no gpio control")
-        elif isinstance(self._gpio_dev, RemoteOT3GPIO):
-            await self._gpio_dev.deactivate_nsync_out()
         else:
-            self._gpio_dev.deactivate_nsync_out()
+            await self._gpio_dev.deactivate_nsync_out()
 
     async def engage_sync(self) -> None:
         if self._gpio_dev is None:
             log.error("no gpio control available")
             raise IOError("no gpio control")
-        elif isinstance(self._gpio_dev, RemoteOT3GPIO):
-            await self._gpio_dev.activate_nsync_out()
         else:
-            self._gpio_dev.activate_nsync_out()
+            await self._gpio_dev.activate_nsync_out()
 
     async def door_state(self) -> DoorState:
         door_open = await get_door_state(self._usb_messenger)

--- a/api/src/opentrons/hardware_control/backends/subsystem_manager.py
+++ b/api/src/opentrons/hardware_control/backends/subsystem_manager.py
@@ -50,7 +50,7 @@ class SubsystemManager:
     """
 
     _can_messenger: can_bus.CanMessenger
-    _usb_messenger: Optional[binary_usb.BinaryMessenger]
+    _usb_messenger: binary_usb.BinaryMessenger
     _tool_detector: tools.detector.ToolDetector
     _network_info: network.NetworkInfo
     _tool_detection_task: "Optional[asyncio.Task[None]]"
@@ -65,7 +65,7 @@ class SubsystemManager:
     def __init__(
         self,
         can_messenger: can_bus.CanMessenger,
-        usb_messenger: Optional[binary_usb.BinaryMessenger],
+        usb_messenger: binary_usb.BinaryMessenger,
         tool_detector: tools.detector.ToolDetector,
         network_info: network.NetworkInfo,
         update_bag: FirmwareUpdate,
@@ -79,14 +79,13 @@ class SubsystemManager:
             NodeId.gantry_x,
             NodeId.gantry_y,
             NodeId.head,
+            USBTarget.rear_panel,
         }
         self._tool_task_condition = asyncio.Condition()
         self._tool_task_state = False
         self._updates_required = {}
         self._updates_ongoing = {}
         self._update_bag = update_bag
-        if self._usb_messenger:
-            self._expected_core_targets.add(USBTarget.rear_panel)
         self._present_tools = tools.types.ToolSummary(
             left=None, right=None, gripper=None
         )

--- a/api/src/opentrons/hardware_control/ot3api.py
+++ b/api/src/opentrons/hardware_control/ot3api.py
@@ -429,7 +429,6 @@ class OT3API(
         config: Union[OT3Config, RobotConfig, None] = None,
         loop: Optional[asyncio.AbstractEventLoop] = None,
         strict_attached_instruments: bool = True,
-        use_usb_bus: bool = False,
         update_firmware: bool = True,
         status_bar_enabled: bool = True,
         feature_flags: Optional[HardwareFeatureFlags] = None,
@@ -447,7 +446,6 @@ class OT3API(
 
         backend = await OT3Controller.build(
             checked_config,
-            use_usb_bus,
             check_updates=update_firmware,
             feature_flags=feature_flags,
         )

--- a/api/src/opentrons/hardware_control/pyro_utils/pyro_process_entry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/pyro_process_entry.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import Pyro5.api as pyro
 
-from opentrons.config import feature_flags as ff
 from opentrons.config import robot_configs
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.pyro_utils.serpent_type_registry import (
@@ -51,7 +50,6 @@ def _build_thread_manager(use_simulator: bool) -> ThreadManager[OT3API]:
     else:
         return ThreadManager(
             OT3API.build_hardware_controller,
-            use_usb_bus=ff.rear_panel_integration(),
             feature_flags=HardwareFeatureFlags.build_from_ff(),
         )
 

--- a/api/src/opentrons/hardware_control/scripts/repl.py
+++ b/api/src/opentrons/hardware_control/scripts/repl.py
@@ -92,7 +92,6 @@ if ff.enable_ot3_hardware_controller():
     def build_thread_manager() -> ThreadManager[Union[API, OT3API]]:
         return ThreadManager(
             OT3API.build_hardware_controller,
-            use_usb_bus=ff.rear_panel_integration(),
             update_firmware=update_firmware,
             feature_flags=HardwareFeatureFlags.build_from_ff(),
         )

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -163,6 +163,7 @@ def mock_can_driver(mock_messenger: mock.AsyncMock) -> AbstractCanDriver:
 @pytest.fixture
 def mock_usb_driver() -> SerialUsbDriver:
     driver = mock.AsyncMock(spec=SerialUsbDriver)
+
     # ignoring this type error because this is a very weird function that will in fact
     # do nothing, but has to have the yield in there for the compiler to make it a
     # generator function
@@ -188,7 +189,7 @@ async def controller(
     mock_usb_driver: SerialUsbDriver,
     mock_eeprom_driver: EEPROMDriver,
 ) -> AsyncIterator[OT3Controller]:
-    with mock.patch("opentrons.hardware_control.backends.ot3controller.OT3GPIO"):
+    with mock.patch("opentrons.hardware_control.backends.ot3controller.RemoteOT3GPIO"):
         controller = OT3Controller(
             config=mock_config,
             driver=mock_can_driver,

--- a/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
+++ b/api/tests/opentrons/hardware_control/backends/test_ot3_controller.py
@@ -162,7 +162,17 @@ def mock_can_driver(mock_messenger: mock.AsyncMock) -> AbstractCanDriver:
 
 @pytest.fixture
 def mock_usb_driver() -> SerialUsbDriver:
-    return mock.AsyncMock(spec=SerialUsbDriver)
+    driver = mock.AsyncMock(spec=SerialUsbDriver)
+    # ignoring this type error because this is a very weird function that will in fact
+    # do nothing, but has to have the yield in there for the compiler to make it a
+    # generator function
+    async def _fake_message_retrieve(d):  # type: ignore[no-untyped-def]
+        while True:
+            await asyncio.sleep(1)
+        yield
+
+    driver.__aiter__ = _fake_message_retrieve
+    return driver
 
 
 @pytest.fixture
@@ -175,11 +185,15 @@ def mock_eeprom_driver() -> EEPROMDriver:
 async def controller(
     mock_config: OT3Config,
     mock_can_driver: AbstractCanDriver,
+    mock_usb_driver: SerialUsbDriver,
     mock_eeprom_driver: EEPROMDriver,
 ) -> AsyncIterator[OT3Controller]:
     with mock.patch("opentrons.hardware_control.backends.ot3controller.OT3GPIO"):
         controller = OT3Controller(
-            mock_config, mock_can_driver, eeprom_driver=mock_eeprom_driver
+            config=mock_config,
+            driver=mock_can_driver,
+            usb_driver=mock_usb_driver,
+            eeprom_driver=mock_eeprom_driver,
         )
         try:
             yield controller

--- a/hardware-testing/hardware_testing/gravimetric/helpers.py
+++ b/hardware-testing/hardware_testing/gravimetric/helpers.py
@@ -49,7 +49,6 @@ def get_api_context(
         config: Union[OT3Config, RobotConfig, None] = None,
         loop: Optional[asyncio.AbstractEventLoop] = None,
         strict_attached_instruments: bool = True,
-        use_usb_bus: bool = False,
         update_firmware: bool = True,
         status_bar_enabled: bool = True,
         feature_flags: Optional[HardwareFeatureFlags] = None,

--- a/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
+++ b/hardware-testing/hardware_testing/opentrons_api/helpers_ot3.py
@@ -315,14 +315,12 @@ async def build_async_ot3_hardware_api(
         builder = OT3API.build_hardware_controller
         stop_server_ot3()
         restart_canbus_ot3()
-        kwargs["use_usb_bus"] = True  # type: ignore[assignment]
     try:
         api = await builder(loop=loop, **kwargs)  # type: ignore[arg-type]
     except Exception as e:
         if is_simulating:
             raise e
         print(e)
-        kwargs["use_usb_bus"] = False  # type: ignore[assignment]
         api = await builder(loop=loop, **kwargs)  # type: ignore[arg-type]
     await reset_api(api)
     return api

--- a/hardware/opentrons_hardware/drivers/__init__.py
+++ b/hardware/opentrons_hardware/drivers/__init__.py
@@ -1,11 +1,9 @@
 """Drivers package."""
 
-from typing import Optional, Union
-
 from .binary_usb import BinaryMessenger
 from .can_bus import CanMessenger
 from .eeprom import EEPROMDriver
-from .gpio import OT3GPIO, RemoteOT3GPIO
+from .gpio import RemoteOT3GPIO
 
 
 class SystemDrivers:
@@ -14,14 +12,14 @@ class SystemDrivers:
     def __init__(
         self,
         can_messenger: CanMessenger,
-        gpio_dev: Union[OT3GPIO, RemoteOT3GPIO],
+        gpio_dev: RemoteOT3GPIO,
         eeprom: EEPROMDriver,
         usb_messenger: BinaryMessenger,
     ) -> None:
         """Constructor"""
         self.can_messenger: CanMessenger = can_messenger
         self.usb_messenger: BinaryMessenger = usb_messenger
-        self.gpio_dev: Union[OT3GPIO, RemoteOT3GPIO] = gpio_dev
+        self.gpio_dev: RemoteOT3GPIO = gpio_dev
         self.eeprom: EEPROMDriver = eeprom
 
 
@@ -30,6 +28,5 @@ __all__ = [
     "CanMessenger",
     "BinaryMessenger",
     "EEPROMDriver",
-    "OT3GPIO",
     "RemoteOT3GPIO",
 ]

--- a/hardware/opentrons_hardware/drivers/__init__.py
+++ b/hardware/opentrons_hardware/drivers/__init__.py
@@ -16,11 +16,11 @@ class SystemDrivers:
         can_messenger: CanMessenger,
         gpio_dev: Union[OT3GPIO, RemoteOT3GPIO],
         eeprom: EEPROMDriver,
-        usb_messenger: Optional[BinaryMessenger] = None,
+        usb_messenger: BinaryMessenger,
     ) -> None:
         """Constructor"""
         self.can_messenger: CanMessenger = can_messenger
-        self.usb_messenger: Optional[BinaryMessenger] = usb_messenger
+        self.usb_messenger: BinaryMessenger = usb_messenger
         self.gpio_dev: Union[OT3GPIO, RemoteOT3GPIO] = gpio_dev
         self.eeprom: EEPROMDriver = eeprom
 

--- a/hardware/opentrons_hardware/drivers/eeprom/build.py
+++ b/hardware/opentrons_hardware/drivers/eeprom/build.py
@@ -1,32 +1,40 @@
 """Factory for building the eeprom driver."""
 
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Iterator, Optional
+from typing import AsyncIterator, Optional
 
-from ..gpio import OT3GPIO
+from ..gpio import RemoteOT3GPIO
 from .eeprom import (
     EEPROMDriver,
+)
+from opentrons_hardware.drivers.binary_usb import (
+    SerialUsbDriver,
+    build_rear_panel_driver,
+    build_rear_panel_messenger,
 )
 
 DEFAULT_EEPROM_PATH = Path("/sys/bus/i2c/devices/3-0050/eeprom")
 
 
-def build_eeprom_driver(
-    gpio: Optional[OT3GPIO] = None, eeprom_path: Optional[Path] = None
+async def build_eeprom_driver(
+    gpio: Optional[RemoteOT3GPIO] = None, eeprom_path: Optional[Path] = None
 ) -> EEPROMDriver:
     """Create an instance of the eeprom driver"""
-    gpio = gpio or OT3GPIO("eeprom_hardware_controller")
+    usb_driver: SerialUsbDriver = await build_rear_panel_driver()
+    usb_messenger = build_rear_panel_messenger(usb_driver)
+    usb_messenger.start()
+    gpio = gpio or RemoteOT3GPIO(usb_messenger, "eeprom_hardware_controller")
     eeprom_path = eeprom_path or DEFAULT_EEPROM_PATH
     eeprom_driver = EEPROMDriver(gpio, eeprom_path=eeprom_path)
     eeprom_driver.setup()
     return eeprom_driver
 
 
-@contextmanager
-def eeprom_driver() -> Iterator[EEPROMDriver]:
+@asynccontextmanager
+async def eeprom_driver() -> AsyncIterator[EEPROMDriver]:
     """Context manager creating an eeprom driver."""
-    d = build_eeprom_driver()
+    d = await build_eeprom_driver()
     try:
         yield d
     finally:

--- a/hardware/opentrons_hardware/drivers/eeprom/eeprom.py
+++ b/hardware/opentrons_hardware/drivers/eeprom/eeprom.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from types import TracebackType
 from typing import Any, Optional, Set, Tuple, Type
 
-from ..gpio import OT3GPIO
+from ..gpio import RemoteOT3GPIO
 from .types import (
     EEPROMData,
     Property,
@@ -36,7 +36,7 @@ class EEPROMDriver:
 
     def __init__(
         self,
-        gpio: OT3GPIO,
+        gpio: RemoteOT3GPIO,
         bus: Optional[int] = DEFAULT_BUS,
         address: Optional[str] = DEFAULT_ADDRESS,
         eeprom_path: Optional[Path] = None,

--- a/hardware/opentrons_hardware/drivers/gpio/__init__.py
+++ b/hardware/opentrons_hardware/drivers/gpio/__init__.py
@@ -16,15 +16,13 @@ from opentrons_hardware.firmware_bindings.messages.binary_message_definitions im
 )
 
 CONSUMER_NAME_DEFAULT: Final[str] = "opentrons"
-ESTOP_OUT_GPIO_NAME: Final[str] = "SODIMM_210"
-NSYNC_OUT_GPIO_NAME: Final[str] = "SODIMM_206"
 EEPROM_WP_OUT_GPIO_NAME: Final[str] = "SODIMM_222"
 
 LOG = getLogger(__name__)
 
 
-class OT3GPIO:
-    """Driver class for OT3 gpio lines."""
+class RemoteOT3GPIO:
+    """Driver class for OT3 gpio lines that are controlled remotely."""
 
     @staticmethod
     def _get_gpiod() -> Any:
@@ -40,82 +38,28 @@ class OT3GPIO:
             LOG.warning("could not import gpiod")
             return mock.MagicMock()
 
-    def __init__(self, consumer_name: Optional[str] = None) -> None:
-        """Build the GPIO handler.
+    def _get_usb_messenger(self) -> BinaryMessenger:
+        return self._usb_messenger
 
-        If a consumer name is provided (which can add more semantic information to
-        other programs trying to find out who holds a line) then it will be used;
-        otherwise, the default is opentrons.
-        """
+    def __init__(
+        self, usb_messenger: BinaryMessenger, consumer_name: Optional[str] = None
+    ) -> None:
+        """Create a diver for controlling gpio lines via a remote device."""
         self._consumer_name = consumer_name or CONSUMER_NAME_DEFAULT
         self._gpiod = self._get_gpiod()
-        self._estop_out_line = self._gpiod.find_line(ESTOP_OUT_GPIO_NAME)
-        self._estop_out_line.request(
-            self._consumer_name, type=self._gpiod.LINE_REQ_DIR_OUT
-        )
-        self._nsync_out_line = self._gpiod.find_line(NSYNC_OUT_GPIO_NAME)
-        self._nsync_out_line.request(
-            self._consumer_name, type=self._gpiod.LINE_REQ_DIR_OUT
-        )
+        self._usb_messenger = usb_messenger
         self._eeprom_wp_out_line = self._gpiod.find_line(EEPROM_WP_OUT_GPIO_NAME)
         self._eeprom_wp_out_line.request(
             self._consumer_name, type=self._gpiod.LINE_REQ_DIR_OUT
         )
-        self.deactivate_estop()
-        self.deactivate_nsync_out()
         self.deactivate_eeprom_wp()
         sleep(1)
 
     def __del__(self) -> None:
         try:
-            self._estop_out_line.release()
-            self._nsync_out_line.release()
             self._eeprom_wp_out_line.release()
         except Exception:
             pass
-
-    def activate_estop(self) -> None:
-        """Assert the emergency stop, which will disable all motors."""
-        self._estop_out_line.set_value(0)
-
-    def deactivate_estop(self) -> None:
-        """Stop asserting the emergency stop.
-
-        If no other node is asserting estop, then motors can be enabled
-        again.
-        """
-        self._estop_out_line.set_value(1)
-
-    def activate_nsync_out(self) -> None:
-        """Assert the nsync out line."""
-        self._nsync_out_line.set_value(0)
-
-    def deactivate_nsync_out(self) -> None:
-        """Stop asserting the nsync out line."""
-        self._nsync_out_line.set_value(1)
-
-    def activate_eeprom_wp(self) -> None:
-        """Assert the eeprom write protect, which will enable writes to the eeprom."""
-        self._eeprom_wp_out_line.set_value(0)
-
-    def deactivate_eeprom_wp(self) -> None:
-        """Stop asserting the eeprom wp line."""
-        self._eeprom_wp_out_line.set_value(1)
-
-
-class RemoteOT3GPIO:
-    """Driver class for OT3 gpio lines that are controlled remotely."""
-
-    def _get_usb_messenger(self) -> Any:
-        if self._usb_messenger is not None:
-            return self._usb_messenger
-        else:
-            LOG.warning("Remote gpio control not connected")
-            return mock.MagicMock()
-
-    def __init__(self, usb_messenger: Optional[BinaryMessenger]) -> None:
-        """Create a diver for controlling gpio lines via a remote device."""
-        self._usb_messenger = usb_messenger
 
     async def activate_estop(self) -> None:
         """Assert the emergency stop, which will disable all motors."""
@@ -136,3 +80,11 @@ class RemoteOT3GPIO:
     async def deactivate_nsync_out(self) -> None:
         """Stop asserting the nsync out line."""
         await self._get_usb_messenger().send(ReleaseSyncOut())
+
+    def activate_eeprom_wp(self) -> None:
+        """Assert the eeprom write protect, which will enable writes to the eeprom."""
+        self._eeprom_wp_out_line.set_value(0)
+
+    def deactivate_eeprom_wp(self) -> None:
+        """Stop asserting the eeprom wp line."""
+        self._eeprom_wp_out_line.set_value(1)

--- a/hardware/opentrons_hardware/firmware_update/run.py
+++ b/hardware/opentrons_hardware/firmware_update/run.py
@@ -163,7 +163,7 @@ class RunUpdate:
     def __init__(
         self,
         can_messenger: CanMessenger,
-        usb_messenger: Optional[BinaryMessenger],
+        usb_messenger: BinaryMessenger,
         update_details: Dict[FirmwareTarget, str],
         retry_count: int,
         timeout_seconds: float,
@@ -199,9 +199,6 @@ class RunUpdate:
         )
 
     async def _reconnect(self, vid: int, pid: int, baudrate: int, timeout: int) -> bool:
-        if self._usb_messenger is None:
-            return False
-
         device_running = False
         for i in range(self._retry_count):
             logger.info(f"attempt #{i} to reconnect")
@@ -409,18 +406,16 @@ class RunUpdate:
             for target, filepath in self._update_details.items()
             if target in NodeId
         ]
-        usb_tasks = []
-        if self._usb_messenger is not None:
-            usb_tasks = [
-                self._run_usb_update(
-                    messenger=self._usb_messenger,
-                    retry_count=self._retry_count,
-                    update_file=filepath,
-                    usb_target=USBTarget(target),
-                )
-                for target, filepath in self._update_details.items()
-                if target in USBTarget
-            ]
+        usb_tasks = [
+            self._run_usb_update(
+                messenger=self._usb_messenger,
+                retry_count=self._retry_count,
+                update_file=filepath,
+                usb_target=USBTarget(target),
+            )
+            for target, filepath in self._update_details.items()
+            if target in USBTarget
+        ]
         tasks = can_tasks + usb_tasks
         task = asyncio.gather(*tasks)
         while True:

--- a/hardware/opentrons_hardware/hardware_control/network.py
+++ b/hardware/opentrons_hardware/hardware_control/network.py
@@ -66,7 +66,7 @@ class NetworkInfo:
     def __init__(
         self,
         can_messenger: CanMessenger,
-        usb_messenger: Optional[BinaryMessenger] = None,
+        usb_messenger: BinaryMessenger,
     ) -> None:
         """Construct.
 
@@ -176,7 +176,7 @@ class NetworkInfo:
 class UsbNetworkInfo:
     """This class is responsible for keeping track of usb devices."""
 
-    def __init__(self, usb_messenger: Optional[BinaryMessenger]) -> None:
+    def __init__(self, usb_messenger: BinaryMessenger) -> None:
         """Construct.
 
         Args:
@@ -221,9 +221,6 @@ class UsbNetworkInfo:
         """
         event = asyncio.Event()
         targets: Dict[USBTarget, DeviceInfoCache] = dict()
-        if self._usb_messenger is None:
-            self._device_info_cache = {}
-            return targets
 
         if not devices:
             return targets

--- a/hardware/opentrons_hardware/hardware_control/rear_panel_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/rear_panel_settings.py
@@ -53,12 +53,9 @@ class RearPinState:
 
 
 async def write_eeprom(
-    messenger: Optional[BinaryMessenger], data_addr: int, data_len: int, data: bytes
+    messenger: BinaryMessenger, data_addr: int, data_len: int, data: bytes
 ) -> bool:
     """Writes up to 8 bytes from the eeprom."""
-    if messenger is None:
-        # the EVT bots don't have switches so just return that the door is closed
-        return False
     if data_addr < 0 or data_addr > 0x4000 or data_len < 0 or data_len > 8:
         return False
     response = await messenger.send_and_receive(
@@ -73,12 +70,9 @@ async def write_eeprom(
 
 
 async def read_eeprom(
-    messenger: Optional[BinaryMessenger], data_addr: int, data_len: int
+    messenger: BinaryMessenger, data_addr: int, data_len: int
 ) -> bytes:
     """Reads up to 8 bytes from the eeprom."""
-    if messenger is None:
-        # the EVT bots don't have switches so just return that the door is closed
-        return b""
     if data_addr < 0 or data_addr > 0x4000 or data_len < 0 or data_len > 8:
         return b""
     response = await messenger.send_and_receive(
@@ -93,11 +87,8 @@ async def read_eeprom(
     return bytes(cast(ReadEEPromResponse, response).data.value)
 
 
-async def get_door_state(messenger: Optional[BinaryMessenger]) -> bool:
+async def get_door_state(messenger: BinaryMessenger) -> bool:
     """Returns true if the door is currently open."""
-    if messenger is None:
-        # the EVT bots don't have switches so just return that the door is closed
-        return False
     response = await messenger.send_and_receive(
         message=DoorSwitchStateRequest(),
         response_type=DoorSwitchStateInfo,
@@ -107,11 +98,8 @@ async def get_door_state(messenger: Optional[BinaryMessenger]) -> bool:
     return bool(cast(DoorSwitchStateInfo, response).door_open.value)
 
 
-async def set_deck_light(setting: int, messenger: Optional[BinaryMessenger]) -> bool:
+async def set_deck_light(setting: int, messenger: BinaryMessenger) -> bool:
     """Turn the deck light on or off."""
-    if messenger is None:
-        # the EVT bots don't have rear panels...
-        return False
     response = await messenger.send_and_receive(
         message=SetDeckLightRequest(setting=utils.UInt8Field(setting)),
         response_type=Ack,
@@ -119,11 +107,8 @@ async def set_deck_light(setting: int, messenger: Optional[BinaryMessenger]) -> 
     return response is not None
 
 
-async def get_deck_light_state(messenger: Optional[BinaryMessenger]) -> bool:
+async def get_deck_light_state(messenger: BinaryMessenger) -> bool:
     """Returns true if the light is currently on."""
-    if messenger is None:
-        # the EVT bots don't have switches so just return that the door is closed
-        return False
     response = await messenger.send_and_receive(
         message=GetDeckLightRequest(),
         response_type=GetDeckLightResponse,
@@ -133,11 +118,8 @@ async def get_deck_light_state(messenger: Optional[BinaryMessenger]) -> bool:
     return bool(cast(GetDeckLightResponse, response).setting.value)
 
 
-async def set_sync_pin(setting: int, messenger: Optional[BinaryMessenger]) -> bool:
+async def set_sync_pin(setting: int, messenger: BinaryMessenger) -> bool:
     """Turn the sync pin on or off."""
-    if messenger is None:
-        # the EVT bots don't have rear panels...
-        return False
     message: BinaryMessageDefinition = ReleaseSyncOut()
     if setting:
         message = EngageSyncOut()
@@ -158,12 +140,9 @@ def _clamp_rgb(val: int) -> int:
 
 
 async def set_ui_color(
-    red: int, blue: int, green: int, white: int, messenger: Optional[BinaryMessenger]
+    red: int, blue: int, green: int, white: int, messenger: BinaryMessenger
 ) -> bool:
     """Command the UI light to set to a particular RGBW value."""
-    if messenger is None:
-        # the EVT bots don't have rear panels...
-        return False
     response = await messenger.send_and_receive(
         message=AddLightActionRequest(
             red=utils.UInt8Field(_clamp_rgb(red)),
@@ -182,11 +161,9 @@ async def set_ui_color(
     return response is not None
 
 
-async def get_all_pin_state(messenger: Optional[BinaryMessenger]) -> RearPinState:
+async def get_all_pin_state(messenger: BinaryMessenger) -> RearPinState:
     """Returns the state of all IO GPIO pins on the rear panel."""
     current_state = RearPinState()
-    if messenger is None:
-        return current_state
 
     # estop port detection pins
     response = await messenger.send_and_receive(

--- a/hardware/opentrons_hardware/hardware_control/rear_panel_settings.py
+++ b/hardware/opentrons_hardware/hardware_control/rear_panel_settings.py
@@ -2,7 +2,7 @@
 
 import logging
 from dataclasses import dataclass
-from typing import Optional, cast
+from typing import cast
 
 from opentrons_hardware.drivers.binary_usb import BinaryMessenger
 from opentrons_hardware.firmware_bindings import utils

--- a/hardware/opentrons_hardware/scripts/can_comm.py
+++ b/hardware/opentrons_hardware/scripts/can_comm.py
@@ -8,9 +8,10 @@ from enum import Enum
 from logging.config import dictConfig
 from typing import Callable, Sequence, Type, TypeVar
 
+from opentrons_hardware.drivers.binary_usb import BinaryMessenger, SerialUsbDriver
 from opentrons_hardware.drivers.can_bus import build
 from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
-from opentrons_hardware.drivers.gpio import OT3GPIO
+from opentrons_hardware.drivers.gpio import RemoteOT3GPIO
 from opentrons_hardware.firmware_bindings.arbitration_id import (
     ArbitrationId,
     ArbitrationIdParts,
@@ -243,8 +244,10 @@ async def run_ui(driver: AbstractCanDriver) -> None:
 async def run(args: argparse.Namespace) -> None:
     """Entry point for script."""
     # build a gpio handler which will automatically release estop
-    gpio = OT3GPIO()
-    gpio.deactivate_estop()
+    usb_driver = SerialUsbDriver(asyncio.get_running_loop())
+    usb_messenger = BinaryMessenger(usb_driver)
+    gpio = RemoteOT3GPIO(usb_messenger)
+    await gpio.deactivate_estop()
     async with build.driver(build_settings(args)) as driver:
         await run_ui(driver)
 

--- a/hardware/opentrons_hardware/scripts/liquid_sense_script.py
+++ b/hardware/opentrons_hardware/scripts/liquid_sense_script.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Iterator, List
 from numpy import float64
 
 import opentrons_hardware.sensors.types as sensor_types
+from opentrons_hardware.drivers.binary_usb import BinaryMessenger, SerialUsbDriver
 from opentrons_hardware.drivers.can_bus import CanMessenger, build
 from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
 from opentrons_hardware.firmware_bindings.constants import (
@@ -128,7 +129,9 @@ async def run_test(messenger: CanMessenger, args: argparse.Namespace) -> None:
     """Run the test."""
     target_z = NodeId["head_" + args.mount[0]]
     target_pipette = NodeId["pipette_" + args.mount]
-    network_info = NetworkInfo(messenger)
+    usb_driver = SerialUsbDriver(asyncio.get_running_loop())
+    usb_messenger = BinaryMessenger(usb_driver)
+    network_info = NetworkInfo(messenger, usb_messenger)
     found = set(await network_info.probe({NodeId.head, target_pipette}, 10))
     if NodeId.head not in found or target_pipette not in found:
         raise RuntimeError(f"could not find targets for {args.mount} in {found}")

--- a/hardware/opentrons_hardware/scripts/move.py
+++ b/hardware/opentrons_hardware/scripts/move.py
@@ -7,8 +7,9 @@ from logging.config import dictConfig
 
 from numpy import float64
 
+from opentrons_hardware.drivers.binary_usb import BinaryMessenger, SerialUsbDriver
 from opentrons_hardware.drivers.can_bus import CanMessenger, build
-from opentrons_hardware.drivers.gpio import OT3GPIO
+from opentrons_hardware.drivers.gpio import RemoteOT3GPIO
 from opentrons_hardware.firmware_bindings.constants import NodeId
 from opentrons_hardware.firmware_bindings.messages.message_definitions import (
     EnableMotorRequest,
@@ -98,8 +99,10 @@ async def run(args: argparse.Namespace) -> None:
     """Entry point for script."""
     async with build.can_messenger(build_settings(args)) as messenger:
         # build a GPIO handler, which will automatically release estop
-        gpio = OT3GPIO(__name__)
-        gpio.deactivate_estop()
+        usb_driver = SerialUsbDriver(asyncio.get_running_loop())
+        usb_messenger = BinaryMessenger(usb_driver)
+        gpio = RemoteOT3GPIO(usb_messenger, __name__)
+        await gpio.deactivate_estop()
         await run_move(messenger)
 
 

--- a/hardware/opentrons_hardware/scripts/network_test.py
+++ b/hardware/opentrons_hardware/scripts/network_test.py
@@ -19,6 +19,7 @@ from enum import Enum, auto
 from logging.config import dictConfig
 from typing import AsyncGenerator, Optional, Set, TextIO, Tuple, Type, Union
 
+from opentrons_hardware.drivers.binary_usb import BinaryMessenger, SerialUsbDriver
 from opentrons_hardware.drivers.can_bus.abstract_driver import AbstractCanDriver
 from opentrons_hardware.drivers.can_bus.build import build_driver
 from opentrons_hardware.drivers.can_bus.can_messenger import CanMessenger
@@ -243,7 +244,9 @@ async def _do_test(
     messenger = CanMessenger(driver)
     messenger.start()
     warner = WarningsWithCooldown()
-    network_info = NetworkInfo(messenger)
+    usb_driver = SerialUsbDriver(asyncio.get_running_loop())
+    usb_messenger = BinaryMessenger(usb_driver)
+    network_info = NetworkInfo(messenger, usb_messenger)
     present = set(await network_info.probe(None, 1))
     if not present and mode != StimulusMode.ONE_TO_NONE:
         raise RuntimeError(

--- a/hardware/opentrons_hardware/scripts/provision_robot.py
+++ b/hardware/opentrons_hardware/scripts/provision_robot.py
@@ -55,6 +55,7 @@ Notes:
 """
 
 import argparse
+import asyncio
 import re
 import subprocess
 import textwrap
@@ -266,7 +267,8 @@ def _get_property_from_barcode() -> Dict[PropId, Any]:
     return {PropId.SERIAL_NUMBER: robot_serial}
 
 
-def _main(args: argparse.Namespace, eeprom_api: EEPROMDriver) -> None:
+def main(args: argparse.Namespace, eeprom_api: EEPROMDriver) -> None:
+    """Provision the robot."""
     if eeprom_api.open() == -1:
         raise RuntimeError("Could not setup eeprom")
 
@@ -290,6 +292,19 @@ def _main(args: argparse.Namespace, eeprom_api: EEPROMDriver) -> None:
 
     # do something here
     print(f"Finished action ({args.action})")
+
+
+async def _main(args: argparse.Namespace) -> None:
+    eeprom_path = Path(f"/sys/bus/i2c/devices/{args.bus}-{args.address}/eeprom")
+    eeprom_api = await build_eeprom_driver(eeprom_path=eeprom_path)
+    try:
+        main(args, eeprom_api)
+    except Exception as e:
+        print(e)
+    finally:
+        eeprom_api._gpio.deactivate_eeprom_wp()
+        eeprom_api.close()
+        print("Exiting.")
 
 
 if __name__ == "__main__":
@@ -323,13 +338,4 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     stop_robot_server()
-    eeprom_path = Path(f"/sys/bus/i2c/devices/{args.bus}-{args.address}/eeprom")
-    eeprom_api = build_eeprom_driver(eeprom_path=eeprom_path)
-    try:
-        _main(args, eeprom_api)
-    except Exception as e:
-        print(e)
-    finally:
-        eeprom_api._gpio.deactivate_eeprom_wp()
-        eeprom_api.close()
-        print("Exiting.")
+    asyncio.run(_main(args))

--- a/hardware/opentrons_hardware/scripts/sensor_pass.py
+++ b/hardware/opentrons_hardware/scripts/sensor_pass.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Iterator, List
 from numpy import float64
 
 import opentrons_hardware.sensors.types as sensor_types
+from opentrons_hardware.drivers.binary_usb import BinaryMessenger, SerialUsbDriver
 from opentrons_hardware.drivers.can_bus import CanMessenger, build
 from opentrons_hardware.firmware_bindings.arbitration_id import ArbitrationId
 from opentrons_hardware.firmware_bindings.constants import (
@@ -96,7 +97,9 @@ async def run_test(messenger: CanMessenger, args: argparse.Namespace) -> None:
     """Run the test."""
     target_z = NodeId["head_" + args.mount[0]]
     target_pipette = NodeId["pipette_" + args.mount]
-    network_info = NetworkInfo(messenger)
+    usb_driver = SerialUsbDriver(asyncio.get_running_loop())
+    usb_messenger = BinaryMessenger(usb_driver)
+    network_info = NetworkInfo(messenger, usb_messenger)
     found = set(await network_info.probe({NodeId.head, target_pipette}, 10))
     if NodeId.head not in found or target_pipette not in found:
         raise RuntimeError(f"could not find targets for {args.mount} in {found}")

--- a/hardware/opentrons_hardware/scripts/update_fw.py
+++ b/hardware/opentrons_hardware/scripts/update_fw.py
@@ -4,13 +4,12 @@ import argparse
 import asyncio
 import logging
 from logging.config import dictConfig
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from typing_extensions import Final
 
 from .can_args import add_can_args, build_settings
 from opentrons_hardware.drivers.binary_usb import (
-    BinaryMessenger,
     SerialUsbDriver,
     build_rear_panel_driver,
     build_rear_panel_messenger,
@@ -59,14 +58,9 @@ async def run(args: argparse.Namespace) -> None:
     retry_count = args.retry_count
     timeout_seconds = args.timeout_seconds
     erase = not args.no_erase
-    usb_messenger: Optional[BinaryMessenger] = None
-    try:
-        usb_driver: SerialUsbDriver = await build_rear_panel_driver()
-        usb_messenger = build_rear_panel_messenger(usb_driver)
-        usb_messenger.start()
-    except IOError as e:
-        if args.target == "rear-panel":
-            raise e
+    usb_driver: SerialUsbDriver = await build_rear_panel_driver()
+    usb_messenger = build_rear_panel_messenger(usb_driver)
+    usb_messenger.start()
 
     update_details = {
         TARGETS[args.target]: args.file,

--- a/hardware/opentrons_hardware/scripts/update_fws.py
+++ b/hardware/opentrons_hardware/scripts/update_fws.py
@@ -5,11 +5,10 @@ import asyncio
 import json
 import logging
 from logging.config import dictConfig
-from typing import Any, Dict, Optional, TextIO
+from typing import Any, Dict, TextIO
 
 from .can_args import add_can_args, build_settings
 from opentrons_hardware.drivers.binary_usb import (
-    BinaryMessenger,
     SerialUsbDriver,
     build_rear_panel_driver,
     build_rear_panel_messenger,
@@ -67,14 +66,9 @@ async def run(args: argparse.Namespace) -> None:
         logger.error("No update targets in details file.")
         return
 
-    usb_messenger: Optional[BinaryMessenger] = None
-    try:
-        usb_driver: SerialUsbDriver = await build_rear_panel_driver()
-        usb_messenger = build_rear_panel_messenger(usb_driver)
-        usb_messenger.start()
-    except IOError as e:
-        if USBTarget.rear_panel in update_details.keys():
-            raise e
+    usb_driver: SerialUsbDriver = await build_rear_panel_driver()
+    usb_messenger = build_rear_panel_messenger(usb_driver)
+    usb_messenger.start()
 
     async with build.can_messenger(build_settings(args)) as can_messenger:
         updater = RunUpdate(

--- a/hardware/tests/opentrons_hardware/drivers/eeprom/test_driver.py
+++ b/hardware/tests/opentrons_hardware/drivers/eeprom/test_driver.py
@@ -9,7 +9,7 @@ from typing import Generator
 import mock
 import pytest
 
-from opentrons_hardware.drivers import OT3GPIO
+from opentrons_hardware.drivers import RemoteOT3GPIO
 from opentrons_hardware.drivers.eeprom import (
     EEPROMDriver,
     PropId,
@@ -26,7 +26,7 @@ def eeprom_api() -> Generator[EEPROMDriver, None, None]:
         with open(eeprom_path, "wb"), open(eeprom_name_path, "w") as fh:
             # write we can get the name and size of the eeprom
             fh.write("24c128")
-        gpio = mock.Mock(spec=OT3GPIO)
+        gpio = mock.Mock(spec=RemoteOT3GPIO)
         yield EEPROMDriver(gpio, eeprom_path=eeprom_path)
 
 

--- a/hardware/tests/opentrons_hardware/hardware_control/test_network.py
+++ b/hardware/tests/opentrons_hardware/hardware_control/test_network.py
@@ -120,13 +120,15 @@ class MockUSBStatusResponder:
                 )
 
 
-async def test_timeout_fires(mock_can_messenger: AsyncMock) -> None:
+async def test_timeout_fires(
+    mock_can_messenger: AsyncMock, mock_usb_messenger: AsyncMock
+) -> None:
     """Test that the timeout functionality works."""
     then = datetime.datetime.utcnow()
     # we expect a timeout, but a handled timeout, and we don't want to hang the tests
     # if it didn't work, so wrap it in a wait_for of our own with a bigger timeout
     # that will raise if it fails
-    network_info = NetworkInfo(mock_can_messenger)
+    network_info = NetworkInfo(mock_can_messenger, mock_usb_messenger)
     nodes = set(
         await asyncio.wait_for(
             network_info.probe({NodeId.gantry_x, NodeId.gantry_y}, 0.5), 1.0
@@ -152,34 +154,40 @@ async def test_timeout_fires(mock_can_messenger: AsyncMock) -> None:
     )
 
 
-async def test_completes_exact_equality(mock_can_messenger: AsyncMock) -> None:
+async def test_completes_exact_equality(
+    mock_can_messenger: AsyncMock, mock_usb_messenger: AsyncMock
+) -> None:
     """Test that if the exact specified nodes exist the probe works."""
     _ = MockCanStatusResponder(mock_can_messenger, [NodeId.gantry_x.value])
     # we should not get to the timeout, but if we did we wouldn't know because it
     # doesn't raise, so wrap it in a smaller timeout so it will raise (it should
     # complete basically instantly)
-    network_info = NetworkInfo(mock_can_messenger)
+    network_info = NetworkInfo(mock_can_messenger, mock_usb_messenger)
     probed = set(await asyncio.wait_for(network_info.probe({NodeId.gantry_x}), 2.0))
     assert probed == {NodeId.gantry_x}
 
 
-async def test_completes_more_than_expected(mock_can_messenger: AsyncMock) -> None:
+async def test_completes_more_than_expected(
+    mock_can_messenger: AsyncMock, mock_usb_messenger: AsyncMock
+) -> None:
     """Test that if more than specified node exists, the probe works."""
     _ = MockCanStatusResponder(
         mock_can_messenger, [NodeId.gantry_y.value, NodeId.gantry_x.value]
     )
     # same deal with the timeout
-    network_info = NetworkInfo(mock_can_messenger)
+    network_info = NetworkInfo(mock_can_messenger, mock_usb_messenger)
     probed = set(await asyncio.wait_for(network_info.probe({NodeId.gantry_x}), 2.0))
     # we should get everything we prepped the network with
     assert probed == {NodeId.gantry_x, NodeId.gantry_y}
 
 
-async def test_handles_bad_node_ids(mock_can_messenger: AsyncMock) -> None:
+async def test_handles_bad_node_ids(
+    mock_can_messenger: AsyncMock, mock_usb_messenger: AsyncMock
+) -> None:
     """Test that invalid node ids are swalloed silently."""
     _ = MockCanStatusResponder(mock_can_messenger, [0x01, NodeId.gantry_x.value])
     # same deal with the timeout
-    network_info = NetworkInfo(mock_can_messenger)
+    network_info = NetworkInfo(mock_can_messenger, mock_usb_messenger)
     probed = set(await asyncio.wait_for(network_info.probe({NodeId.gantry_x}), 2.0))
     # we should get everything we prepped the network with and ignore the bad values
     assert probed == {NodeId.gantry_x}


### PR DESCRIPTION
# Overview
No EVT robot rear panels exist anymore. So lets remove support so we stop encountering the issue where someone or something changes the rear panel feature flags and bricks a bot.