### PR TITLE
fix(server-utils): Fix loggers not logging

### DIFF
--- a/server-utils/server_utils/logging_utils.py
+++ b/server-utils/server_utils/logging_utils.py
@@ -27,6 +27,7 @@ def get_dict_config(log_level: str | int, syslog_id: str) -> dict[str, object]:
     root_formatter, root_handler = _get_root_formatter_and_handler_for_system(syslog_id)
     return {
         "version": 1,
+        "disable_existing_loggers": False,
         # Fix up 3rd-party packages to make sure their logs propagate up to our root
         # handler. Most packages don't need this.
         "loggers": {

--- a/server-utils/server_utils/logging_utils.py
+++ b/server-utils/server_utils/logging_utils.py
@@ -27,6 +27,8 @@ def get_dict_config(log_level: str | int, syslog_id: str) -> dict[str, object]:
     root_formatter, root_handler = _get_root_formatter_and_handler_for_system(syslog_id)
     return {
         "version": 1,
+        # Many modules will already have been imported and will have created their
+        # loggers with logging.getLogger(). Make sure we respect them.
         "disable_existing_loggers": False,
         # Fix up 3rd-party packages to make sure their logs propagate up to our root
         # handler. Most packages don't need this.


### PR DESCRIPTION
## Overview

This fixes a problem where, on a robot, system-server was only printing log messages from `uvicorn`, and not from any of our custom loggers.

## Details

It appears that we've been bitten by [a bad default in `logging.dictConfig()`](https://www.emkor.eu/posts/python-logging-quirk/)?

Across the universe, Python modules create loggers like:

```python
log = logging.getLogger(__name__)
```

It sounds like, by default, `logging.dictConfig()` disables any of those `getLogger()` calls that have already happened, and it leaves alone any of the `getLogger()` calls that come later. (!?)

So the behavior depends on import order. This may explain why this was a problem for system-server but not auth-server. And why this was a problem on real robots but not in local dev environments, which launch the server slightly differently.

My fix is to just to tell `dictConfig()` leave existing loggers alone.

## Test Plan and Hands on Testing

* [x] I pushed this to the same robot, ran `systemctl restart opentrons-system-server`, and noticed new log messages show up.
* [x] `make dev` logs still seem sensible.

## Review requests

Any reason we wouldn't want this behavior, system-wide?

## Risk assessment

It won't affect anything behavioral, but, uh, I evidently understand Python logging less well than I thought, so...🤷 