### PR TITLE
feat(system-server): log to the audit server

### DIFF
--- a/robot-server/robot_server/service/legacy/routers/settings.py
+++ b/robot-server/robot_server/service/legacy/routers/settings.py
@@ -44,6 +44,7 @@ from server_utils.fastapi_utils.app_state import (
     AppState,
     get_app_state,
 )
+from server_utils.fastapi_utils.documented_interaction import get_supplied_user_notes
 from server_utils.persistence.persistence_directory import PersistenceResetter
 
 from robot_server.deck_configuration.fastapi_dependencies import (
@@ -91,13 +92,15 @@ log = logging.getLogger(__name__)
 router = APIRouter()
 
 
-async def _set_oem_mode_request(enable: bool, authorization_header: str | None) -> int:
+async def _set_oem_mode_request(
+    enable: bool, authorization_header: str | None, user_notes_header: str | None
+) -> int:
     """PUT request to set the OEM Mode for the system server."""
-    headers = (
-        {"Authorization": authorization_header}
-        if authorization_header is not None
-        else None
-    )
+    headers: dict[str, str] = {}
+    if authorization_header is not None:
+        headers["Authorization"] = authorization_header
+    if user_notes_header is not None:
+        headers["Opentrons-User-Notes"] = user_notes_header
 
     async with aiohttp.ClientSession() as session:
         async with session.put(
@@ -151,6 +154,7 @@ async def post_settings(
     hardware: Annotated[HardwareControlAPI, Depends(get_hardware)],
     app_state: Annotated[AppState, Depends(get_app_state)],
     robot_type: Annotated[RobotTypeEnum, Depends(get_robot_type_enum)],
+    user_notes: Annotated[str | None, Depends(get_supplied_user_notes)],
     authorization: Annotated[str | None, Header()] = None,
 ) -> AdvancedSettingsResponse:
     """Update advanced setting (feature flag)"""
@@ -162,8 +166,9 @@ async def post_settings(
                 # `None`/`null` to restore to default. Storing `False` instead is close
                 # enough.
                 update.value if update.value is not None else False,
-                # Forward along the client's authorization, if it has authorization.
+                # Forward along the client's authorization and reason, if it has them
                 authorization_header=authorization,
+                user_notes_header=user_notes,
             )
             if resp != 200:
                 # TODO: raise correct error here

--- a/system-server/system_server/app_setup.py
+++ b/system-server/system_server/app_setup.py
@@ -8,6 +8,11 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_redoc_html
 from fastapi.responses import HTMLResponse
 
+from server_utils.audit.fastapi import (
+    audit_logger_middleware,
+    build_audit_client,
+    install_audit_client,
+)
 from server_utils.auth.resource_server.fastapi import (
     AuthorizationError,
     build_authentication_checker,
@@ -35,6 +40,13 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             )
         )
         install_authentication_checker(app.state, authentication_checker)
+        audit_client = await exit_stack.enter_async_context(
+            build_audit_client(
+                audit_server_uds=settings.audit_server_uds,
+                audit_server_url=settings.audit_server_url,
+            )
+        )
+        install_audit_client(app.state, audit_client)
 
         # Start serving requests.
         yield
@@ -60,7 +72,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
+app.middleware("http")(audit_logger_middleware)
 app.middleware("http")(server_timing_middleware())
 
 app.exception_handler(AuthorizationError)(handle_authorization_error)

--- a/system-server/system_server/settings/settings.py
+++ b/system-server/system_server/settings/settings.py
@@ -62,3 +62,21 @@ class SystemServerSettings(BaseSettings):
             ),
         ),
     ] = None
+
+    audit_server_uds: str | None = Field(
+        default=None,
+        description=(
+            "The path to the Unix domain socket where audit-server is listening."
+            " This is mutually exclusive with audit_server_url."
+            " If both are unset, access control is not enforced."
+        ),
+    )
+
+    audit_server_url: str | None = Field(
+        default=None,
+        description=(
+            "The base URL (e.g. `http://localhost:1234`) where audit-server is listening."
+            " This is mutually exclusive with audit_server_uds."
+            " If both are unset, access control is not enforced."
+        ),
+    )

--- a/system-server/system_server/system/authorize/router.py
+++ b/system-server/system_server/system/authorize/router.py
@@ -6,6 +6,8 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query, Response, status
 
+from server_utils.audit.fastapi import skip_audit_logger
+
 from .authorization import authorize_token
 from .models import PostAuthorizeResponse
 from system_server.connection import AuthorizationTracker
@@ -25,8 +27,7 @@ authorize_router = APIRouter()
     "/system/authorize",
     deprecated=True,
     summary="Obtain an authorization token for this session",
-    description=dedent(
-        """\
+    description=dedent("""\
         This was part of an experimental set of endpoints for authorization.
         It's kept for compatibility reasons. Do not use it in new code.
         Use the `/auth` endpoints instead.
@@ -34,11 +35,10 @@ authorize_router = APIRouter()
         Given a valid registration token from `/system/register`,
         this returns a new authorization token, which is not used for anything.
         It also adds an entry to `/system/connected`.
-        """
-    ),
+        """),
     response_model=PostAuthorizeResponse,
     status_code=status.HTTP_201_CREATED,
-    dependencies=[Depends(check_registration_token_header)],
+    dependencies=[Depends(check_registration_token_header), Depends(skip_audit_logger)],
 )
 async def authorize(
     token: Annotated[str, Depends(get_registration_token_header)],

--- a/system-server/system_server/system/connected/router.py
+++ b/system-server/system_server/system/connected/router.py
@@ -16,16 +16,14 @@ connected_router = APIRouter()
     "/system/connected",
     deprecated=True,
     summary="Obtain a list of all active authorizations",
-    description=dedent(
-        """\
+    description=dedent("""\
         This was part of an experimental set of endpoints for authorization.
         It's kept for compatibility reasons. Do not use it in new code.
         Use the `/auth` endpoints instead.
 
         This returns all the active (unexpired) authorizations that were created
         through `/system/authorize`.
-        """
-    ),
+        """),
     status_code=status.HTTP_200_OK,
     response_model=GetConnectedResponse,
 )

--- a/system-server/system_server/system/oem_mode/router.py
+++ b/system-server/system_server/system/oem_mode/router.py
@@ -17,6 +17,7 @@ from fastapi import (
     status,
 )
 
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
@@ -64,7 +65,10 @@ oem_mode_router = APIRouter()
             "message": "OEM Mode unhandled exception."
         },
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("alter OEM mode")),
+    ],
 )
 async def enable_oem_mode_endpoint(
     response: Response,
@@ -100,7 +104,10 @@ async def enable_oem_mode_endpoint(
             "message": "OEM Mode splash unhandled exception."
         },
     },
-    dependencies=[Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        Depends(get_audit_logger("set boot splash")),
+    ],
 )
 async def upload_splash_image(
     response: Response,

--- a/system-server/system_server/system/register/router.py
+++ b/system-server/system_server/system/register/router.py
@@ -7,6 +7,8 @@ from uuid import UUID
 import sqlalchemy
 from fastapi import APIRouter, Depends, Response, status
 
+from server_utils.audit.fastapi import skip_audit_logger
+
 from .dependencies import create_registrant
 from .models import PostRegisterResponse
 from .storage import get_or_create_registration_token
@@ -20,8 +22,7 @@ register_router = APIRouter()
     "/system/register",
     deprecated=True,
     summary="Register a client with this robot",
-    description=dedent(
-        """\
+    description=dedent("""\
         This was part of an experimental set of endpoints for authorization.
         It's kept for compatibility reasons. Do not use it in new code.
         Use the `/auth` endpoints instead.
@@ -29,12 +30,12 @@ register_router = APIRouter()
         This registers a client (basically just storing the information you pass in)
         and returns a registration token that you can pass to `/system/authorize`.
         Identical information is deduplicated, so this is safe to call multiple times.
-        """
-    ),
+        """),
     responses={
         status.HTTP_200_OK: {"model": PostRegisterResponse},
         status.HTTP_201_CREATED: {"model": PostRegisterResponse},
     },
+    dependencies=[Depends(skip_audit_logger)],
 )
 async def register_endpoint(
     response: Response,


### PR DESCRIPTION
# Overview

Integrate audit logging with the system server. The only things we actually log are the OEM mode endpoints; this annoyingly includes forwarding the user notes from the robot server along with the auth token.

## Test Plan and Hands on Testing

- [x] Run the oem mode entry endpoint and the oem mode image endpoint and check that both still work and actually do what they're supposed to

## Changelog

- Robot server forwards user note header when entering OEM mode
- system server forwards audit stuff

## Review requests

- look good?


