### PR TITLE
feat(api): enforce vacuum module residual vacuum checks at analysis

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/common.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/common.py
@@ -272,3 +272,23 @@ def defined_error_data_from_enumerated_error(
         model_utils,
         state_update_if_false_positive=state_update_if_false_positive,
     )
+
+
+def will_equalize_after_operation(
+    *,
+    vent_after: bool,
+    equalize_timeout: int | None,
+    duration: int | None = None,
+    require_duration: bool = True,
+) -> bool:
+    """Whether the operation is expected to clear residual chamber vacuum.
+
+    Residual vacuum is cleared only when the command both vents and waits for
+    equalization (``equalize_timeout`` is not ``None``). Omitting the timeout
+    means do not wait.
+    """
+    if equalize_timeout is None or not vent_after:
+        return False
+    if require_duration and duration is None:
+        return False
+    return equalize_timeout > 0

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/open_vent.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/open_vent.py
@@ -58,6 +58,12 @@ class OpenVentImpl(AbstractCommandImpl[OpenVentParams, SuccessData[OpenVentResul
             if params.equalizeTimeout is not None:
                 await vm_hardware.wait_for_pressure_equalization(params.equalizeTimeout)
 
+        # Equalize wait clears residual va.
+        if params.equalizeTimeout is not None and params.equalizeTimeout > 0:
+            state_update.update_vacuum_module_residual_vacuum(
+                params.moduleId, residual_vacuum=False
+            )
+
         return SuccessData(public=OpenVentResult(), state_update=state_update)
 
 

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/start_run_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/start_run_profile.py
@@ -26,6 +26,9 @@ from opentrons.hardware_control.modules.types import (
 from opentrons.hardware_control.modules.types import (
     VacuumModuleProfileStep as hc_profile_step,
 )
+from opentrons.protocol_engine.commands.vacuum_module.common import (
+    will_equalize_after_operation,
+)
 from opentrons.protocol_engine.resources import ModelUtils
 
 if TYPE_CHECKING:
@@ -123,7 +126,10 @@ class StartRunProfileParams(BaseModel):
     )
     equalizeTimeout: int | SkipJsonSchema[None] = Field(
         None,
-        description="Time in seconds to wait for pressure equalization after the profile completes if ventAfter is True. Does not wait if None.",
+        description=(
+            "Time in seconds to wait for pressure equalization after the profile "
+            "completes if ventAfter is True. Does not wait if None."
+        ),
     )
     taskId: str | None = Field(None, description="The id of the profile task")
 
@@ -163,6 +169,12 @@ class StartRunProfileImpl(AbstractCommandImpl[StartRunProfileParams, _ExecuteRet
                 f"Equalize timeout {e_timeout} is invalid, must be between 0-{MAX_VAC_DURATION_S} seconds."
             )
 
+        clears_residual = will_equalize_after_operation(
+            vent_after=params.ventAfter,
+            equalize_timeout=params.equalizeTimeout,
+            require_duration=False,
+        )
+
         state_update = update_types.StateUpdate()
         profile: List[hc_profile_step] = []
         pump_engaged = False
@@ -172,6 +184,10 @@ class StartRunProfileImpl(AbstractCommandImpl[StartRunProfileParams, _ExecuteRet
                 pump_engaged = step.enablePump
 
         state_update.update_vacuum_module_pump_engaged(params.moduleId, pump_engaged)
+        # Profiles apply vacuum unless the whole profile equalizes at the end.
+        state_update.update_vacuum_module_residual_vacuum(
+            params.moduleId, not clears_residual
+        )
         running_command_id = self._state_view.commands.get_running_command_id()
         if running_command_id is not None:
             state_update.record_module_background_command(

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_power.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_power.py
@@ -17,6 +17,9 @@ from ..command import (
     SuccessData,
 )
 from opentrons.drivers.vacuum_module.driver import MAX_VAC_DURATION_S
+from opentrons.protocol_engine.commands.vacuum_module.common import (
+    will_equalize_after_operation,
+)
 from opentrons.protocol_engine.resources import ModelUtils
 
 if TYPE_CHECKING:
@@ -55,7 +58,10 @@ class StartSetVacuumPowerParams(BaseModel):
     )
     equalizeTimeout: int | SkipJsonSchema[None] = Field(
         None,
-        description="Time in seconds to wait for pressure equalization after opening the vent. Does not wait if None.",
+        description=(
+            "Time in seconds to wait for pressure equalization after opening the vent. "
+            "Does not wait if None."
+        ),
     )
     taskId: str | None = Field(None, description="The id of the task")
 
@@ -93,9 +99,18 @@ class StartSetVacuumPowerImpl(
         self, params: StartSetVacuumPowerParams
     ) -> SuccessData[StartSetVacuumPowerResult]:
         """Start the vacuum pump."""
+        clears_residual = will_equalize_after_operation(
+            vent_after=params.ventAfter,
+            equalize_timeout=params.equalizeTimeout,
+            duration=params.duration,
+        )
+
         state_update = update_types.StateUpdate()
         state_update.update_vacuum_module_pump_engaged(
             params.moduleId, params.duration is None
+        )
+        state_update.update_vacuum_module_residual_vacuum(
+            params.moduleId, not clears_residual
         )
         running_command_id = self._state_view.commands.get_running_command_id()
         if running_command_id is not None:

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_pressure.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_pressure.py
@@ -21,6 +21,9 @@ from opentrons.drivers.vacuum_module.driver import (
     MAX_VAC_DURATION_S,
     MIN_GAUGE_PRESSURE_MBAR,
 )
+from opentrons.protocol_engine.commands.vacuum_module.common import (
+    will_equalize_after_operation,
+)
 from opentrons.protocol_engine.resources import ModelUtils
 
 if TYPE_CHECKING:
@@ -56,7 +59,10 @@ class StartSetVacuumPressureParams(BaseModel):
     )
     equalizeTimeout: int | SkipJsonSchema[None] = Field(
         None,
-        description="Time in seconds to wait for pressure equalization after opening the vent. Does not wait if None.",
+        description=(
+            "Time in seconds to wait for pressure equalization after opening the vent. "
+            "Does not wait if None."
+        ),
     )
     taskId: str | None = Field(None, description="The id of the task")
 
@@ -94,9 +100,18 @@ class StartSetVacuumPressureImpl(
         self, params: StartSetVacuumPressureParams
     ) -> SuccessData[StartSetVacuumPressureResult]:
         """Start the vacuum pump."""
+        clears_residual = will_equalize_after_operation(
+            vent_after=params.ventAfter,
+            equalize_timeout=params.equalizeTimeout,
+            duration=params.duration,
+        )
+
         state_update = update_types.StateUpdate()
         state_update.update_vacuum_module_pump_engaged(
             params.moduleId, params.duration is None
+        )
+        state_update.update_vacuum_module_residual_vacuum(
+            params.moduleId, not clears_residual
         )
         running_command_id = self._state_view.commands.get_running_command_id()
         if running_command_id is not None:

--- a/api/src/opentrons/protocol_engine/execution/vacuum_module_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/vacuum_module_movement_flagger.py
@@ -73,13 +73,26 @@ class VacuumModuleMovementFlagger:
                 "when moving labware to or from it."
             )
 
-        if not self._state_store.config.use_virtual_modules:
-            vacuum_module = await self._get_hardware_vacuum_module(module_id=module_id)
-            if not vacuum_module.pressure_equalized:
+        # Enforce residual vacuum at analysis
+        if self._state_store.config.use_virtual_modules:
+            if vm_substate.residual_vacuum:
                 raise VacuumModuleStillUnderVacuumError(
                     module_id=vm_substate.module_id,
-                    current_gauge_pressure_mbar=vacuum_module.current_gauge_pressure_mbar,
+                    current_gauge_pressure_mbar=0.0,
+                    message=(
+                        f"Vacuum Module {vm_substate.module_id} may still be under "
+                        "vacuum. Vent and wait for pressure equalization before moving "
+                        "labware to or from it."
+                    ),
                 )
+            return
+
+        vacuum_module = await self._get_hardware_vacuum_module(module_id=module_id)
+        if not vacuum_module.pressure_equalized:
+            raise VacuumModuleStillUnderVacuumError(
+                module_id=vm_substate.module_id,
+                current_gauge_pressure_mbar=vacuum_module.current_gauge_pressure_mbar,
+            )
 
     async def _get_hardware_vacuum_module(
         self,

--- a/api/src/opentrons/protocol_engine/state/module_substates/vacuum_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/vacuum_module_substate.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import NewType, Optional
 
 from opentrons.protocol_engine.state.update_types import (
+    NO_CHANGE,
     VacuumModuleStateUpdate,
 )
 
@@ -20,6 +21,7 @@ class VacuumModuleSubState:
 
     module_id: VacuumModuleId
     pump_engaged: bool
+    residual_vacuum: bool = False
     target_pressure: Optional[float] = None
 
     def new_from_state_change(
@@ -29,7 +31,18 @@ class VacuumModuleSubState:
         new_pump_engaged = self.pump_engaged
         if isinstance(update.pump_engaged, bool):
             new_pump_engaged = update.pump_engaged
+
+        new_residual_vacuum = self.residual_vacuum
+        if isinstance(update.residual_vacuum, bool):
+            new_residual_vacuum = update.residual_vacuum
+
+        new_target_pressure = self.target_pressure
+        if update.target_pressure != NO_CHANGE:
+            new_target_pressure = update.target_pressure
+
         return VacuumModuleSubState(
             module_id=self.module_id,
             pump_engaged=new_pump_engaged,
+            residual_vacuum=new_residual_vacuum,
+            target_pressure=new_target_pressure,
         )

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -359,7 +359,9 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 pool_height=0,
             ),
             ModuleModel.is_vacuum_module: VacuumModuleSubState(
-                module_id=VacuumModuleId(module_id), pump_engaged=False
+                module_id=VacuumModuleId(module_id),
+                pump_engaged=False,
+                residual_vacuum=False,
             ),
         }
 

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -406,7 +406,8 @@ class VacuumModuleStateUpdate:
 
     module_id: str
     pump_engaged: bool | NoChangeType = NO_CHANGE
-    target_pressure: float | NoChangeType = NO_CHANGE
+    residual_vacuum: bool | NoChangeType = NO_CHANGE
+    target_pressure: float | None | NoChangeType = NO_CHANGE
 
     @classmethod
     def create_or_override(
@@ -999,6 +1000,18 @@ class StateUpdate:
                 self.vacuum_module_state_update, module_id
             ),
             pump_engaged=pump_engaged,
+        )
+        return self
+
+    def update_vacuum_module_residual_vacuum(
+        self, module_id: str, residual_vacuum: bool
+    ) -> Self:
+        """Set whether the chamber is modeled as still under vacuum."""
+        self.vacuum_module_state_update = dataclasses.replace(
+            VacuumModuleStateUpdate.create_or_override(
+                self.vacuum_module_state_update, module_id
+            ),
+            residual_vacuum=residual_vacuum,
         )
         return self
 

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_common.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_common.py
@@ -21,6 +21,7 @@ from opentrons.protocol_engine.commands.vacuum_module.common import (
     VacuumPressureNotReachedError,
     defined_error_data_from_task_error,
     handle_recoverable_vacuum_error,
+    will_equalize_after_operation,
 )
 from opentrons.protocol_engine.errors import ErrorOccurrence
 from opentrons.protocol_engine.resources import ModelUtils
@@ -190,3 +191,25 @@ def test_handle_recoverable_vacuum_error_populates_operation_error_info_from_hw_
         "target": -100.0,
         "current": -80.0,
     }
+
+
+def test_will_equalize_after_operation() -> None:
+    """It should only clear residual vacuum when equalize is explicitly requested."""
+    assert will_equalize_after_operation(
+        vent_after=True, equalize_timeout=30, duration=10
+    )
+    assert not will_equalize_after_operation(
+        vent_after=True, equalize_timeout=None, duration=10
+    )
+    assert not will_equalize_after_operation(
+        vent_after=False, equalize_timeout=30, duration=10
+    )
+    assert not will_equalize_after_operation(
+        vent_after=True, equalize_timeout=30, duration=None
+    )
+    assert will_equalize_after_operation(
+        vent_after=True, equalize_timeout=30, require_duration=False
+    )
+    assert not will_equalize_after_operation(
+        vent_after=True, equalize_timeout=0, duration=10
+    )

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_open_vent.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_open_vent.py
@@ -80,9 +80,17 @@ async def test_open_vent_waits_to_equalize(
         vm_hardware
     )
 
-    await subject.execute(data)
+    result = await subject.execute(data)
 
     decoy.verify(
         await vm_hardware.set_vent_state(VentState.OPENED),
         await vm_hardware.wait_for_pressure_equalization(30),
+    )
+    expected_state_update = update_types.StateUpdate()
+    expected_state_update.update_vacuum_module_residual_vacuum(
+        "input-vacuum-id", residual_vacuum=False
+    )
+    assert result == SuccessData(
+        public=vm_commands.OpenVentResult(),
+        state_update=expected_state_update,
     )

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_run_profile.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_run_profile.py
@@ -192,6 +192,10 @@ async def test_start_run_profile(
     expected_state_update.update_vacuum_module_pump_engaged(
         "input-vacuum_module-id", False
     )
+    # ventAfter without equalizeTimeout → residual vacuum remains
+    expected_state_update.update_vacuum_module_residual_vacuum(
+        "input-vacuum_module-id", residual_vacuum=True
+    )
 
     assert result == SuccessData(
         public=expected_result,

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_power.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_power.py
@@ -91,6 +91,10 @@ async def test_start_set_vacuum_power(
     )
     expected_state_update = update_types.StateUpdate()
     expected_state_update.update_vacuum_module_pump_engaged("input-vacuum-id", True)
+    # No duration hold → residual vacuum remains (pump holds indefinitely)
+    expected_state_update.update_vacuum_module_residual_vacuum(
+        "input-vacuum-id", residual_vacuum=True
+    )
 
     assert result == SuccessData(
         public=expected_result,

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_pressure.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_pressure.py
@@ -100,6 +100,10 @@ async def test_start_set_vacuum_presure(
 
     expected_state_update = update_types.StateUpdate()
     expected_state_update.update_vacuum_module_pump_engaged("input-vacuum-id", False)
+    # No equalizeTimeout → residual vacuum remains (vent without wait)
+    expected_state_update.update_vacuum_module_residual_vacuum(
+        "input-vacuum-id", residual_vacuum=True
+    )
 
     assert result == SuccessData(
         public=expected_result,

--- a/api/tests/opentrons/protocol_engine/execution/test_vacuum_module_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_vacuum_module_movement_flagger.py
@@ -96,7 +96,11 @@ async def test_ensure_vacuum_module_is_idle_raises_when_pump_engaged(
     decoy.when(
         state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
     ).then_return(
-        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=True)
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-id"),
+            pump_engaged=True,
+            residual_vacuum=True,
+        )
     )
 
     with pytest.raises(VacuumModuleUnderVacuumError, match="pump engaged"):
@@ -122,7 +126,11 @@ async def test_ensure_vacuum_module_is_idle_raises_when_pressure_not_equalized(
     decoy.when(
         state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
     ).then_return(
-        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=False)
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-id"),
+            pump_engaged=False,
+            residual_vacuum=False,
+        )
     )
     decoy.when(
         state_store.modules.get_serial_number(module_id="vacuum-id")
@@ -164,7 +172,11 @@ async def test_ensure_vacuum_module_is_idle_noops_when_pressure_equalized(
     decoy.when(
         state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
     ).then_return(
-        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=False)
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-id"),
+            pump_engaged=False,
+            residual_vacuum=False,
+        )
     )
     decoy.when(
         state_store.modules.get_serial_number(module_id="vacuum-id")
@@ -188,7 +200,7 @@ async def test_ensure_vacuum_module_is_idle_skips_hardware_check_for_virtual_mod
     subject: VacuumModuleMovementFlagger,
     state_store: StateStore,
 ) -> None:
-    """It should not query hardware when using virtual modules."""
+    """It should not query hardware when using virtual modules and residual is clear."""
     decoy.when(state_store.config).then_return(
         Config(
             robot_type="OT-3 Standard",
@@ -199,9 +211,42 @@ async def test_ensure_vacuum_module_is_idle_skips_hardware_check_for_virtual_mod
     decoy.when(
         state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
     ).then_return(
-        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=False)
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-id"),
+            pump_engaged=False,
+            residual_vacuum=False,
+        )
     )
 
     await subject.ensure_vacuum_module_is_idle(
         labware_parent=ModuleLocation(moduleId="vacuum-id")
     )
+
+
+async def test_ensure_vacuum_module_is_idle_raises_virtual_residual_vacuum(
+    decoy: Decoy,
+    subject: VacuumModuleMovementFlagger,
+    state_store: StateStore,
+) -> None:
+    """It should raise on residual vacuum for virtual modules (analysis)."""
+    decoy.when(state_store.config).then_return(
+        Config(
+            robot_type="OT-3 Standard",
+            deck_type=DeckType.OT3_STANDARD,
+            use_virtual_modules=True,
+        )
+    )
+    decoy.when(
+        state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
+    ).then_return(
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-id"),
+            pump_engaged=False,
+            residual_vacuum=True,
+        )
+    )
+
+    with pytest.raises(VacuumModuleStillUnderVacuumError, match="may still be under"):
+        await subject.ensure_vacuum_module_is_idle(
+            labware_parent=ModuleLocation(moduleId="vacuum-id")
+        )

--- a/api/tests/opentrons/protocol_engine/state/module_substates/test_vacuum_module_substate.py
+++ b/api/tests/opentrons/protocol_engine/state/module_substates/test_vacuum_module_substate.py
@@ -1,0 +1,42 @@
+"""Tests for VacuumModuleSubState."""
+
+from opentrons.protocol_engine.state.module_substates.vacuum_module_substate import (
+    VacuumModuleId,
+    VacuumModuleSubState,
+)
+from opentrons.protocol_engine.state.update_types import VacuumModuleStateUpdate
+
+
+def test_new_from_state_change_updates_pump_and_residual() -> None:
+    """It should apply pump and residual vacuum updates."""
+    state = VacuumModuleSubState(
+        module_id=VacuumModuleId("vm-1"),
+        pump_engaged=False,
+        residual_vacuum=False,
+    )
+    updated = state.new_from_state_change(
+        VacuumModuleStateUpdate(
+            module_id="vm-1",
+            pump_engaged=True,
+            residual_vacuum=True,
+        )
+    )
+    assert updated.pump_engaged is True
+    assert updated.residual_vacuum is True
+    assert updated.module_id == VacuumModuleId("vm-1")
+
+
+def test_new_from_state_change_preserves_unspecified_fields() -> None:
+    """NO_CHANGE fields should keep prior values."""
+    state = VacuumModuleSubState(
+        module_id=VacuumModuleId("vm-1"),
+        pump_engaged=True,
+        residual_vacuum=True,
+        target_pressure=-100.0,
+    )
+    updated = state.new_from_state_change(
+        VacuumModuleStateUpdate(module_id="vm-1", residual_vacuum=False)
+    )
+    assert updated.pump_engaged is True
+    assert updated.residual_vacuum is False
+    assert updated.target_pressure == -100.0

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_equalize_move_labware_test.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_equalize_move_labware_test.py
@@ -1,0 +1,556 @@
+"""Test equalize_timeout_s / residual vacuum interactions with move_labware.
+
+Each case is selected via the ``test_case`` runtime parameter so analysis and
+runtime can be validated independently:
+
+| Case id                    | Vacuum path                         | Equalize? | Expected move |
+|----------------------------|-------------------------------------|-----------|---------------|
+| cold_start_move            | none                                | n/a       | PASS          |
+| pressure_hold_equalize     | pressure + duration + vent_after    | yes       | PASS          |
+| pressure_hold_no_equalize  | pressure + duration + vent_after    | no        | FAIL residual |
+| open_vent_equalize         | pressure hold (no eq) then open_vent| yes       | PASS          |
+| open_vent_no_equalize      | pressure hold (no eq) then open_vent| no        | FAIL residual |
+| pump_engaged               | pressure hold forever               | n/a       | FAIL pump on  |
+| stop_without_vent          | pressure hold forever then stop     | no        | FAIL residual |
+| power_hold_equalize        | power + duration + vent_after       | yes       | PASS          |
+| power_hold_no_equalize     | power + duration + vent_after       | no        | FAIL residual |
+| profile_equalize           | profile (ends pump off) + vent      | yes       | PASS          |
+| profile_no_equalize        | profile (ends pump off) + vent      | no        | FAIL residual |
+
+Analysis (virtual modules) uses PE residual-vacuum / pump_engaged state.
+Runtime still uses the hardware gauge for residual vacuum when the pump is off.
+
+Use short pressure setpoints and hold times so runtime runs finish quickly.
+For FAIL cases on real hardware, recover by opening the vent and equalizing,
+then resume so the retried move can succeed.
+"""
+from typing import Callable, Dict, List, cast
+
+from opentrons.hardware_control.modules.types import (
+    VacuumModulePressureStep,
+    VacuumModuleStep,
+)
+from opentrons.protocol_api import (
+    ParameterContext,
+    ProtocolContext,
+    VacuumModuleContext,
+)
+
+metadata = {
+    "protocolName": "Vacuum Module Equalize / Move Labware Cases",
+    "author": "Opentrons <protocols@opentrons.com>",
+    "description": (
+        "Parameterized cases for equalize_timeout_s and residual vacuum "
+        "interactions with move_labware to/from the Vacuum Module."
+    ),
+}
+requirements = {
+    "robotType": "Flex",
+    "apiLevel": "2.30",
+}
+
+# Mild vacuum + short holds keep QC / sim runs fast.
+_DEFAULT_PRESSURE_MBAR = -200
+_DEFAULT_HOLD_S = 8
+_DEFAULT_EQUALIZE_S = 30
+_DEFAULT_POWER_PCT = 40
+
+
+def add_parameters(parameters: ParameterContext) -> None:
+    """Runtime parameters."""
+    parameters.add_str(
+        variable_name="test_case",
+        display_name="Test Case",
+        description="Which equalize / move_labware scenario to run.",
+        default="pressure_hold_equalize",
+        # display_name max 30 chars (RTP validation)
+        choices=[
+            {"display_name": "PASS: cold start move", "value": "cold_start_move"},
+            {
+                "display_name": "PASS: pressure+equalize",
+                "value": "pressure_hold_equalize",
+            },
+            {
+                "display_name": "FAIL: pressure no equalize",
+                "value": "pressure_hold_no_equalize",
+            },
+            {"display_name": "PASS: open_vent+equalize", "value": "open_vent_equalize"},
+            {
+                "display_name": "FAIL: open_vent no equalize",
+                "value": "open_vent_no_equalize",
+            },
+            {"display_name": "FAIL: pump engaged move", "value": "pump_engaged"},
+            {"display_name": "FAIL: stop, vent closed", "value": "stop_without_vent"},
+            {"display_name": "PASS: power+equalize", "value": "power_hold_equalize"},
+            {
+                "display_name": "FAIL: power no equalize",
+                "value": "power_hold_no_equalize",
+            },
+            {"display_name": "PASS: profile+equalize", "value": "profile_equalize"},
+            {
+                "display_name": "FAIL: profile no equalize",
+                "value": "profile_no_equalize",
+            },
+        ],
+    )
+    parameters.add_str(
+        variable_name="collar",
+        display_name="Vacuum Collar",
+        description="Collar loaded on the vacuum module (starts on the module).",
+        default="opentrons_vacuum_manifold_collar_short",
+        choices=[
+            {
+                "display_name": "Opentrons: Short",
+                "value": "opentrons_vacuum_manifold_collar_short",
+            },
+            {
+                "display_name": "Opentrons: Tall",
+                "value": "opentrons_vacuum_manifold_collar_tall",
+            },
+            {
+                "display_name": "Millipore: Short",
+                "value": "millipore_vacuum_manifold_collar_short",
+            },
+            {
+                "display_name": "Millipore: Tall",
+                "value": "millipore_vacuum_manifold_collar_tall",
+            },
+        ],
+    )
+    parameters.add_int(
+        display_name="Target Pressure (mbar)",
+        variable_name="target_pressure_mbar",
+        description="Gauge pressure for pressure / profile cases.",
+        default=_DEFAULT_PRESSURE_MBAR,
+        minimum=-800,
+        maximum=-50,
+    )
+    parameters.add_int(
+        display_name="Hold (seconds)",
+        variable_name="hold_seconds",
+        description="Pump hold duration for timed vacuum / power cases.",
+        default=_DEFAULT_HOLD_S,
+        minimum=3,
+        maximum=120,
+    )
+    parameters.add_int(
+        display_name="Equalize Timeout (seconds)",
+        variable_name="equalize_timeout_s",
+        description="Used only by cases that wait for equalization.",
+        default=_DEFAULT_EQUALIZE_S,
+        minimum=5,
+        maximum=300,
+    )
+    parameters.add_bool(
+        variable_name="use_gripper",
+        display_name="Use Gripper",
+        description="If false, pauses for a manual labware move.",
+        default=True,
+    )
+
+
+def _comment_expectation(ctx: ProtocolContext, should_pass: bool, reason: str) -> None:
+    if should_pass:
+        ctx.comment(f"EXPECT PASS: move_labware should succeed. ({reason})")
+    else:
+        ctx.comment(
+            f"EXPECT FAIL: move_labware should error. ({reason}) "
+            "Analysis: residual vacuum or pump engaged. "
+            "Runtime residual: VacuumModuleStillUnderVacuumError / "
+            "vacuumModuleUnderVacuum. Runtime pump: VacuumModuleUnderVacuumError."
+        )
+
+
+def _move_collar_to_dock(
+    ctx: ProtocolContext,
+    vm_mod: VacuumModuleContext,
+    collar: object,
+    use_gripper: bool,
+) -> None:
+    ctx.move_labware(
+        collar,  # type: ignore[arg-type]
+        vm_mod.manifold_dock,  # type: ignore[attr-defined]
+        use_gripper=use_gripper,
+    )
+
+
+def _return_collar_to_module(
+    ctx: ProtocolContext,
+    vm_mod: VacuumModuleContext,
+    collar: object,
+    use_gripper: bool,
+) -> None:
+    ctx.comment("Cleanup: ensure chamber is atmospheric, return collar to module.")
+    vm_mod.stop_vacuum_pump()
+    vm_mod.open_vent(equalize_timeout_s=_DEFAULT_EQUALIZE_S)
+    ctx.move_labware(collar, vm_mod, use_gripper=use_gripper)  # type: ignore[arg-type]
+
+
+def _case_cold_start_move(
+    ctx: ProtocolContext,
+    vm_mod: VacuumModuleContext,
+    collar: object,
+    use_gripper: bool,
+    pressure_mbar: int,
+    hold_s: int,
+    equalize_s: int,
+) -> None:
+    del pressure_mbar, hold_s, equalize_s
+    _comment_expectation(
+        ctx, True, "no vacuum applied; residual_vacuum and pump_engaged are false"
+    )
+    _move_collar_to_dock(ctx, vm_mod, collar, use_gripper)
+    ctx.move_labware(collar, vm_mod, use_gripper=use_gripper)  # type: ignore[arg-type]
+
+
+def _case_pressure_hold_equalize(
+    ctx: ProtocolContext,
+    vm_mod: VacuumModuleContext,
+    collar: object,
+    use_gripper: bool,
+    pressure_mbar: int,
+    hold_s: int,
+    equalize_s: int,
+) -> None:
+    _comment_expectation(
+        ctx,
+        True,
+        "duration + vent_after + equalize_timeout_s clears residual vacuum in PE",
+    )
+    vm_mod.close_vent()
+    task = vm_mod.start_set_vacuum_pressure(
+        gauge_pressure_mbar=pressure_mbar,
+        duration_s=hold_s,
+        vent_after=True,
+        equalize_timeout_s=equalize_s,
+    )
+    ctx.wait_for_tasks([task])
+    _move_collar_to_dock(ctx, vm_mod, collar, use_gripper)
+    ctx.move_labware(collar, vm_mod, use_gripper=use_gripper)  # type: ignore[arg-type]
+
+
+def _case_pressure_hold_no_equalize(
+    ctx: ProtocolContext,
+    vm_mod: VacuumModuleContext,
+    collar: object,
+    use_gripper: bool,
+    pressure_mbar: int,
+    hold_s: int,
+    equalize_s: int,
+) -> None:
+    del equalize_s
+    _comment_expectation(
+        ctx,
+        False,
+        "vent_after without equalize_timeout_s leaves residual_vacuum true",
+    )
+    vm_mod.close_vent()
+    task = vm_mod.start_set_vacuum_pressure(
+        gauge_pressure_mbar=pressure_mbar,
+        duration_s=hold_s,
+        vent_after=True,
+        # omit equalize_timeout_s → do not wait
+    )
+    ctx.wait_for_tasks([task])
+    _move_collar_to_dock(ctx, vm_mod, collar, use_gripper)
+
+
+def _case_open_vent_equalize(
+    ctx: ProtocolContext,
+    vm_mod: VacuumModuleContext,
+    collar: object,
+    use_gripper: bool,
+    pressure_mbar: int,
+    hold_s: int,
+    equalize_s: int,
+) -> None:
+    _comment_expectation(
+        ctx, True, "open_vent(equalize_timeout_s) clears residual after vacuum"
+    )
+    vm_mod.close_vent()
+    task = vm_mod.start_set_vacuum_pressure(
+        gauge_pressure_mbar=pressure_mbar,
+        duration_s=hold_s,
+        vent_after=False,
+    )
+    ctx.wait_for_tasks([task])
+    vm_mod.stop_vacuum_pump()
+    vm_mod.open_vent(equalize_timeout_s=equalize_s)
+    _move_collar_to_dock(ctx, vm_mod, collar, use_gripper)
+    ctx.move_labware(collar, vm_mod, use_gripper=use_gripper)  # type: ignore[arg-type]
+
+
+def _case_open_vent_no_equalize(
+    ctx: ProtocolContext,
+    vm_mod: VacuumModuleContext,
+    collar: object,
+    use_gripper: bool,
+    pressure_mbar: int,
+    hold_s: int,
+    equalize_s: int,
+) -> None:
+    del equalize_s
+    _comment_expectation(
+        ctx, False, "open_vent() without timeout does not clear residual vacuum"
+    )
+    vm_mod.close_vent()
+    task = vm_mod.start_set_vacuum_pressure(
+        gauge_pressure_mbar=pressure_mbar,
+        duration_s=hold_s,
+        vent_after=False,
+    )
+    ctx.wait_for_tasks([task])
+    vm_mod.stop_vacuum_pump()
+    vm_mod.open_vent()  # no equalize_timeout_s
+    _move_collar_to_dock(ctx, vm_mod, collar, use_gripper)
+
+
+def _case_pump_engaged(
+    ctx: ProtocolContext,
+    vm_mod: VacuumModuleContext,
+    collar: object,
+    use_gripper: bool,
+    pressure_mbar: int,
+    hold_s: int,
+    equalize_s: int,
+) -> None:
+    del hold_s, equalize_s
+    _comment_expectation(
+        ctx, False, "duration_s omitted → pump stays engaged; move must fail"
+    )
+    vm_mod.close_vent()
+    task = vm_mod.start_set_vacuum_pressure(
+        gauge_pressure_mbar=pressure_mbar,
+        # hold forever
+        vent_after=False,
+    )
+    ctx.wait_for_tasks([task])
+    _move_collar_to_dock(ctx, vm_mod, collar, use_gripper)
+
+
+def _case_stop_without_vent(
+    ctx: ProtocolContext,
+    vm_mod: VacuumModuleContext,
+    collar: object,
+    use_gripper: bool,
+    pressure_mbar: int,
+    hold_s: int,
+    equalize_s: int,
+) -> None:
+    del equalize_s
+    _comment_expectation(
+        ctx,
+        False,
+        "stop_vacuum_pump leaves residual vacuum until vent + equalize",
+    )
+    vm_mod.close_vent()
+    task = vm_mod.start_set_vacuum_pressure(
+        gauge_pressure_mbar=pressure_mbar,
+        duration_s=hold_s,
+        vent_after=False,
+    )
+    ctx.wait_for_tasks([task])
+    vm_mod.stop_vacuum_pump()
+    # vent stays closed → residual vacuum
+    _move_collar_to_dock(ctx, vm_mod, collar, use_gripper)
+
+
+def _case_power_hold_equalize(
+    ctx: ProtocolContext,
+    vm_mod: VacuumModuleContext,
+    collar: object,
+    use_gripper: bool,
+    pressure_mbar: int,
+    hold_s: int,
+    equalize_s: int,
+) -> None:
+    del pressure_mbar
+    _comment_expectation(
+        ctx, True, "power hold + vent_after + equalize_timeout_s clears residual"
+    )
+    vm_mod.close_vent()
+    task = vm_mod.start_set_vacuum_power(
+        percent_power=_DEFAULT_POWER_PCT,
+        duration_s=hold_s,
+        vent_after=True,
+        equalize_timeout_s=equalize_s,
+    )
+    ctx.wait_for_tasks([task])
+    _move_collar_to_dock(ctx, vm_mod, collar, use_gripper)
+    ctx.move_labware(collar, vm_mod, use_gripper=use_gripper)  # type: ignore[arg-type]
+
+
+def _case_power_hold_no_equalize(
+    ctx: ProtocolContext,
+    vm_mod: VacuumModuleContext,
+    collar: object,
+    use_gripper: bool,
+    pressure_mbar: int,
+    hold_s: int,
+    equalize_s: int,
+) -> None:
+    del pressure_mbar, equalize_s
+    _comment_expectation(
+        ctx, False, "power hold + vent_after without equalize leaves residual"
+    )
+    vm_mod.close_vent()
+    task = vm_mod.start_set_vacuum_power(
+        percent_power=_DEFAULT_POWER_PCT,
+        duration_s=hold_s,
+        vent_after=True,
+    )
+    ctx.wait_for_tasks([task])
+    _move_collar_to_dock(ctx, vm_mod, collar, use_gripper)
+
+
+def _case_profile_equalize(
+    ctx: ProtocolContext,
+    vm_mod: VacuumModuleContext,
+    collar: object,
+    use_gripper: bool,
+    pressure_mbar: int,
+    hold_s: int,
+    equalize_s: int,
+) -> None:
+    # Final step leaves enable_pump=False so PE pump_engaged is false.
+    # vent_after only opens the vent (does not imply pump state); equalize
+    # clears residual_vacuum independently.
+    _comment_expectation(
+        ctx,
+        True,
+        "profile ends with pump off + vent_after + equalize_timeout_s",
+    )
+    vm_mod.close_vent()
+    # Stop-pump step: enable_pump=False with no pressure/power setpoint.
+    steps: List[VacuumModuleStep] = [
+        VacuumModulePressureStep(
+            enable_pump=True,
+            gauge_pressure_mbar=pressure_mbar,
+            hold_time_seconds=hold_s,
+        ),
+        VacuumModulePressureStep(enable_pump=False, gauge_pressure_mbar=None),
+    ]
+    task = vm_mod.start_execute_profile(
+        steps=steps,
+        repetitions=1,
+        vent_after=True,
+        equalize_timeout_s=equalize_s,
+    )
+    ctx.wait_for_tasks([task])
+    _move_collar_to_dock(ctx, vm_mod, collar, use_gripper)
+    ctx.move_labware(collar, vm_mod, use_gripper=use_gripper)  # type: ignore[arg-type]
+
+
+def _case_profile_no_equalize(
+    ctx: ProtocolContext,
+    vm_mod: VacuumModuleContext,
+    collar: object,
+    use_gripper: bool,
+    pressure_mbar: int,
+    hold_s: int,
+    equalize_s: int,
+) -> None:
+    del equalize_s
+    # Pump left off so the move fails on residual vacuum, not pump_engaged.
+    _comment_expectation(
+        ctx,
+        False,
+        "profile pump off + vent_after without equalize leaves residual",
+    )
+    vm_mod.close_vent()
+    steps: List[VacuumModuleStep] = [
+        VacuumModulePressureStep(
+            enable_pump=True,
+            gauge_pressure_mbar=pressure_mbar,
+            hold_time_seconds=hold_s,
+        ),
+        VacuumModulePressureStep(enable_pump=False, gauge_pressure_mbar=None),
+    ]
+    task = vm_mod.start_execute_profile(
+        steps=steps,
+        repetitions=1,
+        vent_after=True,
+    )
+    ctx.wait_for_tasks([task])
+    _move_collar_to_dock(ctx, vm_mod, collar, use_gripper)
+
+
+_CASES: Dict[
+    str,
+    Callable[
+        [ProtocolContext, VacuumModuleContext, object, bool, int, int, int],
+        None,
+    ],
+] = {
+    "cold_start_move": _case_cold_start_move,
+    "pressure_hold_equalize": _case_pressure_hold_equalize,
+    "pressure_hold_no_equalize": _case_pressure_hold_no_equalize,
+    "open_vent_equalize": _case_open_vent_equalize,
+    "open_vent_no_equalize": _case_open_vent_no_equalize,
+    "pump_engaged": _case_pump_engaged,
+    "stop_without_vent": _case_stop_without_vent,
+    "power_hold_equalize": _case_power_hold_equalize,
+    "power_hold_no_equalize": _case_power_hold_no_equalize,
+    "profile_equalize": _case_profile_equalize,
+    "profile_no_equalize": _case_profile_no_equalize,
+}
+
+_PASS_CASES = frozenset(
+    {
+        "cold_start_move",
+        "pressure_hold_equalize",
+        "open_vent_equalize",
+        "power_hold_equalize",
+        "profile_equalize",
+    }
+)
+
+
+def run(ctx: ProtocolContext) -> None:
+    """Run a single selected equalize / move_labware case."""
+    vm_mod = cast(
+        VacuumModuleContext,
+        ctx.load_module(module_name="vacuumModuleV1", location="A3"),
+    )
+    ctx.load_trash_bin("A1")
+
+    test_case = cast(str, ctx.params.test_case)  # type: ignore[attr-defined]
+    collar_name = cast(str, ctx.params.collar)  # type: ignore[attr-defined]
+    pressure_mbar = cast(int, ctx.params.target_pressure_mbar)  # type: ignore[attr-defined]
+    hold_s = cast(int, ctx.params.hold_seconds)  # type: ignore[attr-defined]
+    equalize_s = cast(int, ctx.params.equalize_timeout_s)  # type: ignore[attr-defined]
+    use_gripper = cast(bool, ctx.params.use_gripper)  # type: ignore[attr-defined]
+
+    if test_case not in _CASES:
+        raise ValueError(f"Unknown test_case: {test_case!r}")
+
+    # Collar starts sealed on the module so vacuum cases have a closed chamber.
+    collar = vm_mod.load_adapter(collar_name)
+
+    ctx.home()
+    ctx.comment(f"=== Case: {test_case} ===")
+    if test_case in _PASS_CASES:
+        ctx.comment("This case is expected to complete successfully.")
+    else:
+        ctx.comment(
+            "This case is expected to fail on move_labware. "
+            "On hardware, recover by venting + equalizing, then resume."
+        )
+        ctx.pause(
+            f"About to run FAIL-expected case '{test_case}'. "
+            "Continue when ready to attempt the blocked move."
+        )
+
+    case_fn = _CASES[test_case]
+    case_fn(ctx, vm_mod, collar, use_gripper, pressure_mbar, hold_s, equalize_s)
+
+    if test_case in _PASS_CASES:
+        ctx.comment(f"Case '{test_case}' completed as expected.")
+    else:
+        # If we got here, either recovery succeeded after a runtime error,
+        # or analysis unexpectedly allowed the move (pre residual-vacuum work).
+        ctx.comment(
+            f"Case '{test_case}' reached cleanup after the move. "
+            "If you expected a hard analysis failure, check residual vacuum tracking."
+        )
+        _return_collar_to_module(ctx, vm_mod, collar, use_gripper)

--- a/hardware-testing/hardware_testing/modules/vacuum_module/scripts/run_equalize_move_labware_cases.sh
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/scripts/run_equalize_move_labware_cases.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Analyze every RTP case of vacuum_module_equalize_move_labware_test.py.
+#
+# Uses `opentrons analyze` (not simulate) because the protocol has runtime
+# parameters. Analysis exercises PE residual-vacuum / pump_engaged checks.
+#
+# Usage (from monorepo root, or any cwd):
+#   ./hardware-testing/hardware_testing/modules/vacuum_module/scripts/run_equalize_move_labware_cases.sh
+#   ./.../run_equalize_move_labware_cases.sh --case pressure_hold_no_equalize
+#   ./.../run_equalize_move_labware_cases.sh --verbose
+#   ./.../run_equalize_move_labware_cases.sh --json-dir /tmp/vm_cases
+#
+# Prerequisites:
+#   make -C api setup   # creates api/.venv with opentrons.cli
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VM_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# monorepo root: hardware-testing/hardware_testing/modules/vacuum_module/scripts -> 5 levels up
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../../.." && pwd)"
+
+PROTOCOL="${VM_ROOT}/protocols/vacuum_module_equalize_move_labware_test.py"
+PYTHON="${REPO_ROOT}/api/.venv/bin/python"
+
+PASS_CASES=(
+  cold_start_move
+  pressure_hold_equalize
+  open_vent_equalize
+  power_hold_equalize
+  profile_equalize
+)
+
+FAIL_CASES=(
+  pressure_hold_no_equalize
+  open_vent_no_equalize
+  pump_engaged
+  stop_without_vent
+  power_hold_no_equalize
+  profile_no_equalize
+)
+
+VERBOSE=0
+JSON_DIR=""
+ONLY_CASE=""
+USE_GRIPPER=true
+
+usage() {
+  cat <<'EOF'
+Analyze vacuum_module_equalize_move_labware_test.py for each RTP test_case.
+
+Options:
+  --case NAME       Run only this test_case value
+  --verbose, -v     Print human-readable analysis JSON on failure (or always for single case)
+  --json-dir DIR    Write per-case analysis JSON to DIR/<case>.json
+  --no-gripper      Pass use_gripper=false in RTP
+  -h, --help        Show this help
+
+Examples:
+  ./run_equalize_move_labware_cases.sh
+  ./run_equalize_move_labware_cases.sh --case pump_engaged --verbose
+  ./run_equalize_move_labware_cases.sh --json-dir /tmp/vm_rtp_cases
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --case)
+      ONLY_CASE="${2:?--case requires a name}"
+      shift 2
+      ;;
+    --verbose | -v)
+      VERBOSE=1
+      shift
+      ;;
+    --json-dir)
+      JSON_DIR="${2:?--json-dir requires a path}"
+      shift 2
+      ;;
+    --no-gripper)
+      USE_GRIPPER=false
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -x "${PYTHON}" ]]; then
+  echo "error: missing ${PYTHON}" >&2
+  echo "Run: make -C api setup" >&2
+  exit 1
+fi
+
+if [[ ! -f "${PROTOCOL}" ]]; then
+  echo "error: protocol not found: ${PROTOCOL}" >&2
+  exit 1
+fi
+
+if [[ -n "${JSON_DIR}" ]]; then
+  mkdir -p "${JSON_DIR}"
+fi
+
+analyze_case() {
+  local case="$1"
+  local expect="$2" # pass | fail
+  local out_file="/dev/null"
+  local -a args
+
+  if [[ -n "${JSON_DIR}" ]]; then
+    out_file="${JSON_DIR}/${case}.json"
+  fi
+
+  args=(
+    -m opentrons.cli analyze
+    "${PROTOCOL}"
+    --check
+    --json-output="${out_file}"
+    --rtp-values="{\"test_case\":\"${case}\",\"use_gripper\":${USE_GRIPPER}}"
+  )
+
+  set +e
+  local output
+  output="$("${PYTHON}" "${args[@]}" 2>&1)"
+  local rc=$?
+  set -e
+
+  if [[ "${expect}" == "pass" ]]; then
+    if [[ ${rc} -eq 0 ]]; then
+      echo "  OK (pass as expected)"
+      return 0
+    fi
+    echo "  UNEXPECTED FAIL (exit ${rc})"
+    if [[ ${VERBOSE} -eq 1 ]] || [[ -n "${ONLY_CASE}" ]]; then
+      echo "${output}"
+    fi
+    return 1
+  fi
+
+  # expect fail
+  if [[ ${rc} -ne 0 ]]; then
+    echo "  OK (fail as expected, exit ${rc})"
+    if [[ ${VERBOSE} -eq 1 ]]; then
+      echo "${output}" | head -n 40
+    fi
+    return 0
+  fi
+
+  echo "  UNEXPECTED PASS (analysis succeeded)"
+  if [[ ${VERBOSE} -eq 1 ]] || [[ -n "${ONLY_CASE}" ]]; then
+    echo "${output}"
+  fi
+  return 1
+}
+
+pass_ok=0
+pass_bad=0
+fail_ok=0
+fail_bad=0
+
+run_pass() {
+  local case="$1"
+  echo "=== PASS expected: ${case} ==="
+  if analyze_case "${case}" pass; then
+    pass_ok=$((pass_ok + 1))
+  else
+    pass_bad=$((pass_bad + 1))
+  fi
+}
+
+run_fail() {
+  local case="$1"
+  echo "=== FAIL expected: ${case} ==="
+  if analyze_case "${case}" fail; then
+    fail_ok=$((fail_ok + 1))
+  else
+    fail_bad=$((fail_bad + 1))
+  fi
+}
+
+echo "Protocol: ${PROTOCOL}"
+echo "Python:   ${PYTHON}"
+echo "RTP:      use_gripper=${USE_GRIPPER}"
+if [[ -n "${JSON_DIR}" ]]; then
+  echo "JSON dir: ${JSON_DIR}"
+fi
+echo
+
+if [[ -n "${ONLY_CASE}" ]]; then
+  found=0
+  for case in "${PASS_CASES[@]}"; do
+    if [[ "${case}" == "${ONLY_CASE}" ]]; then
+      run_pass "${case}"
+      found=1
+      break
+    fi
+  done
+  if [[ ${found} -eq 0 ]]; then
+    for case in "${FAIL_CASES[@]}"; do
+      if [[ "${case}" == "${ONLY_CASE}" ]]; then
+        run_fail "${case}"
+        found=1
+        break
+      fi
+    done
+  fi
+  if [[ ${found} -eq 0 ]]; then
+    echo "error: unknown test_case '${ONLY_CASE}'" >&2
+    echo "PASS: ${PASS_CASES[*]}" >&2
+    echo "FAIL: ${FAIL_CASES[*]}" >&2
+    exit 2
+  fi
+else
+  for case in "${PASS_CASES[@]}"; do
+    run_pass "${case}"
+  done
+  echo
+  for case in "${FAIL_CASES[@]}"; do
+    run_fail "${case}"
+  done
+fi
+
+echo
+echo "Summary"
+echo "  PASS cases: ${pass_ok} ok, ${pass_bad} unexpected failures"
+echo "  FAIL cases: ${fail_ok} ok, ${fail_bad} unexpected passes"
+
+if [[ $((pass_bad + fail_bad)) -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
# Overview

Protocol analysis previously only blocked labware moves to/from a Vacuum Module when PE thought the **pump was still engaged**. Residual chamber vacuum (pump off, chamber not equalized) was only checked on real hardware via the gauge, so protocols could analyze green and fail at runtime with `VacuumModuleStillUnderVacuumError`. This PR adds **residual vacuum** in Protocol Engine state from the vacuum/vent/equalize command sequence and uses that state during analysis.

Residual vacuum is cleared only when a command path **vents and waits** for equalization `equalize_timeout_s > 0`. When `equalize_timeout_s` is omitted, we don't wait for pressurization.

## Test Plan and Hands on Testing

- Local analysis suite via RTP runner):

```bash
./hardware-testing/hardware_testing/modules/vacuum_module/scripts/run_equalize_move_labware_cases.sh
```

## Changelog

- Add `residual_vacuum` to `VacuumModuleSubState` / `VacuumModuleStateUpdate` and `StateUpdate.update_vacuum_module_residual_vacuum()`.
- Vacuum start commands (pressure, power, profile) set residual vacuum based on whether the op is expected to equalize after venting.
- Add `will_equalize_after_operation` helper for shared residual-clearing logic.
- Add equalize / move_labware RTP test protocol and bash analyze runner under `hardware-testing`.

## Review requests

Does this make sense?

## Risk assessment

Low, but some protocols might fail analysis moving forward.