### PR TITLE
fix(shared-data): edit offset location for vacuum module addressable area A4

### DIFF
--- a/shared-data/deck/definitions/5/ot3_standard.json
+++ b/shared-data/deck/definitions/5/ot3_standard.json
@@ -1000,7 +1000,8 @@
         },
         "displayName": "Vacuum Module Dock in A4",
         "features": {},
-        "orientation": "right"
+        "orientation": "right",
+        "$comment": "This value is an eye-test estimate and needs hardware validation."
       }
     ],
     "cutouts": [

--- a/shared-data/deck/definitions/5/ot3_standard.json
+++ b/shared-data/deck/definitions/5/ot3_standard.json
@@ -992,7 +992,7 @@
       {
         "id": "vacuumModuleV1DockA4",
         "areaType": "lidDock",
-        "offsetFromCutoutFixture": [164.0, 0.0, 20.0],
+        "offsetFromCutoutFixture": [159.5, 0.0, 20.0],
         "boundingBox": {
           "xDimension": 128.5,
           "yDimension": 86.5,


### PR DESCRIPTION
## Overview
Resolves:
https://opentrons.atlassian.net/browse/RQA-5739 , https://opentrons.atlassian.net/browse/RQA-5748 

Long term fix here should be to get better hardware-verified measurements of the dimensions of this addressable area for the vacuum module, as well as its offset ; but for now this value causes the gripper to correctly pick up labware from A4