### PR TITLE
fix(app): Prevent inputs from losing focus when the virtual keyboard is tapped

### DIFF
--- a/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/index.tsx
@@ -92,6 +92,7 @@ export function AlphanumericKeyboard({
       buttonAttributes={softwareKeyboardButtonAttributes}
       width="100%"
       debug={debug} // If true, <ENTER> will input a \n
+      preventMouseDownDefault
     />
   )
 }

--- a/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/index.tsx
@@ -88,11 +88,11 @@ export function AlphanumericKeyboard({
       }
       display={customDisplay}
       mergeDisplay={true}
-      useButtonTag={false}
+      useButtonTag={false} // Exclude from the tab order.
       buttonAttributes={softwareKeyboardButtonAttributes}
       width="100%"
       debug={debug} // If true, <ENTER> will input a \n
-      preventMouseDownDefault
+      preventMouseDownDefault // Don't steal focus from inputs.
     />
   )
 }

--- a/app/src/atoms/SoftwareKeyboard/FullKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/FullKeyboard/index.tsx
@@ -154,7 +154,7 @@ export function FullKeyboard({
       }
       display={display}
       mergeDisplay={true}
-      useButtonTag={false}
+      useButtonTag={false} // Exclude from the tab order.
       buttonAttributes={softwareKeyboardButtonAttributes}
       debug={debug} // If true, <ENTER> will input a \n
       baseClass="fullKeyboard"
@@ -176,7 +176,7 @@ export function FullKeyboard({
           buttons: '{shift}',
         },
       ]}
-      preventMouseDownDefault
+      preventMouseDownDefault // Don't steal focus from inputs.
     />
   )
 }

--- a/app/src/atoms/SoftwareKeyboard/IndividualKey/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/IndividualKey/index.tsx
@@ -39,12 +39,12 @@ export function IndividualKey({
       onChange={onChange}
       layoutName="default"
       display={customDisplayForIndividual}
-      useButtonTag={false}
+      useButtonTag={false} // Exclude from the tab order.
       buttonAttributes={softwareKeyboardButtonAttributes}
       {...numericalKeyboard}
       width="100%"
       debug={debug} // If true, <ENTER> will input a \n
-      preventMouseDownDefault
+      preventMouseDownDefault // Don't steal focus from inputs.
     />
   )
 }

--- a/app/src/atoms/SoftwareKeyboard/IndividualKey/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/IndividualKey/index.tsx
@@ -44,6 +44,7 @@ export function IndividualKey({
       {...numericalKeyboard}
       width="100%"
       debug={debug} // If true, <ENTER> will input a \n
+      preventMouseDownDefault
     />
   )
 }

--- a/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/StatelessNumericalKeyboard.tsx
+++ b/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/StatelessNumericalKeyboard.tsx
@@ -62,6 +62,7 @@ export function StatelessNumericalKeyboard({
       layoutName={layoutName}
       layout={numericalKeyboardLayout}
       debug={debug}
+      preventMouseDownDefault
     />
   )
 }

--- a/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/StatelessNumericalKeyboard.tsx
+++ b/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/StatelessNumericalKeyboard.tsx
@@ -57,12 +57,12 @@ export function StatelessNumericalKeyboard({
         )
       }}
       display={numericalCustom}
-      useButtonTag={false}
+      useButtonTag={false} // Exclude from the tab order.
       buttonAttributes={softwareKeyboardButtonAttributes}
       layoutName={layoutName}
       layout={numericalKeyboardLayout}
       debug={debug}
-      preventMouseDownDefault
+      preventMouseDownDefault // Don't steal focus from inputs.
     />
   )
 }

--- a/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
@@ -46,12 +46,12 @@ export function NumericalKeyboard({
       }}
       onChange={onChange}
       display={numericalCustom}
-      useButtonTag={false}
+      useButtonTag={false} // Exclude from the tab order.
       buttonAttributes={softwareKeyboardButtonAttributes}
       layoutName={layoutName}
       layout={numericalKeyboardLayout}
       debug={debug} // If true, <ENTER> will input a \n
-      preventMouseDownDefault
+      preventMouseDownDefault // Don't steal focus from inputs.
     />
   )
 }

--- a/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
+++ b/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/index.tsx
@@ -51,6 +51,7 @@ export function NumericalKeyboard({
       layoutName={layoutName}
       layout={numericalKeyboardLayout}
       debug={debug} // If true, <ENTER> will input a \n
+      preventMouseDownDefault
     />
   )
 }


### PR DESCRIPTION
## Overview

This is a continuation of #21948 / EXEC-2822.

There is a problem with the on-screen keyboard where:

1. An input element is focused.
2. The user taps a virtual keyboard button.
3. The browser moves focus from the input element to the keyboard button. We don't want this.

In  #21948, we switched our on-screen keyboard from using `<button>` tags to using `<div>`s. This prevented the virtual keyboard from *receiving* focus, but it did not prevent the input from *losing* focus. For that, we also need `preventMouseDownDefault`.

## Test Plan and Hands on Testing

* [x] Tested on the ODD login page. It currently has an `onBlur` override that prevents focus from ever leaving the input, so that needs to be commented out first to see this PR's effect.

## Review requests

Agreed with the rationale?

If we do something more for EXEC-2890, this may become redundant, but it should still be harmless.

## Risk assessment

Low, I think? I can't think of anything that would depend on the existing behavior.