### PR TITLE
chore(components): deprecate Banner component

### DIFF
--- a/components/src/molecules/Banner/index.tsx
+++ b/components/src/molecules/Banner/index.tsx
@@ -17,6 +17,12 @@ import type { StyleProps } from '../../primitives'
 export type BannerType =
   'success' | 'warning' | 'error' | 'updating' | 'informing'
 
+/**
+ * the design team has stopped using Banner
+ *
+ * @deprecated Use `InlineNotification`
+ */
+
 export interface BannerProps extends StyleProps {
   /** name constant of the icon to display */
   type: BannerType


### PR DESCRIPTION


# Overview
deprecate Banner component since the design team stopped using it.

closes AUTH-3115

## Test Plan and Hands on Testing

Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.

## Changelog
- deprecate Banner 

## Review requests


## Risk assessment
low
