### PR TITLE
feat(api-client, react-api-client): add post log message mutation 

### DIFF
--- a/api-client/src/audit/index.ts
+++ b/api-client/src/audit/index.ts
@@ -1,6 +1,7 @@
 export { getLogPeriodSummaries } from './getLogPeriodSummaries'
 export { getLogPeriodRaw } from './getLogPeriodRaw'
 export { deleteLogPeriod } from './deleteLogPeriod'
+export { postLogMessage } from './postLogMessage'
 export * from './constants'
 export * from './settings'
 export * from './types'

--- a/api-client/src/audit/postLogMessage.ts
+++ b/api-client/src/audit/postLogMessage.ts
@@ -1,0 +1,27 @@
+import { POST, request } from '../request'
+
+import type { ResponsePromise } from '../request'
+import type { HostConfig } from '../types'
+import type { PostLogMessageData, PostLogMessageResponse } from './types'
+
+/**
+ * Posts a log message to the robot audit log.
+ * To be used for user actions that have no robot side effects but still need to be logged.
+ * @param data.action - the name of the action to be logged. The server prepends this with 'External-'.
+ * @param data.message - a longer detailed description of the specific action being taken.
+ */
+export function postLogMessage(
+  config: HostConfig,
+  data: PostLogMessageData,
+  userNotes?: string
+): ResponsePromise<PostLogMessageResponse> {
+  return request<PostLogMessageResponse, { data: PostLogMessageData }>(
+    POST,
+    '/audit/external/logMessage',
+    config,
+    {
+      body: { data },
+      userNotes,
+    }
+  )
+}

--- a/api-client/src/audit/types.ts
+++ b/api-client/src/audit/types.ts
@@ -14,3 +14,14 @@ export type DownloadedLogPeriodResponse = Blob | string
 export interface DeleteLogPeriodQueryParams {
   deletionKey: string
 }
+
+export interface PostLogMessageData {
+  action: string
+  message: string
+}
+
+export interface PostLogMessageResponse {
+  data: {
+    loggedAt: string
+  }
+}

--- a/react-api-client/src/audit/index.ts
+++ b/react-api-client/src/audit/index.ts
@@ -1,4 +1,5 @@
 export { useDeleteLogPeriodMutation } from './useDeleteLogPeriodMutation'
 export { useLogPeriodRawQuery } from './useLogPeriodRawQuery'
 export { useLogPeriodSummariesQuery } from './useLogPeriodSummariesQuery'
+export { usePostLogMessageMutation } from './usePostLogMessageMutation'
 export * from './settings'

--- a/react-api-client/src/audit/usePostLogMessageMutation.ts
+++ b/react-api-client/src/audit/usePostLogMessageMutation.ts
@@ -1,0 +1,65 @@
+import { postLogMessage } from '@opentrons/api-client'
+
+import { useDocumentedMutation } from '../accessControl'
+import { getQueryKey, useHost } from '../api'
+
+import type {
+  UseMutateFunction,
+  UseMutationOptions,
+  UseMutationResult,
+} from 'react-query'
+import type {
+  PostLogMessageData,
+  PostLogMessageResponse,
+} from '@opentrons/api-client'
+import type { DocumentationState, DocumentedAction } from '../accessControl'
+import type { DocumentedMutationParameters } from '../accessControl/types'
+
+export type UsePostLogMessageMutationResult = UseMutationResult<
+  PostLogMessageResponse,
+  unknown,
+  PostLogMessageData
+> & {
+  postLogMessage: UseMutateFunction<
+    PostLogMessageResponse,
+    unknown,
+    PostLogMessageData
+  >
+}
+
+export type UsePostLogMessageMutationOptions = UseMutationOptions<
+  PostLogMessageResponse,
+  unknown,
+  PostLogMessageData
+>
+
+export function usePostLogMessageMutation(
+  documentationState: DocumentationState,
+  action: DocumentedAction,
+  options: UsePostLogMessageMutationOptions = {}
+): UsePostLogMessageMutationResult {
+  const host = useHost()
+
+  const mutation = useDocumentedMutation<
+    PostLogMessageResponse,
+    unknown,
+    PostLogMessageData
+  >(
+    documentationState,
+    [action],
+    getQueryKey(host, 'audit', 'logMessage'),
+    ({
+      variables,
+      userNotes,
+    }: DocumentedMutationParameters<PostLogMessageData>) =>
+      postLogMessage(host!, variables, userNotes).then(
+        response => response.data
+      ),
+    options
+  )
+
+  return {
+    ...mutation,
+    postLogMessage: mutation.mutate,
+  }
+}

--- a/scripts/eslint-plugin-opentrons/lib/mutating-api-client-exports.json
+++ b/scripts/eslint-plugin-opentrons/lib/mutating-api-client-exports.json
@@ -47,6 +47,7 @@
     "patchAuditSettings",
     "patchAuthSettings",
     "patchRobotServerAccessControlSettings",
+    "postLogMessage",
     "postResetConfig",
     "postWifiConfigure",
     "postWifiDisconnect",


### PR DESCRIPTION
# Overview

Adds `postLogMessage` and `postLogMessageMutation` to match up with our new fancy `/audit/external/postLogMessage` endpoint. Adds an external message to the audit log, to document actions without associated robot changes. 

## Risk assessment

Low