### PR TITLE
feat(api): Enforce vacuum module residual vacuum checks at analysis - cherry-picked

### DIFF
--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/common.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/common.py
@@ -272,3 +272,23 @@ def defined_error_data_from_enumerated_error(
         model_utils,
         state_update_if_false_positive=state_update_if_false_positive,
     )
+
+
+def will_equalize_after_operation(
+    *,
+    vent_after: bool,
+    equalize_timeout: int | None,
+    duration: int | None = None,
+    require_duration: bool = True,
+) -> bool:
+    """Whether the operation is expected to clear residual chamber vacuum.
+
+    Residual vacuum is cleared only when the command both vents and waits for
+    equalization (``equalize_timeout`` is not ``None``). Omitting the timeout
+    means do not wait.
+    """
+    if equalize_timeout is None or not vent_after:
+        return False
+    if require_duration and duration is None:
+        return False
+    return equalize_timeout > 0

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/open_vent.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/open_vent.py
@@ -58,6 +58,12 @@ class OpenVentImpl(AbstractCommandImpl[OpenVentParams, SuccessData[OpenVentResul
             if params.equalizeTimeout is not None:
                 await vm_hardware.wait_for_pressure_equalization(params.equalizeTimeout)
 
+        # Equalize wait clears residual va.
+        if params.equalizeTimeout is not None and params.equalizeTimeout > 0:
+            state_update.update_vacuum_module_residual_vacuum(
+                params.moduleId, residual_vacuum=False
+            )
+
         return SuccessData(public=OpenVentResult(), state_update=state_update)
 
 

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/start_run_profile.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/start_run_profile.py
@@ -26,6 +26,9 @@ from opentrons.hardware_control.modules.types import (
 from opentrons.hardware_control.modules.types import (
     VacuumModuleProfileStep as hc_profile_step,
 )
+from opentrons.protocol_engine.commands.vacuum_module.common import (
+    will_equalize_after_operation,
+)
 from opentrons.protocol_engine.resources import ModelUtils
 
 if TYPE_CHECKING:
@@ -123,7 +126,10 @@ class StartRunProfileParams(BaseModel):
     )
     equalizeTimeout: int | SkipJsonSchema[None] = Field(
         None,
-        description="Time in seconds to wait for pressure equalization after the profile completes if ventAfter is True. Does not wait if None.",
+        description=(
+            "Time in seconds to wait for pressure equalization after the profile "
+            "completes if ventAfter is True. Does not wait if None."
+        ),
     )
     taskId: str | None = Field(None, description="The id of the profile task")
 
@@ -163,6 +169,12 @@ class StartRunProfileImpl(AbstractCommandImpl[StartRunProfileParams, _ExecuteRet
                 f"Equalize timeout {e_timeout} is invalid, must be between 0-{MAX_VAC_DURATION_S} seconds."
             )
 
+        clears_residual = will_equalize_after_operation(
+            vent_after=params.ventAfter,
+            equalize_timeout=params.equalizeTimeout,
+            require_duration=False,
+        )
+
         state_update = update_types.StateUpdate()
         profile: List[hc_profile_step] = []
         pump_engaged = False
@@ -172,6 +184,10 @@ class StartRunProfileImpl(AbstractCommandImpl[StartRunProfileParams, _ExecuteRet
                 pump_engaged = step.enablePump
 
         state_update.update_vacuum_module_pump_engaged(params.moduleId, pump_engaged)
+        # Profiles apply vacuum unless the whole profile equalizes at the end.
+        state_update.update_vacuum_module_residual_vacuum(
+            params.moduleId, not clears_residual
+        )
         running_command_id = self._state_view.commands.get_running_command_id()
         if running_command_id is not None:
             state_update.record_module_background_command(

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_power.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_power.py
@@ -17,6 +17,9 @@ from ..command import (
     SuccessData,
 )
 from opentrons.drivers.vacuum_module.driver import MAX_VAC_DURATION_S
+from opentrons.protocol_engine.commands.vacuum_module.common import (
+    will_equalize_after_operation,
+)
 from opentrons.protocol_engine.resources import ModelUtils
 
 if TYPE_CHECKING:
@@ -55,7 +58,10 @@ class StartSetVacuumPowerParams(BaseModel):
     )
     equalizeTimeout: int | SkipJsonSchema[None] = Field(
         None,
-        description="Time in seconds to wait for pressure equalization after opening the vent. Does not wait if None.",
+        description=(
+            "Time in seconds to wait for pressure equalization after opening the vent. "
+            "Does not wait if None."
+        ),
     )
     taskId: str | None = Field(None, description="The id of the task")
 
@@ -93,9 +99,18 @@ class StartSetVacuumPowerImpl(
         self, params: StartSetVacuumPowerParams
     ) -> SuccessData[StartSetVacuumPowerResult]:
         """Start the vacuum pump."""
+        clears_residual = will_equalize_after_operation(
+            vent_after=params.ventAfter,
+            equalize_timeout=params.equalizeTimeout,
+            duration=params.duration,
+        )
+
         state_update = update_types.StateUpdate()
         state_update.update_vacuum_module_pump_engaged(
             params.moduleId, params.duration is None
+        )
+        state_update.update_vacuum_module_residual_vacuum(
+            params.moduleId, not clears_residual
         )
         running_command_id = self._state_view.commands.get_running_command_id()
         if running_command_id is not None:

--- a/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_pressure.py
+++ b/api/src/opentrons/protocol_engine/commands/vacuum_module/start_set_vacuum_pressure.py
@@ -21,6 +21,9 @@ from opentrons.drivers.vacuum_module.driver import (
     MAX_VAC_DURATION_S,
     MIN_GAUGE_PRESSURE_MBAR,
 )
+from opentrons.protocol_engine.commands.vacuum_module.common import (
+    will_equalize_after_operation,
+)
 from opentrons.protocol_engine.resources import ModelUtils
 
 if TYPE_CHECKING:
@@ -56,7 +59,10 @@ class StartSetVacuumPressureParams(BaseModel):
     )
     equalizeTimeout: int | SkipJsonSchema[None] = Field(
         None,
-        description="Time in seconds to wait for pressure equalization after opening the vent. Does not wait if None.",
+        description=(
+            "Time in seconds to wait for pressure equalization after opening the vent. "
+            "Does not wait if None."
+        ),
     )
     taskId: str | None = Field(None, description="The id of the task")
 
@@ -94,9 +100,18 @@ class StartSetVacuumPressureImpl(
         self, params: StartSetVacuumPressureParams
     ) -> SuccessData[StartSetVacuumPressureResult]:
         """Start the vacuum pump."""
+        clears_residual = will_equalize_after_operation(
+            vent_after=params.ventAfter,
+            equalize_timeout=params.equalizeTimeout,
+            duration=params.duration,
+        )
+
         state_update = update_types.StateUpdate()
         state_update.update_vacuum_module_pump_engaged(
             params.moduleId, params.duration is None
+        )
+        state_update.update_vacuum_module_residual_vacuum(
+            params.moduleId, not clears_residual
         )
         running_command_id = self._state_view.commands.get_running_command_id()
         if running_command_id is not None:

--- a/api/src/opentrons/protocol_engine/execution/vacuum_module_movement_flagger.py
+++ b/api/src/opentrons/protocol_engine/execution/vacuum_module_movement_flagger.py
@@ -73,13 +73,26 @@ class VacuumModuleMovementFlagger:
                 "when moving labware to or from it."
             )
 
-        if not self._state_store.config.use_virtual_modules:
-            vacuum_module = await self._get_hardware_vacuum_module(module_id=module_id)
-            if not vacuum_module.pressure_equalized:
+        # Enforce residual vacuum at analysis
+        if self._state_store.config.use_virtual_modules:
+            if vm_substate.residual_vacuum:
                 raise VacuumModuleStillUnderVacuumError(
                     module_id=vm_substate.module_id,
-                    current_gauge_pressure_mbar=vacuum_module.current_gauge_pressure_mbar,
+                    current_gauge_pressure_mbar=0.0,
+                    message=(
+                        f"Vacuum Module {vm_substate.module_id} may still be under "
+                        "vacuum. Vent and wait for pressure equalization before moving "
+                        "labware to or from it."
+                    ),
                 )
+            return
+
+        vacuum_module = await self._get_hardware_vacuum_module(module_id=module_id)
+        if not vacuum_module.pressure_equalized:
+            raise VacuumModuleStillUnderVacuumError(
+                module_id=vm_substate.module_id,
+                current_gauge_pressure_mbar=vacuum_module.current_gauge_pressure_mbar,
+            )
 
     async def _get_hardware_vacuum_module(
         self,

--- a/api/src/opentrons/protocol_engine/state/module_substates/vacuum_module_substate.py
+++ b/api/src/opentrons/protocol_engine/state/module_substates/vacuum_module_substate.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import NewType, Optional
 
 from opentrons.protocol_engine.state.update_types import (
+    NO_CHANGE,
     VacuumModuleStateUpdate,
 )
 
@@ -20,6 +21,7 @@ class VacuumModuleSubState:
 
     module_id: VacuumModuleId
     pump_engaged: bool
+    residual_vacuum: bool = False
     target_pressure: Optional[float] = None
 
     def new_from_state_change(
@@ -29,7 +31,18 @@ class VacuumModuleSubState:
         new_pump_engaged = self.pump_engaged
         if isinstance(update.pump_engaged, bool):
             new_pump_engaged = update.pump_engaged
+
+        new_residual_vacuum = self.residual_vacuum
+        if isinstance(update.residual_vacuum, bool):
+            new_residual_vacuum = update.residual_vacuum
+
+        new_target_pressure = self.target_pressure
+        if update.target_pressure != NO_CHANGE:
+            new_target_pressure = update.target_pressure
+
         return VacuumModuleSubState(
             module_id=self.module_id,
             pump_engaged=new_pump_engaged,
+            residual_vacuum=new_residual_vacuum,
+            target_pressure=new_target_pressure,
         )

--- a/api/src/opentrons/protocol_engine/state/modules.py
+++ b/api/src/opentrons/protocol_engine/state/modules.py
@@ -359,7 +359,9 @@ class ModuleStore(HasState[ModuleState], HandlesActions):
                 pool_height=0,
             ),
             ModuleModel.is_vacuum_module: VacuumModuleSubState(
-                module_id=VacuumModuleId(module_id), pump_engaged=False
+                module_id=VacuumModuleId(module_id),
+                pump_engaged=False,
+                residual_vacuum=False,
             ),
         }
 

--- a/api/src/opentrons/protocol_engine/state/update_types.py
+++ b/api/src/opentrons/protocol_engine/state/update_types.py
@@ -406,7 +406,8 @@ class VacuumModuleStateUpdate:
 
     module_id: str
     pump_engaged: bool | NoChangeType = NO_CHANGE
-    target_pressure: float | NoChangeType = NO_CHANGE
+    residual_vacuum: bool | NoChangeType = NO_CHANGE
+    target_pressure: float | None | NoChangeType = NO_CHANGE
 
     @classmethod
     def create_or_override(
@@ -999,6 +1000,18 @@ class StateUpdate:
                 self.vacuum_module_state_update, module_id
             ),
             pump_engaged=pump_engaged,
+        )
+        return self
+
+    def update_vacuum_module_residual_vacuum(
+        self, module_id: str, residual_vacuum: bool
+    ) -> Self:
+        """Set whether the chamber is modeled as still under vacuum."""
+        self.vacuum_module_state_update = dataclasses.replace(
+            VacuumModuleStateUpdate.create_or_override(
+                self.vacuum_module_state_update, module_id
+            ),
+            residual_vacuum=residual_vacuum,
         )
         return self
 

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_common.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_common.py
@@ -21,6 +21,7 @@ from opentrons.protocol_engine.commands.vacuum_module.common import (
     VacuumPressureNotReachedError,
     defined_error_data_from_task_error,
     handle_recoverable_vacuum_error,
+    will_equalize_after_operation,
 )
 from opentrons.protocol_engine.errors import ErrorOccurrence
 from opentrons.protocol_engine.resources import ModelUtils
@@ -190,3 +191,25 @@ def test_handle_recoverable_vacuum_error_populates_operation_error_info_from_hw_
         "target": -100.0,
         "current": -80.0,
     }
+
+
+def test_will_equalize_after_operation() -> None:
+    """It should only clear residual vacuum when equalize is explicitly requested."""
+    assert will_equalize_after_operation(
+        vent_after=True, equalize_timeout=30, duration=10
+    )
+    assert not will_equalize_after_operation(
+        vent_after=True, equalize_timeout=None, duration=10
+    )
+    assert not will_equalize_after_operation(
+        vent_after=False, equalize_timeout=30, duration=10
+    )
+    assert not will_equalize_after_operation(
+        vent_after=True, equalize_timeout=30, duration=None
+    )
+    assert will_equalize_after_operation(
+        vent_after=True, equalize_timeout=30, require_duration=False
+    )
+    assert not will_equalize_after_operation(
+        vent_after=True, equalize_timeout=0, duration=10
+    )

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_open_vent.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_open_vent.py
@@ -80,9 +80,17 @@ async def test_open_vent_waits_to_equalize(
         vm_hardware
     )
 
-    await subject.execute(data)
+    result = await subject.execute(data)
 
     decoy.verify(
         await vm_hardware.set_vent_state(VentState.OPENED),
         await vm_hardware.wait_for_pressure_equalization(30),
+    )
+    expected_state_update = update_types.StateUpdate()
+    expected_state_update.update_vacuum_module_residual_vacuum(
+        "input-vacuum-id", residual_vacuum=False
+    )
+    assert result == SuccessData(
+        public=vm_commands.OpenVentResult(),
+        state_update=expected_state_update,
     )

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_run_profile.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_run_profile.py
@@ -192,6 +192,10 @@ async def test_start_run_profile(
     expected_state_update.update_vacuum_module_pump_engaged(
         "input-vacuum_module-id", False
     )
+    # ventAfter without equalizeTimeout → residual vacuum remains
+    expected_state_update.update_vacuum_module_residual_vacuum(
+        "input-vacuum_module-id", residual_vacuum=True
+    )
 
     assert result == SuccessData(
         public=expected_result,

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_power.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_power.py
@@ -91,6 +91,10 @@ async def test_start_set_vacuum_power(
     )
     expected_state_update = update_types.StateUpdate()
     expected_state_update.update_vacuum_module_pump_engaged("input-vacuum-id", True)
+    # No duration hold → residual vacuum remains (pump holds indefinitely)
+    expected_state_update.update_vacuum_module_residual_vacuum(
+        "input-vacuum-id", residual_vacuum=True
+    )
 
     assert result == SuccessData(
         public=expected_result,

--- a/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_pressure.py
+++ b/api/tests/opentrons/protocol_engine/commands/vacuum_module/test_start_set_vacuum_pressure.py
@@ -100,6 +100,10 @@ async def test_start_set_vacuum_presure(
 
     expected_state_update = update_types.StateUpdate()
     expected_state_update.update_vacuum_module_pump_engaged("input-vacuum-id", False)
+    # No equalizeTimeout → residual vacuum remains (vent without wait)
+    expected_state_update.update_vacuum_module_residual_vacuum(
+        "input-vacuum-id", residual_vacuum=True
+    )
 
     assert result == SuccessData(
         public=expected_result,

--- a/api/tests/opentrons/protocol_engine/execution/test_vacuum_module_movement_flagger.py
+++ b/api/tests/opentrons/protocol_engine/execution/test_vacuum_module_movement_flagger.py
@@ -96,7 +96,11 @@ async def test_ensure_vacuum_module_is_idle_raises_when_pump_engaged(
     decoy.when(
         state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
     ).then_return(
-        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=True)
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-id"),
+            pump_engaged=True,
+            residual_vacuum=True,
+        )
     )
 
     with pytest.raises(VacuumModuleUnderVacuumError, match="pump engaged"):
@@ -122,7 +126,11 @@ async def test_ensure_vacuum_module_is_idle_raises_when_pressure_not_equalized(
     decoy.when(
         state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
     ).then_return(
-        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=False)
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-id"),
+            pump_engaged=False,
+            residual_vacuum=False,
+        )
     )
     decoy.when(
         state_store.modules.get_serial_number(module_id="vacuum-id")
@@ -164,7 +172,11 @@ async def test_ensure_vacuum_module_is_idle_noops_when_pressure_equalized(
     decoy.when(
         state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
     ).then_return(
-        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=False)
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-id"),
+            pump_engaged=False,
+            residual_vacuum=False,
+        )
     )
     decoy.when(
         state_store.modules.get_serial_number(module_id="vacuum-id")
@@ -188,7 +200,7 @@ async def test_ensure_vacuum_module_is_idle_skips_hardware_check_for_virtual_mod
     subject: VacuumModuleMovementFlagger,
     state_store: StateStore,
 ) -> None:
-    """It should not query hardware when using virtual modules."""
+    """It should not query hardware when using virtual modules and residual is clear."""
     decoy.when(state_store.config).then_return(
         Config(
             robot_type="OT-3 Standard",
@@ -199,9 +211,42 @@ async def test_ensure_vacuum_module_is_idle_skips_hardware_check_for_virtual_mod
     decoy.when(
         state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
     ).then_return(
-        VacuumModuleSubState(module_id=VacuumModuleId("vacuum-id"), pump_engaged=False)
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-id"),
+            pump_engaged=False,
+            residual_vacuum=False,
+        )
     )
 
     await subject.ensure_vacuum_module_is_idle(
         labware_parent=ModuleLocation(moduleId="vacuum-id")
     )
+
+
+async def test_ensure_vacuum_module_is_idle_raises_virtual_residual_vacuum(
+    decoy: Decoy,
+    subject: VacuumModuleMovementFlagger,
+    state_store: StateStore,
+) -> None:
+    """It should raise on residual vacuum for virtual modules (analysis)."""
+    decoy.when(state_store.config).then_return(
+        Config(
+            robot_type="OT-3 Standard",
+            deck_type=DeckType.OT3_STANDARD,
+            use_virtual_modules=True,
+        )
+    )
+    decoy.when(
+        state_store.modules.get_vacuum_module_substate(module_id="vacuum-id")
+    ).then_return(
+        VacuumModuleSubState(
+            module_id=VacuumModuleId("vacuum-id"),
+            pump_engaged=False,
+            residual_vacuum=True,
+        )
+    )
+
+    with pytest.raises(VacuumModuleStillUnderVacuumError, match="may still be under"):
+        await subject.ensure_vacuum_module_is_idle(
+            labware_parent=ModuleLocation(moduleId="vacuum-id")
+        )


### PR DESCRIPTION
# Overview

This commit [9b3ad201f5aad21e83dfecf2eae2f1afb8470ce7](https://github.com/Opentrons/opentrons/commit/9b3ad201f5aad21e83dfecf2eae2f1afb8470ce7) removed the previous [Opentrons/opentrons#22045](https://github.com/Opentrons/opentrons/pull/22045) changes to the vacuum module. Let's cherry-pick the commit from that pull request back in.