### PR TITLE
fix(api): do not abort vacuum profiles on natural duration end

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -20,6 +20,9 @@ from opentrons.drivers.command_builder import CommandBuilder
 
 log = logging.getLogger(__name__)
 
+SerialResponseKind = Literal["response", "error", "empty-unknown"]
+SerialResponse = tuple[SerialResponseKind, bytes]
+
 
 class SerialConnection:
     @classmethod
@@ -577,20 +580,89 @@ class AsyncResponseSerialConnection(SerialConnection):
                 retries=retries if retries is not None else self._number_of_retries,
             )
 
-    async def _consume_responses(
-        self, acks: int
-    ) -> AsyncIterator[tuple[Literal["response", "error", "empty-unknown"], bytes]]:
+    def _partition_serial_read(self, data: bytes) -> list[SerialResponse]:
+        """Split one serial read into async-error and/or command-response chunks.
+
+        ``read_until(ack)`` can return an interleaved buffer when firmware emits an
+        async notification without its own trailing ack, then a command response:
+
+            b'async ERR401:...\\nM121 ... OK\\n'
+
+        Treating the whole buffer as a single async error consumes the command
+        ack and forces an unnecessary timeout wait for another one.
+        """
+        async_marker = self._async_error_ack.encode()
+        has_async = async_marker in data
+        has_ack = self._ack in data
+
+        if not has_async and not has_ack:
+            return [("empty-unknown", data)]
+        if not has_async:
+            return [("response", data)]
+        return self._split_async_and_command_responses(data)
+
+    def _split_async_and_command_responses(self, data: bytes) -> list[SerialResponse]:
+        """Partition a buffer that contains one or more async markers and acks."""
+        async_marker = self._async_error_ack.encode()
+        parts: list[SerialResponse] = []
+        remaining = data
+
+        while remaining:
+            async_idx = remaining.find(async_marker)
+
+            if async_idx == -1:
+                if remaining.strip():
+                    kind: SerialResponseKind = (
+                        "response" if self._ack in remaining else "empty-unknown"
+                    )
+                    parts.append((kind, remaining))
+                break
+
+            if async_idx > 0:
+                before = remaining[:async_idx]
+                if self._ack in before:
+                    parts.append(("response", before))
+                remaining = remaining[async_idx:]
+                continue
+
+            # `remaining` starts with an async marker.
+            ack_idx = remaining.find(self._ack)
+            if ack_idx == -1:
+                parts.append(("error", remaining))
+                break
+
+            # If a newline appears before the terminating ack, the async message
+            # does not carry its own ack and the trailing frame is a command
+            # response.
+            newline_idx = remaining.find(b"\n")
+            if newline_idx != -1 and newline_idx < ack_idx:
+                parts.append(("error", remaining[: newline_idx + 1]))
+                remaining = remaining[newline_idx + 1 :]
+                continue
+
+            # Async frame includes the terminating ack (older modules / tests).
+            async_end = ack_idx + len(self._ack)
+            parts.append(("error", remaining[:async_end]))
+            remaining = remaining[async_end:]
+
+        return parts
+
+    async def _consume_responses(self, acks: int) -> AsyncIterator[SerialResponse]:
         while acks > 0:
             data = await self._serial.read_until(match=self._ack)
             log.debug(f"{self._name}: Read <- {data!r}")
-            if self._async_error_ack.encode() in data:
-                yield "error", data
-            elif self._ack in data:
-                yield "response", data
-                acks -= 1
-            else:
-                # A read timeout, end
-                yield "empty-unknown", data
+            for kind, chunk in self._partition_serial_read(data):
+                if kind == "error":
+                    yield "error", chunk
+                elif kind == "response":
+                    yield "response", chunk
+                    acks -= 1
+                    if acks <= 0:
+                        return
+                else:
+                    # A read timeout, end
+                    yield "empty-unknown", chunk
+                    return
 
     def _raise_on_parser_error(self, data: str, response: bytes) -> None:
         """Raise an exception if this response contains an error from the gcode parser on the module.

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -227,6 +227,7 @@ class VacuumModule(mod_abc.AbstractModule):
         self._current_cycle_index: Optional[int] = None
         self._total_step_count: Optional[int] = None
         self._current_step_index: Optional[int] = None
+        self._profile_stop_requested = False
         self._error: Optional[str] = None
 
     async def _initialized_callback(self) -> None:
@@ -472,6 +473,7 @@ class VacuumModule(mod_abc.AbstractModule):
 
     async def stop_vacuum(self) -> None:
         """Stop pressure control and the pump; clear software targets."""
+        self._profile_stop_requested = True
         await self._driver.set_vacuum_state(False)
         await self._driver.set_pump_state(False)
         self._reader.reset_pressure_target()
@@ -650,15 +652,6 @@ class VacuumModule(mod_abc.AbstractModule):
                 vent_after=vent_after,
             )
 
-    def _operation_was_stopped(self) -> bool:
-        """Return whether vacuum/pump operation was stopped externally."""
-        vacuum_state = self._reader.vacuum_state
-        pump_state = self._reader.pump_state
-        return not (
-            (vacuum_state.vacuum_enabled if vacuum_state is not None else False)
-            or (pump_state.pump_running if pump_state is not None else False)
-        )
-
     async def _wait_for_step_completion(self, step: VacuumModuleStep) -> bool:
         """Wait for a profile step to complete.
 
@@ -671,7 +664,7 @@ class VacuumModule(mod_abc.AbstractModule):
             await self.wait_for_command_duration()
         else:
             await self.wait_for_target()
-        return step["enable_pump"] and self._operation_was_stopped()
+        return self._profile_stop_requested
 
     async def _execute_profile(
         self,
@@ -708,6 +701,7 @@ class VacuumModule(mod_abc.AbstractModule):
         vent_after: bool = True,
     ) -> None:
         await self.wait_for_is_running()
+        self._profile_stop_requested = False
         self._total_cycle_count = 0
         self._total_step_count = 0
         self._current_cycle_index = 0

--- a/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
+++ b/api/tests/opentrons/drivers/asyncio/communication/test_serial_connection.py
@@ -1,4 +1,4 @@
-from typing import AsyncGenerator, Type, Union
+from typing import AsyncGenerator, Callable, Type, Union
 from unittest.mock import patch
 
 import mock
@@ -18,6 +18,7 @@ from opentrons.drivers.asyncio.communication.errors import (
 from opentrons.drivers.asyncio.communication.serial_connection import (
     AsyncResponseSerialConnection,
     SerialConnection,
+    SerialResponse,
 )
 
 
@@ -421,7 +422,6 @@ async def test_send_data_does_not_retry_async_error(
     successful_response = f"M121 T:0.0 C:-4.7 V:1 {ack}".encode()
     mock_serial_port.read_until.side_effect = [
         combined_response,
-        b"",  # leftover wait for a missing second ack on the first attempt
         successful_response,
         successful_response,
     ]
@@ -432,6 +432,8 @@ async def test_send_data_does_not_retry_async_error(
     # Only the original attempt should write; device errors must not be retried.
     assert mock_serial_port.write.await_count == 1
     mock_serial_port.write.assert_awaited_once_with(data=data.encode())
+    # Combined async + command frame is fully consumed in a single read.
+    assert mock_serial_port.read_until.await_count == 1
 
 
 async def test_send_data_still_retries_missing_response(
@@ -451,6 +453,312 @@ async def test_send_data_still_retries_missing_response(
 
     assert responses == ["M121 T:0.0 C:-4.7 V:1"]
     assert mock_serial_port.write.await_count == 2
+
+
+def _command_response(ack: str, gcode: str = "M121") -> bytes:
+    return f"{gcode} T:0.0 C:-4.7 V:1 {ack}".encode()
+
+
+def _async_error_no_ack(code: str = "ERR401", line_ending: str = "\n") -> bytes:
+    """Vacuum-style async notification without its own trailing ack."""
+    return f"async {code}:vacuum:waste is full{line_ending}".encode()
+
+
+def _async_error_with_ack(ack: str, code: str = "ERR106") -> bytes:
+    """Older-module style async notification that includes a trailing ack."""
+    return f"async {code}:main motor:speedsensor failed {ack}".encode()
+
+
+def _connection_with_ack(
+    mock_serial_port: AsyncMock, ack: str
+) -> AsyncResponseSerialConnection:
+    """Build a connection whose command terminator matches the given ack."""
+    return AsyncResponseSerialConnection(
+        serial=mock_serial_port,
+        ack=ack,
+        name="name",
+        port="port",
+        retry_wait_time_seconds=0,
+        error_keyword="err",
+        alarm_keyword="alarm",
+        async_error_ack="async",
+    )
+
+
+@pytest.mark.parametrize(
+    argnames=["raw", "expected"],
+    argvalues=[
+        # Response only.
+        pytest.param(
+            lambda ack: _command_response(ack),
+            lambda ack: [("response", _command_response(ack))],
+            id="response-only",
+        ),
+        # Async only, no ack (one-shot firmware notification).
+        pytest.param(
+            lambda ack: _async_error_no_ack(),
+            lambda ack: [("error", _async_error_no_ack())],
+            id="async-only-no-ack",
+        ),
+        # Async only, ack-terminated.
+        pytest.param(
+            lambda ack: _async_error_with_ack(ack),
+            lambda ack: [("error", _async_error_with_ack(ack))],
+            id="async-only-with-ack",
+        ),
+        # async ERR...\n + command OK  (vacuum firmware interleave)
+        pytest.param(
+            lambda ack: _async_error_no_ack() + _command_response(ack),
+            lambda ack: [
+                ("error", _async_error_no_ack()),
+                ("response", _command_response(ack)),
+            ],
+            id="async-no-ack-then-response",
+        ),
+        # command OK + async ERR...\n  (async arrives after command ack)
+        pytest.param(
+            lambda ack: _command_response(ack) + b"\n" + _async_error_no_ack(),
+            lambda ack: [
+                ("response", _command_response(ack) + b"\n"),
+                ("error", _async_error_no_ack()),
+            ],
+            id="response-then-async-no-ack",
+        ),
+        # command OK + async with its own ack
+        pytest.param(
+            lambda ack: _command_response(ack) + _async_error_with_ack(ack),
+            lambda ack: [
+                ("response", _command_response(ack)),
+                ("error", _async_error_with_ack(ack)),
+            ],
+            id="response-then-async-with-ack",
+        ),
+        # async with its own ack + command OK
+        pytest.param(
+            lambda ack: _async_error_with_ack(ack) + _command_response(ack),
+            lambda ack: [
+                ("error", _async_error_with_ack(ack)),
+                ("response", _command_response(ack)),
+            ],
+            id="async-with-ack-then-response",
+        ),
+        # Repeated vacuum-style pairs in one buffer.
+        # async\nresponse async\nresponse
+        pytest.param(
+            lambda ack: (
+                _async_error_no_ack("ERR401")
+                + _command_response(ack)
+                + b"\n"
+                + _async_error_no_ack("ERR400")
+                + _command_response(ack, "M122")
+            ),
+            lambda ack: [
+                ("error", _async_error_no_ack("ERR401")),
+                ("response", _command_response(ack) + b"\n"),
+                ("error", _async_error_no_ack("ERR400")),
+                ("response", _command_response(ack, "M122")),
+            ],
+            id="two-async-no-ack-response-pairs",
+        ),
+        # Two ack-terminated async frames then a command response.
+        pytest.param(
+            lambda ack: (
+                _async_error_with_ack(ack, "ERR106")
+                + _async_error_with_ack(ack, "ERR107")
+                + _command_response(ack)
+            ),
+            lambda ack: [
+                ("error", _async_error_with_ack(ack, "ERR106")),
+                ("error", _async_error_with_ack(ack, "ERR107")),
+                ("response", _command_response(ack)),
+            ],
+            id="two-async-with-ack-then-response",
+        ),
+        # Two async-no-ack lines before a single command response.
+        pytest.param(
+            lambda ack: (
+                _async_error_no_ack("ERR401")
+                + _async_error_no_ack("ERR400")
+                + _command_response(ack)
+            ),
+            lambda ack: [
+                ("error", _async_error_no_ack("ERR401")),
+                ("error", _async_error_no_ack("ERR400")),
+                ("response", _command_response(ack)),
+            ],
+            id="two-async-no-ack-then-response",
+        ),
+        # Response sandwiched between async-no-ack notifications.
+        pytest.param(
+            lambda ack: (
+                _async_error_no_ack("ERR401")
+                + _command_response(ack)
+                + b"\n"
+                + _async_error_no_ack("ERR400")
+            ),
+            lambda ack: [
+                ("error", _async_error_no_ack("ERR401")),
+                ("response", _command_response(ack) + b"\n"),
+                ("error", _async_error_no_ack("ERR400")),
+            ],
+            id="async-response-async",
+        ),
+        # Empty / timeout-style reads.
+        pytest.param(
+            lambda ack: b"",
+            lambda ack: [("empty-unknown", b"")],
+            id="empty",
+        ),
+        pytest.param(
+            lambda ack: b"noise without terminator",
+            lambda ack: [("empty-unknown", b"noise without terminator")],
+            id="noise-no-ack-no-async",
+        ),
+        # Whitespace-only after a complete async+response pair is ignored.
+        pytest.param(
+            lambda ack: _async_error_no_ack() + _command_response(ack) + b"   ",
+            lambda ack: [
+                ("error", _async_error_no_ack()),
+                ("response", _command_response(ack) + b"   "),
+            ],
+            id="async-response-trailing-whitespace",
+        ),
+    ],
+)
+def test_partition_serial_read_permutations(
+    async_subject: AsyncResponseSerialConnection,
+    ack: str,
+    raw: Callable[[str], bytes],
+    expected: Callable[[str], list[SerialResponse]],
+) -> None:
+    """Partition async/command interleaves across common firmware shapes."""
+    assert async_subject._partition_serial_read(raw(ack)) == expected(ack)
+
+
+@pytest.mark.parametrize(
+    argnames=["ack"],
+    argvalues=[
+        pytest.param("OK\n", id="lf-ack"),
+        pytest.param("OK\r\n", id="crlf-ack"),
+        # Smoothie / temp-deck / mag-deck style multi-line terminator.
+        pytest.param("ok\r\nok\r\n", id="crlf-double-ok-ack"),
+    ],
+)
+@pytest.mark.parametrize(
+    argnames=["build_raw", "build_expected"],
+    argvalues=[
+        pytest.param(
+            lambda ack, ending: _async_error_no_ack(line_ending=ending)
+            + _command_response(ack),
+            lambda ack, ending: [
+                ("error", _async_error_no_ack(line_ending=ending)),
+                ("response", _command_response(ack)),
+            ],
+            id="async-then-response",
+        ),
+        pytest.param(
+            lambda ack, ending: _command_response(ack)
+            + _async_error_no_ack(line_ending=ending),
+            lambda ack, ending: [
+                ("response", _command_response(ack)),
+                ("error", _async_error_no_ack(line_ending=ending)),
+            ],
+            id="response-then-async",
+        ),
+        pytest.param(
+            lambda ack, ending: (
+                _async_error_no_ack("ERR401", line_ending=ending)
+                + _command_response(ack)
+                + _async_error_no_ack("ERR400", line_ending=ending)
+                + _command_response(ack, "M122")
+            ),
+            lambda ack, ending: [
+                ("error", _async_error_no_ack("ERR401", line_ending=ending)),
+                ("response", _command_response(ack)),
+                ("error", _async_error_no_ack("ERR400", line_ending=ending)),
+                ("response", _command_response(ack, "M122")),
+            ],
+            id="two-pairs",
+        ),
+        pytest.param(
+            lambda ack, ending: _async_error_with_ack(ack)
+            + _command_response(ack),
+            lambda ack, ending: [
+                ("error", _async_error_with_ack(ack)),
+                ("response", _command_response(ack)),
+            ],
+            id="async-with-ack-then-response",
+        ),
+        pytest.param(
+            # Async line uses LF while the command ack uses the device terminator
+            # (e.g. firmware prints async with \n even when OK is \r\n).
+            lambda ack, ending: _async_error_no_ack(line_ending="\n")
+            + _command_response(ack),
+            lambda ack, ending: [
+                ("error", _async_error_no_ack(line_ending="\n")),
+                ("response", _command_response(ack)),
+            ],
+            id="async-lf-command-device-ack",
+        ),
+    ],
+)
+def test_partition_serial_read_with_crlf_and_lf_acks(
+    mock_serial_port: AsyncMock,
+    ack: str,
+    build_raw: Callable[[str, str], bytes],
+    build_expected: Callable[[str, str], list[SerialResponse]],
+) -> None:
+    """CRLF command terminators must not break async/command partitioning.
+
+    Devices may ack with ``OK\\n``, ``OK\\r\\n``, or multi-line ``ok\\r\\nok\\r\\n``.
+    Async notifications are split on the first ``\\n`` before the command ack, so
+    both LF and CRLF line endings on the async line are accepted.
+    """
+    # Prefer matching the async line ending to the ack family when possible.
+    line_ending = "\r\n" if "\r\n" in ack else "\n"
+    subject = _connection_with_ack(mock_serial_port, ack)
+
+    raw = build_raw(ack, line_ending)
+    expected = build_expected(ack, line_ending)
+    assert subject._partition_serial_read(raw) == expected
+
+
+async def test_send_data_raises_async_error_with_crlf_ack_without_extra_wait(
+    mock_serial_port: AsyncMock,
+) -> None:
+    """Interleaved async + CRLF-acked command should raise on a single read."""
+    ack = "OK\r\n"
+    subject = _connection_with_ack(mock_serial_port, ack)
+    data = "M121 "
+    combined = (
+        b"async ERR401:vacuum:waste is full\r\n"
+        + f"M121 T:0.0 C:-4.7 V:1 {ack}".encode()
+    )
+    mock_serial_port.read_until.side_effect = [combined]
+
+    with pytest.raises(ErrorResponse, match="ERR401"):
+        await subject._send_data_multiack(data=data, retries=0, acks=1)
+
+    mock_serial_port.read_until.assert_awaited_once_with(match=ack.encode())
+    mock_serial_port.write.assert_awaited_once_with(data=data.encode())
+
+
+async def test_send_data_raises_async_error_from_interleaved_read_without_extra_wait(
+    mock_serial_port: AsyncMock,
+    async_subject: AsyncResponseSerialConnection,
+    ack: str,
+) -> None:
+    """Interleaved async + command should raise without waiting for another ack."""
+    data = "M121 "
+    error_line = "async ERR401:vacuum:waste is full"
+    combined_response = f"{error_line}\nM121 T:0.0 C:-4.7 V:1 {ack}".encode()
+    mock_serial_port.read_until.side_effect = [combined_response]
+
+    with pytest.raises(ErrorResponse, match="ERR401"):
+        await async_subject._send_data_multiack(data=data, retries=0, acks=1)
+
+    mock_serial_port.read_until.assert_awaited_once_with(match=ack.encode())
+    mock_serial_port.write.assert_awaited_once_with(data=data.encode())
 
 
 def test_default_error_code_raise_exception() -> None:

--- a/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
@@ -972,6 +972,7 @@ async def test_stop_vacuum_stops_pressure_and_pump_and_clears_targets(
     """stop_vacuum should disable pressure control, stop the pump, and clear targets."""
     subject._reader.set_target_pressure(-100.0)
     subject._reader.set_target_power(50.0)
+    assert subject._profile_stop_requested is False
 
     await subject.stop_vacuum()
 
@@ -979,6 +980,7 @@ async def test_stop_vacuum_stops_pressure_and_pump_and_clears_targets(
     decoy.verify(await mock_driver.set_pump_state(start_pump=False))
     assert subject._reader.target_pressure is None
     assert subject._reader.get_target_power() is None
+    assert subject._profile_stop_requested is True
 
 
 async def test_deactivate_stops_vacuum_and_opens_vent(
@@ -1183,17 +1185,8 @@ async def test_execute_profile_aborts_when_stopped(
         await original_execute_cycle_step(step)
 
     async def stop_on_first_wait() -> None:
-        await subject.set_vacuum_state(enable_vacuum=False)
-        subject._reader.vacuum_state = VacuumState(
-            target_gauge_pressure=0,
-            current_gauge_pressure=0,
-            pressure_abs_a=0,
-            pressure_abs_b=0,
-            pressure_atm=0,
-            vacuum_enabled=False,
-            vacuum_duration=0,
-            vent_state=VentState.CLOSED,
-        )
+        # Host-requested stop (not firmware natural duration end).
+        await subject.stop_vacuum()
 
     subject._execute_cycle_step = counting_execute_cycle_step  # type: ignore[method-assign]
     subject.wait_for_command_duration = stop_on_first_wait  # type: ignore[method-assign]
@@ -1201,6 +1194,7 @@ async def test_execute_profile_aborts_when_stopped(
     await subject.execute_profile(profile, vent_after=True)
 
     assert execute_step_count == 1
+    assert subject._profile_stop_requested is True
     decoy.verify(
         await mock_driver.set_vacuum_state(
             enable_vacuum=True,
@@ -1212,6 +1206,196 @@ async def test_execute_profile_aborts_when_stopped(
         ),
     )
     decoy.verify(await mock_driver.set_vent_state(state=VentState.OPENED), times=0)
+
+
+async def test_execute_profile_aborts_on_stop_during_pump_disabled_step(
+    subject: modules.VacuumModule,
+    mock_driver: SimulatingDriver,
+    decoy: Decoy,
+) -> None:
+    """stop_vacuum during enable_pump=False must still abort remaining steps.
+
+    Abort is driven only by _profile_stop_requested, not the current step's
+    enable_pump value.
+    """
+    profile: List[
+        Union[VacuumModuleCycle, VacuumModulePowerStep, VacuumModulePressureStep]
+    ] = [
+        {
+            "enable_pump": False,
+            "hold_time_seconds": 10,
+            "hold_time_minutes": None,
+            "ramp_rate": None,
+            "timeout_seconds": None,
+            "vent_after": None,
+            "gauge_pressure_mbar": None,
+        },
+        {
+            "enable_pump": True,
+            "hold_time_seconds": 10,
+            "hold_time_minutes": None,
+            "ramp_rate": None,
+            "timeout_seconds": None,
+            "vent_after": None,
+            "gauge_pressure_mbar": -200,
+        },
+    ]
+
+    execute_step_count = 0
+    original_execute_cycle_step = subject._execute_cycle_step
+
+    async def counting_execute_cycle_step(step: VacuumModuleStep) -> None:
+        nonlocal execute_step_count
+        execute_step_count += 1
+        await original_execute_cycle_step(step)
+
+    async def stop_on_first_wait() -> None:
+        await subject.stop_vacuum()
+
+    subject._execute_cycle_step = counting_execute_cycle_step  # type: ignore[method-assign]
+    subject.wait_for_command_duration = stop_on_first_wait  # type: ignore[method-assign]
+
+    await subject.execute_profile(profile, vent_after=True)
+
+    assert execute_step_count == 1
+    assert subject._profile_stop_requested is True
+    decoy.verify(await mock_driver.set_vent_state(state=VentState.OPENED), times=0)
+
+
+async def test_execute_profile_continues_after_natural_duration_end(
+    subject: modules.VacuumModule,
+    mock_driver: SimulatingDriver,
+    decoy: Decoy,
+) -> None:
+    """Firmware clears running flags when duration ends; profile must continue.
+
+    Mirrors vacuum firmware vacuum_timer_end_callback, which sets
+    enable_vacuum=false and then stop_vacuum() (pump stopped). Without an
+    explicit host stop_vacuum, remaining pressure/power steps must still run.
+    """
+    profile: List[
+        Union[VacuumModuleCycle, VacuumModulePowerStep, VacuumModulePressureStep]
+    ] = [
+        {
+            "enable_pump": True,
+            "hold_time_seconds": 5,
+            "hold_time_minutes": None,
+            "ramp_rate": None,
+            "timeout_seconds": None,
+            "vent_after": False,
+            "gauge_pressure_mbar": -200,
+        },
+        {
+            "enable_pump": True,
+            "hold_time_seconds": 5,
+            "hold_time_minutes": None,
+            "ramp_rate": None,
+            "timeout_seconds": None,
+            "vent_after": False,
+            "gauge_pressure_mbar": -400,
+        },
+        {
+            "enable_pump": True,
+            "hold_time_seconds": 5,
+            "hold_time_minutes": None,
+            "ramp_rate": None,
+            "timeout_seconds": None,
+            "vent_after": False,
+            "percent_power": 30,
+        },
+    ]
+
+    # After each timed step, firmware reports duration complete and idle.
+    decoy.when(await mock_driver.get_vacuum_state()).then_return(
+        VacuumState(
+            target_gauge_pressure=0,
+            current_gauge_pressure=-200,
+            pressure_abs_a=0,
+            pressure_abs_b=0,
+            pressure_atm=0,
+            vacuum_enabled=False,
+            vacuum_duration=0,
+            vent_state=VentState.CLOSED,
+        )
+    )
+    decoy.when(await mock_driver.get_pump_state()).then_return(
+        PumpState(
+            target_rpm=0,
+            current_rpm=0,
+            target_pwm=0,
+            current_pwm=0,
+            pump_running=False,
+            manual_control=False,
+        )
+    )
+
+    execute_step_count = 0
+    original_execute_cycle_step = subject._execute_cycle_step
+
+    async def counting_execute_cycle_step(step: VacuumModuleStep) -> None:
+        nonlocal execute_step_count
+        execute_step_count += 1
+        await original_execute_cycle_step(step)
+
+    async def _fake_wait_for_command_duration() -> None:
+        # Simulate natural duration end without host stop_vacuum.
+        subject._reader.vacuum_state = VacuumState(
+            target_gauge_pressure=0,
+            current_gauge_pressure=-200,
+            pressure_abs_a=0,
+            pressure_abs_b=0,
+            pressure_atm=0,
+            vacuum_enabled=False,
+            vacuum_duration=0,
+            vent_state=VentState.CLOSED,
+        )
+        subject._reader.pump_state = PumpState(
+            target_rpm=0,
+            current_rpm=0,
+            target_pwm=0,
+            current_pwm=0,
+            pump_running=False,
+            manual_control=False,
+        )
+
+    subject._execute_cycle_step = counting_execute_cycle_step  # type: ignore[method-assign]
+    subject.wait_for_command_duration = (  # type: ignore[method-assign]
+        _fake_wait_for_command_duration
+    )
+
+    await subject.execute_profile(profile, vent_after=False)
+
+    assert execute_step_count == 3
+    # Natural duration end leaves hardware idle, but does not set the host flag.
+    assert subject._profile_stop_requested is False
+    decoy.verify(
+        await mock_driver.set_vacuum_state(
+            enable_vacuum=True,
+            gauge_pressure_mbar=-200,
+            duration_s=5,
+            timeout_s=None,
+            rate=None,
+            vent_after=False,
+        ),
+        await mock_driver.set_vacuum_state(
+            enable_vacuum=True,
+            gauge_pressure_mbar=-400,
+            duration_s=5,
+            timeout_s=None,
+            rate=None,
+            vent_after=False,
+        ),
+        await mock_driver.set_vacuum_state(False),
+        await mock_driver.set_pump_state(
+            start_pump=True,
+            target_rpm=None,
+            duty_cycle=30,
+            duration_s=5,
+            timeout_s=None,
+            rate=None,
+            vent_after=False,
+        ),
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Vacuum firmware clears running/enabled flags when a timed step duration ends; the host previously treated that as an external stop and aborted remaining profile steps
- Track host `stop_vacuum` with `_profile_stop_requested` so multi-step profiles (including mixed pressure/power) continue after natural duration completion
- Abort only on explicit host stop, independent of the current step's `enable_pump`

## Test plan
- [x] `pytest tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py`
- [ ] Run a multi-step `start_execute_profile` with holds (pressure then power) on hardware and confirm all steps execute
- [ ] Confirm `stop_vacuum` mid-profile still aborts remaining steps and skips final `vent_after`