### PR TITLE
chore(js-package-testing): clean up js-package-testing

### DIFF
--- a/js-package-testing/package.json
+++ b/js-package-testing/package.json
@@ -26,7 +26,6 @@
     "@types/react": "18.2.51",
     "@types/react-dom": "18.2.0",
     "@vitejs/plugin-react": "4.2.0",
-    "clsx": "2.1.1",
     "dotenv": "^16.6.1",
     "i18next": "^19.8.3",
     "react": "18.2.0",

--- a/js-package-testing/pnpm-lock.yaml
+++ b/js-package-testing/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: 4.2.0
         version: 4.2.0(vite@7.3.5(@types/node@18.19.130))
-      clsx:
-        specifier: 2.1.1
-        version: 2.1.1
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
@@ -1122,10 +1119,6 @@ packages:
 
   clone-response@1.0.3:
     resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
-
-  clsx@2.1.1:
-    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
-    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2935,8 +2928,6 @@ snapshots:
   clone-response@1.0.3:
     dependencies:
       mimic-response: 1.0.1
-
-  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -952,9 +952,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: 4.2.0
         version: 4.2.0(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))
-      clsx:
-        specifier: 2.1.1
-        version: 2.1.1
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1


### PR DESCRIPTION


# Overview
remove clsx to clean up js-package-testing

closes AUTH-3112

## Test Plan and Hands on Testing
none

## Changelog
- remove `clsx` from `js-package-testing`

## Review requests


## Risk assessment
low
