### PR TITLE
fix(robot-server): Reject `PATCH /runs/{id} {"current": true}` instead of no-opping

### DIFF
--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -7,7 +7,16 @@ import logging
 from datetime import datetime
 from pathlib import Path
 from textwrap import dedent
-from typing import Annotated, Callable, Dict, Final, Literal, Optional, Union
+from typing import (
+    Annotated,
+    Callable,
+    Dict,
+    Final,
+    Literal,
+    Optional,
+    Union,
+    assert_type,
+)
 
 from fastapi import Depends, Query, status
 from pydantic import BaseModel, Field
@@ -428,7 +437,9 @@ async def update_run(
         run_data_manager: Current and historical run data management.
     """
     try:
-        if request_body.data.current is False:
+        if request_body.data.current is not None:
+            # `current` can either be set to false or not be set at all.
+            assert_type(request_body.data.current, Literal[False])
             run_data = await run_data_manager.uncurrent(runId)
         else:
             run_data = run_data_manager.get(runId)

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -428,9 +428,10 @@ async def update_run(
         run_data_manager: Current and historical run data management.
     """
     try:
-        run_data = await run_data_manager.update(
-            runId, current=request_body.data.current
-        )
+        if request_body.data.current is False:
+            run_data = await run_data_manager.uncurrent(runId)
+        else:
+            run_data = run_data_manager.get(runId)
     except RunConflictError as e:
         raise RunNotIdle(detail=str(e)).as_error(status.HTTP_409_CONFLICT) from e
     except RunNotCurrentError as e:

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -1,7 +1,15 @@
 """Manage current and historical run data."""
 
 from datetime import datetime
-from typing import Callable, Dict, List, Mapping, Optional, Sequence, Union
+from typing import (
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Union,
+)
 
 from opentrons import config
 from opentrons.protocol_engine import (
@@ -392,60 +400,46 @@ class RunDataManager:
 
         self._run_store.remove(run_id=run_id)
 
-    async def update(self, run_id: str, current: Optional[bool]) -> Union[Run, BadRun]:
-        """Get and potentially archive the current run.
+    async def uncurrent(self, run_id: str) -> Union[Run, BadRun]:
+        """Archive the current run.
 
         Args:
-            run_id: The run to get and maybe archive.
-            current: Whether to mark the run as current or not.
-                     If `current` set to False, then the run is 'un-current'ed by
-                     stopping the run, saving the final run data to the run store,
-                     and clearing the engine and runner.
-                     If 'current' is True or not specified, we simply fetch the run's
-                     data from memory and database.
+            run_id: The run to un-current.
 
         Returns:
-            The updated run.
+            The run after it has been un-currented.
 
         Raises:
             RunNotFoundError: The run identifier was not found in the database.
             RunNotCurrentError: The run is not the current run.
-            RunConflictError: The run cannot be updated because it is not idle.
+            RunConflictError: The run cannot be un-currented because it is not idle.
         """
         if run_id != self._run_orchestrator_store.current_run_id:
             raise RunNotCurrentError(
-                f"Cannot update {run_id} because it is not the current run."
+                f"Cannot un-current {run_id} because it is not the current run."
             )
 
-        next_current = current if current is False else True
+        run_result = await self._run_orchestrator_store.clear()
+        self._file_provider.clear_run_metadata()
 
-        if next_current is False:
-            run_result = await self._run_orchestrator_store.clear()
-            state_summary = run_result.state_summary
-            parameters = run_result.parameters
-            run_resource: Union[RunResource, BadRunResource] = (
-                self._run_store.update_run_state(
-                    run_id=run_id,
-                    summary=run_result.state_summary,
-                    commands=run_result.commands,
-                    command_annotations=run_result.command_annotations,
-                    run_time_parameters=run_result.parameters,
-                )
+        run_resource: Union[RunResource, BadRunResource] = (
+            self._run_store.update_run_state(
+                run_id=run_id,
+                summary=run_result.state_summary,
+                commands=run_result.commands,
+                command_annotations=run_result.command_annotations,
+                run_time_parameters=run_result.parameters,
             )
-            self._runs_publisher.publish_pre_serialized_commands_notification(run_id)
-            self._file_provider.clear_run_metadata()
-        else:
-            state_summary = self._run_orchestrator_store.get_state_summary()
-            parameters = self._run_orchestrator_store.get_run_time_parameters()
-            run_resource = self._run_store.get(run_id=run_id)
+        )
+        self._runs_publisher.publish_pre_serialized_commands_notification(run_id)
 
         self._runs_publisher.publish_runs_advise_refetch(run_id)
 
         return _build_run(
             run_resource=run_resource,
-            state_summary=state_summary,
-            current=next_current,
-            run_time_parameters=parameters,
+            state_summary=run_result.state_summary,
+            current=False,
+            run_time_parameters=run_result.parameters,
         )
 
     def get_commands_slice(

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -297,7 +297,7 @@ class RunUpdate(BaseModel):
     """Update request data for an existing run."""
 
     current: Annotated[
-        bool | None,
+        Literal[False] | None,
         Field(
             description=(
                 "Whether this run is currently controlling the robot."

--- a/robot-server/robot_server/runs/run_models.py
+++ b/robot-server/robot_server/runs/run_models.py
@@ -1,7 +1,7 @@
 """Request and response models for run resources."""
 
 from datetime import datetime
-from typing import Dict, List, Literal, Optional
+from typing import Annotated, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -296,13 +296,15 @@ class RunCreate(BaseModel):
 class RunUpdate(BaseModel):
     """Update request data for an existing run."""
 
-    current: Optional[bool] = Field(
-        None,
-        description=(
-            "Whether this run is currently controlling the robot."
-            " Setting `current` to `false` will deactivate the run."
+    current: Annotated[
+        bool | None,
+        Field(
+            description=(
+                "Whether this run is currently controlling the robot."
+                " Setting `current` to `false` will deactivate the run."
+            ),
         ),
-    )
+    ] = None
 
 
 class LabwareDefinitionSummary(BaseModel):

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -623,7 +623,7 @@ async def test_update_run_to_not_current(
         hasEverEnteredErrorRecovery=False,
     )
 
-    decoy.when(await mock_run_data_manager.update("run-id", current=False)).then_return(
+    decoy.when(await mock_run_data_manager.uncurrent("run-id")).then_return(
         expected_response
     )
 
@@ -660,9 +660,7 @@ async def test_update_current_none_noop(
         hasEverEnteredErrorRecovery=False,
     )
 
-    decoy.when(await mock_run_data_manager.update("run-id", current=None)).then_return(
-        expected_response
-    )
+    decoy.when(mock_run_data_manager.get("run-id")).then_return(expected_response)
 
     result = await update_run(
         runId="run-id",
@@ -679,9 +677,9 @@ async def test_update_to_current_not_current(
     mock_run_data_manager: RunDataManager,
 ) -> None:
     """It should 409 if attempting to update a not current run."""
-    decoy.when(
-        await mock_run_data_manager.update(run_id="run-id", current=False)
-    ).then_raise(RunNotCurrentError("oh no"))
+    decoy.when(await mock_run_data_manager.uncurrent(run_id="run-id")).then_raise(
+        RunNotCurrentError("oh no")
+    )
 
     with pytest.raises(ApiError) as exc_info:
         await update_run(
@@ -699,9 +697,9 @@ async def test_update_to_current_conflict(
     mock_run_data_manager: RunDataManager,
 ) -> None:
     """It should 409 if attempting to un-current a run that is not idle."""
-    decoy.when(
-        await mock_run_data_manager.update(run_id="run-id", current=False)
-    ).then_raise(RunConflictError("oh no"))
+    decoy.when(await mock_run_data_manager.uncurrent(run_id="run-id")).then_raise(
+        RunConflictError("oh no")
+    )
 
     with pytest.raises(ApiError) as exc_info:
         await update_run(
@@ -719,9 +717,9 @@ async def test_update_to_current_missing(
     mock_run_data_manager: RunDataManager,
 ) -> None:
     """It should 404 if attempting to update a missing run."""
-    decoy.when(
-        await mock_run_data_manager.update(run_id="run-id", current=False)
-    ).then_raise(RunNotFoundError(run_id="run-id"))
+    decoy.when(await mock_run_data_manager.uncurrent(run_id="run-id")).then_raise(
+        RunNotFoundError(run_id="run-id")
+    )
 
     with pytest.raises(ApiError) as exc_info:
         await update_run(

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -2,7 +2,7 @@
 
 import inspect
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List
 from unittest.mock import Mock, sentinel
 
 import pytest

--- a/robot-server/tests/runs/test_run_data_manager.py
+++ b/robot-server/tests/runs/test_run_data_manager.py
@@ -766,7 +766,7 @@ async def test_delete_historical_run(
     decoy.verify(mock_run_store.remove(run_id=run_id), times=1)
 
 
-async def test_update_current(
+async def test_uncurrent(
     decoy: Decoy,
     engine_state_summary: StateSummary,
     run_time_parameters: List[pe_types.RunTimeParameter],
@@ -780,7 +780,7 @@ async def test_update_current(
     mock_file_provider: FileProvider,
     subject: RunDataManager,
 ) -> None:
-    """It should persist the current run and clear the engine on current=false."""
+    """It should persist the current run and clear the engine."""
     run_id = "hello world"
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id)
     decoy.when(await mock_run_orchestrator_store.clear()).then_return(
@@ -803,7 +803,7 @@ async def test_update_current(
         )
     ).then_return(run_resource)
 
-    result = await subject.update(run_id=run_id, current=False)
+    result = await subject.uncurrent(run_id=run_id)
 
     decoy.verify(
         mock_runs_publisher.publish_pre_serialized_commands_notification(run_id),
@@ -841,66 +841,7 @@ async def test_update_current(
     )
 
 
-@pytest.mark.parametrize("current", [None, True])
-async def test_update_current_noop(
-    decoy: Decoy,
-    engine_state_summary: StateSummary,
-    run_time_parameters: List[pe_types.RunTimeParameter],
-    run_resource: RunResource,
-    run_command: commands.Command,
-    mock_run_orchestrator_store: RunOrchestratorStore,
-    mock_run_store: RunStore,
-    mock_runs_publisher: RunsPublisher,
-    subject: RunDataManager,
-    current: Optional[bool],
-) -> None:
-    """It should noop on current=None and current=True."""
-    run_id = "hello world"
-    decoy.when(mock_run_orchestrator_store.current_run_id).then_return(run_id)
-    decoy.when(mock_run_orchestrator_store.get_state_summary()).then_return(
-        engine_state_summary
-    )
-    decoy.when(mock_run_orchestrator_store.get_run_time_parameters()).then_return(
-        run_time_parameters
-    )
-    decoy.when(mock_run_store.get(run_id=run_id)).then_return(run_resource)
-
-    result = await subject.update(run_id=run_id, current=current)
-
-    decoy.verify(await mock_run_orchestrator_store.clear(), times=0)
-    decoy.verify(
-        mock_run_store.update_run_state(
-            run_id=run_id,
-            summary=matchers.Anything(),
-            commands=matchers.Anything(),
-            command_annotations=matchers.Anything(),
-            run_time_parameters=matchers.Anything(),
-        ),
-        mock_runs_publisher.publish_pre_serialized_commands_notification(run_id),
-        times=0,
-    )
-
-    assert result == Run(
-        current=True,
-        id=run_resource.run_id,
-        protocolId=run_resource.protocol_id,
-        createdAt=run_resource.created_at,
-        actions=run_resource.actions,
-        status=engine_state_summary.status,
-        errors=engine_state_summary.errors,
-        hasEverEnteredErrorRecovery=engine_state_summary.hasEverEnteredErrorRecovery,
-        labware=engine_state_summary.labware,
-        labwareOffsets=engine_state_summary.labwareOffsets,
-        pipettes=engine_state_summary.pipettes,
-        modules=engine_state_summary.modules,
-        liquids=engine_state_summary.liquids,
-        liquidClasses=engine_state_summary.liquidClasses,
-        runTimeParameters=run_time_parameters,
-        outputFileIds=engine_state_summary.files,
-    )
-
-
-async def test_update_current_not_allowed(
+async def test_uncurrent_not_allowed(
     decoy: Decoy,
     engine_state_summary: StateSummary,
     run_resource: RunResource,
@@ -909,12 +850,12 @@ async def test_update_current_not_allowed(
     mock_run_store: RunStore,
     subject: RunDataManager,
 ) -> None:
-    """It should noop on current=None."""
+    """It should raise if the run is not current."""
     run_id = "hello world"
     decoy.when(mock_run_orchestrator_store.current_run_id).then_return("some other id")
 
     with pytest.raises(RunNotCurrentError):
-        await subject.update(run_id=run_id, current=False)
+        await subject.uncurrent(run_id=run_id)
 
 
 async def test_create_archives_existing(


### PR DESCRIPTION
## Overview

At any given time, robot-server has at most one "current run." A client can mark a run as "no longer current" by doing `PATCH /runs/{id} {"current": false}`. This is a one-way operation: an un-currented run can never become current again.

However, currently, if the client does a `PATCH` of `{"current": true}`, the server accepts it but silently ignores it.

This PR makes the server explicitly reject it instead, to avoid confusion.

## Test Plan and Hands on Testing

I think we're covered by existing tests.

## Changelog

* Use Pydantic to return a "bad request" error if a client tries to set `current` to `true`.
* Delete the code path that was handling `current=true`.

## Review requests

* Agreed in principle that this is better?

## Risk assessment

Low. This is essentially just deleting one branch of an `if`/`else`.

Hypothetically, there are backwards compatibility concerns with changing the HTTP API like this. But our clients never send `current: true` in practice, and I can't imagine any external clients would want the current behavior of silently no-opping.