### PR TITLE
fix(protocol-visualization): fix bugs that react-doctor detects - protocol-visualization

### DIFF
--- a/protocol-visualization/src/molecules/PerStepOverflowMenu/index.tsx
+++ b/protocol-visualization/src/molecules/PerStepOverflowMenu/index.tsx
@@ -2,6 +2,8 @@ import { MenuItem, MenuList, useOnClickOutside } from '@opentrons/components'
 
 import styles from './perstepoverflowmenu.module.css'
 
+import type { ReactNode } from 'react'
+
 interface PerStepOverflowMenuProps {
   setShowPerStepOverflowMenu: (showPerStepOverflowMenu: boolean) => void
   setMilliSecondsPerFrame: (secondsPerFrame: number) => void
@@ -17,7 +19,7 @@ const PLAYBACK_SPEED_OPTIONS = [
 
 export function PerStepOverflowMenu(
   props: PerStepOverflowMenuProps
-): JSX.Element {
+): ReactNode {
   const { setShowPerStepOverflowMenu, setMilliSecondsPerFrame } = props
   const perStepOverflowWrapperRef = useOnClickOutside<HTMLDivElement>({
     onClickOutside: () => {

--- a/protocol-visualization/src/molecules/PlayBackControls/index.tsx
+++ b/protocol-visualization/src/molecules/PlayBackControls/index.tsx
@@ -13,7 +13,7 @@ import styles from './playbackcontrols.module.css'
 import { formatTime } from './utils/formatTime'
 import { getSpeedMultiplierText } from './utils/getSpeedMultiplierText'
 
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import type { RunTimeCommand } from '@opentrons/shared-data'
 
 interface PlayBackControlsProps {
@@ -28,7 +28,7 @@ interface PlayBackControlsProps {
   onClickStepDetail?: () => void
 }
 
-export function PlayBackControls(props: PlayBackControlsProps): JSX.Element {
+export function PlayBackControls(props: PlayBackControlsProps): ReactNode {
   const {
     isPlaying,
     handlePlayPause,

--- a/protocol-visualization/src/molecules/SlotDetailsEmptyState/index.tsx
+++ b/protocol-visualization/src/molecules/SlotDetailsEmptyState/index.tsx
@@ -5,6 +5,8 @@ import { COLORS, RobotInfoLabel, StyledText } from '@opentrons/components'
 
 import styles from './slotdetailsemptystate.module.css'
 
+import type { ReactNode } from 'react'
+
 interface SlotDetailsEmptyStateProps {
   slotId: string
   headerPortalEl?: HTMLElement | null
@@ -12,7 +14,7 @@ interface SlotDetailsEmptyStateProps {
 
 export function SlotDetailsEmptyState(
   props: SlotDetailsEmptyStateProps
-): JSX.Element {
+): ReactNode {
   const { slotId, headerPortalEl } = props
   const { t } = useTranslation('protocol_visualization')
   const header = (

--- a/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedGroup.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/AnnotatedGroup.tsx
@@ -35,7 +35,7 @@ interface AnnotatedGroupProps {
   // rendered after sub-commands when analysis failed inside this annotation group
   trailingErrorsFooter?: ReactNode | null
 }
-export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
+export function AnnotatedGroup(props: AnnotatedGroupProps): ReactNode {
   const {
     subCommands,
     annotationType,
@@ -116,7 +116,7 @@ export function AnnotatedGroup(props: AnnotatedGroupProps): JSX.Element {
                 scrollTargetId={scrollTargetId}
                 listElement={listElement}
                 fromGroup={true}
-                key={`${subCommand.command.id}_${index}`}
+                key={subCommand.command.id}
                 command={subCommand.command}
                 commandNumber={commandStartNumber + index}
                 analysis={analysis}

--- a/protocol-visualization/src/organisms/AnnotatedSteps/IndividualCommand.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/IndividualCommand.tsx
@@ -7,7 +7,7 @@ import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 import { CommandIcon } from '../../molecules/CommandIcon'
 import styles from './annotatedsteps.module.css'
 
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import type {
   CompletedProtocolAnalysis,
   LabwareDefinition,
@@ -58,7 +58,7 @@ export function IndividualCommand({
   commandNumber,
   scrollTargetId,
   listElement,
-}: IndividualCommandProps): JSX.Element {
+}: IndividualCommandProps): ReactNode {
   const commandRef = useRef<HTMLDivElement | null>(null)
   const iconColor = isHighlighted ? COLORS.purple50 : COLORS.grey50
 

--- a/protocol-visualization/src/organisms/AnnotatedSteps/ProtocolAnalysisErrorModal.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/ProtocolAnalysisErrorModal.tsx
@@ -4,6 +4,7 @@ import i18n from 'i18next'
 
 import { Modal, PrimaryButton, StyledText } from '@opentrons/components'
 
+import type { ReactNode } from 'react'
 import type { AnalysisError } from '@opentrons/shared-data'
 
 interface ProtocolAnalysisErrorModalProps {
@@ -16,7 +17,7 @@ export function ProtocolAnalysisErrorModal({
   errors,
   onClose,
   portalRoot,
-}: ProtocolAnalysisErrorModalProps): JSX.Element {
+}: ProtocolAnalysisErrorModalProps): ReactNode {
   const { t } = useTranslation('protocol_visualization')
   return createPortal(
     <Modal

--- a/protocol-visualization/src/organisms/AnnotatedSteps/ProtocolAnalysisErrorsContent.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/ProtocolAnalysisErrorsContent.tsx
@@ -2,6 +2,7 @@ import { COLORS, Icon, StyledText } from '@opentrons/components'
 
 import styles from './annotatedsteps.module.css'
 
+import type { ReactNode } from 'react'
 import type { AnalysisError } from '@opentrons/shared-data'
 
 interface ProtocolAnalysisErrorsContentProps {
@@ -16,7 +17,7 @@ interface ProtocolAnalysisErrorsContentProps {
 
 export function ProtocolAnalysisErrorsContent(
   props: ProtocolAnalysisErrorsContentProps
-): JSX.Element {
+): ReactNode {
   const {
     errors,
     onShowErrorDetails,

--- a/protocol-visualization/src/organisms/AnnotatedSteps/ProtocolAnalysisPastStepsMessage.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/ProtocolAnalysisPastStepsMessage.tsx
@@ -2,9 +2,11 @@ import { COLORS, StyledText } from '@opentrons/components'
 
 import styles from './annotatedsteps.module.css'
 
+import type { ReactNode } from 'react'
+
 export function ProtocolAnalysisPastStepsMessage(props: {
   t: (key: string) => string
-}): JSX.Element {
+}): ReactNode {
   const { t } = props
 
   return (

--- a/protocol-visualization/src/organisms/AnnotatedSteps/index.tsx
+++ b/protocol-visualization/src/organisms/AnnotatedSteps/index.tsx
@@ -13,7 +13,7 @@ import {
   getLastVisibleAnalysisCommandId,
 } from './utils'
 
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import type {
   AnalysisError,
   CompletedProtocolAnalysis,
@@ -86,7 +86,7 @@ export interface ItemData {
 const DEFAULT_ROW_HEIGHT_PX = 64
 const DEFAULT_STEP_GROUP_SECONDS = 2000
 
-export function AnnotatedSteps(props: AnnotatedStepsProps): JSX.Element {
+export function AnnotatedSteps(props: AnnotatedStepsProps): ReactNode {
   const {
     analysis,
     currentCommandIndex,

--- a/protocol-visualization/src/organisms/CommandSteps/index.tsx
+++ b/protocol-visualization/src/organisms/CommandSteps/index.tsx
@@ -6,7 +6,7 @@ import { COLORS, StyledText } from '@opentrons/components'
 import { AnnotatedSteps } from '../AnnotatedSteps'
 import styles from './commandsteps.module.css'
 
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import type {
   CompletedProtocolAnalysis,
   ProtocolAnalysisOutput,
@@ -23,7 +23,7 @@ interface CommandStepsProps {
   milliSecondsPerFrame: number
   isGlobalPlaying: boolean
 }
-export function CommandSteps(props: CommandStepsProps): JSX.Element {
+export function CommandSteps(props: CommandStepsProps): ReactNode {
   const {
     groupedCommands,
     analysis,

--- a/protocol-visualization/src/organisms/DeckView/DeckViewDetails.tsx
+++ b/protocol-visualization/src/organisms/DeckView/DeckViewDetails.tsx
@@ -10,7 +10,7 @@ import { DeckViewSlots } from './DeckViewSlots'
 import { FixtureCommandSummary } from './FixtureCommandSummary'
 import { Ot2FixedTrashCommandSummary } from './Ot2FixedTrashCommandSummary'
 
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import type {
   CutoutId,
   DeckDefinition,
@@ -37,7 +37,7 @@ interface DeckViewDetailsProps {
   setHoveredSlot: Dispatch<SetStateAction<string | null>>
   selectedRunTimeCommand?: RunTimeCommand
 }
-export function DeckViewDetails(props: DeckViewDetailsProps): JSX.Element {
+export function DeckViewDetails(props: DeckViewDetailsProps): ReactNode {
   const {
     robotState,
     robotType,

--- a/protocol-visualization/src/organisms/DeckView/DeckViewLabware.tsx
+++ b/protocol-visualization/src/organisms/DeckView/DeckViewLabware.tsx
@@ -13,7 +13,7 @@ import { DeckViewOverlay } from './DeckViewOverlay'
 import { LabwareCommandSummary } from './LabwareCommandSummary'
 import { LabwareOnDeck } from './LabwareOnDeck'
 
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import type {
   DeckDefinition,
   Liquid,
@@ -35,7 +35,7 @@ interface DeckViewLabwareProps {
   hoveredSlot: string | null
   selectedRunTimeCommand?: RunTimeCommand
 }
-export function DeckViewLabware(props: DeckViewLabwareProps): JSX.Element {
+export function DeckViewLabware(props: DeckViewLabwareProps): ReactNode {
   const {
     robotState,
     invariantContext,

--- a/protocol-visualization/src/organisms/DeckView/DeckViewLabwareCommandSummaries.tsx
+++ b/protocol-visualization/src/organisms/DeckView/DeckViewLabwareCommandSummaries.tsx
@@ -11,6 +11,7 @@ import { getSlotInLocationStack } from '@opentrons/step-generation'
 import { getActiveLayer } from '../utils/getActiveLayer'
 import { LabwareCommandSummary } from './LabwareCommandSummary'
 
+import type { ReactNode } from 'react'
 import type { DeckDefinition, RunTimeCommand } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '@opentrons/step-generation'
 import type { LabwareEntityExtended } from './index'
@@ -31,7 +32,7 @@ const STACKER_MOVE_MAP: Record<string, string> = {
 
 export function DeckViewLabwareCommandSummaries(
   props: DeckViewLabwareCommandSummariesProps
-): JSX.Element {
+): ReactNode {
   const {
     robotState,
     invariantContext,

--- a/protocol-visualization/src/organisms/DeckView/DeckViewModuleCommandSummaries.tsx
+++ b/protocol-visualization/src/organisms/DeckView/DeckViewModuleCommandSummaries.tsx
@@ -6,6 +6,7 @@ import {
 
 import { ModuleCommandSummary } from './ModuleCommandSummary'
 
+import type { ReactNode } from 'react'
 import type {
   DeckDefinition,
   RobotType,
@@ -23,7 +24,7 @@ interface DeckViewModuleCommandSummariesProps {
 
 export function DeckViewModuleCommandSummaries(
   props: DeckViewModuleCommandSummariesProps
-): JSX.Element {
+): ReactNode {
   const {
     robotState,
     invariantContext,

--- a/protocol-visualization/src/organisms/DeckView/DeckViewModules.tsx
+++ b/protocol-visualization/src/organisms/DeckView/DeckViewModules.tsx
@@ -15,7 +15,7 @@ import { getTopmostLabwareOnModuleFromStack } from '../utils/getTopmostLabwareOn
 import { DeckViewOverlay } from './DeckViewOverlay'
 import { DeckViewStacker } from './DeckViewStacker'
 
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import type { ThermocyclerVizProps } from '@opentrons/components'
 import type {
   DeckDefinition,
@@ -41,7 +41,7 @@ interface DeckViewModulesProps {
   selectedRunTimeCommand?: RunTimeCommand
 }
 
-export function DeckViewModules(props: DeckViewModulesProps): JSX.Element {
+export function DeckViewModules(props: DeckViewModulesProps): ReactNode {
   const {
     robotState,
     invariantContext,

--- a/protocol-visualization/src/organisms/DeckView/DeckViewSlots.tsx
+++ b/protocol-visualization/src/organisms/DeckView/DeckViewSlots.tsx
@@ -8,7 +8,7 @@ import { getSlotIsEmpty } from '../utils/getSlotIsEmpty'
 import { getStagingAreaAddressableAreas } from '../utils/getStagingAreaAddressableAreas'
 import { DeckViewOverlay } from './DeckViewOverlay'
 
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import type {
   CutoutId,
   DeckDefinition,
@@ -28,7 +28,7 @@ interface DeckViewSlotsProps {
   slotIdsBlockedBySpanning: string[]
 }
 
-export function DeckViewSlots(props: DeckViewSlotsProps): JSX.Element {
+export function DeckViewSlots(props: DeckViewSlotsProps): ReactNode {
   const {
     deckDef,
     robotType,

--- a/protocol-visualization/src/organisms/DeckView/DeckViewStacker.tsx
+++ b/protocol-visualization/src/organisms/DeckView/DeckViewStacker.tsx
@@ -14,7 +14,7 @@ import { DeckViewOverlay } from './DeckViewOverlay'
 import { LabwareCommandSummary } from './LabwareCommandSummary'
 import { LabwareOnDeck } from './LabwareOnDeck'
 
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import type {
   CoordinateTuple,
   DeckDefinition,
@@ -51,7 +51,7 @@ interface DeckViewStackerProps {
   renderLabware?: boolean
 }
 
-export function DeckViewStacker(props: DeckViewStackerProps): JSX.Element {
+export function DeckViewStacker(props: DeckViewStackerProps): ReactNode {
   const {
     robotState,
     invariantContext,

--- a/protocol-visualization/src/organisms/DeckView/FixtureCommandSummary.tsx
+++ b/protocol-visualization/src/organisms/DeckView/FixtureCommandSummary.tsx
@@ -6,6 +6,7 @@ import {
 } from '@opentrons/components'
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
+import type { ReactNode } from 'react'
 import type { TrashCutoutId } from '@opentrons/components'
 import type { CutoutId, RunTimeCommand } from '@opentrons/shared-data'
 
@@ -17,7 +18,7 @@ interface FixtureCommandSummaryProps {
 
 export function FixtureCommandSummary(
   props: FixtureCommandSummaryProps
-): JSX.Element {
+): ReactNode {
   const { cutoutId, commandType, type } = props
   const commandSummary = useCommandTypeSummaries(commandType)
 

--- a/protocol-visualization/src/organisms/DeckView/LabwareCommandSummary.tsx
+++ b/protocol-visualization/src/organisms/DeckView/LabwareCommandSummary.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import { DeckLabelSet, useCommandTypeSummaries } from '@opentrons/components'
 
+import type { ReactNode } from 'react'
 import type {
   CoordinateTuple,
   LabwareDefinition2,
@@ -24,7 +25,7 @@ interface LabwareCommandSummaryProps {
 }
 export function LabwareCommandSummary(
   props: LabwareCommandSummaryProps
-): JSX.Element {
+): ReactNode {
   const { labwareDef, position, showModuleIcon, commandType } = props
   const labelContainerRef = useRef<HTMLDivElement>(null)
   const [labelContainerHeight, setLabelContainerHeight] = useState(0)

--- a/protocol-visualization/src/organisms/DeckView/LabwareOnDeck.tsx
+++ b/protocol-visualization/src/organisms/DeckView/LabwareOnDeck.tsx
@@ -8,7 +8,7 @@ import {
 import { getAllWellContentsAtFrame } from '../utils/getAllWellContentsAtFrame'
 import { getMissingTips } from '../utils/getMissingTips'
 
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import type { WellGroup } from '@opentrons/components'
 import type { LabwareDefinition2, Liquid } from '@opentrons/shared-data'
 import type { RobotState } from '@opentrons/step-generation'
@@ -24,7 +24,7 @@ interface LabwareOnDeckProps {
   setHoveredSlot: Dispatch<SetStateAction<string | null>>
 }
 
-export function LabwareOnDeck(props: LabwareOnDeckProps): JSX.Element {
+export function LabwareOnDeck(props: LabwareOnDeckProps): ReactNode {
   const {
     labwareDef,
     labwareId,

--- a/protocol-visualization/src/organisms/DeckView/ModuleCommandSummary.tsx
+++ b/protocol-visualization/src/organisms/DeckView/ModuleCommandSummary.tsx
@@ -11,6 +11,7 @@ import {
   TEMPERATURE_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
+import type { ReactNode } from 'react'
 import type {
   CoordinateTuple,
   DeckSlotId,
@@ -31,7 +32,7 @@ interface ModuleCommandSummaryProps {
 // NOTE: a lot of this is similar to ModuleLabel in PD so we should try to combine them
 export const ModuleCommandSummary = (
   props: ModuleCommandSummaryProps
-): JSX.Element => {
+): ReactNode => {
   const {
     moduleModel,
     position,

--- a/protocol-visualization/src/organisms/DeckView/index.tsx
+++ b/protocol-visualization/src/organisms/DeckView/index.tsx
@@ -28,7 +28,7 @@ import { getIsPipetteOverTrash } from '../utils/getIsPipetteOverTrash'
 import styles from './deckview.module.css'
 import { DeckViewDetails } from './DeckViewDetails'
 
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 import type { StagingAreaLocation, TrashCutoutId } from '@opentrons/components'
 import type {
   CutoutId,
@@ -73,7 +73,7 @@ const lightFill = COLORS.grey35
 const darkFill = COLORS.grey60
 const extraSize = 260
 
-export function DeckView(props: DeckViewProps): JSX.Element {
+export function DeckView(props: DeckViewProps): ReactNode {
   const {
     robotType,
     invariantContext,

--- a/protocol-visualization/src/organisms/LabwareSlotContainer/index.tsx
+++ b/protocol-visualization/src/organisms/LabwareSlotContainer/index.tsx
@@ -21,6 +21,7 @@ import { WellContainer } from '../WellContainer'
 import { WellTooltip } from '../WellTooltip'
 import styles from './labwareslotcontainer.module.css'
 
+import type { ReactNode } from 'react'
 import type { WellGroup } from '@opentrons/components'
 import type { Liquid, RunTimeCommand } from '@opentrons/shared-data'
 import type {
@@ -55,7 +56,7 @@ const HIDE_WELL_CONTAINER_COMMAND_TYPES = [
 
 export function LabwareSlotContainer(
   props: LabwareSlotContainerProps
-): JSX.Element {
+): ReactNode {
   const {
     commands,
     liquids,

--- a/protocol-visualization/src/organisms/ModuleContainer/index.tsx
+++ b/protocol-visualization/src/organisms/ModuleContainer/index.tsx
@@ -16,6 +16,7 @@ import {
 import { ModuleStatusContainer } from '../ModuleStatusContainer'
 import styles from './modulecontainer.module.css'
 
+import type { ReactNode } from 'react'
 import type { ModuleEntities, RobotState } from '@opentrons/step-generation'
 
 interface ModuleContainerProps {
@@ -32,7 +33,7 @@ export function ModuleContainer({
   moduleRobotState,
   slotId,
   headerPortalEl,
-}: ModuleContainerProps): JSX.Element {
+}: ModuleContainerProps): ReactNode {
   const { t } = useTranslation('protocol_visualization')
   const { model } = moduleEntities[moduleId]
   const { moduleState } = moduleRobotState[moduleId]

--- a/protocol-visualization/src/organisms/ModuleStatusContainer.tsx
+++ b/protocol-visualization/src/organisms/ModuleStatusContainer.tsx
@@ -4,13 +4,15 @@ import { StyledText } from '@opentrons/components'
 
 import styles from './ModuleContainer/modulecontainer.module.css'
 
+import type { ReactNode } from 'react'
+
 interface ModuleStatusContainerProps {
   title: string
   children: React.ReactNode
 }
 export const ModuleStatusContainer = (
   props: ModuleStatusContainerProps
-): JSX.Element => {
+): ReactNode => {
   const { t } = useTranslation('protocol_visualization')
   const { title, children } = props
   return (

--- a/protocol-visualization/src/organisms/PipetteContainer/index.tsx
+++ b/protocol-visualization/src/organisms/PipetteContainer/index.tsx
@@ -5,6 +5,7 @@ import { getPipetteNameSpecs } from '@opentrons/shared-data'
 
 import styles from './pipettecontainer.module.css'
 
+import type { ReactNode } from 'react'
 import type { PipetteName } from '@opentrons/shared-data'
 
 interface PipetteContainerProps {
@@ -17,7 +18,7 @@ export function PipetteContainer({
   mount,
   pipetteName,
   selected,
-}: PipetteContainerProps): JSX.Element {
+}: PipetteContainerProps): ReactNode {
   const { t } = useTranslation('protocol_visualization')
   const pipetteDisplayName = getPipetteNameSpecs(pipetteName)?.displayName ?? ''
 

--- a/protocol-visualization/src/organisms/SlotDetails/index.tsx
+++ b/protocol-visualization/src/organisms/SlotDetails/index.tsx
@@ -12,6 +12,7 @@ import { TipDisposalSlot } from '../SlotSpotlight/TipDisposalSlot'
 import { TipPickupSlot } from '../SlotSpotlight/TipPickupSlot'
 import styles from './slotdetails.module.css'
 
+import type { ReactNode } from 'react'
 import type {
   Liquid,
   LoadLabwareRunTimeCommand,
@@ -32,7 +33,7 @@ interface SlotDetailsProps {
   liquids: Liquid[]
   headerPortalEl?: HTMLElement | null
 }
-export function SlotDetails(props: SlotDetailsProps): JSX.Element {
+export function SlotDetails(props: SlotDetailsProps): ReactNode {
   const {
     slotId,
     robotState,
@@ -110,7 +111,7 @@ export function SlotDetails(props: SlotDetailsProps): JSX.Element {
     return 'labware'
   }
 
-  const renderLabwareContent = (): JSX.Element | null => {
+  const renderLabwareContent = (): ReactNode | null => {
     const labwareType = getLabwareType()
     if (topMostLabwareOnSlot == null) {
       return null

--- a/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/index.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlight/LabwareSlot/index.tsx
@@ -24,6 +24,7 @@ import { getAllWellContentsAtFrame } from '../../utils/getAllWellContentsAtFrame
 import { WellTooltip } from '../../WellTooltip'
 import styles from './labwareslot.module.css'
 
+import type { ReactNode } from 'react'
 import type { WellGroup } from '@opentrons/components'
 import type {
   Liquid,
@@ -47,7 +48,7 @@ interface LabwareSlotContainerProps {
   // when set, the header block is rendered into this element via portal
   headerPortalEl?: HTMLElement | null
 }
-export function LabwareSlot(props: LabwareSlotContainerProps): JSX.Element {
+export function LabwareSlot(props: LabwareSlotContainerProps): ReactNode {
   const {
     topLabwareOnSlotId,
     labwareEntities,

--- a/protocol-visualization/src/organisms/SlotSpotlight/TipDisposalSlot/index.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlight/TipDisposalSlot/index.tsx
@@ -5,6 +5,7 @@ import { RobotInfoLabel } from '@opentrons/components'
 
 import styles from './tipdisposalslot.module.css'
 
+import type { ReactNode } from 'react'
 import type { RobotState } from '@opentrons/step-generation'
 
 interface TipDisposalSlotProps {
@@ -18,7 +19,7 @@ export function TipDisposalSlot({
   robotState,
   disposalType,
   headerPortalEl,
-}: TipDisposalSlotProps): JSX.Element {
+}: TipDisposalSlotProps): ReactNode {
   const { t } = useTranslation('protocol_visualization')
   // temporary commenting out for Rs 9.0.0
   // const totalEmptyTips = Object.values(tipState.tipracks).reduce(

--- a/protocol-visualization/src/organisms/SlotSpotlight/TipPickupSlot/index.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlight/TipPickupSlot/index.tsx
@@ -14,6 +14,7 @@ import { getLabwareViewBox } from '@opentrons/shared-data'
 import { getMissingTips } from '../../utils/getMissingTips'
 import styles from './tippickupslot.module.css'
 
+import type { ReactNode } from 'react'
 import type { TipType } from '@opentrons/components'
 import type { RobotState } from '@opentrons/step-generation'
 import type { LabwareEntityExtended } from '../../DeckView'
@@ -25,7 +26,7 @@ interface TipPickupSlotProps {
   headerPortalEl?: HTMLElement | null
 }
 
-export function TipPickupSlot(props: TipPickupSlotProps): JSX.Element {
+export function TipPickupSlot(props: TipPickupSlotProps): ReactNode {
   const { tiprackEntity, robotState, headerPortalEl } = props
   const { t } = useTranslation('protocol_visualization')
   const { id, def, nickName } = tiprackEntity

--- a/protocol-visualization/src/organisms/SlotSpotlightViewer/index.tsx
+++ b/protocol-visualization/src/organisms/SlotSpotlightViewer/index.tsx
@@ -6,6 +6,7 @@ import { ModelessModal } from '@opentrons/components'
 import { SlotDetails } from '../SlotDetails'
 import styles from './slotspotlightviewer.module.css'
 
+import type { ReactNode } from 'react'
 import type { Liquid, ProtocolAnalysisOutput } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '@opentrons/step-generation'
 import type { AppType } from '../../types'
@@ -28,7 +29,7 @@ interface SlotSpotlightViewerProps {
 
 export function SlotSpotlightViewer(
   props: SlotSpotlightViewerProps
-): JSX.Element | null {
+): ReactNode | null {
   const {
     appType,
     slotId,

--- a/protocol-visualization/src/organisms/StepDetailContainer/index.tsx
+++ b/protocol-visualization/src/organisms/StepDetailContainer/index.tsx
@@ -10,6 +10,7 @@ import { getActiveSlotForTiprackDetails } from '../utils/getActiveSlotForTiprack
 import { getIsPipetteActive } from '../utils/getIsPipetteActive'
 import styles from './stepdetailcontainer.module.css'
 
+import type { ReactNode } from 'react'
 import type { Liquid, RunTimeCommand } from '@opentrons/shared-data'
 import type { InvariantContext, RobotState } from '@opentrons/step-generation'
 
@@ -27,7 +28,7 @@ export function StepDetailContainer({
   invariantContext,
   currentCommand,
   liquids,
-}: StepDetailContainerProps): JSX.Element {
+}: StepDetailContainerProps): ReactNode {
   const { labwareEntities, pipetteEntities, moduleEntities } = invariantContext
   const { labware, pipettes } = robotState
   const tiprackActiveSlot = getActiveSlotForTiprackDetails(

--- a/protocol-visualization/src/organisms/TipDisposalContainer/index.tsx
+++ b/protocol-visualization/src/organisms/TipDisposalContainer/index.tsx
@@ -5,6 +5,7 @@ import { EMPTY } from '@opentrons/step-generation'
 
 import styles from './tipdisposalcontainer.module.css'
 
+import type { ReactNode } from 'react'
 import type { RobotState } from '@opentrons/step-generation'
 
 interface TipDisposalContainerProps {
@@ -13,7 +14,7 @@ interface TipDisposalContainerProps {
 
 export function TipDisposalContainer({
   robotState,
-}: TipDisposalContainerProps): JSX.Element {
+}: TipDisposalContainerProps): ReactNode {
   const { t } = useTranslation('protocol_visualization')
   const { tipState } = robotState
   const totalEmptyTips = Object.values(tipState.tipracks).reduce(

--- a/protocol-visualization/src/organisms/TipPickupContainer/index.tsx
+++ b/protocol-visualization/src/organisms/TipPickupContainer/index.tsx
@@ -16,6 +16,7 @@ import { getSlotInLocationStack } from '@opentrons/step-generation'
 import { getMissingTips } from '../utils/getMissingTips'
 import styles from './tippickupcontainer.module.css'
 
+import type { ReactNode } from 'react'
 import type { TipType } from '@opentrons/components'
 import type { LabwareEntity, RobotState } from '@opentrons/step-generation'
 
@@ -24,9 +25,7 @@ interface TipPickupContainerProps {
   robotState: RobotState
 }
 
-export function TipPickupContainer(
-  props: TipPickupContainerProps
-): JSX.Element {
+export function TipPickupContainer(props: TipPickupContainerProps): ReactNode {
   const { tiprackEntity, robotState } = props
   const { t } = useTranslation('protocol_visualization')
   const { id, def } = tiprackEntity

--- a/protocol-visualization/src/organisms/TipSvg.tsx
+++ b/protocol-visualization/src/organisms/TipSvg.tsx
@@ -2,7 +2,7 @@ import { useId } from 'react'
 
 import { COLORS, CURSOR_POINTER } from '@opentrons/components'
 
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 
 interface TipSvgProps {
   volume: number
@@ -26,7 +26,7 @@ export const TipSvg = ({
   setIsHovered,
   isHovered,
   airGapVolume,
-}: TipSvgProps): JSX.Element => {
+}: TipSvgProps): ReactNode => {
   const clipId = useId()
   const airClipId = `${clipId}-air`
 

--- a/protocol-visualization/src/organisms/VisualizerContainer/index.tsx
+++ b/protocol-visualization/src/organisms/VisualizerContainer/index.tsx
@@ -16,7 +16,7 @@ import { SlotSpotlightViewer } from '../SlotSpotlightViewer'
 import { StepDetailContainer } from '../StepDetailContainer'
 import styles from './visualizercontainer.module.css'
 
-import type { MouseEvent } from 'react'
+import type { MouseEvent, ReactNode } from 'react'
 import type { ProtocolAnalysisOutput } from '@opentrons/shared-data'
 import type { AppType, GroupedCommands } from '../../types'
 
@@ -39,7 +39,7 @@ interface ProtocolVisualizationProps {
 
 export function ProtocolVisualization(
   props: ProtocolVisualizationProps
-): JSX.Element {
+): ReactNode {
   const { groupedCommands, analysis, appType } = props
   const createdDate = new Date(analysis.createdAt)
   const { commands, robotType, liquids } = analysis

--- a/protocol-visualization/src/organisms/WellContainer/index.tsx
+++ b/protocol-visualization/src/organisms/WellContainer/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import round from 'lodash/round'
 
@@ -15,6 +15,7 @@ import { getWellVolume } from '../utils/getWellVolume'
 import { WELL_GEOMETRY, WELL_VIEWBOX, WellSvg } from '../WellSvg'
 import styles from './wellcontainer.module.css'
 
+import type { ReactNode } from 'react'
 import type {
   LabwareWellMap,
   Liquid,
@@ -34,7 +35,7 @@ interface WellContainerProps {
   liquids: Liquid[]
   tipMaxVolume: number
 }
-export function WellContainer(props: WellContainerProps): JSX.Element {
+export function WellContainer(props: WellContainerProps): ReactNode {
   const {
     params,
     selectedWellName,
@@ -48,8 +49,6 @@ export function WellContainer(props: WellContainerProps): JSX.Element {
   const { t } = useTranslation('protocol_visualization')
   const [isWellHovered, setIsWellHovered] = useState<boolean>(false)
   const [isTipHovered, setIsTipHovered] = useState<boolean>(false)
-  const lastTipBottomYRef = useRef<number>(WELL_GEOMETRY.bottomY)
-  const lastXPositionSvgRef = useRef<number>(0)
 
   const labwareDepth = wells.A1.depth ?? 0
   const xLabwareWellWidth = wells.A1.x ?? 0
@@ -74,19 +73,23 @@ export function WellContainer(props: WellContainerProps): JSX.Element {
   const wellHeightSvg = WELL_GEOMETRY.bottomY - WELL_GEOMETRY.topY
   const wellWidthSvg = WELL_GEOMETRY.rightX - WELL_GEOMETRY.leftX
 
-  if (labwareDepth != null && labwareDepth > 0 && mmFromBottom != null) {
-    const fractionOfWellHeight = mmFromBottom / labwareDepth
-    const tipBottomY =
-      WELL_GEOMETRY.bottomY - fractionOfWellHeight * wellHeightSvg
-    lastTipBottomYRef.current = round(tipBottomY, SVG_DECIMALS)
-  }
-  const roundedTipBottomY = lastTipBottomYRef.current
+  const roundedTipBottomY = useMemo(() => {
+    if (labwareDepth != null && labwareDepth > 0 && mmFromBottom != null) {
+      const fractionOfWellHeight = mmFromBottom / labwareDepth
+      const tipBottomY =
+        WELL_GEOMETRY.bottomY - fractionOfWellHeight * wellHeightSvg
+      return round(tipBottomY, SVG_DECIMALS)
+    }
+    return WELL_GEOMETRY.bottomY
+  }, [labwareDepth, mmFromBottom, wellHeightSvg])
 
-  if (hasWellLocation && xLabwareWellWidth != null && xLabwareWellWidth > 0) {
-    const xPositionSvg = (wellWidthSvg / xLabwareWellWidth) * xOffset
-    lastXPositionSvgRef.current = round(xPositionSvg, SVG_DECIMALS)
-  }
-  const roundedXPositionSvg = lastXPositionSvgRef.current
+  const roundedXPositionSvg = useMemo(() => {
+    if (hasWellLocation && xLabwareWellWidth != null && xLabwareWellWidth > 0) {
+      const xPositionSvg = (wellWidthSvg / xLabwareWellWidth) * xOffset
+      return round(xPositionSvg, SVG_DECIMALS)
+    }
+    return 0
+  }, [hasWellLocation, xLabwareWellWidth, wellWidthSvg, xOffset])
 
   const { tipColor, tipCurrentVolume, airGapVolume } =
     pipetteLocationLiquidState != null

--- a/protocol-visualization/src/organisms/WellSvg.tsx
+++ b/protocol-visualization/src/organisms/WellSvg.tsx
@@ -2,7 +2,7 @@ import { useId } from 'react'
 
 import { COLORS } from '@opentrons/components'
 
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 
 export const WELL_VIEWBOX = { width: 165, height: 136 }
 export const WELL_GEOMETRY = {
@@ -26,7 +26,7 @@ export function WellSvg({
   color,
   setIsHovered,
   isHovered,
-}: WellSvgProps): JSX.Element {
+}: WellSvgProps): ReactNode {
   const clipId = useId()
   const percent = Math.min(Math.max(volume / maxVolume, 0), 1)
 

--- a/protocol-visualization/src/organisms/WellTooltip/index.tsx
+++ b/protocol-visualization/src/organisms/WellTooltip/index.tsx
@@ -51,7 +51,7 @@ export function WellTooltip({
   children,
   ingredNames,
   liquidDisplayColors,
-}: WellTooltipProps): JSX.Element {
+}: WellTooltipProps): ReactNode {
   const { t } = useTranslation('protocol_visualization')
   const [tooltipState, setTooltipState] =
     useState<TooltipState>(initialTooltipState)


### PR DESCRIPTION
# Overview
fix bugs that react-doctor detects - protocol-visualization to improve the package for oai

there is one case that we still need to use `JSX.Element` for `react-window`.

## Test Plan and Hands on Testing
1. run `npx react-doctor@latest` on edge
2. run `npx react-doctor@latest` on this branch
check the score is improved

## Changelog
- JSX.Element -> ReactNode
- remove unnecessary ref update 

## Review requests


## Risk assessment
low
