### PR TITLE
Chore: Mergeback of chore_release-pd-901 into chore_release-1020-beta

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -6,6 +6,20 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 By installing and using Opentrons software, you agree to the Opentrons End-User License Agreement (EULA). You can view the EULA at [opentrons.com/eula](https://opentrons.com/eula).
 
+## Opentrons Robot Software Changes in 9.1.2
+
+Welcome to the v9.1.2 release of the Opentrons Flex robot software! This release includes bug fixes and improvements.
+
+### Feature Improvements
+
+- Opentrons Flex 96 Filter Tip Racks (20 µL) are compatible with the Opentrons Flex Tip Rack Lid.
+
+### Bug Fixes
+
+- Flex 96-channel pipettes properly align over 8-well reservoirs for liquid handling with a single row of tips.
+
+---
+
 ## Opentrons Robot Software Changes in 9.1.1
 
 Welcome to the v9.1.1 release of the Opentrons Flex robot software! This release enables step grouping to better visualize and organize Python protocols, along with other new features, improvements, and bug fixes.

--- a/api/src/opentrons/hardware_control/modules/retry.py
+++ b/api/src/opentrons/hardware_control/modules/retry.py
@@ -10,8 +10,8 @@ from opentrons.drivers.utils import ParseError
 log = logging.getLogger(__name__)
 
 MODULE_BUILD_RETRIES = 5
-MODULE_BUILD_INITIAL_BACKOFF_S = 0.5
-MODULE_BUILD_MAX_BACKOFF_S = 2.0
+MODULE_BUILD_INITIAL_BACKOFF_S = 0.1
+MODULE_BUILD_MAX_BACKOFF_S = 1.0
 
 # Exceptions that indicate the module is not ready yet and a retry is worthwhile.
 MODULE_BUILD_RETRYABLE_ERRORS: Tuple[Type[BaseException], ...] = (

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/common.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/common.py
@@ -272,23 +272,3 @@ def defined_error_data_from_enumerated_error(
         model_utils,
         state_update_if_false_positive=state_update_if_false_positive,
     )
-
-
-def will_equalize_after_operation(
-    *,
-    vent_after: bool,
-    equalize_timeout: int | None,
-    duration: int | None = None,
-    require_duration: bool = True,
-) -> bool:
-    """Whether the operation is expected to clear residual chamber vacuum.
-
-    Residual vacuum is cleared only when the command both vents and waits for
-    equalization (``equalize_timeout`` is not ``None``). Omitting the timeout
-    means do not wait.
-    """
-    if equalize_timeout is None or not vent_after:
-        return False
-    if require_duration and duration is None:
-        return False
-    return equalize_timeout > 0

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/open_vent.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/open_vent.py
@@ -58,12 +58,6 @@ class OpenVentImpl(AbstractCommandImpl[OpenVentParams, SuccessData[OpenVentResul
             if params.equalizeTimeout is not None:
                 await vm_hardware.wait_for_pressure_equalization(params.equalizeTimeout)
 
-        # Equalize wait clears residual va.
-        if params.equalizeTimeout is not None and params.equalizeTimeout > 0:
-            state_update.update_vacuum_module_residual_vacuum(
-                params.moduleId, residual_vacuum=False
-            )
-
         return SuccessData(public=OpenVentResult(), state_update=state_update)
 
 

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/start_run_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/start_run_profile.py
@@ -26,9 +26,6 @@ from opentrons.hardware_control.modules.types import (
 from opentrons.hardware_control.modules.types import (
     VacuumModuleProfileStep as hc_profile_step,
 )
-from opentrons.protocol_engine.commands.vacuum_module.common import (
-    will_equalize_after_operation,
-)
 from opentrons.protocol_engine.resources import ModelUtils
 
 if TYPE_CHECKING:
@@ -126,10 +123,7 @@ class StartRunProfileParams(BaseModel):
     )
     equalizeTimeout: int | SkipJsonSchema[None] = Field(
         None,
-        description=(
-            "Time in seconds to wait for pressure equalization after the profile "
-            "completes if ventAfter is True. Does not wait if None."
-        ),
+        description="Time in seconds to wait for pressure equalization after the profile completes if ventAfter is True. Does not wait if None.",
     )
     taskId: str | None = Field(None, description="The id of the profile task")
 
@@ -169,12 +163,6 @@ class StartRunProfileImpl(AbstractCommandImpl[StartRunProfileParams, _ExecuteRet
                 f"Equalize timeout {e_timeout} is invalid, must be between 0-{MAX_VAC_DURATION_S} seconds."
             )
 
-        clears_residual = will_equalize_after_operation(
-            vent_after=params.ventAfter,
-            equalize_timeout=params.equalizeTimeout,
-            require_duration=False,
-        )
-
         state_update = update_types.StateUpdate()
         profile: List[hc_profile_step] = []
         pump_engaged = False
@@ -184,10 +172,6 @@ class StartRunProfileImpl(AbstractCommandImpl[StartRunProfileParams, _ExecuteRet
                 pump_engaged = step.enablePump
 
         state_update.update_vacuum_module_pump_engaged(params.moduleId, pump_engaged)
-        # Profiles apply vacuum unless the whole profile equalizes at the end.
-        state_update.update_vacuum_module_residual_vacuum(
-            params.moduleId, not clears_residual
-        )
         running_command_id = self._state_view.commands.get_running_command_id()
         if running_command_id is not None:
             state_update.record_module_background_command(

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_power.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_power.py
@@ -17,9 +17,6 @@ from ..command import (
     SuccessData,
 )
 from opentrons.drivers.vacuum_module.driver import MAX_VAC_DURATION_S
-from opentrons.protocol_engine.commands.vacuum_module.common import (
-    will_equalize_after_operation,
-)
 from opentrons.protocol_engine.resources import ModelUtils
 
 if TYPE_CHECKING:
@@ -58,10 +55,7 @@ class StartSetVacuumPowerParams(BaseModel):
     )
     equalizeTimeout: int | SkipJsonSchema[None] = Field(
         None,
-        description=(
-            "Time in seconds to wait for pressure equalization after opening the vent. "
-            "Does not wait if None."
-        ),
+        description="Time in seconds to wait for pressure equalization after opening the vent. Does not wait if None.",
     )
     taskId: str | None = Field(None, description="The id of the task")
 
@@ -99,18 +93,9 @@ class StartSetVacuumPowerImpl(
         self, params: StartSetVacuumPowerParams
     ) -> SuccessData[StartSetVacuumPowerResult]:
         """Start the vacuum pump."""
-        clears_residual = will_equalize_after_operation(
-            vent_after=params.ventAfter,
-            equalize_timeout=params.equalizeTimeout,
-            duration=params.duration,
-        )
-
         state_update = update_types.StateUpdate()
         state_update.update_vacuum_module_pump_engaged(
             params.moduleId, params.duration is None
-        )
-        state_update.update_vacuum_module_residual_vacuum(
-            params.moduleId, not clears_residual
         )
         running_command_id = self._state_view.commands.get_running_command_id()
         if running_command_id is not None:

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_pressure.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_pressure.py
@@ -21,9 +21,6 @@ from opentrons.drivers.vacuum_module.driver import (
     MAX_VAC_DURATION_S,
     MIN_GAUGE_PRESSURE_MBAR,
 )
-from opentrons.protocol_engine.commands.vacuum_module.common import (
-    will_equalize_after_operation,
-)
 from opentrons.protocol_engine.resources import ModelUtils
 
 if TYPE_CHECKING:
@@ -59,10 +56,7 @@ class StartSetVacuumPressureParams(BaseModel):
     )
     equalizeTimeout: int | SkipJsonSchema[None] = Field(
         None,
-        description=(
-            "Time in seconds to wait for pressure equalization after opening the vent. "
-            "Does not wait if None."
-        ),
+        description="Time in seconds to wait for pressure equalization after opening the vent. Does not wait if None.",
     )
     taskId: str | None = Field(None, description="The id of the task")
 
@@ -100,18 +94,9 @@ class StartSetVacuumPressureImpl(
         self, params: StartSetVacuumPressureParams
     ) -> SuccessData[StartSetVacuumPressureResult]:
         """Start the vacuum pump."""
-        clears_residual = will_equalize_after_operation(
-            vent_after=params.ventAfter,
-            equalize_timeout=params.equalizeTimeout,
-            duration=params.duration,
-        )
-
         state_update = update_types.StateUpdate()
         state_update.update_vacuum_module_pump_engaged(
             params.moduleId, params.duration is None
-        )
-        state_update.update_vacuum_module_residual_vacuum(
-            params.moduleId, not clears_residual
         )
         running_command_id = self._state_view.commands.get_running_command_id()
         if running_command_id is not None:

--- a/api/src/opentrons/protocol_engine/execution/vacuum_module_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/vacuum_module_movement_flagger.py
@@ -73,26 +73,13 @@ class VacuumModuleMovementFlagger:
                 "when moving labware to or from it."
             )
 
-        # Enforce residual vacuum at analysis
-        if self._state_store.config.use_virtual_modules:
-            if vm_substate.residual_vacuum:
+        if not self._state_store.config.use_virtual_modules:
+            vacuum_module = await self._get_hardware_vacuum_module(module_id=module_id)
+            if not vacuum_module.pressure_equalized:
                 raise VacuumModuleStillUnderVacuumError(
                     module_id=vm_substate.module_id,
-                    current_gauge_pressure_mbar=0.0,
-                    message=(
-                        f"Vacuum Module {vm_substate.module_id} may still be under "
-                        "vacuum. Vent and wait for pressure equalization before moving "
-                        "labware to or from it."
-                    ),
+                    current_gauge_pressure_mbar=vacuum_module.current_gauge_pressure_mbar,
                 )
-            return
-
-        vacuum_module = await self._get_hardware_vacuum_module(module_id=module_id)
-        if not vacuum_module.pressure_equalized:
-            raise VacuumModuleStillUnderVacuumError(
-                module_id=vm_substate.module_id,
-                current_gauge_pressure_mbar=vacuum_module.current_gauge_pressure_mbar,
-            )
 
     async def _get_hardware_vacuum_module(
         self,

--- a/api/src/opentrons/protocol_engine/state/module_substates/vacuum_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/vacuum_module_substate.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import NewType, Optional
 
 from opentrons.protocol_engine.state.update_types import (
-    NO_CHANGE,
     VacuumModuleStateUpdate,
 )
 
@@ -21,7 +20,6 @@ class VacuumModuleSubState:
 
     module_id: VacuumModuleId
     pump_engaged: bool
-    residual_vacuum: bool = False
     target_pressure: Optional[float] = None
 
     def new_from_state_change(
@@ -31,18 +29,7 @@ class VacuumModuleSubState:
         new_pump_engaged = self.pump_engaged
         if isinstance(update.pump_engaged, bool):
             new_pump_engaged = update.pump_engaged
-
-        new_residual_vacuum = self.residual_vacuum
-        if isinstance(update.residual_vacuum, bool):
-            new_residual_vacuum = update.residual_vacuum
-
-        new_target_pressure = self.target_pressure
-        if update.target_pressure != NO_CHANGE:
-            new_target_pressure = update.target_pressure
-
         return VacuumModuleSubState(
             module_id=self.module_id,
             pump_engaged=new_pump_engaged,
-            residual_vacuum=new_residual_vacuum,
-            target_pressure=new_target_pressure,
         )

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -359,9 +359,7 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 pool_height=0,
             ),
             ModuleModel.is_vacuum_module: VacuumModuleSubState(
-                module_id=VacuumModuleId(module_id),
-                pump_engaged=False,
-                residual_vacuum=False,
+                module_id=VacuumModuleId(module_id), pump_engaged=False
             ),
         }
 

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -406,8 +406,7 @@ class VacuumModuleStateUpdate:
 
     module_id: str
     pump_engaged: bool | NoChangeType = NO_CHANGE
-    residual_vacuum: bool | NoChangeType = NO_CHANGE
-    target_pressure: float | None | NoChangeType = NO_CHANGE
+    target_pressure: float | NoChangeType = NO_CHANGE
 
     @classmethod
     def create_or_override(
@@ -1000,18 +999,6 @@ class StateUpdate:
                 self.vacuum_module_state_update, module_id
             ),
             pump_engaged=pump_engaged,
-        )
-        return self
-
-    def update_vacuum_module_residual_vacuum(
-        self, module_id: str, residual_vacuum: bool
-    ) -> Self:
-        """Set whether the chamber is modeled as still under vacuum."""
-        self.vacuum_module_state_update = dataclasses.replace(
-            VacuumModuleStateUpdate.create_or_override(
-                self.vacuum_module_state_update, module_id
-            ),
-            residual_vacuum=residual_vacuum,
         )
         return self
 

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_common.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_common.py
@@ -21,7 +21,6 @@ from opentrons.protocol_engine.commands.vacuum_module.common import (
     VacuumPressureNotReachedError,
     defined_error_data_from_task_error,
     handle_recoverable_vacuum_error,
-    will_equalize_after_operation,
 )
 from opentrons.protocol_engine.errors import ErrorOccurrence
 from opentrons.protocol_engine.resources import ModelUtils
@@ -191,25 +190,3 @@ def test_handle_recoverable_vacuum_error_populates_operation_error_info_from_hw_
         "target": -100.0,
         "current": -80.0,
     }
-
-
-def test_will_equalize_after_operation() -> None:
-    """It should only clear residual vacuum when equalize is explicitly requested."""
-    assert will_equalize_after_operation(
-        vent_after=True, equalize_timeout=30, duration=10
-    )
-    assert not will_equalize_after_operation(
-        vent_after=True, equalize_timeout=None, duration=10
-    )
-    assert not will_equalize_after_operation(
-        vent_after=False, equalize_timeout=30, duration=10
-    )
-    assert not will_equalize_after_operation(
-        vent_after=True, equalize_timeout=30, duration=None
-    )
-    assert will_equalize_after_operation(
-        vent_after=True, equalize_timeout=30, require_duration=False
-    )
-    assert not will_equalize_after_operation(
-        vent_after=True, equalize_timeout=0, duration=10
-    )

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_open_vent.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_open_vent.py
@@ -80,17 +80,9 @@ async def test_open_vent_waits_to_equalize(
         vm_hardware
     )
 
-    result = await subject.execute(data)
+    await subject.execute(data)
 
     decoy.verify(
         await vm_hardware.set_vent_state(VentState.OPENED),
         await vm_hardware.wait_for_pressure_equalization(30),
-    )
-    expected_state_update = update_types.StateUpdate()
-    expected_state_update.update_vacuum_module_residual_vacuum(
-        "input-vacuum-id", residual_vacuum=False
-    )
-    assert result == SuccessData(
-        public=vm_commands.OpenVentResult(),
-        state_update=expected_state_update,
     )

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_run_profile.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_run_profile.py
@@ -192,10 +192,6 @@ async def test_start_run_profile(
     expected_state_update.update_vacuum_module_pump_engaged(
         "input-vacuum_module-id", False
     )
-    # ventAfter without equalizeTimeout → residual vacuum remains
-    expected_state_update.update_vacuum_module_residual_vacuum(
-        "input-vacuum_module-id", residual_vacuum=True
-    )
 
     assert result == SuccessData(
         public=expected_result,

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_power.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_power.py
@@ -91,10 +91,6 @@ async def test_start_set_vacuum_power(
     )
     expected_state_update = update_types.StateUpdate()
     expected_state_update.update_vacuum_module_pump_engaged("input-vacuum-id", True)
-    # No duration hold → residual vacuum remains (pump holds indefinitely)
-    expected_state_update.update_vacuum_module_residual_vacuum(
-        "input-vacuum-id", residual_vacuum=True
-    )
 
     assert result == SuccessData(
         public=expected_result,

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_pressure.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_pressure.py
@@ -100,10 +100,6 @@ async def test_start_set_vacuum_presure(
 
     expected_state_update = update_types.StateUpdate()
     expected_state_update.update_vacuum_module_pump_engaged("input-vacuum-id", False)
-    # No equalizeTimeout → residual vacuum remains (vent without wait)
-    expected_state_update.update_vacuum_module_residual_vacuum(
-        "input-vacuum-id", residual_vacuum=True
-    )
 
     assert result == SuccessData(
         public=expected_result,

--- a/api/tests/opentrons/protocol_engine/execution/test_vacuum_module_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_vacuum_module_movement_flagger.py
@@ -96,11 +96,7 @@ async def test_ensure_vacuum_module_is_idle_raises_when_pump_engaged(
     decoy.when(
         state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
     ).then_return(
-        VacuumModuleSubState(
-            module_id=VacuumModuleId("vacuum-id"),
-            pump_engaged=True,
-            residual_vacuum=True,
-        )
+        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=True)
     )
 
     with pytest.raises(VacuumModuleUnderVacuumError, match="pump engaged"):
@@ -126,11 +122,7 @@ async def test_ensure_vacuum_module_is_idle_raises_when_pressure_not_equalized(
     decoy.when(
         state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
     ).then_return(
-        VacuumModuleSubState(
-            module_id=VacuumModuleId("vacuum-id"),
-            pump_engaged=False,
-            residual_vacuum=False,
-        )
+        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=False)
     )
     decoy.when(
         state_store.modules.get_serial_number(module_id="vacuum-id")
@@ -172,11 +164,7 @@ async def test_ensure_vacuum_module_is_idle_noops_when_pressure_equalized(
     decoy.when(
         state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
     ).then_return(
-        VacuumModuleSubState(
-            module_id=VacuumModuleId("vacuum-id"),
-            pump_engaged=False,
-            residual_vacuum=False,
-        )
+        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=False)
     )
     decoy.when(
         state_store.modules.get_serial_number(module_id="vacuum-id")
@@ -200,7 +188,7 @@ async def test_ensure_vacuum_module_is_idle_skips_hardware_check_for_virtual_mod
     subject: VacuumModuleMovementFlagger,
     state_store: StateStore,
 ) -> None:
-    """It should not query hardware when using virtual modules and residual is clear."""
+    """It should not query hardware when using virtual modules."""
     decoy.when(state_store.config).then_return(
         Config(
             robot_type="OT-3 Standard",
@@ -211,42 +199,9 @@ async def test_ensure_vacuum_module_is_idle_skips_hardware_check_for_virtual_mod
     decoy.when(
         state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
     ).then_return(
-        VacuumModuleSubState(
-            module_id=VacuumModuleId("vacuum-id"),
-            pump_engaged=False,
-            residual_vacuum=False,
-        )
+        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=False)
     )
 
     await subject.ensure_vacuum_module_is_idle(
         labware_parent=ModuleLocation(moduleId="vacuum-id")
     )
-
-
-async def test_ensure_vacuum_module_is_idle_raises_virtual_residual_vacuum(
-    decoy: Decoy,
-    subject: VacuumModuleMovementFlagger,
-    state_store: StateStore,
-) -> None:
-    """It should raise on residual vacuum for virtual modules (analysis)."""
-    decoy.when(state_store.config).then_return(
-        Config(
-            robot_type="OT-3 Standard",
-            deck_type=DeckType.OT3_STANDARD,
-            use_virtual_modules=True,
-        )
-    )
-    decoy.when(
-        state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
-    ).then_return(
-        VacuumModuleSubState(
-            module_id=VacuumModuleId("vacuum-id"),
-            pump_engaged=False,
-            residual_vacuum=True,
-        )
-    )
-
-    with pytest.raises(VacuumModuleStillUnderVacuumError, match="may still be under"):
-        await subject.ensure_vacuum_module_is_idle(
-            labware_parent=ModuleLocation(moduleId="vacuum-id")
-        )

--- a/app-shell/build/release-notes.md
+++ b/app-shell/build/release-notes.md
@@ -6,6 +6,12 @@ log][]. For a list of currently known issues, please see the [Opentrons issue tr
 
 By installing and using Opentrons software, you agree to the Opentrons End-User License Agreement (EULA). You can view the EULA at [opentrons.com/eula](https://opentrons.com/eula).
 
+## Opentrons App Changes in 9.1.2
+
+Welcome to the v9.1.2 release of the Opentrons App! This release resolves a bug to prevent the Flex touchscreen from freezing while selecting runtime parameters for a protocol run.
+
+---
+
 ## Opentrons App Changes in 9.1.1
 
 Welcome to the v9.1.1 release of the Opentrons App! This release is designed specifically for use with Opentrons Flex and includes other new features, improvements, and bug fixes.

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
@@ -101,13 +101,17 @@ export function ProtocolSetupLabware({
       ),
     [mostRecentAnalysis]
   )
-  const labwareByLiquidId = getLabwareInfoByLiquidId(
-    mostRecentAnalysis?.commands ?? []
+  const labwareByLiquidId = useMemo(
+    () => getLabwareInfoByLiquidId(mostRecentAnalysis?.commands ?? []),
+    [mostRecentAnalysis?.commands]
   )
-  const stacksWithLaware = getStacksWithLabware(startingDeck)
-  const sortedStartingDeckEntries = Object.entries(stacksWithLaware)
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .filter(([key, value]) => key !== 'offDeck')
+  const sortedStartingDeckEntries = useMemo(
+    () =>
+      Object.entries(getStacksWithLabware(startingDeck))
+        .filter(([location]) => location !== 'offDeck')
+        .sort(([locationA], [locationB]) => locationA.localeCompare(locationB)),
+    [startingDeck]
+  )
   const offDeckItems = useMemo(
     () =>
       mostRecentAnalysis != null
@@ -123,16 +127,26 @@ export function ProtocolSetupLabware({
   const moduleQuery = useModulesQuery({
     refetchInterval: MODULE_REFETCH_INTERVAL_MS,
   })
-  const attachedModules = moduleQuery?.data?.data ?? []
-  const protocolModulesInfo =
-    mostRecentAnalysis != null
-      ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-      : []
+  const attachedModules = useMemo(
+    () => moduleQuery?.data?.data ?? [],
+    [moduleQuery?.data?.data]
+  )
+  const protocolModulesInfo = useMemo(
+    () =>
+      mostRecentAnalysis != null
+        ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+        : [],
+    [mostRecentAnalysis, deckDef]
+  )
 
-  const attachedProtocolModuleMatches = getAttachedProtocolModuleMatches(
-    attachedModules,
-    protocolModulesInfo,
-    deckConfig
+  const attachedProtocolModuleMatches = useMemo(
+    () =>
+      getAttachedProtocolModuleMatches(
+        attachedModules,
+        protocolModulesInfo,
+        deckConfig
+      ),
+    [attachedModules, protocolModulesInfo, deckConfig]
   )
 
   return (
@@ -203,9 +217,9 @@ export function ProtocolSetupLabware({
                     </StyledText>
                   </Flex>
                 </Flex>
-                {sortedStartingDeckEntries.map(([key, value], index) => (
+                {sortedStartingDeckEntries.map(([key, value]) => (
                   <RowLabware
-                    key={index}
+                    key={key}
                     attachedProtocolModules={attachedProtocolModuleMatches}
                     refetchModules={moduleQuery.refetch}
                     slotName={key}
@@ -214,9 +228,9 @@ export function ProtocolSetupLabware({
                     onClick={setSelectedLabwareStack}
                   />
                 ))}
-                {offDeckItems?.map((item, index) => (
+                {offDeckItems.map(item => (
                   <RowLabware
-                    key={index}
+                    key={item.representativeItem.labwareId}
                     attachedProtocolModules={attachedProtocolModuleMatches}
                     refetchModules={moduleQuery.refetch}
                     slotName={'offDeck'}
@@ -496,7 +510,7 @@ function RowLabware({
           {labwareLiquidRenderInfo.map((labware, index) => {
             const quantityTag = offDeckQuantity ?? labware.quantity
             return (
-              <>
+              <Fragment key={labware.labwareId}>
                 <Flex
                   flexDirection={DIRECTION_COLUMN}
                   gridGap={SPACING.spacing4}
@@ -552,7 +566,7 @@ function RowLabware({
                     />
                   ) : null}
                 </Flex>
-              </>
+              </Fragment>
             )
           })}
         </Flex>

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
@@ -103,15 +103,15 @@ export function ProtocolSetupLabware({
   )
   const labwareByLiquidId = useMemo(
     () => getLabwareInfoByLiquidId(mostRecentAnalysis?.commands ?? []),
-    [mostRecentAnalysis]
+    [mostRecentAnalysis?.commands]
   )
-  const stacksWithLaware = useMemo(
-    () => getStacksWithLabware(startingDeck),
+  const sortedStartingDeckEntries = useMemo(
+    () =>
+      Object.entries(getStacksWithLabware(startingDeck))
+        .filter(([location]) => location !== 'offDeck')
+        .sort(([locationA], [locationB]) => locationA.localeCompare(locationB)),
     [startingDeck]
   )
-  const sortedStartingDeckEntries = Object.entries(stacksWithLaware)
-    .sort((a, b) => a[0].localeCompare(b[0]))
-    .filter(([key, value]) => key !== 'offDeck')
   const offDeckItems = useMemo(
     () =>
       mostRecentAnalysis != null
@@ -217,9 +217,9 @@ export function ProtocolSetupLabware({
                     </StyledText>
                   </Flex>
                 </Flex>
-                {sortedStartingDeckEntries.map(([key, value], index) => (
+                {sortedStartingDeckEntries.map(([key, value]) => (
                   <RowLabware
-                    key={index}
+                    key={key}
                     attachedProtocolModules={attachedProtocolModuleMatches}
                     refetchModules={moduleQuery.refetch}
                     slotName={key}
@@ -228,9 +228,9 @@ export function ProtocolSetupLabware({
                     onClick={setSelectedLabwareStack}
                   />
                 ))}
-                {offDeckItems?.map((item, index) => (
+                {offDeckItems.map(item => (
                   <RowLabware
-                    key={index}
+                    key={item.representativeItem.labwareId}
                     attachedProtocolModules={attachedProtocolModuleMatches}
                     refetchModules={moduleQuery.refetch}
                     slotName={'offDeck'}
@@ -510,7 +510,7 @@ function RowLabware({
           {labwareLiquidRenderInfo.map((labware, index) => {
             const quantityTag = offDeckQuantity ?? labware.quantity
             return (
-              <>
+              <Fragment key={labware.labwareId}>
                 <Flex
                   flexDirection={DIRECTION_COLUMN}
                   gridGap={SPACING.spacing4}
@@ -566,7 +566,7 @@ function RowLabware({
                     />
                   ) : null}
                 </Flex>
-              </>
+              </Fragment>
             )
           })}
         </Flex>

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
@@ -33,8 +33,8 @@ import {
   getLabwareInfoByLiquidId,
   getLabwareLiquidRenderInfoFromStack,
   getModuleFromStack,
-  getSortedStartingDeckEntries,
   getStackedItemsOnStartingDeck,
+  getStacksWithLabware,
   HEATERSHAKER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
@@ -101,10 +101,17 @@ export function ProtocolSetupLabware({
       ),
     [mostRecentAnalysis]
   )
-  const labwareByLiquidId = getLabwareInfoByLiquidId(
-    mostRecentAnalysis?.commands ?? []
+  const labwareByLiquidId = useMemo(
+    () => getLabwareInfoByLiquidId(mostRecentAnalysis?.commands ?? []),
+    [mostRecentAnalysis?.commands]
   )
-  const sortedStartingDeckEntries = getSortedStartingDeckEntries(startingDeck)
+  const sortedStartingDeckEntries = useMemo(
+    () =>
+      Object.entries(getStacksWithLabware(startingDeck))
+        .filter(([location]) => location !== 'offDeck')
+        .sort(([locationA], [locationB]) => locationA.localeCompare(locationB)),
+    [startingDeck]
+  )
   const offDeckItems = useMemo(
     () =>
       mostRecentAnalysis != null
@@ -120,16 +127,26 @@ export function ProtocolSetupLabware({
   const moduleQuery = useModulesQuery({
     refetchInterval: MODULE_REFETCH_INTERVAL_MS,
   })
-  const attachedModules = moduleQuery?.data?.data ?? []
-  const protocolModulesInfo =
-    mostRecentAnalysis != null
-      ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-      : []
+  const attachedModules = useMemo(
+    () => moduleQuery?.data?.data ?? [],
+    [moduleQuery?.data?.data]
+  )
+  const protocolModulesInfo = useMemo(
+    () =>
+      mostRecentAnalysis != null
+        ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+        : [],
+    [mostRecentAnalysis, deckDef]
+  )
 
-  const attachedProtocolModuleMatches = getAttachedProtocolModuleMatches(
-    attachedModules,
-    protocolModulesInfo,
-    deckConfig
+  const attachedProtocolModuleMatches = useMemo(
+    () =>
+      getAttachedProtocolModuleMatches(
+        attachedModules,
+        protocolModulesInfo,
+        deckConfig
+      ),
+    [attachedModules, protocolModulesInfo, deckConfig]
   )
 
   return (
@@ -200,20 +217,20 @@ export function ProtocolSetupLabware({
                     </StyledText>
                   </Flex>
                 </Flex>
-                {sortedStartingDeckEntries.map(({ location, stack }, index) => (
+                {sortedStartingDeckEntries.map(([key, value]) => (
                   <RowLabware
-                    key={`${location}_${index}`}
+                    key={key}
                     attachedProtocolModules={attachedProtocolModuleMatches}
                     refetchModules={moduleQuery.refetch}
-                    slotName={location}
-                    stackedItems={stack}
+                    slotName={key}
+                    stackedItems={value}
                     labwareByLiquidId={labwareByLiquidId}
                     onClick={setSelectedLabwareStack}
                   />
                 ))}
-                {offDeckItems?.map((item, index) => (
+                {offDeckItems.map(item => (
                   <RowLabware
-                    key={index}
+                    key={item.representativeItem.labwareId}
                     attachedProtocolModules={attachedProtocolModuleMatches}
                     refetchModules={moduleQuery.refetch}
                     slotName={'offDeck'}
@@ -493,7 +510,7 @@ function RowLabware({
           {labwareLiquidRenderInfo.map((labware, index) => {
             const quantityTag = offDeckQuantity ?? labware.quantity
             return (
-              <>
+              <Fragment key={labware.labwareId}>
                 <Flex
                   flexDirection={DIRECTION_COLUMN}
                   gridGap={SPACING.spacing4}
@@ -549,7 +566,7 @@ function RowLabware({
                     />
                   ) : null}
                 </Flex>
-              </>
+              </Fragment>
             )
           })}
         </Flex>

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
@@ -101,10 +101,14 @@ export function ProtocolSetupLabware({
       ),
     [mostRecentAnalysis]
   )
-  const labwareByLiquidId = getLabwareInfoByLiquidId(
-    mostRecentAnalysis?.commands ?? []
+  const labwareByLiquidId = useMemo(
+    () => getLabwareInfoByLiquidId(mostRecentAnalysis?.commands ?? []),
+    [mostRecentAnalysis]
   )
-  const stacksWithLaware = getStacksWithLabware(startingDeck)
+  const stacksWithLaware = useMemo(
+    () => getStacksWithLabware(startingDeck),
+    [startingDeck]
+  )
   const sortedStartingDeckEntries = Object.entries(stacksWithLaware)
     .sort((a, b) => a[0].localeCompare(b[0]))
     .filter(([key, value]) => key !== 'offDeck')
@@ -123,16 +127,26 @@ export function ProtocolSetupLabware({
   const moduleQuery = useModulesQuery({
     refetchInterval: MODULE_REFETCH_INTERVAL_MS,
   })
-  const attachedModules = moduleQuery?.data?.data ?? []
-  const protocolModulesInfo =
-    mostRecentAnalysis != null
-      ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-      : []
+  const attachedModules = useMemo(
+    () => moduleQuery?.data?.data ?? [],
+    [moduleQuery?.data?.data]
+  )
+  const protocolModulesInfo = useMemo(
+    () =>
+      mostRecentAnalysis != null
+        ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+        : [],
+    [mostRecentAnalysis, deckDef]
+  )
 
-  const attachedProtocolModuleMatches = getAttachedProtocolModuleMatches(
-    attachedModules,
-    protocolModulesInfo,
-    deckConfig
+  const attachedProtocolModuleMatches = useMemo(
+    () =>
+      getAttachedProtocolModuleMatches(
+        attachedModules,
+        protocolModulesInfo,
+        deckConfig
+      ),
+    [attachedModules, protocolModulesInfo, deckConfig]
   )
 
   return (

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ProtocolSetupModulesAndDeck.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupModulesAndDeck/ProtocolSetupModulesAndDeck.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
@@ -84,20 +84,30 @@ export function ProtocolSetupModulesAndDeck({
   const { data: deckConfig = [] } = useNotifyDeckConfigurationQuery({
     refetchInterval: DECK_CONFIG_POLL_MS,
   })
-  const attachedModules =
-    useAttachedModules({
-      refetchInterval: ATTACHED_MODULE_POLL_MS,
-    }) ?? []
+  const attachedModulesData = useAttachedModules({
+    refetchInterval: ATTACHED_MODULE_POLL_MS,
+  })
+  const attachedModules = useMemo(
+    () => attachedModulesData ?? [],
+    [attachedModulesData]
+  )
 
-  const protocolModulesInfo =
-    mostRecentAnalysis != null
-      ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-      : []
+  const protocolModulesInfo = useMemo(
+    () =>
+      mostRecentAnalysis != null
+        ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+        : [],
+    [mostRecentAnalysis, deckDef]
+  )
 
-  const attachedProtocolModuleMatches = getAttachedProtocolModuleMatches(
-    attachedModules,
-    protocolModulesInfo,
-    deckConfig
+  const attachedProtocolModuleMatches = useMemo(
+    () =>
+      getAttachedProtocolModuleMatches(
+        attachedModules,
+        protocolModulesInfo,
+        deckConfig
+      ),
+    [attachedModules, protocolModulesInfo, deckConfig]
   )
 
   const hasModules = attachedProtocolModuleMatches.length > 0

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -261,10 +261,13 @@ function PrepareToRun({
 
   const deckDef = getDeckDefFromRobotType(robotType)
 
-  const protocolModulesInfo =
-    mostRecentAnalysis != null
-      ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-      : []
+  const protocolModulesInfo = useMemo(
+    () =>
+      mostRecentAnalysis != null
+        ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+        : [],
+    [mostRecentAnalysis, deckDef]
+  )
 
   const { missingModuleIds } = getUnmatchedModulesForProtocol(
     attachedModules,
@@ -545,9 +548,11 @@ function PrepareToRun({
   }
 
   // Labware information
-  const { offDeckItems, onDeckItems } = getLabwareSetupItemGroups(
-    mostRecentAnalysis?.commands ?? []
+  const { offDeckItems, onDeckItems } = useMemo(
+    () => getLabwareSetupItemGroups(mostRecentAnalysis?.commands ?? []),
+    [mostRecentAnalysis?.commands]
   )
+
   const onDeckLabwareCount = onDeckItems.length
   const additionalLabwareCount = offDeckItems.length
 
@@ -820,10 +825,13 @@ export function ProtocolSetup(): JSX.Element {
   }, [mostRecentAnalysis?.status])
   const deckDef = getDeckDefFromRobotType(robotType)
 
-  const protocolModulesInfo =
-    mostRecentAnalysis != null
-      ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-      : []
+  const protocolModulesInfo = useMemo(
+    () =>
+      mostRecentAnalysis != null
+        ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+        : [],
+    [mostRecentAnalysis, deckDef]
+  )
 
   const { missingModuleIds } = getUnmatchedModulesForProtocol(
     attachedModules,

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -262,10 +262,13 @@ function PrepareToRun({
 
   const deckDef = getDeckDefFromRobotType(robotType)
 
-  const protocolModulesInfo =
-    mostRecentAnalysis != null
-      ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-      : []
+  const protocolModulesInfo = useMemo(
+    () =>
+      mostRecentAnalysis != null
+        ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+        : [],
+    [mostRecentAnalysis, deckDef]
+  )
 
   const { missingModuleIds } = getUnmatchedModulesForProtocol(
     attachedModules,
@@ -554,9 +557,11 @@ function PrepareToRun({
   }
 
   // Labware information
-  const { offDeckItems, onDeckItems } = getLabwareSetupItemGroups(
-    mostRecentAnalysis?.commands ?? []
+  const { offDeckItems, onDeckItems } = useMemo(
+    () => getLabwareSetupItemGroups(mostRecentAnalysis?.commands ?? []),
+    [mostRecentAnalysis]
   )
+
   const onDeckLabwareCount = onDeckItems.length
   const additionalLabwareCount = offDeckItems.length
 
@@ -829,10 +834,13 @@ export function ProtocolSetup(): JSX.Element {
   }, [mostRecentAnalysis?.status])
   const deckDef = getDeckDefFromRobotType(robotType)
 
-  const protocolModulesInfo =
-    mostRecentAnalysis != null
-      ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
-      : []
+  const protocolModulesInfo = useMemo(
+    () =>
+      mostRecentAnalysis != null
+        ? getProtocolModulesInfo(mostRecentAnalysis, deckDef)
+        : [],
+    [mostRecentAnalysis, deckDef]
+  )
 
   const { missingModuleIds } = getUnmatchedModulesForProtocol(
     attachedModules,

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -559,7 +559,7 @@ function PrepareToRun({
   // Labware information
   const { offDeckItems, onDeckItems } = useMemo(
     () => getLabwareSetupItemGroups(mostRecentAnalysis?.commands ?? []),
-    [mostRecentAnalysis]
+    [mostRecentAnalysis?.commands]
   )
 
   const onDeckLabwareCount = onDeckItems.length

--- a/protocol-designer/release-notes.md
+++ b/protocol-designer/release-notes.md
@@ -8,6 +8,18 @@ By using Opentrons Protocol Designer, you agree to the Opentrons End-User Licens
 
 ---
 
+## Opentrons Protocol Designer Changes in 9.0.1
+
+**Welcome to Protocol Designer 9.0.1!**
+
+This release includes bug fixes for Protocol Designer for Opentrons Flex.
+
+### Bug Fixes
+
+- Flex 20 µL filter pipette tips are compatible with the Flex Stacker in Protocol Designer protocols.
+- Protocol Designer no longer crashes when selecting multiple wells in a transfer step.
+- Flex 96-channel pipettes aspirate and dispense from the proper positions in NEST 8 well reservoirs (22 mL).
+
 ## Opentrons Protocol Designer Changes in 9.0.0
 
 **Welcome to Protocol Designer 9.0.0!**

--- a/protocol-designer/src/file-data/__tests__/createFile.test.ts
+++ b/protocol-designer/src/file-data/__tests__/createFile.test.ts
@@ -247,7 +247,7 @@ CUSTOM_LABWARE = json.loads("""{"fixture/fixture_trash/1":{"ordering":[["A1"]],"
             },
           },
         },
-        version: '9.0.0',
+        version: '9.0.1',
         name: 'opentrons/protocol-designer',
       },
       robot: { model: OT2_ROBOT_TYPE },

--- a/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
+++ b/protocol-designer/src/pages/Designer/DeckSetup/constants.ts
@@ -122,6 +122,7 @@ export const RECOMMENDED_LABWARE_BY_MODULE: {
     'opentrons_flex_96_filtertiprack_1000ul',
     'opentrons_flex_96_filtertiprack_200ul',
     'opentrons_flex_96_filtertiprack_50ul',
+    'opentrons_flex_96_filtertiprack_20ul',
     'opentrons_flex_96_tiprack_1000ul',
     'opentrons_flex_96_tiprack_200ul',
     'opentrons_flex_96_tiprack_50ul',

--- a/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/utils.ts
+++ b/protocol-designer/src/pages/Designer/ProtocolSteps/StepForm/PipetteFields/NozzleAndWellSelectionModal/utils.ts
@@ -175,10 +175,9 @@ export const getEntireWellSelection = (
   const columnIndex = wellOrdering.findIndex(column =>
     column.includes(wellName)
   )
-  const indexInColumn = wellOrdering[columnIndex].findIndex(
-    well => well === wellName
-  )
-  if (columnIndex === -1) return []
+  if (columnIndex === -1) {
+    return []
+  }
   const rowIndex = wellOrdering[columnIndex].indexOf(wellName)
   const is384Plate = wellOrdering.flat().length === 384
 
@@ -226,9 +225,9 @@ export const getEntireWellSelection = (
       return is384Plate
         ? skipEveryOtherWell(
             wellName,
-            column.slice(indexInColumn, Math.min(end, column.length))
+            column.slice(rowIndex, Math.min(end, column.length))
           )
-        : column.slice(indexInColumn, Math.min(end, column.length))
+        : column.slice(rowIndex, Math.min(end, column.length))
     }
     default:
       return [wellName]

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -16,7 +16,7 @@ import { cssModuleSideEffect } from './cssModuleSideEffect'
 
 import type { UserConfig } from 'vite'
 
-const REQUIRED_APP_VERSION = '10.0.0-beta' // PD requires this robot stack version or higher
+const REQUIRED_APP_VERSION = '10.2.0-beta' // PD requires this robot stack version or higher
 const { getVersion, generateBuildInfoHtml } = createGitVersionToolkit({
   project: 'protocol-designer',
 })

--- a/protocol-designer/vite.config.mts
+++ b/protocol-designer/vite.config.mts
@@ -16,7 +16,7 @@ import { cssModuleSideEffect } from './cssModuleSideEffect'
 
 import type { UserConfig } from 'vite'
 
-const REQUIRED_APP_VERSION = '9.0.0' // PD requires this robot stack version or higher
+const REQUIRED_APP_VERSION = '9.1.2' // PD requires this robot stack version or higher
 const { getVersion, generateBuildInfoHtml } = createGitVersionToolkit({
   project: 'protocol-designer',
 })

--- a/shared-data/js/__tests__/getWellNamePerMultiTip.test.ts
+++ b/shared-data/js/__tests__/getWellNamePerMultiTip.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from 'vitest'
 
+import nest_8_reservoir_22ml from '../../labware/definitions/2/nest_8_reservoir_22ml/2.json'
 import fixture_12_trough from '../../labware/fixtures/2/fixture_12_trough.json'
 import fixture_24_tuberack from '../../labware/fixtures/2/fixture_24_tuberack.json'
 import fixture_96_plate from '../../labware/fixtures/2/fixture_96_plate.json'
 import fixture_384_plate from '../../labware/fixtures/2/fixture_384_plate.json'
 import fixture_trash from '../../labware/fixtures/2/fixture_trash.json'
-import { getWellNamePerMultiTip } from '../helpers/getWellNamePerMultiTip'
+import {
+  getWellNamePerMultiTip,
+  getWellNamePerRowMultiTip,
+} from '../helpers/getWellNamePerMultiTip'
 
 import type { LabwareDefinition } from '../types'
 
@@ -14,6 +18,7 @@ const fixture96Plate = fixture_96_plate as LabwareDefinition
 const fixture384Plate = fixture_384_plate as LabwareDefinition
 const fixture12Trough = fixture_12_trough as LabwareDefinition
 const fixture24Tuberack = fixture_24_tuberack as LabwareDefinition
+const nest8Reservoir = nest_8_reservoir_22ml as LabwareDefinition
 const EIGHT_CHANNEL = 8
 
 describe('96 plate', () => {
@@ -159,5 +164,58 @@ describe('12 channel trough', () => {
 
   it('B1 => null (well does not exist)', () => {
     expect(getWellNamePerMultiTip(labware, 'B1', EIGHT_CHANNEL)).toEqual(null)
+  })
+})
+
+describe('getWellNamePerRowMultiTip', () => {
+  it('96 plate A1 => full row A', () => {
+    expect(getWellNamePerRowMultiTip(fixture96Plate, 'A1')).toEqual([
+      'A1',
+      'A2',
+      'A3',
+      'A4',
+      'A5',
+      'A6',
+      'A7',
+      'A8',
+      'A9',
+      'A10',
+      'A11',
+      'A12',
+    ])
+  })
+
+  it('12 trough A1 => one tip per column trough', () => {
+    expect(getWellNamePerRowMultiTip(fixture12Trough, 'A1')).toEqual([
+      'A1',
+      'A2',
+      'A3',
+      'A4',
+      'A5',
+      'A6',
+      'A7',
+      'A8',
+      'A9',
+      'A10',
+      'A11',
+      'A12',
+    ])
+  })
+
+  it('8-well row reservoir centers all tips in one trough', () => {
+    expect(getWellNamePerRowMultiTip(nest8Reservoir, 'A1')).toEqual([
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+      'A1',
+    ])
   })
 })

--- a/shared-data/js/helpers/__tests__/wellSets.test.ts
+++ b/shared-data/js/helpers/__tests__/wellSets.test.ts
@@ -1,7 +1,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 import { get96Channel384WellPlateWells, orderWells } from '..'
-import { ALL, SINGLE } from '../../../command/types'
+import { ALL, COLUMN, ROW, SINGLE } from '../../../command/types'
+import nest_8_reservoir_22ml from '../../../labware/definitions/2/nest_8_reservoir_22ml/2.json'
 import fixture_12_trough from '../../../labware/fixtures/2/fixture_12_trough.json'
 import fixture_96_plate from '../../../labware/fixtures/2/fixture_96_plate.json'
 import fixture_384_plate from '../../../labware/fixtures/2/fixture_384_plate.json'
@@ -22,6 +23,7 @@ const fixture96Plate = fixture_96_plate as LabwareDefinition
 const fixture384Plate = fixture_384_plate as LabwareDefinition
 const fixtureOverlappyWellplate =
   fixture_overlappy_wellplate as LabwareDefinition
+const nest8Reservoir = nest_8_reservoir_22ml as LabwareDefinition
 const EIGHT_CHANNEL = 8
 const NINETY_SIX_CHANNEL = 96
 const wellsForReservoir = [
@@ -222,6 +224,30 @@ describe('canPipetteUseLabware', () => {
     const pipette = fixtureP10MultiV2Specs
     const nozzles = SINGLE
     expect(canPipetteUseLabware(pipette, nozzles, labwareDef)).toBe(true)
+  })
+
+  it('allows 96-channel ROW on row trough reservoirs with centerMultichannelOnWells', () => {
+    const pipette96 = fixtureP100096V2Specs
+
+    // y-axis column probe fails for this def because the quirk centers tips on
+    // narrow row troughs, but X-axis row geometry succeeds.
+    expect(canPipetteUseLabware(pipette96, ALL, nest8Reservoir)).toBe(false)
+    expect(canPipetteUseLabware(pipette96, COLUMN, nest8Reservoir)).toBe(false)
+    expect(canPipetteUseLabware(pipette96, ROW, nest8Reservoir)).toBe(true)
+  })
+
+  it('allows 96-channel ROW on standard 96 plates and 12-trough reservoirs', () => {
+    const pipette96 = fixtureP100096V2Specs
+
+    expect(canPipetteUseLabware(pipette96, ROW, fixture96Plate)).toBe(true)
+    expect(canPipetteUseLabware(pipette96, ROW, fixture12Trough)).toBe(true)
+  })
+
+  it('returns false for 96-channel ROW when wells are too close together', () => {
+    const pipette96 = fixtureP100096V2Specs
+    expect(
+      canPipetteUseLabware(pipette96, ROW, fixtureOverlappyWellplate)
+    ).toBe(false)
   })
 })
 

--- a/shared-data/js/helpers/getWellNamePerMultiTip.ts
+++ b/shared-data/js/helpers/getWellNamePerMultiTip.ts
@@ -8,7 +8,36 @@ import type { ActiveNozzleNumber, LabwareDefinition } from '../types'
 // TODO Ian 2018-03-13 pull pipette offsets/positions from some pipette definitions data
 const OFFSET_8_CHANNEL = 9 // offset in mm between tips
 
-const MULTICHANNEL_TIP_SPAN = OFFSET_8_CHANNEL * (8 - 1) // length in mm from first to last tip of multichannel
+const COLUMN_TIP_COUNT = 8
+const ROW_TIP_COUNT = 12
+
+const MULTICHANNEL_COLUMN_TIP_SPAN = OFFSET_8_CHANNEL * (COLUMN_TIP_COUNT - 1)
+const MULTICHANNEL_ROW_TIP_SPAN = OFFSET_8_CHANNEL * (ROW_TIP_COUNT - 1)
+
+/** returns true when labware is a series of row-length wells (ex: 8-well reservoir). */
+export function isRowLabware(labwareDef: LabwareDefinition): boolean {
+  return (
+    Object.keys(labwareDef.wells).length > 1 && labwareDef.ordering.length === 1
+  )
+}
+
+/** returns true when labware is a series of column-length wells (ex: 12-well reservoir). */
+export function isColumnLabware(labwareDef: LabwareDefinition): boolean {
+  return (
+    Object.keys(labwareDef.wells).length > 1 &&
+    labwareDef.ordering.every(column => column.length === 1)
+  )
+}
+
+function shouldCenterRowTipsOnWell(labwareDef: LabwareDefinition): boolean {
+  if (!getLabwareHasQuirk(labwareDef, 'centerMultichannelOnWells')) {
+    return false
+  }
+  const wellCount = Object.keys(labwareDef.wells).length
+  // single-well reservoirs and row troughs: center the row of tips in X
+  // column troughs keep SBS X spacing so each tip lands in its own trough
+  return wellCount === 1 || isRowLabware(labwareDef)
+}
 
 export function findWellAt(
   labwareDef: LabwareDefinition,
@@ -34,6 +63,45 @@ export function findWellAt(
         Math.abs(y - well.y) < well.yDimension / 2
       )
     })
+}
+
+/**
+ * Given a well, return the wells contacted by a 12-tip row (9 mm pitch -- see const above),
+ * or null if any tip misses a well.
+ *
+ * With centerMultichannelOnWells on row troughs / 1-well reservoirs, the tip
+ * span is centered on the well in X so all tips share one wide trough.
+ */
+export function getWellNamePerRowMultiTip(
+  labwareDef: LabwareDefinition,
+  wellName: string
+): string[] | null {
+  const well = labwareDef.wells[wellName]
+  if (!well) {
+    console.warn(
+      `well "${wellName}" does not exist in labware ${labwareDef?.namespace}/${labwareDef?.parameters?.loadName}, cannot getWellNamePerRowMultiTip`
+    )
+    return null
+  }
+
+  const { x, y } = well
+  let offsetXTipPositions: number[] = range(0, ROW_TIP_COUNT).map(
+    tipNo => x + tipNo * OFFSET_8_CHANNEL
+  )
+
+  if (shouldCenterRowTipsOnWell(labwareDef)) {
+    offsetXTipPositions = offsetXTipPositions.map(
+      tipPosX => tipPosX - MULTICHANNEL_ROW_TIP_SPAN / 2
+    )
+  }
+
+  return offsetXTipPositions.reduce((acc: string[] | null, tipPosX) => {
+    const wellForTip = findWellAt(labwareDef, tipPosX, y)
+    if (acc === null || !wellForTip) {
+      return null
+    }
+    return acc.concat(wellForTip)
+  }, [])
 }
 
 // "topWellName" means well at the "top" of the column we're accessing: usually A row, or B row for 384-format
@@ -65,14 +133,14 @@ export function getWellNamePerMultiTip(
     return test
   }
   const { x, y } = topWell
-  let offsetYTipPositions: number[] = range(0, 8).map(
+  let offsetYTipPositions: number[] = range(0, COLUMN_TIP_COUNT).map(
     tipNo => y - tipNo * OFFSET_8_CHANNEL
   )
 
   if (getLabwareHasQuirk(labwareDef, 'centerMultichannelOnWells')) {
     // move multichannel up in Y by half the pipette's tip span to center it in the well
     offsetYTipPositions = offsetYTipPositions.map(
-      tipPosY => tipPosY + MULTICHANNEL_TIP_SPAN / 2
+      tipPosY => tipPosY + MULTICHANNEL_COLUMN_TIP_SPAN / 2
     )
   }
   // Return null for containers with any undefined wells

--- a/shared-data/js/helpers/index.ts
+++ b/shared-data/js/helpers/index.ts
@@ -19,13 +19,19 @@ import type {
   ThermalAdapterName,
 } from '../types'
 
-export { getWellNamePerMultiTip } from './getWellNamePerMultiTip'
+export {
+  findWellAt,
+  getWellNamePerMultiTip,
+  getWellNamePerRowMultiTip,
+  isColumnLabware,
+  isRowLabware,
+  skipEveryOtherWell,
+} from './getWellNamePerMultiTip'
 export { getWellTotalVolume } from './getWellTotalVolume'
 export { wellIsRect } from './wellIsRect'
 export { orderWells } from './orderWells'
 export { get96Channel384WellPlateWells } from './get96Channel384WellPlateWells'
 export { getTipTypeFromTipRackDefinition } from './getTipTypeFromTipRackDefinition'
-export { skipEveryOtherWell } from './getWellNamePerMultiTip'
 export * from './__fixtures__'
 export * from './parseProtocolCommands'
 export * from './parseProtocolData'

--- a/shared-data/js/helpers/wellSets.ts
+++ b/shared-data/js/helpers/wellSets.ts
@@ -14,8 +14,11 @@
 import uniq from 'lodash/uniq'
 
 import { get96Channel384WellPlateWells, getLabwareDefURI, orderWells } from '.'
-import { SINGLE } from '../../command/types'
-import { getWellNamePerMultiTip } from './getWellNamePerMultiTip'
+import { ROW, SINGLE } from '../../command/types'
+import {
+  getWellNamePerMultiTip,
+  getWellNamePerRowMultiTip,
+} from './getWellNamePerMultiTip'
 
 import type { NozzleConfigurationStyle } from '../../command/types'
 import type {
@@ -27,6 +30,20 @@ import type {
 
 type WellSetByPrimaryWell = string[][]
 
+const VALID_COLUMN_WELL_SET_SIZES = [1, 8] as const
+const VALID_ROW_WELL_SET_SIZES = [1, 12] as const
+
+function isValidWellSet(
+  wellSet: string[],
+  validUniqueCounts: readonly number[]
+): boolean {
+  const uniqueWells = uniq(wellSet)
+  return (
+    uniqueWells.every(well => well != null) &&
+    validUniqueCounts.includes(uniqueWells.length)
+  )
+}
+
 // Compute all well sets for a labware def (non-memoized)
 function _getAllWellSetsForLabware(
   labwareDef: LabwareDefinition
@@ -36,6 +53,22 @@ function _getAllWellSetsForLabware(
 
   for (const well of allWells) {
     const wellSet = getWellNamePerMultiTip(labwareDef, well, 8)
+    if (wellSet != null) {
+      wellSets.push(wellSet)
+    }
+  }
+
+  return wellSets
+}
+
+function _getAllRowWellSetsForLabware(
+  labwareDef: LabwareDefinition
+): WellSetByPrimaryWell {
+  const allWells: string[] = Object.keys(labwareDef.wells)
+  const wellSets: WellSetByPrimaryWell = []
+
+  for (const well of allWells) {
+    const wellSet = getWellNamePerRowMultiTip(labwareDef, well)
     if (wellSet != null) {
       wellSets.push(wellSet)
     }
@@ -226,6 +259,20 @@ export const makeWellSetHelpers = (): WellSetHelpers => {
     }
   }
 
+  const hasValidColumnWellSets = (labwareDef: LabwareDefinition): boolean => {
+    const allWellSets = getAllWellSetsForLabware(labwareDef)
+    return allWellSets.some(wellSet =>
+      isValidWellSet(wellSet, VALID_COLUMN_WELL_SET_SIZES)
+    )
+  }
+
+  const hasValidRowWellSets = (labwareDef: LabwareDefinition): boolean => {
+    const allRowWellSets = _getAllRowWellSetsForLabware(labwareDef)
+    return allRowWellSets.some(wellSet =>
+      isValidWellSet(wellSet, VALID_ROW_WELL_SET_SIZES)
+    )
+  }
+
   const canPipetteUseLabware = (
     pipetteSpec: PipetteV2Specs,
     nozzleConfiguration: NozzleConfigurationStyle,
@@ -238,21 +285,19 @@ export const makeWellSetHelpers = (): WellSetHelpers => {
       // assume all labware can be used by single-channel
       return true
     }
-    if (labwareDef != null) {
-      const allWellSets = getAllWellSetsForLabware(labwareDef)
-      return allWellSets.some(wellSet => {
-        const uniqueWells = uniq(wellSet)
-        // if all wells are non-null, and there are either 1 (reservoir-like)
-        // or 8 (well plate-like) unique wells in the set,
-        // then assume both 8 and 96 channel pipettes will work
-        return (
-          uniqueWells.every(well => well != null) &&
-          [1, 8].includes(uniqueWells.length)
-        )
-      })
-    } else {
+    if (labwareDef == null) {
       return false
     }
+
+    // row tips span X. Use row geometry so row troughs (ex 8-well reservoirs
+    // with centerMultichannelOnWells) are not judged by column Y spacing.
+    if (nozzleConfiguration === ROW) {
+      return hasValidRowWellSets(labwareDef)
+    }
+
+    // column/partial column/full multi: tips span Y.
+    // full 96 nozzles still need Y-aligned wells... row-only troughs stay incompatible.
+    return hasValidColumnWellSets(labwareDef)
   }
   return {
     getAllWellSetsForLabware,

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -50,7 +50,7 @@ import type {
 } from '../types'
 
 export const PAPI_VERSION = '2.29' // oldest version that we need from api/src/opentrons/protocols/api_support/definitions.py, might not be the actual latest version
-export const PD_APPLICATION_VERSION = '9.0.0' // latest PD version to insert into DESIGNER_APPLICATION blob
+export const PD_APPLICATION_VERSION = '9.0.1' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {
   return ['import json', 'from opentrons import protocol_api, types'].join('\n')

--- a/step-generation/src/utils/pythonFileUtils.ts
+++ b/step-generation/src/utils/pythonFileUtils.ts
@@ -53,7 +53,7 @@ import type {
 } from '../types'
 
 export const PAPI_VERSION = '2.30' // oldest version that we need from api/src/opentrons/protocols/api_support/definitions.py, might not be the actual latest version
-export const PD_APPLICATION_VERSION = '9.0.0' // latest PD version to insert into DESIGNER_APPLICATION blob
+export const PD_APPLICATION_VERSION = '9.0.1' // latest PD version to insert into DESIGNER_APPLICATION blob
 
 export function pythonImports(): string {
   return ['import json', 'from opentrons import protocol_api, types'].join('\n')


### PR DESCRIPTION
merge `chore_release-pd-9.0.1` into `chore_release-10.2.0-beta`. There were 3 merge conflicts:

1. ProtocolSetupLabware - accepted new changed from pd 9.0.1
2. `protocol-designer/vite.config.mts` - accepted changes from 1020 beta
3. `step-generation/src/utils/pythonFileUtils.ts` - accpeted changes from both branches so papi version and pd version are the latest