### PR TITLE
fix(api): Fix intermittent PortNotOpen errors during module reconnect.

### DIFF
--- a/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
+++ b/api/src/opentrons/drivers/asyncio/communication/serial_connection.py
@@ -313,6 +313,7 @@ class SerialConnection:
 
         if await self._serial.is_open():
             await self._serial.close()
+        self._name = new_port
         self._serial = await self._build_serial(
             port=new_port,
             baud_rate=self._serial._baud_rate,
@@ -683,18 +684,17 @@ class AsyncResponseSerialConnection(SerialConnection):
                 responses = await self._send_one_retry(data, acks)
                 if responses:
                     return responses
-                log.info(f"{self._name}: retry number {retry}/{retries}")
-
             except Exception:
                 log.exception("Got an error during send")
                 if retry < retries and not self._closed_on_purpose:
                     pass
                 else:
+                    log.warning(f"Already used {retry} {retries} and raising error")
                     raise
             except asyncio.CancelledError:
                 log.exception("Asyncio canceled")
                 raise
-
+            log.info(f"{self._name}: retry number {retry}/{retries}")
             await self.on_retry()
         raise NoResponse(port=self._port, command=data)
 

--- a/api/src/opentrons/hardware_control/module_control.py
+++ b/api/src/opentrons/hardware_control/module_control.py
@@ -289,9 +289,11 @@ class AttachedModulesControl:
             if attached_mod.port != old_mod.port:
                 log.info(f"module moved from {old_mod.port} to {attached_mod.port}")
                 await old_mod.move_port(attached_mod.port, attached_mod.usb_port)
+                log.info("Module port migration complete.")
             await attached_mod.soft_cleanup()
             await old_mod.soft_cleanup()
             await old_mod.attempt_reconnect()
+            log.info("Module reconnection complete.")
             if old_mod in self._recently_removed_modules:
                 self._recently_removed_modules.remove(old_mod)
             self._dedupe_available_modules(old_mod)

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -325,7 +325,7 @@ class HeaterShaker(mod_abc.AbstractModule):
         """
         await self.wait_for_is_running()
         await self._driver.set_temperature(celsius)
-        await self._reader.read_temperature()
+        await self._poller.wait_next_poll()
 
     # TODO(mc, 2022-10-10): remove `awaiting_temperature` argument,
     # and instead, wait until status is holding
@@ -341,7 +341,7 @@ class HeaterShaker(mod_abc.AbstractModule):
             return
 
         await self.wait_for_is_running()
-        await self._reader.read_temperature()
+        await self._poller.wait_next_poll()
 
         async def _await_temperature() -> None:
             if self.temperature_status == TemperatureStatus.HEATING:
@@ -386,7 +386,7 @@ class HeaterShaker(mod_abc.AbstractModule):
         """
         await self.wait_for_is_running()
         await self._driver.set_rpm(rpm)
-        await self._reader.read_rpm()
+        await self._poller.wait_next_poll()
 
         async def _wait() -> None:
             # Wait until we reach the target speed.
@@ -425,7 +425,7 @@ class HeaterShaker(mod_abc.AbstractModule):
         if must_be_running:
             await self.wait_for_is_running()
         await self._driver.deactivate_heater()
-        await self._reader.read_temperature()
+        await self._poller.wait_next_poll()
 
     async def deactivate_shaker(self, must_be_running: bool = True) -> None:
         """Stop shaking and home the plate"""

--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -486,12 +486,15 @@ class HeaterShakerReader(Reader):
         self._set_error(exception)
 
     async def read_temperature(self) -> None:
+        """Do not call directly, for the poller only."""
         self.temperature = await self._driver.get_temperature()
 
     async def read_rpm(self) -> None:
+        """Do not call directly, for the poller only."""
         self.rpm = await self._driver.get_rpm()
 
     async def read_labware_latch(self) -> None:
+        """Do not call directly, for the poller only."""
         self.labware_latch = await self._driver.get_labware_latch_status()
 
     def _set_error(self, exception: Optional[Exception]) -> None:
@@ -512,6 +515,7 @@ class HeaterShakerReader(Reader):
                 self.error = repr(exception)
 
     async def _read_errors(self) -> None:
+        """Do not call directly, for the poller only."""
         try:
             await self._driver.get_error_state()
         except UnhandledGcode:

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -345,7 +345,9 @@ class TempDeckReader(Reader):
         self._debounce_count = DEFAULT_COMMAND_RETRIES
 
     async def read(self) -> None:
-        """Read the module's current and target temperatures."""
+        """Read the module's current and target temperatures.
+
+        Do not call directly, for the poller only."""
         self.temperature = await self._driver.get_temperature()
         # reset on success
         self._debounce_count = DEFAULT_COMMAND_RETRIES

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -177,7 +177,7 @@ class TempDeck(mod_abc.AbstractModule):
         """
         await self.wait_for_is_running()
         await self._driver.set_temperature(celsius)
-        await self._reader.read()
+        await self._poller.wait_next_poll()
 
     async def await_temperature(self, awaiting_temperature: Optional[float]) -> None:
         """Await a target temperature in degrees Celsius.
@@ -195,7 +195,7 @@ class TempDeck(mod_abc.AbstractModule):
             return
 
         await self.wait_for_is_running()
-        await self._reader.read()
+        await self._poller.wait_next_poll()
 
         async def _await_temperature() -> None:
             if awaiting_temperature is None:
@@ -215,7 +215,7 @@ class TempDeck(mod_abc.AbstractModule):
         if must_be_running:
             await self.wait_for_is_running()
         await self._driver.deactivate()
-        await self._reader.read()
+        await self._poller.wait_next_poll()
 
     @property
     def device_info(self) -> Dict[str, str]:

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -259,7 +259,7 @@ class Thermocycler(mod_abc.AbstractModule):
         if must_be_running:
             await self.wait_for_is_running()
         await self._driver.deactivate_lid()
-        await self._reader.read_lid_temperature()
+        await self._poller.wait_next_poll()
 
     async def deactivate_block(self, must_be_running: bool = True) -> None:
         """Deactivate the block peltiers"""
@@ -267,7 +267,7 @@ class Thermocycler(mod_abc.AbstractModule):
             await self.wait_for_is_running()
         self._clear_cycle_counters()
         await self._driver.deactivate_block()
-        await self._reader.read_block_temperature()
+        await self._poller.wait_next_poll()
 
     async def deactivate(self, must_be_running: bool = True) -> None:
         """Deactivate the block peltiers and lid heating pad"""
@@ -275,7 +275,7 @@ class Thermocycler(mod_abc.AbstractModule):
             await self.wait_for_is_running()
         self._clear_cycle_counters()
         await self._driver.deactivate_all()
-        await self._reader.read()
+        await self._poller.wait_next_poll()
 
     async def open(self) -> str:
         """Open the lid if it is closed"""
@@ -513,7 +513,7 @@ class Thermocycler(mod_abc.AbstractModule):
             volume=volume,
             ramp_rate=ramp_rate,
         )
-        await self._reader.read_block_temperature()
+        await self._poller.wait_next_poll()
 
     # TODO(mc, 2022-04-26): de-duplicate with `set_lid_temperature`
     async def set_target_lid_temperature(self, celsius: float) -> None:
@@ -526,7 +526,7 @@ class Thermocycler(mod_abc.AbstractModule):
         """
         await self.wait_for_is_running()
         await self._driver.set_lid_temperature(temp=celsius)
-        await self._reader.read_lid_temperature()
+        await self._poller.wait_next_poll()
 
     async def _wait_for_lid_target(self) -> None:
         """
@@ -534,7 +534,7 @@ class Thermocycler(mod_abc.AbstractModule):
 
         Subject to change without a version bump.
         """
-        await self._reader.read_lid_temperature()
+        await self._poller.wait_next_poll()
 
         while not _temperature_is_holding(self.lid_temp_status):
             await self._poller.wait_next_poll()
@@ -545,7 +545,7 @@ class Thermocycler(mod_abc.AbstractModule):
 
         Subject to change without a version bump.
         """
-        await self._reader.read_block_temperature()
+        await self._poller.wait_next_poll()
 
         while not _temperature_is_holding(self.status):
             await self._poller.wait_next_poll()
@@ -555,7 +555,7 @@ class Thermocycler(mod_abc.AbstractModule):
 
     async def _wait_for_lid_status(self, status: ThermocyclerLidStatus) -> None:
         """Wait for lid status to be status."""
-        await self._reader.read_lid_status()
+        await self._poller.wait_next_poll()
 
         while self.lid_status != status:
             await self._poller.wait_next_poll()

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -808,6 +808,7 @@ class ThermocyclerReader(Reader):
         await self._read_errors()
 
     async def _read_errors(self) -> None:
+        """Do not call directly, for the poller only."""
         try:
             await self._driver.get_error_state()
         except UnhandledGcode:
@@ -818,12 +819,15 @@ class ThermocyclerReader(Reader):
         # error handler can take it.
 
     async def read_lid_status(self) -> None:
+        """Do not call directly, for the poller only."""
         self.lid_status = await self._driver.get_lid_status()
 
     async def read_block_temperature(self) -> None:
+        """Do not call directly, for the poller only."""
         self.block_temperature = await self._driver.get_plate_temperature()
         self._block_temperature_status.update(self.block_temperature)
 
     async def read_lid_temperature(self) -> None:
+        """Do not call directly, for the poller only."""
         self.lid_temperature = await self._driver.get_lid_temperature()
         self._lid_temperature_status.update(self.lid_temperature)


### PR DESCRIPTION
# Overview
Some of the device drivers were directly accessing the reader methods. This causes an intermittent issue with the new reconnect logic if the disconnect happens while the driver is calling directly into that reader since the poller is calls that reader, then there are two different processes trying to use the serial and or reconnect the port at the same time.

Since the purpose of these reads were just to delay the functions until the did one read we can just replace them with a wait for next poll read. Since the poller already has a delay built in between retries this will allow the retry system to perform as intended. 
