### PR TITLE
feat(update-server): add audit logging

### DIFF
--- a/update-server/Makefile
+++ b/update-server/Makefile
@@ -13,7 +13,7 @@ port ?= 34000
 tests ?= tests
 test_opts ?=
 
-files_to_check := otupdate tests
+files_to_check := otupdate tests oe_upload.py
 
 wheel_file = $(call python_get_wheelname,update-server,$(project_rs_default),otupdate)
 # Find the branch, sha, version that will be used to update the VERSION.json file

--- a/update-server/oe_upload.py
+++ b/update-server/oe_upload.py
@@ -8,7 +8,7 @@ import asyncio
 import getpass
 import json
 import sys
-from typing import Optional
+from typing import Any, BinaryIO, Literal
 
 import aiohttp
 
@@ -16,13 +16,15 @@ import aiohttp
 CLIENT_ID = "opentrons_app"
 
 
-async def poll_status(sess, token, root):
+async def poll_status(sess: aiohttp.ClientSession, token: str, root: str) -> Any:
     await asyncio.sleep(1.0)
     resp = await sess.get(root + "/" + token + "/status")
     return await resp.json()
 
 
-async def log_in(session, host: str, username: str, password: str) -> str:
+async def log_in(
+    session: aiohttp.ClientSession, host: str, username: str, password: str
+) -> str:
     """Exchange a username and password for an access token.
 
     The token is issued with whatever scopes the account has; the update flow
@@ -42,21 +44,23 @@ async def log_in(session, host: str, username: str, password: str) -> str:
     if resp.status != 200:
         try:
             error = json.loads(body)
-            message = f'{error["error"]}: {error["error_description"]}'
+            message = f"{error['error']}: {error['error_description']}"
         except (json.JSONDecodeError, KeyError):
             message = body
         sys.stderr.write(f"Error logging in: {resp.status}: {message}\n")
         sys.exit(-1)
-    return json.loads(body)["access_token"]
+    token = json.loads(body)["access_token"]
+    assert isinstance(token, str), "Invalid return from OAuth2 token route"
+    return token
 
 
-async def do_update(
-    update_file: str,
+async def do_update(  # noqa: C901
+    update_file: BinaryIO,
     host: str,
-    pause_between_steps: bool = False,
-    username: Optional[str] = None,
-    password: Optional[str] = None,
-):
+    mode: Literal["auto", "sbs", "normal"],
+    username: str | None = None,
+    password: str | None = None,
+) -> None:
     timeout = aiohttp.ClientTimeout(total=7200)
 
     headers = {}
@@ -69,7 +73,8 @@ async def do_update(
         root = host + "/server/update"
         filename = "system-update.zip"
         print(f"Starting update of {update_file.name} to {host}")
-        begin_resp = await session.post(root + "/begin")
+        begin_data = {"auto_commit_and_restart": mode == "auto"}
+        begin_resp = await session.post(root + "/begin", json=begin_data)
         if begin_resp.status == 409:
             should_cancel = input("Another update is in process! Cancel [yN]? ")
             if should_cancel.lower()[0] == "y":
@@ -81,7 +86,7 @@ async def do_update(
                         f"{cancel_resp.status}: {body}\n"
                     )
                     sys.exit(-1)
-                begin_resp = await session.post(root + "/begin")
+                begin_resp = await session.post(root + "/begin", json=begin_data)
 
         if begin_resp.status != 201:
             body = await begin_resp.text()
@@ -92,12 +97,12 @@ async def do_update(
         token = begin_body["token"]
 
         msg = f"Session created at {root}/{token}"
-        if pause_between_steps:
+        if mode == "sbs":
             input(f"{msg}. Press enter to continue to upload and validation")
         else:
             print(msg)
 
-        print(f"Uploading file...")
+        print("Uploading file...")
         file_resp = await session.post(
             root + "/" + token + "/file", data={filename: update_file}
         )
@@ -108,29 +113,29 @@ async def do_update(
             except json.JSONDecodeError:
                 message = body
             else:
-                message = f'{json_resp["error"]}: {json_resp["message"]}'
+                message = f"{json_resp['error']}: {json_resp['message']}"
             print(f"Error uploading file: {message}")
             sys.exit(-1)
 
         status = await file_resp.json()
         while status["stage"] == "validating":
-            sys.stdout.write(f'{status["message"]}: {status["progress"] * 100:.0f}%\r')
+            sys.stdout.write(f"{status['message']}: {status['progress'] * 100:.0f}%\r")
             status = await poll_status(session, token, root)
         print(msg)
         if status["stage"] == "error":
-            print(f'Error validating: {status["error"]}: {status["message"]}')
+            print(f"Error validating: {status['error']}: {status['message']}")
             sys.exit(-1)
 
         while status["stage"] == "writing":
-            sys.stdout.write(f'{status["message"]}: {status["progress"] * 100:.0f}%\r')
+            sys.stdout.write(f"{status['message']}: {status['progress'] * 100:.0f}%\r")
             status = await poll_status(session, token, root)
 
         if status["stage"] == "error":
-            print(f'Error writing: {status["error"]}: {status["message"]}')
+            print(f"Error writing: {status['error']}: {status['message']}")
             sys.exit(-1)
 
         msg = "File written and validated"
-        if pause_between_steps:
+        if mode == "sbs":
             input(f"{msg}. Press enter to continue to commit")
         else:
             print(msg)
@@ -139,11 +144,11 @@ async def do_update(
             print("Committing update...")
             resp = await session.post(root + "/" + token + "/commit")
             if resp.status != 200:
-                print(f'Error committing: {status["error"]}: ' f'{status["message"]}')
+                print(f"Error committing: {status['error']}: {status['message']}")
                 sys.exit(-1)
 
         msg = "Update committed"
-        if pause_between_steps:
+        if mode == "sbs":
             input(f"{msg}. Press enter to continue to restart")
         else:
             print(msg)
@@ -154,8 +159,7 @@ async def do_update(
             try:
                 body = await resp.json()
                 print(
-                    f"Error restarting: {resp.status}: "
-                    f'{body["error"]: body["message"]}'
+                    f'Error restarting: {resp.status}: {body["error"]: body["message"]}'
                 )
             except (
                 json.JSONDecodeError,
@@ -169,7 +173,7 @@ async def do_update(
         print("Done!")
 
 
-def assure_host(host_arg):
+def assure_host(host_arg: str) -> str:
     if not host_arg.startswith("http"):
         host_arg = "http://" + host_arg
     if not host_arg.endswith(":31950"):
@@ -177,7 +181,7 @@ def assure_host(host_arg):
     return host_arg
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="update OE systems")
     parser.add_argument(
         "update",
@@ -228,11 +232,18 @@ def main():
     if args.username is not None and password is None:
         password = getpass.getpass(f"Password for {args.username}: ")
 
+    def _mode_from_args(auto: bool, sbs: bool) -> Literal["auto", "sbs", "normal"]:
+        if auto:
+            return "auto"
+        if sbs:
+            return "sbs"
+        return "normal"
+
     asyncio.get_event_loop().run_until_complete(
         do_update(
             args.update,
             assure_host(args.host),
-            pause_between_steps=args.step_by_step,
+            mode=_mode_from_args(args.auto, args.step_by_step),
             username=args.username,
             password=password,
         )

--- a/update-server/otupdate/common/cli.py
+++ b/update-server/otupdate/common/cli.py
@@ -47,9 +47,6 @@ def build_root_parser() -> argparse.ArgumentParser:
         f"to {config.PATH_ENVIRONMENT_VARIABLE} env var and "
         f"then default path {config.DEFAULT_PATH}",
     )
-    # auth-server can be reached over either a Unix domain socket or TCP, but not
-    # both, so these mirror the mutually exclusive options that other servers take
-    # as settings.
     auth_server_location = parser.add_mutually_exclusive_group()
     auth_server_location.add_argument(
         "--auth-server-uds",
@@ -67,5 +64,23 @@ def build_root_parser() -> argparse.ArgumentParser:
         default=None,
         help="The base URL (e.g. http://localhost:1234) where auth-server is"
         " listening. Mutually exclusive with --auth-server-uds.",
+    )
+    audit_server_location = parser.add_mutually_exclusive_group()
+    audit_server_location.add_argument(
+        "--audit-server-uds",
+        dest="audit_server_uds",
+        type=str,
+        default=None,
+        help="The path to the Unix domain socket where audit-server is listening."
+        " Mutually exclusive with --audit-server-url."
+        " If neither is given, this robot's default socket path is used.",
+    )
+    audit_server_location.add_argument(
+        "--audit-server-url",
+        dest="audit_server_url",
+        type=str,
+        default=None,
+        help="The base URL (e.g. http://localhost:1234) where audit-server is"
+        " listening. Mutually exclusive with --audit-server-uds.",
     )
     return parser

--- a/update-server/otupdate/common/control.py
+++ b/update-server/otupdate/common/control.py
@@ -14,7 +14,22 @@ import fastapi
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from server_utils.auth.resource_server.fastapi import require_scopes
+from server_utils.audit.audit_server import (
+    Client as AuditClient,
+)
+from server_utils.audit.audit_server import (
+    SubmitAuditLogMessageData,
+)
+from server_utils.audit.fastapi import (
+    get_audit_client,
+    skip_audit_logger,
+)
+from server_utils.auth.resource_server.fastapi import (
+    RequireAuthenticationResult,
+    require_authentication,
+    require_scopes,
+)
+from server_utils.auth.resource_server.types import AuthenticatedResult
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.app_state import (
     AppState,
@@ -92,21 +107,62 @@ def no_actions_set_error() -> APIError:
 @router.post(
     "/server/restart",
     summary="Restart the robot.",
-    dependencies=[fastapi.Depends(require_scopes(Scope.RESTART_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.RESTART_WRITE)),
+        fastapi.Depends(skip_audit_logger),
+    ],
 )
 async def restart(
     actions: Annotated[
         Optional[UpdateActionsInterface], fastapi.Depends(get_update_actions)
     ],
     restart_lock: Annotated[asyncio.Lock, fastapi.Depends(get_restart_lock)],
+    authentication: Annotated[
+        RequireAuthenticationResult, fastapi.Depends(require_authentication)
+    ],
+    audit_client: Annotated[AuditClient, fastapi.Depends(get_audit_client)],
 ) -> ControlMessageResponse:
     """Restart the robot.
 
     Blocks while the restart lock is held.
     """
     if not actions:
+        await audit_client.submit_log_message(
+            SubmitAuditLogMessageData(
+                action="restart robot failed",
+                accountName=(
+                    authentication.username
+                    if isinstance(authentication, AuthenticatedResult)
+                    else "unknown"
+                ),
+                legalName=(
+                    authentication.fullname
+                    if isinstance(authentication, AuthenticatedResult)
+                    else "unknown"
+                ),
+                message="Rebooting machine failed because no actions are set (server error)",
+                reason=None,
+            )
+        )
         raise no_actions_set_error()
 
+    await audit_client.submit_log_message(
+        SubmitAuditLogMessageData(
+            action="restart robot",
+            accountName=(
+                authentication.username
+                if isinstance(authentication, AuthenticatedResult)
+                else "unknown"
+            ),
+            legalName=(
+                authentication.fullname
+                if isinstance(authentication, AuthenticatedResult)
+                else "unknown"
+            ),
+            message="Rebooting machine",
+            reason=None,
+        )
+    )
     async with restart_lock:
         asyncio.get_event_loop().call_later(1, actions.restart)
     return ControlMessageResponse(message="Restarting in 1s")
@@ -115,21 +171,62 @@ async def restart(
 @router.post(
     "/server/shutdown",
     summary="Shut down the robot.",
-    dependencies=[fastapi.Depends(require_scopes(Scope.SHUTDOWN_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.SHUTDOWN_WRITE)),
+        fastapi.Depends(skip_audit_logger),
+    ],
 )
 async def shutdown(
     actions: Annotated[
         Optional[UpdateActionsInterface], fastapi.Depends(get_update_actions)
     ],
     shutdown_lock: Annotated[asyncio.Lock, fastapi.Depends(get_shutdown_lock)],
+    authentication: Annotated[
+        RequireAuthenticationResult, fastapi.Depends(require_authentication)
+    ],
+    audit_client: Annotated[AuditClient, fastapi.Depends(get_audit_client)],
 ) -> ControlMessageResponse:
     """Shut down the robot.
 
     Blocks while the shutdown lock is held.
     """
     if not actions:
+        await audit_client.submit_log_message(
+            SubmitAuditLogMessageData(
+                action="shutdown failed",
+                accountName=(
+                    authentication.username
+                    if isinstance(authentication, AuthenticatedResult)
+                    else "unknown"
+                ),
+                legalName=(
+                    authentication.fullname
+                    if isinstance(authentication, AuthenticatedResult)
+                    else "unknown"
+                ),
+                message="Rebooting machine failed because no actions are set (server error)",
+                reason=None,
+            )
+        )
         raise no_actions_set_error()
 
+    await audit_client.submit_log_message(
+        SubmitAuditLogMessageData(
+            action="shutdown robot",
+            accountName=(
+                authentication.username
+                if isinstance(authentication, AuthenticatedResult)
+                else "unknown"
+            ),
+            legalName=(
+                authentication.fullname
+                if isinstance(authentication, AuthenticatedResult)
+                else "unknown"
+            ),
+            message="Shutting down robot",
+            reason=None,
+        )
+    )
     async with shutdown_lock:
         asyncio.get_event_loop().call_later(1, actions.shutdown)
     return ControlMessageResponse(message="Shutting down in 1s")

--- a/update-server/otupdate/common/name_management/__init__.py
+++ b/update-server/otupdate/common/name_management/__init__.py
@@ -49,6 +49,7 @@ from typing import Annotated
 import fastapi
 from pydantic import BaseModel
 
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
@@ -76,7 +77,10 @@ def _bad_request(message: str) -> APIError:
 @router.post(
     "/server/name",
     summary="Set the robot's name.",
-    dependencies=[fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.ROBOT_SETTINGS_WRITE)),
+        fastapi.Depends(get_audit_logger("change robot name")),
+    ],
 )
 async def set_name_endpoint(
     request: fastapi.Request,

--- a/update-server/otupdate/common/ssh_key_management.py
+++ b/update-server/otupdate/common/ssh_key_management.py
@@ -13,6 +13,7 @@ from typing import IO, Any, Generator, List, Tuple
 import fastapi
 from pydantic import BaseModel
 
+from server_utils.audit.fastapi import get_audit_logger
 from server_utils.auth.resource_server.fastapi import require_scopes
 from server_utils.auth.scopes import Scope
 
@@ -173,6 +174,7 @@ async def list_keys() -> ListKeysResponse:
     dependencies=[
         fastapi.Depends(require_scopes(Scope.SSH_KEYS_WRITE)),
         fastapi.Depends(require_linklocal),
+        fastapi.Depends(get_audit_logger("add ssh key")),
     ],
 )
 async def add(request: fastapi.Request) -> AddKeyResponse:
@@ -226,6 +228,7 @@ async def add(request: fastapi.Request) -> AddKeyResponse:
     dependencies=[
         fastapi.Depends(require_scopes(Scope.SSH_KEYS_WRITE)),
         fastapi.Depends(require_linklocal),
+        fastapi.Depends(get_audit_logger("remove ssh public keys")),
     ],
 )
 async def clear() -> ModifyKeysResponse:
@@ -251,6 +254,7 @@ async def clear() -> ModifyKeysResponse:
     dependencies=[
         fastapi.Depends(require_scopes(Scope.SSH_KEYS_WRITE)),
         fastapi.Depends(require_linklocal),
+        fastapi.Depends(get_audit_logger("remove one ssh public key")),
     ],
 )
 async def remove(key_md5: str) -> ModifyKeysResponse:
@@ -284,7 +288,10 @@ async def remove(key_md5: str) -> ModifyKeysResponse:
     "/server/ssh_keys/from_local",
     status_code=201,
     summary="Authorize public keys found on attached storage.",
-    dependencies=[fastapi.Depends(require_scopes(Scope.SSH_KEYS_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.SSH_KEYS_WRITE)),
+        fastapi.Depends(get_audit_logger("load ssh key from usb")),
+    ],
 )
 async def add_from_local() -> AddLocalKeysResponse:
     """Add a public keys from usb device to the authorized_keys file.

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -15,7 +15,19 @@ from typing import Annotated, Optional, Self
 import fastapi
 from fastapi.responses import JSONResponse
 
-from server_utils.auth.resource_server.fastapi import require_scopes
+from server_utils.audit.audit_server import (
+    Client as AuditClient,
+)
+from server_utils.audit.audit_server import (
+    SubmitAuditLogMessageData,
+)
+from server_utils.audit.fastapi import get_audit_client, get_audit_logger
+from server_utils.auth.resource_server.fastapi import (
+    RequireAuthenticationResult,
+    require_authentication,
+    require_scopes,
+)
+from server_utils.auth.resource_server.types import AuthenticatedResult
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.app_state import AppState, get_app_state
 
@@ -26,6 +38,8 @@ from .session import Stages, UpdateSession, get_current_session, set_current_ses
 from otupdate.openembedded.update_actions import UPDATE_PKG_OE
 
 VALID_UPDATE_PKG = UPDATE_PKG_OE
+_UPDATE_SERVER_SYSTEM_NAME = "system"
+_UPDATE_SERVER_SYSTEM_FULLNAME = "authentication subsystem"
 
 LOG = logging.getLogger(__name__)
 
@@ -61,7 +75,10 @@ def require_session(
     "/server/update/begin",
     status_code=201,
     summary="Create an update session.",
-    dependencies=[fastapi.Depends(require_scopes(Scope.UPDATES_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.UPDATES_WRITE)),
+        fastapi.Depends(get_audit_logger("start update session")),
+    ],
 )
 async def begin(
     request: fastapi.Request,
@@ -145,7 +162,10 @@ async def status(
     "/server/update/{session}/file",
     status_code=201,
     summary="Upload a system update file.",
-    dependencies=[fastapi.Depends(require_scopes(Scope.UPDATES_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.UPDATES_WRITE)),
+        fastapi.Depends(get_audit_logger("upload update file")),
+    ],
 )
 async def file_upload(
     request: fastapi.Request,
@@ -156,6 +176,10 @@ async def file_upload(
         fastapi.Depends(update_actions.get_update_actions),
     ],
     restart_lock: Annotated[asyncio.Lock, fastapi.Depends(get_restart_lock)],
+    authentication: Annotated[
+        RequireAuthenticationResult, fastapi.Depends(require_authentication)
+    ],
+    audit_client: Annotated[AuditClient, fastapi.Depends(get_audit_client)],
 ) -> JSONResponse:
     """Serves /update/:session/file
 
@@ -198,6 +222,8 @@ async def file_upload(
         os.path.join(session.download_path, found_names[-1]),
         actions,
         restart_lock,
+        audit_client,
+        authentication,
     )
 
     return JSONResponse(status_code=201, content=dict(session.state))
@@ -206,7 +232,10 @@ async def file_upload(
 @router.post(
     "/server/update/{session}/commit",
     summary="Commit a validated update.",
-    dependencies=[fastapi.Depends(require_scopes(Scope.UPDATES_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.UPDATES_WRITE)),
+        fastapi.Depends(get_audit_logger("commit update")),
+    ],
 )
 async def commit(
     session: Annotated[UpdateSession, fastapi.Depends(require_session)],
@@ -242,7 +271,10 @@ async def commit(
 @router.post(
     "/server/update/cancel",
     summary="Cancel the active update session.",
-    dependencies=[fastapi.Depends(require_scopes(Scope.UPDATES_WRITE))],
+    dependencies=[
+        fastapi.Depends(require_scopes(Scope.UPDATES_WRITE)),
+        fastapi.Depends(get_audit_logger("cancel update")),
+    ],
 )
 async def cancel(
     app_state: Annotated[AppState, fastapi.Depends(get_app_state)],
@@ -304,6 +336,8 @@ def _begin_validate_and_write(
     downloaded_update_path: str,
     actions: update_actions.UpdateActionsInterface,
     restart_lock: asyncio.Lock,
+    audit_client: AuditClient,
+    authentication: RequireAuthenticationResult,
 ) -> None:
     """Start validating and writing the file in the background.
 
@@ -335,6 +369,19 @@ def _begin_validate_and_write(
             restart_lock,
             actions,
             session,
+        )
+        if isinstance(authentication, AuthenticatedResult):
+            auth_string = f", update started by user={authentication.username} name={authentication.fullname}"
+        else:
+            auth_string = ""
+        await audit_client.submit_log_message(
+            SubmitAuditLogMessageData(
+                action="autocommit update",
+                accountName=_UPDATE_SERVER_SYSTEM_NAME,
+                legalName=_UPDATE_SERVER_SYSTEM_FULLNAME,
+                message="Committing update file and rebooting" + auth_string,
+                reason=None,
+            )
         )
         actions.restart()
 

--- a/update-server/otupdate/openembedded/__init__.py
+++ b/update-server/otupdate/openembedded/__init__.py
@@ -8,6 +8,8 @@ from fastapi.openapi.docs import get_redoc_html
 from fastapi.responses import HTMLResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
+from server_utils.audit.audit_server import Client as AuditClient
+from server_utils.audit.fastapi import audit_logger_middleware, install_audit_client
 from server_utils.auth.resource_server.authentication_checker import (
     AuthenticationChecker,
 )
@@ -68,6 +70,7 @@ class LogErrorMiddleware:
 async def get_app(
     name_synchronizer: name_management.NameSynchronizer,
     authentication_checker: AuthenticationChecker,
+    audit_client: AuditClient,
     system_version_file: Optional[str] = None,
     config_file_override: Optional[str] = None,
     name_override: Optional[str] = None,
@@ -97,6 +100,7 @@ async def get_app(
     app.add_middleware(LogErrorMiddleware)
     app.exception_handler(APIError)(handle_api_error)
     app.exception_handler(AuthorizationError)(handle_authorization_error)
+    app.middleware("http")(audit_logger_middleware)
 
     config.install_config(app.state, config_obj)
     control.install_control(
@@ -109,6 +113,7 @@ async def get_app(
     )
     name_management.install_name_synchronizer(name_synchronizer, app.state)
     install_authentication_checker(app.state, authentication_checker)
+    install_audit_client(app.state, audit_client)
 
     app.include_router(control.router)
     app.include_router(update.router)

--- a/update-server/otupdate/openembedded/__main__.py
+++ b/update-server/otupdate/openembedded/__main__.py
@@ -5,6 +5,9 @@ Entrypoint for the openembedded update server
 import asyncio
 import logging
 
+from server_utils.audit.fastapi import (
+    build_audit_client,
+)
 from server_utils.auth.resource_server.fastapi import (
     build_authentication_checker,
 )
@@ -16,6 +19,10 @@ from otupdate.common.run_application import run_and_notify_up
 # The Unix domain socket where opentrons-auth-server is configured to listen,
 # on this type of robot. Used unless the command line overrides it.
 _DEFAULT_AUTH_SERVER_UDS = "/run/opentrons-auth-server.sock"
+
+# The Unix domain socket where opentrons-audit-server is configured to listen,
+# on this type of robot. Used unless the command line overrides it.
+_DEFAULT_AUDIT_SERVER_UDS = "/run/opentrons-audit-server.sock"
 
 LOG = logging.getLogger(__name__)
 
@@ -31,6 +38,11 @@ async def main() -> None:
     if auth_server_uds is None and auth_server_url is None:
         auth_server_uds = _DEFAULT_AUTH_SERVER_UDS
 
+    audit_server_uds = args.audit_server_uds
+    audit_server_url = args.audit_server_url
+    if audit_server_uds is None and audit_server_url is None:
+        audit_server_uds = _DEFAULT_AUDIT_SERVER_UDS
+
     # Because this involves restarting Avahi, this must happen early,
     # before the NameSynchronizer starts up and connects to Avahi.
     LOG.info("Setting static hostname")
@@ -45,6 +57,9 @@ async def main() -> None:
         name_management.NameSynchronizer.start(
             constants.MODEL_OT3
         ) as name_synchronizer,
+        build_audit_client(
+            audit_server_uds=audit_server_uds, audit_server_url=audit_server_url
+        ) as audit_client,
     ):
         LOG.info("Building openembedded update server")
         app = await get_app(
@@ -52,6 +67,7 @@ async def main() -> None:
             authentication_checker=authentication_checker,
             system_version_file=args.version_file,
             config_file_override=args.config_file,
+            audit_client=audit_client,
         )
 
         LOG.info(

--- a/update-server/otupdate/openembedded/__main__.py
+++ b/update-server/otupdate/openembedded/__main__.py
@@ -4,6 +4,9 @@ Entrypoint for the openembedded update server
 
 import asyncio
 import logging
+import sys
+import traceback
+from logging.config import dictConfig
 
 from server_utils.audit.fastapi import (
     build_audit_client,
@@ -11,9 +14,10 @@ from server_utils.audit.fastapi import (
 from server_utils.auth.resource_server.fastapi import (
     build_authentication_checker,
 )
+from server_utils.logging_utils import get_dict_config
 
 from . import get_app
-from otupdate.common import cli, constants, name_management, systemd
+from otupdate.common import cli, constants, name_management
 from otupdate.common.run_application import run_and_notify_up
 
 # The Unix domain socket where opentrons-auth-server is configured to listen,
@@ -31,7 +35,13 @@ async def main() -> None:
     parser = cli.build_root_parser()
     args = parser.parse_args()
 
-    systemd.configure_logging(getattr(logging, args.log_level.upper()))
+    try:
+        log_config = get_dict_config(args.log_level.upper(), "opentrons-update")
+        dictConfig(log_config)
+    except Exception as e:
+        # needs to be a print because logging doesn't work yet!
+        print("Error: Couldn't configure logging!", file=sys.stderr)  # noqa: T201
+        traceback.print_exception(e, file=sys.stderr)
 
     auth_server_uds = args.auth_server_uds
     auth_server_url = args.auth_server_url

--- a/update-server/tests/common/conftest.py
+++ b/update-server/tests/common/conftest.py
@@ -8,7 +8,9 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+from decoy import Decoy
 
+from server_utils.audit.audit_server import Client as AuditClient
 from server_utils.auth.resource_server.authentication_checker import (
     AlwaysAllowedAuthenticationChecker,
 )
@@ -23,9 +25,18 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 one_up = os.path.abspath(os.path.join(__file__, "../../"))
 
 
+@pytest.fixture
+def mock_audit_logger(decoy: Decoy) -> AuditClient:
+    return decoy.mock(cls=AuditClient)
+
+
 @pytest.fixture(params=[openembedded])
 async def test_cli(
-    otupdate_config, request, version_file_path, mock_name_synchronizer
+    otupdate_config,
+    request,
+    version_file_path,
+    mock_name_synchronizer,
+    mock_audit_logger: AuditClient,
 ) -> AsyncGenerator[Tuple[UpdateServerClient, str], None]:
     """
     Build an app using dummy versions, then build a test client and return it
@@ -37,6 +48,7 @@ async def test_cli(
         config_file_override=otupdate_config,
         boot_id_override="dummy-boot-id-abc123",
         authentication_checker=AlwaysAllowedAuthenticationChecker(),
+        audit_client=mock_audit_logger,
     )
     async with UpdateServerClient(app) as client:
         yield client, cli_client_pkg.__name__

--- a/update-server/tests/openembedded/conftest.py
+++ b/update-server/tests/openembedded/conftest.py
@@ -5,7 +5,9 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+from decoy import Decoy
 
+from server_utils.audit.audit_server import Client as AuditClient
 from server_utils.auth.resource_server.authentication_checker import (
     AlwaysAllowedAuthenticationChecker,
 )
@@ -23,6 +25,11 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 
 @pytest.fixture
+def mock_audit_logger(decoy: Decoy) -> AuditClient:
+    return decoy.mock(cls=AuditClient)
+
+
+@pytest.fixture
 def mock_update_actions_interface(
     mock_root_fs_interface: MagicMock, mock_partition_manager_invalid_switch: MagicMock
 ) -> MagicMock:
@@ -37,7 +44,10 @@ def mock_update_actions_interface(
 
 @pytest.fixture
 async def test_cli(
-    otupdate_config, version_file_path, mock_name_synchronizer
+    otupdate_config,
+    version_file_path,
+    mock_name_synchronizer,
+    mock_audit_logger: AuditClient,
 ) -> AsyncGenerator[UpdateServerClient, None]:
     """
     Build an app using dummy versions, then build a test client and return it
@@ -48,6 +58,7 @@ async def test_cli(
         config_file_override=otupdate_config,
         boot_id_override="dummy-boot-id-abc123",
         authentication_checker=AlwaysAllowedAuthenticationChecker(),
+        audit_client=mock_audit_logger,
     )
     async with UpdateServerClient(app) as client:
         yield client


### PR DESCRIPTION
# Overview

Once the update server is a fastapi application, it's really easy to integrate audit logging! The only weird bit is that we need to log the automatically-occuring commit and restart when you run an update with the autorun flag, and we need to log inline in the response function for restart and shutdown since, you know, we might not have time afterward.

## Test Plan and Hands on Testing

- [ ] run on a flex and look at your logs

## Changelog

- adds audit log to update server

## Review requests

- Does the autocommit thing seem reasonable?

## Risk assessment

- medium; shouldn't affect behavior, but also is in the update server
