### PR TITLE
fix(api): wait_next_poll raises an error right away instead waiting f…

### DIFF
--- a/api/src/opentrons/hardware_control/modules/heater_shaker.py
+++ b/api/src/opentrons/hardware_control/modules/heater_shaker.py
@@ -325,7 +325,7 @@ class HeaterShaker(mod_abc.AbstractModule):
         """
         await self.wait_for_is_running()
         await self._driver.set_temperature(celsius)
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
     # TODO(mc, 2022-10-10): remove `awaiting_temperature` argument,
     # and instead, wait until status is holding
@@ -341,7 +341,7 @@ class HeaterShaker(mod_abc.AbstractModule):
             return
 
         await self.wait_for_is_running()
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
         async def _await_temperature() -> None:
             if self.temperature_status == TemperatureStatus.HEATING:
@@ -386,7 +386,7 @@ class HeaterShaker(mod_abc.AbstractModule):
         """
         await self.wait_for_is_running()
         await self._driver.set_rpm(rpm)
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
         async def _wait() -> None:
             # Wait until we reach the target speed.
@@ -425,7 +425,7 @@ class HeaterShaker(mod_abc.AbstractModule):
         if must_be_running:
             await self.wait_for_is_running()
         await self._driver.deactivate_heater()
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
     async def deactivate_shaker(self, must_be_running: bool = True) -> None:
         """Stop shaking and home the plate"""

--- a/api/src/opentrons/hardware_control/modules/tempdeck.py
+++ b/api/src/opentrons/hardware_control/modules/tempdeck.py
@@ -177,7 +177,7 @@ class TempDeck(mod_abc.AbstractModule):
         """
         await self.wait_for_is_running()
         await self._driver.set_temperature(celsius)
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
     async def await_temperature(self, awaiting_temperature: Optional[float]) -> None:
         """Await a target temperature in degrees Celsius.
@@ -195,7 +195,7 @@ class TempDeck(mod_abc.AbstractModule):
             return
 
         await self.wait_for_is_running()
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
         async def _await_temperature() -> None:
             if awaiting_temperature is None:
@@ -215,7 +215,7 @@ class TempDeck(mod_abc.AbstractModule):
         if must_be_running:
             await self.wait_for_is_running()
         await self._driver.deactivate()
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
     @property
     def device_info(self) -> Dict[str, str]:

--- a/api/src/opentrons/hardware_control/modules/thermocycler.py
+++ b/api/src/opentrons/hardware_control/modules/thermocycler.py
@@ -259,7 +259,7 @@ class Thermocycler(mod_abc.AbstractModule):
         if must_be_running:
             await self.wait_for_is_running()
         await self._driver.deactivate_lid()
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
     async def deactivate_block(self, must_be_running: bool = True) -> None:
         """Deactivate the block peltiers"""
@@ -267,7 +267,7 @@ class Thermocycler(mod_abc.AbstractModule):
             await self.wait_for_is_running()
         self._clear_cycle_counters()
         await self._driver.deactivate_block()
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
     async def deactivate(self, must_be_running: bool = True) -> None:
         """Deactivate the block peltiers and lid heating pad"""
@@ -275,7 +275,7 @@ class Thermocycler(mod_abc.AbstractModule):
             await self.wait_for_is_running()
         self._clear_cycle_counters()
         await self._driver.deactivate_all()
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
     async def open(self) -> str:
         """Open the lid if it is closed"""
@@ -513,7 +513,7 @@ class Thermocycler(mod_abc.AbstractModule):
             volume=volume,
             ramp_rate=ramp_rate,
         )
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
     # TODO(mc, 2022-04-26): de-duplicate with `set_lid_temperature`
     async def set_target_lid_temperature(self, celsius: float) -> None:
@@ -526,7 +526,7 @@ class Thermocycler(mod_abc.AbstractModule):
         """
         await self.wait_for_is_running()
         await self._driver.set_lid_temperature(temp=celsius)
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
     async def _wait_for_lid_target(self) -> None:
         """
@@ -534,10 +534,10 @@ class Thermocycler(mod_abc.AbstractModule):
 
         Subject to change without a version bump.
         """
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
         while not _temperature_is_holding(self.lid_temp_status):
-            await self._poller.wait_next_poll()
+            await self._poller.wait_next_good_poll()
 
     async def _wait_for_block_target(self) -> None:
         """
@@ -545,20 +545,20 @@ class Thermocycler(mod_abc.AbstractModule):
 
         Subject to change without a version bump.
         """
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
         while not _temperature_is_holding(self.status):
-            await self._poller.wait_next_poll()
+            await self._poller.wait_next_good_poll()
 
         while self.hold_time is not None and self.hold_time > 0:
-            await self._poller.wait_next_poll()
+            await self._poller.wait_next_good_poll()
 
     async def _wait_for_lid_status(self, status: ThermocyclerLidStatus) -> None:
         """Wait for lid status to be status."""
-        await self._poller.wait_next_poll()
+        await self._poller.wait_next_good_poll()
 
         while self.lid_status != status:
-            await self._poller.wait_next_poll()
+            await self._poller.wait_next_good_poll()
 
     @property
     def lid_target(self) -> Optional[float]:

--- a/api/src/opentrons/hardware_control/poller.py
+++ b/api/src/opentrons/hardware_control/poller.py
@@ -72,6 +72,24 @@ class Poller:
         self._poll_waiters.append(poll_future)
         await poll_future
 
+    async def wait_next_good_poll(self, retries: int = 4) -> None:
+        """Wait for the next good poll to complete.
+
+        If called in the middle of a read, it will not return until
+        the next complete read. If a read raises an exception,
+        it will retry retries number of time before the exception is
+        passed through to `wait_next_good_poll`.
+        """
+        for r in range(retries):
+            try:
+                await self.wait_next_poll()
+                return
+            except BaseException:
+                if r < (retries - 1):
+                    pass
+                else:
+                    raise
+
     @contextlib.asynccontextmanager
     async def _use_read_lock(self) -> AsyncGenerator[None, None]:
         self._read_lock = self._read_lock or asyncio.Lock()


### PR DESCRIPTION
# Overview
Lost my way with all of the asyncio callbacks a little bit. 
wait_next_poll raises an error right away using set_exception on the waiter instead waiting for a good poll. 
So it needs a new helper function this allows the poller to try a few times before raising the error so we get the best of both worlds where we don't have two different threads trying to disconnect/retry but still allows individual reads not to raise on the first error.