### PR TITLE
fix(ODD): Re-ordering calibration pages during 96ch attachment with a waste chute

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardSteps.ts
@@ -177,6 +177,11 @@ export const getPipetteWizardSteps = (
               flowType,
             },
             { section: SECTIONS.RESULTS, mount: LEFT, flowType: FLOWS.ATTACH },
+            {
+              section: SECTIONS.ATTACH_PROBE,
+              mount: LEFT,
+              flowType,
+            },
             ...(is96ChannelCalibrateAndWasteChute
               ? [
                   {
@@ -186,11 +191,6 @@ export const getPipetteWizardSteps = (
                   },
                 ]
               : []),
-            {
-              section: SECTIONS.ATTACH_PROBE,
-              mount: LEFT,
-              flowType,
-            },
             {
               section: SECTIONS.DETACH_PROBE,
               mount: LEFT,

--- a/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
+++ b/app/src/organisms/PipetteWizardFlows/getPipetteWizardStepsForProtocol.ts
@@ -416,7 +416,7 @@ const fromEmptyGantryAttachNinetySix = (
   ...(wasteChute
     ? [
         {
-          section: SECTIONS.REMOVE_WASTE_CHUTE,
+          section: SECTIONS.ATTACH_WASTE_CHUTE,
           mount: LEFT,
           flowType: FLOWS.DETACH,
         },


### PR DESCRIPTION
# Overview

Fixes RQA-5769: 96ch attach with waste chute showed remove chute+begin cal before attach probe. Aligns step order with other 96ch + chute paths. This also fixes the attach flow showing detach page instead of attach page when attaching within a protocol.

## Test Plan and Hands on Testing

Tested attach flow both outside and inside a protocol with a waste chute attached. Both completed successfully.

## Changelog

Empty-gantry attach: ATTACH_PROBE before REMOVE_WASTE_CHUTE. Protocol empty-gantry: post-cal step is ATTACH_WASTE_CHUTE (was REMOVE)

## Review requests

Confirm this flow is the intended order: install probe -> remove chute -> calibrate.

## Risk assessment

Low. The step-list is only for 96ch + waste chute empty-gantry. Mitigated by ODD hands-on test of the flow.