### PR TITLE
fix(shared-data): update vacuum module A4 cutout offset

### DIFF
--- a/shared-data/deck/definitions/5/ot3_standard.json
+++ b/shared-data/deck/definitions/5/ot3_standard.json
@@ -992,7 +992,7 @@
       {
         "id": "vacuumModuleV1DockA4",
         "areaType": "lidDock",
-        "offsetFromCutoutFixture": [164.0, 0.0, 20.0],
+        "offsetFromCutoutFixture": [159.5, 0.0, 20.0],
         "boundingBox": {
           "xDimension": 128.5,
           "yDimension": 86.5,
@@ -1000,7 +1000,8 @@
         },
         "displayName": "Vacuum Module Dock in A4",
         "features": {},
-        "orientation": "right"
+        "orientation": "right",
+        "$comment": "This value is an eye-test estimate and needs hardware validation."
       }
     ],
     "cutouts": [


### PR DESCRIPTION
## Overview
Adds [this commit](https://github.com/Opentrons/opentrons/commit/d919dee2b82b7112174795fa4d506677b562338a) to chore release for the vacuum module beta.