### PR TITLE
docs(api): vacuum module docstrings revisions

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -2155,17 +2155,16 @@ class VacuumModuleContext(ModuleContext):
         - ``vent_after``: whether to open the vent after that step completes
 
         Args:
-            steps: Ordered list of step dictionaries that make up one cycle.
-            repetitions: How many times to run the full list of steps. Defaults
-                to ``1``.
-            vent_after: Whether to open the vent after the entire profile
-                finishes. Defaults to ``False``.
-            equalize_timeout_s: Optional seconds to wait for chamber pressure to
-                return near atmospheric after the profile if ``vent_after`` is
-                ``True``. If omitted, the command does not wait for equalization.
-
-        Returns:
-            A task representing the concurrent profile run.
+            steps: List of step dictionaries defining the profile cycle. Each step dictionary supports:
+                * `enable_pump` (bool): whether to enable the pump motor.
+                * `hold_time_seconds` (float, optional): time in seconds to hold pressure/power for after target is reached.
+                * `hold_time_minutes` (float, optional): time in minutes to hold pressure/power for after target is reached.
+                * `ramp_rate` (float, optional): rate to increase the motor power at (get unit for this).
+                * `timeout_seconds` (int, optional): the time to wait for target pressure/power before throwing an error.
+                * `vent_after` (bool, optional): whether to open the vent after the step is complete.
+            repetitions: How many times to perform the entire profile.
+            vent_after: whether to open the vent after the profile is complete.
+            equalize_timeout_s: the time to wait for the module to equalize pressure after venting before throwing an error.
         """
         repetitions = validation.ensure_profile_repetition_count(repetitions)
         validated_steps = validation.ensure_vacuum_module_profile(

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1865,9 +1865,8 @@ class VacuumModuleContext(ModuleContext):
     [`ProtocolContext.wait_for_tasks()`][opentrons.protocol_api.ProtocolContext.wait_for_tasks]
     when the protocol must wait for vacuum control to finish.
 
-    Moving labware to or from the Vacuum Module is blocked while the pump is engaged
-    or while the chamber is still under vacuum (gauge pressure outside atmospheric
-    tolerance). Open the vent and wait for pressure to equalize before moving labware.
+    Moving labware to or from the Vacuum Module is blocked while the pump is running
+    or while the system is still under vacuum. To move labware, stop the pump, then open the vent, and wait for the pressure to return to atmospheric (0 mbar).
     """
 
     _core: VacuumModuleCore
@@ -1881,19 +1880,21 @@ class VacuumModuleContext(ModuleContext):
     @property
     @requires_version(2, 30)
     def max_gauge_pressure_mbar(self) -> int:
-        """Strongest allowed vacuum setpoint as gauge pressure in mbar.
+        """The deepest vacuum pressure supported by the module, currently -800 mbar.
 
-        This is the most negative permitted value (currently -800 mbar).
-        Gauge pressure of 0 mbar is atmospheric; more negative values are deeper vacuum.
+        Values are gauge pressure in mbar relative to atmospheric pressure (0 mbar).
+        Lower (more negative) values represent deeper vacuum. Pass this value to
+        [`start_set_vacuum_pressure()`][opentrons.protocol_api.VacuumModuleContext.start_set_vacuum_pressure] to set the target vacuum pressure.
         """
         return self._core.get_max_gauge_pressure_mbar()
 
     @property
     @requires_version(2, 30)
     def min_gauge_pressure_mbar(self) -> int:
-        """Weakest allowed vacuum setpoint as gauge pressure in mbar.
+        """The minimum vacuum pressure supported by the module, currently 0 mbar.
 
-        This is the least negative permitted value (currently 0 mbar, atmospheric).
+        Values are gauge pressure in mbar relative to atmospheric pressure (0 mbar).
+        Lower (more negative) values represent deeper vacuum.
         """
         return self._core.get_min_gauge_pressure_mbar()
 
@@ -1902,7 +1903,9 @@ class VacuumModuleContext(ModuleContext):
     def manifold_dock(self) -> ModuleFixtureLocation:
         """Deck location for the Vacuum Module manifold dock / staging area.
 
-        Use this with
+        The dock is the raised, rectangular part of the deck adapter. It sits in slot A4, adjacent to the recessed part of the adapter that holds the vacuum base in slot A3. The dock holds a short or tall manifold collar when they are not in use on the manifold base.
+
+        Use this location with
         [`load_adapter_to_dock()`][opentrons.protocol_api.VacuumModuleContext.load_adapter_to_dock]
         or
         [`move_to_dock()`][opentrons.protocol_api.VacuumModuleContext.move_to_dock]
@@ -1919,11 +1922,11 @@ class VacuumModuleContext(ModuleContext):
         namespace: Optional[str] = None,
         version: Optional[int] = None,
     ) -> Labware:
-        """Load a collar or other adapter onto the Vacuum Module dock.
+        """Load a short or tall collar onto the Vacuum Module dock.
 
-        The parameters of this function behave like those of
+        Works like 
         [`ProtocolContext.load_adapter()`][opentrons.protocol_api.ProtocolContext.load_adapter],
-        except the adapter is loaded onto
+        but loads the collar onto
         [`manifold_dock`][opentrons.protocol_api.VacuumModuleContext.manifold_dock]
         instead of a deck slot. Note that the parameter `name` here corresponds to
         `load_name` on the `ProtocolContext` function.
@@ -1970,11 +1973,11 @@ class VacuumModuleContext(ModuleContext):
         pick_up_offset: Optional[Mapping[str, float]] = None,
         drop_offset: Optional[Mapping[str, float]] = None,
     ) -> None:
-        """Move labware onto the Vacuum Module dock.
+        """Move a short or tall collar onto the Vacuum Module dock.
 
-        This is a convenience wrapper around
+        Works like
         [`ProtocolContext.move_labware()`][opentrons.protocol_api.ProtocolContext.move_labware]
-        with the destination set to
+        but sets the collar destination to
         [`manifold_dock`][opentrons.protocol_api.VacuumModuleContext.manifold_dock].
 
         Args:
@@ -2016,31 +2019,27 @@ class VacuumModuleContext(ModuleContext):
         vent_after: Optional[bool] = None,
         equalize_timeout_s: Optional[int] = None,
     ) -> Task:
-        """Start closed-loop vacuum control to a gauge pressure and return immediately.
+        """Start closed-loop vacuum control without pausing protocol execution.
 
         Starts the Vacuum Module pump under pressure control and returns a
         [`Task`][opentrons.protocol_api.Task] representing concurrent execution.
-        The protocol continues while the module ramps to and holds the target.
+        The protocol continues while the module ramps to and holds the target pressure.
 
         Pass the task to
         [`ProtocolContext.wait_for_tasks()`][opentrons.protocol_api.ProtocolContext.wait_for_tasks]
         to wait for the vacuum operation to finish.
 
         Args:
-            gauge_pressure_mbar: Target gauge pressure in mbar. Must be between
-                [`max_gauge_pressure_mbar`][opentrons.protocol_api.VacuumModuleContext.max_gauge_pressure_mbar]
-                and
-                [`min_gauge_pressure_mbar`][opentrons.protocol_api.VacuumModuleContext.min_gauge_pressure_mbar]
-                (inclusive). ``0`` is atmospheric; more negative is stronger vacuum.
-            duration_s: Seconds to hold the target pressure after it is reached.
-                If omitted, the module holds the target until stopped.
-            ramp_rate: Optional rate of pressure change in mbar/s while approaching
-                the target.
-            timeout_s: Optional maximum seconds allowed to reach the target before
+            gauge_pressure_mbar: Target gauge pressure in mbar, from `0` to `-800` inclusive (defined by [`min_gauge_pressure_mbar`][opentrons.protocol_api.VacuumModuleContext.min_gauge_pressure_mbar] and [`max_gauge_pressure_mbar`][opentrons.protocol_api.VacuumModuleContext.max_gauge_pressure_mbar]). A value of `0` is atmospheric pressure; lower (more negative) values represent deeper vacuum.
+            duration_s: The time, in seconds, to hold the target pressure after reaching it.
+                If omitted, the module holds the target pressure until stopped.
+            ramp_rate: Rate of pressure change in mbar/s while approaching
+                the target pressure.
+            timeout_s: The maximum time, in seconds, allowed to reach the target before
                 a timeout error is raised.
             vent_after: Whether to open the vent after the hold duration completes.
                 Only applies when ``duration_s`` is set.
-            equalize_timeout_s: Optional seconds to wait for chamber pressure to
+            equalize_timeout_s: The maximum time, in seconds, to wait for system pressure to
                 return near atmospheric after venting. Only applies when
                 ``duration_s`` is set and ``vent_after`` is ``True``. If omitted,
                 the command does not wait for equalization.
@@ -2070,7 +2069,7 @@ class VacuumModuleContext(ModuleContext):
         vent_after: Optional[bool] = None,
         equalize_timeout_s: Optional[int] = None,
     ) -> Task:
-        """Start open-loop vacuum pump power control and return immediately.
+        """Start open-loop vacuum pump power control without pausing protocol execution.
 
         Sets the pump duty cycle as a percentage and returns a
         [`Task`][opentrons.protocol_api.Task] representing concurrent execution.
@@ -2083,17 +2082,17 @@ class VacuumModuleContext(ModuleContext):
         to wait for the operation to finish.
 
         Args:
-            percent_power: Pump duty cycle as a percentage from 1 to 100.
-            duration_s: Seconds to hold the target power after it is reached.
+            percent_power: Pump duty cycle as a percentage, from `1` to `100` inclusive.
+            duration_s: Time, in seconds, to hold the target power after reaching it.
                 If omitted, the module holds the target until stopped.
-            ramp_rate: Optional rate of power change while approaching the target.
-            timeout_s: Optional maximum seconds allowed to reach the target power
+            ramp_rate: Rate of power change while approaching the target.
+            timeout_s: The maximum time, in seconds, allowed to reach the target power
                 before a timeout error is raised.
             vent_after: Whether to open the vent after the hold duration completes.
-                Only applies when ``duration_s`` is set.
-            equalize_timeout_s: Optional seconds to wait for chamber pressure to
+                Only applies when `duration_s` is set.
+            equalize_timeout_s: The maximum time, in seconds, to wait for chamber pressure to
                 return near atmospheric after venting. Only applies when
-                ``duration_s`` is set and ``vent_after`` is ``True``. If omitted,
+                `duration_s` is set and `vent_after` is `True`. If omitted,
                 the command does not wait for equalization.
 
         Returns:
@@ -2113,11 +2112,11 @@ class VacuumModuleContext(ModuleContext):
     @requires_version(2, 30)
     @publish(command=cmds.vacuum_module_stop_vacuum)
     def stop_vacuum_pump(self) -> None:
-        """Stop the vacuum pump and pressure/power control.
+        """Stop the vacuum pump and disable active pressure and power control.
 
-        Disables active vacuum control. Open the vent separately with
+        Shuts off the pump motor and cancels any target pressure or power limits. To release vacuum and return the chamber to atmospheric pressure, call
         [`open_vent()`][opentrons.protocol_api.VacuumModuleContext.open_vent]
-        if the chamber should equalize to atmosphere.
+        separately.
         """
         self._core.stop_vacuum()
 
@@ -2130,29 +2129,24 @@ class VacuumModuleContext(ModuleContext):
         vent_after: bool = False,
         equalize_timeout_s: Optional[int] = None,
     ) -> Task:
-        """Start a Vacuum Module profile and return immediately.
+        """Start a Vacuum Module profile without pausing protocol execution.
 
-        Runs a cycle of ``steps`` for the given number of ``repetitions`` and
-        returns a [`Task`][opentrons.protocol_api.Task] representing concurrent
-        execution. Pass the task to
+        Executes a sequence of `steps` for the specified number of `repetitions`
+        and returns a [`Task`][opentrons.protocol_api.Task] representing
+        concurrent execution. Protocol execution continues while the module runs
+        the profile.
+
+        Pass the task to
         [`ProtocolContext.wait_for_tasks()`][opentrons.protocol_api.ProtocolContext.wait_for_tasks]
-        to wait for the profile to complete.
+        to wait for the profile to finish.
 
-        Each step is a dictionary with a required ``enable_pump`` key and either
+        Each step is a dictionary with a required `enable_pump` key and either
         a pressure or power setpoint:
 
-        - **Pressure step:** ``gauge_pressure_mbar`` (int, mbar gauge)
-        - **Power step:** ``percent_power`` (int, 0–100)
+        - Pressure step: `gauge_pressure_mbar` (int, mbar gauge)
+        - Power step: `percent_power` (int, 0–100)
 
-        A step must not set both ``gauge_pressure_mbar`` and ``percent_power``.
-
-        Optional step keys:
-
-        - ``hold_time_seconds`` / ``hold_time_minutes``: hold time after the
-          target is reached (combined if both are set)
-        - ``ramp_rate``: ramp rate toward the target (mbar/s for pressure steps)
-        - ``timeout_seconds``: max seconds to reach the target before erroring
-        - ``vent_after``: whether to open the vent after that step completes
+        A step must not set both `gauge_pressure_mbar` and `percent_power`.
 
         Args:
             steps: List of step dictionaries defining the profile cycle. Each step dictionary supports:
@@ -2165,6 +2159,9 @@ class VacuumModuleContext(ModuleContext):
             repetitions: How many times to perform the entire profile.
             vent_after: whether to open the vent after the profile is complete.
             equalize_timeout_s: the time to wait for the module to equalize pressure after venting before throwing an error.
+
+        Returns:
+            A task representing the concurrent vacuum profile execution.
         """
         repetitions = validation.ensure_profile_repetition_count(repetitions)
         validated_steps = validation.ensure_vacuum_module_profile(

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -2151,7 +2151,7 @@ class VacuumModuleContext(ModuleContext):
     @publish(command=cmds.vacuum_module_close_vent)
     def close_vent(self) -> None:
         """Close the vent so the system can hold vacuum.
-        
+
         The module will not hold vacuum while the vent is open.
         """
         self._core.close_vent()

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1867,6 +1867,8 @@ class VacuumModuleContext(ModuleContext):
 
     Moving labware to or from the Vacuum Module is blocked while the pump is running
     or while the system is still under vacuum. To move labware, stop the pump, then open the vent, and wait for the pressure to return to atmospheric (0 mbar).
+
+    *New in version 2.30*
     """
 
     _core: VacuumModuleCore
@@ -1882,9 +1884,7 @@ class VacuumModuleContext(ModuleContext):
     def max_gauge_pressure_mbar(self) -> int:
         """The maximum (deepest) vacuum pressure supported by the module (-800 mbar).
 
-        Values are gauge pressure in mbar relative to atmospheric pressure (0 mbar).
-        Lower (more negative) values represent deeper vacuum. Pass this value to
-        [`start_set_vacuum_pressure()`][opentrons.protocol_api.VacuumModuleContext.start_set_vacuum_pressure] to set the maximum supported target vacuum pressure.
+        Values are gauge pressure in mbar relative to atmospheric pressure (0 mbar). Lower (more negative) values represent deeper vacuum. Pass this value to [`start_set_vacuum_pressure()`][opentrons.protocol_api.VacuumModuleContext.start_set_vacuum_pressure] to set the maximum supported target vacuum pressure.
         """
         return self._core.get_max_gauge_pressure_mbar()
 
@@ -1893,10 +1893,7 @@ class VacuumModuleContext(ModuleContext):
     def min_gauge_pressure_mbar(self) -> int:
         """The minimum vacuum pressure supported by the module (0 mbar, or atmospheric pressure).
 
-        Values are gauge pressure in mbar relative to atmospheric pressure.
-        Lower (more negative) values represent deeper vacuum. Pass this value to
-        [`start_set_vacuum_pressure()`][opentrons.protocol_api.VacuumModuleContext.start_set_vacuum_pressure]
-        to set the minimum supported target vacuum pressure.
+        Values are gauge pressure in mbar relative to atmospheric pressure. Lower (more negative) values represent deeper vacuum. Pass this value to [`start_set_vacuum_pressure()`][opentrons.protocol_api.VacuumModuleContext.start_set_vacuum_pressure] to set the minimum supported target vacuum pressure.
         """
         return self._core.get_min_gauge_pressure_mbar()
 
@@ -1926,12 +1923,7 @@ class VacuumModuleContext(ModuleContext):
     ) -> Labware:
         """Load a short or tall collar onto the Vacuum Module dock.
 
-        Works like 
-        [`ProtocolContext.load_adapter()`][opentrons.protocol_api.ProtocolContext.load_adapter],
-        but loads the collar onto
-        [`manifold_dock`][opentrons.protocol_api.VacuumModuleContext.manifold_dock]
-        instead of a deck slot. Note that the parameter `name` here corresponds to
-        `load_name` on the `ProtocolContext` function.
+        Works like [`ProtocolContext.load_adapter()`][opentrons.protocol_api.ProtocolContext.load_adapter], but loads the collar onto [`manifold_dock`][opentrons.protocol_api.VacuumModuleContext.manifold_dock] instead of a deck slot. Note that the parameter `name` here corresponds to `load_name` on the `ProtocolContext` function.
 
         Args:
             name: The load name of the adapter labware definition.
@@ -1975,19 +1967,13 @@ class VacuumModuleContext(ModuleContext):
     ) -> None:
         """Move a short or tall collar onto the Vacuum Module dock.
 
-        Works like
-        [`ProtocolContext.move_labware()`][opentrons.protocol_api.ProtocolContext.move_labware]
-        but sets the collar destination to
-        [`manifold_dock`][opentrons.protocol_api.VacuumModuleContext.manifold_dock].
+        Works like [`ProtocolContext.move_labware()`][opentrons.protocol_api.ProtocolContext.move_labware] but sets the collar destination to [`manifold_dock`][opentrons.protocol_api.VacuumModuleContext.manifold_dock].
 
         Args:
             labware: The labware to move.
-            use_gripper: Whether to use the Flex Gripper. If `False`, the protocol
-                pauses for a manual move.
-            pick_up_offset: An optional offset applied when picking up labware.
-                Keys are axis names (`"x"`, `"y"`, `"z"`) in mm.
-            drop_offset: An optional offset applied when placing labware.
-                Keys are axis names (`"x"`, `"y"`, `"z"`) in mm.
+            use_gripper: An optional flag specifying whether to use the Flex Gripper. If `False`, the protocol pauses for a manual move.
+            pick_up_offset: An optional offset applied when picking up labware. Keys are axis names (`"x"`, `"y"`, `"z"`) in mm.
+            drop_offset: An optional offset applied when placing labware. Keys are axis names (`"x"`, `"y"`, `"z"`) in mm.
         """
         _pick_up_offset = (
             validation.ensure_valid_labware_offset_vector(pick_up_offset)
@@ -2021,21 +2007,17 @@ class VacuumModuleContext(ModuleContext):
     ) -> Task:
         """Start closed-loop vacuum control without pausing protocol execution.
 
-        Starts the Vacuum Module pump under pressure control and returns a
-        [`Task`][opentrons.protocol_api.Task] representing concurrent execution.
-        The protocol continues while the module ramps to and holds the target pressure.
+        Starts the Vacuum Module pump under pressure control and returns a [`Task`][opentrons.protocol_api.Task] representing concurrent execution. The protocol continues while the module ramps to and holds the target pressure.
 
-        Pass the task to
-        [`ProtocolContext.wait_for_tasks()`][opentrons.protocol_api.ProtocolContext.wait_for_tasks]
-        to wait for the vacuum operation to finish.
+        Pass the task to [`ProtocolContext.wait_for_tasks()`][opentrons.protocol_api.ProtocolContext.wait_for_tasks] to wait for the vacuum operation to finish.
 
         Args:
             gauge_pressure_mbar: Target gauge pressure in mbar, from `0` to `-800` inclusive (defined by [`min_gauge_pressure_mbar`][opentrons.protocol_api.VacuumModuleContext.min_gauge_pressure_mbar] and [`max_gauge_pressure_mbar`][opentrons.protocol_api.VacuumModuleContext.max_gauge_pressure_mbar]). A value of `0` is atmospheric pressure; lower (more negative) values represent deeper vacuum.
-            duration_s: An optional argument that sets the time, in seconds, to hold the target pressure after reaching it. If omitted, the module holds the target pressure until stopped.
-            ramp_rate: An optional argument that sets the rate of pressure change in mbar/s while approaching the target pressure.
-            timeout_s: An optional argument that sets the maximum time, in seconds, allowed to reach the target before a timeout error is raised.
-            vent_after: An optional argument that specifies whether to open the vent after the hold duration completes. Only applies when `duration_s` is set.
-            equalize_timeout_s: An optional argument that sets the maximum time, in seconds, to wait for system pressure to return near atmospheric after venting. Only applies when `duration_s` is set and `vent_after` is `True`. If omitted, the command does not wait for equalization.
+            duration_s: An optional time, in seconds, to hold the target pressure after reaching it. If omitted, the module holds the target pressure until stopped.
+            ramp_rate: An optional rate of pressure change, in mbar/s, while approaching the target pressure.
+            timeout_s: An optional maximum duration, in seconds, allowed to reach the target before raising a timeout error.
+            vent_after: Optionally specifies whether to open the vent after the hold duration completes. Only applies when `duration_s` is set.
+            equalize_timeout_s: An optional maximum wait time, in seconds, to wait for system pressure to return near atmospheric after venting. Only applies when `duration_s` is set and `vent_after` is `True`. If omitted, the command does not wait for equalization. Waiting is recommended before moving labware to or from the module.
 
         Returns:
             A task representing the concurrent vacuum operation.
@@ -2064,24 +2046,17 @@ class VacuumModuleContext(ModuleContext):
     ) -> Task:
         """Start open-loop vacuum pump power control without pausing protocol execution.
 
-        Sets the pump duty cycle as a percentage (%) and returns a
-        [`Task`][opentrons.protocol_api.Task] representing concurrent execution.
-        Use this when you want fixed pump power instead of closed-loop pressure
-        control via
-        [`start_set_vacuum_pressure()`][opentrons.protocol_api.VacuumModuleContext.start_set_vacuum_pressure].
+        Sets the pump duty cycle as a percentage (%) and returns a [`Task`][opentrons.protocol_api.Task] representing concurrent execution. Use this when you want fixed pump power instead of closed-loop pressure control via [`start_set_vacuum_pressure()`][opentrons.protocol_api.VacuumModuleContext.start_set_vacuum_pressure].
 
-        Pass the task to
-        [`ProtocolContext.wait_for_tasks()`][opentrons.protocol_api.ProtocolContext.wait_for_tasks]
-        to wait for the operation to finish.
+        Pass the task to [`ProtocolContext.wait_for_tasks()`][opentrons.protocol_api.ProtocolContext.wait_for_tasks] to wait for the operation to finish.
 
         Args:
             percent_power: % pump duty cycle, from `1` to `100` inclusive.
-            duration_s: An optional argument that sets the time, in seconds, to hold the target power after reaching it. If omitted, the module holds the target until stopped.
-            ramp_rate: An optional argument that sets the rate of power change while approaching the target.
-            timeout_s: An optional argument that sets the maximum time, in seconds, allowed to reach the target power
-                before a timeout error is raised.
-            vent_after: An optional argument that specifies whether to open the vent after the hold duration completes. Only applies when `duration_s` is set.
-            equalize_timeout_s: An optional argument that sets the maximum time, in seconds, to wait for chamber pressure to return near atmospheric after venting. Only applies when `duration_s` is set and `vent_after` is `True`. If omitted, the command does not wait for equalization.
+            duration_s: An optional time, in seconds, to hold the target power after reaching it. If omitted, the module holds the target until stopped.
+            ramp_rate: An optional rate of power change while approaching the target.
+            timeout_s: An optional maximum duration, in seconds, allowed to reach the target power before raising a timeout error.
+            vent_after: Optionally specifies whether to open the vent after the hold duration completes. Only applies when `duration_s` is set.
+            equalize_timeout_s: An optional maximum wait time, in seconds, to wait for system pressure to return near atmospheric after venting. Only applies when `duration_s` is set and `vent_after` is `True`. If omitted, the command does not wait for equalization. Waiting is recommended before moving labware to or from the module.
 
         Returns:
             A task representing the concurrent vacuum operation.
@@ -2102,9 +2077,7 @@ class VacuumModuleContext(ModuleContext):
     def stop_vacuum_pump(self) -> None:
         """Stop the vacuum pump and disable active pressure and power control.
 
-        Shuts off the pump motor and cancels any target pressure or power limits. To release vacuum and return the chamber to atmospheric pressure, call
-        [`open_vent()`][opentrons.protocol_api.VacuumModuleContext.open_vent]
-        separately.
+        Shuts off the pump motor and cancels any target pressure or power limits. To release vacuum and return the chamber to atmospheric pressure, call [`open_vent()`][opentrons.protocol_api.VacuumModuleContext.open_vent] separately.
         """
         self._core.stop_vacuum()
 
@@ -2119,17 +2092,11 @@ class VacuumModuleContext(ModuleContext):
     ) -> Task:
         """Start a Vacuum Module profile without pausing protocol execution.
 
-        Executes a sequence of `steps` for the specified number of `repetitions`
-        and returns a [`Task`][opentrons.protocol_api.Task] representing
-        concurrent execution. Protocol execution continues while the module runs
-        the profile.
+        Executes a sequence of `steps` for the specified number of `repetitions` and returns a [`Task`][opentrons.protocol_api.Task] representing concurrent execution. Protocol execution continues while the module runs the profile.
 
-        Pass the task to
-        [`ProtocolContext.wait_for_tasks()`][opentrons.protocol_api.ProtocolContext.wait_for_tasks]
-        to wait for the profile to finish.
+        Pass the task to [`ProtocolContext.wait_for_tasks()`][opentrons.protocol_api.ProtocolContext.wait_for_tasks] to wait for the profile to finish.
 
-        Each step is a dictionary with a required `enable_pump` key and either
-        a pressure or power setpoint:
+        Each step is a dictionary with a required `enable_pump` key and either a pressure or power setpoint:
 
         - Pressure step: `gauge_pressure_mbar` (int, mbar gauge)
         - Power step: `percent_power` (int, 0–100)
@@ -2143,13 +2110,13 @@ class VacuumModuleContext(ModuleContext):
                 * `enable_pump` (bool): whether to enable the pump motor.
                 * `hold_time_seconds` (float, optional): time in seconds to hold pressure/power for after target is reached.
                 * `hold_time_minutes` (float, optional): time in minutes to hold pressure/power for after target is reached.
-                * `ramp_rate` (float, optional): rate to increase the motor power at (get unit for this).
-                * `timeout_seconds` (int, optional): the time to wait for target pressure/power before throwing an error.
+                * `ramp_rate` (float, optional): rate of pressure or power change while approaching setpoint.
+                * `timeout_seconds` (int, optional): maximum wait time, in seconds, to reach target setpoint before timing out.
                 * `vent_after` (bool, optional): whether to open the vent after the step is complete.
 
-            repetitions: An optional argument specifying how many times to perform the entire profile.
-            vent_after: An optional argument specifying whether to open the vent after the profile is complete.
-            equalize_timeout_s: An optional argument specifying the time, in seconds, to wait for the module to equalize pressure after venting before throwing an error.
+            repetitions: An optional cycle count specifying how many times to repeat the profile sequence.
+            vent_after: Optionally specifies whether to open the vent after all profile repetitions complete.
+            equalize_timeout_s: An optional maximum wait time, in seconds, to wait for system pressure to return near atmospheric after venting. Only applies when `vent_after` is `True`. If omitted, the command does not wait for equalization. Waiting is recommended before moving labware to or from the module.
 
         Returns:
             A task representing the concurrent vacuum profile execution.
@@ -2176,7 +2143,7 @@ class VacuumModuleContext(ModuleContext):
         Opens the vent to release vacuum and return system pressure to atmospheric. The module will not hold vacuum while the vent is open.
 
         Args:
-            equalize_timeout_s: An optional argument that sets the maximum time, in seconds, to wait for the system to return to atmospheric pressure after opening the vent. If omitted, the command opens the vent and returns without waiting for equalization. Waiting is recommended before moving labware to or from the module.
+            equalize_timeout_s: An optional maximum wait time, in seconds, to wait for system pressure to return near atmospheric after venting. If omitted, the command opens the vent and returns without waiting for equalization. Waiting is recommended before moving labware to or from the module.
         """
         self._core.open_vent(equalize_timeout_s=equalize_timeout_s)
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1880,21 +1880,23 @@ class VacuumModuleContext(ModuleContext):
     @property
     @requires_version(2, 30)
     def max_gauge_pressure_mbar(self) -> int:
-        """The deepest vacuum pressure supported by the module, currently -800 mbar.
+        """The maximum (deepest) vacuum pressure supported by the module (-800 mbar).
 
         Values are gauge pressure in mbar relative to atmospheric pressure (0 mbar).
         Lower (more negative) values represent deeper vacuum. Pass this value to
-        [`start_set_vacuum_pressure()`][opentrons.protocol_api.VacuumModuleContext.start_set_vacuum_pressure] to set the target vacuum pressure.
+        [`start_set_vacuum_pressure()`][opentrons.protocol_api.VacuumModuleContext.start_set_vacuum_pressure] to set the maximum supported target vacuum pressure.
         """
         return self._core.get_max_gauge_pressure_mbar()
 
     @property
     @requires_version(2, 30)
     def min_gauge_pressure_mbar(self) -> int:
-        """The minimum vacuum pressure supported by the module, currently 0 mbar.
+        """The minimum vacuum pressure supported by the module (0 mbar, or atmospheric pressure).
 
-        Values are gauge pressure in mbar relative to atmospheric pressure (0 mbar).
-        Lower (more negative) values represent deeper vacuum.
+        Values are gauge pressure in mbar relative to atmospheric pressure.
+        Lower (more negative) values represent deeper vacuum. Pass this value to
+        [`start_set_vacuum_pressure()`][opentrons.protocol_api.VacuumModuleContext.start_set_vacuum_pressure]
+        to set the minimum supported target vacuum pressure.
         """
         return self._core.get_min_gauge_pressure_mbar()
 
@@ -1933,10 +1935,8 @@ class VacuumModuleContext(ModuleContext):
 
         Args:
             name: The load name of the adapter labware definition.
-            namespace: The namespace of the labware definition. If omitted, the default
-                Opentrons namespace is used.
-            version: The version of the labware definition. If omitted, the latest
-                compatible version is used.
+            namespace: An optional namespace for the labware definition. If omitted, the default Opentrons namespace is used.
+            version: An optional version of the labware definition. If omitted, the latest compatible version is used.
 
         Returns:
             The initialized and loaded adapter object.
@@ -1982,12 +1982,12 @@ class VacuumModuleContext(ModuleContext):
 
         Args:
             labware: The labware to move.
-            use_gripper: Whether to use the Flex Gripper. If ``False``, the protocol
+            use_gripper: Whether to use the Flex Gripper. If `False`, the protocol
                 pauses for a manual move.
-            pick_up_offset: Optional offset applied when picking up the labware.
-                Keys are axis names (``"x"``, ``"y"``, ``"z"``) in mm.
-            drop_offset: Optional offset applied when dropping the labware.
-                Keys are axis names (``"x"``, ``"y"``, ``"z"``) in mm.
+            pick_up_offset: An optional offset applied when picking up the labware.
+                Keys are axis names (`"x"`, `"y"`, `"z"`) in mm.
+            drop_offset: An optional offset applied when dropping the labware.
+                Keys are axis names (`"x"`, `"y"`, `"z"`) in mm.
         """
         _pick_up_offset = (
             validation.ensure_valid_labware_offset_vector(pick_up_offset)
@@ -2031,18 +2031,11 @@ class VacuumModuleContext(ModuleContext):
 
         Args:
             gauge_pressure_mbar: Target gauge pressure in mbar, from `0` to `-800` inclusive (defined by [`min_gauge_pressure_mbar`][opentrons.protocol_api.VacuumModuleContext.min_gauge_pressure_mbar] and [`max_gauge_pressure_mbar`][opentrons.protocol_api.VacuumModuleContext.max_gauge_pressure_mbar]). A value of `0` is atmospheric pressure; lower (more negative) values represent deeper vacuum.
-            duration_s: The time, in seconds, to hold the target pressure after reaching it.
-                If omitted, the module holds the target pressure until stopped.
-            ramp_rate: Rate of pressure change in mbar/s while approaching
-                the target pressure.
-            timeout_s: The maximum time, in seconds, allowed to reach the target before
-                a timeout error is raised.
-            vent_after: Whether to open the vent after the hold duration completes.
-                Only applies when ``duration_s`` is set.
-            equalize_timeout_s: The maximum time, in seconds, to wait for system pressure to
-                return near atmospheric after venting. Only applies when
-                ``duration_s`` is set and ``vent_after`` is ``True``. If omitted,
-                the command does not wait for equalization.
+            duration_s: An optional argument that sets the time, in seconds, to hold the target pressure after reaching it. If omitted, the module holds the target pressure until stopped.
+            ramp_rate: An optional argument that sets the rate of pressure change in mbar/s while approaching the target pressure.
+            timeout_s: An optional argument that sets the maximum time, in seconds, allowed to reach the target before a timeout error is raised.
+            vent_after: An optional argument that specifies whether to open the vent after the hold duration completes. Only applies when `duration_s` is set.
+            equalize_timeout_s: An optional argument that sets the maximum time, in seconds, to wait for system pressure to return near atmospheric after venting. Only applies when `duration_s` is set and `vent_after` is `True`. If omitted, the command does not wait for equalization.
 
         Returns:
             A task representing the concurrent vacuum operation.
@@ -2083,14 +2076,14 @@ class VacuumModuleContext(ModuleContext):
 
         Args:
             percent_power: Pump duty cycle as a percentage, from `1` to `100` inclusive.
-            duration_s: Time, in seconds, to hold the target power after reaching it.
+            duration_s: (Optional) Time, in seconds, to hold the target power after reaching it.
                 If omitted, the module holds the target until stopped.
-            ramp_rate: Rate of power change while approaching the target.
-            timeout_s: The maximum time, in seconds, allowed to reach the target power
+            ramp_rate: (Optional) Rate of power change while approaching the target.
+            timeout_s: (Optional) The maximum time, in seconds, allowed to reach the target power
                 before a timeout error is raised.
-            vent_after: Whether to open the vent after the hold duration completes.
+            vent_after: (Optional) Whether to open the vent after the hold duration completes.
                 Only applies when `duration_s` is set.
-            equalize_timeout_s: The maximum time, in seconds, to wait for chamber pressure to
+            equalize_timeout_s: (Optional)The maximum time, in seconds, to wait for chamber pressure to
                 return near atmospheric after venting. Only applies when
                 `duration_s` is set and `vent_after` is `True`. If omitted,
                 the command does not wait for equalization.
@@ -2156,9 +2149,9 @@ class VacuumModuleContext(ModuleContext):
                 * `ramp_rate` (float, optional): rate to increase the motor power at (get unit for this).
                 * `timeout_seconds` (int, optional): the time to wait for target pressure/power before throwing an error.
                 * `vent_after` (bool, optional): whether to open the vent after the step is complete.
-            repetitions: How many times to perform the entire profile.
-            vent_after: whether to open the vent after the profile is complete.
-            equalize_timeout_s: the time to wait for the module to equalize pressure after venting before throwing an error.
+            repetitions: (Optional) How many times to perform the entire profile.
+            vent_after: (Optional) Whether to open the vent after the profile is complete.
+            equalize_timeout_s: (Optional) The time, in seconds, to wait for the module to equalize pressure after venting before throwing an error.
 
         Returns:
             A task representing the concurrent vacuum profile execution.
@@ -2180,19 +2173,17 @@ class VacuumModuleContext(ModuleContext):
     @requires_version(2, 30)
     @publish(command=cmds.vacuum_module_open_vent)
     def open_vent(self, equalize_timeout_s: Optional[int] = None) -> None:
-        """Open the vent to atmosphere.
+        """Open the vent valve to bring the system to atmospheric pressure.
+
+        Opens the vent valve to release vacuum inside the manifold and return system pressure to atmospheric. The module will not hold vacuum while the vent is open.
 
         Args:
-            equalize_timeout_s: Optional seconds to wait for chamber gauge
-                pressure to return near atmospheric after the vent opens. If
-                omitted, the command opens the vent and returns without waiting
-                for equalization. Waiting is recommended before moving labware
-                to or from the module.
+            equalize_timeout_s: (Optional) The maximum time, in seconds, to wait for the system to return to atmospheric pressure after opening the vent. If omitted, the command opens the vent and returns without waiting for equalization. Waiting is recommended before moving labware to or from the module.
         """
         self._core.open_vent(equalize_timeout_s=equalize_timeout_s)
 
     @requires_version(2, 30)
     @publish(command=cmds.vacuum_module_close_vent)
     def close_vent(self) -> None:
-        """Close the vent so the chamber can hold vacuum."""
+        """Close the vent so the system can hold vacuum."""
         self._core.close_vent()

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1911,7 +1911,7 @@ class VacuumModuleContext(ModuleContext):
         [`load_adapter_to_dock()`][opentrons.protocol_api.VacuumModuleContext.load_adapter_to_dock]
         or
         [`move_to_dock()`][opentrons.protocol_api.VacuumModuleContext.move_to_dock]
-        to place adapters or labware on the dock next to the module.
+        to place collars on the dock next to the module.
         """
         base_slot = self._core.get_deck_slot().id
         area_name = f"{self.model}Dock{base_slot[0]}4"
@@ -1984,9 +1984,9 @@ class VacuumModuleContext(ModuleContext):
             labware: The labware to move.
             use_gripper: Whether to use the Flex Gripper. If `False`, the protocol
                 pauses for a manual move.
-            pick_up_offset: An optional offset applied when picking up the labware.
+            pick_up_offset: An optional offset applied when picking up labware.
                 Keys are axis names (`"x"`, `"y"`, `"z"`) in mm.
-            drop_offset: An optional offset applied when dropping the labware.
+            drop_offset: An optional offset applied when placing labware.
                 Keys are axis names (`"x"`, `"y"`, `"z"`) in mm.
         """
         _pick_up_offset = (
@@ -2064,7 +2064,7 @@ class VacuumModuleContext(ModuleContext):
     ) -> Task:
         """Start open-loop vacuum pump power control without pausing protocol execution.
 
-        Sets the pump duty cycle as a percentage and returns a
+        Sets the pump duty cycle as a percentage (%) and returns a
         [`Task`][opentrons.protocol_api.Task] representing concurrent execution.
         Use this when you want fixed pump power instead of closed-loop pressure
         control via
@@ -2075,18 +2075,13 @@ class VacuumModuleContext(ModuleContext):
         to wait for the operation to finish.
 
         Args:
-            percent_power: Pump duty cycle as a percentage, from `1` to `100` inclusive.
-            duration_s: (Optional) Time, in seconds, to hold the target power after reaching it.
-                If omitted, the module holds the target until stopped.
-            ramp_rate: (Optional) Rate of power change while approaching the target.
-            timeout_s: (Optional) The maximum time, in seconds, allowed to reach the target power
+            percent_power: % pump duty cycle, from `1` to `100` inclusive.
+            duration_s: An optional argument that sets the time, in seconds, to hold the target power after reaching it. If omitted, the module holds the target until stopped.
+            ramp_rate: An optional argument that sets the rate of power change while approaching the target.
+            timeout_s: An optional argument that sets the maximum time, in seconds, allowed to reach the target power
                 before a timeout error is raised.
-            vent_after: (Optional) Whether to open the vent after the hold duration completes.
-                Only applies when `duration_s` is set.
-            equalize_timeout_s: (Optional)The maximum time, in seconds, to wait for chamber pressure to
-                return near atmospheric after venting. Only applies when
-                `duration_s` is set and `vent_after` is `True`. If omitted,
-                the command does not wait for equalization.
+            vent_after: An optional argument that specifies whether to open the vent after the hold duration completes. Only applies when `duration_s` is set.
+            equalize_timeout_s: An optional argument that sets the maximum time, in seconds, to wait for chamber pressure to return near atmospheric after venting. Only applies when `duration_s` is set and `vent_after` is `True`. If omitted, the command does not wait for equalization.
 
         Returns:
             A task representing the concurrent vacuum operation.
@@ -2139,19 +2134,22 @@ class VacuumModuleContext(ModuleContext):
         - Pressure step: `gauge_pressure_mbar` (int, mbar gauge)
         - Power step: `percent_power` (int, 0–100)
 
-        A step must not set both `gauge_pressure_mbar` and `percent_power`.
+        !!! note
+            A step _must not_ set both `gauge_pressure_mbar` and `percent_power`.
 
         Args:
             steps: List of step dictionaries defining the profile cycle. Each step dictionary supports:
+
                 * `enable_pump` (bool): whether to enable the pump motor.
                 * `hold_time_seconds` (float, optional): time in seconds to hold pressure/power for after target is reached.
                 * `hold_time_minutes` (float, optional): time in minutes to hold pressure/power for after target is reached.
                 * `ramp_rate` (float, optional): rate to increase the motor power at (get unit for this).
                 * `timeout_seconds` (int, optional): the time to wait for target pressure/power before throwing an error.
                 * `vent_after` (bool, optional): whether to open the vent after the step is complete.
-            repetitions: (Optional) How many times to perform the entire profile.
-            vent_after: (Optional) Whether to open the vent after the profile is complete.
-            equalize_timeout_s: (Optional) The time, in seconds, to wait for the module to equalize pressure after venting before throwing an error.
+
+            repetitions: An optional argument specifying how many times to perform the entire profile.
+            vent_after: An optional argument specifying whether to open the vent after the profile is complete.
+            equalize_timeout_s: An optional argument specifying the time, in seconds, to wait for the module to equalize pressure after venting before throwing an error.
 
         Returns:
             A task representing the concurrent vacuum profile execution.
@@ -2173,12 +2171,12 @@ class VacuumModuleContext(ModuleContext):
     @requires_version(2, 30)
     @publish(command=cmds.vacuum_module_open_vent)
     def open_vent(self, equalize_timeout_s: Optional[int] = None) -> None:
-        """Open the vent valve to bring the system to atmospheric pressure.
+        """Open the vent valve to bring the system to atmospheric pressure (0 mbar).
 
-        Opens the vent valve to release vacuum inside the manifold and return system pressure to atmospheric. The module will not hold vacuum while the vent is open.
+        Opens the vent to release vacuum and return system pressure to atmospheric. The module will not hold vacuum while the vent is open.
 
         Args:
-            equalize_timeout_s: (Optional) The maximum time, in seconds, to wait for the system to return to atmospheric pressure after opening the vent. If omitted, the command opens the vent and returns without waiting for equalization. Waiting is recommended before moving labware to or from the module.
+            equalize_timeout_s: An optional argument that sets the maximum time, in seconds, to wait for the system to return to atmospheric pressure after opening the vent. If omitted, the command opens the vent and returns without waiting for equalization. Waiting is recommended before moving labware to or from the module.
         """
         self._core.open_vent(equalize_timeout_s=equalize_timeout_s)
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -2016,8 +2016,8 @@ class VacuumModuleContext(ModuleContext):
             duration_s: An optional time, in seconds, to hold the target pressure after reaching it. If omitted, the module holds the target pressure until stopped.
             ramp_rate: An optional rate of pressure change, in mbar/s, while approaching the target pressure.
             timeout_s: An optional maximum duration, in seconds, allowed to reach the target before raising a timeout error.
-            vent_after: Optionally specifies whether to open the vent after the hold duration completes. Only applies when `duration_s` is set.
-            equalize_timeout_s: An optional maximum wait time, in seconds, to wait for system pressure to return near atmospheric after venting. Only applies when `duration_s` is set and `vent_after` is `True`. If omitted, the command does not wait for equalization. Waiting is recommended before moving labware to or from the module.
+            vent_after: Set to `True` to open the vent and return system pressure to atmospheric after the hold duration completes. Only applies when `duration_s` is set.
+            equalize_timeout_s: Sets the optional maximum wait time, in seconds, to wait for system pressure to return near atmospheric after venting. Only applies when `duration_s` is set and `vent_after` is `True`. If omitted, the command does not wait for equalization. Waiting is recommended before moving labware to or from the module.
 
         Returns:
             A task representing the concurrent vacuum operation.
@@ -2053,10 +2053,10 @@ class VacuumModuleContext(ModuleContext):
         Args:
             percent_power: % pump duty cycle, from `1` to `100` inclusive.
             duration_s: An optional time, in seconds, to hold the target power after reaching it. If omitted, the module holds the target until stopped.
-            ramp_rate: An optional rate of power change while approaching the target.
+            ramp_rate: An optional rate of power change, in percentage points per second (%/s), while approaching the target power.
             timeout_s: An optional maximum duration, in seconds, allowed to reach the target power before raising a timeout error.
-            vent_after: Optionally specifies whether to open the vent after the hold duration completes. Only applies when `duration_s` is set.
-            equalize_timeout_s: An optional maximum wait time, in seconds, to wait for system pressure to return near atmospheric after venting. Only applies when `duration_s` is set and `vent_after` is `True`. If omitted, the command does not wait for equalization. Waiting is recommended before moving labware to or from the module.
+            vent_after: Set to `True` to open the vent and return system pressure to atmospheric after the hold duration completes. Only applies when `duration_s` is set.
+            equalize_timeout_s: Sets the optional maximum wait time, in seconds, to wait for system pressure to return near atmospheric after venting. Only applies when `duration_s` is set and `vent_after` is `True`. If omitted, the command does not wait for equalization. Waiting is recommended before moving labware to or from the module.
 
         Returns:
             A task representing the concurrent vacuum operation.
@@ -2107,16 +2107,16 @@ class VacuumModuleContext(ModuleContext):
         Args:
             steps: List of step dictionaries defining the profile cycle. Each step dictionary supports:
 
-                * `enable_pump` (bool): whether to enable the pump motor.
-                * `hold_time_seconds` (float, optional): time in seconds to hold pressure/power for after target is reached.
-                * `hold_time_minutes` (float, optional): time in minutes to hold pressure/power for after target is reached.
-                * `ramp_rate` (float, optional): rate of pressure or power change while approaching setpoint.
-                * `timeout_seconds` (int, optional): maximum wait time, in seconds, to reach target setpoint before timing out.
-                * `vent_after` (bool, optional): whether to open the vent after the step is complete.
+                * `enable_pump` (bool): Whether to enable the pump motor.
+                * `hold_time_seconds` (float, optional): The number of seconds to hold pressure/power for after target is reached. If `hold_time_minutes` is also specified, the times are added together.
+                * `hold_time_minutes` (float, optional): The number of minutes to hold pressure/power for after target is reached. If `hold_time_seconds` is also specified, the times are added together.
+                * `ramp_rate` (float, optional): The rate of pressure or power change while approaching setpoint.
+                * `timeout_seconds` (int, optional): The maximum wait time, in seconds, to reach target setpoint before timing out.
+                * `vent_after` (bool, optional): Set to `True` to open the vent and return system pressure to atmospheric after all profile repetitions complete.
 
             repetitions: An optional cycle count specifying how many times to repeat the profile sequence.
-            vent_after: Optionally specifies whether to open the vent after all profile repetitions complete.
-            equalize_timeout_s: An optional maximum wait time, in seconds, to wait for system pressure to return near atmospheric after venting. Only applies when `vent_after` is `True`. If omitted, the command does not wait for equalization. Waiting is recommended before moving labware to or from the module.
+            vent_after: Set to `true` to open the vent and return to atmospheric pressure after all profile repetitions complete.
+            equalize_timeout_s: Sets the optional maximum wait time, in seconds, to wait for system pressure to return near atmospheric after venting. Only applies when `vent_after` is `True`. If omitted, the command does not wait for equalization. Waiting is recommended before moving labware to or from the module.
 
         Returns:
             A task representing the concurrent vacuum profile execution.
@@ -2143,7 +2143,7 @@ class VacuumModuleContext(ModuleContext):
         The module will not hold vacuum while the vent is open.
 
         Args:
-            equalize_timeout_s: An optional maximum wait time, in seconds, to wait for system pressure to return near atmospheric after venting. If omitted, the command opens the vent and returns without waiting for equalization. Waiting is recommended before moving labware to or from the module.
+            equalize_timeout_s: Sets the optional maximum wait time, in seconds, to wait for system pressure to return near atmospheric after venting. If omitted, the command opens the vent and returns without waiting for equalization. Waiting is recommended before moving labware to or from the module.
         """
         self._core.open_vent(equalize_timeout_s=equalize_timeout_s)
 

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -2140,7 +2140,7 @@ class VacuumModuleContext(ModuleContext):
     def open_vent(self, equalize_timeout_s: Optional[int] = None) -> None:
         """Open the vent valve to bring the system to atmospheric pressure (0 mbar).
 
-        Opens the vent to release vacuum and return system pressure to atmospheric. The module will not hold vacuum while the vent is open.
+        The module will not hold vacuum while the vent is open.
 
         Args:
             equalize_timeout_s: An optional maximum wait time, in seconds, to wait for system pressure to return near atmospheric after venting. If omitted, the command opens the vent and returns without waiting for equalization. Waiting is recommended before moving labware to or from the module.
@@ -2150,5 +2150,8 @@ class VacuumModuleContext(ModuleContext):
     @requires_version(2, 30)
     @publish(command=cmds.vacuum_module_close_vent)
     def close_vent(self) -> None:
-        """Close the vent so the system can hold vacuum."""
+        """Close the vent so the system can hold vacuum.
+        
+        The module will not hold vacuum while the vent is open.
+        """
         self._core.close_vent()

--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -2077,7 +2077,7 @@ class VacuumModuleContext(ModuleContext):
     def stop_vacuum_pump(self) -> None:
         """Stop the vacuum pump and disable active pressure and power control.
 
-        Shuts off the pump motor and cancels any target pressure or power limits. To release vacuum and return the chamber to atmospheric pressure, call [`open_vent()`][opentrons.protocol_api.VacuumModuleContext.open_vent] separately.
+        Shuts off the pump motor and cancels any target pressure or power limits. To release vacuum and return the system to atmospheric pressure, call [`open_vent()`][opentrons.protocol_api.VacuumModuleContext.open_vent] separately.
         """
         self._core.stop_vacuum()
 

--- a/docs/python-api/docs/modules/vacuum.md
+++ b/docs/python-api/docs/modules/vacuum.md
@@ -1,0 +1,6 @@
+---
+Title: "Python API: Vacuum Module"
+description: How to use the Vacuum Module in a Python protocol.
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. 

--- a/docs/python-api/docs/reference/vacuum.md
+++ b/docs/python-api/docs/reference/vacuum.md
@@ -1,0 +1,9 @@
+---
+title: "Python API Reference: Vacuum Module"
+description: "Vacuum Module class reference for the Python Protocol API."
+---
+
+::: opentrons.protocol_api.VacuumModuleContext
+    options:
+      inherited_members: true
+      

--- a/docs/python-api/mkdocs.yml
+++ b/docs/python-api/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
       - Magnetic Module: modules/magnetic-module.md
       - Temperature Module: modules/temperature-module.md
       - Thermocycler Module: modules/thermocycler.md
+      - Vacuum Module: modules/vacuum.md
       - Concurrent Module Actions: modules/concurrent.md
       - Loading Multiple Modules of the Same Type: modules/multiple-same-type.md
   - Deck Slots: deck-slots.md
@@ -69,6 +70,7 @@ nav:
         - Magnetic Module: reference/magnetic-module.md
         - Temperature Module: reference/temperature-module.md
         - Thermocycler: reference/thermocycler.md
+        - Vacuum Module: reference/vacuum.md
       - Useful Types: reference/types.md
       - Execute and Simulate: reference/execute-simulate.md
 


### PR DESCRIPTION
# Overview

This updates and revises the descriptive text (docstrings) for the VacuumModuleContext API. Text in `module_context.py`.

Sandbox: https://sandbox.docs.opentrons.com/vacuum-module-api-documentation/python-api/reference/vacuum/

RTC-1002

## Test Plan and Hands on Testing

Have others review and comment.

## Changelog

For the docs site:
- **nav:** Adds `nav` entry to `python-api/mkdocs.yml`: `- Vacuum Module: reference/vacuum.md`
- **reference doc:** Adds new reference doc to API docs: `vacuum.md` to `python-api/docs/reference/vacuum.md`
- **module doc:** Adds new module doc to API docs  **(placeholder only):** `vacuum.md` to `python-api/docs/modules/`

For API files:
- **docstrings:** Revises docstrings in `class VacuumModuleContext` in `api/src/opentrons/protocol_api/module_contexts.py`

Tried to apply uniform text to all the text descriptions for the Vacuum Module methods.

## Review requests

- Are these accurate and clear?
- Do any revisions change the definitions from what they should be?

## Risk assessment

Risk of creating confusion if descriptions are inaccurate. 
