### PR TITLE
refactor(api): Consolidate dataclass identification and registry into OpentronsPyroSerializer

### DIFF
--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -28,6 +28,7 @@ import opentrons.hardware_control.types
 import opentrons.types
 from opentrons.util.pyro.pyro_serialization import (
     OpentronsPyroSerializer,
+    find_dataclasses_in_packages,
     find_enums_in_packages,
     find_pydantic_classes_in_packages,
     find_typed_dict_classes_in_packages,
@@ -264,34 +265,21 @@ def register_hardware_types() -> None:
     )
 
     # Dataclass generic registration
-    # todo(chb, 07-08-2026): This should probably be changed to automatically detect our pyro compatible dataclasses once the cross-layer classes all have `to_pyro` and `from_pyro` methods
-    opentrons_dataclass_types = [
-        opentrons.drivers.vacuum_module.types.VacuumState,
-        opentrons.drivers.vacuum_module.types.PumpState,
-        opentrons.drivers.types.ABSMeasurementConfig,
-        opentrons.hardware_control.modules.module_calibration.ModuleCalibrationOffset,
-        opentrons.hardware_control.modules.types.BundledFirmware,
-        opentrons.drivers.rpi_drivers.types.USBPort,
-        opentrons.hardware_control.types.SubsystemConnectionNotification,
-        opentrons.hardware_control.types.ModuleConnectedNotification,
-        opentrons.hardware_control.types.ModuleDisconnectedNotification,
-        opentrons.hardware_control.types.AsynchronousModuleErrorNotification,
-        opentrons.hardware_control.types.ErrorMessageNotification,
-        opentrons.hardware_control.types.EstopStateNotification,
-        opentrons.hardware_control.types.DoorStateNotification,
-        opentrons.types.Point,
-        opentrons.hardware_control.ot3_calibration.OT3Transforms,
-        opentrons.hardware_control.instruments.ot3.instrument_calibration.PipetteOffsetSummary,
-        opentrons.hardware_control.instruments.ot3.instrument_calibration.GripperCalibrationOffset,
-        opentrons.hardware_control.types.EstopOverallStatus,
-    ]
-
+    opentrons_dataclass_types = find_dataclasses_in_packages(
+        [
+            opentrons.drivers.vacuum_module.types,
+            opentrons.drivers.types,
+            opentrons.hardware_control.modules.module_calibration,
+            opentrons.hardware_control.modules.types,
+            opentrons.drivers.rpi_drivers.types,
+            opentrons.hardware_control.types,
+            opentrons.types,
+            opentrons.hardware_control.ot3_calibration,
+            opentrons.hardware_control.instruments.ot3.instrument_calibration,
+        ]
+    )
     for dataclass_type in opentrons_dataclass_types:
-        register_type_to_serpent(
-            class_type=dataclass_type,
-            dict_to_class=dataclass_type.from_pyro_dict,  # type: ignore
-            class_to_dict=dataclass_type.to_pyro_dict,  # type: ignore
-        )
+        OpentronsPyroSerializer.register_dataclass(dataclass_type)
 
     # handle Typed Dicts for the hardware controller
     OpentronsPyroSerializer.register_opentrons_typed_dicts(_typed_dict_dict_to_class)

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -5,6 +5,7 @@ import enum
 import inspect
 import pickle
 from contextlib import contextmanager
+from dataclasses import is_dataclass
 from types import ModuleType
 from typing import Any, Callable, Iterator
 
@@ -61,6 +62,20 @@ def find_pydantic_classes_in_packages(
             if issubclass(obj, BaseModel) and obj is not BaseModel:
                 pydantic_classes.append(obj)
     return pydantic_classes
+
+
+def find_dataclasses_in_packages(modules: list[ModuleType]) -> list[type]:
+    """Returns a list of dataclasses that contain `to_pyro_dict` and `from_pyro_dict` staticmethods in the given list of moduels."""
+    dataclasses = []
+    for module in modules:
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            if (
+                is_dataclass(obj)
+                and hasattr(obj, "to_pyro_dict")
+                and hasattr(obj, "from_pyro_dict")
+            ):
+                dataclasses.append(obj)
+    return dataclasses
 
 
 def find_typed_dict_classes_in_packages(
@@ -144,6 +159,7 @@ class OpentronsPyroSerializer:
     _enum_class_name_to_type: dict[str, type[enum.Enum]] = {}
     _typed_dict_class_name_to_type: dict[str, type[TypedDict]] = {}  # type: ignore
     _generic_error_class_name_to_error: dict[str, type[BaseException]] = {}
+    _dataclass_class_name_to_type: dict[str, type] = {}
 
     @classmethod
     def register_enum(cls, enum_type: type[enum.Enum]) -> None:
@@ -219,6 +235,28 @@ class OpentronsPyroSerializer:
         return model.model_validate(d)
 
     @classmethod
+    def register_dataclass(cls, dataclass_type: type) -> None:
+        """Registers a dataclass type to be sent and received via pyro proxies."""
+        if is_dataclass(dataclass_type):
+            if hasattr(dataclass_type, "to_pyro_dict") and hasattr(
+                dataclass_type, "from_pyro_dict"
+            ):
+                class_name = register_type_to_serpent(
+                    class_type=dataclass_type,
+                    dict_to_class=dataclass_type.from_pyro_dict,
+                    class_to_dict=dataclass_type.to_pyro_dict,
+                )
+                cls._dataclass_class_name_to_type[class_name] = dataclass_type
+            else:
+                raise TypeError(
+                    f"Dataclass {dataclass_type} does not satisfy `to_pyro_dict` and `from_pyro_dict` attribute requirements."
+                )
+        else:
+            raise TypeError(
+                f"Type {dataclass_type} is not a dataclass and could not be registered."
+            )
+
+    @classmethod
     def register_basic_error(cls, error_type: type[BaseException]) -> None:
         """Registers a basic error with no specially handled args to be handled via pyro proxies."""
         class_name = register_type_to_serpent(
@@ -283,6 +321,7 @@ class OpentronsPyroSerializer:
             cls._pydantic_class_name_to_model,
             cls._enum_class_name_to_type,
             cls._typed_dict_class_name_to_type,
+            cls._dataclass_class_name_to_type,
             # Sometimes the hardware API sends floats in the form of numpy float 64s. If they happen
             # to be in a non-builtin dict wrapper, they won't get handled by the normal pyro serialization
             # so we need to handle it here by adding it to the list of registries.


### PR DESCRIPTION
# Overview
Expands on and centralizes previous refactor to dataclass serialization. With the serialization fully moved into `OpentronsPyroSerializer` class this now puts dataclasses directly in line with Enum types and Pydantic models regarding serialization pattern, and gives in-class standard for use of `to_pyro_dict` and `from_pyro_dict` cross-layer pattern enforcement. This also gets us away from explicit class registration, and lets us crawl modules for classes that we expect to cross layers instead.

## Test Plan and Hands on Testing
- [x] Validate serializer integration test for hardware layer continues to give good coverage

## Changelog

- Added `register_dataclass` to the OpentronsPyroSerializer
- Removed direct class registration reference and opted for module crawling in line with Pydantic and Enum registration patterns

## Review requests
This PR doesn't touch robot server and protocol process layers yet, we could start to do that now or save that for later. Those layers mostly make use of Pydantic models for cross-layer types, not dataclasses, so its a lower priority there.

## Risk assessment
Low - expands on previous refactor