### PR TITLE
fix(components): Fix SecondaryButton focus styling

### DIFF
--- a/components/src/atoms/buttons/SecondaryButton.tsx
+++ b/components/src/atoms/buttons/SecondaryButton.tsx
@@ -35,12 +35,6 @@ export const SecondaryButton = styled.button.withConfig<SecondaryButtonProps>({
   font-weight: ${TYPOGRAPHY.fontWeightSemiBold};
   line-height: ${TYPOGRAPHY.lineHeight20};
 
-  &:hover,
-  &:focus {
-    box-shadow: ${props =>
-      props['aria-disabled'] ? 'none' : '0px 3px 6px 0px rgba(0, 0, 0, 0.23)'};
-  }
-
   &:hover {
     color: ${props => {
       if (props['aria-disabled']) return COLORS.grey40

--- a/components/src/atoms/buttons/SecondaryButton.tsx
+++ b/components/src/atoms/buttons/SecondaryButton.tsx
@@ -48,19 +48,8 @@ export const SecondaryButton = styled.button.withConfig<SecondaryButtonProps>({
   }
 
   &:focus-visible {
-    color: ${props => {
-      if (props['aria-disabled']) return COLORS.grey40
-      return props.isDangerous ? COLORS.red60 : COLORS.blue60
-    }};
-    border-color: ${props => {
-      if (props['aria-disabled']) return COLORS.grey30
-      return props.isDangerous ? COLORS.red50 : COLORS.blue60
-    }};
-    box-shadow: ${props =>
-      props['aria-disabled']
-        ? 'none'
-        : `outline: 2px solid ${COLORS.blue50};
-    outline-offset: 0.25rem;`};
+    outline: 2px solid ${COLORS.blue50};
+    outline-offset: 0.25rem;
   }
 
   &:active {


### PR DESCRIPTION
## Overview

This fixes a few issues with `SecondaryButton`'s styling.

## Details

* It had a drop shadow sometimes. This isn't in the designs. I think it was left over from an older version or something. This PR just deletes it. This closes AUTH-3091.

* We had some broken CSS syntax. An `outline` value was getting stuffed inside a `box-shadow` value, so it didn't have any effect.

* In addition to adding a focus `outline`, we were changing the text and border color. This looked weird to me, like maybe those colors got slightly out-of-sync with the main colors at some point.

  The designs don't indicate that the colors should change, so I just deleted this. We still have the `outline`, which I think is a clearer, more conventional, and more consistent indicator of focus.

* We were suppressing the `outline` when the button was `aria-disabled`. I think in general, we should not do this, because it's a usability and accessibility problem. If the browser thinks that an element is `focus-visible`, then we *must* indicate focus _somehow_. And the best way to do that is with the same `outline` as usual.

## Test Plan and Hands on Testing

<img width="218" height="64" alt="Screenshot 2026-07-29 at 6 14 00 PM" src="https://github.com/user-attachments/assets/48c10029-5ebd-4781-aa92-3870ee87d5b4" />


## Review requests

Agreed with all changes?

## Risk assessment

Low. Effects are confined to just this component.