### PR TITLE
fix(api): Update hardware entrypoint API instance reference and update Pyro interface to support property fset and fdel

### DIFF
--- a/api/src/opentrons/hardware_control/pyro_utils/pyro_process_entry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/pyro_process_entry.py
@@ -71,7 +71,7 @@ async def build_and_run_hwc_pyro(simulate: bool) -> None:
     log.info("Building OT-3 API Instance")
 
     # todo(chb: 2026-02-18): Make this support simulated hardware controller - important for unit tests
-    ot3api = await _build_api(use_simulator=simulate)
+    thread_managed_ot3api = await _build_api(use_simulator=simulate)
 
     def _daemon_request_loop(pyroname: str, resource: Any, registry: Any) -> None:
         # todo(chb: 2026-02-18): For the PYRONAMEs registered with the nameserver, do we want them to live in a centralized location (shared-data)?
@@ -80,7 +80,7 @@ async def build_and_run_hwc_pyro(simulate: bool) -> None:
 
     daemon_request_thread = threading.Thread(
         target=_daemon_request_loop,
-        args=("OT3API", ot3api, register_hardware_types),
+        args=("OT3API", thread_managed_ot3api.managed_obj, register_hardware_types),
         daemon=True,
     )
 

--- a/api/src/opentrons/hardware_control/pyro_utils/pyro_process_entry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/pyro_process_entry.py
@@ -102,7 +102,7 @@ async def build_and_run_hwc_pyro(simulate: bool) -> None:
 
     # Handle firmware updates on the hardware api
     async def _do_update() -> None:
-        async for update in ot3api.update_firmware():
+        async for update in thread_managed_ot3api.update_firmware():
             log.info(f"Update: {update.subsystem.name}: {update.progress}%")
 
     await _do_update()

--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -216,26 +216,6 @@ def _path_dict_to_class(  # type: ignore
     return Path(d["path_str"])
 
 
-# ABSMeasurementConfig registry
-def _ABSMeasurementConfig_class_to_dict(obj) -> Dict:  # type: ignore
-    return {
-        "__class__": "opentrons.drivers.types.ABSMeasurementConfig",
-        "measure_mode": obj.measure_mode.value,
-        "sample_wavelengths": obj.sample_wavelengths,
-        "reference_wavelength": obj.reference_wavelength,
-    }
-
-
-def _ABSMeasurementConfig_dict_to_class(  # type: ignore
-    classname, d
-) -> opentrons.drivers.types.ABSMeasurementConfig:
-    return opentrons.drivers.types.ABSMeasurementConfig(
-        measure_mode=opentrons.drivers.types.ABSMeasurementMode(d["measure_mode"]),
-        sample_wavelengths=d["sample_wavelengths"],
-        reference_wavelength=d["reference_wavelength"],
-    )
-
-
 # Handy function to map all registries for the Hardware controller
 def register_hardware_types() -> None:
     """Registers serialize and deserialize behavior for Opentrons Hardware types and classes.

--- a/api/src/opentrons/hardware_control/types.py
+++ b/api/src/opentrons/hardware_control/types.py
@@ -36,17 +36,21 @@ from opentrons.util.pyro.pyro_serialization import (
 if TYPE_CHECKING:
     from .modules.types import ModuleModel
 
-    def _module_model_reconstructor(
-        module_str: str,
-    ) -> ModuleModel:
-        for model in get_args(ModuleModel):
-            try:
-                return model[module_str]  # type: ignore
-            except Exception:
-                pass
-        raise ValueError(
-            f"Cannot determine module model during deserialization for: {module_str}"
-        )
+
+def _module_model_reconstructor(
+    module_str: str,
+) -> "ModuleModel":
+    # Import the class here for references during deserialization
+    from opentrons.hardware_control.modules.types import ModuleModel
+
+    for model in get_args(ModuleModel):
+        try:
+            return model[module_str]  # type: ignore
+        except Exception:
+            pass
+    raise ValueError(
+        f"Cannot determine module model during deserialization for: {module_str}"
+    )
 
 
 MODULE_LOG = logging.getLogger(__name__)

--- a/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_client_async_adapter.py
@@ -92,7 +92,10 @@ def _build_classdict(
     async_method_names = [method["__name__"] for method in async_methods.values()]
     # Attach PSO exposed methods to the AsyncClientPyroObject
     for method in pso._pyroMethods:
-        if method in async_method_names and not force_synchronous:
+        if "__fset" in method or "__fdel" in method:
+            # Ignore exposed property attributes
+            pass
+        elif method in async_method_names and not force_synchronous:
             # For methods that are awaitable wrap them as an async reference that forwards the call to the PSO Proxy.
             method_metadata: dict[str, Any] = async_methods[method]
             async_method = wrap_as_async(method_metadata)
@@ -103,10 +106,23 @@ def _build_classdict(
     # Attach PSO exposed attributes to the AsyncClientPyroObject
     for attr in pso._pyroAttrs:
         # For property attributes we use to attach a wrapped `getattr` call for that attribute.
+        # If setter and deleter functions exist on the server-side alias they are reconstructed client-side here.
         # This is set as a new property of the AsyncClientPyroObject that forwards calls to the PSO Proxy.
+
+        fset = None
+        fdel = None
+        if attr + "__fset" in pso._pyroMethods:
+            fset = wrap_parameter_validation(pso, attr + "__fset")
+        if attr + "__fdel" in pso._pyroMethods:
+            fdel = wrap_parameter_validation(pso, attr + "__fdel")
+        prop = property(
+            fget=wrap_property(pso, attr),
+            fset=fset,
+            fdel=fdel,
+        )
         yield (
             attr,
-            property(wrap_property(pso, attr)),
+            prop,
         )
     yield "_proxy", pso
 

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -379,6 +379,18 @@ def _build_classdict(  # noqa: C901
                     execute_inbound_call_on_event_loop(core_obj, attr)  # type: ignore
                 )
                 yield (name, exposed)
+                if attr.fset:
+                    bound_method = MethodType(pyro.expose(attr.fset), core_obj)
+                    exposed_fset = execute_inbound_call_on_event_loop(
+                        core_obj, bound_method
+                    )
+                    yield (name + "__fset", parameter_validation_wrapper(exposed_fset))
+                if attr.fdel:
+                    bound_method = MethodType(pyro.expose(attr.fdel), core_obj)
+                    exposed_fdel = execute_inbound_call_on_event_loop(
+                        core_obj, bound_method
+                    )
+                    yield (name + "__fdel", parameter_validation_wrapper(exposed_fdel))
 
     # Attach the known async methods list to the PSO as a private member and expose a getter method
     yield ("_pyro_async_methods", async_methods)

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -630,11 +630,6 @@ def convert_result_to_proxy(  # noqa: C901
         try:
             proxy_list = []
             for r in result:
-                if hasattr(r, "__weakref__"):
-                    # If the resulting object contains a weakref then utilize the inner instance
-                    # Example - CallBridger wrapping an AbstractModule
-                    r = r.__weakref__()
-
                 pyro_synchronous_obj = utility.find_PSO(r)
                 if pyro_synchronous_obj is None:
                     if not hasattr(r, "_loop"):

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_pyro.py
@@ -64,6 +64,7 @@ from opentrons.hardware_control.types import (
     DoorStateNotification,
     HardwareEvent,
     HardwareEventHandler,
+    HardwareFeatureFlags,
     OT3Mount,
 )
 from opentrons.types import Mount, Point
@@ -436,7 +437,7 @@ async def test_pyro_module_properties(
     def _pyro_daemon() -> None:
         # Wait for the nameserver to be ready so locate_ns can succeed.
         name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
-        create_pyro_daemon("OT3API", ot3_hardware, register_hardware_types)
+        create_pyro_daemon("OT3API", ot3_hardware.managed_obj, register_hardware_types)
 
     ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
     server_thread = threading.Thread(target=_pyro_daemon, daemon=True)
@@ -532,7 +533,7 @@ async def test_pyro_vacuum_module_serialization(
     def _pyro_daemon() -> None:
         # Wait for the nameserver to be ready so locate_ns can succeed.
         name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
-        create_pyro_daemon("OT3API", ot3_hardware, register_hardware_types)
+        create_pyro_daemon("OT3API", ot3_hardware.managed_obj, register_hardware_types)
 
     ns_thread = threading.Thread(target=_nameserver_loop, daemon=True)
     server_thread = threading.Thread(target=_pyro_daemon, daemon=True)
@@ -609,7 +610,7 @@ async def test_pyro_async_wrapped_calls(  # noqa: C901
     def _pyro_daemon() -> None:
         # Wait for the nameserver to be ready so locate_ns can succeed.
         name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
-        create_pyro_daemon("OT3API", ot3_hardware, register_hardware_types)
+        create_pyro_daemon("OT3API", ot3_hardware.managed_obj, register_hardware_types)
 
     class cool_door_class:
         def __init__(self, loop: asyncio.AbstractEventLoop):
@@ -699,6 +700,24 @@ async def test_pyro_async_wrapped_calls(  # noqa: C901
         ot3api.build_temporary_identity_calibration().deck_calibration.status.source
         is None
     )
+
+    old_flags = HardwareFeatureFlags(
+        use_old_aspiration_functions=False,
+        require_estop=True,
+        overpressure_detection_enabled=True,
+        stall_detection_enabled=True,
+    )
+    new_flags = HardwareFeatureFlags(
+        use_old_aspiration_functions=True,
+        require_estop=True,
+        overpressure_detection_enabled=True,
+        stall_detection_enabled=True,
+    )
+
+    ot3api.hardware_feature_flags = new_flags
+    assert ot3api.hardware_feature_flags == new_flags
+    ot3api.hardware_feature_flags = old_flags
+    assert ot3api.hardware_feature_flags == old_flags
 
     ot3_proxy._pyroRelease()  # type: ignore
 

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -203,7 +203,7 @@ async def _setup_OT3API_pyro_resource(
     def _ot3api_pyro_daemon() -> None:
         # Wait for the nameserver to be ready so locate_ns can succeed.
         name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
-        create_pyro_daemon("OT3API", hw_api, register_hardware_types)
+        create_pyro_daemon("OT3API", hw_api.managed_obj, register_hardware_types)
 
     ot3api_thread = threading.Thread(target=_ot3api_pyro_daemon, daemon=True)
     ot3api_thread.start()


### PR DESCRIPTION
# Overview
Covers EXEC-2887

**THE PROBLEM:**
The hardware entry process and some of the hardware layer pyro tests were utilizing a ThreadManager as the object exposed through Pyro. This lead to a handful of nasty underlying issues:
- When generating the PSO alias class, we check the `core_obj`'s `__class__` dunder method to determine what elements of that class to expose through Pyro. However, the ThreadManager uses a `__get_attribute__` overload which exposed the inner OT3APIs `__class__`, causing the aliased class to present purely as an OT3API.
- When arguments on the alias class attempt to call their bound method, they provide the bounded `core_obj` as the self to reference, but since the true `self` in this case was the ThreadManager instance and not the actual OT3API, it lead to things like `home(self)` turning into `home(ThreadManager)` which then causes calls inside that method to call on a self that is the ThreadManager instance. This turns things like `self._backend` references into `ThreadManager._backend`, which then loops around back through the ThreadManager's `__get_attribute__` into the actual inner `OT3API._backend`. This doesn't break anything yet, but may have been the source of some of our slowdown!
- Where this oroboros starts to eat its own tail is things like the setter for `hardware_feature_flags`, which calls `self._feature_flags = feature_flags`. This would instead set a new metadata field on the ThreadManager instance equal to the incoming value, instead of the inner OT3API instance. It would never be passed through `__get_attribute__`. This means that when the next call to the property `hardware_feature_flags` occurred, it would go like this: `ThreadManager.hardware_feature_flags` -> `__get_attribute__` -> `OT3API.hardware_feature_flags`, which would return `OT3API._feature_flags`, a variable which had never had it's value updated. The information was lost, whoops!
- This problem extended to things like `attached_modules` which had AbstractModules wrapped in a CallBridger. We originally got around this by looking at the `__weakref__` of those entities, but this turned out the be a bandaid over an issue coming downstream from the fact that we were exposing the ThreadManager instance.

**THE SOLUTION:**

- Simply don't provide the thread manager to Pyro for exposure, instead provide the inner `managed_obj` instance of the OT3API instead
- All the intended methods are exposed, and modules no longer need to go through some extra step to get turned into PSOs themselves
- We can now implement an easy solution for exposing setters and deleters on properties, detailed below

**Property fset and fdel exposure:**
Previously we were not mapping the setter and deleter clauses for an ingested `core_obj` in the PyroSynchronousObject nor were we mapping those setters and deleters back to the aliased equivalent on the AsyncClientPyroObject. This change closes that gap and allows things like `OT3API.hardware_feature_flags` to be used as expected.


## Test Plan and Hands on Testing

- [x] Expand unit test coverage to test property logic
- [x] Update existing unit tests for new managed hardware approach
- [x] Test the following protocol on a flex:
```
from opentrons.protocol_api import ProtocolContext

requirements = {
	"robotType": "Flex",
	"apiLevel": "2.28"
}

def run(protocol_context: ProtocolContext):
    trash1 = protocol_context.load_trash_bin("A3")

    tip_rack = protocol_context.load_labware("opentrons_flex_96_tiprack_50ul", "C2")
    custom_lw = protocol_context.load_labware("qiagen_96_tuberack_500ul", "C1")
    plate = protocol_context.load_labware("nest_96_wellplate_200ul_flat", "D2")
    instrument = protocol_context.load_instrument('flex_8channel_50', mount="right", tip_racks=[tip_rack])
    protocol_context.capture_image(home_before=False, filename="my_cool_pic")

    absr = protocol_context.load_module(module_name="absorbanceReaderV1", location="D3")
    absr.close_lid()
    absr.initialize(mode="single", wavelengths=[450])
    absr.open_lid()
    protocol_context.move_labware(plate, absr, use_gripper=True)
    absr.close_lid()
    absr.read(export_filename="my_data")
    
    instrument.configure_nozzle_layout(style=SINGLE, start="H1", tip_racks=[tip_rack])
    instrument.pick_up_tip()
    instrument.aspirate(volume=25, location=custom_lw.wells_by_name()["A1"])
    instrument.dispense(volume=25, location=custom_lw.wells_by_name()["B1"])

    instrument.return_tip()
    instrument.configure_nozzle_layout(style=ALL, tip_racks=[tip_rack])
    instrument.pick_up_tip()
    instrument.return_tip()
    instrument.pick_up_tip()
    instrument.return_tip()
```

## Changelog
- Entry process for the hardware layer now passes in the `managed_obj` OT3API instance of the thread manager for the pyro to expose through a PSO
- Removed the __weakref__ direct reference used to correct the CallBridger attached modules, it would result in an error with the CallBridger no longer present for modules
- Expanded the class generator on client and server side to create a mapping for these property functions.
- Removed redundant/unused ABSMeasurementConfig serpent converters

## Review requests
This is a relatively light change to the PyroSynchronousObject class generator itself, but does have downstream ripples regarding "how stuff works". In theory, everything is "the same" but with one step removed for all OT3API operations (we no longer call through a thread manager as "self", looping back outside of the function to use the thread managers `__get_attribute__` for inner calls like `_backend`).

Is there anything else special about properties this is missing?

## Risk assessment
Low - covers a gap in our pyro capabilities and fixes an issue in the setup of the hardware layer that had knock on effects to our class generation.