### PR TITLE
feat(robot-server): Add a stub implementation for signedBy

### DIFF
--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -434,7 +434,9 @@ async def remove_run(
     responses={
         status.HTTP_200_OK: {"model": SimpleBody[Run]},
         status.HTTP_404_NOT_FOUND: {"model": ErrorBody[RunNotFound]},
-        status.HTTP_409_CONFLICT: {"model": ErrorBody[Union[RunStopped, RunNotIdle]]},
+        status.HTTP_409_CONFLICT: {
+            "model": ErrorBody[RunStopped | RunNotIdle | RunNotComplete]
+        },
     },
     dependencies=[
         Depends(require_scopes(Scope.ROBOT_CONTROL_WRITE)),

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -58,6 +58,7 @@ from ..dependencies import (
 from ..run_auto_deleter import RunAutoDeleter
 from ..run_data_manager import (
     RunDataManager,
+    RunNotCompleteError,
     RunNotCurrentError,
 )
 from ..run_models import (
@@ -143,6 +144,14 @@ class RunStopped(ErrorDetails):
 
     id: Literal["RunStopped"] = "RunStopped"
     title: str = "Run Stopped"
+    errorCode: str = ErrorCodes.GENERAL_ERROR.value.code
+
+
+class RunNotComplete(ErrorDetails):
+    """An error if one tries to sign a run that has not completed."""
+
+    id: Literal["RunNotComplete"] = "RunNotComplete"
+    title: str = "Run Not Complete"
     errorCode: str = ErrorCodes.GENERAL_ERROR.value.code
 
 
@@ -445,16 +454,26 @@ async def update_run(
         run_data_manager: Current and historical run data management.
     """
     try:
+        run_data: Run | BadRun | None = None
+        if request_body.data.signedBy is not None:
+            # Depending on settings, updating `current` may require `signedBy`
+            # to have already been set, so we need to process `signedBy` first.
+            run_data = run_data_manager.set_signed_by(
+                run_id=runId, signed_by=request_body.data.signedBy
+            )
         if request_body.data.current is not None:
             # `current` can either be set to false or not be set at all.
             assert_type(request_body.data.current, Literal[False])
             run_data = await run_data_manager.uncurrent(runId)
-        else:
+
+        if run_data is None:
             run_data = run_data_manager.get(runId)
     except RunConflictError as e:
         raise RunNotIdle(detail=str(e)).as_error(status.HTTP_409_CONFLICT) from e
     except RunNotCurrentError as e:
         raise RunStopped(detail=str(e)).as_error(status.HTTP_409_CONFLICT) from e
+    except RunNotCompleteError as e:
+        raise RunNotComplete(detail=str(e)).as_error(status.HTTP_409_CONFLICT) from e
     except RunNotFoundError as e:
         raise RunNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
 

--- a/robot-server/robot_server/runs/run_data_manager.py
+++ b/robot-server/robot_server/runs/run_data_manager.py
@@ -153,6 +153,10 @@ class RunNotCurrentError(ValueError):
     """Error raised when a requested run is not the current run."""
 
 
+class RunNotCompleteError(ValueError):
+    """Error raised when trying to sign a run that has not completed."""
+
+
 class PreSerializedCommandsNotAvailableError(LookupError):
     """Error raised when a run's commands are not available as pre-serialized list of commands."""
 
@@ -443,6 +447,34 @@ class RunDataManager:
             current=False,
             run_time_parameters=run_result.parameters,
         )
+
+    def set_signed_by(self, run_id: str, signed_by: str) -> Union[Run, BadRun]:
+        """Record that a human has reviewed the current completed run.
+
+        Args:
+            run_id: The run to sign.
+            signed_by: Signature of the user who reviewed the run.
+
+        Returns:
+            The run after the signature has been stored.
+
+        Raises:
+            RunNotCurrentError: The run is not the current run.
+            RunNotCompleteError: The run has not reached a terminal status.
+        """
+        if run_id != self._run_orchestrator_store.current_run_id:
+            raise RunNotCurrentError(
+                f"Cannot sign {run_id} because it is not the current run."
+            )
+
+        if not self._run_orchestrator_store.get_is_run_terminal():
+            raise RunNotCompleteError(
+                f"Cannot sign {run_id} because it has not completed."
+            )
+
+        self._run_store.set_signed_by(run_id=run_id, signed_by=signed_by)
+        self._runs_publisher.publish_runs_advise_refetch(run_id)
+        return self.get(run_id=run_id)
 
     def get_commands_slice(
         self,


### PR DESCRIPTION
# Overview

This is a quick and dirty partial implementation of the `signedBy` field, to unblock frontend testing. This goes towards EXEC-2858 and EXEC-2860.

## Test Plan and Hands on Testing

Tested with Postman. Automated tests will come in a follow-up.

## Changelog

* If a client does `PATCH /runs/{id} {"signedBy": "Blah"}`, the `signedBy` value will be stored persistently and returned in future `GET /runs/{id}` requests.
* The `PATCH` will be rejected with a proper error if the given run is not the current one.
* The `PATCH` will be rejected with a proper error if the run is still ongoing.

## Review requests

None in particular.

## Risk assessment

Low.