### PR TITLE
feat(audit-server): Log access to own methods

### DIFF
--- a/audit-server/audit_server/app.py
+++ b/audit-server/audit_server/app.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, Request, Response
 from opentrons_shared_data.errors.exceptions import AuditLoggingError
 
 from server_utils import systemd_utils
+from server_utils.audit.fastapi import audit_logger_middleware, install_audit_client
 from server_utils.auth.resource_server.authentication_checker import (
     FailedClosedAuthenticationChecker,
 )
@@ -37,6 +38,7 @@ from server_utils.robot.robot_server import RobotNameandSerial
 
 from audit_server.log_export.router import router as log_export_router
 from audit_server.log_ingest.router import router as ingest_router
+from audit_server.log_self_client import LocalClient
 from audit_server.log_storage.dependency import build_log_data_manager, build_log_store
 from audit_server.persistence.database import sql_engine_ctx
 from audit_server.persistence.fastapi_dependencies import (
@@ -157,6 +159,8 @@ async def _lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             )
         )
         install_authentication_checker(app.state, authentication_checker)
+        local_log_client = LocalClient(log_data_manager)
+        install_audit_client(app.state, local_log_client)
         await log_data_manager.rotate_periods()
         systemd_utils.notify_up()
         yield
@@ -180,3 +184,5 @@ app = FastAPI(
 app.include_router(ingest_router)
 app.include_router(log_export_router)
 app.include_router(settings_router)
+
+app.middleware("http")(audit_logger_middleware)

--- a/audit-server/audit_server/log_ingest/router.py
+++ b/audit-server/audit_server/log_ingest/router.py
@@ -10,6 +10,7 @@ from opentrons_shared_data.errors.exceptions import (
     KeyStorageUnavailableError,
 )
 
+from server_utils.audit.fastapi import skip_audit_logger
 from server_utils.auth.resource_server.fastapi import (
     RequireAuthenticationResult,
     require_authentication,
@@ -56,6 +57,7 @@ router = fastapi.APIRouter()
             "description": "The audit log request failed for an unknown reason."
         },
     },
+    dependencies=[fastapi.Depends(skip_audit_logger)],
 )
 async def post_log_message(
     request_body: RequestModel[SubmitAuditLogMessageData],
@@ -110,7 +112,10 @@ async def post_log_message(
             "description": "The audit log request failed for an unknown reason."
         },
     },
-    dependencies=[fastapi.Depends(require_scopes(Scope.AUDIT_LOG_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.AUDIT_LOG_WRITE)),
+        fastapi.Depends(skip_audit_logger),
+    ],
 )
 async def post_external_log_message(
     request_body: RequestModel[SubmitExternalAuditLogMessageData],

--- a/audit-server/audit_server/log_self_client.py
+++ b/audit-server/audit_server/log_self_client.py
@@ -1,0 +1,41 @@
+"""server_utils.audit.audit_server.Client implementation for local log storage."""
+
+import datetime
+from typing import override
+
+from server_utils.audit.audit_server import (
+    Client as SUClient,
+)
+from server_utils.audit.audit_server import (
+    SubmitAuditLogMessageData as SUSubmitData,
+)
+from server_utils.audit.audit_server import (
+    SubmitAuditLogSuccessData as SUSuccessData,
+)
+
+from .log_ingest.models import AuditLogMessage
+from audit_server.log_storage.log_data_manager import LogDataManager
+
+
+class LocalClient(SUClient):
+    """An 'audit client' that provides direct access to the log data manager."""
+
+    def __init__(self, log_data_manager: LogDataManager) -> None:
+        """Build the LocalClient and provide the log data manager."""
+        self._log_data_manager = log_data_manager
+
+    @override
+    async def submit_log_message(self, message: SUSubmitData) -> SUSuccessData:
+        """Submit a log locally."""
+        ingest_time = datetime.datetime.now(datetime.timezone.utc)
+        to_log = AuditLogMessage(
+            action=message.action,
+            accountName=message.accountName,
+            legalName=message.legalName,
+            message=message.message,
+            reason=message.reason,
+            loggedAt=ingest_time,
+        )
+        message_str = to_log.model_dump_json(indent=None)
+        await self._log_data_manager.store_log(message_str)
+        return SUSuccessData(loggedAt=ingest_time)

--- a/audit-server/audit_server/settings/router.py
+++ b/audit-server/audit_server/settings/router.py
@@ -11,6 +11,7 @@ from typing import Annotated
 
 import fastapi
 
+from server_utils.audit.fastapi import get_audit_logger, skip_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.models.json_api import (
@@ -66,6 +67,7 @@ async def get_logging_enabled_settings(  # noqa: D103
     path="/audit/internal/loggingEnabled",
     summary="Change the logging-enabled setting",
     description="Enable or disable audit logging.",
+    dependencies=[fastapi.Depends(skip_audit_logger)],
 )
 async def patch_logging_enabled_settings(  # noqa: D103
     request_body: RequestModel[PatchLoggingEnabledRequestData],
@@ -132,7 +134,10 @@ async def get_settings(  # noqa: D103
         Only fields present in the request body are updated. The new settings
         are returned.
         """),
-    dependencies=[fastapi.Depends(require_scopes(Scope.AUTH_SETTINGS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.AUTH_SETTINGS_WRITE)),
+        fastapi.Depends(get_audit_logger("update audit settings")),
+    ],
 )
 async def patch_settings(  # noqa: D103
     request_body: RequestModel[PatchSettingsRequestData],
@@ -154,7 +159,10 @@ async def patch_settings(  # noqa: D103
 
         The new settings are returned.
         """),
-    dependencies=[fastapi.Depends(require_scopes(Scope.AUTH_SETTINGS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.AUTH_SETTINGS_WRITE)),
+        fastapi.Depends(get_audit_logger("reset audit settings")),
+    ],
 )
 async def delete_settings(  # noqa: D103
     settings_store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],

--- a/audit-server/tests/test_access_control_coverage.py
+++ b/audit-server/tests/test_access_control_coverage.py
@@ -1,0 +1,63 @@
+# noqa: D100
+
+from __future__ import annotations
+
+import pytest
+
+from server_utils.testing_utils.get_declared_security import get_declared_security
+
+from audit_server.app import app
+
+# Endpoints that are deliberately missing access control for some reason.
+IGNORED_ENDPOINTS: set[tuple[str, str]] = {
+    # internal endpoints are covered by auth from the external interface
+    ("post", "/audit/internal/logMessage"),
+    ("patch", "/audit/internal/loggingEnabled"),
+    # this is for logging a message and we don't need to log a message that we logged a message
+    ("post", "/audit/external/logMessage"),
+}
+
+
+# We assume these HTTP methods will never modify anything or control the robot,
+# and thus probably do not need access control.
+IGNORED_METHODS: set[str] = {"get"}
+
+
+def test_access_control_coverage() -> None:
+    """Look for endpoints that should have access control but don't."""
+    endpoint_info = get_declared_security(app.openapi())
+
+    # Sanity check to make sure the extraction worked.
+    assert endpoint_info
+
+    bad_endpoints = [
+        (method, path)
+        for (method, path), has_security in endpoint_info.items()
+        if not has_security
+        and method not in IGNORED_METHODS
+        and (method, path) not in IGNORED_ENDPOINTS
+    ]
+
+    bad_endpoints.sort(
+        key=lambda method_and_path: (method_and_path[1], method_and_path[0])
+    )
+
+    if bad_endpoints:
+        endpoint_lines = "\n".join(
+            f"* {method} {path}" for method, path in bad_endpoints
+        )
+        message = (
+            f"HTTP endpoints are missing access control."
+            f"\n\n"
+            f"Based on the HTTP API that this server is publicly declaring,"
+            f" these endpoints appear to be controlling or changing something on the robot,"
+            f" but they do not appear to be protected behind any access control."
+            f"\n\n"
+            f"If an endpoint needs access control, add `require_scopes()` to it."
+            f"\n\n"
+            f"If an endpoint does not need access control, exclude it from this check."
+            f" Edit {__file__}."
+            f"\n\n"
+            f"{endpoint_lines}"
+        )
+        pytest.fail(message)


### PR DESCRIPTION
The audit server needs to put access to its own methods in the audit log. We're obviously not going to do this via HTTP, so make our own little client and send stuff to it.

Also add an access control completeness check.

## Testing
- [x] put it on a robot, hit some audit endpoints, observe some messages

Closes EXEC-2875

