### PR TITLE
fix(api): Regression correction of serialization for NamedTuples

### DIFF
--- a/api/src/opentrons/drivers/flex_stacker/types.py
+++ b/api/src/opentrons/drivers/flex_stacker/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, fields
 from enum import Enum
-from typing import Dict, List, Optional, Any
+from typing import Any, Dict, List, Optional
 
 from opentrons_shared_data.util import StrEnum
 
@@ -356,14 +356,12 @@ class TOFMeasurementResult:
         }
 
     @staticmethod
-    def from_pyro_dict(
-        classname: Any, data: Dict[str, Any]
-    ) -> "TOFMeasurementResult":
+    def from_pyro_dict(classname: Any, data: Dict[str, Any]) -> "TOFMeasurementResult":
         """Consumed by Serpent, convert from a Pyro Dictionary."""
         return TOFMeasurementResult(
             sensor=TOFSensor(data["sensor"]),
             kind=MeasurementKind(data["kind"]),
-            bins=data["bins"]
+            bins=data["bins"],
         )
 
 

--- a/api/src/opentrons/drivers/flex_stacker/types.py
+++ b/api/src/opentrons/drivers/flex_stacker/types.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, fields
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 
 from opentrons_shared_data.util import StrEnum
 
@@ -344,6 +344,27 @@ class TOFMeasurementResult:
     sensor: TOFSensor
     kind: MeasurementKind
     bins: Dict[int, List[float]]
+
+    @staticmethod
+    def to_pyro_dict(obj: "TOFMeasurementResult") -> Dict[str, Any]:
+        """Consumed by Serpent, convert type to a Pyro Dictionary."""
+        return {
+            "__class__": f"{obj.__module__}.{obj.__class__.__qualname__}",
+            "sensor": obj.sensor.value,
+            "kind": obj.kind.value,
+            "bins": obj.bins,
+        }
+
+    @staticmethod
+    def from_pyro_dict(
+        classname: Any, data: Dict[str, Any]
+    ) -> "TOFMeasurementResult":
+        """Consumed by Serpent, convert from a Pyro Dictionary."""
+        return TOFMeasurementResult(
+            sensor=TOFSensor(data["sensor"]),
+            kind=MeasurementKind(data["kind"]),
+            bins=data["bins"]
+        )
 
 
 @dataclass

--- a/api/src/opentrons/hardware_control/modules/module_calibration.py
+++ b/api/src/opentrons/hardware_control/modules/module_calibration.py
@@ -38,9 +38,9 @@ class ModuleCalibrationOffset:
             modified = None
         return {
             "__class__": f"{obj.__module__}.{obj.__class__.__qualname__}",
-            "offset_x": obj.offset.x,
-            "offset_y": obj.offset.y,
-            "offset_z": obj.offset.z,
+            "offset_x": float(obj.offset.x),
+            "offset_y": float(obj.offset.y),
+            "offset_z": float(obj.offset.z),
             "module_id": obj.module_id,
             "module": obj.module.value,
             "source": obj.source.value,

--- a/api/src/opentrons/hardware_control/ot3_calibration.py
+++ b/api/src/opentrons/hardware_control/ot3_calibration.py
@@ -1139,9 +1139,9 @@ class OT3Transforms(RobotCalibration):
 
         def _point_to_dict(point: Point) -> Dict[str, float]:
             return {
-                "x": point.x,
-                "y": point.y,
-                "z": point.z,
+                "x": float(point.x),
+                "y": float(point.y),
+                "z": float(point.z),
             }
 
         transform_dict["carriage_offset"] = _point_to_dict(obj.carriage_offset)

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -28,7 +28,7 @@ import opentrons.hardware_control.types
 import opentrons.types
 from opentrons.util.pyro.pyro_serialization import (
     OpentronsPyroSerializer,
-    find_dataclasses_in_packages,
+    find_opentrons_classes_in_packages,
     find_enums_in_packages,
     find_pydantic_classes_in_packages,
     find_typed_dict_classes_in_packages,
@@ -39,8 +39,49 @@ from opentrons.util.pyro.pyro_serialization import (
 
 Pyro5.config.SERPENT_BYTES_REPR = True  # type: ignore
 
-# Type Dict registration handlers
+# Hardware package lists
 
+HARDWARE_ENUM_PACKAGES = [
+    opentrons.types,
+    opentrons.config.types,
+    opentrons.hardware_control.types,
+    opentrons.hardware_control.dev_types,
+    opentrons_shared_data.pipette.pipette_definition,
+    opentrons_shared_data.pipette.types,
+    opentrons_shared_data.errors.codes,
+    opentrons.hardware_control.peripherals.types,
+    opentrons_shared_data.gripper.gripper_definition,
+    opentrons.calibration_storage.types,
+    opentrons.drivers.types,
+    opentrons.hardware_control.modules.types,
+    opentrons.drivers.vacuum_module.types,
+]
+
+HARDWARE_PYDANTIC_PACKAGES = [
+    opentrons.types,
+    opentrons.config.types,
+    opentrons.hardware_control.types,
+    opentrons.hardware_control.protocols.types,
+    opentrons_shared_data.pipette.pipette_definition,
+    opentrons.hardware_control.nozzle_manager,
+    opentrons_shared_data.gripper.gripper_definition,
+    opentrons.calibration_storage.ot3.models.v1,
+    opentrons.hardware_control.nozzle_manager,
+]
+
+HARDWARE_CLASS_PACKAGES = [
+    opentrons.drivers.vacuum_module.types,
+    opentrons.drivers.types,
+    opentrons.hardware_control.modules.module_calibration,
+    opentrons.hardware_control.modules.types,
+    opentrons.drivers.rpi_drivers.types,
+    opentrons.hardware_control.types,
+    opentrons.types,
+    opentrons.hardware_control.ot3_calibration,
+    opentrons.hardware_control.instruments.ot3.instrument_calibration,
+]
+
+# Type Dict registration handlers
 
 def _pipetted_dict_dict_to_class(  # type: ignore
     classname, d
@@ -197,41 +238,13 @@ def register_hardware_types() -> None:
     """Registers serialize and deserialize behavior for Opentrons Hardware types and classes.
     Pyro serializes our dataclasses into dicts, but doesn't convert them back to their native types automatically.
     """
-    opentrons_types = find_enums_in_packages(
-        [
-            opentrons.types,
-            opentrons.config.types,
-            opentrons.hardware_control.types,
-            opentrons.hardware_control.dev_types,
-            opentrons_shared_data.pipette.pipette_definition,
-            opentrons_shared_data.pipette.types,
-            opentrons_shared_data.errors.codes,
-            opentrons.hardware_control.peripherals.types,
-            opentrons_shared_data.gripper.gripper_definition,
-            opentrons.calibration_storage.types,
-            opentrons.drivers.types,
-            opentrons.hardware_control.modules.types,
-            opentrons.drivers.vacuum_module.types,
-        ]
-    )
+    opentrons_types = find_enums_in_packages(HARDWARE_ENUM_PACKAGES)
 
     with serpent_enum_registration():
         for enum_type in opentrons_types:
             OpentronsPyroSerializer.register_enum(enum_type)
 
-    opentrons_pydantic_types = find_pydantic_classes_in_packages(
-        [
-            opentrons.types,
-            opentrons.config.types,
-            opentrons.hardware_control.types,
-            opentrons.hardware_control.protocols.types,
-            opentrons_shared_data.pipette.pipette_definition,
-            opentrons.hardware_control.nozzle_manager,
-            opentrons_shared_data.gripper.gripper_definition,
-            opentrons.calibration_storage.ot3.models.v1,
-            opentrons.hardware_control.nozzle_manager,
-        ]
-    )
+    opentrons_pydantic_types = find_pydantic_classes_in_packages(HARDWARE_PYDANTIC_PACKAGES)
     for pydantic_type in opentrons_pydantic_types:
         OpentronsPyroSerializer.register_pydantic_model(pydantic_type)
 
@@ -265,21 +278,9 @@ def register_hardware_types() -> None:
     )
 
     # Dataclass generic registration
-    opentrons_dataclass_types = find_dataclasses_in_packages(
-        [
-            opentrons.drivers.vacuum_module.types,
-            opentrons.drivers.types,
-            opentrons.hardware_control.modules.module_calibration,
-            opentrons.hardware_control.modules.types,
-            opentrons.drivers.rpi_drivers.types,
-            opentrons.hardware_control.types,
-            opentrons.types,
-            opentrons.hardware_control.ot3_calibration,
-            opentrons.hardware_control.instruments.ot3.instrument_calibration,
-        ]
-    )
-    for dataclass_type in opentrons_dataclass_types:
-        OpentronsPyroSerializer.register_dataclass(dataclass_type)
+    opentrons_class_types = find_opentrons_classes_in_packages(HARDWARE_CLASS_PACKAGES)
+    for class_type in opentrons_class_types:
+        OpentronsPyroSerializer.register_class(class_type)
 
     # handle Typed Dicts for the hardware controller
     OpentronsPyroSerializer.register_opentrons_typed_dicts(_typed_dict_dict_to_class)

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -28,8 +28,8 @@ import opentrons.hardware_control.types
 import opentrons.types
 from opentrons.util.pyro.pyro_serialization import (
     OpentronsPyroSerializer,
-    find_opentrons_classes_in_packages,
     find_enums_in_packages,
+    find_opentrons_classes_in_packages,
     find_pydantic_classes_in_packages,
     find_typed_dict_classes_in_packages,
     register_enumerated_errors,
@@ -79,9 +79,11 @@ HARDWARE_CLASS_PACKAGES = [
     opentrons.types,
     opentrons.hardware_control.ot3_calibration,
     opentrons.hardware_control.instruments.ot3.instrument_calibration,
+    opentrons.drivers.flex_stacker.types,
 ]
 
 # Type Dict registration handlers
+
 
 def _pipetted_dict_dict_to_class(  # type: ignore
     classname, d
@@ -244,7 +246,9 @@ def register_hardware_types() -> None:
         for enum_type in opentrons_types:
             OpentronsPyroSerializer.register_enum(enum_type)
 
-    opentrons_pydantic_types = find_pydantic_classes_in_packages(HARDWARE_PYDANTIC_PACKAGES)
+    opentrons_pydantic_types = find_pydantic_classes_in_packages(
+        HARDWARE_PYDANTIC_PACKAGES
+    )
     for pydantic_type in opentrons_pydantic_types:
         OpentronsPyroSerializer.register_pydantic_model(pydantic_type)
 

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -14,6 +14,7 @@ import opentrons_shared_data.pipette.types
 import opentrons.calibration_storage.ot3.models.v1
 import opentrons.calibration_storage.types
 import opentrons.config.types
+import opentrons.drivers.flex_stacker.types
 import opentrons.drivers.rpi_drivers.types
 import opentrons.drivers.types
 import opentrons.drivers.vacuum_module.types

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -981,6 +981,27 @@ class HardwareFeatureFlags:
             stall_detection_enabled=feature_flags.stall_detection_enabled(),
             overpressure_detection_enabled=feature_flags.overpressure_detection_enabled(),
         )
+    
+    @staticmethod
+    def to_pyro_dict(obj: "HardwareFeatureFlags") -> Dict[str, Any]:
+        """Consumed by Serpent, convert type to a Pyro Dictionary."""
+        return {
+            "__class__": f"{obj.__module__}.{obj.__class__.__qualname__}",
+            "use_old_aspiration_functions": obj.use_old_aspiration_functions,
+            "require_estop": obj.require_estop,
+            "stall_detection_enabled": obj.stall_detection_enabled,
+            "overpressure_detection_enabled": obj.overpressure_detection_enabled,
+        }
+
+    @staticmethod
+    def from_pyro_dict(classname: Any, data: Dict[str, Any]) -> "HardwareFeatureFlags":
+        """Consumed by Serpent, convert from a Pyro Dictionary."""
+        return HardwareFeatureFlags(
+            use_old_aspiration_functions=data["use_old_aspiration_functions"],
+            require_estop=data["require_estop"],
+            stall_detection_enabled=data["stall_detection_enabled"],
+            overpressure_detection_enabled=data["overpressure_detection_enabled"],
+        )
 
 
 class EarlyLiquidSenseTrigger(RuntimeError):

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -1100,7 +1100,7 @@ class PipetteSensorData:
             "__class__": f"{obj.__module__}.{obj.__class__.__qualname__}",
             "sensor_type": obj.sensor_type.value,
             "_as_int": obj._as_int,
-            "_as_float": obj._as_float,
+            "_as_float": float(obj._as_float),
         }
 
     @staticmethod

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -888,17 +888,14 @@ class StatusBarUpdateEvent:
         return {
             "__class__": f"{obj.__module__}.{obj.__class__.__qualname__}",
             "state": obj.state.value,
-            "enabled": obj.enabled
+            "enabled": obj.enabled,
         }
 
     @staticmethod
-    def from_pyro_dict(
-        classname: Any, data: Dict[str, Any]
-    ) -> "StatusBarUpdateEvent":
+    def from_pyro_dict(classname: Any, data: Dict[str, Any]) -> "StatusBarUpdateEvent":
         """Consumed by Serpent, convert from a Pyro Dictionary."""
         return StatusBarUpdateEvent(
-            state=StatusBarState(data["state"]),
-            enabled=data["enabled"]
+            state=StatusBarState(data["state"]), enabled=data["enabled"]
         )
 
 

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -882,6 +882,25 @@ class StatusBarUpdateEvent:
     state: StatusBarState
     enabled: bool
 
+    @staticmethod
+    def to_pyro_dict(obj: "StatusBarUpdateEvent") -> Dict[str, Any]:
+        """Consumed by Serpent, convert type to a Pyro Dictionary."""
+        return {
+            "__class__": f"{obj.__module__}.{obj.__class__.__qualname__}",
+            "state": obj.state.value,
+            "enabled": obj.enabled
+        }
+
+    @staticmethod
+    def from_pyro_dict(
+        classname: Any, data: Dict[str, Any]
+    ) -> "StatusBarUpdateEvent":
+        """Consumed by Serpent, convert from a Pyro Dictionary."""
+        return StatusBarUpdateEvent(
+            state=StatusBarState(data["state"]),
+            enabled=data["enabled"]
+        )
+
 
 StatusBarUpdateListener = Callable[[StatusBarUpdateEvent], None]
 StatusBarUpdateUnsubscriber = Callable[[], None]
@@ -981,7 +1000,7 @@ class HardwareFeatureFlags:
             stall_detection_enabled=feature_flags.stall_detection_enabled(),
             overpressure_detection_enabled=feature_flags.overpressure_detection_enabled(),
         )
-    
+
     @staticmethod
     def to_pyro_dict(obj: "HardwareFeatureFlags") -> Dict[str, Any]:
         """Consumed by Serpent, convert type to a Pyro Dictionary."""
@@ -1076,6 +1095,25 @@ class PipetteSensorData:
     @property
     def to_int(self) -> int:
         return self._as_int
+
+    @staticmethod
+    def to_pyro_dict(obj: "PipetteSensorData") -> Dict[str, Any]:
+        """Consumed by Serpent, convert type to a Pyro Dictionary."""
+        return {
+            "__class__": f"{obj.__module__}.{obj.__class__.__qualname__}",
+            "sensor_type": obj.sensor_type.value,
+            "_as_int": obj._as_int,
+            "_as_float": obj._as_float,
+        }
+
+    @staticmethod
+    def from_pyro_dict(classname: Any, data: Dict[str, Any]) -> "PipetteSensorData":
+        """Consumed by Serpent, convert from a Pyro Dictionary."""
+        return PipetteSensorData(
+            sensor_type=PipetteSensorType(data["sensor_type"]),
+            _as_int=data["_as_int"],
+            _as_float=data["_as_float"],
+        )
 
 
 PipetteSensorResponseQueue = Queue[Dict[PipetteSensorId, List[PipetteSensorData]]]

--- a/api/src/opentrons/types.py
+++ b/api/src/opentrons/types.py
@@ -85,9 +85,9 @@ class Point(NamedTuple):
         """Consumed by Serpent, convert type to a Pyro Dictionary."""
         return {
             "__class__": f"{obj.__module__}.{obj.__class__.__qualname__}",
-            "x": obj.x,
-            "y": obj.y,
-            "z": obj.z,
+            "x": float(obj.x),  # Types are constructed to float to avoid numpy.float64
+            "y": float(obj.y),
+            "z": float(obj.z),
         }
 
     @staticmethod

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -64,13 +64,13 @@ def find_pydantic_classes_in_packages(
     return pydantic_classes
 
 
-def find_dataclasses_in_packages(modules: list[ModuleType]) -> list[type]:
-    """Returns a list of dataclasses that contain `to_pyro_dict` and `from_pyro_dict` staticmethods in the given list of moduels."""
+def find_opentrons_classes_in_packages(modules: list[ModuleType]) -> list[type]:
+    """Returns a list of dataclasses and NamedTuples that contain `to_pyro_dict` and `from_pyro_dict` staticmethods in the given list of moduels."""
     dataclasses = []
     for module in modules:
         for name, obj in inspect.getmembers(module, inspect.isclass):
             if (
-                is_dataclass(obj)
+                (is_dataclass(obj) or _is_namedtuple_instance(obj))
                 and hasattr(obj, "to_pyro_dict")
                 and hasattr(obj, "from_pyro_dict")
             ):
@@ -151,6 +151,12 @@ def register_enumerated_errors() -> None:
         class_to_dict=enumerated_error_class_to_dict,
     )
 
+def _is_namedtuple_instance(cls: Any) -> bool:
+    """Validate if an object is a NamedTuple instance."""
+    try:
+        return issubclass(cls, tuple) and hasattr(cls, '_fields')
+    except TypeError:
+        return False
 
 class OpentronsPyroSerializer:
     """A pyro serializer for custom Opentrons classes."""
@@ -235,25 +241,25 @@ class OpentronsPyroSerializer:
         return model.model_validate(d)
 
     @classmethod
-    def register_dataclass(cls, dataclass_type: type) -> None:
-        """Registers a dataclass type to be sent and received via pyro proxies."""
-        if is_dataclass(dataclass_type):
-            if hasattr(dataclass_type, "to_pyro_dict") and hasattr(
-                dataclass_type, "from_pyro_dict"
+    def register_class(cls, class_type: type) -> None:
+        """Registers a dataclass or NamedTuple type to be sent and received via pyro proxies."""
+        if is_dataclass(class_type) or _is_namedtuple_instance(class_type):
+            if hasattr(class_type, "to_pyro_dict") and hasattr(
+                class_type, "from_pyro_dict"
             ):
                 class_name = register_type_to_serpent(
-                    class_type=dataclass_type,
-                    dict_to_class=dataclass_type.from_pyro_dict,
-                    class_to_dict=dataclass_type.to_pyro_dict,
+                    class_type=class_type,
+                    dict_to_class=class_type.from_pyro_dict,
+                    class_to_dict=class_type.to_pyro_dict,
                 )
-                cls._dataclass_class_name_to_type[class_name] = dataclass_type
+                cls._dataclass_class_name_to_type[class_name] = class_type
             else:
                 raise TypeError(
-                    f"Dataclass {dataclass_type} does not satisfy `to_pyro_dict` and `from_pyro_dict` attribute requirements."
+                    f"Class {class_type} does not satisfy `to_pyro_dict` and `from_pyro_dict` attribute requirements."
                 )
         else:
             raise TypeError(
-                f"Type {dataclass_type} is not a dataclass and could not be registered."
+                f"Type {class_type} is not a dataclass or NamedTuple and could not be registered."
             )
 
     @classmethod

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -151,12 +151,14 @@ def register_enumerated_errors() -> None:
         class_to_dict=enumerated_error_class_to_dict,
     )
 
+
 def _is_namedtuple_instance(cls: Any) -> bool:
     """Validate if an object is a NamedTuple instance."""
     try:
-        return issubclass(cls, tuple) and hasattr(cls, '_fields')
+        return issubclass(cls, tuple) and hasattr(cls, "_fields")
     except TypeError:
         return False
+
 
 class OpentronsPyroSerializer:
     """A pyro serializer for custom Opentrons classes."""

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -4,9 +4,8 @@ import asyncio
 import inspect
 import socket
 import threading
-import types
 from dataclasses import is_dataclass
-from typing import Any, Union, get_args, get_origin, get_type_hints
+from typing import Any, get_args, get_type_hints
 
 import pytest
 from decoy import Decoy
@@ -35,11 +34,15 @@ from opentrons.hardware_control.modules import (
     Thermocycler,
     VacuumModule,
 )
-from opentrons.hardware_control.modules.types import MagneticBlockModel
+from opentrons.hardware_control.modules.types import (
+    MagneticBlockModel,
+    SimulatingModule,
+)
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.poller import Poller
 from opentrons.hardware_control.pyro_utils.serpent_type_registry import (
-    register_hardware_types, HARDWARE_CLASS_PACKAGES
+    HARDWARE_CLASS_PACKAGES,
+    register_hardware_types,
 )
 from opentrons.hardware_control.types import DoorState
 from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
@@ -48,8 +51,11 @@ from opentrons.util.pyro.pyro_serialization import find_opentrons_classes_in_pac
 
 TEST_PYRO_TIMEOUT = 5
 
-# List of types to not validate, ususally these are OT-2 Types
-_TYPES_TO_SKIP = [RobotConfig]
+# List of types to not validate, always list a reason
+_TYPES_TO_SKIP = [
+    RobotConfig,  # OT-2 Only
+    SimulatingModule,  # Only used in OT3API build methods, irrelevant to clients
+]
 
 
 @pytest.fixture
@@ -224,80 +230,70 @@ async def _setup_OT3API_pyro_resource(
     return ot3_async  # type: ignore
 
 
-def _is_optional(hint: Any) -> bool:
-    origin = get_origin(hint)
-
-    if origin is Union or (hasattr(types, "UnionType") and origin is types.UnionType):
-        # Return True if type(None) is one of the allowed types in the union
-        return type(None) in get_args(hint)
-
-    return False
-
 def _is_namedtuple_instance(cls: Any) -> bool:
     try:
-        return issubclass(cls, tuple) and hasattr(cls, '_fields')
+        return issubclass(cls, tuple) and hasattr(cls, "_fields")
     except TypeError:
         return False
 
-def _test_proxy_serialization_coverage(  # noqa: C901
+
+def _collect_exposed_dataclasses_and_namedtuples(  # noqa: C901
     original_class: type, acpo_instance: Any
-) -> None:
-    """Scrape over the provided proxy to gather as much information on parameters, mock errors and serialization as possible."""
+) -> list[type]:
+    """Scrape over the provided proxy to gather as much information on exposed dataclasses and named tuples"""
+    class_list: list[type] = []
+    seen: set[int] = set()
     proxy: pyro.Proxy = acpo_instance._proxy
     proxy._pyroBind()  # type: ignore
     pyro_methods: list[str] = getattr(proxy, "get_pyro_attributes_with_proxy_result")
     pyro_methods.append("get_pyro_async_methods")
     pyro_methods.append("get_pyro_attributes_with_proxy_result")
-    # After grabing the inner proxies for all these safely wrapped results, we'll use these to troll through the metadata
 
-    def _validate_serialization_coverage(value: Any, attr: Any) -> None:
-        if value not in _TYPES_TO_SKIP:
-            # Validate that we contain a to and from, with the from returning the type expected, in a given dataclass
-            if hasattr(value, "to_pyro_dict") and hasattr(value, "from_pyro_dict"):
-                return_type = get_type_hints(value.from_pyro_dict).get("return")
-                try:
-                    assert return_type is value
-                except Exception as e:
-                    raise ValueError(
-                        f"Exception: {e} - type missmatch for 'from_pyro_dict' of attribute {attr}, expected value: {value} return value: {return_type}"
-                    )
-            elif is_dataclass(value) or _is_namedtuple_instance(value):
-                raise ValueError(
-                    f"Pyro Serialization missing for {value} of attribute call {attr} in class {original_class}."
-                )
-
-    def _inspect_value_status(value: Any, attr: Any) -> None:
-        inspectable_value = value
-        if _is_optional(value):
-            inspectable_value = get_args(value)
+    def _resolve_type_hints(obj: Any, attr_name: str) -> dict[str, Any]:
         try:
-            iter(inspectable_value)
-            is_iterable = True
-        except TypeError:
-            is_iterable = False
-        if is_iterable:
-            for item in inspectable_value:
-                if is_dataclass(item) or _is_namedtuple_instance(item):
-                    _validate_serialization_coverage(value=item, attr=attr)
-        else:
-            if is_dataclass(inspectable_value) or _is_namedtuple_instance(inspectable_value):
-                _validate_serialization_coverage(value=inspectable_value, attr=attr)
+            return get_type_hints(obj)
+        except Exception as e:
+            raise ValueError(
+                f"Could not resolve type hints for {original_class.__name__}.{attr_name}: {e}"
+            ) from e
 
-    # For each Method exposed by this pyro object, check the parameters and return values of the original class for dataclass usage
+    def _collect_serializable_types(
+        hint: Any, collected: list[type], seen: set[int]
+    ) -> None:
+        if id(hint) in seen:
+            return
+        seen.add(id(hint))
+        if (
+            isinstance(hint, type)
+            and (is_dataclass(hint) or _is_namedtuple_instance(hint))
+            and hint not in _TYPES_TO_SKIP
+        ):
+            collected.append(hint)
+        for arg in get_args(hint):
+            for inner in arg if isinstance(arg, list) else [arg]:
+                _collect_serializable_types(inner, collected, seen)
+
+    # Scrape the exposed methods
     for method in proxy._pyroMethods:
-        # Check all methods that are not decorated to expose proxies
-        if method not in pyro_methods:
-            original_class_method = getattr(original_class, method)
-            for key, value in original_class_method.__annotations__.items():
-                _inspect_value_status(value, method)
+        if not hasattr(original_class, method):
+            continue
+        original_class_method = getattr(original_class, method)
+        hints = _resolve_type_hints(original_class_method, method)
+        if method in pyro_methods:
+            hints.pop("return", None)
+        for value in hints.values():
+            _collect_serializable_types(value, class_list, seen)
 
+    # Scrape the exposed properties
     for attribute in proxy._pyroAttrs:
-        if attribute not in pyro_methods:
-            original_class_attribute = getattr(original_class, attribute)
-            return_annotation = inspect.signature(
-                original_class_attribute.fget
-            ).return_annotation
-            _inspect_value_status(return_annotation, attribute)
+        if attribute in pyro_methods:
+            continue
+        original_class_attribute = getattr(original_class, attribute)
+        hints = _resolve_type_hints(original_class_attribute.fget, attribute)
+        for value in hints.values():
+            _collect_serializable_types(value, class_list, seen)
+
+    return class_list
 
 
 async def test_serialization_coverage(
@@ -312,7 +308,7 @@ async def test_serialization_coverage(
     st_reader_mocked_driver: modules.flex_stacker.FlexStackerReader,
     mock_feature_flags: None,
 ) -> None:
-    """Test will check for serialization coverage of dataclasses exposed by the OT3API and subsequent Module APIs."""
+    """Test will check for serialization coverage of dataclasses and named tuples exposed by the OT3API and subsequent Module APIs."""
     decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
     decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(True)
 
@@ -355,66 +351,41 @@ async def test_serialization_coverage(
     )
     assert len(ot3api_async_instance.attached_modules) == len(modules_list_NO_MAG_BLOCK)
 
-    # Run tests for the OT3API
-    _test_proxy_serialization_coverage(
+    # Collect classes from the OT3API
+    class_cover_list = _collect_exposed_dataclasses_and_namedtuples(
         original_class=OT3API, acpo_instance=ot3api_async_instance
     )
 
-    # Run tests for the Module APIs
+    hardware_registry_class_list = find_opentrons_classes_in_packages(
+        HARDWARE_CLASS_PACKAGES
+    )
+    hardware_registry_class_list = list(set(hardware_registry_class_list))
+
+    # Collect classes from the Module APIs
     mod_counter = 0
     for module in wrapped_api.attached_modules:
-        _test_proxy_serialization_coverage(
-            original_class=module.__class__,
-            acpo_instance=ot3api_async_instance.attached_modules[mod_counter],
+        class_cover_list = (
+            class_cover_list
+            + _collect_exposed_dataclasses_and_namedtuples(
+                original_class=module.__class__,
+                acpo_instance=ot3api_async_instance.attached_modules[mod_counter],
+            )
         )
+        class_cover_list = list(set(class_cover_list))
         mod_counter += 1
 
+    for item in class_cover_list:
+        if hasattr(item, "to_pyro_dict") and hasattr(item, "from_pyro_dict"):
+            return_type = get_type_hints(item.from_pyro_dict).get("return")
+            try:
+                assert return_type is item
+            except Exception as e:
+                raise ValueError(
+                    f"{e} - type missmatch for 'from_pyro_dict' of type: {item}"
+                )
+        elif is_dataclass(item) or _is_namedtuple_instance(item):
+            raise ValueError(f"Pyro Serialization missing for {item}.")
 
-def _test_proxy_class_module_finder_coverage(  # noqa: C901
-    original_class: type, acpo_instance: Any
-) -> list[type]:
-    """Scrape over the provided proxy to gather as much information on parameters, mock errors and serialization as possible."""
-    class_list = []
-    proxy: pyro.Proxy = acpo_instance._proxy
-    proxy._pyroBind()  # type: ignore
-    pyro_methods: list[str] = getattr(proxy, "get_pyro_attributes_with_proxy_result")
-    pyro_methods.append("get_pyro_async_methods")
-    pyro_methods.append("get_pyro_attributes_with_proxy_result")
-    def _inspect_value_status_in_module(value: Any) -> None:
-        inspectable_value = value
-        if _is_optional(value):
-            inspectable_value = get_args(value)
-        try:
-            iter(inspectable_value)
-            is_iterable = True
-        except TypeError:
-            is_iterable = False
-        if is_iterable:
-            for item in inspectable_value:
-                if (is_dataclass(item) or _is_namedtuple_instance(item)) and hasattr(item, "to_pyro_dict") and hasattr(item, "from_pyro_dict"):
-                    class_list.append(item)
-        else:
-            if (is_dataclass(inspectable_value) or _is_namedtuple_instance(inspectable_value)) and hasattr(inspectable_value, "to_pyro_dict") and hasattr(inspectable_value, "from_pyro_dict"):
-                class_list.append(inspectable_value)
-                
-
-    # For each Method exposed by this pyro object, check the parameters and return values of the original class for dataclass usage
-    for method in proxy._pyroMethods:
-        # Check all methods that are not decorated to expose proxies
-        if method not in pyro_methods:
-            original_class_method = getattr(original_class, method)
-            for key, value in original_class_method.__annotations__.items():
-                _inspect_value_status_in_module(value)
-
-    for attribute in proxy._pyroAttrs:
-        if attribute not in pyro_methods:
-            original_class_attribute = getattr(original_class, attribute)
-            return_annotation = inspect.signature(
-                original_class_attribute.fget
-            ).return_annotation
-            _inspect_value_status_in_module(return_annotation)
-
-    return class_list
 
 async def test_module_registration_coverage(
     decoy: Decoy,
@@ -428,7 +399,7 @@ async def test_module_registration_coverage(
     st_reader_mocked_driver: modules.flex_stacker.FlexStackerReader,
     mock_feature_flags: None,
 ) -> None:
-    """Test will check for to see if serializable values are all covered in the class module registry."""
+    """Test will check for to see if the hardware class package used in registration covers exposed dataclasses and namedtuples."""
     decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
     decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(True)
 
@@ -471,20 +442,25 @@ async def test_module_registration_coverage(
     )
     assert len(ot3api_async_instance.attached_modules) == len(modules_list_NO_MAG_BLOCK)
 
-    # Run tests for the OT3API
-    class_cover_list = _test_proxy_class_module_finder_coverage(
+    # Collect classes from the OT3API
+    class_cover_list = _collect_exposed_dataclasses_and_namedtuples(
         original_class=OT3API, acpo_instance=ot3api_async_instance
     )
 
-    hardware_registry_class_list = find_opentrons_classes_in_packages(HARDWARE_CLASS_PACKAGES)
+    hardware_registry_class_list = find_opentrons_classes_in_packages(
+        HARDWARE_CLASS_PACKAGES
+    )
     hardware_registry_class_list = list(set(hardware_registry_class_list))
 
-    # Run tests for the Module APIs
+    # Collect classes from the Module APIs
     mod_counter = 0
     for module in wrapped_api.attached_modules:
-        class_cover_list = class_cover_list + _test_proxy_class_module_finder_coverage(
-            original_class=module.__class__,
-            acpo_instance=ot3api_async_instance.attached_modules[mod_counter],
+        class_cover_list = (
+            class_cover_list
+            + _collect_exposed_dataclasses_and_namedtuples(
+                original_class=module.__class__,
+                acpo_instance=ot3api_async_instance.attached_modules[mod_counter],
+            )
         )
         class_cover_list = list(set(class_cover_list))
         mod_counter += 1

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -39,16 +39,17 @@ from opentrons.hardware_control.modules.types import MagneticBlockModel
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.poller import Poller
 from opentrons.hardware_control.pyro_utils.serpent_type_registry import (
-    register_hardware_types,
+    register_hardware_types, HARDWARE_CLASS_PACKAGES
 )
-from opentrons.hardware_control.types import DoorState, HardwareFeatureFlags
+from opentrons.hardware_control.types import DoorState
 from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
 from opentrons.util.pyro.pyro_daemon_utility import create_pyro_daemon
+from opentrons.util.pyro.pyro_serialization import find_opentrons_classes_in_packages
 
 TEST_PYRO_TIMEOUT = 5
 
-# List of types to not validate, ususally these are OT-2 Types that are in a union or something thats handled through a special pyro-behavior decorator
-_TYPES_TO_SKIP = [RobotConfig, HardwareFeatureFlags]
+# List of types to not validate, ususally these are OT-2 Types
+_TYPES_TO_SKIP = [RobotConfig]
 
 
 @pytest.fixture
@@ -232,6 +233,11 @@ def _is_optional(hint: Any) -> bool:
 
     return False
 
+def _is_namedtuple_instance(cls: Any) -> bool:
+    try:
+        return issubclass(cls, tuple) and hasattr(cls, '_fields')
+    except TypeError:
+        return False
 
 def _test_proxy_serialization_coverage(  # noqa: C901
     original_class: type, acpo_instance: Any
@@ -255,7 +261,7 @@ def _test_proxy_serialization_coverage(  # noqa: C901
                     raise ValueError(
                         f"Exception: {e} - type missmatch for 'from_pyro_dict' of attribute {attr}, expected value: {value} return value: {return_type}"
                     )
-            elif is_dataclass(value):
+            elif is_dataclass(value) or _is_namedtuple_instance(value):
                 raise ValueError(
                     f"Pyro Serialization missing for {value} of attribute call {attr} in class {original_class}."
                 )
@@ -271,10 +277,10 @@ def _test_proxy_serialization_coverage(  # noqa: C901
             is_iterable = False
         if is_iterable:
             for item in inspectable_value:
-                if is_dataclass(item):
+                if is_dataclass(item) or _is_namedtuple_instance(item):
                     _validate_serialization_coverage(value=item, attr=attr)
         else:
-            if is_dataclass(inspectable_value):
+            if is_dataclass(inspectable_value) or _is_namedtuple_instance(inspectable_value):
                 _validate_serialization_coverage(value=inspectable_value, attr=attr)
 
     # For each Method exposed by this pyro object, check the parameters and return values of the original class for dataclass usage
@@ -362,3 +368,125 @@ async def test_serialization_coverage(
             acpo_instance=ot3api_async_instance.attached_modules[mod_counter],
         )
         mod_counter += 1
+
+
+def _test_proxy_class_module_finder_coverage(  # noqa: C901
+    original_class: type, acpo_instance: Any
+) -> list[type]:
+    """Scrape over the provided proxy to gather as much information on parameters, mock errors and serialization as possible."""
+    class_list = []
+    proxy: pyro.Proxy = acpo_instance._proxy
+    proxy._pyroBind()  # type: ignore
+    pyro_methods: list[str] = getattr(proxy, "get_pyro_attributes_with_proxy_result")
+    pyro_methods.append("get_pyro_async_methods")
+    pyro_methods.append("get_pyro_attributes_with_proxy_result")
+    def _inspect_value_status_in_module(value: Any) -> None:
+        inspectable_value = value
+        if _is_optional(value):
+            inspectable_value = get_args(value)
+        try:
+            iter(inspectable_value)
+            is_iterable = True
+        except TypeError:
+            is_iterable = False
+        if is_iterable:
+            for item in inspectable_value:
+                if (is_dataclass(item) or _is_namedtuple_instance(item)) and hasattr(item, "to_pyro_dict") and hasattr(item, "from_pyro_dict"):
+                    class_list.append(item)
+        else:
+            if (is_dataclass(inspectable_value) or _is_namedtuple_instance(inspectable_value)) and hasattr(inspectable_value, "to_pyro_dict") and hasattr(inspectable_value, "from_pyro_dict"):
+                class_list.append(inspectable_value)
+                
+
+    # For each Method exposed by this pyro object, check the parameters and return values of the original class for dataclass usage
+    for method in proxy._pyroMethods:
+        # Check all methods that are not decorated to expose proxies
+        if method not in pyro_methods:
+            original_class_method = getattr(original_class, method)
+            for key, value in original_class_method.__annotations__.items():
+                _inspect_value_status_in_module(value)
+
+    for attribute in proxy._pyroAttrs:
+        if attribute not in pyro_methods:
+            original_class_attribute = getattr(original_class, attribute)
+            return_annotation = inspect.signature(
+                original_class_attribute.fget
+            ).return_annotation
+            _inspect_value_status_in_module(return_annotation)
+
+    return class_list
+
+async def test_module_registration_coverage(
+    decoy: Decoy,
+    ot3_hardware: ThreadManager[OT3API],
+    mock_driver: SimulatingDriver,
+    tc_reader_mocked_driver: modules.thermocycler.ThermocyclerReader,
+    hs_reader_mocked_driver: modules.heater_shaker.HeaterShakerReader,
+    td_reader_mocked_driver: modules.tempdeck.TempDeckReader,
+    vm_reader_mocked_driver: modules.vacuum_module.VacuumModuleReader,
+    ar_reader_mocked_driver: modules.absorbance_reader.AbsorbanceReaderReader,
+    st_reader_mocked_driver: modules.flex_stacker.FlexStackerReader,
+    mock_feature_flags: None,
+) -> None:
+    """Test will check for to see if serializable values are all covered in the class module registry."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(True)
+
+    wrapped_api = ot3_hardware.wrapped()
+    wrapped_api._backend.module_controls = decoy.mock(cls=AttachedModulesControl)
+    tc = decoy.mock(cls=Thermocycler)
+    hs = decoy.mock(cls=HeaterShaker)
+    td = decoy.mock(cls=TempDeck)
+    td_2 = decoy.mock(cls=TempDeck)
+    vm = decoy.mock(cls=VacuumModule)
+    st = decoy.mock(cls=FlexStacker)
+    ar = decoy.mock(cls=AbsorbanceReader)
+    decoy.when(wrapped_api._backend.module_controls.available_modules).then_return(
+        [tc, hs, td, td_2, vm, st, ar]
+    )
+    for mod in wrapped_api._backend.module_controls.available_modules:
+        decoy.when(mod._driver).then_return(mock_driver)  # type: ignore
+
+    # Mock out the pollers for these modules that will be stopped
+    decoy.when(tc._poller).then_return(Poller(tc_reader_mocked_driver, interval=0.01))
+    decoy.when(hs._poller).then_return(Poller(hs_reader_mocked_driver, interval=0.01))
+    decoy.when(td._poller).then_return(Poller(td_reader_mocked_driver, interval=0.01))
+    decoy.when(td_2._poller).then_return(Poller(td_reader_mocked_driver, interval=0.01))
+    decoy.when(vm._poller).then_return(Poller(vm_reader_mocked_driver, interval=0.01))
+    decoy.when(st._poller).then_return(Poller(st_reader_mocked_driver, interval=0.01))
+    decoy.when(ar._poller).then_return(Poller(ar_reader_mocked_driver, interval=0.01))
+
+    name_server_ready = threading.Event()
+
+    await _setup_namerserver(name_server_ready=name_server_ready)
+    ot3api_async_instance = await _setup_OT3API_pyro_resource(
+        ot3_hardware,
+        name_server_ready,
+    )
+
+    # Assert that there are as many testable proxy modules as there are actual modules for integration coverage
+    # DEVELOPER NOTE: if this part is failing, you need to add a missing module to the module mocks above.
+    modules_list_NO_MAG_BLOCK = tuple(
+        arg for arg in get_args(ModuleModel) if arg != MagneticBlockModel
+    )
+    assert len(ot3api_async_instance.attached_modules) == len(modules_list_NO_MAG_BLOCK)
+
+    # Run tests for the OT3API
+    class_cover_list = _test_proxy_class_module_finder_coverage(
+        original_class=OT3API, acpo_instance=ot3api_async_instance
+    )
+
+    hardware_registry_class_list = find_opentrons_classes_in_packages(HARDWARE_CLASS_PACKAGES)
+    hardware_registry_class_list = list(set(hardware_registry_class_list))
+
+    # Run tests for the Module APIs
+    mod_counter = 0
+    for module in wrapped_api.attached_modules:
+        class_cover_list = class_cover_list + _test_proxy_class_module_finder_coverage(
+            original_class=module.__class__,
+            acpo_instance=ot3api_async_instance.attached_modules[mod_counter],
+        )
+        class_cover_list = list(set(class_cover_list))
+        mod_counter += 1
+
+    assert set(class_cover_list) == set(hardware_registry_class_list)


### PR DESCRIPTION
# Overview
Covers RQA-5771

This PR fixes an issue introduced in the dataclass coverage refactor. Previously we were explicitly registering certain named tuple types for serialization. When the hardware registry was refactored to automate dataclass collection and serialization, coverage for the named tuples was lost.

The integration test has been expanded and a new regression test for the resgistry package collection has been added. Alongside this several types that did not have serialization before have coverage now. These types did not leave their layer or were not exposed previously, but have been given coverage because they are or will be accessible from the surface of the proxy interface.

## Test Plan and Hands on Testing

- [x] Run protocol on Flex that executes pick up tip and pipetting actions
- [x] Ensure regression test and integration test pass as expected

## Changelog
Correct serialization coverage for NamedTuples like `Point`, expanded serialization coverage to include `StatusBarUpdateEvent`, `TOFMeasurementResult`, and `PipetteSensorData`

## Review requests

## Risk assessment
Low - fixes a pyro error on edge introduced by a refactor.