### PR TITLE
feat(app): wire up robot out of storage modal

### DIFF
--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -267,14 +267,7 @@
   "robot_logs": "Robot Logs",
   "robot_out_of_memory": "Robot out of memory",
   "robot_storage": "Robot Storage",
-<<<<<<< Updated upstream
-  "robot_storage_almost_full": "Robot storage is almost full",
-=======
-<<<<<<< Updated upstream
-=======
   "robot_storage_almost_full": "Robot’s file storage is full",
->>>>>>> Stashed changes
->>>>>>> Stashed changes
   "run": "Run",
   "run_a_protocol": "Run a protocol",
   "run_again": "Run again",

--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -81,6 +81,7 @@
   "delete_selected_run_records": "Delete selected protocol run records?",
   "delete_selected_run_records_description": "Deleting the selected protocol run records will permanently remove them from the robot, along with all associated files. This action cannot be undone.",
   "delete_selected_run_records_recommendation": "We recommend downloading all protocol files before proceeding.",
+  "delete_to_run": "Download and delete old protocol run records and associated files to free up space before starting a run.",
   "deleting_all_run_records": "Deleting all run records",
   "detach_gripper": "Detach gripper",
   "detach_pipette": "Detach pipette",
@@ -125,6 +126,7 @@
   "file_name_protocol": "Protocol",
   "file_name_run_log": "Run log",
   "file_name_runtime_parameters": "Runtime parameters",
+  "file_storage_full": "File storage full",
   "file_type": "File type",
   "files": "Files",
   "firmware_update_available": "Firmware update available",
@@ -263,8 +265,16 @@
   "robot_control_not_available": "Some robot controls are not available when run is in progress",
   "robot_initializing": "Initializing...",
   "robot_logs": "Robot Logs",
+  "robot_out_of_memory": "Robot out of memory",
   "robot_storage": "Robot Storage",
+<<<<<<< Updated upstream
   "robot_storage_almost_full": "Robot storage is almost full",
+=======
+<<<<<<< Updated upstream
+=======
+  "robot_storage_almost_full": "Robot’s file storage is full",
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
   "run": "Run",
   "run_a_protocol": "Run a protocol",
   "run_again": "Run again",

--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import first from 'lodash/first'
@@ -22,6 +23,7 @@ import {
 } from '@opentrons/react-api-client'
 import { FLEX_ROBOT_TYPE } from '@opentrons/shared-data'
 
+import { getTopPortalEl } from '/app/App/portal'
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { ApiHostProvider } from '/app/local-resources/api-host-provider/ApiHostProvider'
 import { useTrackCreateProtocolRunEvent } from '/app/organisms/Desktop/Devices/hooks'
@@ -29,12 +31,14 @@ import { LegacyApplyHistoricOffsets } from '/app/organisms/LegacyApplyHistoricOf
 import { useOffsetCandidatesForAnalysis } from '/app/organisms/LegacyApplyHistoricOffsets/hooks/useOffsetCandidatesForAnalysis'
 import { useRobotType } from '/app/redux-resources/robots'
 import { useIsRobotOnWrongVersionOfSoftware } from '/app/redux/robot-update'
+import { useIsRobotOutOfStorage } from '/app/resources/devices'
 import {
   getRunTimeParameterFilesForRun,
   getRunTimeParameterValuesForRun,
 } from '/app/transformations/runs'
 
 import { ChooseRobotSlideout } from '../ChooseRobotSlideout'
+import { RobotOutOfStorageModal } from '../Devices/RobotOutOfStorageModal.tsx'
 import { useCreateRunFromProtocol } from './useCreateRunFromProtocol'
 
 import type { MouseEventHandler } from 'react'
@@ -107,6 +111,10 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
   const documentationState = useDocumentationState()
   const { uploadCsvFile } = useUploadCsvFileMutation(documentationState)
 
+  const isRobotOutOfStorage = useIsRobotOutOfStorage()
+  const [showRobotOutOfStorageModal, setShowRobotOutOfStorageModal] =
+    useState<boolean>(false)
+
   const {
     createRunFromProtocolSource,
     runCreationError,
@@ -141,6 +149,11 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
       : []
   )
   const handleProceed: MouseEventHandler<HTMLButtonElement> = () => {
+    if (isRobotOutOfStorage) {
+      setShowRobotOutOfStorageModal(true)
+      return
+    }
+
     trackCreateProtocolRunEvent({ name: 'createProtocolRecordRequest' })
     const dataFilesForProtocolMap = runTimeParametersOverrides.reduce<
       Record<string, File>
@@ -251,6 +264,10 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
             {offsetsComponent}
             <PrimaryButton
               onClick={() => {
+                if (isRobotOutOfStorage) {
+                  setShowRobotOutOfStorageModal(true)
+                  return
+                }
                 setCurrentPage(2)
               }}
               width="100%"
@@ -323,42 +340,64 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
   }
 
   return (
-    <ChooseRobotSlideout
-      multiSlideout={hasRunTimeParameters ? { currentPage } : null}
-      isExpanded={showSlideout}
-      isSelectedRobotOnDifferentSoftwareVersion={
-        isSelectedRobotOnDifferentSoftwareVersion
-      }
-      onCloseClick={() => {
-        onCloseClick()
-        resetRunTimeParameters()
-        setCurrentPage(1)
-        setSelectedRobot(null)
-      }}
-      title={
-        hasRunTimeParameters && currentPage === 2
-          ? t('select_parameters_for_robot', {
-              robot_name: selectedRobot?.name,
-            })
-          : t('choose_robot_to_run', {
-              protocol_name: protocolDisplayName,
-            })
-      }
-      runTimeParametersOverrides={runTimeParametersOverrides}
-      setRunTimeParametersOverrides={setRunTimeParametersOverrides}
-      footer={footer}
-      selectedRobot={selectedRobot}
-      setSelectedRobot={setSelectedRobot}
-      robotType={robotType}
-      isCreatingRun={isCreatingRun}
-      reset={resetCreateRun}
-      runCreationError={runCreationError}
-      runCreationErrorCode={runCreationErrorCode}
-      showIdleOnly
-      setHasParamError={setHasParamError}
-      resetRunTimeParameters={resetRunTimeParameters}
-      setHasMissingFileParam={setHasMissingFileParam}
-    />
+    <>
+      {showRobotOutOfStorageModal
+        ? createPortal(
+            <RobotOutOfStorageModal
+              onConfirm={() => {
+                if (selectedRobot != null) {
+                  navigate(
+                    `/devices/${selectedRobot?.name}/robot-settings/file-manager`
+                  )
+                  return
+                }
+                setShowRobotOutOfStorageModal(false)
+              }}
+              onClose={() => {
+                setShowRobotOutOfStorageModal(false)
+              }}
+            />,
+            getTopPortalEl()
+          )
+        : null}
+
+      <ChooseRobotSlideout
+        multiSlideout={hasRunTimeParameters ? { currentPage } : null}
+        isExpanded={showSlideout}
+        isSelectedRobotOnDifferentSoftwareVersion={
+          isSelectedRobotOnDifferentSoftwareVersion
+        }
+        onCloseClick={() => {
+          onCloseClick()
+          resetRunTimeParameters()
+          setCurrentPage(1)
+          setSelectedRobot(null)
+        }}
+        title={
+          hasRunTimeParameters && currentPage === 2
+            ? t('select_parameters_for_robot', {
+                robot_name: selectedRobot?.name,
+              })
+            : t('choose_robot_to_run', {
+                protocol_name: protocolDisplayName,
+              })
+        }
+        runTimeParametersOverrides={runTimeParametersOverrides}
+        setRunTimeParametersOverrides={setRunTimeParametersOverrides}
+        footer={footer}
+        selectedRobot={selectedRobot}
+        setSelectedRobot={setSelectedRobot}
+        robotType={robotType}
+        isCreatingRun={isCreatingRun}
+        reset={resetCreateRun}
+        runCreationError={runCreationError}
+        runCreationErrorCode={runCreationErrorCode}
+        showIdleOnly
+        setHasParamError={setHasParamError}
+        resetRunTimeParameters={resetRunTimeParameters}
+        setHasMissingFileParam={setHasMissingFileParam}
+      />
+    </>
   )
 }
 

--- a/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
+++ b/app/src/organisms/Desktop/ChooseRobotToRunProtocolSlideout/index.tsx
@@ -198,6 +198,22 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
       })
   }
 
+  const handleProceedToRTP = (): void => {
+    if (isRobotOutOfStorage) {
+      setShowRobotOutOfStorageModal(true)
+      return
+    }
+    setCurrentPage(2)
+  }
+
+  const handleClickManageFiles = (): void => {
+    if (selectedRobot != null) {
+      navigate(`/devices/${selectedRobot.name}/robot-settings/file-manager`)
+      return
+    }
+    setShowRobotOutOfStorageModal(false)
+  }
+
   const isSelectedRobotOnDifferentSoftwareVersion =
     useIsRobotOnWrongVersionOfSoftware(selectedRobot?.name ?? '')
 
@@ -263,13 +279,7 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
           <>
             {offsetsComponent}
             <PrimaryButton
-              onClick={() => {
-                if (isRobotOutOfStorage) {
-                  setShowRobotOutOfStorageModal(true)
-                  return
-                }
-                setCurrentPage(2)
-              }}
+              onClick={handleProceedToRTP}
               width="100%"
               disabled={
                 isCreatingRun ||
@@ -344,15 +354,7 @@ export function ChooseRobotToRunProtocolSlideoutComponent(
       {showRobotOutOfStorageModal
         ? createPortal(
             <RobotOutOfStorageModal
-              onConfirm={() => {
-                if (selectedRobot != null) {
-                  navigate(
-                    `/devices/${selectedRobot?.name}/robot-settings/file-manager`
-                  )
-                  return
-                }
-                setShowRobotOutOfStorageModal(false)
-              }}
+              onConfirm={handleClickManageFiles}
               onClose={() => {
                 setShowRobotOutOfStorageModal(false)
               }}

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/hooks/useActionButtonProperties.ts
@@ -29,10 +29,12 @@ import {
   getCameraUsageState,
   getMissingSetupSteps,
 } from '/app/redux/protocol-runs'
+import { useIsRobotOutOfStorage } from '/app/resources/devices'
 
 import { isAnyHeaterShakerShaking } from '../../../RunHeaderModalContainer/modals'
 import { useActionBtnDisabledUtils } from './useActionBtnDisabledUtils'
 
+import type { Dispatch, SetStateAction } from 'react'
 import type { IconName } from '@opentrons/components'
 import type { StepKey } from '/app/redux/protocol-runs'
 import type { State } from '/app/redux/types'
@@ -51,6 +53,7 @@ interface UseButtonPropertiesProps extends BaseActionButtonProps {
   areCameraPreferencesConfirmed: boolean
   isClosingCurrentRun: boolean
   isCameraReadyToRun: boolean
+  setShowRobotOutOfStorageModal: Dispatch<SetStateAction<boolean>>
 }
 
 // Returns ActionButton properties.
@@ -77,6 +80,7 @@ export function useActionButtonProperties({
   isValidRunAgain,
   protocolRunHeaderRef,
   isCameraReadyToRun,
+  setShowRobotOutOfStorageModal,
 }: UseButtonPropertiesProps): {
   buttonText: string
   handleButtonClick: () => void
@@ -105,6 +109,8 @@ export function useActionButtonProperties({
   let buttonText = ''
   let handleButtonClick = (): void => {}
   let buttonIconName: IconName | null = null
+
+  const isRobotOutOfMemory = useIsRobotOutOfStorage()
 
   const handlePlay = (): void => {
     play()
@@ -205,6 +211,8 @@ export function useActionButtonProperties({
           },
           { onSettled: handlePlay }
         )
+      } else if (isRobotOutOfMemory) {
+        setShowRobotOutOfStorageModal(true)
       } else {
         handlePlay()
       }
@@ -213,6 +221,11 @@ export function useActionButtonProperties({
     buttonIconName = isResetRunLoadingRef.current ? 'ot-spinner' : 'play'
     buttonText = t('run_again')
     handleButtonClick = () => {
+      if (isRobotOutOfMemory) {
+        setShowRobotOutOfStorageModal(true)
+        return
+      }
+
       isResetRunLoadingRef.current = true
       reset({
         onError: () => {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/index.tsx
@@ -125,7 +125,7 @@ export function ActionButton(props: ActionButtonProps): JSX.Element {
             }
           />
         ) : null}
-        <StyledText as="pSemiBold" whiteSpace={NO_WRAP}>
+        <StyledText desktopStyle="bodyDefaultSemiBold" whiteSpace={NO_WRAP}>
           {buttonText}
         </StyledText>
       </PrimaryButton>

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderContent/ActionButton/index.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react'
 import { useSelector } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
 
 import { RUN_STATUS_STOP_REQUESTED } from '@opentrons/api-client'
 import {
@@ -20,6 +22,7 @@ import { getCameraUsageState } from '/app/redux/protocol-runs'
 import { useIsRobotOnWrongVersionOfSoftware } from '/app/redux/robot-update'
 import { useCurrentRunId, useProtocolDetailsForRun } from '/app/resources/runs'
 
+import { RobotOutOfStorageModal } from '../../../../RobotOutOfStorageModal.tsx'
 import { getFallbackRobotSerialNumber } from '../../utils'
 import { useActionButtonProperties } from './hooks'
 
@@ -67,6 +70,9 @@ export function ActionButton(props: ActionButtonProps): JSX.Element {
   const robot = useRobot(robotName)
   const robotSerialNumber = getFallbackRobotSerialNumber(robot)
   const robotAnalyticsData = useRobotAnalyticsData(robotName)
+  const [showRobotOutOfStorageModal, setShowRobotOutOfStorageModal] =
+    useState<boolean>(false)
+  const navigate = useNavigate()
 
   const { buttonText, handleButtonClick, buttonIconName } =
     useActionButtonProperties({
@@ -83,33 +89,46 @@ export function ActionButton(props: ActionButtonProps): JSX.Element {
       isRobotOnWrongVersionOfSoftware,
       areCameraPreferencesConfirmed,
       isCameraReadyToRun,
+      setShowRobotOutOfStorageModal,
       ...props,
     })
   return (
-    <PrimaryButton
-      justifyContent={JUSTIFY_CENTER}
-      alignItems={ALIGN_CENTER}
-      boxShadow="none"
-      display={DISPLAY_FLEX}
-      onClick={handleButtonClick}
-      borderRadius={BORDERS.borderRadiusFull}
-      gap={buttonIconName != null ? SPACING.spacing8 : 0}
-    >
-      {buttonIconName != null ? (
-        <Icon
-          name={buttonIconName}
-          size="1rem"
-          spin={
-            isProtocolNotReady ||
-            runStatus === RUN_STATUS_STOP_REQUESTED ||
-            isResetRunLoadingRef.current ||
-            isClosingCurrentRun
-          }
+    <>
+      {showRobotOutOfStorageModal ? (
+        <RobotOutOfStorageModal
+          onConfirm={() => {
+            navigate(`/devices/${robotName}/robot-settings/file-manager`)
+          }}
+          onClose={() => {
+            setShowRobotOutOfStorageModal(false)
+          }}
         />
       ) : null}
-      <StyledText as="pSemiBold" whiteSpace={NO_WRAP}>
-        {buttonText}
-      </StyledText>
-    </PrimaryButton>
+      <PrimaryButton
+        justifyContent={JUSTIFY_CENTER}
+        alignItems={ALIGN_CENTER}
+        boxShadow="none"
+        display={DISPLAY_FLEX}
+        onClick={handleButtonClick}
+        borderRadius={BORDERS.borderRadiusFull}
+        gap={buttonIconName != null ? SPACING.spacing8 : 0}
+      >
+        {buttonIconName != null ? (
+          <Icon
+            name={buttonIconName}
+            size="1rem"
+            spin={
+              isProtocolNotReady ||
+              runStatus === RUN_STATUS_STOP_REQUESTED ||
+              isResetRunLoadingRef.current ||
+              isClosingCurrentRun
+            }
+          />
+        ) : null}
+        <StyledText as="pSemiBold" whiteSpace={NO_WRAP}>
+          {buttonText}
+        </StyledText>
+      </PrimaryButton>
+    </>
   )
 }

--- a/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRunOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/RecentProtocolRuns/HistoricalProtocolRunOverflowMenu.tsx
@@ -40,7 +40,7 @@ import {
   useDeleteRunMutation,
 } from '@opentrons/react-api-client'
 
-import { getModalPortalEl } from '/app/App/portal'
+import { getModalPortalEl, getTopPortalEl } from '/app/App/portal'
 import { Divider } from '/app/atoms/structure'
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useRunControls } from '/app/organisms/RunTimeControl'
@@ -60,9 +60,12 @@ import { useIsRobotOnWrongVersionOfSoftware } from '/app/redux/robot-update'
 import {
   useDownloadRunRecord,
   useIsEstopNotDisengaged,
+  useIsRobotOutOfStorage,
 } from '/app/resources/devices'
 
-import type { MouseEventHandler } from 'react'
+import { RobotOutOfStorageModal } from '../RobotOutOfStorageModal.tsx'
+
+import type { Dispatch, MouseEventHandler, SetStateAction } from 'react'
 import type { Run, RunData } from '@opentrons/api-client'
 import type { IconProps } from '@opentrons/components'
 
@@ -96,35 +99,56 @@ export function HistoricalProtocolRunOverflowMenu(
     }
   )
   const isEstopNotDisengaged = useIsEstopNotDisengaged(robotName)
+  const [showRobotOutOfStorageModal, setShowRobotOutOfStorageModal] =
+    useState<boolean>(false)
+  const navigate = useNavigate()
 
   return (
-    <Flex
-      flexDirection={DIRECTION_COLUMN}
-      position={POSITION_RELATIVE}
-      data-testid="HistoricalProtocolRunOverflowMenu_OverflowMenu"
-    >
-      <OverflowBtn
-        alignSelf={ALIGN_FLEX_END}
-        onClick={handleOverflowClick}
-        disabled={isEstopNotDisengaged}
-      />
-      {showOverflowMenu ? (
-        <>
-          <Box
-            ref={protocolRunOverflowWrapperRef}
-            data-testid={`HistoricalProtocolRunOverflowMenu_${run.id}`}
-          >
-            <MenuDropdown
-              {...props}
-              downloadRunRecord={downloadRunRecord}
-              isDownloading={isDownloading}
-              closeOverflowMenu={handleOverflowClick}
-            />
-          </Box>
-          {menuOverlay}
-        </>
-      ) : null}
-    </Flex>
+    <>
+      {showRobotOutOfStorageModal
+        ? createPortal(
+            <RobotOutOfStorageModal
+              onConfirm={() => {
+                navigate(`/devices/${robotName}/robot-settings/file-manager`)
+              }}
+              onClose={() => {
+                setShowRobotOutOfStorageModal(false)
+              }}
+            />,
+            getTopPortalEl()
+          )
+        : null}
+
+      <Flex
+        flexDirection={DIRECTION_COLUMN}
+        position={POSITION_RELATIVE}
+        data-testid="HistoricalProtocolRunOverflowMenu_OverflowMenu"
+      >
+        <OverflowBtn
+          alignSelf={ALIGN_FLEX_END}
+          onClick={handleOverflowClick}
+          disabled={isEstopNotDisengaged}
+        />
+        {showOverflowMenu ? (
+          <>
+            <Box
+              ref={protocolRunOverflowWrapperRef}
+              data-testid={`HistoricalProtocolRunOverflowMenu_${run.id}`}
+            >
+              <MenuDropdown
+                {...props}
+                downloadRunRecord={downloadRunRecord}
+                isDownloading={isDownloading}
+                closeOverflowMenu={handleOverflowClick}
+                setShowRobotOutOfStorageModal={setShowRobotOutOfStorageModal}
+                setShowOverflowMenu={setShowOverflowMenu}
+              />
+            </Box>
+            {menuOverlay}
+          </>
+        ) : null}
+      </Flex>
+    </>
   )
 }
 
@@ -132,6 +156,8 @@ interface MenuDropdownProps extends HistoricalProtocolRunOverflowMenuProps {
   closeOverflowMenu: MouseEventHandler<HTMLButtonElement>
   downloadRunRecord: () => void
   isDownloading: boolean
+  setShowRobotOutOfStorageModal: Dispatch<SetStateAction<boolean>>
+  setShowOverflowMenu: Dispatch<SetStateAction<boolean>>
 }
 function MenuDropdown(props: MenuDropdownProps): JSX.Element {
   const { t } = useTranslation('device_details')
@@ -145,6 +171,8 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
     downloadRunRecord,
     isDownloading,
     runHasImages,
+    setShowRobotOutOfStorageModal,
+    setShowOverflowMenu,
   } = props
 
   const { id: runId } = run
@@ -180,7 +208,16 @@ function MenuDropdown(props: MenuDropdownProps): JSX.Element {
 
   const robotSerialNumber =
     robot?.health?.robot_serial ?? robot?.serverHealth?.serialNumber ?? null
+
+  const isRobotOutOfStorage = useIsRobotOutOfStorage()
+
   const handleResetClick: MouseEventHandler<HTMLButtonElement> = (e): void => {
+    if (isRobotOutOfStorage) {
+      setShowRobotOutOfStorageModal(true)
+      setShowOverflowMenu(false)
+      return
+    }
+
     e.preventDefault()
     e.stopPropagation()
 

--- a/app/src/organisms/Desktop/Devices/RobotCard.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
@@ -36,6 +37,7 @@ import { ModuleIcon } from '/app/molecules/ModuleIcon'
 import { useIsFlex } from '/app/redux-resources/robots'
 import { CONNECTABLE, getRobotModelByName } from '/app/redux/discovery'
 import { useNotifyCamera } from '/app/resources/camera/useNotifyCamera'
+import { useIsRobotOutOfStorage } from '/app/resources/devices'
 
 import { UpdateRobotBanner } from '../UpdateRobotBanner'
 import {
@@ -43,6 +45,7 @@ import {
   useErrorRecoveryBanner,
 } from './ErrorRecoveryBanner'
 import { ReachableBanner } from './ReachableBanner'
+import { RobotOutOfStorageNotification } from './RobotOutOfStorageNotification'
 import { RobotOverflowMenu } from './RobotOverflowMenu'
 import { RobotStatusHeader } from './RobotStatusHeader'
 
@@ -66,6 +69,11 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
   )
 
   const { showRecoveryBanner, recoveryIntent } = useErrorRecoveryBanner()
+  const isRobotOutOfStorage = useIsRobotOutOfStorage()
+  const [
+    showRobotOutOfStorageNotification,
+    setShowRobotOutOfStorageNotification,
+  ] = useState<boolean>(isRobotOutOfStorage)
 
   return robot != null ? (
     <Flex
@@ -94,6 +102,15 @@ export function RobotCard(props: RobotCardProps): JSX.Element | null {
           <ErrorRecoveryBanner
             recoveryIntent={recoveryIntent}
             marginRight={SPACING.spacing24}
+          />
+        ) : null}
+        {showRobotOutOfStorageNotification ? (
+          <RobotOutOfStorageNotification
+            robotName={robotName}
+            onCloseClick={e => {
+              e?.stopPropagation()
+              setShowRobotOutOfStorageNotification(false)
+            }}
           />
         ) : null}
         <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>

--- a/app/src/organisms/Desktop/Devices/RobotOutOfStorageModal.tsx/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOutOfStorageModal.tsx/index.tsx
@@ -11,7 +11,7 @@ import {
 
 import styles from './robotoutofstoragemodal.module.css'
 
-import type React from 'react'
+import type { ReactNode } from 'react'
 
 interface RobotOutOfStorageModalProps {
   onConfirm: () => void
@@ -20,7 +20,7 @@ interface RobotOutOfStorageModalProps {
 
 export function RobotOutOfStorageModal(
   props: RobotOutOfStorageModalProps
-): React.ReactNode {
+): ReactNode {
   const { onConfirm, onClose } = props
   const { t } = useTranslation('device_details')
   return (

--- a/app/src/organisms/Desktop/Devices/RobotOutOfStorageModal.tsx/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOutOfStorageModal.tsx/index.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next'
+
+import {
+  COLORS,
+  Icon,
+  Modal,
+  PrimaryButton,
+  SecondaryButton,
+  StyledText,
+} from '@opentrons/components'
+
+import styles from './robotoutofstoragemodal.module.css'
+
+import type React from 'react'
+
+interface RobotOutOfStorageModalProps {
+  onConfirm: () => void
+  onClose: () => void
+}
+
+export function RobotOutOfStorageModal(
+  props: RobotOutOfStorageModalProps
+): React.ReactNode {
+  const { onConfirm, onClose } = props
+  const { t } = useTranslation('device_details')
+  return (
+    <Modal
+      type="warning"
+      title={t('robot_storage_almost_full')}
+      onClose={onClose}
+      footer={
+        <div className={styles.footer}>
+          <SecondaryButton onClick={onClose}>{t('cancel')}</SecondaryButton>
+          <PrimaryButton onClick={onConfirm}>{t('manage_files')}</PrimaryButton>
+        </div>
+      }
+    >
+      <div className={styles.modal_content}>
+        <Icon size="2.5rem" name="ot-alert" color={COLORS.yellow50} />
+        <div className={styles.text_container}>
+          <StyledText desktopStyle="headingSmallBold">
+            {t('file_storage_full')}
+          </StyledText>
+          <StyledText desktopStyle="bodyDefaultRegular" color={COLORS.grey60}>
+            {t('delete_to_run')}
+          </StyledText>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/app/src/organisms/Desktop/Devices/RobotOutOfStorageModal.tsx/robotoutofstoragemodal.module.css
+++ b/app/src/organisms/Desktop/Devices/RobotOutOfStorageModal.tsx/robotoutofstoragemodal.module.css
@@ -1,0 +1,22 @@
+.footer {
+  display: flex;
+  padding: 0 var(--spacing-24) var(--spacing-24);
+  gap: var(--spacing-8);
+  justify-content: flex-end;
+}
+
+.modal_content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-24);
+  padding: var(--spacing-40);
+  align-items: center;
+}
+
+.text_container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-8);
+  align-items: center;
+  text-align: center;
+}

--- a/app/src/organisms/Desktop/Devices/RobotOutOfStorageModal.tsx/robotoutofstoragemodal.module.css
+++ b/app/src/organisms/Desktop/Devices/RobotOutOfStorageModal.tsx/robotoutofstoragemodal.module.css
@@ -1,22 +1,22 @@
 .footer {
   display: flex;
+  justify-content: flex-end;
   padding: 0 var(--spacing-24) var(--spacing-24);
   gap: var(--spacing-8);
-  justify-content: flex-end;
 }
 
 .modal_content {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-24);
-  padding: var(--spacing-40);
   align-items: center;
+  padding: var(--spacing-40);
+  gap: var(--spacing-24);
 }
 
 .text_container {
   display: flex;
   flex-direction: column;
-  gap: var(--spacing-8);
   align-items: center;
+  gap: var(--spacing-8);
   text-align: center;
 }

--- a/app/src/organisms/Desktop/Devices/RobotOutOfStorageNotification/__tests__/RobotOutOfStorageNotification.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOutOfStorageNotification/__tests__/RobotOutOfStorageNotification.test.tsx
@@ -29,7 +29,11 @@ describe('RobotOutOfStorageNotification', () => {
   })
   it('renders body text', () => {
     render()
+<<<<<<< Updated upstream
     screen.getByText('Robot storage is almost full')
+=======
+    screen.getByText('Robot’s file storage is full')
+>>>>>>> Stashed changes
     screen.getByText(
       'Download and delete old protocol run records and associated files to free up space before starting a run.'
     )

--- a/app/src/organisms/Desktop/Devices/RobotOutOfStorageNotification/__tests__/RobotOutOfStorageNotification.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOutOfStorageNotification/__tests__/RobotOutOfStorageNotification.test.tsx
@@ -29,11 +29,7 @@ describe('RobotOutOfStorageNotification', () => {
   })
   it('renders body text', () => {
     render()
-<<<<<<< Updated upstream
-    screen.getByText('Robot storage is almost full')
-=======
     screen.getByText('Robot’s file storage is full')
->>>>>>> Stashed changes
     screen.getByText(
       'Download and delete old protocol run records and associated files to free up space before starting a run.'
     )

--- a/app/src/organisms/Desktop/Devices/RobotOutOfStorageNotification/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOutOfStorageNotification/index.tsx
@@ -5,42 +5,26 @@ import { InlineNotification } from '@opentrons/components'
 
 interface RobotOutOfStorageNotificationProps {
   robotName: string
-<<<<<<< Updated upstream
-=======
   onCloseClick?: (e?: MouseEvent) => void
->>>>>>> Stashed changes
 }
 
 export function RobotOutOfStorageNotification(
   props: RobotOutOfStorageNotificationProps
 ): JSX.Element {
-<<<<<<< Updated upstream
-  const { robotName } = props
-=======
   const { robotName, onCloseClick } = props
->>>>>>> Stashed changes
   const { t } = useTranslation('device_details')
   const navigate = useNavigate()
 
   return (
     <InlineNotification
-<<<<<<< Updated upstream
       type="error"
       heading={t('robot_storage_almost_full')}
       message={t('downlad_and_delete_to_run')}
       linkText={t('manage_files')}
       onLinkClick={() => {
-=======
-      type="alert"
-      heading={t('robot_storage_almost_full')}
-      message={t('downlad_and_delete_to_run')}
-      linkText={t('manage_files')}
-      onCloseClick={onCloseClick}
-      onLinkClick={e => {
-        e.stopPropagation()
->>>>>>> Stashed changes
         navigate(`/devices/${robotName}/robot-settings/file-manager`)
       }}
+      onCloseClick={onCloseClick}
     />
   )
 }

--- a/app/src/organisms/Desktop/Devices/RobotOutOfStorageNotification/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOutOfStorageNotification/index.tsx
@@ -5,22 +5,40 @@ import { InlineNotification } from '@opentrons/components'
 
 interface RobotOutOfStorageNotificationProps {
   robotName: string
+<<<<<<< Updated upstream
+=======
+  onCloseClick?: (e?: MouseEvent) => void
+>>>>>>> Stashed changes
 }
 
 export function RobotOutOfStorageNotification(
   props: RobotOutOfStorageNotificationProps
 ): JSX.Element {
+<<<<<<< Updated upstream
   const { robotName } = props
+=======
+  const { robotName, onCloseClick } = props
+>>>>>>> Stashed changes
   const { t } = useTranslation('device_details')
   const navigate = useNavigate()
 
   return (
     <InlineNotification
+<<<<<<< Updated upstream
       type="error"
       heading={t('robot_storage_almost_full')}
       message={t('downlad_and_delete_to_run')}
       linkText={t('manage_files')}
       onLinkClick={() => {
+=======
+      type="alert"
+      heading={t('robot_storage_almost_full')}
+      message={t('downlad_and_delete_to_run')}
+      linkText={t('manage_files')}
+      onCloseClick={onCloseClick}
+      onLinkClick={e => {
+        e.stopPropagation()
+>>>>>>> Stashed changes
         navigate(`/devices/${robotName}/robot-settings/file-manager`)
       }}
     />

--- a/app/src/organisms/Desktop/Devices/RobotOutOfStorageNotification/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOutOfStorageNotification/index.tsx
@@ -17,7 +17,7 @@ export function RobotOutOfStorageNotification(
 
   return (
     <InlineNotification
-      type="error"
+      type="alert"
       heading={t('robot_storage_almost_full')}
       message={t('downlad_and_delete_to_run')}
       linkText={t('manage_files')}

--- a/app/src/organisms/Desktop/Devices/RobotOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOverflowMenu.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { css } from 'styled-components'
 
 import {
@@ -28,9 +28,11 @@ import { ChooseProtocolSlideout } from '/app/organisms/Desktop/ChooseProtocolSli
 import { useIsRobotBusy } from '/app/redux-resources/robots'
 import { CONNECTABLE, removeRobot } from '/app/redux/discovery'
 import { useIsRobotOnWrongVersionOfSoftware } from '/app/redux/robot-update'
+import { useIsRobotOutOfStorage } from '/app/resources/devices'
 import { useCurrentRunId } from '/app/resources/runs'
 
 import { ConnectionTroubleshootingModal } from './ConnectionTroubleshootingModal'
+import { RobotOutOfStorageModal } from './RobotOutOfStorageModal.tsx'
 
 import type { MouseEvent, MouseEventHandler, ReactNode } from 'react'
 import type { StyleProps } from '@opentrons/components'
@@ -66,10 +68,19 @@ export function RobotOverflowMenu(props: RobotOverflowMenuProps): JSX.Element {
 
   const isRobotBusy = useIsRobotBusy({ poll: true })
 
+  const isRobotOutOfStorage = useIsRobotOutOfStorage()
+  const [showRobotOutOfStorageModal, setShowRobotOutOfStorageModal] =
+    useState<boolean>(false)
+  const navigate = useNavigate()
+
   const handleClickRun: MouseEventHandler<HTMLButtonElement> = e => {
-    e.preventDefault()
-    e.stopPropagation()
-    setShowChooseProtocolSlideout(true)
+    if (isRobotOutOfStorage) {
+      setShowRobotOutOfStorageModal(true)
+    } else {
+      e.preventDefault()
+      e.stopPropagation()
+      setShowChooseProtocolSlideout(true)
+    }
     setShowOverflowMenu(false)
   }
   const handleClickConnectionTroubleshooting: MouseEventHandler<
@@ -155,57 +166,73 @@ export function RobotOverflowMenu(props: RobotOverflowMenuProps): JSX.Element {
     )
   }
   return (
-    <Flex
-      data-testid={`RobotCard_${String(robot.name)}_overflowMenu`}
-      flexDirection={DIRECTION_COLUMN}
-      position={POSITION_RELATIVE}
-      onClick={(e: MouseEvent) => {
-        e.stopPropagation()
-      }}
-      {...styleProps}
-    >
-      <OverflowBtn
-        alignSelf={ALIGN_FLEX_END}
-        aria-label="RobotOverflowMenu_button"
-        onClick={handleOverflowClick}
-      />
-      {showOverflowMenu && !showConnectionTroubleshootingModal ? (
-        <Flex
-          whiteSpace={NO_WRAP}
-          zIndex={10}
-          borderRadius={BORDERS.borderRadius8}
-          boxShadow="0px 1px 3px rgba(0, 0, 0, 0.2)"
-          position={POSITION_ABSOLUTE}
-          backgroundColor={COLORS.white}
-          top="2.25rem"
-          right="0"
-          flexDirection={DIRECTION_COLUMN}
-        >
-          {menuItems}
-        </Flex>
-      ) : null}
-      {showChooseProtocolSlideout && robot.status === CONNECTABLE ? (
-        <ChooseProtocolSlideout
-          robot={robot}
-          showSlideout={showChooseProtocolSlideout}
-          onCloseClick={() => {
-            setShowChooseProtocolSlideout(false)
-          }}
-        />
-      ) : null}
-      {createPortal(
-        <>
-          {showOverflowMenu && menuOverlay}
-          {showConnectionTroubleshootingModal ? (
-            <ConnectionTroubleshootingModal
-              onClose={() => {
-                setShowConnectionTroubleshootingModal(false)
+    <>
+      {showRobotOutOfStorageModal
+        ? createPortal(
+            <RobotOutOfStorageModal
+              onConfirm={() => {
+                navigate(`/devices/${robot.name}/robot-settings/file-manager`)
               }}
-            />
-          ) : null}
-        </>,
-        getTopPortalEl()
-      )}
-    </Flex>
+              onClose={() => {
+                setShowRobotOutOfStorageModal(false)
+              }}
+            />,
+            getTopPortalEl()
+          )
+        : null}
+
+      <Flex
+        data-testid={`RobotCard_${String(robot.name)}_overflowMenu`}
+        flexDirection={DIRECTION_COLUMN}
+        position={POSITION_RELATIVE}
+        onClick={(e: MouseEvent) => {
+          e.stopPropagation()
+        }}
+        {...styleProps}
+      >
+        <OverflowBtn
+          alignSelf={ALIGN_FLEX_END}
+          aria-label="RobotOverflowMenu_button"
+          onClick={handleOverflowClick}
+        />
+        {showOverflowMenu && !showConnectionTroubleshootingModal ? (
+          <Flex
+            whiteSpace={NO_WRAP}
+            zIndex={10}
+            borderRadius={BORDERS.borderRadius8}
+            boxShadow="0px 1px 3px rgba(0, 0, 0, 0.2)"
+            position={POSITION_ABSOLUTE}
+            backgroundColor={COLORS.white}
+            top="2.25rem"
+            right="0"
+            flexDirection={DIRECTION_COLUMN}
+          >
+            {menuItems}
+          </Flex>
+        ) : null}
+        {showChooseProtocolSlideout && robot.status === CONNECTABLE ? (
+          <ChooseProtocolSlideout
+            robot={robot}
+            showSlideout={showChooseProtocolSlideout}
+            onCloseClick={() => {
+              setShowChooseProtocolSlideout(false)
+            }}
+          />
+        ) : null}
+        {createPortal(
+          <>
+            {showOverflowMenu && menuOverlay}
+            {showConnectionTroubleshootingModal ? (
+              <ConnectionTroubleshootingModal
+                onClose={() => {
+                  setShowConnectionTroubleshootingModal(false)
+                }}
+              />
+            ) : null}
+          </>,
+          getTopPortalEl()
+        )}
+      </Flex>
+    </>
   )
 }

--- a/app/src/organisms/Desktop/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOverview.tsx
@@ -26,7 +26,15 @@ import {
   useRobot,
 } from '/app/redux-resources/robots'
 import { CONNECTABLE, getRobotModelByName } from '/app/redux/discovery'
+<<<<<<< Updated upstream
 import { useIsRobotOutOfMemory, useLights } from '/app/resources/devices'
+=======
+<<<<<<< Updated upstream
+import { useLights } from '/app/resources/devices'
+=======
+import { useIsRobotOutOfStorage, useLights } from '/app/resources/devices'
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
 
 import { UpdateRobotBanner } from '../UpdateRobotBanner'
 import { CalibrationStatusBanner } from './CalibrationStatusBanner'
@@ -68,8 +76,16 @@ export function RobotOverview({
 
   useUSBRegistration(robot)
 
+<<<<<<< Updated upstream
   const isRobotOutOfMemory = useIsRobotOutOfMemory()
 
+=======
+<<<<<<< Updated upstream
+=======
+  const isRobotOutOfStorage = useIsRobotOutOfStorage()
+
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
   return robot != null ? (
     <>
       <Flex
@@ -108,9 +124,18 @@ export function RobotOverview({
                 marginBottom={SPACING.spacing8}
               />
             ) : null}
+<<<<<<< Updated upstream
             {isRobotOutOfMemory ? (
               <RobotOutOfStorageNotification robotName={robotName} />
             ) : null}
+=======
+<<<<<<< Updated upstream
+=======
+            {isRobotOutOfStorage ? (
+              <RobotOutOfStorageNotification robotName={robotName} />
+            ) : null}
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>
               <RobotStatusHeader
                 name={robot.name}

--- a/app/src/organisms/Desktop/Devices/RobotOverview.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOverview.tsx
@@ -26,15 +26,7 @@ import {
   useRobot,
 } from '/app/redux-resources/robots'
 import { CONNECTABLE, getRobotModelByName } from '/app/redux/discovery'
-<<<<<<< Updated upstream
-import { useIsRobotOutOfMemory, useLights } from '/app/resources/devices'
-=======
-<<<<<<< Updated upstream
-import { useLights } from '/app/resources/devices'
-=======
 import { useIsRobotOutOfStorage, useLights } from '/app/resources/devices'
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 
 import { UpdateRobotBanner } from '../UpdateRobotBanner'
 import { CalibrationStatusBanner } from './CalibrationStatusBanner'
@@ -76,16 +68,8 @@ export function RobotOverview({
 
   useUSBRegistration(robot)
 
-<<<<<<< Updated upstream
-  const isRobotOutOfMemory = useIsRobotOutOfMemory()
-
-=======
-<<<<<<< Updated upstream
-=======
   const isRobotOutOfStorage = useIsRobotOutOfStorage()
 
->>>>>>> Stashed changes
->>>>>>> Stashed changes
   return robot != null ? (
     <>
       <Flex
@@ -124,18 +108,9 @@ export function RobotOverview({
                 marginBottom={SPACING.spacing8}
               />
             ) : null}
-<<<<<<< Updated upstream
-            {isRobotOutOfMemory ? (
-              <RobotOutOfStorageNotification robotName={robotName} />
-            ) : null}
-=======
-<<<<<<< Updated upstream
-=======
             {isRobotOutOfStorage ? (
               <RobotOutOfStorageNotification robotName={robotName} />
             ) : null}
->>>>>>> Stashed changes
->>>>>>> Stashed changes
             <Flex flexDirection={DIRECTION_COLUMN} gridGap={SPACING.spacing16}>
               <RobotStatusHeader
                 name={robot.name}

--- a/app/src/organisms/Desktop/Devices/RobotOverviewOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOverviewOverflowMenu.tsx
@@ -139,7 +139,7 @@ export const RobotOverviewOverflowMenu = (
                 navigate(`/devices/${robot.name}/robot-settings/file-manager`)
               }}
               onClose={() => {
-                setShowChooseProtocolSlideout(false)
+                setShowRobotOutOfStorageModal(false)
               }}
             />,
             getTopPortalEl()

--- a/app/src/organisms/Desktop/Devices/RobotOverviewOverflowMenu.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotOverviewOverflowMenu.tsx
@@ -33,11 +33,13 @@ import { CONNECTABLE, REACHABLE, UNREACHABLE } from '/app/redux/discovery'
 import { restartRobot } from '/app/redux/robot-admin'
 import { useIsRobotOnWrongVersionOfSoftware } from '/app/redux/robot-update'
 import { checkShellUpdate } from '/app/redux/shell'
+import { useIsRobotOutOfStorage } from '/app/resources/devices'
 import { useFullShutdownMutation } from '/app/resources/devices/hooks/useFullShutdownMutation'
 import { useIsEstopNotDisengaged } from '/app/resources/devices/hooks/useIsEstopNotDisengaged'
 import { useCanDisconnect } from '/app/resources/networking/hooks'
 import { useCurrentRunId } from '/app/resources/runs'
 
+import { RobotOutOfStorageModal } from './RobotOutOfStorageModal.tsx'
 import { DisconnectModal } from './RobotSettings/ConnectNetwork/DisconnectModal'
 import { handleUpdateBuildroot } from './RobotSettings/UpdateBuildroot'
 
@@ -60,7 +62,6 @@ export const RobotOverviewOverflowMenu = (
     showOverflowMenu,
     setShowOverflowMenu,
   } = useMenuHandleClickOutside()
-  const navigate = useNavigate()
   const isRobotBusy = useIsRobotBusy()
   const runId = useCurrentRunId()
   const [targetProps, tooltipProps] = useHoverTooltip()
@@ -80,6 +81,11 @@ export const RobotOverviewOverflowMenu = (
       }
     },
   })
+
+  const isRobotOutOfStorage = useIsRobotOutOfStorage()
+  const [showRobotOutOfStorageModal, setShowRobotOutOfStorageModal] =
+    useState<boolean>(false)
+  const navigate = useNavigate()
 
   const handleClickRestart: MouseEventHandler<HTMLButtonElement> = () => {
     dispatch(restartRobot(robot.name))
@@ -108,6 +114,10 @@ export const RobotOverviewOverflowMenu = (
   })
 
   const handleClickRun: MouseEventHandler<HTMLButtonElement> = () => {
+    if (isRobotOutOfStorage) {
+      setShowRobotOutOfStorageModal(true)
+      return
+    }
     setShowChooseProtocolSlideout(true)
   }
 
@@ -122,6 +132,19 @@ export const RobotOverviewOverflowMenu = (
 
   return (
     <Flex data-testid="RobotOverview_overflowMenu" position={POSITION_RELATIVE}>
+      {showRobotOutOfStorageModal
+        ? createPortal(
+            <RobotOutOfStorageModal
+              onConfirm={() => {
+                navigate(`/devices/${robot.name}/robot-settings/file-manager`)
+              }}
+              onClose={() => {
+                setShowChooseProtocolSlideout(false)
+              }}
+            />,
+            getTopPortalEl()
+          )
+        : null}
       {showDisconnectModal
         ? createPortal(
             <DisconnectModal

--- a/app/src/resources/devices/hooks/__tests__/useIsRobotOutOfStorage.test.ts
+++ b/app/src/resources/devices/hooks/__tests__/useIsRobotOutOfStorage.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, vi } from 'vitest'
+
+import { useAccessControlEnabledQuery } from '@opentrons/react-api-client'
+
+import { useIsRobotOutOfStorage } from '../useIsRobotOutOfStorage'
+
+vi.mock('@opentrons/react-api-client')
+
+describe('useIsRobotOutOfStorage', () => {
+  it('returns false if robot is not in access control mode', () => {
+    vi.mocked(useAccessControlEnabledQuery).mockReturnValue({
+      data: { data: { accessControlEnabled: false } },
+    } as any)
+  })
+})

--- a/app/src/resources/devices/hooks/__tests__/useIsRobotOutOfStorage.test.ts
+++ b/app/src/resources/devices/hooks/__tests__/useIsRobotOutOfStorage.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
 
-import { useAccessControlEnabledQuery } from '@opentrons/react-api-client'
+import {
+  useAccessControlEnabledQuery,
+  useHealth,
+} from '@opentrons/react-api-client'
 
 import { useIsRobotOutOfStorage } from '../useIsRobotOutOfStorage'
 
@@ -11,5 +15,41 @@ describe('useIsRobotOutOfStorage', () => {
     vi.mocked(useAccessControlEnabledQuery).mockReturnValue({
       data: { data: { accessControlEnabled: false } },
     } as any)
+    vi.mocked(useHealth).mockReturnValue(undefined)
+    const { result } = renderHook(useIsRobotOutOfStorage)
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false if robot is in access control mode but storage space remains', () => {
+    vi.mocked(useAccessControlEnabledQuery).mockReturnValue({
+      data: { data: { accessControlEnabled: true } },
+    } as any)
+    vi.mocked(useHealth).mockReturnValue({
+      disk_details: { systemTotalMb: 100, systemAvailableMb: 90 },
+    } as any)
+    const { result } = renderHook(useIsRobotOutOfStorage)
+    expect(result.current).toBe(false)
+  })
+
+  it('returns true if robot is in access control mode and used space is greater than limit', () => {
+    vi.mocked(useAccessControlEnabledQuery).mockReturnValue({
+      data: { data: { accessControlEnabled: true } },
+    } as any)
+    vi.mocked(useHealth).mockReturnValue({
+      disk_details: { systemTotalMb: 100, systemAvailableMb: 5 },
+    } as any)
+    const { result } = renderHook(useIsRobotOutOfStorage)
+    expect(result.current).toBe(true)
+  })
+
+  it('returns true if robot is in access control mode and used space equals limit', () => {
+    vi.mocked(useAccessControlEnabledQuery).mockReturnValue({
+      data: { data: { accessControlEnabled: true } },
+    } as any)
+    vi.mocked(useHealth).mockReturnValue({
+      disk_details: { systemTotalMb: 100, systemAvailableMb: 10 },
+    } as any)
+    const { result } = renderHook(useIsRobotOutOfStorage)
+    expect(result.current).toBe(true)
   })
 })

--- a/app/src/resources/devices/hooks/index.ts
+++ b/app/src/resources/devices/hooks/index.ts
@@ -5,5 +5,12 @@ export * from './useDownloadSelectedRuns'
 export * from './useDownloadRobotLogs'
 export * from './useFullShutdownMutation'
 export * from './useIsEstopNotDisengaged'
+<<<<<<< Updated upstream
 export * from './useIsRobotOutOfMemory'
+=======
+<<<<<<< Updated upstream
+=======
+export * from './useIsRobotOutOfStorage'
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
 export * from './useLights'

--- a/app/src/resources/devices/hooks/index.ts
+++ b/app/src/resources/devices/hooks/index.ts
@@ -5,12 +5,5 @@ export * from './useDownloadSelectedRuns'
 export * from './useDownloadRobotLogs'
 export * from './useFullShutdownMutation'
 export * from './useIsEstopNotDisengaged'
-<<<<<<< Updated upstream
-export * from './useIsRobotOutOfMemory'
-=======
-<<<<<<< Updated upstream
-=======
 export * from './useIsRobotOutOfStorage'
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 export * from './useLights'

--- a/app/src/resources/devices/hooks/useIsRobotOutOfStorage.ts
+++ b/app/src/resources/devices/hooks/useIsRobotOutOfStorage.ts
@@ -1,0 +1,23 @@
+import {
+  useAccessControlEnabledQuery,
+  useHealth,
+} from '@opentrons/react-api-client'
+
+// subject to change
+const MAX_STORAGE_PERCENTAGE = 90
+
+export function useIsRobotOutOfStorage(): boolean {
+  const health = useHealth()
+  const { data } = useAccessControlEnabledQuery()
+  if (data?.data.accessControlEnabled !== true) {
+    return false
+  }
+
+  const totalMb = health?.disk_details?.systemTotalMb
+  const availableMb = health?.disk_details?.systemAvailableMb
+  if (totalMb == null || availableMb == null) {
+    return false
+  }
+  const percentUsed = ((totalMb - availableMb) / totalMb) * 100
+  return percentUsed >= MAX_STORAGE_PERCENTAGE
+}


### PR DESCRIPTION
# Overview

This PR creates and wires up a new Desktop modal for informing the user that the robot is out of storage, and cannot initiate a run. Also edits the style for the notification analog for this logc, and wires up the notification in RobotCard in the devices landing page.

Closes EXEC-2815


https://github.com/user-attachments/assets/c914eaf6-5102-42f4-b336-9479d5c7085b

## Test Plan and Hands on Testing

To mock robot full storage, you can early `return true` in `useIsRobotOutOfStorage`. 

#### Devices landing
- Find a CRS-enabled robot, and verify that the notification renders on the robot card. Verify that it is dismissible, and clicking "Manage files" directs you to the robot's file manager
- On the robot card's overflow menu, click Run a protocol and verify new out of storage modal shows

#### Robot overview
- On a CRS-enabled robot's overview page, open the overflow menu, and select "Run a protocol"
- Verify new out of storage modal shows

#### Run history
- On a CRS-enabled robot's overview page's run history, select the overflow menu for any recent run
- Select "Rerun protocol now" and verify that modal shows

#### Run screen
- On a CRS-enabled robot's overview page's run history, select the overflow menu for any recent run
- Select "Run again" and verify that the modal shows

#### Choose Robot Slideout
- From protocols landing, select any protocol's overflow > "Start setup"
- Click the CRS-enabled robot and call to action button, and verify that the modal shows


## Changelog

- create new modal for showing robot out of storage
- block users trying to run on a full robot using this modal
- make design updates to notification analog and wire up in ``RobotCard`
- use consistent nomenclature (`storage` over `memory`)

## Review requests

See test plan. Did I correctly audit all the possible locations for initiating a run from the Desktop app?

## Risk assessment

lowish