### PR TITLE
fix(server-utils): handle endpoint errors in audit

### DIFF
--- a/server-utils/server_utils/audit/audit_server.py
+++ b/server-utils/server_utils/audit/audit_server.py
@@ -66,8 +66,10 @@ class LocalHTTPClient(Client):
                 # https://github.com/aio-libs/aiohttp/issues/11324.
                 base_url="http://localhost",
             )
+            _log.info(f"Built audit client to connect to socket at {audit_server_uds}")
         elif audit_server_url is not None:
             session = aiohttp.ClientSession(base_url=audit_server_url)
+            _log.info(f"Built audit client to connect to url at {audit_server_url}")
         else:
             raise ValueError("Specify audit_server_uds or audit_server_url.")
 

--- a/server-utils/server_utils/audit/fastapi.py
+++ b/server-utils/server_utils/audit/fastapi.py
@@ -90,7 +90,13 @@ async def _do_call(
     request: Request, call_next: Callable[[Request], Awaitable[Response]]
 ) -> tuple[Response, None] | tuple[None, BaseException]:
     try:
-        return (await call_next(request)), None
+        response = await call_next(request)
+        if None is response:
+            _log.error(f"Endpoint function returned {response} but did not raise")
+            raise RuntimeError(
+                f"Endpoint function for {request.method} {request.url.path} did not response"
+            )
+        return response, None
     except BaseException as exc:
         return None, exc
 
@@ -171,16 +177,19 @@ async def audit_logger_middleware(
     await _handle_autolog(audit_logger, request, response)
 
     try:
-        _log.debug("Sending audit log")
+        _log.info("Sending audit log")
         await audit_logger.log()
     except BaseException as audit_exc:
+        _log.exception("Failure in audit logging")
         if cached_exc:
             raise BaseExceptionGroup(
                 "Failure in route and failure in audit log", [cached_exc, audit_exc]
             )
         else:
             raise
-    assert response is not None, "Unexpected lack of response in logging"
+    if cached_exc:
+        raise cached_exc
+    assert response is not None, "Unexpected lack of response in audit logging"
     return response
 
 

--- a/server-utils/server_utils/audit/fastapi.py
+++ b/server-utils/server_utils/audit/fastapi.py
@@ -94,7 +94,7 @@ async def _do_call(
         if None is response:
             _log.error(f"Endpoint function returned {response} but did not raise")
             raise RuntimeError(
-                f"Endpoint function for {request.method} {request.url.path} did not response"
+                f"Endpoint function for {request.method} {request.url.path} did not return response"
             )
         return response, None
     except BaseException as exc:


### PR DESCRIPTION
# Overview

In the audit middleware, we have this nice thing to catch exceptions from endpoint functions, send audit logs around them, and then reraise them. We very carefully reraise cached exceptions if we ourselves have a problem. But we forget to raise the exception in the middleware happy path, oops.

## Test Plan and Hands on Testing

- [x] an endpoint that raises an error should just raise its own error

