### PR TITLE
refactor(robot-server): Delete an unused internal attribute from RunDataManager

### DIFF
--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -54,7 +54,7 @@ from robot_server.service.pyro_utils.resource_utilities import (
     get_pyro_resource,
     register_run_orchestrator_store_to_pyro_resource,
 )
-from robot_server.service.task_runner import TaskRunner, get_task_runner
+from robot_server.service.task_runner import get_task_runner
 from robot_server.settings import get_settings
 
 _run_store_accessor = AppStateAccessor[RunStore]("run_store")
@@ -224,7 +224,6 @@ async def get_is_okay_to_create_maintenance_run(
 
 async def get_run_data_manager(
     app_state: Annotated[AppState, Depends(get_app_state)],
-    task_runner: Annotated[TaskRunner, Depends(get_task_runner)],
     run_orchestrator_store: Annotated[
         RunOrchestratorStore, Depends(get_run_orchestrator_store)
     ],
@@ -247,7 +246,6 @@ async def get_run_data_manager(
             run_store=run_store,
             error_recovery_setting_store=error_recovery_setting_store,
             camera_setting_store=camera_setting_store,
-            task_runner=task_runner,
             runs_publisher=runs_publisher,
             file_provider=file_provider,
         )

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -40,7 +40,6 @@ from robot_server.camera.settings.store import CameraSettingStore
 from robot_server.error_recovery.settings.store import ErrorRecoverySettingStore
 from robot_server.protocols.protocol_store import ProtocolResource
 from robot_server.service.notifications import RunsPublisher
-from robot_server.service.task_runner import TaskRunner
 
 _INITIAL_ERROR_RECOVERY_RULES: list[ErrorRecoveryRule] = []
 
@@ -165,7 +164,6 @@ class RunDataManager:
         run_store: RunStore,
         error_recovery_setting_store: ErrorRecoverySettingStore,
         camera_setting_store: CameraSettingStore,
-        task_runner: TaskRunner,
         runs_publisher: RunsPublisher,
         file_provider: FileProvider,
     ) -> None:
@@ -180,7 +178,6 @@ class RunDataManager:
         # This error recovery mapping stuff probably belongs in RunOrchestratorStore.
         self._current_run_error_recovery_rules: List[ErrorRecoveryRule] = []
 
-        self._task_runner = task_runner
         self._runs_publisher = runs_publisher
         self._file_provider = file_provider
 

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -68,7 +68,6 @@ from robot_server.runs.run_store import (
     RunStore,
 )
 from robot_server.service.notifications import RunsPublisher
-from robot_server.service.task_runner import TaskRunner
 
 
 def mock_notify_publishers() -> None:
@@ -100,12 +99,6 @@ def mock_error_recovery_setting_store(decoy: Decoy) -> ErrorRecoverySettingStore
 def mock_camera_setting_store(decoy: Decoy) -> CameraSettingStore:
     """Get a mock CameraSettingStore."""
     return decoy.mock(cls=CameraSettingStore)
-
-
-@pytest.fixture()
-def mock_task_runner(decoy: Decoy) -> TaskRunner:
-    """Get a mock background TaskRunner."""
-    return decoy.mock(cls=TaskRunner)
 
 
 @pytest.fixture()
@@ -248,7 +241,6 @@ def subject(
     mock_run_store: RunStore,
     mock_error_recovery_setting_store: ErrorRecoverySettingStore,
     mock_camera_setting_store: CameraSettingStore,
-    mock_task_runner: TaskRunner,
     mock_runs_publisher: RunsPublisher,
     mock_file_provider: FileProvider,
 ) -> RunDataManager:
@@ -258,7 +250,6 @@ def subject(
         run_store=mock_run_store,
         error_recovery_setting_store=mock_error_recovery_setting_store,
         camera_setting_store=mock_camera_setting_store,
-        task_runner=mock_task_runner,
         runs_publisher=mock_runs_publisher,
         file_provider=mock_file_provider,
     )


### PR DESCRIPTION
This just deletes some dead code. `RunDataManager` had a `task_runner` arg that wasn't being used anywhere.