### PR TITLE
feat(auth-server): audit logging

### DIFF
--- a/auth-server/auth_server/app.py
+++ b/auth-server/auth_server/app.py
@@ -1,16 +1,22 @@
 """The server's ASGI app object."""
 
+import asyncio
+import logging
 from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator, Optional
-import asyncio
-import logging
 
 from fastapi import FastAPI
 from fastapi.openapi.docs import get_redoc_html
 from fastapi.responses import HTMLResponse
 
 from server_utils import systemd_utils
+from server_utils.audit.audit_server import (
+    Client as AuditClient,
+)
+from server_utils.audit.audit_server import (
+    SubmitAuditLogMessageData,
+)
 from server_utils.audit.fastapi import (
     audit_logger_middleware,
     build_audit_client,
@@ -20,10 +26,6 @@ from server_utils.auth.resource_server.fastapi import (
     AuthorizationError,
     handle_authorization_error,
     install_authentication_checker,
-)
-from server_utils.audit.audit_server import (
-    Client as AuditClient,
-    SubmitAuditLogMessageData,
 )
 
 from auth_server.api_error import APIError, handle_api_error
@@ -61,6 +63,10 @@ def _get_persistence_directory_root(settings: AuthServerSettings) -> Optional[Pa
     if settings.persistence_directory == "automatically_make_temporary":
         return None
     return settings.persistence_directory
+
+
+def _oauth_audit_log(audit_client: AuditClient, action: str, message: str) -> None:
+    asyncio.create_task(_do_oauth_audit_log(audit_client, action, message))
 
 
 async def _do_oauth_audit_log(
@@ -107,9 +113,7 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         oauth2_backend = OAuth2Backend(
             user_store,
             settings_store,
-            lambda action, message: asyncio.create_task(
-                _do_oauth_audit_log(audit_client, action, message)
-            ),
+            lambda action, message: _oauth_audit_log(audit_client, action, message),
         )
         install_oauth2_backend(app.state, oauth2_backend)
         user_service = UserDataManager(

--- a/auth-server/auth_server/app.py
+++ b/auth-server/auth_server/app.py
@@ -1,6 +1,6 @@
 """The server's ASGI app object."""
 
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator, Optional
 
@@ -9,6 +9,11 @@ from fastapi.openapi.docs import get_redoc_html
 from fastapi.responses import HTMLResponse
 
 from server_utils import systemd_utils
+from server_utils.audit.fastapi import (
+    audit_logger_middleware,
+    build_audit_client,
+    install_audit_client,
+)
 from server_utils.auth.resource_server.fastapi import (
     AuthorizationError,
     handle_authorization_error,
@@ -59,7 +64,8 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     active_subdirectory = await prepare_active_subdirectory(prepared_root)
     db_path = active_subdirectory / DB_FILE
 
-    with sql_engine_ctx(db_path) as engine:
+    async with AsyncExitStack() as exit_stack:
+        engine = exit_stack.enter_context(sql_engine_ctx(db_path))
         set_sql_engine(app.state, engine)
 
         user_store = UserStore(sql_engine=engine)
@@ -75,7 +81,13 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             settings_store, oauth2_backend
         )
         install_authentication_checker(app.state, authentication_checker)
-
+        audit_client = await exit_stack.enter_async_context(
+            build_audit_client(
+                audit_server_uds=settings.audit_server_uds,
+                audit_server_url=settings.audit_server_url,
+            )
+        )
+        install_audit_client(app.state, audit_client)
         systemd_utils.notify_up()
         yield
 
@@ -102,6 +114,7 @@ app = FastAPI(
     openapi_tags=_TAGS,
 )
 
+app.middleware("http")(audit_logger_middleware)
 
 app.exception_handler(APIError)(handle_api_error)
 app.exception_handler(AuthorizationError)(handle_authorization_error)

--- a/auth-server/auth_server/app.py
+++ b/auth-server/auth_server/app.py
@@ -3,6 +3,8 @@
 from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
 from typing import AsyncGenerator, Optional
+import asyncio
+import logging
 
 from fastapi import FastAPI
 from fastapi.openapi.docs import get_redoc_html
@@ -18,6 +20,10 @@ from server_utils.auth.resource_server.fastapi import (
     AuthorizationError,
     handle_authorization_error,
     install_authentication_checker,
+)
+from server_utils.audit.audit_server import (
+    Client as AuditClient,
+    SubmitAuditLogMessageData,
 )
 
 from auth_server.api_error import APIError, handle_api_error
@@ -45,6 +51,9 @@ from auth_server.users.store import UserStore
 from auth_server.users.user_data_manager import UserDataManager
 
 _REDOC_CDN_URL = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js"
+_AUTH_SERVER_AUDIT_SYSTEM_NAME = "system"
+_AUTH_SERVER_AUDIT_SYSTEM_FULLNAME = "authentication subsystem"
+_LOG = logging.getLogger(__name__)
 
 
 def _get_persistence_directory_root(settings: AuthServerSettings) -> Optional[Path]:
@@ -52,6 +61,24 @@ def _get_persistence_directory_root(settings: AuthServerSettings) -> Optional[Pa
     if settings.persistence_directory == "automatically_make_temporary":
         return None
     return settings.persistence_directory
+
+
+async def _do_oauth_audit_log(
+    audit_client: AuditClient, action: str, message: str
+) -> None:
+    try:
+        await audit_client.submit_log_message(
+            SubmitAuditLogMessageData(
+                action=action,
+                message=message,
+                accountName=_AUTH_SERVER_AUDIT_SYSTEM_NAME,
+                legalName=_AUTH_SERVER_AUDIT_SYSTEM_FULLNAME,
+                reason=None,
+            )
+        )
+        _LOG.info(f"{action}: {message}")
+    except BaseException:
+        _LOG.exception("audit log for login failed")
 
 
 @asynccontextmanager
@@ -67,10 +94,23 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     async with AsyncExitStack() as exit_stack:
         engine = exit_stack.enter_context(sql_engine_ctx(db_path))
         set_sql_engine(app.state, engine)
+        audit_client = await exit_stack.enter_async_context(
+            build_audit_client(
+                audit_server_uds=settings.audit_server_uds,
+                audit_server_url=settings.audit_server_url,
+            )
+        )
+        install_audit_client(app.state, audit_client)
 
         user_store = UserStore(sql_engine=engine)
         settings_store = SettingsStore(sql_engine=engine)
-        oauth2_backend = OAuth2Backend(user_store, settings_store)
+        oauth2_backend = OAuth2Backend(
+            user_store,
+            settings_store,
+            lambda action, message: asyncio.create_task(
+                _do_oauth_audit_log(audit_client, action, message)
+            ),
+        )
         install_oauth2_backend(app.state, oauth2_backend)
         user_service = UserDataManager(
             user_store=user_store, settings_store=settings_store
@@ -81,13 +121,6 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             settings_store, oauth2_backend
         )
         install_authentication_checker(app.state, authentication_checker)
-        audit_client = await exit_stack.enter_async_context(
-            build_audit_client(
-                audit_server_uds=settings.audit_server_uds,
-                audit_server_url=settings.audit_server_url,
-            )
-        )
-        install_audit_client(app.state, audit_client)
         systemd_utils.notify_up()
         yield
 

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -8,11 +8,11 @@ from typing import (
     Any,
     Callable,
     NotRequired,
+    Protocol,
     TypedDict,
     TypeGuard,
     cast,
     override,
-    Protocol,
 )
 
 import fastapi
@@ -41,7 +41,11 @@ _CLIENT_ID = "opentrons_app"
 
 
 class SendAuditLog(Protocol):
-    def __call__(self, action: str, message: str) -> None: ...
+    """Callback function to send an audit log out-of-band. Doesn't block."""
+
+    def __call__(self, action: str, message: str) -> None:
+        """See class docstring."""
+        ...
 
 
 class Backend:
@@ -339,7 +343,9 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         # This server only supports username+password grants.
         grant_ok = grant_type in ("password", "refresh_token")
         if not grant_ok:
-            self.__send_audit_log(f"login failed: unacceptable grant type {grant_type}")
+            self.__send_audit_log(
+                "login failed", f"unacceptable grant type {grant_type}"
+            )
         return grant_ok
 
     @override

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -4,7 +4,16 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Any, Callable, NotRequired, TypedDict, TypeGuard, cast, override
+from typing import (
+    Any,
+    Callable,
+    NotRequired,
+    TypedDict,
+    TypeGuard,
+    cast,
+    override,
+    Protocol,
+)
 
 import fastapi
 import oauthlib.common
@@ -31,10 +40,19 @@ _log = logging.getLogger(__name__)
 _CLIENT_ID = "opentrons_app"
 
 
+class SendAuditLog(Protocol):
+    def __call__(self, action: str, message: str) -> None: ...
+
+
 class Backend:
     """A backend that our server can use to process OAuth 2 requests."""
 
-    def __init__(self, user_store: UserStore, settings_store: SettingsStore) -> None:
+    def __init__(
+        self,
+        user_store: UserStore,
+        settings_store: SettingsStore,
+        send_audit_log: SendAuditLog,
+    ) -> None:
         def get_token_expires_in(request: oauthlib.common.Request) -> int:
             idle_logout_setting = settings_store.get_settings().idleLogout
             return int(idle_logout_setting)
@@ -43,7 +61,11 @@ class Backend:
         # grant type.
         self._inner_backend = oauthlib.oauth2.LegacyApplicationServer(
             _RequestValidator(
-                _TokenStore(), user_store, settings_store, lambda: datetime.now(tz=UTC)
+                _TokenStore(),
+                user_store,
+                settings_store,
+                lambda: datetime.now(tz=UTC),
+                send_audit_log,
             ),
             token_expires_in=get_token_expires_in,
         )
@@ -66,6 +88,7 @@ class Backend:
             )
         )
         headers, body, status_code = token_response
+
         return fastapi.Response(
             headers=headers,
             content=body,
@@ -134,11 +157,13 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         user_store: UserStore,
         settings_store: SettingsStore,
         get_now: Callable[[], datetime],
+        send_audit_log: SendAuditLog,
     ) -> None:
         self.__token_store = token_store
         self.__user_store = user_store
         self.__settings_store = settings_store
         self.__get_now = get_now
+        self.__send_audit_log = send_audit_log
 
         super().__init__()
 
@@ -148,7 +173,12 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         self, client_id: str, request: oauthlib.common.Request
     ) -> bool:
         """Simple validity check: does the client exist? Not banned?"""
-        return client_id == _CLIENT_ID
+        client_id_ok = client_id == _CLIENT_ID
+        if not client_id_ok:
+            self.__send_audit_log(
+                "login failed", f"login with client id {client_id} not allowed"
+            )
+        return client_id_ok
 
     @override
     @pydantic.validate_call(config=_validate_call_config)
@@ -175,10 +205,14 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
             unrecognized_scope = False
 
         if unrecognized_scope:
+            self.__send_audit_log(
+                "login failed",
+                f"login for {user.username} requested unrecognized scopes: {scopes}",
+            )
             return False
 
         requested_scopes = set(scopes)
-        return requested_scopes.issubset(
+        scopes_ok = requested_scopes.issubset(
             s.api_name
             for s in get_scope_set_of_user(
                 user,
@@ -186,6 +220,16 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
                 self.__settings_store.get_settings().passwordResetTime,
             )
         )
+        if not scopes_ok:
+            self.__send_audit_log(
+                "login failed",
+                f"login for {user.username} requested scopes it may not access",
+            )
+        else:
+            self.__send_audit_log(
+                "login succeeded", f"login for {user.username} succeeded"
+            )
+        return scopes_ok
 
     @override
     @pydantic.validate_call(config=_validate_call_config)
@@ -220,6 +264,7 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
             request.client = _Client(client_id=client_id)  # type: ignore[attr-defined]
             return True
         else:
+            self.__send_audit_log("login failed", f"unrecognized client id {client_id}")
             return False
 
     @override
@@ -243,6 +288,7 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
 
         if user is None:
             # Unrecognized username.
+            self.__send_audit_log("login failed", f"unrecognized user name {username}")
             raise _CustomInvalidCredentialsError(login_attempts_remaining=None)
 
         password_is_correct = password_hash.verify(password, user.hashed_password)
@@ -262,6 +308,14 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         )
 
         if is_currently_locked or not password_is_correct:
+            reason = (
+                "account is locked"
+                if is_currently_locked
+                else f"incorrect password, {attempts_remaining} attempts remaining"
+            )
+            self.__send_audit_log(
+                "login failed", f"user {username} failed to login: {reason}"
+            )
             raise _CustomInvalidCredentialsError(attempts_remaining)
 
         # If the credentials pass the gauntlet above, it's a successful login.
@@ -283,7 +337,10 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
     ) -> bool:
         """Return whether the given grant type is allowed for the given client."""
         # This server only supports username+password grants.
-        return grant_type in ("password", "refresh_token")
+        grant_ok = grant_type in ("password", "refresh_token")
+        if not grant_ok:
+            self.__send_audit_log(f"login failed: unacceptable grant type {grant_type}")
+        return grant_ok
 
     @override
     @pydantic.validate_call(config=_validate_call_config)
@@ -349,6 +406,9 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
             request.user = user  # type: ignore[attr-defined]
             return True
         else:
+            self.__send_audit_log(
+                "login expired", "client submitted an invalid refresh token"
+            )
             return False
 
     @override

--- a/auth-server/auth_server/oauth2/fastapi_dependencies.py
+++ b/auth-server/auth_server/oauth2/fastapi_dependencies.py
@@ -24,23 +24,12 @@ def install_oauth2_backend(app_state: AppState, backend: Backend) -> None:
     _app_state_accessor.set_on(app_state, backend)
 
 
-def install_oath2_sql_engine(app_state: AppState, sql_engine: SQLEngine) -> None:
-    """Initialize the server's singleton OAuth 2 backend and store it for later retrieval.
-
-    This should be called once at server startup.
-    """
-    user_store = UserStore(sql_engine=sql_engine)
-    settings_store = SettingsStore(sql_engine=sql_engine)
-    backend = Backend(user_store, settings_store)
-    _app_state_accessor.set_on(app_state, backend)
-
-
 def get_oauth2_backend(
     app_state: Annotated[AppState, Depends(get_app_state)],
 ) -> Backend:
     """Return the server's singleton OAuth 2 backend."""
     backend = _app_state_accessor.get_from(app_state)
-    assert backend is not None, (
-        "Forgot to initialize OAuth 2 backend at server startup?"
-    )
+    assert (
+        backend is not None
+    ), "Forgot to initialize OAuth 2 backend at server startup?"
     return backend

--- a/auth-server/auth_server/oauth2/fastapi_dependencies.py
+++ b/auth-server/auth_server/oauth2/fastapi_dependencies.py
@@ -1,7 +1,6 @@
 from typing import Annotated
 
 from fastapi import Depends
-from sqlalchemy.engine import Engine as SQLEngine
 
 from server_utils.fastapi_utils.app_state import (
     AppState,
@@ -10,8 +9,6 @@ from server_utils.fastapi_utils.app_state import (
 )
 
 from .backend import Backend
-from auth_server.settings.store import SettingsStore
-from auth_server.users.store import UserStore
 
 _app_state_accessor = AppStateAccessor[Backend]("oauth2_backend")
 
@@ -29,7 +26,7 @@ def get_oauth2_backend(
 ) -> Backend:
     """Return the server's singleton OAuth 2 backend."""
     backend = _app_state_accessor.get_from(app_state)
-    assert (
-        backend is not None
-    ), "Forgot to initialize OAuth 2 backend at server startup?"
+    assert backend is not None, (
+        "Forgot to initialize OAuth 2 backend at server startup?"
+    )
     return backend

--- a/auth-server/auth_server/oauth2/router.py
+++ b/auth-server/auth_server/oauth2/router.py
@@ -4,13 +4,15 @@ from typing import Annotated
 
 import fastapi
 
+from server_utils.audit.fastapi import skip_audit_logger
+
 from .backend import Backend
 from .fastapi_dependencies import get_oauth2_backend
 
 router = fastapi.APIRouter(prefix="/auth")
 
 
-@router.post("/oauth2/token")
+@router.post("/oauth2/token", dependencies=[fastapi.Depends(skip_audit_logger)])
 async def token_endpoint(
     request: fastapi.Request,
     oauth2_backend: Annotated[Backend, fastapi.Depends(get_oauth2_backend)],
@@ -23,7 +25,7 @@ async def token_endpoint(
     )
 
 
-@router.post("/oauth2/introspect")
+@router.post("/oauth2/introspect", dependencies=[fastapi.Depends(skip_audit_logger)])
 async def introspection_endpoint(
     request: fastapi.Request,
     oauth2_backend: Annotated[Backend, fastapi.Depends(get_oauth2_backend)],

--- a/auth-server/auth_server/server_settings.py
+++ b/auth-server/auth_server/server_settings.py
@@ -51,7 +51,7 @@ class AuthServerSettings(BaseSettings):
         description=(
             "The path to the Unix domain socket where audit-server is listening."
             " This is mutually exclusive with audit_server_url."
-            " If both are unset, access control is not enforced."
+            " If both are unset, audit logging cannot happen."
         ),
     )
 
@@ -60,6 +60,6 @@ class AuthServerSettings(BaseSettings):
         description=(
             "The base URL (e.g. `http://localhost:1234`) where audit-server is listening."
             " This is mutually exclusive with audit_server_uds."
-            " If both are unset, access control is not enforced."
+            " If both are unset, audit logging cannot happen."
         ),
     )

--- a/auth-server/auth_server/server_settings.py
+++ b/auth-server/auth_server/server_settings.py
@@ -45,3 +45,21 @@ class AuthServerSettings(BaseSettings):
         description="Path to Alembic config file.",
         validation_alias="ALEMBIC_CONFIG",  # read ALEMBIC_CONFIG from env (no OT_ prefix)
     )
+
+    audit_server_uds: str | None = Field(
+        default=None,
+        description=(
+            "The path to the Unix domain socket where audit-server is listening."
+            " This is mutually exclusive with audit_server_url."
+            " If both are unset, access control is not enforced."
+        ),
+    )
+
+    audit_server_url: str | None = Field(
+        default=None,
+        description=(
+            "The base URL (e.g. `http://localhost:1234`) where audit-server is listening."
+            " This is mutually exclusive with audit_server_uds."
+            " If both are unset, access control is not enforced."
+        ),
+    )

--- a/auth-server/auth_server/settings/router.py
+++ b/auth-server/auth_server/settings/router.py
@@ -3,6 +3,7 @@ from typing import Annotated
 
 import fastapi
 
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.models.json_api import (
@@ -50,7 +51,10 @@ async def get_access_control_enabled_settings(  # noqa: D103
     "/auth/settings/accessControlEnabled",
     summary="Change access control enabled settings",
     description="Change the access control enabled settings.",
-    dependencies=[fastapi.Depends(require_scopes(Scope.AUTH_SETTINGS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.AUTH_SETTINGS_WRITE)),
+        fastapi.Depends(get_audit_logger("update CRS enabled")),
+    ],
 )
 async def patch_access_control_settings(  # noqa: D103
     request_body: RequestModel[PatchAccessControlRequestData],
@@ -72,14 +76,15 @@ async def patch_access_control_settings(  # noqa: D103
 @router.patch(
     "/auth/settings",
     summary="Change auth settings",
-    description=dedent(
-        """\
+    description=dedent("""\
         Change authorization and authentication settings.
 
         The new settings are returned.
-        """
-    ),
-    dependencies=[fastapi.Depends(require_scopes(Scope.AUTH_SETTINGS_WRITE))],
+        """),
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.AUTH_SETTINGS_WRITE)),
+        fastapi.Depends(get_audit_logger("edit CRS settings")),
+    ],
 )
 async def patch_settings(  # noqa: D103
     request_body: RequestModel[PatchSettingsRequestData],
@@ -92,14 +97,15 @@ async def patch_settings(  # noqa: D103
 @router.delete(
     "/auth/settings",
     summary="Reset auth settings",
-    description=dedent(
-        """\
+    description=dedent("""\
         Reset authorization and authentication settings to their defaults.
 
         The new settings are returned.
-        """
-    ),
-    dependencies=[fastapi.Depends(require_scopes(Scope.AUTH_SETTINGS_WRITE))],
+        """),
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.AUTH_SETTINGS_WRITE)),
+        fastapi.Depends(get_audit_logger("reset CRS settings")),
+    ],
 )
 async def delete_settings(  # noqa: D103
     settings_store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],

--- a/auth-server/auth_server/users/router.py
+++ b/auth-server/auth_server/users/router.py
@@ -3,6 +3,8 @@ from typing import Annotated
 
 import fastapi
 
+from server_utils.audit.audit_logger import AuditLogger
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import (
     RequireAuthenticationResult,
     require_authentication,
@@ -20,6 +22,7 @@ from server_utils.fastapi_utils.models.json_api import (
 from auth_server.api_error import APIError
 from auth_server.users.dependencies import get_user_by_username, get_user_data_manager
 from auth_server.users.models import (
+    AccountType,
     ErrorBody,
     PasswordMissingSpecialCharactersErrorDetails,
     PasswordTooShortErrorDetails,
@@ -63,10 +66,23 @@ async def post_users(
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)
     ],
+    audit_logger: Annotated[
+        AuditLogger,
+        fastapi.Depends(
+            get_audit_logger(
+                "create user",
+                # Custom logs of request body to avoid logging passwords
+                auto_log_request_body=False,
+            ),
+        ),
+    ],
 ) -> PydanticResponse[SimpleBody[UserResponse]]:
     """Create a user."""
     user_create = request_body.data
     now = datetime.datetime.now(tz=datetime.UTC)
+    audit_logger.append_message_chunk(
+        f"New user with username={user_create.username}, fullName={user_create.fullName}, accountType={user_create.accountType}"
+    )
     try:
         new_user = user_data_manager.create_user(
             username=user_create.username,
@@ -129,7 +145,10 @@ async def get_user(
     responses={
         fastapi.status.HTTP_204_NO_CONTENT: {"description": "User deleted"},
     },
-    dependencies=[fastapi.Depends(require_scopes(Scope.USERS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.USERS_WRITE)),
+        fastapi.Depends(get_audit_logger("delete user")),
+    ],
 )
 async def delete_user(
     user: Annotated[UserResponse, fastapi.Depends(get_user_by_username)],
@@ -168,10 +187,32 @@ async def update_user(
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)
     ],
+    audit_logger: Annotated[
+        AuditLogger,
+        fastapi.Depends(get_audit_logger("update user", auto_log_request_body=False)),
+    ],
 ) -> PydanticResponse[SimpleBody[UserResponse]]:
     """Update a user by its unique identifier."""
     update_data = request_body.data
     now = datetime.datetime.now(tz=datetime.UTC)
+
+    def _field_or_empty(field_name: str, field: str | AccountType | bool | None) -> str:
+        if field is None:
+            return ""
+        return f"{field_name}={str(field)}"
+
+    audit_logger.append_message_chunk(
+        "Update user: "
+        + ", ".join(
+            [
+                _field_or_empty("username", update_data.username),
+                _field_or_empty("fullName", update_data.fullName),
+                _field_or_empty("accountType", update_data.accountType),
+                _field_or_empty("resetPassword", update_data.resetPassword),
+                _field_or_empty("locked", update_data.locked),
+            ]
+        )
+    )
     try:
         updated_user = user_data_manager.update_user(
             user.username,
@@ -223,7 +264,12 @@ async def update_user(
         fastapi.status.HTTP_200_OK: {"model": SimpleBody[ResetPasswordResponse]},
         fastapi.status.HTTP_404_NOT_FOUND: {"userNotFound": None},
     },
-    dependencies=[fastapi.Depends(require_scopes(Scope.USERS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.USERS_WRITE)),
+        fastapi.Depends(
+            get_audit_logger("reset password", auto_log_response_body=False)
+        ),
+    ],
 )
 async def reset_user_password(
     user: Annotated[UserResponse, fastapi.Depends(get_user_by_username)],
@@ -307,6 +353,16 @@ async def update_self(
     user_data_manager: Annotated[
         UserDataManager, fastapi.Depends(get_user_data_manager)
     ],
+    audit_logger: Annotated[
+        AuditLogger,
+        fastapi.Depends(
+            get_audit_logger(
+                "update own user",
+                # Custom logs of request body to avoid logging passwords
+                auto_log_request_body=False,
+            ),
+        ),
+    ],
 ) -> PydanticResponse[SimpleBody[UserResponse]]:
     """Update the current user's profile and/or password."""
     if not isinstance(authentication, AuthenticatedResult):
@@ -315,7 +371,22 @@ async def update_self(
             detail="This endpoint needs an access token to determine the current user.",
         )
 
+    def _field_or_empty(field_name: str, field: str | AccountType | bool | None) -> str:
+        if field is None:
+            return ""
+        return f"{field_name}={str(field)}"
+
     update_data = request_body.data
+    audit_logger.append_message_chunk(
+        "Update self: "
+        + ", ".join(
+            [
+                _field_or_empty("username", update_data.username),
+                _field_or_empty("fullName", update_data.fullName),
+            ]
+        )
+    )
+
     if (
         update_data.username is None
         and update_data.fullName is None


### PR DESCRIPTION
# Overview

Add audit logging to the auth server.

We log the settings endpoints straightforwardly with little customization. User creation and editing needs custom request body handling to make sure we don't log passwords.

Oauth stuff takes a little more annoying insight. We could log in the endpoints, but then we'd have to look at the token responses that come from oauthlib, and by the time they get back to the endpoint the token responses are already serialized to form-data responses and we'd have to reparse them, which would be annoying. Instead, we can integrate logging into the oauth backend with a little callback that creates tasks to send the audit log messages.

The audit log messages are also a little annoying; they have to be done in a way that eventually bypasses user-notes requirements, since a user can set user-note minimum length requirements and we don't want to have to emit 50,000 letters "a" or whatever. For now, I'm just not sending them, since those requirements aren't correctly enforced. When we do enforce it, we'll either have to add a special thing to the messages you send on the unix domain socket to be logged that indicates these are system messages, or reserve the username `system` for things like this.

## Test Plan and Hands on Testing

- [x] push to a flex and note that stuff gets logged when you do things on the auth server

## Changelog

- integrate audit logging into auth server endpoints

## Review requests

- happy with the task thing?

## Risk assessment

low; the code here is in execution pretty simple.
