### PR TITLE
feat(app): Make Compliance Ready Software features available without a feature flag

### DIFF
--- a/app/src/assets/localization/en/app_settings.json
+++ b/app/src/assets/localization/en/app_settings.json
@@ -1,5 +1,4 @@
 {
-  "__dev_internal__accessControlMode": "Enable frontend for Compliance Ready Software (access control mode)",
   "__dev_internal__enableLabwareCreator": "Enable App Labware Creator",
   "__dev_internal__enableRunNotes": "Display Notes During a Protocol Run",
   "__dev_internal__forceHttpPolling": "Poll all network requests instead of using MQTT",

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsAdvanced.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsAdvanced.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { createPortal } from 'react-dom'
-import { useSelector } from 'react-redux'
 
 import {
   ALIGN_CENTER,
@@ -21,7 +20,6 @@ import { ToggleButton } from '/app/atoms/buttons'
 import { Divider } from '/app/atoms/structure'
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useIsFlex, useRobot } from '/app/redux-resources/robots'
-import { getFeatureFlags } from '/app/redux/config'
 import { getRobotSerialNumber, UNREACHABLE } from '/app/redux/discovery'
 import { useIsEstopNotDisengaged } from '/app/resources/devices/hooks/useIsEstopNotDisengaged'
 import { useCurrentRun } from '/app/resources/runs'
@@ -78,7 +76,6 @@ export function RobotSettingsAdvanced({
 
   const isEstopNotDisengaged = useIsEstopNotDisengaged(robotName)
   const currentRun = useCurrentRun()
-  const featureFlags = useSelector(getFeatureFlags)
 
   const robot = useRobot(robotName)
   const isFlex = useIsFlex(robotName)
@@ -171,20 +168,16 @@ export function RobotSettingsAdvanced({
         <RobotServerVersion robotName={robotName} />
         <Divider marginY={SPACING.spacing16} />
         <RobotInformation robotName={robotName} />
-        {featureFlags.accessControlMode ? (
-          <>
-            <Divider marginY={SPACING.spacing16} />
-            <EnableComplianceReadySoftware
-              isRobotBusy={isRobotBusy}
-              robotName={robotName}
-            />
-            <Divider marginY={SPACING.spacing16} />
-            <EnterRobotEncryptionKey
-            // Note: Unlike other buttons on this page,
-            // this should be available even if the robot is busy.
-            />
-          </>
-        ) : null}
+        <Divider marginY={SPACING.spacing16} />
+        <EnableComplianceReadySoftware
+          isRobotBusy={isRobotBusy}
+          robotName={robotName}
+        />
+        <Divider marginY={SPACING.spacing16} />
+        <EnterRobotEncryptionKey
+        // Note: Unlike other buttons on this page,
+        // this should be available even if the robot is busy.
+        />
         {isFlex ? null : (
           <>
             <Divider marginY={SPACING.spacing16} />

--- a/app/src/organisms/Desktop/Devices/RobotSettings/__tests__/RobotSettingsAdvanced.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/__tests__/RobotSettingsAdvanced.test.tsx
@@ -8,7 +8,6 @@ import '@testing-library/jest-dom/vitest'
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { useIsFlex, useIsRobotBusy } from '/app/redux-resources/robots'
-import { getFeatureFlags } from '/app/redux/config'
 import { getShellUpdateState } from '/app/redux/shell'
 import { useCurrentRun } from '/app/resources/runs'
 
@@ -32,19 +31,11 @@ import {
 } from '../AdvancedTab'
 import { RobotSettingsAdvanced } from '../RobotSettingsAdvanced'
 
-import type * as Config from '/app/redux/config'
 import type { ShellUpdateState } from '/app/redux/shell/types'
 import type * as ShellUpdate from '/app/redux/shell/update'
 
 vi.mock('/app/redux-resources/robots')
 vi.mock('/app/redux/discovery/selectors')
-vi.mock('/app/redux/config', async importOriginal => {
-  const actual = await importOriginal<typeof Config>()
-  return {
-    ...actual,
-    getFeatureFlags: vi.fn(),
-  }
-})
 vi.mock('/app/redux/shell/update', async importOriginal => {
   const actual = await importOriginal<typeof ShellUpdate>()
   return {
@@ -136,7 +127,6 @@ describe('RobotSettings Advanced tab', () => {
     vi.mocked(EnableComplianceReadySoftware).mockReturnValue(
       <div>Mock EnableComplianceReadySoftware Section</div>
     )
-    vi.mocked(getFeatureFlags).mockReturnValue({})
     vi.mocked(useIsRobotBusy).mockReturnValue(false)
     vi.mocked(useCurrentRun).mockReturnValue(null)
   })
@@ -150,28 +140,12 @@ describe('RobotSettings Advanced tab', () => {
     screen.getByText('Mock AboutRobotName Section')
   })
 
-  it('should not render EnableComplianceReadySoftware when accessControlMode is off', () => {
-    render()
-    expect(
-      screen.queryByText('Mock EnableComplianceReadySoftware Section')
-    ).toBeNull()
-  })
-
-  it('should not render EnterRobotEncryptionKey when accessControlMode is off', () => {
-    render()
-    expect(
-      screen.queryByText('Mock EnterRobotEncryptionKey Section')
-    ).toBeNull()
-  })
-
-  it('should render EnableComplianceReadySoftware when accessControlMode is on', () => {
-    vi.mocked(getFeatureFlags).mockReturnValue({ accessControlMode: true })
+  it('should render EnableComplianceReadySoftware section', () => {
     render()
     screen.getByText('Mock EnableComplianceReadySoftware Section')
   })
 
-  it('should render EnterRobotEncryptionKey when accessControlMode is on', () => {
-    vi.mocked(getFeatureFlags).mockReturnValue({ accessControlMode: true })
+  it('should render EnterRobotEncryptionKey section', () => {
     render()
     screen.getByText('Mock EnterRobotEncryptionKey Section')
   })

--- a/app/src/pages/ODD/RobotSettingsDashboard/RobotSettingsList.tsx
+++ b/app/src/pages/ODD/RobotSettingsDashboard/RobotSettingsList.tsx
@@ -89,8 +89,6 @@ export function RobotSettingsList(props: RobotSettingsListProps): JSX.Element {
   const appLanguage = useSelector(getAppLanguage)
   const currentLanguageOption = LANGUAGES.find(lng => lng.value === appLanguage)
 
-  const devInternalFlags = useSelector(getFeatureFlags)
-
   return (
     <div className={styles.main_content}>
       <Navigation />
@@ -226,16 +224,14 @@ export function RobotSettingsList(props: RobotSettingsListProps): JSX.Element {
           }}
           iconName="privacy"
         />
-        {devInternalFlags?.accessControlMode ? (
-          <RobotSettingButton
-            settingName={t('robot_encryption_key')}
-            dataTestId="RobotSettingButton_encryption"
-            onClick={() => {
-              setCurrentOption('RobotEncryptionKey')
-            }}
-            iconName="verified"
-          />
-        ) : null}
+        <RobotSettingButton
+          settingName={t('robot_encryption_key')}
+          dataTestId="RobotSettingButton_encryption"
+          onClick={() => {
+            setCurrentOption('RobotEncryptionKey')
+          }}
+          iconName="verified"
+        />
         <RobotSettingButton
           settingName={i18n.format(
             t('app_settings:error_recovery_mode'),

--- a/app/src/pages/ODD/RobotSettingsDashboard/__tests__/RobotSettingsDashboard.test.tsx
+++ b/app/src/pages/ODD/RobotSettingsDashboard/__tests__/RobotSettingsDashboard.test.tsx
@@ -30,7 +30,6 @@ import { FileManager } from '/app/organisms/ODD/RobotSettingsDashboard/FileManag
 import {
   getAppLanguage,
   getConfig,
-  getFeatureFlags,
   toggleConfigValue,
   toggleDevtools,
 } from '/app/redux/config'
@@ -157,7 +156,6 @@ describe('RobotSettingsDashboard', () => {
       toggleERSettings: mockToggleER,
     })
     vi.mocked(getAppLanguage).mockReturnValue(MOCK_DEFAULT_LANGUAGE)
-    vi.mocked(getFeatureFlags).mockReturnValue({ accessControlMode: false })
     vi.mocked(getConfig).mockReturnValue({
       update: { automaticallyDownloadUpdates: false },
     } as Config)
@@ -413,7 +411,6 @@ describe('RobotSettingsDashboard', () => {
   })
 
   it('should render the component when tapping show encryption key', () => {
-    vi.mocked(getFeatureFlags).mockReturnValue({ accessControlMode: true })
     render()
     const button = screen.getByText('Robot encryption key')
     fireEvent.click(button)

--- a/app/src/redux/config/constants.ts
+++ b/app/src/redux/config/constants.ts
@@ -9,7 +9,6 @@ export const DEV_INTERNAL_FLAGS: DevInternalFlag[] = [
   'reactQueryDevtools',
   'reactScan',
   'quickTransferProtocolContentsLog',
-  'accessControlMode',
   'robotSearchBar',
   'showGitDetails',
 ]

--- a/app/src/redux/config/schema-types.ts
+++ b/app/src/redux/config/schema-types.ts
@@ -17,7 +17,6 @@ export type DevInternalFlag =
   | 'reactQueryDevtools'
   | 'reactScan'
   | 'quickTransferProtocolContentsLog'
-  | 'accessControlMode'
   | 'robotSearchBar'
   | 'showGitDetails'
 


### PR DESCRIPTION
## Overview

As we prepare to release Compliance Ready Software, this removes the frontend feature flag for it. (The frontend will now always behave as if it's true.) This closes EXEC-2545.

Note that most features of Compliance Ready Software will still only be available if it's enabled *on the robot.* This PR effectively just unlocks the first-time setup buttons in the settings pages.

## Test Plan and Hands on Testing

None needed.

## Review requests

None.

## Risk assessment

Low.
