### PR TITLE
fix(components): Fix button size and adjust focus rings

### DIFF
--- a/components/src/atoms/buttons/PrimaryButton/DefaultPrimaryButton.tsx
+++ b/components/src/atoms/buttons/PrimaryButton/DefaultPrimaryButton.tsx
@@ -27,7 +27,7 @@ export const DefaultPrimaryButton: StyledComponent<any, any> = styled(Btn)`
 
   &:focus-visible {
     outline: 2px solid ${COLORS.blue50};
-    outline-offset: 0.25rem;
+    outline-offset: 0.125rem;
   }
 
   &:active {

--- a/components/src/atoms/buttons/PrimaryButton/altprimarybutton.module.css
+++ b/components/src/atoms/buttons/PrimaryButton/altprimarybutton.module.css
@@ -11,9 +11,9 @@
   line-height: var(--line-height-20);
 }
 
-.alt_primary_button:focus {
-  background-color: var(--grey-35);
-  box-shadow: none;
+.alt_primary_button:focus-visible {
+  outline: 2px solid var(--blue-50);
+  outline-offset: 0.125rem;
 }
 
 .alt_primary_button:active {

--- a/components/src/atoms/buttons/PrimaryButton/warningprimarybutton.module.css
+++ b/components/src/atoms/buttons/PrimaryButton/warningprimarybutton.module.css
@@ -12,6 +12,11 @@
   text-transform: none;
 }
 
+.alert_primary_button:focus-visible {
+  outline: 2px solid var(--blue-50);
+  outline-offset: 0.125rem;
+}
+
 .alert_primary_button:hover {
   background-color: var(--red-55);
   box-shadow: 0 0 0;

--- a/components/src/atoms/buttons/PrimaryButton/warningprimarybutton.module.css
+++ b/components/src/atoms/buttons/PrimaryButton/warningprimarybutton.module.css
@@ -6,7 +6,9 @@
   box-shadow: 0 0 0;
   color: var(--white);
   cursor: pointer;
+  font-size: var(--font-size-h3);
   font-weight: var(--font-weight-semi-bold);
+  line-height: var(--line-height-20);
   text-transform: none;
 }
 

--- a/components/src/atoms/buttons/SecondaryButton.tsx
+++ b/components/src/atoms/buttons/SecondaryButton.tsx
@@ -49,7 +49,7 @@ export const SecondaryButton = styled.button.withConfig<SecondaryButtonProps>({
 
   &:focus-visible {
     outline: 2px solid ${COLORS.blue50};
-    outline-offset: 0.25rem;
+    outline-offset: 0.125rem;
   }
 
   &:active {


### PR DESCRIPTION
## Overview

This PR makes a couple of fixes to our button styles.

## Changelog

* Give `<PrimaryButton variant="warning">` the same `font-size` and `line-height` values that are present in `<PrimaryButton variant="default">` and in `<SecondaryButton>`. This fixes an issue where it was too short, AUTH-3085.
* Adjust the `focus-visible` state on all the `<PrimaryButton>` variants to match the designs.

## Test Plan and Hands on Testing

Before (note the size difference):

<img width="558" height="130" alt="Screenshot 2026-07-29 at 8 39 47 PM" src="https://github.com/user-attachments/assets/84667342-ec4d-4ef6-826d-321f5ed5a5de" />


After:

https://github.com/user-attachments/assets/74ae071c-fa99-433d-bb51-d244347eea0d

* [x] The "Cancel" and "Enable Compliance Ready Software" buttons are now the same size. (Almost. `<SecondaryButton>` is 2px too tall because of its border, but that's a separate issue.)
* [x] The focus rings now match the designs.

## Review requests

None in particular.

## Risk assessment

Medium. Changing the height of `<PrimaryButton variant="warning">` may affect layout in surprising ways.