### PR TITLE
fix(shared-data): resolve positions for vacuum module dock addressable areas

### DIFF
--- a/shared-data/js/fixtures.ts
+++ b/shared-data/js/fixtures.ts
@@ -381,14 +381,13 @@ export function getPositionFromSlotId(
   //  the hopper doesn't have its own AddressableAreaName
   hopperAdjustedOffset?: number
 ): CoordinateTuple | null {
-  const cutoutWithSlot =
-    deckDef.robot.model === FLEX_ROBOT_TYPE
-      ? FLEX_CUTOUT_BY_SLOT_ID[slotId]
-      : OT2_CUTOUT_BY_SLOT_ID[slotId]
+  const cutoutWithSlot = getCutoutIdForSlotOrAddressableArea(slotId, deckDef)
 
   const cutoutPosition =
-    deckDef.locations.cutouts.find(cutout => cutout.id === cutoutWithSlot)
-      ?.position ?? null
+    cutoutWithSlot != null
+      ? (deckDef.locations.cutouts.find(cutout => cutout.id === cutoutWithSlot)
+          ?.position ?? null)
+      : null
 
   // adjust for offset from cutout
   const offsetFromCutoutFixture = getAddressableAreaFromSlotId(slotId, deckDef)
@@ -406,6 +405,41 @@ export function getPositionFromSlotId(
       : null
 
   return slotPosition
+}
+
+/**
+ * Resolve the cutout that hosts a slot or addressable area.
+ *
+ * Standard single/staging slots are looked up via the hard-coded maps.
+ * Module-specific addressable areas (e.g. vacuumModuleV1DockA4) are not in those
+ * maps, so fall back to finding which cutout fixture provides the AA in the deck def.
+ * Without this, labware on the vacuum module dock resolves to null coordinates and
+ * MoveLabwareOnDeck animates it from off-deck.
+ */
+function getCutoutIdForSlotOrAddressableArea(
+  slotId: string,
+  deckDef: DeckDefinition
+): CutoutId | OT2CutoutId | null {
+  const fromSlotMap: CutoutId | OT2CutoutId | undefined =
+    deckDef.robot.model === FLEX_ROBOT_TYPE
+      ? FLEX_CUTOUT_BY_SLOT_ID[slotId]
+      : OT2_CUTOUT_BY_SLOT_ID[slotId]
+
+  if (fromSlotMap != null) {
+    return fromSlotMap
+  }
+
+  // Module addressable areas (vacuum dock, stacker shuttle, etc.)
+  for (const cutoutFixture of deckDef.cutoutFixtures) {
+    const match = Object.entries(cutoutFixture.providesAddressableAreas).find(
+      ([_, providedAAs]) => (providedAAs as string[]).includes(slotId)
+    )
+    if (match != null) {
+      return match[0] as CutoutId
+    }
+  }
+
+  return null
 }
 
 export function getPositionFromAddressableAreaId(args: {

--- a/shared-data/js/helpers/__tests__/positionMath.test.ts
+++ b/shared-data/js/helpers/__tests__/positionMath.test.ts
@@ -6,6 +6,7 @@ import {
   getDeckSlotOriginToLabwareOrigin,
   getLabwareViewBox,
   getModuleDef,
+  getPositionFromSlotId,
   getSchema2Dimensions,
   ot3StandardDeckV5 as ot3StandardDeckV5Untyped,
 } from '../..'
@@ -82,6 +83,48 @@ describe('computeLabwareOrigin()', () => {
         z: 31,
       })
     })
+  })
+
+  test('resolves collar origin on the vacuum module dock (vacuumModuleV1DockA4)', () => {
+    // Recovery/move animations pass addressableAreaName vacuumModuleV1DockA4 as the
+    // slot id. That AA is not in FLEX_CUTOUT_BY_SLOT_ID; position must still resolve
+    // so the collar does not animate from off-deck.
+    const collarDef =
+      getAllDefinitions()['opentrons/opentrons_vacuum_manifold_collar_tall/1']
+
+    const result = computeLabwareOrigin({
+      labwareDefinitionsTopToBottom: [collarDef],
+      moduleDefinition: null,
+      slotId: 'vacuumModuleV1DockA4',
+      deckDefinition: OT3_DECK_DEF,
+    })
+
+    // cutoutA3 [328, 321, 0] + vacuumModuleV1DockA4 offset [164, 0, 20]
+    expect(result).toStrictEqual({
+      x: 492,
+      y: 321,
+      z: 20,
+    })
+  })
+})
+
+describe('getPositionFromSlotId()', () => {
+  it('returns coordinates for standard staging slot A4', () => {
+    expect(getPositionFromSlotId('A4', OT3_DECK_DEF)).toStrictEqual([
+      492, 321, 14.5,
+    ])
+  })
+
+  it('returns coordinates for vacuum module dock addressable area', () => {
+    expect(
+      getPositionFromSlotId('vacuumModuleV1DockA4', OT3_DECK_DEF)
+    ).toStrictEqual([492, 321, 20])
+  })
+
+  it('returns coordinates for vacuum module main addressable area', () => {
+    expect(
+      getPositionFromSlotId('vacuumModuleV1A3', OT3_DECK_DEF)
+    ).toStrictEqual([328, 321, 19])
   })
 })
 


### PR DESCRIPTION
# Overview

Fix recovery/move-labware deck animations when the vacuum manifold collar starts on the vacuum dock (`vacuumModuleV1DockA4`). The `getPositionFromSlotId` only resolved standard slots via a hard-coded cutout map. Module addressable areas returned null, so `MoveLabwareOnDeck` treated the collar as off-deck and animated it from off-deck onto A3+A4.

Closes: [RQA-5759](https://opentrons.atlassian.net/browse/RQA-5759)

# Test Plan and Hands on Testing

- [ ] Recovery manual move collar from dock A4 → vacuum module A3; confirm animation starts on dock and lands on module

# Changelog

- `getPositionFromSlotId` falls back to deck-definition cutout lookup for module addressable areas (e.g. `vacuumModuleV1DockA4`, `vacuumModuleV1A3`)
- Adds unit coverage for vacuum dock/main AA positioning

# Review requests

- Confirm the deck-def fallback is the right place for this (vs expanding `FLEX_CUTOUT_BY_SLOT_ID` only)

# Risk assessment

Low. Behavior is unchanged for standard slots; only previously unresolved module AAs gain coordinates. Affects deck sim / recovery move animation positioning.

[RQA-5759]: https://opentrons.atlassian.net/browse/RQA-5759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ