### PR TITLE
feat(app): provide optional min width styling for RoundTab

### DIFF
--- a/app/src/molecules/RoundTab/index.tsx
+++ b/app/src/molecules/RoundTab/index.tsx
@@ -39,9 +39,18 @@ const disabledRoundTabStyling = css`
   }
 `
 
-const RoundNavLink = styled(NavLink)`
+interface RoundNavLinkProps {
+  minWidth?: string
+}
+
+const RoundNavLink = styled(NavLink)<RoundNavLinkProps>`
   ${baseRoundTabStyling}
   color: ${COLORS.black90};
+  ${({ minWidth }) =>
+    minWidth != null &&
+    css`
+      min-width: ${minWidth};
+    `}
 
   &:hover {
     background-color: ${COLORS.purple35};
@@ -63,6 +72,7 @@ interface RoundTabProps {
   to: string
   tabName: string
   end?: boolean
+  minWidth?: string
 }
 
 export function RoundTab({
@@ -71,6 +81,7 @@ export function RoundTab({
   to,
   tabName,
   end,
+  minWidth,
 }: RoundTabProps): JSX.Element {
   const [targetProps, tooltipProps] = useHoverTooltip()
   return disabled ? (
@@ -83,7 +94,7 @@ export function RoundTab({
       ) : null}
     </>
   ) : (
-    <RoundNavLink to={to} replace end={end}>
+    <RoundNavLink to={to} replace end={end} minWidth={minWidth}>
       {tabName}
     </RoundNavLink>
   )

--- a/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
+++ b/app/src/pages/Desktop/Devices/RobotSettings/index.tsx
@@ -3,7 +3,12 @@ import { useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { Navigate, useParams } from 'react-router-dom'
 
-import { Banner, LegacyStyledText, SPACING } from '@opentrons/components'
+import {
+  Banner,
+  FLEX_MAX_CONTENT,
+  LegacyStyledText,
+  SPACING,
+} from '@opentrons/components'
 import { useAccessControlEnabledQuery } from '@opentrons/react-api-client'
 
 import { ApiHostProvider } from '/app/local-resources/api-host-provider/ApiHostProvider'
@@ -160,32 +165,38 @@ export function RobotSettingsComponent({
             to={`/devices/${robotName}/robot-settings/calibration`}
             tabName={t('calibration')}
             disabled={isCalibrationDisabled}
+            minWidth={FLEX_MAX_CONTENT}
           />
           <RoundTab
             to={`/devices/${robotName}/robot-settings/networking`}
             tabName={t('networking')}
             disabled={isNetworkingDisabled}
+            minWidth={FLEX_MAX_CONTENT}
           />
           <RoundTab
             to={`/devices/${robotName}/robot-settings/camera`}
             tabName={t('camera')}
             disabled={false}
+            minWidth={FLEX_MAX_CONTENT}
           />
           <RoundTab
             to={`/devices/${robotName}/robot-settings/file-manager`}
             tabName={t('file_manager')}
             disabled={false}
+            minWidth={FLEX_MAX_CONTENT}
           />
           <RoundTab
             to={`/devices/${robotName}/robot-settings/advanced`}
             tabName={t('advanced')}
             disabled={false}
+            minWidth={FLEX_MAX_CONTENT}
           />
           {showComplianceReadyTab ? (
             <RoundTab
               to={`/devices/${robotName}/robot-settings/compliance-ready`}
               tabName={t('compliance_ready')}
               disabled={false}
+              minWidth={FLEX_MAX_CONTENT}
             />
           ) : null}
           {devToolsOn ? (
@@ -193,6 +204,7 @@ export function RobotSettingsComponent({
               to={`/devices/${robotName}/robot-settings/feature-flags`}
               tabName={t('feature_flags')}
               disabled={false}
+              minWidth={FLEX_MAX_CONTENT}
             />
           ) : null}
         </div>

--- a/app/src/pages/Desktop/Devices/RobotSettings/robotsettings.module.css
+++ b/app/src/pages/Desktop/Devices/RobotSettings/robotsettings.module.css
@@ -30,6 +30,7 @@
 .tabs_row {
   display: flex;
   gap: var(--spacing-4);
+  overflow: scroll;
 }
 
 .content_section {

--- a/app/src/pages/Desktop/Devices/RobotSettings/robotsettings.module.css
+++ b/app/src/pages/Desktop/Devices/RobotSettings/robotsettings.module.css
@@ -29,7 +29,7 @@
 
 .tabs_row {
   display: flex;
-  overflow: scroll;
+  overflow: auto;
   gap: var(--spacing-4);
 }
 

--- a/app/src/pages/Desktop/Devices/RobotSettings/robotsettings.module.css
+++ b/app/src/pages/Desktop/Devices/RobotSettings/robotsettings.module.css
@@ -29,8 +29,8 @@
 
 .tabs_row {
   display: flex;
-  gap: var(--spacing-4);
   overflow: scroll;
+  gap: var(--spacing-4);
 }
 
 .content_section {


### PR DESCRIPTION
# Overview

Without disrupting all implementations of RoundTab, provides caller an optional minWidth override, to be used specifically in the calls at Desktop's RobotSettings. Now, settings tabs are set to not collapse to multiple lines of text, and their container is scrollable.

### Before
 
<img width="792" height="769" alt="Screenshot 2026-07-28 at 2 51 19 PM" src="https://github.com/user-attachments/assets/86838d8c-04c9-42f8-bdeb-06ce10b1f149" />

### After

https://github.com/user-attachments/assets/dd0b38ee-7436-4beb-bed9-57f7e3c9ea47


## Test Plan and Hands on Testing

- on desktop app navigate to a CRS device's settings
- verify that the round tabs for each setting expand to their content's max width, and the container for all settings tabs is horizontally scrollable

## Changelog

- add optional `minWidth` override prop in app's `RoundTab`
- set this prop from `RobotSetting`'s round tabs
- set the tabs' container overflow to `scroll`

## Review requests

see test plan

## Risk assessment

low