### PR TITLE
feat(robot-server): log actions to the audit server

### DIFF
--- a/robot-server/robot_server/access_control/settings/router.py
+++ b/robot-server/robot_server/access_control/settings/router.py
@@ -4,6 +4,7 @@ from typing import Annotated
 
 import fastapi
 
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -39,7 +40,10 @@ async def get_access_control_settings(  # noqa: D103
     router.patch,
     path=_PATH,
     summary="Set access control settings",
-    dependencies=[fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        fastapi.Depends(get_audit_logger("change compliance ready software settings")),
+    ],
 )
 async def patch_access_control_settings(  # noqa: D103
     request_body: RequestModel[RequestData],
@@ -55,7 +59,10 @@ async def patch_access_control_settings(  # noqa: D103
     router.delete,
     path=_PATH,
     summary="Reset access control settings to defaults",
-    dependencies=[fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        fastapi.Depends(get_audit_logger("reset compliance ready software settings")),
+    ],
 )
 async def delete_access_control_settings(  # noqa: D103
     store: Annotated[

--- a/robot-server/robot_server/commands/router.py
+++ b/robot-server/robot_server/commands/router.py
@@ -8,6 +8,7 @@ from opentrons.protocol_engine import CommandIntent
 from opentrons.protocol_engine.errors import CommandDoesNotExistError
 from opentrons.protocol_runner import RunOrchestrator
 from opentrons_shared_data.errors import ErrorCodes
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -51,7 +52,10 @@ class CommandNotFound(ErrorDetails):
         status.HTTP_201_CREATED: {"model": SimpleBody[StatelessCommand]},
         status.HTTP_409_CONFLICT: {"model": ErrorBody[RunActive]},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("run stateless command")),
+    ],
 )
 async def create_command(
     request_body: RequestModel[StatelessCommandCreate],

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -11,6 +11,7 @@ from starlette.background import BackgroundTask
 
 from opentrons.protocol_reader import FileHasher, FileReaderWriter
 from opentrons_shared_data.data_files import DataFileInfo, DataFileSource, MimeType
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -104,11 +105,9 @@ class DataFileInUse(ErrorDetails):
     datafiles_router.post,
     path="/dataFiles",
     summary="Upload a data file",
-    description=dedent(
-        """
+    description=dedent("""
         Upload data file(s) to your device.
-        """
-    ),
+        """),
     status_code=status.HTTP_201_CREATED,
     responses={
         status.HTTP_200_OK: {"model": SimpleBody[DataFile]},
@@ -124,7 +123,10 @@ class DataFileInUse(ErrorDetails):
         },
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[FileNotFound]},
     },
-    dependencies=[Depends(require_scopes(Scope.RUN_DATA_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.RUN_DATA_WRITE)),
+        Depends(get_audit_logger("upload data file")),
+    ],
 )
 async def upload_data_file(
     data_files_directory: Annotated[Path, Depends(get_data_files_directory)],
@@ -316,9 +318,11 @@ async def get_all_data_files(
                     id=data_file_info.id,
                     name=data_file_info.name,
                     createdAt=data_file_info.created_at,
-                    source=DataFileSource.GENERATED
-                    if data_file_info.generated
-                    else DataFileSource.UPLOADED,
+                    source=(
+                        DataFileSource.GENERATED
+                        if data_file_info.generated
+                        else DataFileSource.UPLOADED
+                    ),
                 )
                 for data_file_info in data_files
             ],
@@ -336,7 +340,10 @@ async def get_all_data_files(
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[FileIdNotFound]},
         status.HTTP_409_CONFLICT: {"model": ErrorBody[DataFileInUse]},
     },
-    dependencies=[Depends(require_scopes(Scope.RUN_DATA_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.RUN_DATA_WRITE)),
+        Depends(get_audit_logger("delete data file")),
+    ],
 )
 async def delete_file_by_id(
     dataFileId: str,
@@ -430,8 +437,7 @@ async def get_data_files_by_run_id(
     datafiles_router.get,
     path="/dataFiles/{runId}/images",
     summary="Get a list of image-specific metadata for all camera image files associated with a given run.",
-    description=dedent(
-        """
+    description=dedent("""
         Get a list of image-specific metadata for camera image files associated with a given run.
         "\n\n"
         The camera image file metadata are returned in order from newest to oldest.
@@ -441,8 +447,7 @@ async def get_data_files_by_run_id(
         "\n\n"
         This endpoint returns camera image file metadata. Use `GET /runs/{runId}/images/{fileName}`
          to get a specific camera image file.
-        """
-    ),
+        """),
     responses={
         status.HTTP_200_OK: {"model": SimpleMultiBody[ImageFileMetadata]},
     },
@@ -511,19 +516,20 @@ async def get_run_image_metadata(
     datafiles_router.delete,
     path="/dataFiles/{runId}/images",
     summary="Delete all camera images for a run",
-    description=dedent(
-        """
+    description=dedent("""
         Delete all camera image files associated with a run from both the database
         and filesystem storage.
 
         This operation cannot be undone.
-        """
-    ),
+        """),
     responses={
         status.HTTP_200_OK: {"model": SimpleEmptyBody},
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
     },
-    dependencies=[Depends(require_scopes(Scope.RUN_DATA_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.RUN_DATA_WRITE)),
+        Depends(get_audit_logger("delete images for run")),
+    ],
 )
 async def delete_run_images(
     runId: str,
@@ -556,13 +562,11 @@ async def delete_run_images(
 @datafiles_router.get(
     path="/dataFiles/{runId}/images/download",
     summary="Download all camera images for a run as a zip file",
-    description=dedent(
-        """
+    description=dedent("""
         Download all camera image files associated with a run as a single zip archive.
 
         The zip file will contain all JPEG images captured during the protocol run.
-        """
-    ),
+        """),
     responses={
         status.HTTP_200_OK: {
             "content": {"application/zip": {}},

--- a/robot-server/robot_server/deck_configuration/router.py
+++ b/robot-server/robot_server/deck_configuration/router.py
@@ -7,6 +7,7 @@ import fastapi
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
 
 from opentrons_shared_data.deck.types import DeckDefinitionV5
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -61,7 +62,10 @@ router = LightRouter()
             "model": ErrorBody[models.InvalidDeckConfiguration]
         },
     },
-    dependencies=[fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        fastapi.Depends(get_audit_logger("set deck configuration")),
+    ],
 )
 async def put_deck_configuration(  # noqa: D103
     request_body: RequestModel[models.DeckConfigurationRequest],

--- a/robot-server/robot_server/error_recovery/settings/router.py
+++ b/robot-server/robot_server/error_recovery/settings/router.py
@@ -4,6 +4,7 @@ from typing import Annotated
 
 import fastapi
 
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -37,7 +38,10 @@ async def get_error_recovery_settings(  # noqa: D103
     router.patch,
     path=_PATH,
     summary="Set error recovery settings",
-    dependencies=[fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        fastapi.Depends(get_audit_logger("change error recovery settings")),
+    ],
 )
 async def patch_error_recovery_settings(  # noqa: D103
     request_body: RequestModel[RequestData],
@@ -54,7 +58,10 @@ async def patch_error_recovery_settings(  # noqa: D103
     router.delete,
     path=_PATH,
     summary="Reset error recovery settings to defaults",
-    dependencies=[fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        fastapi.Depends(get_audit_logger("reset error recovery settings")),
+    ],
 )
 async def delete_error_recovery_settings(  # noqa: D103
     store: Annotated[

--- a/robot-server/robot_server/labware_offsets/router.py
+++ b/robot-server/robot_server/labware_offsets/router.py
@@ -7,7 +7,7 @@ from typing import Annotated, Literal
 import fastapi
 from pydantic.json_schema import SkipJsonSchema
 
-from server_utils.audit.fastapi import skip_audit_logger
+from server_utils.audit.fastapi import get_audit_logger, skip_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -54,7 +54,10 @@ router = LightRouter()
         depending on whether you provided a single offset or a list in the request body's `data`.
         """),
     status_code=201,
-    dependencies=[fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        fastapi.Depends(get_audit_logger("add labware offset")),
+    ],
 )
 async def post_labware_offsets(  # noqa: D103
     store: Annotated[LabwareOffsetStore, fastapi.Depends(get_labware_offset_store)],
@@ -195,7 +198,10 @@ async def search_labware_offsets(  # noqa: D103
     path="/labwareOffsets/{id}",
     summary="Delete a single labware offset",
     description="Delete a single labware offset. The deleted offset is returned.",
-    dependencies=[fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        fastapi.Depends(get_audit_logger("delete labware offset")),
+    ],
 )
 async def delete_labware_offset(  # noqa: D103
     store: Annotated[LabwareOffsetStore, fastapi.Depends(get_labware_offset_store)],
@@ -218,7 +224,10 @@ async def delete_labware_offset(  # noqa: D103
     router.delete,
     path="/labwareOffsets",
     summary="Delete all labware offsets",
-    dependencies=[fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        fastapi.Depends(get_audit_logger("delete all labware offsets")),
+    ],
 )
 async def delete_all_labware_offsets(  # noqa: D103
     store: Annotated[LabwareOffsetStore, fastapi.Depends(get_labware_offset_store)],

--- a/robot-server/robot_server/maintenance_runs/router/base_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/base_router.py
@@ -14,6 +14,7 @@ from typing_extensions import Literal
 
 from opentrons.protocol_engine.resources.camera_provider import CameraProvider
 from opentrons.protocol_engine.types import EngineStatus
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -136,22 +137,23 @@ async def get_run_data_from_url(
     base_router.post,
     path="/maintenance_runs",
     summary="Create a maintenance run",
-    description=dedent(
-        """
+    description=dedent("""
         Create a new maintenance run to track robot interaction.
 
         If a maintenance run already exists, it will be cleared
         and a new one will be created.
 
         Will raise an error if a *protocol* run exists and is not idle.
-        """
-    ),
+        """),
     status_code=status.HTTP_201_CREATED,
     responses={
         status.HTTP_201_CREATED: {"model": SimpleBody[MaintenanceRun]},
         status.HTTP_409_CONFLICT: {"model": ErrorBody[ProtocolRunIsActive]},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("create maintenance run")),
+    ],
 )
 async def create_run(
     run_data_manager: Annotated[
@@ -277,7 +279,10 @@ async def get_run(
         status.HTTP_200_OK: {"model": SimpleEmptyBody},
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("delete maintenance run")),
+    ],
 )
 async def remove_run(
     runId: str,

--- a/robot-server/robot_server/maintenance_runs/router/commands_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/commands_router.py
@@ -18,6 +18,7 @@ from opentrons.protocol_engine import (
     errors as pe_errors,
 )
 from opentrons.protocol_engine.errors import CommandDoesNotExistError
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -98,16 +99,14 @@ async def get_current_run_from_url(
     commands_router.post,
     path="/maintenance_runs/{runId}/commands",
     summary="Enqueue a command",
-    description=textwrap.dedent(
-        """
+    description=textwrap.dedent("""
         Add a single command to the maintenance run.
 
         These commands will execute immediately and in the order they are
         enqueued. The execution of these commands cannot be paused,
         but a maintenance run can be deleted at any point, as long as there
         are no commands running.
-        """
-    ),
+        """),
     status_code=status.HTTP_201_CREATED,
     responses={
         status.HTTP_201_CREATED: {"model": SimpleBody[pe_commands.Command]},
@@ -119,7 +118,10 @@ async def get_current_run_from_url(
             ]
         },
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("execute command in maintenance run")),
+    ],
 )
 async def create_run_command(
     request_body: RequestModel[pe_commands.CommandCreate],

--- a/robot-server/robot_server/maintenance_runs/router/labware_router.py
+++ b/robot-server/robot_server/maintenance_runs/router/labware_router.py
@@ -11,6 +11,7 @@ from opentrons.protocol_engine import (
     LegacyLabwareOffsetCreate,
 )
 from opentrons_shared_data.labware.labware_definition import LabwareDefinition
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -52,7 +53,10 @@ labware_router = LightRouter()
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
         status.HTTP_409_CONFLICT: {"model": ErrorBody[RunNotIdle]},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("add labware offset to maintenance run")),
+    ],
 )
 async def add_labware_offset(
     request_body: RequestModel[
@@ -111,7 +115,10 @@ async def add_labware_offset(
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
         status.HTTP_409_CONFLICT: {"model": ErrorBody[RunNotIdle]},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("add labware to maintenance run")),
+    ],
 )
 async def add_labware_definition(
     request_body: RequestModel[LabwareDefinition],

--- a/robot-server/robot_server/robot/control/router.py
+++ b/robot-server/robot_server/robot/control/router.py
@@ -7,6 +7,7 @@ from fastapi import Depends, status
 from opentrons.config import feature_flags as ff
 from opentrons.hardware_control import HardwareControlAPI
 from opentrons_shared_data.robot.types import RobotType, RobotTypeEnum
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -72,7 +73,10 @@ async def get_estop_status(
         status.HTTP_200_OK: {"model": SimpleBody[EstopStatusModel]},
         status.HTTP_403_FORBIDDEN: {"model": ErrorBody[NotSupportedOnOT2]},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("clear estop")),
+    ],
 )
 async def put_acknowledge_estop_disengage(
     estop_handler: Annotated[EstopHandler, Depends(get_estop_handler)],

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -32,6 +32,7 @@ from opentrons.protocol_engine.resources.camera_provider import CameraProvider
 from opentrons.protocol_engine.types import CSVRuntimeParamPaths, DeckSlotLocation
 from opentrons_shared_data.errors import ErrorCodes
 from opentrons_shared_data.robot.types import RobotTypeEnum
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import (
     get_access_control_status,
     require_scopes,
@@ -185,14 +186,12 @@ async def get_run_data_from_url(
     base_router.post,
     path="/runs",
     summary="Create a run",
-    description=dedent(
-        """
+    description=dedent("""
         Create a new run to track robot interaction.
 
         When too many runs already exist, old ones will be automatically deleted
         to make room for the new one.
-        """
-    ),
+        """),
     status_code=status.HTTP_201_CREATED,
     responses={
         status.HTTP_201_CREATED: {"model": SimpleBody[Run]},
@@ -200,7 +199,10 @@ async def get_run_data_from_url(
         status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": ErrorBody[FileIdNotFound]},
         status.HTTP_409_CONFLICT: {"model": ErrorBody[RunAlreadyActive]},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("create protocol run")),
+    ],
 )
 async def create_run(  # noqa: C901
     run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
@@ -385,7 +387,10 @@ async def get_run(
         status.HTTP_200_OK: {"model": SimpleEmptyBody},
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("delete protocol run")),
+    ],
 )
 async def remove_run(
     runId: str,
@@ -422,7 +427,10 @@ async def remove_run(
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
         status.HTTP_409_CONFLICT: {"model": ErrorBody[Union[RunStopped, RunNotIdle]]},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("update protocol run")),
+    ],
 )
 async def update_run(
     runId: str,
@@ -537,13 +545,11 @@ async def get_run_commands_error(
     base_router.get,
     path="/runs/{runId}/currentState",
     summary="Get a run's current state.",
-    description=dedent(
-        """
+    description=dedent("""
         Get current state associated with a run if the run is current.
         "\n\n"
         Note that this endpoint is experimental and subject to change.
-        """
-    ),
+        """),
     responses={
         status.HTTP_200_OK: {"model": Body[RunCurrentState, CurrentStateLinks]},
         status.HTTP_409_CONFLICT: {"model": ErrorBody[RunStopped]},

--- a/robot-server/robot_server/runs/router/camera_router.py
+++ b/robot-server/robot_server/runs/router/camera_router.py
@@ -18,6 +18,7 @@ from opentrons.protocol_engine.resources.camera_provider import (
 from opentrons.system import camera
 from opentrons_shared_data.errors import ErrorCodes
 from opentrons_shared_data.robot.types import RobotType
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -64,7 +65,10 @@ camera_router = LightRouter()
         status.HTTP_409_CONFLICT: {"model": ErrorBody[Union[RunStopped, RunNotIdle]]},
         status.HTTP_503_SERVICE_UNAVAILABLE: {},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("change run camera settings")),
+    ],
 )
 async def add_camera_settings(
     request_body: RequestModel[CameraEnable],
@@ -95,15 +99,21 @@ async def add_camera_settings(
         )
 
     camera_settings = CameraSettings(
-        cameraEnabled=request_body.data.cameraEnabled
-        if request_body.data.cameraEnabled is not None
-        else False,
-        liveStreamEnabled=request_body.data.liveStreamEnabled
-        if request_body.data.liveStreamEnabled is not None
-        else False,
-        errorRecoveryCameraEnabled=request_body.data.errorRecoveryCameraEnabled
-        if request_body.data.errorRecoveryCameraEnabled is not None
-        else False,
+        cameraEnabled=(
+            request_body.data.cameraEnabled
+            if request_body.data.cameraEnabled is not None
+            else False
+        ),
+        liveStreamEnabled=(
+            request_body.data.liveStreamEnabled
+            if request_body.data.liveStreamEnabled is not None
+            else False
+        ),
+        errorRecoveryCameraEnabled=(
+            request_body.data.errorRecoveryCameraEnabled
+            if request_body.data.errorRecoveryCameraEnabled is not None
+            else False
+        ),
     )
 
     response_data = run_orchestrator_store.add_camera_enablement_settings(
@@ -114,9 +124,11 @@ async def add_camera_settings(
     # Restart the stream with any the newest live stream settings
     await camera.update_live_stream_status(
         robot_type=robot_type,
-        stream_status=response_data.liveStreamEnabled
-        if response_data.cameraEnabled is True
-        else False,
+        stream_status=(
+            response_data.liveStreamEnabled
+            if response_data.cameraEnabled is True
+            else False
+        ),
         camera_settings=await camera_provider.get_camera_settings(),
         override_settings=camera_settings,
     )
@@ -149,7 +161,10 @@ async def add_camera_settings(
         status.HTTP_409_CONFLICT: {"model": ErrorBody[Union[RunStopped, RunNotIdle]]},
         status.HTTP_503_SERVICE_UNAVAILABLE: {},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("change run camera capture settings")),
+    ],
 )
 async def add_camera_capture_image_settings(
     request_body: RequestModel[CameraCaptureImageSettings],
@@ -246,7 +261,10 @@ async def get_camera_capture_image_settings(
         },
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[FileNotFound]},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("capture run preview image")),
+    ],
 )
 async def post_camera_preview_image(
     request_body: RequestModel[CameraCaptureImageSettings],

--- a/robot-server/robot_server/runs/router/error_recovery_policy_router.py
+++ b/robot-server/robot_server/runs/router/error_recovery_policy_router.py
@@ -5,6 +5,7 @@ from typing import Annotated
 
 from fastapi import Depends, status
 
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -28,19 +29,20 @@ error_recovery_policy_router = LightRouter()
     error_recovery_policy_router.put,
     path="/runs/{runId}/errorRecoveryPolicy",
     summary="Set a run's error recovery policy",
-    description=dedent(
-        """
+    description=dedent("""
         Update how to handle different kinds of command failures.
 
         For this to have any effect, error recovery must also be enabled globally.
         See `PATCH /errorRecovery/settings`.
-        """
-    ),
+        """),
     responses={
         status.HTTP_200_OK: {"model": SimpleEmptyBody},
         status.HTTP_409_CONFLICT: {"model": ErrorBody[RunStopped]},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("change run error recovery policy")),
+    ],
 )
 async def put_error_recovery_policy(
     runId: str,

--- a/robot-server/robot_server/service/labware/router.py
+++ b/robot-server/robot_server/service/labware/router.py
@@ -10,6 +10,7 @@ from fastapi import Depends, status
 from typing_extensions import Literal, NoReturn
 
 from opentrons_shared_data.errors import ErrorCodes
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -101,7 +102,10 @@ async def get_specific_labware_calibration(
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody},
         status.HTTP_410_GONE: {"model": ErrorBody[LabwareCalibrationEndpointsRemoved]},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("remove legacy labware calibration")),
+    ],
 )
 async def delete_specific_labware_calibration(
     calibrationId: str,

--- a/robot-server/robot_server/service/legacy/routers/camera.py
+++ b/robot-server/robot_server/service/legacy/routers/camera.py
@@ -18,6 +18,7 @@ from opentrons.system import camera
 from opentrons.system.camera import PREVIEW_IMAGE, StreamConfigurationKeys
 from opentrons_shared_data.errors import ErrorCodes
 from opentrons_shared_data.robot.types import RobotType
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.models.json_api import RequestModel
@@ -58,7 +59,10 @@ DEFAULT_CAMERA_PATH = f"/dev/{DEFAULT_CAMERA_ID}"
     responses={
         status.HTTP_400_BAD_REQUEST: {"model": LegacyErrorResponse},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("change camera enable")),
+    ],
 )
 async def post_camera(
     request_body: RequestModel[CameraEnable],
@@ -203,7 +207,10 @@ async def get_camera_capture_image_settings(
     responses={
         status.HTTP_503_SERVICE_UNAVAILABLE: {},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("change camera settings")),
+    ],
 )
 async def add_camera_capture_image_settings(
     request_body: RequestModel[CameraCaptureImageSettings],
@@ -238,7 +245,10 @@ async def add_camera_capture_image_settings(
     responses={
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[FileNotFound]},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("capture preview image")),
+    ],
 )
 async def post_camera_preview_image(
     request_body: RequestModel[CameraCaptureImageSettings],
@@ -325,7 +335,10 @@ async def post_camera_preview_image(
     "/camera/picture",
     description="Capture an image from the OT-2's on-board camera and return it",
     responses={status.HTTP_200_OK: {"content": {JPG: {}}, "description": "The image"}},
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("capture image")),
+    ],
 )
 async def post_picture_capture(
     camera_settings_store: Annotated[
@@ -406,7 +419,10 @@ async def get_live_stream(
     responses={
         status.HTTP_400_BAD_REQUEST: {"model": LegacyErrorResponse},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("change camera stream settings")),
+    ],
 )
 async def post_live_stream_settings(
     request_body: RequestModel[LiveStreamSettings],

--- a/robot-server/robot_server/service/legacy/routers/control.py
+++ b/robot-server/robot_server/service/legacy/routers/control.py
@@ -12,6 +12,7 @@ from opentrons.hardware_control import (
 from opentrons.hardware_control.types import Axis, CriticalPoint
 from opentrons.types import Mount, Point
 from opentrons_shared_data.errors import ErrorCodes
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
@@ -27,7 +28,10 @@ router = APIRouter()
     "/identify",
     summary="Blink the lights",
     description="Blink the gantry lights so you can pick it out of a crowd",
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("blink lights")),
+    ],
 )
 async def post_identify(
     seconds: Annotated[int, Query(..., description="Time to blink the lights for")],
@@ -84,7 +88,10 @@ async def get_robot_positions() -> control.RobotPositionsResponse:
         status.HTTP_403_FORBIDDEN: {"model": LegacyErrorResponse},
     },
     deprecated=True,
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("legacy robot move")),
+    ],
 )
 async def post_move_robot(
     robot_move_target: control.RobotMoveTarget,
@@ -109,7 +116,10 @@ async def post_move_robot(
         status.HTTP_400_BAD_REQUEST: {"model": LegacyErrorResponse},
         status.HTTP_403_FORBIDDEN: {"model": LegacyErrorResponse},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("legacy robot home")),
+    ],
 )
 async def post_home_robot(
     robot_home_target: control.RobotHomeTarget,
@@ -161,7 +171,10 @@ async def get_robot_light_state(
     summary="Turn the lights on or off",
     description="Turn the rail lights on or off",
     response_model=control.RobotLightState,
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("toggle robot lights")),
+    ],
 )
 async def post_robot_light_state(
     robot_light_state: control.RobotLightState,

--- a/robot-server/robot_server/service/legacy/routers/modules.py
+++ b/robot-server/robot_server/service/legacy/routers/modules.py
@@ -8,6 +8,7 @@ from opentrons.hardware_control import HardwareControlAPI, modules
 from opentrons.hardware_control.modules import AbstractModule
 from opentrons_shared_data.errors.codes import ErrorCodes
 from opentrons_shared_data.errors.exceptions import APIRemoved, ModuleNotPresent
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
@@ -77,7 +78,10 @@ async def get_modules(
         status.HTTP_404_NOT_FOUND: {"model": LegacyErrorResponse},
     },
     deprecated=True,
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("execute module command")),
+    ],
 )
 async def post_serial_command(
     command: SerialCommand,
@@ -145,7 +149,10 @@ async def post_serial_command(
         status.HTTP_404_NOT_FOUND: {"model": LegacyErrorResponse},
         status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": LegacyErrorResponse},
     },
-    dependencies=[Depends(require_scopes(Scope.UPDATES_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.UPDATES_WRITE)),
+        Depends(get_audit_logger("update module firmware")),
+    ],
 )
 async def post_serial_update(
     serial: typing.Annotated[str, Path(..., description="Serial number of the module")],

--- a/robot-server/robot_server/service/legacy/routers/motors.py
+++ b/robot-server/robot_server/service/legacy/routers/motors.py
@@ -9,6 +9,7 @@ from opentrons.hardware_control.types import Axis
 from opentrons.protocol_engine.errors import HardwareNotSupportedError
 from opentrons.protocol_engine.resources.ot3_validation import ensure_ot3_hardware
 from opentrons_shared_data.errors import ErrorCodes
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
@@ -50,7 +51,10 @@ async def get_engaged_motors(
     "/motors/disengage",
     description="Disengage a motor or set of motors",
     response_model=V1BasicResponse,
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("disengage motor")),
+    ],
 )
 async def post_disengage_motors(
     axes: model.Axes, hardware: Annotated[HardwareControlAPI, Depends(get_hardware)]

--- a/robot-server/robot_server/service/legacy/routers/networking.py
+++ b/robot-server/robot_server/service/legacy/routers/networking.py
@@ -19,6 +19,7 @@ from starlette.responses import JSONResponse
 
 from opentrons.system import nmcli, wifi
 from opentrons_shared_data.errors import ErrorCodes
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
@@ -126,7 +127,10 @@ def _massage_nmcli_error(error_string: str) -> str:
         status.HTTP_400_BAD_REQUEST: {"model": LegacyErrorResponse},
         status.HTTP_401_UNAUTHORIZED: {"model": LegacyErrorResponse},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("connect to wifi")),
+    ],
 )
 async def post_wifi_configure(
     configuration: WifiConfiguration,
@@ -185,7 +189,10 @@ async def get_wifi_keys() -> WifiKeyFiles:
     response_model=AddWifiKeyFileResponse,
     status_code=status.HTTP_201_CREATED,
     response_model_exclude_unset=True,
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("add new wifi key")),
+    ],
 )
 async def post_wifi_key(
     response: Response,
@@ -221,7 +228,10 @@ async def post_wifi_key(
     responses={
         status.HTTP_404_NOT_FOUND: {"model": LegacyErrorResponse},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("delete wifi key")),
+    ],
 )
 async def delete_wifi_key(
     key_uuid: Annotated[
@@ -280,7 +290,10 @@ async def get_eap_options() -> EapOptions:
     response_model=V1BasicResponse,
     responses={status.HTTP_200_OK: {"model": V1BasicResponse}},
     status_code=status.HTTP_207_MULTI_STATUS,
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("disconnect from wifi")),
+    ],
 )
 async def post_wifi_disconnect(wifi_ssid: WifiNetwork) -> JSONResponse:
     ok, message = await nmcli.wifi_disconnect(wifi_ssid.ssid)

--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -37,6 +37,7 @@ from opentrons_shared_data.pipette import (
     types as pip_types,
 )
 from opentrons_shared_data.robot.types import RobotTypeEnum
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.app_state import (
@@ -140,7 +141,10 @@ async def _hardware_subprocess_transition(enable: bool, app_state: AppState) -> 
         status.HTTP_400_BAD_REQUEST: {"model": LegacyErrorResponse},
         status.HTTP_500_INTERNAL_SERVER_ERROR: {"model": LegacyErrorResponse},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("change feature flag")),
+    ],
 )
 async def post_settings(
     update: AdvancedSettingRequest,
@@ -236,7 +240,10 @@ def _create_settings_response(robot_type: RobotTypeEnum) -> AdvancedSettingsResp
     responses={
         status.HTTP_422_UNPROCESSABLE_ENTITY: {"model": LegacyErrorResponse},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("change log level")),
+    ],
 )
 async def post_log_level_local(
     log_level: LogLevel, hardware: Annotated[HardwareControlAPI, Depends(get_hardware)]
@@ -270,7 +277,10 @@ async def post_log_level_local(
     ),
     response_model=LegacyErrorResponse,
     deprecated=True,
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("change legacy log upstreaming")),
+    ],
 )
 async def post_log_level_upstream(log_level: LogLevel) -> V1BasicResponse:
     raise LegacyErrorResponse(
@@ -312,7 +322,10 @@ async def get_settings_reset_options(
         status.HTTP_403_FORBIDDEN: {"model": LegacyErrorResponse},
         status.HTTP_503_SERVICE_UNAVAILABLE: {"model": LegacyErrorResponse},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("reset settings")),
+    ],
 )
 async def post_settings_reset_options(
     factory_reset_commands: Dict[reset_util.ResetOptionId, bool],
@@ -456,7 +469,10 @@ async def get_pipette_setting(
     responses={
         status.HTTP_412_PRECONDITION_FAILED: {"model": LegacyErrorResponse},
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("change OT-2 pipette settings")),
+    ],
 )
 async def patch_pipette_setting(
     pipette_id: str,

--- a/robot-server/robot_server/service/pipette_offset/router.py
+++ b/robot-server/robot_server/service/pipette_offset/router.py
@@ -6,6 +6,7 @@ from starlette import status
 from opentrons import types as ot_types
 from opentrons.calibration_storage.ot2 import models, pipette_offset
 from opentrons.hardware_control import API
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
@@ -79,7 +80,10 @@ async def get_all_pipette_offset_calibrations(
     summary="Delete a pipette offset calibration",
     description="Delete one specific pipette calibration by pipette serial and mount.",
     responses={status.HTTP_404_NOT_FOUND: {"model": ErrorBody}},
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("delete pipette offset")),
+    ],
 )
 async def delete_specific_pipette_offset_calibration(
     pipette_id: str,

--- a/robot-server/robot_server/service/session/router.py
+++ b/robot-server/robot_server/service/session/router.py
@@ -4,6 +4,7 @@ from typing import Annotated, Optional
 from fastapi import APIRouter, Depends, Query
 from starlette import status as http_status_codes
 
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.models.json_api import ResourceLink
@@ -60,7 +61,10 @@ def get_session(manager: SessionManager, session_id: IdentifierType) -> BaseSess
     deprecated=True,
     response_model=SessionResponse,
     status_code=http_status_codes.HTTP_201_CREATED,
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("make ot-2 calibration session")),
+    ],
 )
 async def create_session_handler(
     create_request: SessionCreateRequest,
@@ -89,7 +93,10 @@ async def create_session_handler(
     ),
     deprecated=True,
     response_model=SessionResponse,
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("delete ot2- calibration session")),
+    ],
 )
 async def delete_session_handler(
     sessionId: IdentifierType,
@@ -159,7 +166,10 @@ async def get_sessions_handler(
     ),
     deprecated=True,
     response_model=CommandResponse,
-    dependencies=[Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),
+        Depends(get_audit_logger("execute OT-2 calibration command")),
+    ],
 )
 async def session_command_execute_handler(
     sessionId: IdentifierType,

--- a/robot-server/robot_server/service/tip_length/router.py
+++ b/robot-server/robot_server/service/tip_length/router.py
@@ -7,6 +7,7 @@ from opentrons.calibration_storage import types as cal_types
 from opentrons.calibration_storage.ot2 import models, tip_length
 from opentrons.hardware_control import API
 from opentrons_shared_data.pipette.types import LabwareUri
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
@@ -103,7 +104,10 @@ async def get_all_tip_length_calibrations(
     description="Delete one specific tip length calibration by pipette "
     "serial and tiprack uri",
     responses={status.HTTP_404_NOT_FOUND: {"model": ErrorBody}},
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("delete tip length calibration")),
+    ],
 )
 async def delete_specific_tip_length_calibration(
     _: Annotated[API, Depends(get_ot2_hardware)],

--- a/robot-server/robot_server/subsystems/router.py
+++ b/robot-server/robot_server/subsystems/router.py
@@ -7,6 +7,7 @@ from fastapi import Depends, Request, Response, status
 from typing_extensions import Literal
 
 from opentrons.hardware_control import HardwareControlAPI, ThreadManagedHardware
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -346,7 +347,10 @@ async def get_update_process(
             "model": ErrorBody[FirmwareUpdateFailed]
         },
     },
-    dependencies=[Depends(require_scopes(Scope.UPDATES_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.UPDATES_WRITE)),
+        Depends(get_audit_logger("start subsystem update")),
+    ],
 )
 async def begin_subsystem_update(
     subsystem: SubSystem,

--- a/robot-server/robot_server/system/router.py
+++ b/robot-server/robot_server/system/router.py
@@ -9,6 +9,7 @@ from datetime import datetime
 
 from fastapi import Depends
 
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -53,7 +54,10 @@ async def get_time() -> SystemTimeResponse:
     description="Update system time",
     summary="Set robot time",
     response_model=SystemTimeResponse,
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("update system time")),
+    ],
 )
 async def set_time(new_time: SystemTimeRequest) -> SystemTimeResponse:
     """Set the robot's system time."""

--- a/server-utils/server_utils/audit/audit_logger.py
+++ b/server-utils/server_utils/audit/audit_logger.py
@@ -27,12 +27,20 @@ class AuditLogger:
     def __init__(
         self,
         audit_client: AuditClient,
+        request: Request,
         *,
         auto_log_request_head: bool,
         auto_log_response_head: bool,
         auto_log_request_body: bool,
         auto_log_response_body: bool,
     ) -> None:
+        """Build an audit logger object.
+
+        The audit logger has little logic of its own; the audit client argument
+        is captured and used internally, but the rest of the initializer arguments
+        are just stashed as instance attributes for the audit_logger_middleware
+        to read and do different things with.
+        """
         self._audit_client = audit_client
         self._action: str | None = None
         self._message_chunks: list[str] = []
@@ -45,6 +53,7 @@ class AuditLogger:
         self.auto_log_response_body = auto_log_response_body
         self.did_log = False
         self.should_log = True
+        self.request = request
 
     def set_action_from_request(self: Self, request: Request) -> Self:
         """Set the action to log based on the request.

--- a/server-utils/server_utils/audit/fastapi.py
+++ b/server-utils/server_utils/audit/fastapi.py
@@ -145,6 +145,29 @@ async def audit_logger_middleware(
         )
         return await _return_or_raise(response, cached_exc)
 
+    # the way an ASGI application stack works is that each ASGI application gets a
+    # "scope", which is a map of data, and a send and receive callback. Each application
+    # then parses messages and sends responses. This is pretty inconvenient, so when
+    # you're using Starlette or FastAPI, those frameworks wrap the scope and callbacks
+    # into an object like Request, which capture a bunch of the data from the scope
+    # and give it nice names, and add nice methods with nice caching logic.
+    #
+    # The problem is that they do this Request() wrapping process separately for each
+    # ASGI application, and a middleware is a separate ASGI application from the
+    # endpoint stack. That means that the Request() object we get in this middleware
+    # is different from the Request() object that the endpoint function and its FastAPI
+    # dependencies get, and that's an issue because the request body caching that
+    # Request() offers is just done as an instance attribute of the Request object. So
+    # if we try to get request.body() here, this Request doesn't have a cached body
+    # and tries to get it from uvicorn... which doesn't do any request caching.
+    #
+    # To fix this, we stash the request object from the endpoint function ASGI application
+    # on the audit logger object in the get_audit_logger dependency, and then use _that_
+    # Request object instead of the one that was passed into the middleware. This is maybe
+    # a little gross, since the applications are logically separate, but since this is
+    # ASGI and the separation is "different asyncio task" it's fine.
+    new_request = audit_logger.request
+    request = new_request
     await _handle_autolog(audit_logger, request, response)
 
     try:
@@ -244,6 +267,7 @@ def get_audit_logger(
             auto_log_response_head=auto_log_response_head,
             auto_log_request_body=auto_log_request_body,
             auto_log_response_body=auto_log_response_body,
+            request=request,
         )
         if action is not None:
             audit_logger.set_action(action)

--- a/server-utils/server_utils/audit/fastapi.py
+++ b/server-utils/server_utils/audit/fastapi.py
@@ -127,17 +127,12 @@ async def audit_logger_middleware(
     """
     response, cached_exc = await _do_call(request, call_next)
 
-    # NOTE: This should be uncommented as soon as audit logging is implemented
-    # throughout robot server. That didn't happen in the commit in which it was
-    # added because that commit was to get this functionality in to parallelize
-    # further work. In the future, audit logger should only be added to a server
-    # when that server is ready for full integration.
-    # if not hasattr(request.state, "audit_logger"):
-    #     if request.method in MUTATING_HTTP_METHODS:
-    #         _log.error(
-    #             f"Request {request.method} {request.url.path} should add an audit log or explicitly skip audit logging but does not"
-    #         )
-    #     return await _return_or_raise(response, cached_exc)
+    if not hasattr(request.state, "audit_logger"):
+        if request.method in MUTATING_HTTP_METHODS:
+            _log.error(
+                f"Request {request.method} {request.url.path} should add an audit log or explicitly skip audit logging but does not"
+            )
+        return await _return_or_raise(response, cached_exc)
     if request.method not in MUTATING_HTTP_METHODS:
         return await _return_or_raise(response, cached_exc)
     audit_logger = getattr(request.state, "audit_logger", None)

--- a/server-utils/tests/audit/test_audit_logger.py
+++ b/server-utils/tests/audit/test_audit_logger.py
@@ -36,6 +36,7 @@ def subject(mock_client: Client, request: pytest.FixtureRequest) -> AuditLogger:
     """An audit logger."""
     return AuditLogger(
         audit_client=mock_client,
+        request=None,  # type: ignore[arg-type]
         auto_log_request_head=True,
         auto_log_response_head=True,
         auto_log_request_body=True,
@@ -51,6 +52,10 @@ def parametrized_subject(
     return (
         AuditLogger(
             audit_client=mock_client,
+            # gross: AuditLogger isn't meant to be built ahead of time like this,
+            # but since all the weirdnesses we encounter by doing it are handled
+            # in fixtures we can get away with it
+            request=None,  # type: ignore[arg-type]
             auto_log_request_head=True,
             auto_log_response_head=True,
             auto_log_request_body=True,
@@ -81,21 +86,28 @@ def subject_client(parametrized_subject: AuditLogger) -> Iterator[TestClient]:
     """A fastapi test client for making requests."""
 
     async def body_handler(request: Request) -> Response:
+        # a typical route handler will use the request body if it exists, so
+        # this test handler should too
+        await request.body()
+        parametrized_subject.request = request
         await parametrized_subject.append_request_body_to_message(request)
         await parametrized_subject.log()
         return Response(content="body")
 
     async def method_path_handler(request: Request) -> Response:
+        parametrized_subject.request = request
         parametrized_subject.append_request_method_path_to_message(request)
         await parametrized_subject.log()
         return Response(content="method")
 
     async def query_param_handler(request: Request) -> Response:
+        parametrized_subject.request = request
         parametrized_subject.append_request_query_params_to_message(request)
         await parametrized_subject.log()
         return Response(content="queryparams")
 
     async def headers_handler(request: Request) -> Response:
+        parametrized_subject.request = request
         parametrized_subject.append_request_headers_to_message(request)
         await parametrized_subject.log()
         return Response(content="headers")


### PR DESCRIPTION
# Overview

After #22036 , we can easily send stuff to the audit server. So do that from the robot server!

We can customize the audit log payloads, but after testing a whole ton of the endpoints the defaults actually work pretty well (once we fix the issue in c5066da7fbcd0d9a59866c2145092cc070e0ffbc which is a little gross - see that commit's log and the big comment in audit logging middleware for more).

## Test Plan and Hands on Testing

- [x] Run a whole bunch of endpoints on a robot and check that the logs go in the log server!

## Changelog

- Add the audit logger dependency to all endpoints that require logging (POST, PUT, PATCH, DELETE)
- Fix an issue with the way we handled request bodies that caused the endpoints to never return when requesting the body

## Review requests

Normal

Closes EXEC-7872
