### PR TITLE
test(app): "Stand back, robot is in motion" message during LPC

### DIFF
--- a/app/src/organisms/LabwarePositionCheck/LPCWizardFlex.tsx
+++ b/app/src/organisms/LabwarePositionCheck/LPCWizardFlex.tsx
@@ -71,7 +71,7 @@ export function LPCWizardFlex(props: LPCWizardFlexProps): JSX.Element {
   )
 }
 
-function LPCWizardContent(props: LPCWizardContentProps): JSX.Element {
+export function LPCWizardContent(props: LPCWizardContentProps): JSX.Element {
   const { t } = useTranslation('shared')
   const currentStep = useSelector(selectCurrentStep(props.runId))
   const { isRobotMoving, errorMessage, unableToDetect } = props.commandUtils

--- a/app/src/organisms/LabwarePositionCheck/__tests__/LPCWizardFlex.test.tsx
+++ b/app/src/organisms/LabwarePositionCheck/__tests__/LPCWizardFlex.test.tsx
@@ -1,0 +1,50 @@
+import { useSelector } from 'react-redux'
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, it, vi } from 'vitest'
+
+import { renderWithProviders } from '/app/__testing-utils__'
+import { i18n } from '/app/i18n'
+import {
+  MockLPCContentContainer,
+  mockLPCContentProps,
+} from '/app/organisms/LabwarePositionCheck/__fixtures__'
+import { LPCWizardContent } from '/app/organisms/LabwarePositionCheck/LPCWizardFlex'
+
+import type { ComponentProps } from 'react'
+
+vi.mock('react-redux', async importOriginal => {
+  const actual = await importOriginal<typeof useSelector>()
+  return {
+    ...actual,
+    useSelector: vi.fn(),
+  }
+})
+
+vi.mock('/app/organisms/LabwarePositionCheck/LPCContentContainer', () => ({
+  LPCContentContainer: MockLPCContentContainer,
+}))
+
+const render = (props: ComponentProps<typeof LPCWizardContent>) => {
+  return renderWithProviders(<LPCWizardContent {...props} />, {
+    i18nInstance: i18n,
+  })[0]
+}
+
+describe('LPCWizardContent', () => {
+  let props: ComponentProps<typeof LPCWizardContent>
+
+  beforeEach(() => {
+    props = {
+      ...mockLPCContentProps,
+      commandUtils: {
+        ...mockLPCContentProps.commandUtils,
+        isRobotMoving: true,
+      },
+    }
+  })
+
+  it('renders the stand back message while the robot is moving', () => {
+    render(props)
+    screen.getByText('Stand back, robot is in motion')
+  })
+})

--- a/app/src/organisms/LegacyLabwarePositionCheck/__tests__/CheckItem.test.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/__tests__/CheckItem.test.tsx
@@ -652,12 +652,6 @@ describe('CheckItem', () => {
       false
     )
   })
-  it('renders the stand back message when the robot is moving', () => {
-    props = { ...props, isRobotMoving: true, robotType: FLEX_ROBOT_TYPE }
-    render(props)
-    screen.getByText('Stand back, robot is in motion')
-  })
-
   it('executes correct chained commands when confirm placement CTA is clicked when using probe for LPC', async () => {
     props = {
       ...props,

--- a/app/src/organisms/LegacyLabwarePositionCheck/__tests__/CheckItem.test.tsx
+++ b/app/src/organisms/LegacyLabwarePositionCheck/__tests__/CheckItem.test.tsx
@@ -652,6 +652,12 @@ describe('CheckItem', () => {
       false
     )
   })
+  it('renders the stand back message when the robot is moving', () => {
+    props = { ...props, isRobotMoving: true, robotType: FLEX_ROBOT_TYPE }
+    render(props)
+    screen.getByText('Stand back, robot is in motion')
+  })
+
   it('executes correct chained commands when confirm placement CTA is clicked when using probe for LPC', async () => {
     props = {
       ...props,


### PR DESCRIPTION
# Overview

Context: I've been closing out old OT-2 tickets post-fork, and I wanted to close [RQA-1224](https://opentrons.atlassian.net/browse/RQA-1224). It's been marked _Ready for review_ for years — I assumed it was implemented, but wanted to be sure. Writing a test would calm my demons.

After chasing the legacy code path, I realized that there's a new path for Flex only. It also didn't have a test. But now it does.

## Test Plan and Hands on Testing

- Automated test. Fails when introducing a deliberate wrong string.
- Manually compared new test file structure to similar app tests.

## Changelog

New test file `LPCWizardFlex.test.tsx`, based on the structure of its sibling `LPCProbeNotAttached.test.tsx`

## Review requests

- Test is cromulent (structure, coverage)?
- More tests are better, right? 😇 

## Risk assessment

low

[RQA-1224]: https://opentrons.atlassian.net/browse/RQA-1224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ