### PR TITLE
feat(app, odd): document confirming liquids and labware placement

### DIFF
--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -10,6 +10,7 @@
   "attach_pipette_right": "Launching attach pipette on right mount flow",
   "calibrate": "Calibrating",
   "capture_preview_image": "Capturing preview image",
+  "confirm_placements": "Confirming liquids and labware placements",
   "connect_wifi": "Connect to wifi network",
   "create_camera_image_settings": "Updating camera image settings",
   "create_offsets": "Saving new labware offsets",

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabware.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabware.test.tsx
@@ -7,6 +7,7 @@ import { useHoverTooltip } from '@opentrons/components'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
 import { getIsLabwareOffsetCodeSnippetsOn } from '/app/redux/config'
 import {
   useLPCDisabledReason,
@@ -36,6 +37,9 @@ vi.mock('/app/organisms/RunTimeControl/hooks')
 vi.mock('/app/redux/config')
 vi.mock('/app/resources/runs')
 vi.mock('/app/redux-resources/robots')
+vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
+  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+}))
 
 const ROBOT_NAME = 'otie'
 const RUN_ID = '1'

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabware.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/__tests__/SetupLabware.test.tsx
@@ -4,10 +4,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { when } from 'vitest-when'
 
 import { useHoverTooltip } from '@opentrons/components'
+import { usePostLogMessageMutation } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
-import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
+import {
+  ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+  createReasonNotRequiredDocumentationState,
+} from '/app/local-resources/access-control/__fixtures__/documentationState'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { getIsLabwareOffsetCodeSnippetsOn } from '/app/redux/config'
 import {
   useLPCDisabledReason,
@@ -22,11 +27,20 @@ import { getModuleTypesThatRequireExtraAttention } from '../../utils/getModuleTy
 import { SetupLabwareList } from '../SetupLabwareList'
 import { SetupLabwareMap } from '../SetupLabwareMap'
 
+import type * as ReactApiClient from '@opentrons/react-api-client'
+
 vi.mock('@opentrons/components', async () => {
   const actual = await vi.importActual('@opentrons/components')
   return {
     ...actual,
     useHoverTooltip: vi.fn(),
+  }
+})
+vi.mock('@opentrons/react-api-client', async importOriginal => {
+  const actual = await importOriginal<typeof ReactApiClient>()
+  return {
+    ...actual,
+    usePostLogMessageMutation: vi.fn(),
   }
 })
 vi.mock('../SetupLabwareList')
@@ -37,12 +51,11 @@ vi.mock('/app/organisms/RunTimeControl/hooks')
 vi.mock('/app/redux/config')
 vi.mock('/app/resources/runs')
 vi.mock('/app/redux-resources/robots')
-vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
-  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
-}))
+vi.mock('/app/local-resources/access-control/useDocumentationState')
 
 const ROBOT_NAME = 'otie'
 const RUN_ID = '1'
+const mockPostLogMessage = vi.fn()
 
 const render = () => {
   let labwareConfirmed = false
@@ -93,6 +106,12 @@ describe('SetupLabware', () => {
     vi.mocked(useNotifyRunQuery).mockReturnValue({} as any)
     vi.mocked(useHoverTooltip).mockReturnValue([{}, {}] as any)
     vi.mocked(useRunHasStarted).mockReturnValue(false)
+    vi.mocked(useDocumentationState).mockReturnValue(
+      ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+    )
+    vi.mocked(usePostLogMessageMutation).mockReturnValue({
+      postLogMessage: mockPostLogMessage,
+    } as any)
   })
 
   afterEach(() => {
@@ -119,5 +138,23 @@ describe('SetupLabware', () => {
     })
 
     expect(btn).toBeDisabled()
+  })
+
+  it('sends a message to the audit log when CRS is on and placements are confirmed', () => {
+    vi.mocked(useDocumentationState).mockReturnValue(
+      createReasonNotRequiredDocumentationState()
+    )
+    render()
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm placements' }))
+    expect(mockPostLogMessage).toHaveBeenCalledWith(
+      {
+        action: 'confirm liquid and labware placements',
+        message:
+          'user confirmed liquid and labware placements before running protocol',
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+      })
+    )
   })
 })

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/SetupLabware/index.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import map from 'lodash/map'
 
@@ -10,7 +11,9 @@ import {
   Tooltip,
   useHoverTooltip,
 } from '@opentrons/components'
+import { usePostLogMessageMutation } from '@opentrons/react-api-client'
 
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useToggleGroup } from '/app/molecules/ToggleGroup/useToggleGroup'
 import { useIsFlex } from '/app/redux-resources/robots'
 import { useStoredProtocolAnalysis } from '/app/resources/analysis'
@@ -33,7 +36,7 @@ interface SetupLabwareProps {
 
 export function SetupLabware(props: SetupLabwareProps): JSX.Element {
   const { robotName, runId, labwareConfirmed, setLabwareConfirmed } = props
-  const { t } = useTranslation('protocol_setup')
+  const { t } = useTranslation(['protocol_setup', 'audit_log'])
   const robotProtocolAnalysis = useMostRecentCompletedAnalysis(runId)
   const storedProtocolAnalysis = useStoredProtocolAnalysis(runId)
   const protocolAnalysis = robotProtocolAnalysis ?? storedProtocolAnalysis
@@ -53,10 +56,36 @@ export function SetupLabware(props: SetupLabwareProps): JSX.Element {
   const moduleTypesThatRequireExtraAttention =
     getModuleTypesThatRequireExtraAttention(moduleModels)
 
+  const documentationState = useDocumentationState()
+  const { postLogMessage } = usePostLogMessageMutation(
+    documentationState,
+    'confirm_placements'
+  )
+
   // TODO(jh, 11-13-24): These disabled tooltips are used throughout setup flows. Let's consolidate them.
   const [targetProps, tooltipProps] = useHoverTooltip()
   const runHasStarted = useRunHasStarted(runId)
   const tooltipText = runHasStarted ? t('protocol_run_started') : null
+
+  const handleProceed = useCallback(() => {
+    if (documentationState.isLoading) return
+    if (documentationState.accessControlEnabled) {
+      postLogMessage(
+        {
+          action: 'confirm liquid and labware placements',
+          message:
+            'user confirmed liquid and labware placements before running protocol',
+        },
+        {
+          onSuccess: () => {
+            setLabwareConfirmed(true)
+          },
+        }
+      )
+    } else {
+      setLabwareConfirmed(true)
+    }
+  }, [documentationState, postLogMessage, setLabwareConfirmed])
 
   return (
     <>
@@ -79,9 +108,7 @@ export function SetupLabware(props: SetupLabwareProps): JSX.Element {
       </Flex>
       <Flex justifyContent={JUSTIFY_CENTER} marginTop={SPACING.spacing16}>
         <PrimaryButton
-          onClick={() => {
-            setLabwareConfirmed(true)
-          }}
+          onClick={handleProceed}
           disabled={labwareConfirmed || runHasStarted}
           {...targetProps}
         >

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/__tests__/ProtocolSetupLabware.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/__tests__/ProtocolSetupLabware.test.tsx
@@ -6,6 +6,7 @@ import { when } from 'vitest-when'
 import {
   useCreateLiveCommandMutation,
   useModulesQuery,
+  usePostLogMessageMutation,
 } from '@opentrons/react-api-client'
 import {
   getStackedItemsOnStartingDeck,
@@ -15,7 +16,11 @@ import {
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
-import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
+import {
+  ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
+  createReasonNotRequiredDocumentationState,
+} from '/app/local-resources/access-control/__fixtures__/documentationState'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useModuleCommandAnalytics } from '/app/redux-resources/analytics'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 import { useMostRecentCompletedAnalysis } from '/app/resources/runs'
@@ -41,6 +46,7 @@ vi.mock('@opentrons/react-api-client', async importOriginal => {
     ...actual,
     useCreateLiveCommandMutation: vi.fn(),
     useModulesQuery: vi.fn(),
+    usePostLogMessageMutation: vi.fn(),
   }
 })
 vi.mock('@opentrons/shared-data', async importOriginal => {
@@ -51,9 +57,7 @@ vi.mock('@opentrons/shared-data', async importOriginal => {
   }
 })
 
-vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
-  useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
-}))
+vi.mock('/app/local-resources/access-control/useDocumentationState')
 vi.mock('/app/resources/runs')
 vi.mock('/app/transformations/analysis/getProtocolModulesInfo')
 vi.mock('/app/resources/deck_configuration')
@@ -63,6 +67,7 @@ const RUN_ID = "otie's run"
 const mockSetSetupScreen = vi.fn()
 const mockRefetch = vi.fn()
 const mockCreateLiveCommand = vi.fn()
+const mockPostLogMessage = vi.fn()
 
 const render = () => {
   let confirmed = false
@@ -96,12 +101,18 @@ describe('ProtocolSetupLabware', () => {
     when(vi.mocked(getProtocolModulesInfo))
       .calledWith(mockRecentAnalysis, ot3StandardDeckDef as any)
       .thenReturn(mockProtocolModuleInfo)
+    vi.mocked(useDocumentationState).mockReturnValue(
+      ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+    )
     vi.mocked(useModulesQuery).mockReturnValue({
       ...mockUseModulesQueryOpen,
       refetch: mockRefetch,
     } as any)
     vi.mocked(useCreateLiveCommandMutation).mockReturnValue({
       createLiveCommand: mockCreateLiveCommand,
+    } as any)
+    vi.mocked(usePostLogMessageMutation).mockReturnValue({
+      postLogMessage: mockPostLogMessage,
     } as any)
     vi.mocked(useNotifyDeckConfigurationQuery).mockReturnValue({
       data: [
@@ -252,5 +263,23 @@ describe('ProtocolSetupLabware', () => {
     render()
     fireEvent.click(screen.getByRole('button', { name: 'Display List View' }))
     screen.getByText('Open')
+  })
+
+  it('sends a message to the audit log when CRS is on and placements are confirmed', () => {
+    vi.mocked(useDocumentationState).mockReturnValue(
+      createReasonNotRequiredDocumentationState()
+    )
+    render()
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm placements' }))
+    expect(mockPostLogMessage).toHaveBeenCalledWith(
+      {
+        action: 'confirm liquid and labware placements',
+        message:
+          'user confirmed liquid and labware placements before running protocol',
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+      })
+    )
   })
 })

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupLabware/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo, useState } from 'react'
+import { Fragment, useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { css } from 'styled-components'
 
@@ -26,6 +26,7 @@ import {
 import {
   useCreateLiveCommandMutation,
   useModulesQuery,
+  usePostLogMessageMutation,
 } from '@opentrons/react-api-client'
 import {
   FLEX_ROBOT_TYPE,
@@ -150,6 +151,33 @@ export function ProtocolSetupLabware({
     [attachedModules, protocolModulesInfo, deckConfig]
   )
 
+  const documentationState = useDocumentationState()
+  const { postLogMessage } = usePostLogMessageMutation(
+    documentationState,
+    'confirm_placements'
+  )
+  const handleProceed = useCallback(() => {
+    if (documentationState.isLoading) return
+    if (documentationState.accessControlEnabled) {
+      postLogMessage(
+        {
+          action: 'confirm liquid and labware placements',
+          message:
+            'user confirmed liquid and labware placements before running protocol',
+        },
+        {
+          onSuccess: () => {
+            setIsConfirmed(true)
+            setSetupScreen('prepare to run')
+          },
+        }
+      )
+    } else {
+      setIsConfirmed(true)
+      setSetupScreen('prepare to run')
+    }
+  }, [documentationState, postLogMessage, setIsConfirmed, setSetupScreen])
+
   return (
     <>
       {selectedLabwareStack != null && mostRecentAnalysis != null ? (
@@ -184,10 +212,7 @@ export function ProtocolSetupLabware({
             ) : (
               <SmallButton
                 buttonText={t('confirm_placements')}
-                onClick={() => {
-                  setIsConfirmed(true)
-                  setSetupScreen('prepare to run')
-                }}
+                onClick={handleProceed}
                 buttonCategory="rounded"
               />
             )}

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -187,6 +187,7 @@ type AuditLogAction =
   | 'delete_log_period'
   | 'sign_run'
   | 'delete_log_periods'
+  | 'confirm_placements'
 
 /**
  * Type used for DocumentedActions - keys and info to enable correct rendering of actions in the 'list actions' popup in the Documentation Required Modal.


### PR DESCRIPTION
# Overview

Adds documentation for confirming liquid and labware placements. In practice, this just adds a message to the audit log saying 'user confirmed liquid and labware placements'.

https://github.com/user-attachments/assets/c3c0ba59-80e8-4a84-8071-d719c5489bbc


https://github.com/user-attachments/assets/a75ccbbb-879d-43ec-863b-76e6e5202e7e

<img width="1208" height="131" alt="Screenshot 2026-07-30 at 2 00 25 PM" src="https://github.com/user-attachments/assets/e9e4f716-473a-41f3-b185-94b2f6bdfa80" />


## Test Plan and Hands on Testing

Confirming liquid and labware placements on the protocol setup screen should prompt for documentation on CRS bots, and still work on non-CRS bots.

## Risk assessment

Low