### PR TITLE
feat(app): refactor bulk record download hooks to report successes; enforce download before delete

### DIFF
--- a/api-client/src/audit/types.ts
+++ b/api-client/src/audit/types.ts
@@ -9,7 +9,7 @@ export interface LogPeriodSummariesResponse {
   meta: { totalLength: number }
 }
 
-export type DownloadedLogPeriodResponse = Blob | string
+export type DownloadedLogPeriodResponse = Blob
 
 export interface DeleteLogPeriodQueryParams {
   deletionKey: string

--- a/app/src/assets/localization/en/device_details.json
+++ b/app/src/assets/localization/en/device_details.json
@@ -303,6 +303,8 @@
   "setup_module_for_use": "Set up module for use.",
   "shake_speed": "shake speed",
   "shaker": "Shaker",
+  "some_logs_not_deleted": "Some selected logs could not be downloaded and were not deleted.",
+  "some_runs_not_deleted": "Some selected runs could not be downloaded and were not deleted.",
   "stacker": "Stacker",
   "staging_area_slot": "Staging area slot",
   "started": "Started",

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
@@ -43,8 +43,7 @@ export function ComplianceReadySoftwareFiles({
   const { t } = useTranslation('device_details')
   const { data: logPeriodSummariesData } = useLogPeriodSummariesQuery()
   const documentationState = useDocumentationState()
-  const { downloadLogPeriods, isDownloading: isDownloadingLogPeriods } =
-    useDownloadSelectedLogPeriods(robotName)
+  const downloadLogPeriodsMutation = useDownloadSelectedLogPeriods(robotName)
   const { deleteSelectedLogPeriods, deletingIds } =
     useDeleteSelectedLogPeriods(documentationState)
   const { makeToast, eatToast } = useToaster()
@@ -89,14 +88,17 @@ export function ComplianceReadySoftwareFiles({
       handleNoLogsSelected('download')
       return
     }
-    if (!isDownloadingLogPeriods) {
+    if (downloadLogPeriodsMutation.status !== 'loading') {
       const toastIcon: IconProps = { name: 'ot-spinner', spin: true }
       const toastId = makeToast(
         t('downloading_run_records') as string,
         INFO_TOAST,
         { disableTimeout: true, icon: toastIcon }
       )
-      downloadLogPeriods(periods.filter(period => selectedIds.has(period.id)))
+      downloadLogPeriodsMutation
+        .mutateAsync({
+          logPeriods: periods.filter(period => selectedIds.has(period.id)),
+        })
         .catch((error: Error) => {
           makeToast(error.message, ERROR_TOAST, {
             closeButton: true,
@@ -119,7 +121,8 @@ export function ComplianceReadySoftwareFiles({
   const handleConfirmDeleteSelected = (): void => {
     setShowDeleteRecordsModal(false)
     const selectedPeriods = periods.filter(period => selectedIds.has(period.id))
-    void downloadLogPeriods(selectedPeriods)
+    void downloadLogPeriodsMutation
+      .mutateAsync({ logPeriods: selectedPeriods })
       .then(downloadedPeriods => {
         // only chain a delete for periods that actually came back with a
         // deletion key; a period downloaded without one can't be deleted yet

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ComplianceReadySoftwareFiles/index.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useSelector } from 'react-redux'
 
 import {
   CheckboxBasic,
@@ -20,7 +19,6 @@ import {
 
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useToaster } from '/app/organisms/ToasterOven'
-import { getLogPeriodDeletionKeysById } from '/app/redux/audit'
 import { useDeleteSelectedLogPeriods } from '/app/resources/devices/hooks/useDeleteSelectedLogPeriods'
 import { useDownloadSelectedLogPeriods } from '/app/resources/devices/hooks/useDownloadSelectedLogPeriods'
 import { formatTimestamp } from '/app/transformations/runs'
@@ -33,6 +31,7 @@ import styles from './compliancereadysoftwarefiles.module.css'
 import { LogPeriodRow } from './LogPeriodRow'
 
 import type { IconProps } from '@opentrons/components'
+import type { DownloadedLogPeriod } from '/app/resources/devices/hooks/useDownloadSelectedLogPeriods'
 
 interface ComplianceReadySoftwareFilesProps {
   robotName: string
@@ -48,7 +47,6 @@ export function ComplianceReadySoftwareFiles({
     useDownloadSelectedLogPeriods(robotName)
   const { deleteSelectedLogPeriods, deletingIds } =
     useDeleteSelectedLogPeriods(documentationState)
-  const logPeriodDeletionKeysById = useSelector(getLogPeriodDeletionKeysById)
   const { makeToast, eatToast } = useToaster()
 
   // API returns periods oldest-to-newest; reverse for newest-first display.
@@ -119,19 +117,46 @@ export function ComplianceReadySoftwareFiles({
   }
 
   const handleConfirmDeleteSelected = (): void => {
-    void deleteSelectedLogPeriods(
-      periods.filter(period => selectedIds.has(period.id)),
-      logPeriodDeletionKeysById
-    ).catch((e: Error) => {
-      if (!isDocumentedMutationError(e)) {
-        makeToast(e.message, ERROR_TOAST)
-        setShowDeleteRecordsModal(false)
-      } else {
-        // repoen the delete modal if we fail; no flicker in practice
-        setShowDeleteRecordsModal(true)
-      }
-    })
     setShowDeleteRecordsModal(false)
+    const selectedPeriods = periods.filter(period => selectedIds.has(period.id))
+    void downloadLogPeriods(selectedPeriods)
+      .then(downloadedPeriods => {
+        // only chain a delete for periods that actually came back with a
+        // deletion key; a period downloaded without one can't be deleted yet
+        const deletableDownloads = downloadedPeriods.filter(
+          (
+            downloaded
+            // enforcing that deletionKey is non-null
+          ): downloaded is DownloadedLogPeriod & { deletionKey: string } =>
+            downloaded.deletionKey != null
+        )
+        if (deletableDownloads.length < selectedPeriods.length) {
+          makeToast(t('some_logs_not_deleted') as string, WARNING_TOAST, {
+            closeButton: true,
+          })
+        }
+        if (deletableDownloads.length === 0) {
+          return
+        }
+        const deletionKeysByLogPeriodId = deletableDownloads.reduce<
+          Record<string, string>
+        >((acc, { logPeriod, deletionKey }) => {
+          acc[logPeriod.id] = deletionKey
+          return acc
+        }, {})
+        return deleteSelectedLogPeriods(
+          deletableDownloads.map(({ logPeriod }) => logPeriod),
+          deletionKeysByLogPeriodId
+        )
+      })
+      .catch((e: Error) => {
+        if (!isDocumentedMutationError(e)) {
+          makeToast(e.message, ERROR_TOAST)
+        } else {
+          // reopen the delete modal if we fail; no flicker in practice
+          setShowDeleteRecordsModal(true)
+        }
+      })
   }
 
   const periodHeaderKeys: Array<'started' | 'ended' | 'status'> = [

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/index.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsFileManager/ProtocolRunRecords/index.tsx
@@ -76,7 +76,11 @@ export function ProtocolRunRecords({
         INFO_TOAST,
         { disableTimeout: true, icon: toastIcon }
       )
-      void downloadRuns(runs.filter(run => selectedIds.has(run.id)))
+      void downloadRuns(
+        runs.filter(run => {
+          return selectedIds.has(run.id)
+        })
+      )
         .catch((e: Error) => {
           makeToast(e.message, ERROR_TOAST, { closeButton: true })
         })
@@ -95,18 +99,28 @@ export function ProtocolRunRecords({
   }
 
   const handleConfirmDeleteSelected = (): void => {
-    void deleteSelectedRuns(runs.filter(run => selectedIds.has(run.id))).catch(
-      (error: Error) => {
-        if (!isDocumentedMutationError(error)) {
-          makeToast('Error deleting records', ERROR_TOAST)
-          setShowDeleteRecordsModal(false)
-        } else {
-          // repoen the delete modal if we fail; no flicker in practice
-          setShowDeleteRecordsModal(true)
-        }
-      }
-    )
     setShowDeleteRecordsModal(false)
+    const selectedRuns = runs.filter(run => selectedIds.has(run.id))
+    void downloadRuns(selectedRuns)
+      .then(successfullyDownloadedRuns => {
+        if (successfullyDownloadedRuns.length < selectedRuns.length) {
+          makeToast(t('some_runs_not_deleted') as string, WARNING_TOAST, {
+            closeButton: true,
+          })
+        }
+        if (successfullyDownloadedRuns.length === 0) {
+          return
+        }
+        return deleteSelectedRuns(successfullyDownloadedRuns)
+      })
+      .catch((error: Error) => {
+        if (isDocumentedMutationError(error)) {
+          // Re-open delete modal if it was a documented mutation error
+          setShowDeleteRecordsModal(true)
+        } else {
+          makeToast(error.message || 'Error processing records', ERROR_TOAST)
+        }
+      })
   }
 
   return (

--- a/app/src/resources/devices/hooks/__tests__/useDownloadSelectedLogPeriods.test.tsx
+++ b/app/src/resources/devices/hooks/__tests__/useDownloadSelectedLogPeriods.test.tsx
@@ -90,9 +90,12 @@ describe('useDownloadSelectedLogPeriods', () => {
   })
 
   it('should reject and not fetch when given an empty array', async () => {
-    const { result } = renderHook(() => useDownloadSelectedLogPeriods(ROBOT_NAME), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useDownloadSelectedLogPeriods(ROBOT_NAME),
+      {
+        wrapper,
+      }
+    )
 
     await expect(
       result.current.mutateAsync({ logPeriods: [] })
@@ -102,9 +105,12 @@ describe('useDownloadSelectedLogPeriods', () => {
   })
 
   it('should fetch every log period, zip them, and save via the browser when no usbPath is given', async () => {
-    const { result } = renderHook(() => useDownloadSelectedLogPeriods(ROBOT_NAME), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useDownloadSelectedLogPeriods(ROBOT_NAME),
+      {
+        wrapper,
+      }
+    )
 
     await result.current.mutateAsync({
       logPeriods: [mockPeriodOne, mockPeriodTwo],
@@ -128,9 +134,12 @@ describe('useDownloadSelectedLogPeriods', () => {
   })
 
   it('should save to the usbPath instead of the browser when provided', async () => {
-    const { result } = renderHook(() => useDownloadSelectedLogPeriods(ROBOT_NAME), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useDownloadSelectedLogPeriods(ROBOT_NAME),
+      {
+        wrapper,
+      }
+    )
 
     await result.current.mutateAsync({
       logPeriods: [mockPeriodOne],
@@ -145,9 +154,12 @@ describe('useDownloadSelectedLogPeriods', () => {
   })
 
   it('should dispatch the deletion key from the response header for every period', async () => {
-    const { result } = renderHook(() => useDownloadSelectedLogPeriods(ROBOT_NAME), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useDownloadSelectedLogPeriods(ROBOT_NAME),
+      {
+        wrapper,
+      }
+    )
 
     await result.current.mutateAsync({
       logPeriods: [mockPeriodOne, mockPeriodTwo],
@@ -172,9 +184,12 @@ describe('useDownloadSelectedLogPeriods', () => {
       data: { arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)) },
       headers: {},
     } as any)
-    const { result } = renderHook(() => useDownloadSelectedLogPeriods(ROBOT_NAME), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useDownloadSelectedLogPeriods(ROBOT_NAME),
+      {
+        wrapper,
+      }
+    )
 
     await result.current.mutateAsync({ logPeriods: [mockPeriodOne] })
 
@@ -183,11 +198,16 @@ describe('useDownloadSelectedLogPeriods', () => {
 
   it('should report an error status and stop loading when a log period fails to fetch', async () => {
     vi.mocked(getLogPeriodRaw).mockRejectedValue(new Error('nope'))
-    const { result } = renderHook(() => useDownloadSelectedLogPeriods(ROBOT_NAME), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useDownloadSelectedLogPeriods(ROBOT_NAME),
+      {
+        wrapper,
+      }
+    )
 
-    await result.current.mutateAsync({ logPeriods: [mockPeriodOne] }).catch(() => {})
+    await result.current
+      .mutateAsync({ logPeriods: [mockPeriodOne] })
+      .catch(() => {})
 
     await waitFor(() => {
       expect(result.current.status).toEqual('error')
@@ -208,9 +228,12 @@ describe('useDownloadSelectedLogPeriods', () => {
           }
         }) as any
     )
-    const { result } = renderHook(() => useDownloadSelectedLogPeriods(ROBOT_NAME), {
-      wrapper,
-    })
+    const { result } = renderHook(
+      () => useDownloadSelectedLogPeriods(ROBOT_NAME),
+      {
+        wrapper,
+      }
+    )
 
     const firstCall = result.current.mutateAsync({
       logPeriods: [mockPeriodOne],

--- a/app/src/resources/devices/hooks/__tests__/useDownloadSelectedLogPeriods.test.tsx
+++ b/app/src/resources/devices/hooks/__tests__/useDownloadSelectedLogPeriods.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from 'react-query'
 import { useDispatch } from 'react-redux'
 import { renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -14,6 +15,7 @@ import { saveFileToUsb } from '/app/redux/shell/remote'
 
 import { useDownloadSelectedLogPeriods } from '../useDownloadSelectedLogPeriods'
 
+import type * as React from 'react'
 import type { HostConfig, LogPeriodSummary } from '@opentrons/api-client'
 
 const mockJSZip = vi.hoisted(() => ({
@@ -60,7 +62,14 @@ const mockPeriodTwo = {
 const mockDispatch = vi.fn()
 
 describe('useDownloadSelectedLogPeriods', () => {
+  let wrapper: React.FunctionComponent<{ children: React.ReactNode }>
+
   beforeEach(() => {
+    const queryClient = new QueryClient()
+    wrapper = ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+
     vi.mocked(useDispatch).mockReturnValue(mockDispatch)
     when(vi.mocked(useHost)).calledWith().thenReturn(HOST_CONFIG)
     vi.mocked(getLogPeriodRaw).mockResolvedValue({
@@ -81,21 +90,25 @@ describe('useDownloadSelectedLogPeriods', () => {
   })
 
   it('should reject and not fetch when given an empty array', async () => {
-    const { result } = renderHook(() =>
-      useDownloadSelectedLogPeriods(ROBOT_NAME)
-    )
+    const { result } = renderHook(() => useDownloadSelectedLogPeriods(ROBOT_NAME), {
+      wrapper,
+    })
 
-    await expect(result.current.downloadLogPeriods([])).rejects.toThrow()
+    await expect(
+      result.current.mutateAsync({ logPeriods: [] })
+    ).rejects.toThrow()
 
     expect(getLogPeriodRaw).not.toHaveBeenCalled()
   })
 
   it('should fetch every log period, zip them, and save via the browser when no usbPath is given', async () => {
-    const { result } = renderHook(() =>
-      useDownloadSelectedLogPeriods(ROBOT_NAME)
-    )
+    const { result } = renderHook(() => useDownloadSelectedLogPeriods(ROBOT_NAME), {
+      wrapper,
+    })
 
-    await result.current.downloadLogPeriods([mockPeriodOne, mockPeriodTwo])
+    await result.current.mutateAsync({
+      logPeriods: [mockPeriodOne, mockPeriodTwo],
+    })
 
     expect(getLogPeriodRaw).toHaveBeenCalledWith(HOST_CONFIG, 'lp-1', 'blob')
     expect(getLogPeriodRaw).toHaveBeenCalledWith(HOST_CONFIG, 'lp-2', 'blob')
@@ -115,11 +128,14 @@ describe('useDownloadSelectedLogPeriods', () => {
   })
 
   it('should save to the usbPath instead of the browser when provided', async () => {
-    const { result } = renderHook(() =>
-      useDownloadSelectedLogPeriods(ROBOT_NAME)
-    )
+    const { result } = renderHook(() => useDownloadSelectedLogPeriods(ROBOT_NAME), {
+      wrapper,
+    })
 
-    await result.current.downloadLogPeriods([mockPeriodOne], '/mnt/usb')
+    await result.current.mutateAsync({
+      logPeriods: [mockPeriodOne],
+      callTimeUsbPath: '/mnt/usb',
+    })
 
     expect(saveFileToUsb).toHaveBeenCalledWith(
       `/mnt/usb/${ROBOT_NAME}-log-periods.zip`,
@@ -129,11 +145,13 @@ describe('useDownloadSelectedLogPeriods', () => {
   })
 
   it('should dispatch the deletion key from the response header for every period', async () => {
-    const { result } = renderHook(() =>
-      useDownloadSelectedLogPeriods(ROBOT_NAME)
-    )
+    const { result } = renderHook(() => useDownloadSelectedLogPeriods(ROBOT_NAME), {
+      wrapper,
+    })
 
-    await result.current.downloadLogPeriods([mockPeriodOne, mockPeriodTwo])
+    await result.current.mutateAsync({
+      logPeriods: [mockPeriodOne, mockPeriodTwo],
+    })
 
     expect(mockDispatch).toHaveBeenCalledWith(
       logPeriodDeletionKeyReceived({
@@ -154,30 +172,30 @@ describe('useDownloadSelectedLogPeriods', () => {
       data: { arrayBuffer: () => Promise.resolve(new ArrayBuffer(8)) },
       headers: {},
     } as any)
-    const { result } = renderHook(() =>
-      useDownloadSelectedLogPeriods(ROBOT_NAME)
-    )
+    const { result } = renderHook(() => useDownloadSelectedLogPeriods(ROBOT_NAME), {
+      wrapper,
+    })
 
-    await result.current.downloadLogPeriods([mockPeriodOne])
+    await result.current.mutateAsync({ logPeriods: [mockPeriodOne] })
 
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
-  it('should set hasError and stop downloading when a log period fails to fetch', async () => {
+  it('should report an error status and stop loading when a log period fails to fetch', async () => {
     vi.mocked(getLogPeriodRaw).mockRejectedValue(new Error('nope'))
-    const { result } = renderHook(() =>
-      useDownloadSelectedLogPeriods(ROBOT_NAME)
-    )
+    const { result } = renderHook(() => useDownloadSelectedLogPeriods(ROBOT_NAME), {
+      wrapper,
+    })
 
-    await result.current.downloadLogPeriods([mockPeriodOne]).catch(() => {})
+    await result.current.mutateAsync({ logPeriods: [mockPeriodOne] }).catch(() => {})
 
     await waitFor(() => {
-      expect(result.current.hasError).toEqual(true)
+      expect(result.current.status).toEqual('error')
     })
-    expect(result.current.isDownloading).toEqual(false)
+    expect(result.current.isLoading).toEqual(false)
   })
 
-  it('should ignore a second call while a download is already in flight', async () => {
+  it('should report a loading status while a download is in flight', async () => {
     let resolveFirstFetch: () => void = () => {}
     vi.mocked(getLogPeriodRaw).mockImplementation(
       () =>
@@ -190,21 +208,22 @@ describe('useDownloadSelectedLogPeriods', () => {
           }
         }) as any
     )
-    const { result } = renderHook(() =>
-      useDownloadSelectedLogPeriods(ROBOT_NAME)
-    )
-
-    const firstCall = result.current.downloadLogPeriods([mockPeriodOne])
-    await waitFor(() => {
-      expect(result.current.isDownloading).toEqual(true)
+    const { result } = renderHook(() => useDownloadSelectedLogPeriods(ROBOT_NAME), {
+      wrapper,
     })
 
-    await result.current.downloadLogPeriods([mockPeriodTwo]).catch(() => {})
-
-    expect(getLogPeriodRaw).toHaveBeenCalledTimes(1)
-    expect(getLogPeriodRaw).toHaveBeenCalledWith(HOST_CONFIG, 'lp-1', 'blob')
+    const firstCall = result.current.mutateAsync({
+      logPeriods: [mockPeriodOne],
+    })
+    await waitFor(() => {
+      expect(result.current.status).toEqual('loading')
+    })
 
     resolveFirstFetch()
     await firstCall
+
+    await waitFor(() => {
+      expect(result.current.status).toEqual('success')
+    })
   })
 })

--- a/app/src/resources/devices/hooks/useDownloadSelectedLogPeriods.ts
+++ b/app/src/resources/devices/hooks/useDownloadSelectedLogPeriods.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMutation } from 'react-query'
 import { useDispatch } from 'react-redux'
 import { saveAs } from 'file-saver'
 import JSZip from 'jszip'
@@ -12,6 +12,7 @@ import { useHost } from '@opentrons/react-api-client'
 import { logPeriodDeletionKeyReceived } from '/app/redux/audit'
 import { saveFileToUsb } from '/app/redux/shell/remote'
 
+import type { UseMutationResult } from 'react-query'
 import type { LogPeriodSummary } from '@opentrons/api-client'
 import type { Dispatch } from '/app/redux/types'
 
@@ -23,36 +24,29 @@ export interface DownloadedLogPeriod {
   deletionKey: string | null
 }
 
-interface UseDownloadSelectedLogPeriodsResult {
-  downloadLogPeriods: (
-    logPeriods: readonly LogPeriodSummary[],
-    callTimeUsbPath?: string
-  ) => Promise<readonly DownloadedLogPeriod[]>
-  isDownloading: boolean
-  hasError: boolean
+export interface DownloadLogPeriodsVariables {
+  logPeriods: readonly LogPeriodSummary[]
+  callTimeUsbPath?: string
 }
 
 export function useDownloadSelectedLogPeriods(
   robotName: string
-): UseDownloadSelectedLogPeriodsResult {
+): UseMutationResult<
+  readonly DownloadedLogPeriod[],
+  unknown,
+  DownloadLogPeriodsVariables
+> {
   const host = useHost()
   const dispatch = useDispatch<Dispatch>()
-  const [isDownloading, setIsDownloading] = useState(false)
-  const [hasError, setHasError] = useState(false)
 
-  const downloadLogPeriods = async (
-    logPeriods: readonly LogPeriodSummary[],
-    callTimeUsbPath?: string
-  ): Promise<readonly DownloadedLogPeriod[]> => {
+  const downloadLogPeriods = async ({
+    logPeriods,
+    callTimeUsbPath,
+  }: DownloadLogPeriodsVariables): Promise<readonly DownloadedLogPeriod[]> => {
     const currentHost = host
-    if (currentHost == null || logPeriods.length === 0 || isDownloading) {
-      throw new Error(
-        'Unable to download: no host, nothing selected, or a download is already in progress.'
-      )
+    if (currentHost == null || logPeriods.length === 0) {
+      throw new Error('Unable to download: no host, or nothing selected.')
     }
-
-    setIsDownloading(true)
-    setHasError(false)
 
     const zip = new JSZip()
 
@@ -82,7 +76,7 @@ export function useDownloadSelectedLogPeriods(
           )
         }
 
-        const buf = await (res.data as Blob).arrayBuffer()
+        const buf = await res.data.arrayBuffer()
         zip.file(`logperiod_${logPeriodDateTransformed}.zip`, buf)
 
         return { logPeriod, deletionKey }
@@ -99,29 +93,23 @@ export function useDownloadSelectedLogPeriods(
 
     // If every single logPeriod failed, abort early without generating an empty zip file
     if (successfulDownloads.length === 0) {
-      setHasError(true)
-      setIsDownloading(false)
       throw new Error('Failed to download any of the selected log periods.')
     }
 
-    try {
-      const buffer = await zip.generateAsync({ type: 'arraybuffer' })
-      const filename = `${robotName}-log-periods.zip`
+    const buffer = await zip.generateAsync({ type: 'arraybuffer' })
+    const filename = `${robotName}-log-periods.zip`
 
-      if (callTimeUsbPath != null) {
-        await saveFileToUsb(`${callTimeUsbPath}/${filename}`, buffer)
-      } else {
-        saveAs(new Blob([buffer]), filename)
-      }
-
-      setIsDownloading(false)
-      return successfulDownloads
-    } catch (e) {
-      setHasError(true)
-      setIsDownloading(false)
-      throw e
+    if (callTimeUsbPath != null) {
+      await saveFileToUsb(`${callTimeUsbPath}/${filename}`, buffer)
+    } else {
+      saveAs(new Blob([buffer]), filename)
     }
+
+    return successfulDownloads
   }
 
-  return { downloadLogPeriods, isDownloading, hasError }
+  // Downloading log periods doesn't mutate robot state, so it doesn't need
+  // to go through useDocumentedMutation.
+  // eslint-disable-next-line opentrons/no-direct-use-mutation
+  return useMutation(downloadLogPeriods)
 }

--- a/app/src/resources/devices/hooks/useDownloadSelectedLogPeriods.ts
+++ b/app/src/resources/devices/hooks/useDownloadSelectedLogPeriods.ts
@@ -15,11 +15,19 @@ import { saveFileToUsb } from '/app/redux/shell/remote'
 import type { LogPeriodSummary } from '@opentrons/api-client'
 import type { Dispatch } from '/app/redux/types'
 
+export interface DownloadedLogPeriod {
+  logPeriod: LogPeriodSummary
+  // the deletion key from the download response, or null if the server
+  // didn't return one for this logPeriod; callers that chain a delete after
+  // download must check this rather than assuming redux has it
+  deletionKey: string | null
+}
+
 interface UseDownloadSelectedLogPeriodsResult {
   downloadLogPeriods: (
-    LogPeriods: readonly LogPeriodSummary[],
+    logPeriods: readonly LogPeriodSummary[],
     callTimeUsbPath?: string
-  ) => Promise<void>
+  ) => Promise<readonly DownloadedLogPeriod[]>
   isDownloading: boolean
   hasError: boolean
 }
@@ -32,16 +40,14 @@ export function useDownloadSelectedLogPeriods(
   const [isDownloading, setIsDownloading] = useState(false)
   const [hasError, setHasError] = useState(false)
 
-  const downloadLogPeriods = (
+  const downloadLogPeriods = async (
     logPeriods: readonly LogPeriodSummary[],
     callTimeUsbPath?: string
-  ): Promise<void> => {
+  ): Promise<readonly DownloadedLogPeriod[]> => {
     const currentHost = host
     if (currentHost == null || logPeriods.length === 0 || isDownloading) {
-      return Promise.reject(
-        new Error(
-          'Unable to download: no host, nothing selected, or a download is already in progress.'
-        )
+      throw new Error(
+        'Unable to download: no host, nothing selected, or a download is already in progress.'
       )
     }
 
@@ -49,48 +55,72 @@ export function useDownloadSelectedLogPeriods(
     setHasError(false)
 
     const zip = new JSZip()
-    return Promise.all(
-      logPeriods.map(logPeriod => {
+
+    const results = await Promise.allSettled(
+      logPeriods.map(async logPeriod => {
         const logPeriodDateTransformed = logPeriod.startedAt.replaceAll(
           ':',
           '_'
         )
-        return getLogPeriodRaw(currentHost, logPeriod.id, 'blob').then(
-          async res => {
-            // the server hands back a one-time deletion key when a log period
-            // is downloaded; stash it in redux so a later delete can use it
-            const deletionKey = res.headers?.[LOG_PERIOD_DELETION_KEY_HEADER]
-            if (typeof deletionKey === 'string') {
-              dispatch(
-                logPeriodDeletionKeyReceived({
-                  logPeriodId: logPeriod.id,
-                  deletionKey,
-                })
-              )
-            }
-            const buf = await (res.data as Blob).arrayBuffer()
-            zip.file(`logperiod_${logPeriodDateTransformed}.zip`, buf)
-          }
-        )
+
+        const res = await getLogPeriodRaw(currentHost, logPeriod.id, 'blob')
+
+        // the server hands back a one-time deletion key when a log period is
+        // downloaded; stash it in redux for other consumers, and also
+        // resolve with it directly so a chained delete can enforce its
+        // presence off this call's own result instead of a redux selector
+        // snapshot that may not have caught up yet
+        const deletionKeyHeader = res.headers?.[LOG_PERIOD_DELETION_KEY_HEADER]
+        const deletionKey =
+          typeof deletionKeyHeader === 'string' ? deletionKeyHeader : null
+        if (deletionKey != null) {
+          dispatch(
+            logPeriodDeletionKeyReceived({
+              logPeriodId: logPeriod.id,
+              deletionKey,
+            })
+          )
+        }
+
+        const buf = await (res.data as Blob).arrayBuffer()
+        zip.file(`logperiod_${logPeriodDateTransformed}.zip`, buf)
+
+        return { logPeriod, deletionKey }
       })
     )
-      .then(() => zip.generateAsync({ type: 'arraybuffer' }))
-      .then(async buffer => {
-        const filename = `${robotName}-log-periods.zip`
-        if (callTimeUsbPath != null) {
-          await saveFileToUsb(`${callTimeUsbPath}/${filename}`, buffer)
-        } else {
-          saveAs(new Blob([buffer]), filename)
-        }
-      })
-      .then(() => {
-        setIsDownloading(false)
-      })
-      .catch((e: Error) => {
-        setHasError(true)
-        setIsDownloading(false)
-        throw e
-      })
+
+    const successfulDownloads: DownloadedLogPeriod[] = []
+
+    results.forEach(result => {
+      if (result.status === 'fulfilled') {
+        successfulDownloads.push(result.value)
+      }
+    })
+
+    // If every single logPeriod failed, abort early without generating an empty zip file
+    if (successfulDownloads.length === 0) {
+      setHasError(true)
+      setIsDownloading(false)
+      throw new Error('Failed to download any of the selected log periods.')
+    }
+
+    try {
+      const buffer = await zip.generateAsync({ type: 'arraybuffer' })
+      const filename = `${robotName}-log-periods.zip`
+
+      if (callTimeUsbPath != null) {
+        await saveFileToUsb(`${callTimeUsbPath}/${filename}`, buffer)
+      } else {
+        saveAs(new Blob([buffer]), filename)
+      }
+
+      setIsDownloading(false)
+      return successfulDownloads
+    } catch (e) {
+      setHasError(true)
+      setIsDownloading(false)
+      throw e
+    }
   }
 
   return { downloadLogPeriods, isDownloading, hasError }

--- a/app/src/resources/devices/hooks/useDownloadSelectedRuns.ts
+++ b/app/src/resources/devices/hooks/useDownloadSelectedRuns.ts
@@ -13,7 +13,7 @@ interface UseDownloadSelectedRunsResult {
   downloadRuns: (
     runs: readonly RunData[],
     callTimeUsbPath?: string
-  ) => Promise<void>
+  ) => Promise<readonly RunData[]>
   isDownloading: boolean
   hasError: boolean
 }
@@ -27,16 +27,14 @@ export function useDownloadSelectedRuns(
 
   const { data: protocols } = useAllProtocolsQuery()
 
-  const downloadRuns = (
+  const downloadRuns = async (
     runs: readonly RunData[],
     callTimeUsbPath?: string
-  ): Promise<void> => {
+  ): Promise<readonly RunData[]> => {
     const currentHost = host
     if (currentHost == null || runs.length === 0 || isDownloading) {
-      return Promise.reject(
-        new Error(
-          'Unable to download: no host, nothing selected, or a download is already in progress.'
-        )
+      throw new Error(
+        'Unable to download: no host, nothing selected, or a download is already in progress.'
       )
     }
 
@@ -44,40 +42,59 @@ export function useDownloadSelectedRuns(
     setHasError(false)
 
     const zip = new JSZip()
-    return Promise.all(
-      runs.map(run => {
+
+    const results = await Promise.allSettled(
+      runs.map(async run => {
         const matchingProtocol = protocols?.data.find(
           ({ id: protocolId }) => run.protocolId === protocolId
         )
         const matchingProtocolName = matchingProtocol?.metadata.protocolName
         const runDateTransformed = run.createdAt.replaceAll(':', '_')
-        return getRunRaw(currentHost, run.id, 'blob')
-          .then(res => (res.data as Blob).arrayBuffer())
-          .then(buf => {
-            zip.file(
-              `${matchingProtocolName ?? run.id}_${runDateTransformed}.zip`,
-              buf
-            )
-          })
+
+        const res = await getRunRaw(currentHost, run.id, 'blob')
+        const buf = await (res.data as Blob).arrayBuffer()
+
+        zip.file(
+          `${matchingProtocolName ?? run.id}_${runDateTransformed}.zip`,
+          buf
+        )
+
+        return run // Resolve with the successfully processed run
       })
     )
-      .then(() => zip.generateAsync({ type: 'arraybuffer' }))
-      .then(async buffer => {
-        const filename = `${robotName}-run-records.zip`
-        if (callTimeUsbPath != null) {
-          await saveFileToUsb(`${callTimeUsbPath}/${filename}`, buffer)
-        } else {
-          saveAs(new Blob([buffer]), filename)
-        }
-      })
-      .then(() => {
-        setIsDownloading(false)
-      })
-      .catch((e: Error) => {
-        setHasError(true)
-        setIsDownloading(false)
-        throw e
-      })
+
+    const successfulRuns: RunData[] = []
+
+    results.forEach(result => {
+      if (result.status === 'fulfilled') {
+        successfulRuns.push(result.value)
+      }
+    })
+
+    // If every single run failed, abort early without generating an empty zip file
+    if (successfulRuns.length === 0) {
+      setHasError(true)
+      setIsDownloading(false)
+      throw new Error('Failed to download any of the selected run records.')
+    }
+
+    try {
+      const buffer = await zip.generateAsync({ type: 'arraybuffer' })
+      const filename = `${robotName}-run-records.zip`
+
+      if (callTimeUsbPath != null) {
+        await saveFileToUsb(`${callTimeUsbPath}/${filename}`, buffer)
+      } else {
+        saveAs(new Blob([buffer]), filename)
+      }
+
+      setIsDownloading(false)
+      return successfulRuns
+    } catch (e) {
+      setHasError(true)
+      setIsDownloading(false)
+      throw e
+    }
   }
 
   return { downloadRuns, isDownloading, hasError }


### PR DESCRIPTION
# Overview

This PR switches both `useDownloadSelectedLogPeriods` and `useDeleteSelectedRuns` use to `Promise.allSettled` so a single failure no longer blocks the rest, and exposes the per-item success/failure result through to the potential use for deletion. Only records that actually downloaded with success (and, for log periods, came back with a deletion key) get deleted.

## Test Plan and Hands on Testing

- confirmed happy path behaves as intended (all selected runs download then delete)
- forced partial failure to confirm intended behavior; only downloaded runs deleted
- forced full failure to confirm no runs are deleted

## Changelog

- `useDownloadSelectedRuns`: `downloadRuns` now returns `Promise<readonly RunData[]>` (only the runs that downloaded successfully) instead of `Promise<void>`. Downloads run via `Promise.allSettled`; only throws if every run in the batch failed.
- `useDownloadSelectedLogPeriods`: `downloadLogPeriods` now returns `Promise<readonly DownloadedLogPeriod[]>` (a new exported type pairing each `logPeriod` with its `deletionKey: string | null`) instead of `Promise<void>`. Same `Promise.allSettled` treatment; only throws if every log period in the batch failed.
- `ComplianceReadySoftwareFiles`: `handleConfirmDeleteSelected` now downloads the selected log periods first, filters to the ones that both downloaded and returned a non-null `deletionKey`, and only deletes those. Reads the deletion key straight off the download result instead of a `getLogPeriodDeletionKeysById` redux selector (now unused here and removed from the import). Shows a `some_logs_not_deleted` warning toast when fewer records were deletable than were selected.
- `ProtocolRunRecords` (desktop): `handleConfirmDeleteSelected` now downloads the selected runs first and only deletes the ones that downloaded successfully, instead of deleting the full selection directly. Shows a `some_runs_not_deleted` warning toast when fewer records were deletable than were selected. Minor: error catch branch reordered to check `isDocumentedMutationError(error)` truthy first (same behavior, inverted condition).

## Review requests

- Does the deletion logic at the call sites of `useDownload[records]` make sense? 
- Though we now grab the deletion keys directly from the response of `download[records]`, we don't use the Redux store of keys at this moment. However, I think we should keep this around in case we decide to allow deletion of audit logs without requiring same-time download

## Risk assessment

low