### PR TITLE
feat(audit-server): add external audit log endpoint

### DIFF
--- a/audit-server/audit_server/log_ingest/models.py
+++ b/audit-server/audit_server/log_ingest/models.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Annotated
 
 import pydantic
 
@@ -15,6 +16,23 @@ class SubmitAuditLogMessageData(_StrictBaseModel):
     legalName: str
     message: str
     reason: str | None
+
+
+class SubmitExternalAuditLogMessageData(_StrictBaseModel):
+    """Message body for submitting an external audit log message."""
+
+    action: Annotated[
+        str,
+        pydantic.Field(
+            description="A short name for the action being logged. e.g. 'change update channel' or 'confirm labware placement'. The system will prepend this with 'External-'."
+        ),
+    ]
+    message: Annotated[
+        str,
+        pydantic.Field(
+            description="A longer message describing the specific action being logged."
+        ),
+    ]
 
 
 class AuditLogMessage(SubmitAuditLogMessageData):

--- a/audit-server/audit_server/log_ingest/router.py
+++ b/audit-server/audit_server/log_ingest/router.py
@@ -10,6 +10,14 @@ from opentrons_shared_data.errors.exceptions import (
     KeyStorageUnavailableError,
 )
 
+from server_utils.auth.resource_server.fastapi import (
+    RequireAuthenticationResult,
+    require_authentication,
+    require_scopes,
+)
+from server_utils.auth.resource_server.types import AuthenticationNotRequiredResult
+from server_utils.auth.scopes import Scope
+from server_utils.fastapi_utils.documented_interaction import get_supplied_user_notes
 from server_utils.fastapi_utils.models.json_api import (
     PydanticResponse,
     RequestModel,
@@ -20,6 +28,7 @@ from .models import (
     AuditLogMessage,
     SubmitAuditLogMessageData,
     SubmitAuditLogSuccessData,
+    SubmitExternalAuditLogMessageData,
 )
 from audit_server.log_storage.dependency import get_log_data_manager
 from audit_server.log_storage.log_data_manager import LogDataManager
@@ -60,6 +69,72 @@ async def post_log_message(
         legalName=request_body.data.legalName,
         message=request_body.data.message,
         reason=request_body.data.reason,
+        loggedAt=ingest_time,
+    )
+    message_str = message.model_dump_json(indent=None)
+    try:
+        await log_data_manager.store_log(message_str)
+    except KeyStorageUnavailableError as exc:
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "Audit log message could not be signed: key-server is unavailable."
+            ),
+        ) from exc
+    except AuditLoggingError as exc:
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Audit log could not be stored.",
+        ) from exc
+    return await PydanticResponse.create(
+        status_code=fastapi.status.HTTP_201_CREATED,
+        content=SimpleBody(data=SubmitAuditLogSuccessData(loggedAt=ingest_time)),
+    )
+
+
+@PydanticResponse.wrap_route(
+    router.post,
+    path="/audit/external/logMessage",
+    summary="Log an external audit message to the robot database. Use this endpoint to log messages not associated with robot actions.",
+    responses={
+        fastapi.status.HTTP_201_CREATED: {
+            "model": SimpleBody[SubmitAuditLogSuccessData]
+        },
+        fastapi.status.HTTP_503_SERVICE_UNAVAILABLE: {
+            "description": (
+                "Key-server could not be reached, so the audit log message"
+                " could not be signed."
+            ),
+        },
+        fastapi.status.HTTP_500_INTERNAL_SERVER_ERROR: {
+            "description": "The audit log request failed for an unknown reason."
+        },
+    },
+    dependencies=[fastapi.Depends(require_scopes(Scope.AUDIT_LOG_WRITE))],
+)
+async def post_external_log_message(
+    request_body: RequestModel[SubmitExternalAuditLogMessageData],
+    log_data_manager: Annotated[LogDataManager, fastapi.Depends(get_log_data_manager)],
+    user_notes: Annotated[str | None, fastapi.Depends(get_supplied_user_notes)],
+    authentication: Annotated[
+        RequireAuthenticationResult, fastapi.Depends(require_authentication)
+    ],
+) -> PydanticResponse[SimpleBody[SubmitAuditLogSuccessData]]:
+    """Log an external audit message."""
+    ingest_time = datetime.datetime.now(datetime.timezone.utc)
+    if isinstance(authentication, AuthenticationNotRequiredResult):
+        raise fastapi.HTTPException(
+            status_code=fastapi.status.HTTP_418_IM_A_TEAPOT,
+            detail=(
+                "Audit log is not available while Compliance Ready Software is inactive."
+            ),
+        )
+    message = AuditLogMessage(
+        action=f"External-{request_body.data.action}",
+        accountName=authentication.username,
+        legalName=authentication.fullname,
+        message=request_body.data.message,
+        reason=user_notes,
         loggedAt=ingest_time,
     )
     message_str = message.model_dump_json(indent=None)

--- a/audit-server/tests/log_ingest/test_router.py
+++ b/audit-server/tests/log_ingest/test_router.py
@@ -10,11 +10,18 @@ import pytest
 from decoy import Decoy
 from opentrons_shared_data.errors.exceptions import KeyStorageUnavailableError
 
+from server_utils.auth.resource_server.types import (
+    AuthenticatedResult,
+    AuthenticationNotRequiredResult,
+)
 from server_utils.fastapi_utils.models.json_api import RequestModel
 
 from .. import LogPayloadMatcher, RecentTimestampMatcher
-from audit_server.log_ingest.models import SubmitAuditLogMessageData
-from audit_server.log_ingest.router import post_log_message
+from audit_server.log_ingest.models import (
+    SubmitAuditLogMessageData,
+    SubmitExternalAuditLogMessageData,
+)
+from audit_server.log_ingest.router import post_external_log_message, post_log_message
 from audit_server.log_storage.log_data_manager import LogDataManager
 
 
@@ -161,3 +168,59 @@ async def test_returns_503_when_key_server_unavailable(
         await post_log_message(
             RequestModel(data=log_data), log_data_manager=mock_log_data_manager
         )
+
+
+async def test_raises_if_authentication_is_not_required(
+    mock_log_data_manager: LogDataManager,
+) -> None:
+    """If CRS mode is disabled, the endpoint must raise a 418."""
+    with pytest.raises(fastapi.HTTPException) as exc_info:
+        await post_external_log_message(
+            RequestModel(
+                data=SubmitExternalAuditLogMessageData(action="test", message="test")
+            ),
+            log_data_manager=mock_log_data_manager,
+            user_notes="test",
+            authentication=AuthenticationNotRequiredResult(),
+        )
+    assert exc_info.value.status_code == 418
+    assert (
+        exc_info.value.detail
+        == "Audit log is not available while Compliance Ready Software is inactive."
+    )
+
+
+async def test_forwards_data_if_authentication_is_required(
+    mock_log_data_manager: LogDataManager, decoy: Decoy
+) -> None:
+    """If CRS mode is enabled, the endpoint must forward the data to the log data manager."""
+    decoy.when(
+        await mock_log_data_manager.store_log(
+            cast(
+                Any,
+                LogPayloadMatcher(
+                    message=SubmitAuditLogMessageData(
+                        action="External-test-action",
+                        message="our message",
+                        reason="our reason",
+                        accountName="testusername",
+                        legalName="Test User",
+                    ),
+                    loggedAt=RecentTimestampMatcher(),
+                ),
+            )
+        )
+    ).then_return("")
+    response = await post_external_log_message(
+        RequestModel(
+            data=SubmitExternalAuditLogMessageData(
+                action="test-action", message="our message"
+            )
+        ),
+        log_data_manager=mock_log_data_manager,
+        user_notes="our reason",
+        authentication=AuthenticatedResult(
+            username="testusername", fullname="Test User", scope="audit_log.write"
+        ),
+    )
+    assert response.status_code == 201

--- a/auth-server/auth_server/users/models.py
+++ b/auth-server/auth_server/users/models.py
@@ -32,6 +32,7 @@ ACCOUNT_TYPE_TO_SCOPES: dict[AccountType, set[Scope]] = {
         Scope.USERS_READ_SELF,
         Scope.USERS_WRITE_SELF,
         Scope.PROTOCOLS_WRITE,
+        Scope.AUDIT_LOG_WRITE,
     },
     # Auditors should have read-only access to everything. Our read-only endpoints are
     # mostly accessible without authentication, but there are some exceptions. This

--- a/server-utils/server_utils/auth/scopes.py
+++ b/server-utils/server_utils/auth/scopes.py
@@ -94,6 +94,11 @@ class Scope(enum.Enum):
         "Create, update, and delete users.",
     )
 
+    AUDIT_LOG_WRITE = (
+        "audit_log.write",
+        "Write arbitrary audit logs to the audit server.",
+    )
+
     _description: str
 
     def __new__(cls, api_name: str, description: str) -> Self:  # noqa: D102

--- a/server-utils/server_utils/auth/scopes.py
+++ b/server-utils/server_utils/auth/scopes.py
@@ -96,7 +96,7 @@ class Scope(enum.Enum):
 
     AUDIT_LOG_WRITE = (
         "audit_log.write",
-        "Write arbitrary audit logs to the audit server.",
+        "Write arbitrary audit logs.",
     )
 
     _description: str


### PR DESCRIPTION
# Overview

Adds an endpoint for logging 'external' actions - aka actions with no associated robot server changes that still need to be logged, e.g. confirming labware placement during a protocol run.

I had to add a new scope for this: AUDIT_LOG_WRITE. We probably not use this scope anywhere else.

Pair programmed with Seth thank you Seth :) 

## Test Plan and Hands on Testing

Posting to `/audit/external/logMessage` should work. 

## Review requests

did I break anything? baby's first endpoint.

## Risk assessment

Low