### PR TITLE
test(e2e-testing): addresses 8-channel transfers in testing

### DIFF
--- a/e2e-testing/automation/pd_pages/__init__.py
+++ b/e2e-testing/automation/pd_pages/__init__.py
@@ -7,7 +7,7 @@ from .deck_config_page import DeckConfigPage
 from .heater_shaker_step_form_page import HeaterShakerStepPage
 from .landing_page import LandingPage
 from .magnetic_module_step_form_page import AddMagneticModule
-from .mix_step_form import MixStepForm
+from .mix_step_form import MixStepForm, add_mix_step
 from .module_config_page import ModuleConfigPage
 from .pipette_modal import PipetteModal
 from .protocol_editor_page import ProtocolEditorPage
@@ -15,7 +15,7 @@ from .settings_page import SettingsPage
 from .tc_step_form_page import ThermocyclerStepPage
 from .tempdeck_step_form_page import TemperatureStepPage
 from .timeline import Timeline
-from .transfer_form import TransferPage, TransferStepConfig, add_transfer_step
+from .transfer_form import TransferPage, TransferStepConfig, add_transfer_step, add_transfer_steps
 
 __all__ = [
     "BasePage",
@@ -32,7 +32,9 @@ __all__ = [
     "HeaterShakerStepPage",
     "TransferPage",
     "TransferStepConfig",
+    "add_mix_step",
     "add_transfer_step",
+    "add_transfer_steps",
     "Timeline",
     "AddMagneticModule",
 ]

--- a/e2e-testing/automation/pd_pages/mix_step_form.py
+++ b/e2e-testing/automation/pd_pages/mix_step_form.py
@@ -7,6 +7,7 @@ from typing import Iterable, Literal, Optional, Sequence
 from playwright.sync_api import Locator, Page
 
 from automation.base_page import BasePage
+from automation.pd_pages.protocol_editor_page import ProtocolEditorPage
 
 
 class MixStepForm(BasePage):
@@ -508,3 +509,38 @@ class MixStepForm(BasePage):
 
         texts = [" ".join(text.split()) for text in list_item.locator("p").all_inner_texts()]
         return any(option_text in text for text in texts)
+
+
+def add_mix_step(
+    editor: ProtocolEditorPage,
+    mix_form: MixStepForm,
+    *,
+    pipette: str,
+    tip_rack: str,
+    labware: str,
+    wells: Sequence[str],
+    volume: str,
+    repetitions: str,
+    nozzle_config: MixStepForm.NozzleConfig = "All nozzles (recommended)",
+    partial_count: Optional[int] = None,
+    primary_nozzle: Optional[str] = None,
+) -> None:
+    """Add and save a basic mix step through the four-part wizard."""
+    editor.add_step("Mix")
+    mix_form.select_pipette(pipette)
+    mix_form.select_tiprack(tip_rack)
+    mix_form.select_labware(labware)
+    mix_form.open_nozzle_and_well_selector()
+    mix_form.select_nozzle_configuration(
+        nozzle_config,
+        partial_count=partial_count,
+        primary_nozzle=primary_nozzle,
+    )
+    mix_form.expect_mix_well_modal(labware)
+    mix_form.select_wells(wells)
+    mix_form.enter_volume(volume)
+    mix_form.enter_mix_repetitions(repetitions)
+    mix_form.click_continue()
+    mix_form.click_continue()
+    mix_form.click_continue()
+    mix_form.save_step()

--- a/e2e-testing/automation/pd_pages/transfer_form.py
+++ b/e2e-testing/automation/pd_pages/transfer_form.py
@@ -2,7 +2,7 @@
 
 import re
 from dataclasses import dataclass
-from typing import List, Literal, Optional, Union
+from typing import List, Literal, Optional, Sequence, Union
 
 from playwright.sync_api import Locator, Page, expect
 
@@ -717,7 +717,7 @@ class TransferPage(BasePage):
         self.page.get_by_role("button", name="Save", exact=True).last.click()
 
 
-@dataclass
+@dataclass(frozen=True)
 class TransferStepConfig:
     """Configuration for a single transfer step in the wizard."""
 
@@ -736,6 +736,44 @@ class TransferStepConfig:
     nozzle_config: TransferPage.NozzleConfig = "All nozzles (recommended)"
     partial_count: Optional[int] = None
     primary_nozzle: Optional[str] = None
+
+    @classmethod
+    def partial_nozzles(
+        cls,
+        *,
+        tip_rack: str,
+        source_labware: str,
+        dest_labware: str,
+        source_wells: Union[str, List[str]],
+        dest_wells: Union[str, List[str]],
+        path: str,
+        volume: str,
+        change_tip: str,
+        partial_count: int,
+        primary_nozzle: str,
+        pipette: Optional[str] = None,
+        drop_location: str = "Tip rack",
+        tip_tracking: TransferPage.TipTrackingMode = "Automatic tip tracking (recommended)",
+        manual_tips: Optional[List[str]] = None,
+    ) -> "TransferStepConfig":
+        """Build a transfer configured for a partial-nozzle pipette layout."""
+        return cls(
+            tip_rack=tip_rack,
+            source_labware=source_labware,
+            dest_labware=dest_labware,
+            source_wells=source_wells,
+            dest_wells=dest_wells,
+            path=path,
+            volume=volume,
+            change_tip=change_tip,
+            pipette=pipette,
+            drop_location=drop_location,
+            tip_tracking=tip_tracking,
+            manual_tips=manual_tips,
+            nozzle_config="Partial nozzles",
+            partial_count=partial_count,
+            primary_nozzle=primary_nozzle,
+        )
 
 
 def add_transfer_step(
@@ -771,3 +809,14 @@ def add_transfer_step(
         tip_tracking=config.tip_tracking,
         manual_tips=config.manual_tips,
     )
+
+
+def add_transfer_steps(
+    editor: ProtocolEditorPage,
+    transfer: TransferPage,
+    steps: Sequence[tuple[str, TransferStepConfig]],
+) -> None:
+    """Add labeled transfer steps and report each scenario in test output."""
+    for label, config in steps:
+        print(f"  - {label}")
+        add_transfer_step(editor, transfer, config)

--- a/e2e-testing/fixtures/protocol/9/single_eight_partial_tip_full.py
+++ b/e2e-testing/fixtures/protocol/9/single_eight_partial_tip_full.py
@@ -1,0 +1,97 @@
+import json
+from opentrons import protocol_api, types
+
+metadata = {
+    "protocolName": "single_eight_partial_tip_test",
+    "created": "2026-05-22T20:17:01.862Z",
+    "internalAppBuildDate": "Tue, 05 May 2026 15:37:27 GMT",
+    "lastModified": "2026-05-22T20:25:17.372Z",
+    "protocolDesigner": "8.10.1",
+    "source": "Protocol Designer",
+}
+
+requirements = {"robotType": "Flex", "apiLevel": "2.28"}
+
+def run(protocol: protocol_api.ProtocolContext) -> None:
+    # Load Modules:
+    thermocycler_module_1 = protocol.load_module("thermocyclerModuleV2", "B1")
+    flex_stacker_module_1 = protocol.load_module("flexStackerModuleV1", "A4")
+    temperature_module_1 = protocol.load_module("temperatureModuleV2", "C1")
+    heater_shaker_module_1 = protocol.load_module("heaterShakerModuleV1", "D1")
+
+    # Load Adapters:
+    adapter_1 = heater_shaker_module_1.load_adapter(
+        "opentrons_universal_flat_adapter_type_b",
+        namespace="opentrons",
+        version=1,
+    )
+
+    # Load Labware:
+    tip_rack_1 = protocol.load_labware(
+        "opentrons_flex_96_filtertiprack_20ul",
+        location="C3",
+        namespace="opentrons",
+        version=1,
+    )
+    tip_rack_2 = protocol.load_labware(
+        "opentrons_flex_96_filtertiprack_1000ul",
+        location="B2",
+        namespace="opentrons",
+        version=1,
+    )
+    well_plate_1 = protocol.load_labware(
+        "corning_384_wellplate_112ul_flat",
+        location="A3",
+        namespace="opentrons",
+        version=5,
+    )
+    aluminum_block_1 = temperature_module_1.load_labware(
+        "opentrons_24_aluminumblock_generic_2ml_screwcap",
+        namespace="opentrons",
+        version=3,
+    )
+    well_plate_2 = adapter_1.load_labware(
+        "thermofisher_nunc_maxisorp_lockwell_elisa",
+        namespace="opentrons",
+        version=1,
+    )
+    well_plate_3 = thermocycler_module_1.load_labware(
+        "opentrons_96_wellplate_200ul_pcr_full_skirt",
+        namespace="opentrons",
+        version=4,
+    )
+
+    # Load Pipettes:
+    pipette_left = protocol.load_instrument("flex_1channel_50", "left")
+    pipette_right = protocol.load_instrument("flex_8channel_1000", "right")
+
+    # Load Waste Chute:
+    waste_chute = protocol.load_waste_chute()
+
+    # Define Liquids:
+    liquid_1 = protocol.define_liquid(
+        "f",
+        display_color="#b925ff",
+    )
+
+    # Load Liquids:
+    aluminum_block_1.load_liquid(
+        wells=[
+            "A1", "B1", "C1", "D1", "A2", "B2", "C2", "D2",
+            "A3", "B3", "C3", "D3", "A4", "B4", "C4", "D4",
+            "A5", "B5", "C5", "D5", "A6", "B6", "C6", "D6"
+        ],
+        liquid=liquid_1,
+        volume=12,
+    )
+
+    # PROTOCOL STEPS
+
+    # Step 1: thermocycler
+    thermocycler_module_1.open_lid()
+
+    # Step 2: Heater-Shaker
+    heater_shaker_module_1.close_labware_latch()
+    heater_shaker_module_1.deactivate_heater()
+
+DESIGNER_APPLICATION = """{"robot":{"model":"OT-3 Standard"},"designerApplication":{"name":"opentrons/protocol-designer","version":"8.10.0","data":{"pipetteTiprackAssignments":{"5677ca62-3b96-4eaf-bbd5-badd25b6dde5":["opentrons/opentrons_flex_96_filtertiprack_20ul/1"],"ba4f015c-f81b-4b15-ae3d-78b555902700":["opentrons/opentrons_flex_96_filtertiprack_1000ul/1"]},"dismissedWarnings":{"form":[],"timeline":[]},"ingredients":{"0":{"displayName":"f","displayColor":"#b925ff","liquidClass":"water","description":null,"liquidGroupId":"0"}},"ingredLocations":{"6818d423-e410-42c9-aafa-738a0964cf7a:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/3":{"A1":{"0":{"volume":12}},"B1":{"0":{"volume":12}},"C1":{"0":{"volume":12}},"D1":{"0":{"volume":12}},"A2":{"0":{"volume":12}},"B2":{"0":{"volume":12}},"C2":{"0":{"volume":12}},"D2":{"0":{"volume":12}},"A3":{"0":{"volume":12}},"B3":{"0":{"volume":12}},"C3":{"0":{"volume":12}},"D3":{"0":{"volume":12}},"A4":{"0":{"volume":12}},"B4":{"0":{"volume":12}},"C4":{"0":{"volume":12}},"D4":{"0":{"volume":12}},"A5":{"0":{"volume":12}},"B5":{"0":{"volume":12}},"C5":{"0":{"volume":12}},"D5":{"0":{"volume":12}},"A6":{"0":{"volume":12}},"B6":{"0":{"volume":12}},"C6":{"0":{"volume":12}},"D6":{"0":{"volume":12}}}},"savedStepForms":{"__INITIAL_DECK_SETUP_STEP__":{"stepType":"manualIntervention","id":"__INITIAL_DECK_SETUP_STEP__","labwareLocationUpdate":{"39c3fc1f-18d5-44b5-b93e-e66086848117:opentrons/opentrons_flex_96_filtertiprack_20ul/1":"C3","7792dcbe-557e-4172-98b4-d6c478316cd4:opentrons/opentrons_flex_96_filtertiprack_1000ul/1":"B2","64ef0bc1-355c-4218-aba5-e38e7f302857:opentrons/corning_384_wellplate_112ul_flat/5":"A3","6818d423-e410-42c9-aafa-738a0964cf7a:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/3":"a6c022dd-076d-4e31-93c9-b6aec2353059:temperatureModuleType","b1c1aee7-bb48-4ec2-9dbc-abb71eebba3e:opentrons/opentrons_universal_flat_adapter_type_b/1":"52de89e7-b77b-44fc-bfd6-c2254c4fd733:heaterShakerModuleType","f71cdbb6-50f1-4003-81c9-8561c680a8da:opentrons/thermofisher_nunc_maxisorp_lockwell_elisa/1":"b1c1aee7-bb48-4ec2-9dbc-abb71eebba3e:opentrons/opentrons_universal_flat_adapter_type_b/1","77990549-c44a-4f5e-a3b3-ef5da0873e18:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/4":"574a1f40-4512-42f1-a493-458c12abb818:thermocyclerModuleType"},"pipetteLocationUpdate":{"5677ca62-3b96-4eaf-bbd5-badd25b6dde5":"left","ba4f015c-f81b-4b15-ae3d-78b555902700":"right"},"moduleLocationUpdate":{"574a1f40-4512-42f1-a493-458c12abb818:thermocyclerModuleType":"B1","eb7905b0-692b-4d5a-9b8b-9ba3948bf715:flexStackerModuleType":"A4","a6c022dd-076d-4e31-93c9-b6aec2353059:temperatureModuleType":"C1","52de89e7-b77b-44fc-bfd6-c2254c4fd733:heaterShakerModuleType":"D1"},"moduleStateUpdate":{},"trashBinLocationUpdate":{},"wasteChuteLocationUpdate":{"2541ae7f-73bd-4d56-bdf1-15d749b4eb5e:wasteChute":"cutoutD3"},"stagingAreaLocationUpdate":{},"gripperLocationUpdate":{"cc4e61e2-b2df-44c8-856a-dfa118b0d805:gripper":"mounted"}},"b6c88739-1a10-4c82-ad26-90581b0c21cf":{"id":"b6c88739-1a10-4c82-ad26-90581b0c21cf","stepType":"thermocycler","stepName":"thermocycler","stepDetails":"","stepNumber":0,"blockIsActive":false,"blockTargetTemp":null,"lidIsActive":false,"lidOpen":true,"lidTargetTemp":null,"moduleId":"574a1f40-4512-42f1-a493-458c12abb818:thermocyclerModuleType","orderedProfileItems":[],"profileItemsById":{},"profileTargetLidTemp":null,"profileVolume":null,"thermocyclerFormType":"thermocyclerState"},"328ddea6-bca3-4e29-b936-c6bfd5b16d7a":{"id":"328ddea6-bca3-4e29-b936-c6bfd5b16d7a","stepType":"heaterShaker","stepName":"Heater-Shaker","stepDetails":"","stepNumber":0,"heaterShakerSetTimer":null,"heaterShakerTimer":null,"latchOpen":false,"moduleId":"52de89e7-b77b-44fc-bfd6-c2254c4fd733:heaterShakerModuleType","setHeaterShakerTemperature":null,"setShake":null,"targetHeaterShakerTemperature":null,"targetSpeed":null}},"orderedStepIds":["b6c88739-1a10-4c82-ad26-90581b0c21cf","328ddea6-bca3-4e29-b936-c6bfd5b16d7a"],"pipettes":{"5677ca62-3b96-4eaf-bbd5-badd25b6dde5":{"pipetteName":"p50_single_flex"},"ba4f015c-f81b-4b15-ae3d-78b555902700":{"pipetteName":"p1000_multi_flex"}},"modules":{"574a1f40-4512-42f1-a493-458c12abb818:thermocyclerModuleType":{"model":"thermocyclerModuleV2"},"eb7905b0-692b-4d5a-9b8b-9ba3948bf715:flexStackerModuleType":{"model":"flexStackerModuleV1"},"a6c022dd-076d-4e31-93c9-b6aec2353059:temperatureModuleType":{"model":"temperatureModuleV2"},"52de89e7-b77b-44fc-bfd6-c2254c4fd733:heaterShakerModuleType":{"model":"heaterShakerModuleV1"}},"labware":{"39c3fc1f-18d5-44b5-b93e-e66086848117:opentrons/opentrons_flex_96_filtertiprack_20ul/1":{"displayName":"Opentrons Flex 96 Filter Tip Rack 20 µL","labwareDefURI":"opentrons/opentrons_flex_96_filtertiprack_20ul/1"},"7792dcbe-557e-4172-98b4-d6c478316cd4:opentrons/opentrons_flex_96_filtertiprack_1000ul/1":{"displayName":"Opentrons Flex 96 Filter Tip Rack 1000 µL","labwareDefURI":"opentrons/opentrons_flex_96_filtertiprack_1000ul/1"},"64ef0bc1-355c-4218-aba5-e38e7f302857:opentrons/corning_384_wellplate_112ul_flat/5":{"displayName":"Corning 384 Well Plate 112 µL Flat","labwareDefURI":"opentrons/corning_384_wellplate_112ul_flat/5"},"6818d423-e410-42c9-aafa-738a0964cf7a:opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/3":{"displayName":"Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap","labwareDefURI":"opentrons/opentrons_24_aluminumblock_generic_2ml_screwcap/3"},"b1c1aee7-bb48-4ec2-9dbc-abb71eebba3e:opentrons/opentrons_universal_flat_adapter_type_b/1":{"displayName":"Opentrons Universal Flat Heater-Shaker Adapter Type B","labwareDefURI":"opentrons/opentrons_universal_flat_adapter_type_b/1"},"f71cdbb6-50f1-4003-81c9-8561c680a8da:opentrons/thermofisher_nunc_maxisorp_lockwell_elisa/1":{"displayName":"ThermoFisher Nunc MaxiSorp Lockwell ELISA","labwareDefURI":"opentrons/thermofisher_nunc_maxisorp_lockwell_elisa/1"},"77990549-c44a-4f5e-a3b3-ef5da0873e18:opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/4":{"displayName":"Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt","labwareDefURI":"opentrons/opentrons_96_wellplate_200ul_pcr_full_skirt/4"}}}},"metadata":{"protocolName":"single_eight_partial_tip_test","author":"","description":"","source":"Protocol Designer","created":1779481021862,"lastModified":1779481517372}}"""

--- a/e2e-testing/tests/pd/test_pd_8ch_single_partial_full.py
+++ b/e2e-testing/tests/pd/test_pd_8ch_single_partial_full.py
@@ -1,0 +1,570 @@
+"""E2E: 8-channel partial/single tip pickup and 1ch multi-transfer workflows."""
+
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import Page
+
+from automation.pd_pages import (
+    MixStepForm,
+    ProtocolEditorPage,
+    Timeline,
+    TransferPage,
+    TransferStepConfig,
+    add_mix_step,
+    add_transfer_steps,
+)
+from utility import assert_export_downloads_clean_protocol, import_protocol_and_open_editor
+
+PROTOCOL_PATH = "fixtures/protocol/9/single_eight_partial_tip_full.py"
+
+PLATE_384 = "Corning 384 Well Plate 112 µL Flat"
+TEMP_24 = "Opentrons 24 Well Aluminum Block with Generic 2 mL Screwcap"
+TC_96 = "Opentrons Tough 96 Well Plate 200 µL PCR Full Skirt"
+PIPETTE_8CH = "Flex 8-Channel 1000 µL"
+PIPETTE_1CH = "Flex 1-Channel 50 µL"
+TIPRACK_1000 = "Opentrons Flex 96 Filter Tip Rack 1000 µL"
+TIPRACK_20 = "Opentrons Flex 96 Filter Tip Rack 20 µL"
+
+_PARTIAL: TransferPage.NozzleConfig = "Partial nozzles"
+_SINGLE: TransferPage.NozzleConfig = "Single nozzle"
+_MANUAL: TransferPage.TipTrackingMode = "Manual tip tracking"
+_AUTO: TransferPage.TipTrackingMode = "Automatic tip tracking (recommended)"
+
+TEMP_24_WELLS = [f"{row}{col}" for col in range(1, 7) for row in "ABCD"]
+
+# Fixture ships with thermocycler + heater-shaker before wizard-authored steps.
+SETUP_STEP_COUNT = 2
+PARTIAL_8CH_SAMPLE_STEP_INDICES = [2, 8, 14, 19]
+SINGLE_NOZZLE_SAMPLE_STEP_INDICES = [2, 5, 7]
+
+
+@pytest.mark.pdE2E
+@pytest.mark.slow
+@pytest.mark.timeout(900)
+def test_pd_8ch_partial_all_counts_paths_and_tip_strategies(page: Page, pd_exports_dir: Path) -> None:
+    """Exercise 8ch partial 2–7 nozzle pickups across transfer/distribute/consolidate.
+
+    Ordering constraints:
+    - Prefer Once (incl. manual) before Always so automatic tip use does not block
+      later manual tip selection.
+    - First transfer uses deck 384 (thermocycler lid is open); later steps use TC 96.
+    """
+    import_protocol_and_open_editor(page, PROTOCOL_PATH, migration=True)
+    editor = ProtocolEditorPage(page)
+    transfer = TransferPage(page)
+
+    print("=== 8ch partial strategy suite ===")
+    print("1) Single-transfer phase (Once before Always)")
+    transfer_steps = [
+        (
+            "3/8 transfer Once manual 384 P23→P24",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=PLATE_384,
+                dest_labware=PLATE_384,
+                source_wells="P23",
+                dest_wells="P24",
+                path="Single transfer",
+                volume="20",
+                change_tip="Once",
+                tip_tracking=_MANUAL,
+                manual_tips=["A4"],
+                partial_count=3,
+                primary_nozzle="F1",
+            ),
+        ),
+        (
+            "4/8 transfer Once manual TC E1→E2 (tips A1)",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells="E1",
+                dest_wells="E2",
+                path="Single transfer",
+                volume="20",
+                change_tip="Once",
+                tip_tracking=_MANUAL,
+                manual_tips=["A1"],
+                partial_count=4,
+                primary_nozzle="E1",
+            ),
+        ),
+        (
+            "6/8 transfer Once manual TC C7→C8 (tips A7)",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells="C7",
+                dest_wells="C8",
+                path="Single transfer",
+                volume="20",
+                change_tip="Once",
+                tip_tracking=_MANUAL,
+                manual_tips=["A7"],
+                partial_count=6,
+                primary_nozzle="C1",
+            ),
+        ),
+        (
+            "7/8 transfer Once auto waste TC B8→B9",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells="B8",
+                dest_wells="B9",
+                path="Single transfer",
+                volume="20",
+                change_tip="Once",
+                drop_location="Waste Chute",
+                tip_tracking=_AUTO,
+                partial_count=7,
+                primary_nozzle="B1",
+            ),
+        ),
+        (
+            "5/8 transfer Always auto return TC D6→D7",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells="D6",
+                dest_wells="D7",
+                path="Single transfer",
+                volume="20",
+                change_tip="Always",
+                tip_tracking=_AUTO,
+                partial_count=5,
+                primary_nozzle="D1",
+            ),
+        ),
+    ]
+    add_transfer_steps(editor, transfer, transfer_steps)
+
+    print("2) Distribute phase (Once before Always)")
+    distribute_steps = [
+        (
+            "2/8 distribute Once manual G2→G3/G4/G5 (tips A2)",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells="G2",
+                dest_wells=["G3", "G4", "G5"],
+                path="Distribute",
+                volume="20",
+                change_tip="Once",
+                tip_tracking=_MANUAL,
+                manual_tips=["A2"],
+                partial_count=2,
+                primary_nozzle="G1",
+            ),
+        ),
+        (
+            "4/8 distribute Once auto return E5→E6/E7/E8",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells="E5",
+                dest_wells=["E6", "E7", "E8"],
+                path="Distribute",
+                volume="20",
+                change_tip="Once",
+                tip_tracking=_AUTO,
+                partial_count=4,
+                primary_nozzle="E1",
+            ),
+        ),
+        (
+            "6/8 distribute Once manual C7→C8/C9/C10 (tips A7)",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells="C7",
+                dest_wells=["C8", "C9", "C10"],
+                path="Distribute",
+                volume="20",
+                change_tip="Once",
+                tip_tracking=_MANUAL,
+                manual_tips=["A7"],
+                partial_count=6,
+                primary_nozzle="C1",
+            ),
+        ),
+        (
+            "3/8 distribute Always auto return F4→F5/F6/F7",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells="F4",
+                dest_wells=["F5", "F6", "F7"],
+                path="Distribute",
+                volume="20",
+                change_tip="Always",
+                tip_tracking=_AUTO,
+                partial_count=3,
+                primary_nozzle="F1",
+            ),
+        ),
+        (
+            "5/8 distribute Always auto waste D6→D7/D8/D9",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells="D6",
+                dest_wells=["D7", "D8", "D9"],
+                path="Distribute",
+                volume="20",
+                change_tip="Always",
+                drop_location="Waste Chute",
+                tip_tracking=_AUTO,
+                partial_count=5,
+                primary_nozzle="D1",
+            ),
+        ),
+        (
+            "7/8 distribute Always auto return B8→B9/B10/B11",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells="B8",
+                dest_wells=["B9", "B10", "B11"],
+                path="Distribute",
+                volume="20",
+                change_tip="Always",
+                tip_tracking=_AUTO,
+                partial_count=7,
+                primary_nozzle="B1",
+            ),
+        ),
+    ]
+    add_transfer_steps(editor, transfer, distribute_steps)
+
+    print("3) Consolidate phase (Once before Always)")
+    consolidate_steps = [
+        (
+            "2/8 consolidate Once auto return G2/G3/G4→G3",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells=["G2", "G3", "G4"],
+                dest_wells="G3",
+                path="Consolidate",
+                volume="20",
+                change_tip="Once",
+                tip_tracking=_AUTO,
+                partial_count=2,
+                primary_nozzle="G1",
+            ),
+        ),
+        (
+            "3/8 consolidate Once manual F4/F5/F6→F5 (tips A4)",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells=["F4", "F5", "F6"],
+                dest_wells="F5",
+                path="Consolidate",
+                volume="20",
+                change_tip="Once",
+                tip_tracking=_MANUAL,
+                manual_tips=["A4"],
+                partial_count=3,
+                primary_nozzle="F1",
+            ),
+        ),
+        (
+            "5/8 consolidate Once manual D6/D7/D8→D7 (tips A6)",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells=["D6", "D7", "D8"],
+                dest_wells="D7",
+                path="Consolidate",
+                volume="20",
+                change_tip="Once",
+                tip_tracking=_MANUAL,
+                manual_tips=["A6"],
+                partial_count=5,
+                primary_nozzle="D1",
+            ),
+        ),
+        (
+            "7/8 consolidate Once auto return B8/B9/B10→B9",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells=["B8", "B9", "B10"],
+                dest_wells="B9",
+                path="Consolidate",
+                volume="20",
+                change_tip="Once",
+                tip_tracking=_AUTO,
+                partial_count=7,
+                primary_nozzle="B1",
+            ),
+        ),
+        (
+            "4/8 consolidate Always auto waste E5/E6/E7→E6",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells=["E5", "E6", "E7"],
+                dest_wells="E6",
+                path="Consolidate",
+                volume="20",
+                change_tip="Always",
+                drop_location="Waste Chute",
+                tip_tracking=_AUTO,
+                partial_count=4,
+                primary_nozzle="E1",
+            ),
+        ),
+        (
+            "6/8 consolidate Always auto return C7/C8/C9→C8",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=TC_96,
+                dest_labware=TC_96,
+                source_wells=["C7", "C8", "C9"],
+                dest_wells="C8",
+                path="Consolidate",
+                volume="20",
+                change_tip="Always",
+                tip_tracking=_AUTO,
+                partial_count=6,
+                primary_nozzle="C1",
+            ),
+        ),
+    ]
+    add_transfer_steps(editor, transfer, consolidate_steps)
+
+    print("4) Cross-labware 384→TC partial transfer")
+    cross_steps = [
+        (
+            "5/8 transfer 384→TC Always manual waste (tips A12)",
+            TransferStepConfig.partial_nozzles(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=PLATE_384,
+                dest_labware=TC_96,
+                source_wells="H23",
+                dest_wells="H1",
+                path="Single transfer",
+                volume="30",
+                change_tip="Always",
+                drop_location="Waste Chute",
+                tip_tracking=_MANUAL,
+                manual_tips=["A12"],
+                partial_count=5,
+                primary_nozzle="D1",
+            ),
+        ),
+    ]
+    add_transfer_steps(editor, transfer, cross_steps)
+
+    authored = len(transfer_steps) + len(distribute_steps) + len(consolidate_steps) + len(cross_steps)
+    print("5) Timeline + export validation")
+    timeline = Timeline(page)
+    timeline.wait_for_timeline_steps(min_steps=SETUP_STEP_COUNT + authored)
+    timeline.expect_no_known_regression_errors()
+    timeline.select_transfer_steps_sample(PARTIAL_8CH_SAMPLE_STEP_INDICES, expect_no_errors=True)
+    assert_export_downloads_clean_protocol(
+        page,
+        editor,
+        pd_exports_dir,
+        filename="8ch_partial_all_counts.py",
+    )
+
+
+@pytest.mark.pdE2E
+@pytest.mark.slow
+@pytest.mark.timeout(300)
+def test_pd_8ch_partial_mix_on_96_well(page: Page, pd_exports_dir: Path) -> None:
+    """Exercise 8ch partial-nozzle pickup on a mix step targeting a 96-well plate."""
+    import_protocol_and_open_editor(page, PROTOCOL_PATH, migration=True)
+    editor = ProtocolEditorPage(page)
+    mix_form = MixStepForm(page)
+
+    print("=== 8ch partial mix suite ===")
+    print("1) Add Mix step with 4/8 partial nozzles on TC 96")
+    add_mix_step(
+        editor,
+        mix_form,
+        pipette=PIPETTE_8CH,
+        tip_rack=TIPRACK_1000,
+        labware=TC_96,
+        wells=["D1", "E1"],
+        volume="30",
+        repetitions="3",
+        nozzle_config=_PARTIAL,
+        partial_count=4,
+        primary_nozzle="E1",
+    )
+
+    print("2) Timeline + export validation")
+    timeline = Timeline(page)
+    timeline.wait_for_timeline_steps(min_steps=SETUP_STEP_COUNT + 1)
+    timeline.expect_no_known_regression_errors()
+    timeline.select_transfer_steps_sample([SETUP_STEP_COUNT], expect_no_errors=True)
+    assert_export_downloads_clean_protocol(
+        page,
+        editor,
+        pd_exports_dir,
+        filename="8ch_partial_mix_96well.py",
+    )
+
+
+@pytest.mark.pdE2E
+@pytest.mark.slow
+@pytest.mark.timeout(600)
+def test_pd_8ch_single_nozzle_and_1ch_workflows(page: Page, pd_exports_dir: Path) -> None:
+    """Exercise 8ch single-nozzle distribute and 1ch distribute/consolidate/transfer."""
+    import_protocol_and_open_editor(page, PROTOCOL_PATH, migration=True)
+    editor = ProtocolEditorPage(page)
+    transfer = TransferPage(page)
+
+    print("=== 8ch single-nozzle + 1ch suite ===")
+    print("1) 8ch single-nozzle transfers")
+    eight_ch_steps = [
+        (
+            "8ch single distribute 384→temp Always auto",
+            TransferStepConfig(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=PLATE_384,
+                dest_labware=TEMP_24,
+                source_wells="A1",
+                dest_wells=TEMP_24_WELLS,
+                path="Distribute",
+                volume="30",
+                change_tip="Always",
+                nozzle_config=_SINGLE,
+            ),
+        ),
+        (
+            "8ch single transfer 384→TC Once manual (tips H12)",
+            TransferStepConfig(
+                pipette=PIPETTE_8CH,
+                tip_rack=TIPRACK_1000,
+                source_labware=PLATE_384,
+                dest_labware=TC_96,
+                source_wells="A2",
+                dest_wells="A1",
+                path="Single transfer",
+                volume="30",
+                change_tip="Once",
+                tip_tracking=_MANUAL,
+                manual_tips=["H12"],
+                nozzle_config=_SINGLE,
+            ),
+        ),
+    ]
+    add_transfer_steps(editor, transfer, eight_ch_steps)
+
+    print("2) 1ch distribute / consolidate / transfer")
+    one_ch_steps = [
+        (
+            "1ch distribute TC→temp Always",
+            TransferStepConfig(
+                pipette=PIPETTE_1CH,
+                tip_rack=TIPRACK_20,
+                source_labware=TC_96,
+                dest_labware=TEMP_24,
+                source_wells="A1",
+                dest_wells=["A1", "A2", "A3"],
+                path="Distribute",
+                volume="20",
+                change_tip="Always",
+            ),
+        ),
+        (
+            "1ch consolidate temp→TC Once waste",
+            TransferStepConfig(
+                pipette=PIPETTE_1CH,
+                tip_rack=TIPRACK_20,
+                source_labware=TEMP_24,
+                dest_labware=TC_96,
+                source_wells=["B1", "B2"],
+                dest_wells="B1",
+                path="Consolidate",
+                volume="10",
+                change_tip="Once",
+                drop_location="Waste Chute",
+            ),
+        ),
+        # Never follows adjacent 1ch Once (same single-tip nozzle count).
+        (
+            "1ch transfer TC→temp Once manual (tips A1)",
+            TransferStepConfig(
+                pipette=PIPETTE_1CH,
+                tip_rack=TIPRACK_20,
+                source_labware=TC_96,
+                dest_labware=TEMP_24,
+                source_wells="C1",
+                dest_wells="C1",
+                path="Single transfer",
+                volume="20",
+                change_tip="Once",
+                tip_tracking=_MANUAL,
+                manual_tips=["A1"],
+            ),
+        ),
+        (
+            "1ch transfer temp→TC Never (reuse manual tip)",
+            TransferStepConfig(
+                pipette=PIPETTE_1CH,
+                tip_rack=TIPRACK_20,
+                source_labware=TEMP_24,
+                dest_labware=TC_96,
+                source_wells="D1",
+                dest_wells="D1",
+                path="Single transfer",
+                volume="20",
+                change_tip="Never",
+            ),
+        ),
+    ]
+    add_transfer_steps(editor, transfer, one_ch_steps)
+
+    print("3) Timeline + export validation")
+    timeline = Timeline(page)
+    timeline.wait_for_timeline_steps(min_steps=SETUP_STEP_COUNT + len(eight_ch_steps) + len(one_ch_steps))
+    timeline.expect_no_known_regression_errors()
+    timeline.select_transfer_steps_sample(SINGLE_NOZZLE_SAMPLE_STEP_INDICES, expect_no_errors=True)
+    assert_export_downloads_clean_protocol(
+        page,
+        editor,
+        pd_exports_dir,
+        filename="8ch_single_nozzle_and_1ch.py",
+    )

--- a/e2e-testing/tests/pd/test_pd_96ch_tip_strategies.py
+++ b/e2e-testing/tests/pd/test_pd_96ch_tip_strategies.py
@@ -6,8 +6,13 @@ from typing import List, Union
 import pytest
 from playwright.sync_api import Page
 
-from automation.pd_pages import ProtocolEditorPage, Timeline, TransferPage
-from automation.pd_pages.transfer_form import TransferStepConfig, add_transfer_step
+from automation.pd_pages import (
+    ProtocolEditorPage,
+    Timeline,
+    TransferPage,
+    TransferStepConfig,
+    add_transfer_steps,
+)
 from utility import assert_export_downloads_clean_protocol, import_protocol_and_open_editor
 
 PROTOCOL_PATH = "fixtures/protocol/9/96_channel_setup.py"
@@ -42,16 +47,6 @@ def _wells(
     path: str = "Single transfer",
 ) -> tuple[Union[str, List[str]], Union[str, List[str]]]:
     return _WELLS_384[(nozzle_config, primary, path)]
-
-
-def _run_transfers(
-    editor: ProtocolEditorPage,
-    transfer: TransferPage,
-    steps: list[tuple[str, TransferStepConfig]],
-) -> None:
-    for label, config in steps:
-        print(f"  - {label}")
-        add_transfer_step(editor, transfer, config)
 
 
 @pytest.mark.pdE2E
@@ -105,7 +100,7 @@ def test_pd_96ch_tip_strategies_sequential(page: Page, pd_exports_dir: Path) -> 
         )
         for label, change_tip, drop, tip_tracking, manual_tips in column_specs
     ]
-    _run_transfers(editor, transfer, column_steps)
+    add_transfer_steps(editor, transfer, column_steps)
 
     print("3) Single-nozzle strategy phase")
     single_specs = [
@@ -138,7 +133,7 @@ def test_pd_96ch_tip_strategies_sequential(page: Page, pd_exports_dir: Path) -> 
                 ),
             )
         )
-    _run_transfers(editor, transfer, single_steps)
+    add_transfer_steps(editor, transfer, single_steps)
 
     print("4) Full-rack strategy phase")
     full_rack_specs = [
@@ -166,7 +161,7 @@ def test_pd_96ch_tip_strategies_sequential(page: Page, pd_exports_dir: Path) -> 
         )
         for label, src, dst, change_tip, drop, tip_tracking, manual_tips in full_rack_specs
     ]
-    _run_transfers(editor, transfer, full_rack_steps)
+    add_transfer_steps(editor, transfer, full_rack_steps)
 
     print("5) Timeline + export validation")
     # 1 move + 3 column + 5 single + 3 full-rack


### PR DESCRIPTION
[RQA-5273](https://opentrons.atlassian.net/browse/RQA-5273)

# Overview

End-to-end coverage for Flex 8-channel partial and single-nozzle pickup, plus related 1-channel multi-path transfers, including tip tracking modes, labware variety, timeline health, and clean Python export.

[RQA-5273]: https://opentrons.atlassian.net/browse/RQA-5273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ