### PR TITLE
feat(robot-server): Add a signed_by column to the run table

### DIFF
--- a/robot-server/robot_server/persistence/_migrations/v17_to_v18.py
+++ b/robot-server/robot_server/persistence/_migrations/v17_to_v18.py
@@ -1,0 +1,30 @@
+"""Migrate the persistence directory from schema 17 to 18.
+
+Summary of changes from schema 17:
+
+- Adds a "signed_by" column to the "run" table.
+"""
+
+from pathlib import Path
+
+from server_utils.persistence.folder_migrator import Migration
+
+from ..database import sql_engine_ctx
+from ..file_and_directory_names import DB_FILE
+from ..tables import schema_18
+from ._util import add_column, copy_contents
+
+
+class Migration17to18(Migration):  # noqa: D101
+    def migrate(self, source_dir: Path, dest_dir: Path) -> None:
+        """Migrate the persistence directory from schema 17 to 18."""
+        copy_contents(source_dir=source_dir, dest_dir=dest_dir)
+
+        dest_db_file = dest_dir / DB_FILE
+
+        with sql_engine_ctx(dest_db_file) as dest_engine:
+            add_column(
+                dest_engine,
+                schema_18.run_table.name,
+                schema_18.run_table.c.signed_by,
+            )

--- a/robot-server/robot_server/persistence/file_and_directory_names.py
+++ b/robot-server/robot_server/persistence/file_and_directory_names.py
@@ -8,7 +8,7 @@ v2/deck_configuration.json, etc.
 
 from typing import Final
 
-LATEST_VERSION_DIRECTORY: Final = "17"
+LATEST_VERSION_DIRECTORY: Final = "18"
 
 DECK_CONFIGURATION_FILE: Final = "deck_configuration.json"
 PROTOCOLS_DIRECTORY: Final = "protocols"

--- a/robot-server/robot_server/persistence/manage_persistence_directory.py
+++ b/robot-server/robot_server/persistence/manage_persistence_directory.py
@@ -28,6 +28,7 @@ from ._migrations import (
     v14_to_v15,
     v15_to_v16,
     v16_to_v17,
+    v17_to_v18,
 )
 from .file_and_directory_names import LATEST_VERSION_DIRECTORY
 
@@ -69,7 +70,8 @@ def make_migration_orchestrator(prepared_root: Path) -> MigrationOrchestrator:
             v13_to_v14.Migration13to14(subdirectory="14"),
             v14_to_v15.Migration14to15(subdirectory="15"),
             v15_to_v16.Migration15to16(subdirectory="16"),
-            v16_to_v17.Migration16to17(subdirectory=LATEST_VERSION_DIRECTORY),
+            v16_to_v17.Migration16to17(subdirectory="17"),
+            v17_to_v18.Migration17to18(subdirectory=LATEST_VERSION_DIRECTORY),
         ],
         temp_file_prefix="temp-",
     )

--- a/robot-server/robot_server/persistence/tables/__init__.py
+++ b/robot-server/robot_server/persistence/tables/__init__.py
@@ -1,7 +1,7 @@
 """SQL database schemas."""
 
 # Re-export the latest schema.
-from .schema_16 import (
+from .schema_18 import (
     BooleanSettingKey,
     CommandStatusSQLEnum,
     PrimitiveParamSQLEnum,

--- a/robot-server/robot_server/persistence/tables/schema_18.py
+++ b/robot-server/robot_server/persistence/tables/schema_18.py
@@ -1,0 +1,604 @@
+"""v18 of our SQLite schema."""
+
+import enum
+
+import sqlalchemy
+
+from server_utils.sql_utils import UTCDateTime
+
+metadata = sqlalchemy.MetaData()
+
+
+class PrimitiveParamSQLEnum(enum.Enum):
+    """Enum type to store primitive param type."""
+
+    INT = "int"
+    FLOAT = "float"
+    BOOL = "bool"
+    STR = "str"
+
+
+class ProtocolKindSQLEnum(enum.Enum):
+    """What kind a stored protocol is."""
+
+    STANDARD = "standard"
+    QUICK_TRANSFER = "quick-transfer"
+
+
+class CommandStatusSQLEnum(enum.Enum):
+    """Command status sql enum."""
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+protocol_table = sqlalchemy.Table(
+    "protocol",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.String,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "created_at",
+        UTCDateTime,
+        nullable=False,
+    ),
+    sqlalchemy.Column("protocol_key", sqlalchemy.String, nullable=True),
+    sqlalchemy.Column(
+        "protocol_kind",
+        sqlalchemy.Enum(
+            ProtocolKindSQLEnum,
+            values_callable=lambda obj: [e.value for e in obj],
+            validate_strings=True,
+            create_constraint=True,
+        ),
+        index=True,
+        nullable=False,
+    ),
+)
+
+
+analysis_table = sqlalchemy.Table(
+    "analysis",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.String,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "protocol_id",
+        sqlalchemy.String,
+        sqlalchemy.ForeignKey("protocol.id"),
+        index=True,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "analyzer_version",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "completed_analysis",
+        # Stores a JSON string. See CompletedAnalysisStore.
+        sqlalchemy.String,
+        nullable=False,
+    ),
+)
+
+
+analysis_primitive_type_rtp_table = sqlalchemy.Table(
+    "analysis_primitive_rtp_table",
+    metadata,
+    sqlalchemy.Column(
+        "row_id",
+        sqlalchemy.Integer,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "analysis_id",
+        sqlalchemy.ForeignKey("analysis.id"),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_variable_name",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_type",
+        sqlalchemy.Enum(
+            PrimitiveParamSQLEnum,
+            values_callable=lambda obj: [e.value for e in obj],
+            create_constraint=True,
+            # todo(mm, 2024-09-24): Can we add validate_strings=True here?
+        ),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_value",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+)
+
+
+analysis_csv_rtp_table = sqlalchemy.Table(
+    "analysis_csv_rtp_table",
+    metadata,
+    sqlalchemy.Column(
+        "row_id",
+        sqlalchemy.Integer,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "analysis_id",
+        sqlalchemy.ForeignKey("analysis.id"),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_variable_name",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "file_id",
+        sqlalchemy.ForeignKey("data_files.id"),
+        nullable=True,
+    ),
+)
+
+
+run_table = sqlalchemy.Table(
+    "run",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.String,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "created_at",
+        UTCDateTime,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "protocol_id",
+        sqlalchemy.String,
+        sqlalchemy.ForeignKey("protocol.id"),
+        nullable=True,
+    ),
+    sqlalchemy.Column(
+        "state_summary",
+        sqlalchemy.String,
+        nullable=True,
+    ),
+    sqlalchemy.Column("engine_status", sqlalchemy.String, nullable=True),
+    sqlalchemy.Column("_updated_at", UTCDateTime, nullable=True),
+    sqlalchemy.Column(
+        "run_time_parameters",
+        # Stores a JSON string. See RunStore.
+        sqlalchemy.String,
+        nullable=True,
+    ),
+    sqlalchemy.Column(
+        "input_file_ids",
+        # Stores a JSON array of input_ids from input_data_files table
+        sqlalchemy.String,
+        nullable=True,
+    ),
+    sqlalchemy.Column(
+        "output_file_ids",
+        # Stores a JSON array of output_ids from output_data_files table
+        sqlalchemy.String,
+        nullable=True,
+    ),
+    sqlalchemy.Column(
+        "signed_by",
+        sqlalchemy.String,
+        nullable=True,
+    ),
+)
+
+
+action_table = sqlalchemy.Table(
+    "action",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.String,
+        primary_key=True,
+    ),
+    sqlalchemy.Column("created_at", UTCDateTime, nullable=False),
+    sqlalchemy.Column("action_type", sqlalchemy.String, nullable=False),
+    sqlalchemy.Column(
+        "run_id",
+        sqlalchemy.String,
+        sqlalchemy.ForeignKey("run.id"),
+        nullable=False,
+    ),
+)
+
+
+run_command_table = sqlalchemy.Table(
+    "run_command",
+    metadata,
+    sqlalchemy.Column("row_id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "run_id", sqlalchemy.String, sqlalchemy.ForeignKey("run.id"), nullable=False
+    ),
+    # command_index in commands enumeration
+    sqlalchemy.Column("index_in_run", sqlalchemy.Integer, nullable=False),
+    sqlalchemy.Column("command_id", sqlalchemy.String, nullable=False),
+    sqlalchemy.Column("command", sqlalchemy.String, nullable=False),
+    sqlalchemy.Column(
+        "command_intent",
+        sqlalchemy.String,
+        # nullable=True to match the underlying SQL, which is nullable because of a bug
+        # in the migration that introduced this column. This is not intended to ever be
+        # null in practice.
+        nullable=True,
+    ),
+    sqlalchemy.Column("command_error", sqlalchemy.String, nullable=True),
+    sqlalchemy.Column(
+        "command_status",
+        sqlalchemy.Enum(
+            CommandStatusSQLEnum,
+            values_callable=lambda obj: [e.value for e in obj],
+            validate_strings=True,
+            # nullable=True because it was easier for the migration to add the column
+            # this way. This is not intended to ever be null in practice.
+            nullable=True,
+            # todo(mm, 2024-11-20): We want create_constraint=True here. Something
+            # about the way we compare SQL in test_tables.py is making that difficult--
+            # even when we correctly add the constraint in the migration, the SQL
+            # doesn't compare equal to what create_constraint=True here would emit.
+            create_constraint=False,
+        ),
+    ),
+    sqlalchemy.Index(
+        "ix_run_run_id_command_id",  # An arbitrary name for the index.
+        "run_id",
+        "command_id",
+        unique=True,
+    ),
+    sqlalchemy.Index(
+        "ix_run_run_id_index_in_run",  # An arbitrary name for the index.
+        "run_id",
+        "index_in_run",
+        unique=True,
+    ),
+    sqlalchemy.Index(
+        "ix_run_run_id_command_status_index_in_run",  # An arbitrary name for the index.
+        "run_id",
+        "command_status",
+        "index_in_run",
+        unique=True,
+    ),
+)
+
+
+class AnnotationSourceSQLEnum(enum.Enum):
+    """Source of an annotation."""
+
+    USER_COMMAND = "userCommand"
+    SYSTEM_COMMAND = "systemCommand"
+
+
+command_annotation_table = sqlalchemy.Table(
+    "command_annotation",
+    metadata,
+    sqlalchemy.Column("row_id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "run_id",
+        sqlalchemy.String,
+        sqlalchemy.ForeignKey("run.id"),
+        nullable=False,
+    ),
+    sqlalchemy.Column("annotation_id", sqlalchemy.String, nullable=False),
+    sqlalchemy.Column("name", sqlalchemy.String, nullable=False),
+    sqlalchemy.Column("description", sqlalchemy.String, nullable=True),
+    sqlalchemy.Column(
+        "source",
+        sqlalchemy.Enum(
+            AnnotationSourceSQLEnum,
+            values_callable=lambda obj: [e.value for e in obj],
+            create_constraint=True,
+            validate_strings=True,
+        ),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parent_id",
+        sqlalchemy.String,
+        nullable=True,
+    ),
+    # Stores a JSON string
+    sqlalchemy.Column("params", sqlalchemy.String, nullable=True),
+    sqlalchemy.ForeignKeyConstraint(
+        ["run_id", "parent_id"],
+        ["command_annotation.run_id", "command_annotation.annotation_id"],
+        ondelete="CASCADE",  # As of the addition of this table, we do not anticipate deleting a parent annotation without deleting its children. So we are enabling cascading deletes.
+    ),
+    sqlalchemy.Index(
+        "ix_run_id_annotation_id",
+        "run_id",
+        "annotation_id",
+        unique=True,
+    ),
+)
+
+
+command_to_annotation_table = sqlalchemy.Table(
+    "command_to_annotation",
+    metadata,
+    sqlalchemy.Column("row_id", sqlalchemy.Integer, primary_key=True),
+    sqlalchemy.Column(
+        "run_id",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "command_id",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "annotation_id",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.ForeignKeyConstraint(
+        ["run_id", "command_id"], ["run_command.run_id", "run_command.command_id"]
+    ),
+    sqlalchemy.ForeignKeyConstraint(
+        ["run_id", "annotation_id"],
+        ["command_annotation.run_id", "command_annotation.annotation_id"],
+    ),
+    sqlalchemy.Index(
+        "ix_c2a_run_id_command_id_annotation_id",  # c2a stands for command_to_annotation
+        "run_id",
+        "command_id",
+        "annotation_id",
+        unique=True,
+    ),
+)
+
+# stores the metadata describing the physical file
+data_files_table = sqlalchemy.Table(
+    "data_files",
+    metadata,
+    sqlalchemy.Column(
+        "id",
+        sqlalchemy.String,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "name",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "path",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "stored",
+        sqlalchemy.Boolean,
+        nullable=False,
+        default=True,
+    ),
+    sqlalchemy.Column(
+        "generated",
+        sqlalchemy.Boolean,
+        nullable=False,
+        index=True,
+    ),
+    sqlalchemy.Column(
+        "mime_type",
+        sqlalchemy.String,
+        nullable=False,
+        index=True,
+    ),
+    sqlalchemy.Column(
+        "file_hash",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "created_at",
+        UTCDateTime,
+        nullable=False,
+    ),
+)
+
+# table for data files serving as input to a run
+input_data_files_table = sqlalchemy.Table(
+    "input_data_files",
+    metadata,
+    sqlalchemy.Column(
+        "file_id",
+        sqlalchemy.String,
+        sqlalchemy.ForeignKey("data_files.id"),
+        nullable=False,
+        index=True,
+    ),
+    sqlalchemy.Column(
+        "run_id",
+        sqlalchemy.String,
+        sqlalchemy.ForeignKey("run.id"),
+        nullable=False,
+        index=True,
+    ),
+    sqlalchemy.PrimaryKeyConstraint("file_id", "run_id"),
+)
+
+
+# data files generated as output during a run
+output_data_files_table = sqlalchemy.Table(
+    "output_data_files",
+    metadata,
+    sqlalchemy.Column(
+        "run_id",
+        sqlalchemy.String,
+        sqlalchemy.ForeignKey("run.id"),
+        nullable=False,
+        index=True,
+    ),
+    sqlalchemy.Column(
+        "command_id",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "prev_command_id",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "file_id",
+        sqlalchemy.String,
+        sqlalchemy.ForeignKey("data_files.id"),
+        nullable=False,
+        index=True,
+    ),
+    sqlalchemy.PrimaryKeyConstraint("file_id", "run_id"),
+)
+
+
+run_csv_rtp_table = sqlalchemy.Table(
+    "run_csv_rtp_table",
+    metadata,
+    sqlalchemy.Column(
+        "row_id",
+        sqlalchemy.Integer,
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "run_id",
+        sqlalchemy.ForeignKey("run.id"),
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "parameter_variable_name",
+        sqlalchemy.String,
+        nullable=False,
+    ),
+    sqlalchemy.Column(
+        "file_id",
+        sqlalchemy.ForeignKey("data_files.id"),
+        nullable=True,
+    ),
+)
+
+
+class BooleanSettingKey(enum.Enum):
+    """Keys for boolean settings."""
+
+    ENABLE_ERROR_RECOVERY = "enable_error_recovery"
+    ENABLE_CAMERA = "enable_camera"
+    ENABLE_LIVE_STREAM = "enable_live_stream"
+    ENABLE_ERROR_RECOVERY_CAMERA = "enable_error_recovery_camera"
+    REQUIRE_SIGNOFF_FOR_PROTOCOL_LOG = "require_signoff_for_protocol_log"
+    REQUIRE_LOGS_TO_BE_SAVED_IN_APP = "require_logs_to_be_saved_in_app"
+    DELETE_OVER_MAX_ON_DISK_PROTOCOLS = "delete_over_max_on_disk_protocols"
+
+
+boolean_setting_table = sqlalchemy.Table(
+    "boolean_setting_extended",
+    metadata,
+    sqlalchemy.Column(
+        "key",
+        sqlalchemy.Enum(
+            BooleanSettingKey,
+            values_callable=lambda obj: [e.value for e in obj],
+            validate_strings=True,
+            create_constraint=False,
+            native_enum=False,
+            length=200,
+        ),
+        primary_key=True,
+    ),
+    sqlalchemy.Column(
+        "value",
+        sqlalchemy.Boolean,
+        nullable=False,
+    ),
+)
+
+camera_capture_image_settings_table = sqlalchemy.Table(
+    "camera_capture_image_settings",
+    metadata,
+    sqlalchemy.Column("camera_id", sqlalchemy.String, primary_key=True),
+    sqlalchemy.Column("resolution_x", sqlalchemy.Integer, nullable=True),
+    sqlalchemy.Column("resolution_y", sqlalchemy.Integer, nullable=True),
+    sqlalchemy.Column("zoom", sqlalchemy.Float, nullable=True),
+    sqlalchemy.Column("pan_x", sqlalchemy.Integer, nullable=True),
+    sqlalchemy.Column("pan_y", sqlalchemy.Integer, nullable=True),
+    sqlalchemy.Column("contrast", sqlalchemy.Float, nullable=True),
+    sqlalchemy.Column("brightness", sqlalchemy.Float, nullable=True),
+    sqlalchemy.Column("saturation", sqlalchemy.Float, nullable=True),
+)
+
+
+labware_offset_table = sqlalchemy.Table(
+    "labware_offset_with_sequence",
+    metadata,
+    # Numeric row ID for ordering:
+    sqlalchemy.Column("row_id", sqlalchemy.Integer, primary_key=True),
+    # String UUID for exposing over HTTP:
+    sqlalchemy.Column(
+        "offset_id", sqlalchemy.String, nullable=False, unique=True, index=True
+    ),
+    # The URI identifying the labware definition that this offset applies to.
+    sqlalchemy.Column("definition_uri", sqlalchemy.String, nullable=False),
+    # The offset itself:
+    sqlalchemy.Column("vector_x", sqlalchemy.Float, nullable=False),
+    sqlalchemy.Column("vector_y", sqlalchemy.Float, nullable=False),
+    sqlalchemy.Column("vector_z", sqlalchemy.Float, nullable=False),
+    # Whether this record is "active", i.e. whether it should be considered as a
+    # candidate to apply to runs and affect actual robot motion:
+    sqlalchemy.Column("active", sqlalchemy.Boolean, nullable=False),
+    # When this record was created:
+    sqlalchemy.Column("created_at", UTCDateTime, nullable=False),
+    sqlalchemy.Index(
+        "ix__labware_offset_with_sequence__active__row_id",  # An arbitrary name for the index.
+        "active",
+        "row_id",
+        unique=True,
+    ),
+)
+
+labware_offset_location_sequence_components_table = sqlalchemy.Table(
+    "labware_offset_sequence_components",
+    metadata,
+    # ID for this row, which largely won't be used
+    sqlalchemy.Column("row_id", sqlalchemy.Integer, primary_key=True),
+    # Which offset this belongs to
+    sqlalchemy.Column(
+        "offset_id",
+        sqlalchemy.ForeignKey(
+            "labware_offset_with_sequence.row_id",
+        ),
+        nullable=False,
+        index=True,
+    ),
+    # Its position within the sequence
+    sqlalchemy.Column("sequence_ordinal", sqlalchemy.Integer, nullable=False),
+    # An identifier for the component; in practice this will be an enum entry (of the kind values
+    # of the LabwareOffsetSequenceComponent models) but by keeping that out of the schema we don't
+    # have to change the schema if we add something new there
+    sqlalchemy.Column("component_kind", sqlalchemy.String, nullable=False),
+    # The value of the component, which will differ in kind by what component it is, and would be
+    # annoying to further schematize without yet more normalization. If we ever add a sequence component
+    # that has more than one value in it (think twice before doing this), pick a primary value that you'll
+    # be searching by and put that here.
+    sqlalchemy.Column("primary_component_value", sqlalchemy.String, nullable=False),
+    # If the value of the component has more than one thing in it, dump it to json and put it here.
+    sqlalchemy.Column("component_value_json", sqlalchemy.String, nullable=False),
+)

--- a/robot-server/robot_server/runs/run_store.py
+++ b/robot-server/robot_server/runs/run_store.py
@@ -71,6 +71,7 @@ class RunResource:
     protocol_id: Optional[str]
     created_at: datetime
     actions: List[RunAction]
+    signed_by: Optional[str]
 
 
 @dataclass(frozen=True)
@@ -91,6 +92,7 @@ class BadRunResource:
     protocol_id: Optional[str]
     created_at: datetime
     actions: List[RunAction]
+    signed_by: Optional[str]
     error: EnumeratedError
 
 
@@ -269,6 +271,29 @@ class RunStore:
 
         self._clear_caches()
 
+    def set_signed_by(self, run_id: str, signed_by: str) -> None:
+        """Set the signed_by value for a run.
+
+        Args:
+            run_id: The run to update.
+            signed_by: Signature of the user who reviewed the run.
+
+        Raises:
+            RunNotFoundError: The given run ID was not found in the store.
+        """
+        update = (
+            sqlalchemy.update(run_table)
+            .where(run_table.c.id == run_id)
+            .values(signed_by=signed_by)
+        )
+
+        with self._sql_engine.begin() as transaction:
+            if not self._run_exists(run_id, transaction):
+                raise RunNotFoundError(run_id=run_id)
+            transaction.execute(update)
+
+        self._clear_caches()
+
     def get_all_csv_rtp(self) -> List[CSVParameterRunResource]:
         """Get all of the csv rtp from the run_csv_rtp_table."""
         select_all_csv_rtp = sqlalchemy.select(run_csv_rtp_table).order_by(
@@ -328,6 +353,7 @@ class RunStore:
             created_at=created_at,
             protocol_id=protocol_id,
             actions=[],
+            signed_by=None,
         )
         insert = sqlalchemy.insert(run_table).values(
             _convert_run_to_sql_values(run=run)
@@ -880,7 +906,12 @@ class RunStore:
 
 
 # The columns that must be present in a row passed to _convert_row_to_run().
-_run_columns = [run_table.c.id, run_table.c.protocol_id, run_table.c.created_at]
+_run_columns = [
+    run_table.c.id,
+    run_table.c.protocol_id,
+    run_table.c.created_at,
+    run_table.c.signed_by,
+]
 
 
 def _convert_row_to_csv_rtp(
@@ -906,6 +937,7 @@ def _convert_row_to_run(
     run_id = row.id
     protocol_id = row.protocol_id
     created_at = row.created_at
+    signed_by = row.signed_by
     # Checking the fundamental data types here are not covered by the error handling
     # because if they fire, the only thing we can do to address the issue is immediately
     # delete the row while we still have a handle on it from sql - we won't have any
@@ -914,6 +946,9 @@ def _convert_row_to_run(
     assert isinstance(run_id, str), f"Run ID {run_id} is not a string"
     assert protocol_id is None or isinstance(protocol_id, str), (
         f"Protocol ID {protocol_id} is not a string or None"
+    )
+    assert signed_by is None or isinstance(signed_by, str), (
+        f"signed_by {signed_by} is not a string or None"
     )
     try:
         actions = [
@@ -932,6 +967,7 @@ def _convert_row_to_run(
             created_at=created_at,
             protocol_id=protocol_id,
             actions=[],
+            signed_by=signed_by,
             error=InvalidStoredData(
                 message="This run has invalid or unknown actions. It has likely been saved in a future version of software.",
                 detail={"kind": "bad-actions"},
@@ -945,6 +981,7 @@ def _convert_row_to_run(
         created_at=created_at,
         protocol_id=protocol_id,
         actions=actions,
+        signed_by=signed_by,
     )
 
 
@@ -953,6 +990,7 @@ def _convert_run_to_sql_values(run: RunResource) -> Dict[str, object]:
         "id": run.run_id,
         "created_at": run.created_at,
         "protocol_id": run.protocol_id,
+        "signed_by": run.signed_by,
     }
 
 

--- a/robot-server/tests/persistence/test_tables.py
+++ b/robot-server/tests/persistence/test_tables.py
@@ -29,6 +29,7 @@ from robot_server.persistence.tables import (
     schema_14,
     schema_15,
     schema_16,
+    schema_18,
 )
 
 # The statements that we expect to emit when we create a fresh database.
@@ -43,7 +44,260 @@ from robot_server.persistence.tables import (
 #   * Adding, removing, or renaming a constraint or relation.
 #
 # Whitespace and formatting changes, on the other hand, are allowed.
-EXPECTED_STATEMENTS_V16 = [
+
+EXPECTED_STATEMENTS_LATEST = EXPECTED_STATEMENTS_V18 = [
+    """
+    CREATE TABLE protocol (
+        id VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        protocol_key VARCHAR,
+        protocol_kind VARCHAR(14) NOT NULL,
+        PRIMARY KEY (id),
+        CONSTRAINT protocolkindsqlenum CHECK (protocol_kind IN ('standard', 'quick-transfer'))
+    )
+    """,
+    """
+    CREATE TABLE analysis (
+        id VARCHAR NOT NULL,
+        protocol_id VARCHAR NOT NULL,
+        analyzer_version VARCHAR NOT NULL,
+        completed_analysis VARCHAR NOT NULL,
+        PRIMARY KEY (id),
+        FOREIGN KEY(protocol_id) REFERENCES protocol (id)
+    )
+    """,
+    """
+    CREATE TABLE analysis_primitive_rtp_table (
+        row_id INTEGER NOT NULL,
+        analysis_id VARCHAR NOT NULL,
+        parameter_variable_name VARCHAR NOT NULL,
+        parameter_type VARCHAR(5) NOT NULL,
+        parameter_value VARCHAR NOT NULL,
+        PRIMARY KEY (row_id),
+        FOREIGN KEY(analysis_id) REFERENCES analysis (id),
+        CONSTRAINT primitiveparamsqlenum CHECK (parameter_type IN ('int', 'float', 'bool', 'str'))
+    )
+    """,
+    """
+    CREATE TABLE analysis_csv_rtp_table (
+        row_id INTEGER NOT NULL,
+        analysis_id VARCHAR NOT NULL,
+        parameter_variable_name VARCHAR NOT NULL,
+        file_id VARCHAR,
+        PRIMARY KEY (row_id),
+        FOREIGN KEY(analysis_id) REFERENCES analysis (id),
+        FOREIGN KEY(file_id) REFERENCES data_files (id)
+    )
+    """,
+    """
+    CREATE INDEX ix_analysis_protocol_id ON analysis (protocol_id)
+    """,
+    """
+    CREATE TABLE run (
+        id VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        protocol_id VARCHAR,
+        state_summary VARCHAR,
+        engine_status VARCHAR,
+        _updated_at DATETIME,
+        run_time_parameters VARCHAR,
+        input_file_ids VARCHAR,
+        output_file_ids VARCHAR,
+        signed_by VARCHAR,
+        PRIMARY KEY (id),
+        FOREIGN KEY(protocol_id) REFERENCES protocol (id)
+    )
+    """,
+    """
+    CREATE TABLE action (
+        id VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        action_type VARCHAR NOT NULL,
+        run_id VARCHAR NOT NULL,
+        PRIMARY KEY (id),
+        FOREIGN KEY(run_id) REFERENCES run (id)
+    )
+    """,
+    """
+    CREATE TABLE run_command (
+        row_id INTEGER NOT NULL,
+        run_id VARCHAR NOT NULL,
+        index_in_run INTEGER NOT NULL,
+        command_id VARCHAR NOT NULL,
+        command VARCHAR NOT NULL,
+        command_intent VARCHAR,
+        command_error VARCHAR,
+        command_status VARCHAR(9),
+        PRIMARY KEY (row_id),
+        FOREIGN KEY(run_id) REFERENCES run (id)
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX ix_run_run_id_command_id ON run_command (run_id, command_id)
+    """,
+    """
+    CREATE UNIQUE INDEX ix_run_run_id_index_in_run ON run_command (run_id, index_in_run)
+    """,
+    """
+    CREATE UNIQUE INDEX ix_run_run_id_command_status_index_in_run ON run_command (run_id, command_status, index_in_run)
+    """,
+    """
+    CREATE INDEX ix_protocol_protocol_kind ON protocol (protocol_kind)
+    """,
+    """
+    CREATE TABLE command_annotation (
+        row_id INTEGER NOT NULL,
+        run_id VARCHAR NOT NULL,
+        annotation_id VARCHAR NOT NULL,
+        name VARCHAR NOT NULL,
+        description VARCHAR,
+        source VARCHAR(13) NOT NULL,
+        parent_id VARCHAR,
+        params VARCHAR,
+        PRIMARY KEY (row_id),
+        FOREIGN KEY(run_id, parent_id) REFERENCES command_annotation (run_id, annotation_id) ON DELETE CASCADE,
+        FOREIGN KEY(run_id) REFERENCES run (id),
+        CONSTRAINT annotationsourcesqlenum CHECK (source IN ('userCommand', 'systemCommand'))
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX ix_run_id_annotation_id ON command_annotation (run_id, annotation_id)
+    """,
+    """
+    CREATE TABLE command_to_annotation (
+        row_id INTEGER NOT NULL,
+        run_id VARCHAR NOT NULL,
+        command_id VARCHAR NOT NULL,
+        annotation_id VARCHAR NOT NULL,
+        PRIMARY KEY (row_id),
+        FOREIGN KEY(run_id, command_id) REFERENCES run_command (run_id, command_id),
+        FOREIGN KEY(run_id, annotation_id) REFERENCES command_annotation (run_id, annotation_id)
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX ix_c2a_run_id_command_id_annotation_id ON command_to_annotation (run_id, command_id, annotation_id)
+    """,
+    """
+    CREATE TABLE data_files (
+        id VARCHAR NOT NULL,
+        name VARCHAR NOT NULL,
+        path VARCHAR NOT NULL,
+        stored BOOLEAN NOT NULL,
+        generated BOOLEAN NOT NULL,
+        mime_type VARCHAR NOT NULL,
+        file_hash VARCHAR NOT NULL,
+        created_at DATETIME NOT NULL,
+        PRIMARY KEY (id)
+    )
+    """,
+    """
+    CREATE INDEX ix_data_files_generated ON data_files (generated)
+    """,
+    """
+    CREATE INDEX ix_data_files_mime_type ON data_files (mime_type)
+    """,
+    """
+    CREATE TABLE input_data_files (
+        file_id VARCHAR NOT NULL,
+        run_id VARCHAR NOT NULL,
+        PRIMARY KEY (file_id, run_id),
+        FOREIGN KEY(file_id) REFERENCES data_files (id),
+        FOREIGN KEY(run_id) REFERENCES run (id)
+    )
+    """,
+    """
+    CREATE INDEX ix_input_data_files_file_id ON input_data_files (file_id)
+    """,
+    """
+    CREATE INDEX ix_input_data_files_run_id ON input_data_files (run_id)
+    """,
+    """
+    CREATE TABLE output_data_files (
+        run_id VARCHAR NOT NULL,
+        command_id VARCHAR NOT NULL,
+        prev_command_id VARCHAR NOT NULL,
+        file_id VARCHAR NOT NULL,
+        PRIMARY KEY (file_id, run_id),
+        FOREIGN KEY(run_id) REFERENCES run (id),
+        FOREIGN KEY(file_id) REFERENCES data_files (id)
+    )
+    """,
+    """
+    CREATE INDEX ix_output_data_files_run_id ON output_data_files (run_id)
+    """,
+    """
+    CREATE INDEX ix_output_data_files_file_id ON output_data_files (file_id)
+    """,
+    """
+    CREATE TABLE run_csv_rtp_table (
+        row_id INTEGER NOT NULL,
+        run_id VARCHAR NOT NULL,
+        parameter_variable_name VARCHAR NOT NULL,
+        file_id VARCHAR,
+        PRIMARY KEY (row_id),
+        FOREIGN KEY(run_id) REFERENCES run (id),
+        FOREIGN KEY(file_id) REFERENCES data_files (id)
+    )
+    """,
+    """
+    CREATE TABLE boolean_setting_extended (
+        "key" VARCHAR(200) NOT NULL,
+        value BOOLEAN NOT NULL,
+        PRIMARY KEY ("key")
+    )
+    """,
+    """
+    CREATE TABLE camera_capture_image_settings (
+        camera_id VARCHAR NOT NULL,
+        resolution_x INTEGER,
+        resolution_y INTEGER,
+        zoom FLOAT,
+        pan_x INTEGER,
+        pan_y INTEGER,
+        contrast FLOAT,
+        brightness FLOAT,
+        saturation FLOAT,
+        PRIMARY KEY (camera_id)
+    )
+    """,
+    """
+    CREATE TABLE labware_offset_with_sequence (
+        row_id INTEGER NOT NULL,
+        offset_id VARCHAR NOT NULL,
+        definition_uri VARCHAR NOT NULL,
+        vector_x FLOAT NOT NULL,
+        vector_y FLOAT NOT NULL,
+        vector_z FLOAT NOT NULL,
+        active BOOLEAN NOT NULL,
+        created_at DATETIME NOT NULL,
+        PRIMARY KEY (row_id)
+    )
+    """,
+    """
+    CREATE UNIQUE INDEX ix__labware_offset_with_sequence__active__row_id ON labware_offset_with_sequence (active, row_id)
+    """,
+    """
+    CREATE UNIQUE INDEX ix_labware_offset_with_sequence_offset_id ON labware_offset_with_sequence (offset_id)
+    """,
+    """
+    CREATE TABLE labware_offset_sequence_components (
+       row_id INTEGER NOT NULL,
+       offset_id INTEGER NOT NULL,
+       sequence_ordinal INTEGER NOT NULL,
+       component_kind VARCHAR NOT NULL,
+       primary_component_value VARCHAR NOT NULL,
+       component_value_json VARCHAR NOT NULL,
+       PRIMARY KEY (row_id),
+       FOREIGN KEY(offset_id) REFERENCES labware_offset_with_sequence (row_id)
+    )
+    """,
+    """
+    CREATE INDEX ix_labware_offset_sequence_components_offset_id ON labware_offset_sequence_components (offset_id)
+    """,
+]
+
+# schema 17 = schema 16 with file permissions
+EXPECTED_STATEMENTS_V17 = EXPECTED_STATEMENTS_V16 = [
     """
     CREATE TABLE protocol (
         id VARCHAR NOT NULL,
@@ -292,9 +546,6 @@ EXPECTED_STATEMENTS_V16 = [
     CREATE INDEX ix_labware_offset_sequence_components_offset_id ON labware_offset_sequence_components (offset_id)
     """,
 ]
-
-EXPECTED_STATEMENTS_V17 = EXPECTED_STATEMENTS_V16
-EXPECTED_STATEMENTS_LATEST = EXPECTED_STATEMENTS_V17
 
 EXPECTED_STATEMENTS_V15 = [
     """
@@ -2064,25 +2315,27 @@ EXPECTED_STATEMENTS_V2 = [
 @pytest.mark.parametrize(
     ("metadata", "expected_statements"),
     [
-        (latest_metadata, EXPECTED_STATEMENTS_LATEST),
-        (
+        pytest.param(latest_metadata, EXPECTED_STATEMENTS_LATEST, id="latest"),
+        pytest.param(schema_18.metadata, EXPECTED_STATEMENTS_V18, id="v18"),
+        pytest.param(
             schema_16.metadata,
             EXPECTED_STATEMENTS_V17,
+            id="v17",
         ),  # schema 17 = schema 16 with file permissions
-        (schema_16.metadata, EXPECTED_STATEMENTS_V16),
-        (schema_15.metadata, EXPECTED_STATEMENTS_V15),
-        (schema_14.metadata, EXPECTED_STATEMENTS_V14),
-        (schema_13.metadata, EXPECTED_STATEMENTS_V13),
-        (schema_11.metadata, EXPECTED_STATEMENTS_V11),
-        (schema_10.metadata, EXPECTED_STATEMENTS_V10),
-        (schema_09.metadata, EXPECTED_STATEMENTS_V9),
-        (schema_08.metadata, EXPECTED_STATEMENTS_V8),
-        (schema_07.metadata, EXPECTED_STATEMENTS_V7),
-        (schema_06.metadata, EXPECTED_STATEMENTS_V6),
-        (schema_05.metadata, EXPECTED_STATEMENTS_V5),
-        (schema_04.metadata, EXPECTED_STATEMENTS_V4),
-        (schema_03.metadata, EXPECTED_STATEMENTS_V3),
-        (schema_02.metadata, EXPECTED_STATEMENTS_V2),
+        pytest.param(schema_16.metadata, EXPECTED_STATEMENTS_V16, id="v16"),
+        pytest.param(schema_15.metadata, EXPECTED_STATEMENTS_V15, id="v15"),
+        pytest.param(schema_14.metadata, EXPECTED_STATEMENTS_V14, id="v14"),
+        pytest.param(schema_13.metadata, EXPECTED_STATEMENTS_V13, id="v13"),
+        pytest.param(schema_11.metadata, EXPECTED_STATEMENTS_V11, id="v11"),
+        pytest.param(schema_10.metadata, EXPECTED_STATEMENTS_V10, id="v10"),
+        pytest.param(schema_09.metadata, EXPECTED_STATEMENTS_V9, id="v9"),
+        pytest.param(schema_08.metadata, EXPECTED_STATEMENTS_V8, id="v8"),
+        pytest.param(schema_07.metadata, EXPECTED_STATEMENTS_V7, id="v7"),
+        pytest.param(schema_06.metadata, EXPECTED_STATEMENTS_V6, id="v6"),
+        pytest.param(schema_05.metadata, EXPECTED_STATEMENTS_V5, id="v5"),
+        pytest.param(schema_04.metadata, EXPECTED_STATEMENTS_V4, id="v4"),
+        pytest.param(schema_03.metadata, EXPECTED_STATEMENTS_V3, id="v3"),
+        pytest.param(schema_02.metadata, EXPECTED_STATEMENTS_V2, id="v2"),
     ],
 )
 def test_creating_from_metadata_emits_expected_statements(

--- a/robot-server/tests/runs/test_run_auto_deleter.py
+++ b/robot-server/tests/runs/test_run_auto_deleter.py
@@ -25,6 +25,7 @@ def _make_dummy_run_resource(run_id: str, protocol_id: str) -> RunResource:
         protocol_id=protocol_id,
         created_at=datetime.min,
         actions=[],
+        signed_by=None,
     )
 
 

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -223,6 +223,7 @@ def run_resource() -> RunResource:
         protocol_id=None,
         created_at=datetime(year=2022, month=2, day=2),
         actions=[],
+        signed_by=None,
     )
 
 
@@ -660,6 +661,7 @@ async def test_get_all_runs(
         protocol_id=None,
         created_at=datetime(year=2022, month=2, day=2),
         actions=[],
+        signed_by=None,
     )
 
     historical_run_resource = RunResource(
@@ -668,6 +670,7 @@ async def test_get_all_runs(
         protocol_id=None,
         created_at=datetime(year=2023, month=3, day=3),
         actions=[],
+        signed_by=None,
     )
 
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("current-run")

--- a/robot-server/tests/runs/test_run_store.py
+++ b/robot-server/tests/runs/test_run_store.py
@@ -380,6 +380,7 @@ async def test_update_run_state(
         protocol_id=None,
         created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         actions=[action],
+        signed_by=None,
     )
     assert run_summary_result == state_summary
     assert parameters_result == run_time_parameters
@@ -501,6 +502,7 @@ def test_add_run(subject: RunStore) -> None:
         protocol_id=None,
         created_at=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
         actions=[],
+        signed_by=None,
     )
 
 
@@ -514,6 +516,43 @@ def test_insert_actions_missing_run_id(subject: RunStore) -> None:
 
     with pytest.raises(RunNotFoundError, match="missing-run-id"):
         subject.insert_action(run_id="missing-run-id", action=action)
+
+
+def test_set_signed_by(subject: RunStore) -> None:
+    """It should store the signed_by value for a run."""
+    subject.insert(
+        run_id="run-id",
+        protocol_id=None,
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+    )
+
+    subject.set_signed_by(run_id="run-id", signed_by="Alice Example")
+
+    assert subject.get(run_id="run-id") == RunResource(
+        ok=True,
+        run_id="run-id",
+        protocol_id=None,
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+        actions=[],
+        signed_by="Alice Example",
+    )
+
+    subject.set_signed_by(run_id="run-id", signed_by="Bob Example")
+
+    assert subject.get(run_id="run-id") == RunResource(
+        ok=True,
+        run_id="run-id",
+        protocol_id=None,
+        created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
+        actions=[],
+        signed_by="Bob Example",
+    )
+
+
+def test_set_signed_by_missing_run_id(subject: RunStore) -> None:
+    """It should raise if the run does not exist."""
+    with pytest.raises(RunNotFoundError, match="missing-run-id"):
+        subject.set_signed_by(run_id="missing-run-id", signed_by="Alice Example")
 
 
 def test_insert_run_missing_protocol_id(subject: RunStore) -> None:
@@ -542,6 +581,7 @@ def test_get_run_no_actions(subject: RunStore) -> None:
         protocol_id=None,
         created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         actions=[],
+        signed_by=None,
     )
 
 
@@ -569,6 +609,7 @@ def test_get_run(subject: RunStore) -> None:
         protocol_id=None,
         created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
         actions=[action],
+        signed_by=None,
     )
 
 
@@ -591,6 +632,7 @@ def test_get_run_missing(subject: RunStore) -> None:
                     protocol_id=None,
                     created_at=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
                     actions=[],
+                    signed_by=None,
                 )
             ],
         ),
@@ -603,6 +645,7 @@ def test_get_run_missing(subject: RunStore) -> None:
                     protocol_id=None,
                     created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
                     actions=[],
+                    signed_by=None,
                 ),
                 RunResource(
                     ok=True,
@@ -610,6 +653,7 @@ def test_get_run_missing(subject: RunStore) -> None:
                     protocol_id=None,
                     created_at=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
                     actions=[],
+                    signed_by=None,
                 ),
             ],
         ),
@@ -622,6 +666,7 @@ def test_get_run_missing(subject: RunStore) -> None:
                     protocol_id=None,
                     created_at=datetime(year=2021, month=1, day=1, tzinfo=timezone.utc),
                     actions=[],
+                    signed_by=None,
                 ),
                 RunResource(
                     ok=True,
@@ -629,6 +674,7 @@ def test_get_run_missing(subject: RunStore) -> None:
                     protocol_id=None,
                     created_at=datetime(year=2022, month=2, day=2, tzinfo=timezone.utc),
                     actions=[],
+                    signed_by=None,
                 ),
             ],
         ),


### PR DESCRIPTION
## Overview

This goes towards EXEC-2858 and its friends.

When a user signs off on a run, we need to store their "signature." This sets up the persistence layer to do that.

Nothing actually uses this, yet. Future PRs will enforce that a run has been signed off before it's "un-currented."

## Test Plan and Hands on Testing

The included unit tests should be sufficient for this.

## Changelog

* Add the column.
* Add the migration and migration accessories.
* Add a new method to `RunStore` to allow getting and setting the values. Nothing calls it yet.

## Review requests

None in particular.

## Risk assessment

Low. 
