### PR TITLE
test(api): Expanded unit test coverage of data type serialization

### DIFF
--- a/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/serpent_type_registry.py
@@ -26,6 +26,7 @@ import opentrons.hardware_control.nozzle_manager
 import opentrons.hardware_control.peripherals.types
 import opentrons.hardware_control.protocols.types
 import opentrons.hardware_control.types
+import opentrons.hardware_control.util
 import opentrons.types
 from opentrons.util.pyro.pyro_serialization import (
     OpentronsPyroSerializer,
@@ -56,6 +57,8 @@ HARDWARE_ENUM_PACKAGES = [
     opentrons.drivers.types,
     opentrons.hardware_control.modules.types,
     opentrons.drivers.vacuum_module.types,
+    opentrons.drivers.flex_stacker.types,
+    opentrons.hardware_control.util,
 ]
 
 HARDWARE_PYDANTIC_PACKAGES = [

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -6,6 +6,7 @@ import socket
 import threading
 from dataclasses import is_dataclass
 from datetime import datetime
+from enum import StrEnum
 from pathlib import Path
 from typing import Any, Dict, get_args, get_type_hints
 
@@ -16,6 +17,7 @@ from Pyro5 import nameserver
 
 import opentrons_shared_data.pipette.types as pipette_types
 from opentrons_shared_data.errors import ErrorCodes
+from opentrons_shared_data.errors.categories import ErrorCategories
 from opentrons_shared_data.errors.exceptions import CommunicationError
 from opentrons_shared_data.gripper import GripperModel
 from opentrons_shared_data.pipette import (
@@ -67,13 +69,17 @@ from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.poller import Poller
 from opentrons.hardware_control.pyro_utils.serpent_type_registry import (
     HARDWARE_CLASS_PACKAGES,
+    HARDWARE_ENUM_PACKAGES,
     register_hardware_types,
 )
 from opentrons.hardware_control.robot_calibration import DeckCalibration
 from opentrons.hardware_control.types import DoorState
 from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
 from opentrons.util.pyro.pyro_daemon_utility import create_pyro_daemon
-from opentrons.util.pyro.pyro_serialization import find_opentrons_classes_in_packages
+from opentrons.util.pyro.pyro_serialization import (
+    find_enums_in_packages,
+    find_opentrons_classes_in_packages,
+)
 
 TEST_PYRO_TIMEOUT = 5
 
@@ -701,10 +707,83 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
     hw_types.HardwareFeatureFlags: hw_types.HardwareFeatureFlags(
         False, True, True, True
     ),
+    stacker_types.LEDPattern: stacker_types.LEDPattern.PULSE,
+    vac_types.LEDPattern: vac_types.LEDPattern.STATIC,
+    module_types.AbsorbanceReaderModel: module_types.AbsorbanceReaderModel.ABSORBANCE_READER_V1,
+    hw_types.GripperJawState: hw_types.GripperJawState.UNHOMED,
+    stacker_types.StackerAxis: stacker_types.StackerAxis.X,
+    module_types.ModuleType: module_types.ModuleType.THERMOCYCLER,
+    module_types.HeaterShakerModuleModel: module_types.HeaterShakerModuleModel.HEATER_SHAKER_V1,
+    vac_types.VentState: vac_types.VentState.CLOSED,
+    module_types.LidStatus: module_types.LidStatus.ON,
+    hw_types.HardwareEventType: hw_types.HardwareEventType.DOOR_SWITCH_CHANGE,
+    calibration_types.SourceType: calibration_types.SourceType.default,
+    module_types.StackerAxisState: module_types.StackerAxisState.UNKNOWN,
+    ot_types.PipetteMountType: ot_types.PipetteMountType.LEFT,
+    hw_types.UpdateState: hw_types.UpdateState.queued,
+    ot_types.TransferTipPolicy: ot_types.TransferTipPolicy.ONCE,
+    module_types.VacuumModuleStatus: module_types.VacuumModuleStatus.IDLE,
+    driver_types.AbsorbanceReaderDeviceState: driver_types.AbsorbanceReaderDeviceState.OK,
+    pipette_types.Quirks: pipette_types.Quirks.pickupTipShake,
+    GripperModel: GripperModel.v1,
+    vac_types.HardwareRevision: vac_types.HardwareRevision.NFF,
+    config_types.OT3AxisKind: config_types.OT3AxisKind.X,
+    ot_types.DeckSlotName: ot_types.DeckSlotName.SLOT_1,
+    pipette_types.PipetteChannelType: pipette_types.PipetteChannelType.SINGLE_CHANNEL,
+    hw_types.ExecutionState: hw_types.ExecutionState.RUNNING,
+    hw_types.EstopAttachLocation: hw_types.EstopAttachLocation.LEFT,
+    ot_types.OT3MountType: ot_types.OT3MountType.LEFT,
+    driver_types.HeaterShakerLabwareLatchStatus: driver_types.HeaterShakerLabwareLatchStatus.IDLE_CLOSED,
+    module_types.SpeedStatus: module_types.SpeedStatus.IDLE,
+    module_types.VacuumModuleModel: module_types.VacuumModuleModel.VACUUM_MODULE_V1,
+    module_types.LatchState: module_types.LatchState.CLOSED,
+    pipette_types.LiquidClasses: pipette_types.LiquidClasses.default,
+    module_types.MagneticBlockModel: module_types.MagneticBlockModel.MAGNETIC_BLOCK_V1,
+    module_types.FlexStackerStatus: module_types.FlexStackerStatus.IDLE,
+    driver_types.AbsorbanceReaderLidStatus: driver_types.AbsorbanceReaderLidStatus.ON,
+    module_types.VacuumOperationMode: module_types.VacuumOperationMode.POWER,
+    ot_types.NozzleConfigurationType: ot_types.NozzleConfigurationType.FULL,
+    driver_types.ABSMeasurementMode: driver_types.ABSMeasurementMode.SINGLE,
+    module_types.TemperatureModuleModel: module_types.TemperatureModuleModel.TEMPERATURE_V1,
+    module_types.MagneticStatus: module_types.MagneticStatus.DISENGAGED,
+    pipette_types.PipetteOEMType: pipette_types.PipetteOEMType.OT,
+    peripheral_types.PeripheralType: peripheral_types.PeripheralType.BARCODE_SCANNER,
+    pipette_types.PipetteModelType: pipette_types.PipetteModelType.p1000,
+    hw_types.HardwareAction: hw_types.HardwareAction.ASPIRATE,
+    hw_types.BoardRevision: hw_types.BoardRevision.UNKNOWN,
+    module_types.VentStatus: module_types.VentStatus.CLOSED,
+    module_types.HeaterShakerStatus: module_types.HeaterShakerStatus.IDLE,
+    hw_types.EstopPhysicalStatus: hw_types.EstopPhysicalStatus.ENGAGED,
+    vac_types.LEDColor: vac_types.LEDColor.RED,
+    DoorState: DoorState.CLOSED,
+    module_types.HopperDoorState: module_types.HopperDoorState.CLOSED,
+    hw_types.PipetteSensorType: hw_types.PipetteSensorType.capacitive,
+    ot_types.StagingSlotName: ot_types.StagingSlotName.SLOT_A4,
+    module_types.PlatformState: module_types.PlatformState.RETRACTED,
+    ot_types.MeniscusTrackingTarget: ot_types.MeniscusTrackingTarget.START,
+    module_types.ThermocyclerModuleModel: module_types.ThermocyclerModuleModel.THERMOCYCLER_V2,
+    module_types.TemperatureStatus: module_types.TemperatureStatus.IDLE,
+    pipette_types.AvailableUnits: pipette_types.AvailableUnits.mm,
+    module_types.AbsorbanceReaderStatus: module_types.AbsorbanceReaderStatus.IDLE,
+    ot_types.AxisType: ot_types.AxisType.X,
+    ot_types.MountType: ot_types.MountType.LEFT,
+    hw_types.PipetteSubType: hw_types.PipetteSubType.pipette_single,
+    driver_types.AbsorbanceReaderPlatePresence: driver_types.AbsorbanceReaderPlatePresence.PRESENT,
+    pipette_types.PipetteGenerationType: pipette_types.PipetteGenerationType.GEN2,
+    module_types.MagneticModuleModel: module_types.MagneticModuleModel.MAGNETIC_V2,
+    pipette_types.PipetteNameType: pipette_types.PipetteNameType.P1000_SINGLE,
+    vac_types.GCODE: vac_types.GCODE.GET_DEVICE_INFO,
+    pipette_types.PipetteTipType: pipette_types.PipetteTipType.t1000,
+    driver_types.ThermocyclerLidStatus: driver_types.ThermocyclerLidStatus.CLOSED,
+    hw_types.EstopState: hw_types.EstopState.DISENGAGED,
+    module_types.FlexStackerModuleModel: module_types.FlexStackerModuleModel.FLEX_STACKER_V1,
 }
 
+# This list should only include types that are either builtins that we work around or error related content thats delt with via pickle
+TYPES_TO_SKIP = [ErrorCodes, ErrorCategories, StrEnum]
 
-async def test_serialization_validation() -> None:
+
+async def test_serialization_validation_with_mock_data() -> None:  # noqa: C901
     """Test to check if types registered in the hardware class package properly serialize and deserialize."""
 
     class DataTester:
@@ -768,16 +847,21 @@ async def test_serialization_validation() -> None:
         HARDWARE_CLASS_PACKAGES
     )
     hardware_registry_class_list = list(set(hardware_registry_class_list))
+    enum_registry_class_list = find_enums_in_packages(HARDWARE_ENUM_PACKAGES)
+    enum_registry_class_list = list(set(enum_registry_class_list))
+    # todo(chb, 7-30-26): Expand this test to test the pydantic serialization as well - will require new mocks
+    # pydantic_registry_class_list = find_pydantic_classes_in_packages(HARDWARE_PYDANTIC_PACKAGES)
+    # pydantic_registry_class_list = list(set(pydantic_registry_class_list))
+
+    exposed_class_list = hardware_registry_class_list + enum_registry_class_list
 
     # Validate each class can be sent over pyro and come back deserialized in the expected format
-    for clazz in hardware_registry_class_list:
-        try:
-            mock_data = CLASS_TYPE_MOCK_TABLE[clazz]
-        except KeyError as e:
-            raise KeyError(f"{e} - Mock data missing for type {clazz}")
+    for clazz in exposed_class_list:
+        if clazz not in TYPES_TO_SKIP:
+            try:
+                mock_data = CLASS_TYPE_MOCK_TABLE[clazz]
+            except KeyError as e:
+                raise KeyError(f"{e} - Mock data missing for type {clazz}")
 
-        deserialized_output = tester_proxy.data_in_data_out(mock_data)
-        assert deserialized_output == mock_data
-
-
-# todo(chb, 7-30-26): Expand this test to test the enum serialization and the pydantic serialization as well
+            deserialized_output = tester_proxy.data_in_data_out(mock_data)
+            assert deserialized_output == mock_data

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -827,7 +827,7 @@ async def test_serialization_validation_with_mock_data() -> None:  # noqa: C901
 
     ns = pyro.locate_ns()
     retries_counter = 0
-    while ns.count() < 1:
+    while ns.count() < 2:
         # Wait and try again, the resource isnt registered yet
         await asyncio.sleep(0.01)
         retries_counter += 1

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -493,6 +493,7 @@ async def test_module_registration_coverage(
     assert set(class_cover_list) == set(hardware_registry_class_list)
 
 
+# Mock out of a bunch of the data types that we know leave this layer to be tested elsewhere
 CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
     hw_types.Axis: hw_types.Axis.X,
     hw_types.OT3Mount: hw_types.OT3Mount.LEFT,
@@ -699,9 +700,6 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
     hw_types.HardwareFeatureFlags: hw_types.HardwareFeatureFlags(False, True, True, True)
 }
 
-# ERROR COLLECTION LISTS
-
-
 async def test_serialization_validation() -> None:
     """Test to check if types registered in the hardware class package properly serialize and deserialize."""
 
@@ -777,3 +775,5 @@ async def test_serialization_validation() -> None:
 
         deserialized_output = tester_proxy.data_in_data_out(mock_data)
         assert deserialized_output == mock_data
+
+#todo(chb, 7-30-26): Expand this test to test the enum serialization and the pydantic serialization as well

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -5,7 +5,28 @@ import inspect
 import socket
 import threading
 from dataclasses import is_dataclass
-from typing import Any, get_args, get_type_hints
+from typing import Any, get_args, get_type_hints, Union, Dict
+from pathlib import Path
+
+from datetime import datetime
+
+import opentrons.hardware_control.types as hw_types
+import opentrons.hardware_control.dev_types as dev_types
+import opentrons.hardware_control.modules.mod_abc as mod_abc
+import opentrons.hardware_control.modules.types as module_types
+import opentrons.hardware_control.peripherals.types as peripheral_types
+import opentrons_shared_data.pipette.types as pipette_types
+import opentrons.types as ot_types
+import opentrons.config.types as config_types
+from opentrons_shared_data.pipette import (
+    load_data as load_pipette_data,
+)
+from opentrons.hardware_control.ot3_calibration import OT3Transforms
+from opentrons.hardware_control.robot_calibration import DeckCalibration
+import opentrons.calibration_storage.types as calibration_types
+from opentrons.config import gripper_config as gc
+import opentrons.drivers.types as driver_types
+import opentrons.drivers.vacuum_module.types as vac_types
 
 import pytest
 from decoy import Decoy
@@ -48,6 +69,7 @@ from opentrons.hardware_control.types import DoorState
 from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
 from opentrons.util.pyro.pyro_daemon_utility import create_pyro_daemon
 from opentrons.util.pyro.pyro_serialization import find_opentrons_classes_in_packages
+from opentrons_shared_data.gripper import GripperModel
 
 TEST_PYRO_TIMEOUT = 5
 
@@ -466,3 +488,106 @@ async def test_module_registration_coverage(
         mod_counter += 1
 
     assert set(class_cover_list) == set(hardware_registry_class_list)
+
+CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
+    hw_types.Axis: hw_types.Axis.X,
+    hw_types.OT3Mount: hw_types.OT3Mount.LEFT,
+    ot_types.Mount: ot_types.Mount.LEFT,
+    hw_types.CriticalPoint: hw_types.CriticalPoint.MOUNT,
+    ot_types.Point: ot_types.Point(1, 2, 3),
+    hw_types.InstrumentProbeType: hw_types.InstrumentProbeType.PRIMARY,
+    dev_types.AttachedGripper: dev_types.AttachedGripper(config=gc.load(GripperModel.v1), id="test"),
+    dev_types.AttachedPipette: dev_types.AttachedPipette(
+        config=load_pipette_data.load_definition(
+            pipette_types.PipetteModelType("p1000"),
+            pipette_types.PipetteChannelType(1),
+            pipette_types.PipetteVersionType(major=3, minor=3),
+            pipette_types.PipetteOEMType(pipette_types.PipetteOEMType.OT),
+        ),
+        id="fakepip",
+    ),
+    hw_types.SubSystem: hw_types.SubSystem.gantry_x,
+    hw_types.StatusBarState: hw_types.StatusBarState.IDLE,
+    hw_types.TipScrapeType: hw_types.TipScrapeType.LEFT_ONE_COL,
+    hw_types.TipStateType: hw_types.TipStateType.ABSENT,
+    Union[
+            module_types.MagneticModuleModel,
+            module_types.TemperatureModuleModel,
+            module_types.ThermocyclerModuleModel,
+            module_types.HeaterShakerModuleModel,
+            module_types.MagneticBlockModel,
+            module_types.AbsorbanceReaderModel,
+            module_types.FlexStackerModuleModel,
+            module_types.VacuumModuleModel,
+        ]: module_types.ThermocyclerModuleModel.THERMOCYCLER_V2,
+    peripheral_types.BarcodeScannerModel: peripheral_types.BarcodeScannerModel.BARCODE_SCANNER_V1,
+    hw_types.GripperProbe: hw_types.GripperProbe.FRONT,
+    hw_types.InstrumentProbeType: None,
+    hw_types.PauseType: hw_types.PauseType.PAUSE,
+    config_types.GantryLoad: config_types.GantryLoad.HIGH_THROUGHPUT_1000,
+    config_types.CapacitivePassSettings: config_types.CapacitivePassSettings(
+        prep_distance_mm=1.0,
+        max_overrun_distance_mm=2.0,
+        speed_mm_per_s=3.0,
+        sensor_threshold_pf=5.0
+    ),
+    hw_types.CriticalPoint: hw_types.CriticalPoint.MOUNT,
+    OT3Transforms: OT3Transforms(
+        deck_calibration=DeckCalibration(
+            attitude= [[0.0, 1.0]],
+            source= calibration_types.SourceType.default,
+            status= calibration_types.CalibrationStatus(
+                markedBad=False,
+                source=calibration_types.SourceType.default,
+                markedAt=datetime.now(),
+            ),
+            belt_attitude = None,
+            last_modified = datetime.now(),
+            pipette_calibrated_with = None,
+            tiprack = None,
+        ),
+        carriage_offset=ot_types.Point(1,1,1),
+        left_mount_offset=ot_types.Point(1,1,1),
+        right_mount_offset=ot_types.Point(1,1,1),
+        gripper_mount_offset=ot_types.Point(1,1,1),
+    ),
+    config_types.LiquidProbeSettings: config_types.LiquidProbeSettings(
+        mount_speed=1.0,
+        plunger_speed=2.0,
+        plunger_impulse_time=3.0,
+        sensor_threshold_pascals=4.0,
+        aspirate_while_sensing=False,
+        z_overlap_between_passes_mm=5.0,
+        plunger_reset_offset=6.0,
+        samples_for_baselining=1,
+        sample_time_sec=7.0,
+    ),
+    hw_types.PipetteSensorId: hw_types.PipetteSensorId.S1,
+    hw_types.PipetteSensorData: hw_types.PipetteSensorData(sensor_type=hw_types.PipetteSensorType.capacitive, _as_int=0x01, _as_float=0x01),
+    hw_types.MotionChecks: hw_types.MotionChecks.HIGH,
+    driver_types.ABSMeasurementConfig: driver_types.ABSMeasurementConfig(measure_mode=driver_types.ABSMeasurementMode.SINGLE, sample_wavelengths=[100, 200], reference_wavelength=100),
+    module_types.BundledFirmware: module_types.BundledFirmware(version="v1", path=Path("coolpath")),
+    vac_types.PumpState: vac_types.PumpState(target_rpm=0.1, current_rpm=0.2, target_pwm=1.5, current_pwm=2.5, pump_running=False, manual_control=True),
+    hw_types.ModuleConnectedNotification: hw_types.ModuleConnectedNotification(module_serial="123", name="coolmod", port="456", event=hw_types.HardwareEventType.MODULE_CONNECTED)
+}
+
+ # ERROR COLLECTION LISTS
+
+
+
+def test_serialization_validation() -> None:
+    """Test to check if types registered in the hardware class package properly serialize and deserialize."""
+
+    hardware_registry_class_list = find_opentrons_classes_in_packages(
+            HARDWARE_CLASS_PACKAGES
+        )
+    hardware_registry_class_list = list(set(hardware_registry_class_list))
+
+    for clazz in hardware_registry_class_list:
+        try:
+            serializable_dict = clazz.to_pyro_dict(CLASS_TYPE_MOCK_TABLE[clazz])
+        except KeyError as e:
+            raise KeyError(f"{e} - Mock data missing for type {clazz}")
+
+        deserialized_output = clazz.from_pyro_dict("dummy_classname", serializable_dict)
+        assert deserialized_output == CLASS_TYPE_MOCK_TABLE[clazz]

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -768,7 +768,14 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
             code=ErrorCodes.COMMUNICATION_ERROR,
             message="BIG_ERRORS",
             detail={"apple": "pie", "cheese": "cake"},
-            wrapping=None,  # CASEY TODO
+            wrapping=[
+                CommunicationError(
+                    code=ErrorCodes.COMMUNICATION_ERROR,
+                    message="BIG_ERRORS_INNER",
+                    detail={"apple_inner": "pie_inner", "cheese_inner": "cake_inner"},
+                    wrapping=None,
+                ),
+            ],
         ),
         module_serial="1234ABC",
         module_model=module_types.VacuumModuleModel.VACUUM_MODULE_V1,

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -5,37 +5,39 @@ import inspect
 import socket
 import threading
 from dataclasses import is_dataclass
-from typing import Any, get_args, get_type_hints, Union, Dict
-from pathlib import Path
-
 from datetime import datetime
-
-import opentrons.hardware_control.types as hw_types
-import opentrons.hardware_control.dev_types as dev_types
-import opentrons.hardware_control.modules.mod_abc as mod_abc
-import opentrons.hardware_control.modules.types as module_types
-import opentrons.hardware_control.peripherals.types as peripheral_types
-import opentrons_shared_data.pipette.types as pipette_types
-import opentrons.types as ot_types
-import opentrons.config.types as config_types
-from opentrons_shared_data.pipette import (
-    load_data as load_pipette_data,
-)
-from opentrons.hardware_control.ot3_calibration import OT3Transforms
-from opentrons.hardware_control.robot_calibration import DeckCalibration
-import opentrons.calibration_storage.types as calibration_types
-from opentrons.config import gripper_config as gc
-import opentrons.drivers.types as driver_types
-import opentrons.drivers.vacuum_module.types as vac_types
+from pathlib import Path
+from typing import Any, Dict, Union, get_args, get_type_hints
 
 import pytest
 from decoy import Decoy
 from Pyro5 import api as pyro
 from Pyro5 import nameserver
 
+import opentrons_shared_data.pipette.types as pipette_types
+from opentrons_shared_data.errors.exceptions import VacuumModuleWasteFullError
+from opentrons_shared_data.gripper import GripperModel
+from opentrons_shared_data.pipette import (
+    load_data as load_pipette_data,
+)
 from opentrons_shared_data.robot.types import RobotTypeEnum
 
+import opentrons.calibration_storage.types as calibration_types
+import opentrons.config.types as config_types
+import opentrons.drivers.flex_stacker.types as stacker_types
+import opentrons.drivers.rpi_drivers.types as rpi_types
+import opentrons.drivers.types as driver_types
+import opentrons.drivers.vacuum_module.types as vac_types
+import opentrons.hardware_control.dev_types as dev_types
+import opentrons.hardware_control.instruments.ot3.instrument_calibration as instr_calibration_types
+import opentrons.hardware_control.modules.mod_abc as mod_abc
+import opentrons.hardware_control.modules.module_calibration as mod_cal
+import opentrons.hardware_control.modules.types as module_types
+import opentrons.hardware_control.peripherals.types as peripheral_types
+import opentrons.hardware_control.types as hw_types
+import opentrons.types as ot_types
 from opentrons.config import feature_flags
+from opentrons.config import gripper_config as gc
 from opentrons.config.types import RobotConfig
 from opentrons.drivers.heater_shaker.simulator import SimulatingDriver
 from opentrons.drivers.thermocycler.simulator import (
@@ -59,17 +61,18 @@ from opentrons.hardware_control.modules.types import (
     MagneticBlockModel,
     SimulatingModule,
 )
+from opentrons.hardware_control.ot3_calibration import OT3Transforms
 from opentrons.hardware_control.ot3api import OT3API
 from opentrons.hardware_control.poller import Poller
 from opentrons.hardware_control.pyro_utils.serpent_type_registry import (
     HARDWARE_CLASS_PACKAGES,
     register_hardware_types,
 )
+from opentrons.hardware_control.robot_calibration import DeckCalibration
 from opentrons.hardware_control.types import DoorState
 from opentrons.util.pyro.pyro_client_async_adapter import AsyncClientPyroObject
 from opentrons.util.pyro.pyro_daemon_utility import create_pyro_daemon
 from opentrons.util.pyro.pyro_serialization import find_opentrons_classes_in_packages
-from opentrons_shared_data.gripper import GripperModel
 
 TEST_PYRO_TIMEOUT = 5
 
@@ -489,6 +492,7 @@ async def test_module_registration_coverage(
 
     assert set(class_cover_list) == set(hardware_registry_class_list)
 
+
 CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
     hw_types.Axis: hw_types.Axis.X,
     hw_types.OT3Mount: hw_types.OT3Mount.LEFT,
@@ -496,7 +500,9 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
     hw_types.CriticalPoint: hw_types.CriticalPoint.MOUNT,
     ot_types.Point: ot_types.Point(1, 2, 3),
     hw_types.InstrumentProbeType: hw_types.InstrumentProbeType.PRIMARY,
-    dev_types.AttachedGripper: dev_types.AttachedGripper(config=gc.load(GripperModel.v1), id="test"),
+    dev_types.AttachedGripper: dev_types.AttachedGripper(
+        config=gc.load(GripperModel.v1), id="test"
+    ),
     dev_types.AttachedPipette: dev_types.AttachedPipette(
         config=load_pipette_data.load_definition(
             pipette_types.PipetteModelType("p1000"),
@@ -511,15 +517,15 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
     hw_types.TipScrapeType: hw_types.TipScrapeType.LEFT_ONE_COL,
     hw_types.TipStateType: hw_types.TipStateType.ABSENT,
     Union[
-            module_types.MagneticModuleModel,
-            module_types.TemperatureModuleModel,
-            module_types.ThermocyclerModuleModel,
-            module_types.HeaterShakerModuleModel,
-            module_types.MagneticBlockModel,
-            module_types.AbsorbanceReaderModel,
-            module_types.FlexStackerModuleModel,
-            module_types.VacuumModuleModel,
-        ]: module_types.ThermocyclerModuleModel.THERMOCYCLER_V2,
+        module_types.MagneticModuleModel,
+        module_types.TemperatureModuleModel,
+        module_types.ThermocyclerModuleModel,
+        module_types.HeaterShakerModuleModel,
+        module_types.MagneticBlockModel,
+        module_types.AbsorbanceReaderModel,
+        module_types.FlexStackerModuleModel,
+        module_types.VacuumModuleModel,
+    ]: module_types.ThermocyclerModuleModel.THERMOCYCLER_V2,
     peripheral_types.BarcodeScannerModel: peripheral_types.BarcodeScannerModel.BARCODE_SCANNER_V1,
     hw_types.GripperProbe: hw_types.GripperProbe.FRONT,
     hw_types.InstrumentProbeType: None,
@@ -529,27 +535,27 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
         prep_distance_mm=1.0,
         max_overrun_distance_mm=2.0,
         speed_mm_per_s=3.0,
-        sensor_threshold_pf=5.0
+        sensor_threshold_pf=5.0,
     ),
     hw_types.CriticalPoint: hw_types.CriticalPoint.MOUNT,
     OT3Transforms: OT3Transforms(
         deck_calibration=DeckCalibration(
-            attitude= [[0.0, 1.0]],
-            source= calibration_types.SourceType.default,
-            status= calibration_types.CalibrationStatus(
+            attitude=[[0.0, 1.0]],
+            source=calibration_types.SourceType.default,
+            status=calibration_types.CalibrationStatus(
                 markedBad=False,
                 source=calibration_types.SourceType.default,
                 markedAt=datetime.now(),
             ),
-            belt_attitude = None,
-            last_modified = datetime.now(),
-            pipette_calibrated_with = None,
-            tiprack = None,
+            belt_attitude=None,
+            last_modified=datetime.now(),
+            pipette_calibrated_with=None,
+            tiprack=None,
         ),
-        carriage_offset=ot_types.Point(1,1,1),
-        left_mount_offset=ot_types.Point(1,1,1),
-        right_mount_offset=ot_types.Point(1,1,1),
-        gripper_mount_offset=ot_types.Point(1,1,1),
+        carriage_offset=ot_types.Point(1, 1, 1),
+        left_mount_offset=ot_types.Point(1, 1, 1),
+        right_mount_offset=ot_types.Point(1, 1, 1),
+        gripper_mount_offset=ot_types.Point(1, 1, 1),
     ),
     config_types.LiquidProbeSettings: config_types.LiquidProbeSettings(
         mount_speed=1.0,
@@ -563,31 +569,231 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
         sample_time_sec=7.0,
     ),
     hw_types.PipetteSensorId: hw_types.PipetteSensorId.S1,
-    hw_types.PipetteSensorData: hw_types.PipetteSensorData(sensor_type=hw_types.PipetteSensorType.capacitive, _as_int=0x01, _as_float=0x01),
+    hw_types.PipetteSensorData: hw_types.PipetteSensorData(
+        sensor_type=hw_types.PipetteSensorType.capacitive, _as_int=0x01, _as_float=0x01
+    ),
     hw_types.MotionChecks: hw_types.MotionChecks.HIGH,
-    driver_types.ABSMeasurementConfig: driver_types.ABSMeasurementConfig(measure_mode=driver_types.ABSMeasurementMode.SINGLE, sample_wavelengths=[100, 200], reference_wavelength=100),
-    module_types.BundledFirmware: module_types.BundledFirmware(version="v1", path=Path("coolpath")),
-    vac_types.PumpState: vac_types.PumpState(target_rpm=0.1, current_rpm=0.2, target_pwm=1.5, current_pwm=2.5, pump_running=False, manual_control=True),
-    hw_types.ModuleConnectedNotification: hw_types.ModuleConnectedNotification(module_serial="123", name="coolmod", port="456", event=hw_types.HardwareEventType.MODULE_CONNECTED)
+    driver_types.ABSMeasurementConfig: driver_types.ABSMeasurementConfig(
+        measure_mode=driver_types.ABSMeasurementMode.SINGLE,
+        sample_wavelengths=[100, 200],
+        reference_wavelength=100,
+    ),
+    module_types.BundledFirmware: module_types.BundledFirmware(
+        version="v1", path=Path("coolpath")
+    ),
+    vac_types.PumpState: vac_types.PumpState(
+        target_rpm=0.1,
+        current_rpm=0.2,
+        target_pwm=1.5,
+        current_pwm=2.5,
+        pump_running=False,
+        manual_control=True,
+    ),
+    rpi_types.USBPort: rpi_types.USBPort(
+        name="USB",
+        port_number=10,
+        port_group=rpi_types.PortGroup.MAIN,
+        hub=True,
+        hub_port=11,
+        device_path="cooldevpath",
+    ),
+    hw_types.HepaUVState: hw_types.HepaUVState(
+        light_on=True, uv_duration_s=100, remaining_time_s=60
+    ),
+    hw_types.HepaFanState: hw_types.HepaFanState(fan_on=True, duty_cycle=10),
+    hw_types.EstopStateNotification: hw_types.EstopStateNotification(
+        event=hw_types.HardwareEventType.ESTOP_CHANGE,
+        old_state=hw_types.EstopState.DISENGAGED,
+        new_state=hw_types.EstopState.PHYSICALLY_ENGAGED,
+    ),
+    hw_types.DoorStateNotification: hw_types.DoorStateNotification(
+        event=hw_types.HardwareEventType.DOOR_SWITCH_CHANGE,
+        new_state=DoorState.CLOSED,
+        module_serial=None,
+    ),
+    hw_types.ModuleConnectedNotification: hw_types.ModuleConnectedNotification(
+        module_serial="123",
+        name="coolmod",
+        port="456",
+        event=hw_types.HardwareEventType.MODULE_CONNECTED,
+    ),
+    hw_types.ModuleDisconnectedNotification: hw_types.ModuleDisconnectedNotification(
+        event=hw_types.HardwareEventType.MODULE_DISCONNECTED,
+        module_model=module_types.ThermocyclerModuleModel,
+        port="123",
+        module_serial="ABCDF4",
+    ),
+    hw_types.SubsystemConnectionNotification: hw_types.SubsystemConnectionNotification(
+        event=hw_types.HardwareEventType.SUBSYSTEM_CONNECTION
+    ),
+    hw_types.AsynchronousModuleErrorNotification: hw_types.AsynchronousModuleErrorNotification(
+        exception=VacuumModuleWasteFullError(
+            serial="1234ABC",
+            mode="coolmode",
+            target=10.1,
+            current=11.3,
+            message="coolmsg",
+            detail=None,  # CASEY TODO
+            wrapping=None,  # CASEY TODO
+        ),
+        module_serial="1234ABC",
+        module_model=module_types.VacuumModuleModel,
+        port="1",
+        event=hw_types.HardwareEventType.ASYNCHRONOUS_MODULE_ERROR,
+    ),
+    hw_types.ErrorMessageNotification: hw_types.ErrorMessageNotification(
+        event=hw_types.HardwareEventType.ERROR_MESSAGE, message="AGGA"
+    ),
+    hw_types.StatusBarUpdateEvent: hw_types.StatusBarUpdateEvent(
+        state=hw_types.StatusBarState.SOFTWARE_ERROR, enabled=True
+    ),
+    hw_types.EstopOverallStatus: hw_types.EstopOverallStatus(
+        state=hw_types.EstopState.DISENGAGED,
+        left_physical_state=hw_types.EstopPhysicalStatus.ENGAGED,
+        right_physical_state=hw_types.EstopPhysicalStatus.DISENGAGED,
+    ),
+    instr_calibration_types.GripperCalibrationOffset: instr_calibration_types.GripperCalibrationOffset(
+        status=instr_calibration_types.CalibrationStatus(
+            markedBad=False,
+            source=instr_calibration_types.SourceType.factory,
+            markedAt=datetime.now(),
+        ),
+        offset=ot_types.Point(0.1, 0.2, 0.3),
+        source=instr_calibration_types.SourceType.calibration_check,
+        last_modified=datetime.now(),
+    ),
+    instr_calibration_types.PipetteOffsetSummary: instr_calibration_types.PipetteOffsetSummary(
+        offset=ot_types.Point(0.1, 0.2, 0.3),
+        source=instr_calibration_types.SourceType.calibration_check,
+        status=instr_calibration_types.CalibrationStatus(
+            markedBad=False,
+            source=instr_calibration_types.SourceType.factory,
+            markedAt=datetime.now(),
+        ),
+        last_modified=datetime.now(),
+        reasonability_check_failures=[
+            instr_calibration_types.ReasonabilityCheckFailure(
+                kind="inconsistent-pipette-offset",
+                offsets={ot_types.Mount.RIGHT: ot_types.Point(0.1, 0.2, 0.3)},
+                limit=5.1,
+            )
+        ],
+    ),
+    mod_cal.ModuleCalibrationOffset: mod_cal.ModuleCalibrationOffset(
+        offset=ot_types.Point(0.1, 0.2, 0.3),
+        module_id="id",
+        module=module_types.ThermocyclerModuleModel,
+        source=mod_cal.SourceType.factory,
+        status=mod_cal.CalibrationStatus(
+            markedBad=False,
+            source=mod_cal.SourceType.calibration_check,
+            markedAt=datetime.now(),
+        ),
+        mount=hw_types.OT3Mount.LEFT,
+        instrument_id="123",
+        last_modified=datetime.now(),
+        slot="D1",
+    ),
+    vac_types.VacuumState: vac_types.VacuumState(
+        target_gauge_pressure=1.1,
+        current_gauge_pressure=2.2,
+        pressure_abs_a=3.3,
+        pressure_abs_b=4.4,
+        pressure_atm=5.5,
+        vacuum_enabled=True,
+        vacuum_duration=100,
+        vent_state=vac_types.VentState.OPENED,
+    ),
+    stacker_types.TOFMeasurementResult: stacker_types.TOFMeasurementResult(
+        sensor=stacker_types.TOFSensor.X,
+        kind=stacker_types.MeasurementKind.HISTOGRAM,
+        bins={1: [1.0, 2.1]},
+    ),
+    hw_types.HardwareFeatureFlags: hw_types.HardwareFeatureFlags(False, True, True, True)
 }
 
- # ERROR COLLECTION LISTS
+# ERROR COLLECTION LISTS
 
 
-
-def test_serialization_validation() -> None:
+async def test_serialization_validation() -> None:
     """Test to check if types registered in the hardware class package properly serialize and deserialize."""
 
+    class DataTester:
+        """Class for testing data serializaiton over pyro"""
+
+        @pyro.expose
+        def data_in_data_out(self, value: Any) -> Any:
+            return value
+
+    tester = DataTester()
+
+    name_server_ready = threading.Event()
+    await _setup_namerserver(name_server_ready=name_server_ready)
+
+    def _ot3api_pyro_daemon() -> None:
+        # Wait for the nameserver to be ready so locate_ns can succeed.
+        name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
+        register_hardware_types()
+        with pyro.Daemon() as daemon:  # type: ignore
+            # Create a guaranteed synchronous adapted alias to the resource
+            daemon.register(tester)
+            try:
+                with pyro.locate_ns() as ns:
+                    # Register our objects URI with the system nameserver
+                    try:
+                        ns.register("TEST_PROXY", daemon.uriFor(tester))
+
+                        # Maintain a request loop to handle requests on our resource instance from remote processes
+                        daemon.requestLoop()
+                    finally:
+                        ns.remove(name="TEST_PROXY")
+            except Exception as e:
+                raise ValueError("Test Nameserver not found.")
+            finally:
+                daemon.close()
+
+    ot3api_thread = threading.Thread(target=_ot3api_pyro_daemon, daemon=True)
+    ot3api_thread.start()
+
+    ns = pyro.locate_ns()
+    retries_counter = 0
+    uri = None
+    while retries_counter <= 10:
+        # Wait and try again, the resource isnt registered yet
+        try:
+            uri = ns.lookup("TEST_PROXY")
+            break
+        except Exception:
+            await asyncio.sleep(0.01)
+            retries_counter += 1
+
+    # Stop waiting for the nameserver, will fail on pyro.resolve (something is wrong with nameserver and/or daemon)
+    if uri is None:
+        raise TimeoutError("TEST FAILURE ON PYRO NAMESERVER IN SERIALIZER TEST SETUP.")
+
+    uri = pyro.resolve(uri="PYRONAME:TEST_PROXY")
+    tester_proxy = pyro.Proxy(uri)  # type: ignore
+
+
+    # Get the hardware registry
     hardware_registry_class_list = find_opentrons_classes_in_packages(
-            HARDWARE_CLASS_PACKAGES
-        )
+        HARDWARE_CLASS_PACKAGES
+    )
     hardware_registry_class_list = list(set(hardware_registry_class_list))
 
+    # Validate each class can be sent over pyro and come back deserialized in the expected format
     for clazz in hardware_registry_class_list:
         try:
-            serializable_dict = clazz.to_pyro_dict(CLASS_TYPE_MOCK_TABLE[clazz])
+            mock_data = CLASS_TYPE_MOCK_TABLE[clazz]
         except KeyError as e:
             raise KeyError(f"{e} - Mock data missing for type {clazz}")
 
-        deserialized_output = clazz.from_pyro_dict("dummy_classname", serializable_dict)
-        assert deserialized_output == CLASS_TYPE_MOCK_TABLE[clazz]
+        try:
+            deserialized_output = tester_proxy.data_in_data_out(mock_data)
+        except Exception as e:
+            print(f"Failed serialization on: {mock_data} - {e}")
+        try:
+            assert deserialized_output == mock_data
+        except:
+            print("failed assert")
+    raise ValueError("done")

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -264,6 +264,64 @@ async def _setup_OT3API_pyro_resource(
     return ot3_async  # type: ignore
 
 
+async def _setup_and_validate_modules_on_OT3API_and_nameserver(
+    decoy: Decoy,
+    ot3_hardware: ThreadManager[OT3API],
+    mock_driver: SimulatingDriver,
+    tc_reader_mocked_driver: modules.thermocycler.ThermocyclerReader,
+    hs_reader_mocked_driver: modules.heater_shaker.HeaterShakerReader,
+    td_reader_mocked_driver: modules.tempdeck.TempDeckReader,
+    vm_reader_mocked_driver: modules.vacuum_module.VacuumModuleReader,
+    ar_reader_mocked_driver: modules.absorbance_reader.AbsorbanceReaderReader,
+    st_reader_mocked_driver: modules.flex_stacker.FlexStackerReader,
+    mock_feature_flags: None,
+) -> OT3API:
+    """This sets up a nameserver, an OT3API and modules for testing suites to crawl over."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(True)
+
+    wrapped_api = ot3_hardware.wrapped()
+    wrapped_api._backend.module_controls = decoy.mock(cls=AttachedModulesControl)
+    tc = decoy.mock(cls=Thermocycler)
+    hs = decoy.mock(cls=HeaterShaker)
+    td = decoy.mock(cls=TempDeck)
+    td_2 = decoy.mock(cls=TempDeck)
+    vm = decoy.mock(cls=VacuumModule)
+    st = decoy.mock(cls=FlexStacker)
+    ar = decoy.mock(cls=AbsorbanceReader)
+    decoy.when(wrapped_api._backend.module_controls.available_modules).then_return(
+        [tc, hs, td, td_2, vm, st, ar]
+    )
+    for mod in wrapped_api._backend.module_controls.available_modules:
+        decoy.when(mod._driver).then_return(mock_driver)  # type: ignore
+
+    # Mock out the pollers for these modules that will be stopped
+    decoy.when(tc._poller).then_return(Poller(tc_reader_mocked_driver, interval=0.01))
+    decoy.when(hs._poller).then_return(Poller(hs_reader_mocked_driver, interval=0.01))
+    decoy.when(td._poller).then_return(Poller(td_reader_mocked_driver, interval=0.01))
+    decoy.when(td_2._poller).then_return(Poller(td_reader_mocked_driver, interval=0.01))
+    decoy.when(vm._poller).then_return(Poller(vm_reader_mocked_driver, interval=0.01))
+    decoy.when(st._poller).then_return(Poller(st_reader_mocked_driver, interval=0.01))
+    decoy.when(ar._poller).then_return(Poller(ar_reader_mocked_driver, interval=0.01))
+
+    name_server_ready = threading.Event()
+
+    await _setup_namerserver(name_server_ready=name_server_ready)
+    ot3api_async_instance = await _setup_OT3API_pyro_resource(
+        ot3_hardware,
+        name_server_ready,
+    )
+
+    # Assert that there are as many testable proxy modules as there are actual modules for integration coverage
+    # DEVELOPER NOTE: if this part is failing, you need to add a missing module to the module mocks above.
+    modules_list_NO_MAG_BLOCK = tuple(
+        arg for arg in get_args(ModuleModel) if arg != MagneticBlockModel
+    )
+    assert len(ot3api_async_instance.attached_modules) == len(modules_list_NO_MAG_BLOCK)
+
+    return ot3api_async_instance
+
+
 def _is_namedtuple_instance(cls: Any) -> bool:
     try:
         return issubclass(cls, tuple) and hasattr(cls, "_fields")
@@ -358,47 +416,19 @@ async def test_serialization_coverage(
     mock_feature_flags: None,
 ) -> None:
     """Test will check for serialization coverage of dataclasses and named tuples exposed by the OT3API and subsequent Module APIs."""
-    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
-    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(True)
-
     wrapped_api = ot3_hardware.wrapped()
-    wrapped_api._backend.module_controls = decoy.mock(cls=AttachedModulesControl)
-    tc = decoy.mock(cls=Thermocycler)
-    hs = decoy.mock(cls=HeaterShaker)
-    td = decoy.mock(cls=TempDeck)
-    td_2 = decoy.mock(cls=TempDeck)
-    vm = decoy.mock(cls=VacuumModule)
-    st = decoy.mock(cls=FlexStacker)
-    ar = decoy.mock(cls=AbsorbanceReader)
-    decoy.when(wrapped_api._backend.module_controls.available_modules).then_return(
-        [tc, hs, td, td_2, vm, st, ar]
-    )
-    for mod in wrapped_api._backend.module_controls.available_modules:
-        decoy.when(mod._driver).then_return(mock_driver)  # type: ignore
-
-    # Mock out the pollers for these modules that will be stopped
-    decoy.when(tc._poller).then_return(Poller(tc_reader_mocked_driver, interval=0.01))
-    decoy.when(hs._poller).then_return(Poller(hs_reader_mocked_driver, interval=0.01))
-    decoy.when(td._poller).then_return(Poller(td_reader_mocked_driver, interval=0.01))
-    decoy.when(td_2._poller).then_return(Poller(td_reader_mocked_driver, interval=0.01))
-    decoy.when(vm._poller).then_return(Poller(vm_reader_mocked_driver, interval=0.01))
-    decoy.when(st._poller).then_return(Poller(st_reader_mocked_driver, interval=0.01))
-    decoy.when(ar._poller).then_return(Poller(ar_reader_mocked_driver, interval=0.01))
-
-    name_server_ready = threading.Event()
-
-    await _setup_namerserver(name_server_ready=name_server_ready)
-    ot3api_async_instance = await _setup_OT3API_pyro_resource(
+    ot3api_async_instance = await _setup_and_validate_modules_on_OT3API_and_nameserver(
+        decoy,
         ot3_hardware,
-        name_server_ready,
+        mock_driver,
+        tc_reader_mocked_driver,
+        hs_reader_mocked_driver,
+        td_reader_mocked_driver,
+        vm_reader_mocked_driver,
+        ar_reader_mocked_driver,
+        st_reader_mocked_driver,
+        mock_feature_flags,
     )
-
-    # Assert that there are as many testable proxy modules as there are actual modules for integration coverage
-    # DEVELOPER NOTE: if this part is failing, you need to add a missing module to the module mocks above.
-    modules_list_NO_MAG_BLOCK = tuple(
-        arg for arg in get_args(ModuleModel) if arg != MagneticBlockModel
-    )
-    assert len(ot3api_async_instance.attached_modules) == len(modules_list_NO_MAG_BLOCK)
 
     # Collect classes from the OT3API
     class_cover_list = _collect_exposed_types(
@@ -449,47 +479,19 @@ async def test_module_registration_coverage(
     mock_feature_flags: None,
 ) -> None:
     """Test will check for to see if the hardware class package used in registration covers exposed dataclasses and namedtuples."""
-    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
-    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(True)
-
     wrapped_api = ot3_hardware.wrapped()
-    wrapped_api._backend.module_controls = decoy.mock(cls=AttachedModulesControl)
-    tc = decoy.mock(cls=Thermocycler)
-    hs = decoy.mock(cls=HeaterShaker)
-    td = decoy.mock(cls=TempDeck)
-    td_2 = decoy.mock(cls=TempDeck)
-    vm = decoy.mock(cls=VacuumModule)
-    st = decoy.mock(cls=FlexStacker)
-    ar = decoy.mock(cls=AbsorbanceReader)
-    decoy.when(wrapped_api._backend.module_controls.available_modules).then_return(
-        [tc, hs, td, td_2, vm, st, ar]
-    )
-    for mod in wrapped_api._backend.module_controls.available_modules:
-        decoy.when(mod._driver).then_return(mock_driver)  # type: ignore
-
-    # Mock out the pollers for these modules that will be stopped
-    decoy.when(tc._poller).then_return(Poller(tc_reader_mocked_driver, interval=0.01))
-    decoy.when(hs._poller).then_return(Poller(hs_reader_mocked_driver, interval=0.01))
-    decoy.when(td._poller).then_return(Poller(td_reader_mocked_driver, interval=0.01))
-    decoy.when(td_2._poller).then_return(Poller(td_reader_mocked_driver, interval=0.01))
-    decoy.when(vm._poller).then_return(Poller(vm_reader_mocked_driver, interval=0.01))
-    decoy.when(st._poller).then_return(Poller(st_reader_mocked_driver, interval=0.01))
-    decoy.when(ar._poller).then_return(Poller(ar_reader_mocked_driver, interval=0.01))
-
-    name_server_ready = threading.Event()
-
-    await _setup_namerserver(name_server_ready=name_server_ready)
-    ot3api_async_instance = await _setup_OT3API_pyro_resource(
+    ot3api_async_instance = await _setup_and_validate_modules_on_OT3API_and_nameserver(
+        decoy,
         ot3_hardware,
-        name_server_ready,
+        mock_driver,
+        tc_reader_mocked_driver,
+        hs_reader_mocked_driver,
+        td_reader_mocked_driver,
+        vm_reader_mocked_driver,
+        ar_reader_mocked_driver,
+        st_reader_mocked_driver,
+        mock_feature_flags,
     )
-
-    # Assert that there are as many testable proxy modules as there are actual modules for integration coverage
-    # DEVELOPER NOTE: if this part is failing, you need to add a missing module to the module mocks above.
-    modules_list_NO_MAG_BLOCK = tuple(
-        arg for arg in get_args(ModuleModel) if arg != MagneticBlockModel
-    )
-    assert len(ot3api_async_instance.attached_modules) == len(modules_list_NO_MAG_BLOCK)
 
     # Collect classes from the OT3API
     class_cover_list = _collect_exposed_types(
@@ -532,47 +534,19 @@ async def test_enum_registration_coverage(
     mock_feature_flags: None,
 ) -> None:
     """Test will check for to see if the hardware class package used in registration covers all exposed enums."""
-    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
-    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(True)
-
     wrapped_api = ot3_hardware.wrapped()
-    wrapped_api._backend.module_controls = decoy.mock(cls=AttachedModulesControl)
-    tc = decoy.mock(cls=Thermocycler)
-    hs = decoy.mock(cls=HeaterShaker)
-    td = decoy.mock(cls=TempDeck)
-    td_2 = decoy.mock(cls=TempDeck)
-    vm = decoy.mock(cls=VacuumModule)
-    st = decoy.mock(cls=FlexStacker)
-    ar = decoy.mock(cls=AbsorbanceReader)
-    decoy.when(wrapped_api._backend.module_controls.available_modules).then_return(
-        [tc, hs, td, td_2, vm, st, ar]
-    )
-    for mod in wrapped_api._backend.module_controls.available_modules:
-        decoy.when(mod._driver).then_return(mock_driver)  # type: ignore
-
-    # Mock out the pollers for these modules that will be stopped
-    decoy.when(tc._poller).then_return(Poller(tc_reader_mocked_driver, interval=0.01))
-    decoy.when(hs._poller).then_return(Poller(hs_reader_mocked_driver, interval=0.01))
-    decoy.when(td._poller).then_return(Poller(td_reader_mocked_driver, interval=0.01))
-    decoy.when(td_2._poller).then_return(Poller(td_reader_mocked_driver, interval=0.01))
-    decoy.when(vm._poller).then_return(Poller(vm_reader_mocked_driver, interval=0.01))
-    decoy.when(st._poller).then_return(Poller(st_reader_mocked_driver, interval=0.01))
-    decoy.when(ar._poller).then_return(Poller(ar_reader_mocked_driver, interval=0.01))
-
-    name_server_ready = threading.Event()
-
-    await _setup_namerserver(name_server_ready=name_server_ready)
-    ot3api_async_instance = await _setup_OT3API_pyro_resource(
+    ot3api_async_instance = await _setup_and_validate_modules_on_OT3API_and_nameserver(
+        decoy,
         ot3_hardware,
-        name_server_ready,
+        mock_driver,
+        tc_reader_mocked_driver,
+        hs_reader_mocked_driver,
+        td_reader_mocked_driver,
+        vm_reader_mocked_driver,
+        ar_reader_mocked_driver,
+        st_reader_mocked_driver,
+        mock_feature_flags,
     )
-
-    # Assert that there are as many testable proxy modules as there are actual modules for integration coverage
-    # DEVELOPER NOTE: if this part is failing, you need to add a missing module to the module mocks above.
-    modules_list_NO_MAG_BLOCK = tuple(
-        arg for arg in get_args(ModuleModel) if arg != MagneticBlockModel
-    )
-    assert len(ot3api_async_instance.attached_modules) == len(modules_list_NO_MAG_BLOCK)
 
     # Collect classes from the OT3API
     class_cover_list = _collect_exposed_types(

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -514,6 +514,8 @@ async def test_module_registration_coverage(
         class_cover_list = list(set(class_cover_list))
         mod_counter += 1
 
+    # Because dataclasses/named tuples use bespoke `to_pyro_dict` and `from_pyro_dict` serialization
+    # the types exposed by the Pyro interface should always be the same as the types registered.
     assert set(class_cover_list) == set(hardware_registry_class_list)
 
 
@@ -593,6 +595,8 @@ async def test_enum_registration_coverage(
         class_cover_list = list(set(class_cover_list))
         mod_counter += 1
 
+    # This test uses <= because the `find_enums_in_packages` crawler is actually finding more enums than there are
+    # exposed via the Pyro interface. We just want to make sure all the exposed ones are in that registry.
     assert set(class_cover_list) <= set(hardware_registry_class_list)
 
 

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, get_args, get_type_hints
 
 import pytest
 from decoy import Decoy
+from pydantic import BaseModel
 from Pyro5 import api as pyro
 from Pyro5 import nameserver
 
@@ -72,6 +73,7 @@ from opentrons.hardware_control.poller import Poller
 from opentrons.hardware_control.pyro_utils.serpent_type_registry import (
     HARDWARE_CLASS_PACKAGES,
     HARDWARE_ENUM_PACKAGES,
+    HARDWARE_PYDANTIC_PACKAGES,
     register_hardware_types,
 )
 from opentrons.hardware_control.robot_calibration import DeckCalibration
@@ -81,6 +83,7 @@ from opentrons.util.pyro.pyro_daemon_utility import create_pyro_daemon
 from opentrons.util.pyro.pyro_serialization import (
     find_enums_in_packages,
     find_opentrons_classes_in_packages,
+    find_pydantic_classes_in_packages,
 )
 
 TEST_PYRO_TIMEOUT = 5
@@ -329,7 +332,7 @@ def _is_namedtuple_instance(cls: Any) -> bool:
         return False
 
 
-def _collect_serializable_types(
+def _collect_serializable_types(  # noqa: C901
     hint: Any, collected: list[type], seen: set[int], type_qualifier: str
 ) -> None:
     if id(hint) in seen:
@@ -353,6 +356,13 @@ def _collect_serializable_types(
         except TypeError:
             # wrapped arguments can be capture on recursive checks
             pass
+    elif type_qualifier == "pydantic":
+        if (
+            issubclass(hint, BaseModel)
+            and hint is not BaseModel
+            and hint not in _TYPES_TO_SKIP
+        ):
+            collected.append(hint)
     else:
         raise ValueError(f"Invalid type qualifier for test: {type_qualifier}")
     for arg in get_args(hint):
@@ -571,6 +581,61 @@ async def test_enum_registration_coverage(
 
     # This test uses <= because the `find_enums_in_packages` crawler is actually finding more enums than there are
     # exposed via the Pyro interface. We just want to make sure all the exposed ones are in that registry.
+    assert set(class_cover_list) <= set(hardware_registry_class_list)
+
+
+async def test_pydantic_registration_coverage(
+    decoy: Decoy,
+    ot3_hardware: ThreadManager[OT3API],
+    mock_driver: SimulatingDriver,
+    tc_reader_mocked_driver: modules.thermocycler.ThermocyclerReader,
+    hs_reader_mocked_driver: modules.heater_shaker.HeaterShakerReader,
+    td_reader_mocked_driver: modules.tempdeck.TempDeckReader,
+    vm_reader_mocked_driver: modules.vacuum_module.VacuumModuleReader,
+    ar_reader_mocked_driver: modules.absorbance_reader.AbsorbanceReaderReader,
+    st_reader_mocked_driver: modules.flex_stacker.FlexStackerReader,
+    mock_feature_flags: None,
+) -> None:
+    """Test will check for to see if the hardware class package used in registration covers all exposed pydantic models."""
+    wrapped_api = ot3_hardware.wrapped()
+    ot3api_async_instance = await _setup_and_validate_modules_on_OT3API_and_nameserver(
+        decoy,
+        ot3_hardware,
+        mock_driver,
+        tc_reader_mocked_driver,
+        hs_reader_mocked_driver,
+        td_reader_mocked_driver,
+        vm_reader_mocked_driver,
+        ar_reader_mocked_driver,
+        st_reader_mocked_driver,
+        mock_feature_flags,
+    )
+
+    # Collect classes from the OT3API
+    class_cover_list = _collect_exposed_types(
+        original_class=OT3API,
+        acpo_instance=ot3api_async_instance,
+        type_qualifier="pydantic",
+    )
+
+    hardware_registry_class_list = find_pydantic_classes_in_packages(
+        HARDWARE_PYDANTIC_PACKAGES
+    )
+    hardware_registry_class_list = list(set(hardware_registry_class_list))
+
+    # Collect classes from the Module APIs
+    mod_counter = 0
+    for module in wrapped_api.attached_modules:
+        class_cover_list = class_cover_list + _collect_exposed_types(
+            original_class=module.__class__,
+            acpo_instance=ot3api_async_instance.attached_modules[mod_counter],
+            type_qualifier="pydantic",
+        )
+        class_cover_list = list(set(class_cover_list))
+        mod_counter += 1
+
+    # This test uses <= because the `find_pydantic_classes_in_packages` crawler is actually finding more pydantic models than
+    # there are exposed via the Pyro interface. We just want to make sure all the exposed ones are in that registry.
     assert set(class_cover_list) <= set(hardware_registry_class_list)
 
 

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -795,70 +795,43 @@ async def test_serialization_validation_with_mock_data() -> None:  # noqa: C901
 
     tester = DataTester()
 
-    name_server_ready = threading.Event()
-    await _setup_namerserver(name_server_ready=name_server_ready)
-
-    def _data_tester_pyro_daemon() -> None:
-        # Wait for the nameserver to be ready so locate_ns can succeed.
-        name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
+    with pyro.Daemon() as daemon:  # type: ignore
+        # Create a pyro daemon hosting the resource
         register_hardware_types()
-        with pyro.Daemon() as daemon:  # type: ignore
-            # Create a guaranteed synchronous adapted alias to the resource
-            daemon.register(tester)
-            try:
-                with pyro.locate_ns() as ns:
-                    # Register our objects URI with the system nameserver
-                    try:
-                        ns.register("TEST_PROXY", daemon.uriFor(tester))
+        daemon.register(tester)
 
-                        # Maintain a request loop to handle requests on our resource instance from remote processes
-                        daemon.requestLoop()
-                    finally:
-                        ns.remove(name="TEST_PROXY")
-            except Exception as e:
-                raise ValueError(f"Test Nameserver not found - {e}")
+        def _tester_request_daemon_request_loop() -> None:
+            try:
+                # Maintain a request loop to handle requests on our resource instance from "remote" portion of the test
+                daemon.requestLoop()
             finally:
                 daemon.close()
 
-    tester_resource_thread = threading.Thread(
-        target=_data_tester_pyro_daemon, daemon=True
-    )
-    tester_resource_thread.start()
+        tester_request_loop = threading.Thread(
+            target=_tester_request_daemon_request_loop, daemon=True
+        )
+        tester_request_loop.start()
 
-    ns = pyro.locate_ns()
-    retries_counter = 0
-    while ns.count() < 2:
-        # Wait and try again, the resource isnt registered yet
-        await asyncio.sleep(0.01)
-        retries_counter += 1
-        if retries_counter > 10:
-            # Stop waiting for the nameserver, will fail on pyro.resolve (something is wrong with nameserver and/or daemon)
-            raise TimeoutError("TEST FAILURE ON PYRO NAMESERVER.")
+        tester_proxy = pyro.Proxy(daemon.uriFor(tester))  # type: ignore
 
-    tester_proxy = pyro.Proxy(pyro.resolve(uri="PYRONAME:TEST_PROXY"))  # type: ignore
+        # Get the hardware registry
+        hardware_registry_class_list = find_opentrons_classes_in_packages(
+            HARDWARE_CLASS_PACKAGES
+        )
+        hardware_registry_class_list = list(set(hardware_registry_class_list))
+        enum_registry_class_list = find_enums_in_packages(HARDWARE_ENUM_PACKAGES)
+        enum_registry_class_list = list(set(enum_registry_class_list))
+        exposed_class_list = hardware_registry_class_list + enum_registry_class_list
 
-    # Get the hardware registry
-    hardware_registry_class_list = find_opentrons_classes_in_packages(
-        HARDWARE_CLASS_PACKAGES
-    )
-    hardware_registry_class_list = list(set(hardware_registry_class_list))
-    enum_registry_class_list = find_enums_in_packages(HARDWARE_ENUM_PACKAGES)
-    enum_registry_class_list = list(set(enum_registry_class_list))
-    # todo(chb, 7-30-26): Expand this test to test the pydantic serialization as well - will require new mocks
-    # pydantic_registry_class_list = find_pydantic_classes_in_packages(HARDWARE_PYDANTIC_PACKAGES)
-    # pydantic_registry_class_list = list(set(pydantic_registry_class_list))
+        # Validate each class can be sent over pyro and come back deserialized in the expected format
+        for clazz in exposed_class_list:
+            if clazz not in TYPES_TO_SKIP:
+                try:
+                    mock_data = CLASS_TYPE_MOCK_TABLE[clazz]
+                except KeyError as e:
+                    raise KeyError(f"{e} - Mock data missing for type {clazz}")
 
-    exposed_class_list = (
-        hardware_registry_class_list + enum_registry_class_list
-    )  # + pydantic_registry_class_list
+                deserialized_output = tester_proxy.data_in_data_out(mock_data)
+                assert deserialized_output == mock_data
 
-    # Validate each class can be sent over pyro and come back deserialized in the expected format
-    for clazz in exposed_class_list:
-        if clazz not in TYPES_TO_SKIP:
-            try:
-                mock_data = CLASS_TYPE_MOCK_TABLE[clazz]
-            except KeyError as e:
-                raise KeyError(f"{e} - Mock data missing for type {clazz}")
-
-            deserialized_output = tester_proxy.data_in_data_out(mock_data)
-            assert deserialized_output == mock_data
+        daemon.close()

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -15,7 +15,7 @@ from Pyro5 import api as pyro
 from Pyro5 import nameserver
 
 import opentrons_shared_data.pipette.types as pipette_types
-from opentrons_shared_data.errors.exceptions import VacuumModuleWasteFullError
+from opentrons_shared_data.errors.exceptions import CommunicationError, ErrorCodes
 from opentrons_shared_data.gripper import GripperModel
 from opentrons_shared_data.pipette import (
     load_data as load_pipette_data,
@@ -516,16 +516,6 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
     hw_types.StatusBarState: hw_types.StatusBarState.IDLE,
     hw_types.TipScrapeType: hw_types.TipScrapeType.LEFT_ONE_COL,
     hw_types.TipStateType: hw_types.TipStateType.ABSENT,
-    Union[
-        module_types.MagneticModuleModel,
-        module_types.TemperatureModuleModel,
-        module_types.ThermocyclerModuleModel,
-        module_types.HeaterShakerModuleModel,
-        module_types.MagneticBlockModel,
-        module_types.AbsorbanceReaderModel,
-        module_types.FlexStackerModuleModel,
-        module_types.VacuumModuleModel,
-    ]: module_types.ThermocyclerModuleModel.THERMOCYCLER_V2,
     peripheral_types.BarcodeScannerModel: peripheral_types.BarcodeScannerModel.BARCODE_SCANNER_V1,
     hw_types.GripperProbe: hw_types.GripperProbe.FRONT,
     hw_types.InstrumentProbeType: None,
@@ -619,7 +609,7 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
     ),
     hw_types.ModuleDisconnectedNotification: hw_types.ModuleDisconnectedNotification(
         event=hw_types.HardwareEventType.MODULE_DISCONNECTED,
-        module_model=module_types.ThermocyclerModuleModel,
+        module_model=module_types.ThermocyclerModuleModel.THERMOCYCLER_V2,
         port="123",
         module_serial="ABCDF4",
     ),
@@ -627,17 +617,14 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
         event=hw_types.HardwareEventType.SUBSYSTEM_CONNECTION
     ),
     hw_types.AsynchronousModuleErrorNotification: hw_types.AsynchronousModuleErrorNotification(
-        exception=VacuumModuleWasteFullError(
-            serial="1234ABC",
-            mode="coolmode",
-            target=10.1,
-            current=11.3,
-            message="coolmsg",
-            detail=None,  # CASEY TODO
-            wrapping=None,  # CASEY TODO
+        exception=CommunicationError(
+            code=ErrorCodes.COMMUNICATION_ERROR,
+            message="BIG_ERRORS",
+            detail={"apple": "pie", "cheese": "cake"},
+            wrapping=None # CASEY TODO
         ),
         module_serial="1234ABC",
-        module_model=module_types.VacuumModuleModel,
+        module_model=module_types.VacuumModuleModel.VACUUM_MODULE_V1,
         port="1",
         event=hw_types.HardwareEventType.ASYNCHRONOUS_MODULE_ERROR,
     ),
@@ -682,7 +669,7 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
     mod_cal.ModuleCalibrationOffset: mod_cal.ModuleCalibrationOffset(
         offset=ot_types.Point(0.1, 0.2, 0.3),
         module_id="id",
-        module=module_types.ThermocyclerModuleModel,
+        module=module_types.ModuleType.THERMOCYCLER,
         source=mod_cal.SourceType.factory,
         status=mod_cal.CalibrationStatus(
             markedBad=False,
@@ -788,12 +775,5 @@ async def test_serialization_validation() -> None:
         except KeyError as e:
             raise KeyError(f"{e} - Mock data missing for type {clazz}")
 
-        try:
-            deserialized_output = tester_proxy.data_in_data_out(mock_data)
-        except Exception as e:
-            print(f"Failed serialization on: {mock_data} - {e}")
-        try:
-            assert deserialized_output == mock_data
-        except:
-            print("failed assert")
-    raise ValueError("done")
+        deserialized_output = tester_proxy.data_in_data_out(mock_data)
+        assert deserialized_output == mock_data

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -1,6 +1,7 @@
 """Tests to enforce serialization for dataclasses from the hardware api layer."""
 
 import asyncio
+import enum
 import inspect
 import socket
 import threading
@@ -37,6 +38,7 @@ import opentrons.hardware_control.modules.module_calibration as mod_cal
 import opentrons.hardware_control.modules.types as module_types
 import opentrons.hardware_control.peripherals.types as peripheral_types
 import opentrons.hardware_control.types as hw_types
+import opentrons.hardware_control.util as hw_util
 import opentrons.types as ot_types
 from opentrons.calibration_storage.ot3.models.v1 import CalibrationStatus
 from opentrons.config import feature_flags
@@ -269,8 +271,39 @@ def _is_namedtuple_instance(cls: Any) -> bool:
         return False
 
 
-def _collect_exposed_dataclasses_and_namedtuples(  # noqa: C901
-    original_class: type, acpo_instance: Any
+def _collect_serializable_types(
+    hint: Any, collected: list[type], seen: set[int], type_qualifier: str
+) -> None:
+    if id(hint) in seen:
+        return
+    seen.add(id(hint))
+    if type_qualifier == "dataclass_namedtuple":
+        if (
+            isinstance(hint, type)
+            and (is_dataclass(hint) or _is_namedtuple_instance(hint))
+            and hint not in _TYPES_TO_SKIP
+        ):
+            collected.append(hint)
+    elif type_qualifier == "enum":
+        try:
+            if (
+                issubclass(hint, enum.Enum)
+                and hint is not enum.Enum
+                and hint not in _TYPES_TO_SKIP
+            ):
+                collected.append(hint)
+        except TypeError:
+            # wrapped arguments can be capture on recursive checks
+            pass
+    else:
+        raise ValueError(f"Invalid type qualifier for test: {type_qualifier}")
+    for arg in get_args(hint):
+        for inner in arg if isinstance(arg, list) else [arg]:
+            _collect_serializable_types(inner, collected, seen, type_qualifier)
+
+
+def _collect_exposed_types(  # noqa: C901
+    original_class: type, acpo_instance: Any, type_qualifier: str
 ) -> list[type]:
     """Scrape over the provided proxy to gather as much information on exposed dataclasses and named tuples"""
     class_list: list[type] = []
@@ -289,22 +322,6 @@ def _collect_exposed_dataclasses_and_namedtuples(  # noqa: C901
                 f"Could not resolve type hints for {original_class.__name__}.{attr_name}: {e}"
             ) from e
 
-    def _collect_serializable_types(
-        hint: Any, collected: list[type], seen: set[int]
-    ) -> None:
-        if id(hint) in seen:
-            return
-        seen.add(id(hint))
-        if (
-            isinstance(hint, type)
-            and (is_dataclass(hint) or _is_namedtuple_instance(hint))
-            and hint not in _TYPES_TO_SKIP
-        ):
-            collected.append(hint)
-        for arg in get_args(hint):
-            for inner in arg if isinstance(arg, list) else [arg]:
-                _collect_serializable_types(inner, collected, seen)
-
     # Scrape the exposed methods
     for method in proxy._pyroMethods:
         if not hasattr(original_class, method):
@@ -314,7 +331,7 @@ def _collect_exposed_dataclasses_and_namedtuples(  # noqa: C901
         if method in pyro_methods:
             hints.pop("return", None)
         for value in hints.values():
-            _collect_serializable_types(value, class_list, seen)
+            _collect_serializable_types(value, class_list, seen, type_qualifier)
 
     # Scrape the exposed properties
     for attribute in proxy._pyroAttrs:
@@ -323,7 +340,7 @@ def _collect_exposed_dataclasses_and_namedtuples(  # noqa: C901
         original_class_attribute = getattr(original_class, attribute)
         hints = _resolve_type_hints(original_class_attribute.fget, attribute)
         for value in hints.values():
-            _collect_serializable_types(value, class_list, seen)
+            _collect_serializable_types(value, class_list, seen, type_qualifier)
 
     return class_list
 
@@ -384,8 +401,10 @@ async def test_serialization_coverage(
     assert len(ot3api_async_instance.attached_modules) == len(modules_list_NO_MAG_BLOCK)
 
     # Collect classes from the OT3API
-    class_cover_list = _collect_exposed_dataclasses_and_namedtuples(
-        original_class=OT3API, acpo_instance=ot3api_async_instance
+    class_cover_list = _collect_exposed_types(
+        original_class=OT3API,
+        acpo_instance=ot3api_async_instance,
+        type_qualifier="dataclass_namedtuple",
     )
 
     hardware_registry_class_list = find_opentrons_classes_in_packages(
@@ -396,12 +415,10 @@ async def test_serialization_coverage(
     # Collect classes from the Module APIs
     mod_counter = 0
     for module in wrapped_api.attached_modules:
-        class_cover_list = (
-            class_cover_list
-            + _collect_exposed_dataclasses_and_namedtuples(
-                original_class=module.__class__,
-                acpo_instance=ot3api_async_instance.attached_modules[mod_counter],
-            )
+        class_cover_list = class_cover_list + _collect_exposed_types(
+            original_class=module.__class__,
+            acpo_instance=ot3api_async_instance.attached_modules[mod_counter],
+            type_qualifier="dataclass_namedtuple",
         )
         class_cover_list = list(set(class_cover_list))
         mod_counter += 1
@@ -475,8 +492,10 @@ async def test_module_registration_coverage(
     assert len(ot3api_async_instance.attached_modules) == len(modules_list_NO_MAG_BLOCK)
 
     # Collect classes from the OT3API
-    class_cover_list = _collect_exposed_dataclasses_and_namedtuples(
-        original_class=OT3API, acpo_instance=ot3api_async_instance
+    class_cover_list = _collect_exposed_types(
+        original_class=OT3API,
+        acpo_instance=ot3api_async_instance,
+        type_qualifier="dataclass_namedtuple",
     )
 
     hardware_registry_class_list = find_opentrons_classes_in_packages(
@@ -487,12 +506,10 @@ async def test_module_registration_coverage(
     # Collect classes from the Module APIs
     mod_counter = 0
     for module in wrapped_api.attached_modules:
-        class_cover_list = (
-            class_cover_list
-            + _collect_exposed_dataclasses_and_namedtuples(
-                original_class=module.__class__,
-                acpo_instance=ot3api_async_instance.attached_modules[mod_counter],
-            )
+        class_cover_list = class_cover_list + _collect_exposed_types(
+            original_class=module.__class__,
+            acpo_instance=ot3api_async_instance.attached_modules[mod_counter],
+            type_qualifier="dataclass_namedtuple",
         )
         class_cover_list = list(set(class_cover_list))
         mod_counter += 1
@@ -500,7 +517,86 @@ async def test_module_registration_coverage(
     assert set(class_cover_list) == set(hardware_registry_class_list)
 
 
-# Mock out of a bunch of the data types that we know leave this layer to be tested elsewhere
+async def test_enum_registration_coverage(
+    decoy: Decoy,
+    ot3_hardware: ThreadManager[OT3API],
+    mock_driver: SimulatingDriver,
+    tc_reader_mocked_driver: modules.thermocycler.ThermocyclerReader,
+    hs_reader_mocked_driver: modules.heater_shaker.HeaterShakerReader,
+    td_reader_mocked_driver: modules.tempdeck.TempDeckReader,
+    vm_reader_mocked_driver: modules.vacuum_module.VacuumModuleReader,
+    ar_reader_mocked_driver: modules.absorbance_reader.AbsorbanceReaderReader,
+    st_reader_mocked_driver: modules.flex_stacker.FlexStackerReader,
+    mock_feature_flags: None,
+) -> None:
+    """Test will check for to see if the hardware class package used in registration covers all exposed enums."""
+    decoy.when(feature_flags.hardware_subprocess_enabled()).then_return(True)
+    decoy.when(feature_flags.protocol_subprocess_enabled()).then_return(True)
+
+    wrapped_api = ot3_hardware.wrapped()
+    wrapped_api._backend.module_controls = decoy.mock(cls=AttachedModulesControl)
+    tc = decoy.mock(cls=Thermocycler)
+    hs = decoy.mock(cls=HeaterShaker)
+    td = decoy.mock(cls=TempDeck)
+    td_2 = decoy.mock(cls=TempDeck)
+    vm = decoy.mock(cls=VacuumModule)
+    st = decoy.mock(cls=FlexStacker)
+    ar = decoy.mock(cls=AbsorbanceReader)
+    decoy.when(wrapped_api._backend.module_controls.available_modules).then_return(
+        [tc, hs, td, td_2, vm, st, ar]
+    )
+    for mod in wrapped_api._backend.module_controls.available_modules:
+        decoy.when(mod._driver).then_return(mock_driver)  # type: ignore
+
+    # Mock out the pollers for these modules that will be stopped
+    decoy.when(tc._poller).then_return(Poller(tc_reader_mocked_driver, interval=0.01))
+    decoy.when(hs._poller).then_return(Poller(hs_reader_mocked_driver, interval=0.01))
+    decoy.when(td._poller).then_return(Poller(td_reader_mocked_driver, interval=0.01))
+    decoy.when(td_2._poller).then_return(Poller(td_reader_mocked_driver, interval=0.01))
+    decoy.when(vm._poller).then_return(Poller(vm_reader_mocked_driver, interval=0.01))
+    decoy.when(st._poller).then_return(Poller(st_reader_mocked_driver, interval=0.01))
+    decoy.when(ar._poller).then_return(Poller(ar_reader_mocked_driver, interval=0.01))
+
+    name_server_ready = threading.Event()
+
+    await _setup_namerserver(name_server_ready=name_server_ready)
+    ot3api_async_instance = await _setup_OT3API_pyro_resource(
+        ot3_hardware,
+        name_server_ready,
+    )
+
+    # Assert that there are as many testable proxy modules as there are actual modules for integration coverage
+    # DEVELOPER NOTE: if this part is failing, you need to add a missing module to the module mocks above.
+    modules_list_NO_MAG_BLOCK = tuple(
+        arg for arg in get_args(ModuleModel) if arg != MagneticBlockModel
+    )
+    assert len(ot3api_async_instance.attached_modules) == len(modules_list_NO_MAG_BLOCK)
+
+    # Collect classes from the OT3API
+    class_cover_list = _collect_exposed_types(
+        original_class=OT3API,
+        acpo_instance=ot3api_async_instance,
+        type_qualifier="enum",
+    )
+
+    hardware_registry_class_list = find_enums_in_packages(HARDWARE_ENUM_PACKAGES)
+    hardware_registry_class_list = list(set(hardware_registry_class_list))
+
+    # Collect classes from the Module APIs
+    mod_counter = 0
+    for module in wrapped_api.attached_modules:
+        class_cover_list = class_cover_list + _collect_exposed_types(
+            original_class=module.__class__,
+            acpo_instance=ot3api_async_instance.attached_modules[mod_counter],
+            type_qualifier="enum",
+        )
+        class_cover_list = list(set(class_cover_list))
+        mod_counter += 1
+
+    assert set(class_cover_list) <= set(hardware_registry_class_list)
+
+
+# Mock out the data types that are known to leave the hardware layer
 CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
     hw_types.Axis: hw_types.Axis.X,
     hw_types.OT3Mount: hw_types.OT3Mount.LEFT,
@@ -777,6 +873,18 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
     driver_types.ThermocyclerLidStatus: driver_types.ThermocyclerLidStatus.CLOSED,
     hw_types.EstopState: hw_types.EstopState.DISENGAGED,
     module_types.FlexStackerModuleModel: module_types.FlexStackerModuleModel.FLEX_STACKER_V1,
+    stacker_types.TOFSensorState: stacker_types.TOFSensorState.MEASURING,
+    stacker_types.MeasurementKind: stacker_types.MeasurementKind.HISTOGRAM,
+    stacker_types.HardwareRevision: stacker_types.HardwareRevision.PVT,
+    stacker_types.Direction: stacker_types.Direction.RETRACT,
+    stacker_types.TOFSensor: stacker_types.TOFSensor.Z,
+    stacker_types.LEDColor: stacker_types.LEDColor.YELLOW,
+    stacker_types.TOFSensorMode: stacker_types.TOFSensorMode.MEASURE,
+    stacker_types.ActiveRange: stacker_types.ActiveRange.SHORT_RANGE,
+    stacker_types.GCODE: stacker_types.GCODE.SET_LED,
+    stacker_types.SpadMapID: stacker_types.SpadMapID.SPAD_MAP_ID_3,
+    stacker_types.MoveResult: stacker_types.MoveResult.NO_ERROR,
+    hw_util.DeckTransformState: hw_util.DeckTransformState.SINGULARITY,
 }
 
 # This list should only include types that are either builtins that we work around or error related content thats delt with via pickle
@@ -784,7 +892,11 @@ TYPES_TO_SKIP = [ErrorCodes, ErrorCategories, StrEnum]
 
 
 async def test_serialization_validation_with_mock_data() -> None:  # noqa: C901
-    """Test to check if types registered in the hardware class package properly serialize and deserialize."""
+    """Test to check if types registered in the hardware class package properly serialize and deserialize.
+
+    A big part of the reason why this test works is because of the above tests verifying the surface of the proxy interface
+    only exposes types included in the hardware packages used by the hardware serpent registry.
+    """
 
     class DataTester:
         """Class for testing data serializaiton over pyro"""
@@ -814,7 +926,7 @@ async def test_serialization_validation_with_mock_data() -> None:  # noqa: C901
 
         tester_proxy = pyro.Proxy(daemon.uriFor(tester))  # type: ignore
 
-        # Get the hardware registry
+        # Get the hardware types covered by the registry
         hardware_registry_class_list = find_opentrons_classes_in_packages(
             HARDWARE_CLASS_PACKAGES
         )
@@ -829,6 +941,13 @@ async def test_serialization_validation_with_mock_data() -> None:  # noqa: C901
                 try:
                     mock_data = CLASS_TYPE_MOCK_TABLE[clazz]
                 except KeyError as e:
+                    # DEVELOPER NOTE: If you get a type here that you didn't expect to be exposed via pyro, there are two cases to consider:
+                    # 1. It was exposed unintentionally, like through a module's driver layer. Public facing functions on module definitions
+                    # get automatically exposed, even if nothing in the Protocol Engine or Robot-Server use them. If it's a callable api attribute
+                    # then it's types are exposed!
+                    # 2. The type was collected by our registration packages even though nothing exposes it. This can happen because we crawl a package
+                    # for types like Enums and Pydantic models, in the event that those types need serializing over pyro. If it's an easy type to mock out
+                    # then please mock it anyways, something might expose it some day causing other tests to fail!
                     raise KeyError(f"{e} - Mock data missing for type {clazz}")
 
                 deserialized_output = tester_proxy.data_in_data_out(mock_data)

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -7,7 +7,7 @@ import threading
 from dataclasses import is_dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Union, get_args, get_type_hints
+from typing import Any, Dict, get_args, get_type_hints
 
 import pytest
 from decoy import Decoy
@@ -15,7 +15,8 @@ from Pyro5 import api as pyro
 from Pyro5 import nameserver
 
 import opentrons_shared_data.pipette.types as pipette_types
-from opentrons_shared_data.errors.exceptions import CommunicationError, ErrorCodes
+from opentrons_shared_data.errors import ErrorCodes
+from opentrons_shared_data.errors.exceptions import CommunicationError
 from opentrons_shared_data.gripper import GripperModel
 from opentrons_shared_data.pipette import (
     load_data as load_pipette_data,
@@ -30,12 +31,12 @@ import opentrons.drivers.types as driver_types
 import opentrons.drivers.vacuum_module.types as vac_types
 import opentrons.hardware_control.dev_types as dev_types
 import opentrons.hardware_control.instruments.ot3.instrument_calibration as instr_calibration_types
-import opentrons.hardware_control.modules.mod_abc as mod_abc
 import opentrons.hardware_control.modules.module_calibration as mod_cal
 import opentrons.hardware_control.modules.types as module_types
 import opentrons.hardware_control.peripherals.types as peripheral_types
 import opentrons.hardware_control.types as hw_types
 import opentrons.types as ot_types
+from opentrons.calibration_storage.ot3.models.v1 import CalibrationStatus
 from opentrons.config import feature_flags
 from opentrons.config import gripper_config as gc
 from opentrons.config.types import RobotConfig
@@ -622,7 +623,7 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
             code=ErrorCodes.COMMUNICATION_ERROR,
             message="BIG_ERRORS",
             detail={"apple": "pie", "cheese": "cake"},
-            wrapping=None # CASEY TODO
+            wrapping=None,  # CASEY TODO
         ),
         module_serial="1234ABC",
         module_model=module_types.VacuumModuleModel.VACUUM_MODULE_V1,
@@ -643,19 +644,19 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
     instr_calibration_types.GripperCalibrationOffset: instr_calibration_types.GripperCalibrationOffset(
         status=instr_calibration_types.CalibrationStatus(
             markedBad=False,
-            source=instr_calibration_types.SourceType.factory,
+            source=calibration_types.SourceType.factory,
             markedAt=datetime.now(),
         ),
         offset=ot_types.Point(0.1, 0.2, 0.3),
-        source=instr_calibration_types.SourceType.calibration_check,
+        source=calibration_types.SourceType.calibration_check,
         last_modified=datetime.now(),
     ),
     instr_calibration_types.PipetteOffsetSummary: instr_calibration_types.PipetteOffsetSummary(
         offset=ot_types.Point(0.1, 0.2, 0.3),
-        source=instr_calibration_types.SourceType.calibration_check,
-        status=instr_calibration_types.CalibrationStatus(
+        source=calibration_types.SourceType.calibration_check,
+        status=calibration_types.CalibrationStatus(
             markedBad=False,
-            source=instr_calibration_types.SourceType.factory,
+            source=calibration_types.SourceType.factory,
             markedAt=datetime.now(),
         ),
         last_modified=datetime.now(),
@@ -671,10 +672,10 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
         offset=ot_types.Point(0.1, 0.2, 0.3),
         module_id="id",
         module=module_types.ModuleType.THERMOCYCLER,
-        source=mod_cal.SourceType.factory,
-        status=mod_cal.CalibrationStatus(
+        source=calibration_types.SourceType.factory,
+        status=CalibrationStatus(
             markedBad=False,
-            source=mod_cal.SourceType.calibration_check,
+            source=calibration_types.SourceType.calibration_check,
             markedAt=datetime.now(),
         ),
         mount=hw_types.OT3Mount.LEFT,
@@ -697,8 +698,11 @@ CLASS_TYPE_MOCK_TABLE: Dict[type, Any] = {
         kind=stacker_types.MeasurementKind.HISTOGRAM,
         bins={1: [1.0, 2.1]},
     ),
-    hw_types.HardwareFeatureFlags: hw_types.HardwareFeatureFlags(False, True, True, True)
+    hw_types.HardwareFeatureFlags: hw_types.HardwareFeatureFlags(
+        False, True, True, True
+    ),
 }
+
 
 async def test_serialization_validation() -> None:
     """Test to check if types registered in the hardware class package properly serialize and deserialize."""
@@ -733,7 +737,7 @@ async def test_serialization_validation() -> None:
                     finally:
                         ns.remove(name="TEST_PROXY")
             except Exception as e:
-                raise ValueError("Test Nameserver not found.")
+                raise ValueError(f"Test Nameserver not found - {e}")
             finally:
                 daemon.close()
 
@@ -759,7 +763,6 @@ async def test_serialization_validation() -> None:
     uri = pyro.resolve(uri="PYRONAME:TEST_PROXY")
     tester_proxy = pyro.Proxy(uri)  # type: ignore
 
-
     # Get the hardware registry
     hardware_registry_class_list = find_opentrons_classes_in_packages(
         HARDWARE_CLASS_PACKAGES
@@ -776,4 +779,5 @@ async def test_serialization_validation() -> None:
         deserialized_output = tester_proxy.data_in_data_out(mock_data)
         assert deserialized_output == mock_data
 
-#todo(chb, 7-30-26): Expand this test to test the enum serialization and the pydantic serialization as well
+
+# todo(chb, 7-30-26): Expand this test to test the enum serialization and the pydantic serialization as well

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -81,7 +81,7 @@ from opentrons.util.pyro.pyro_serialization import (
     find_opentrons_classes_in_packages,
 )
 
-TEST_PYRO_TIMEOUT = 10
+TEST_PYRO_TIMEOUT = 5
 
 # List of types to not validate, always list a reason
 _TYPES_TO_SKIP = [
@@ -827,19 +827,13 @@ async def test_serialization_validation_with_mock_data() -> None:  # noqa: C901
 
     ns = pyro.locate_ns()
     retries_counter = 0
-    uri = None
-    while retries_counter <= 10:
+    while ns.count() < 1:
         # Wait and try again, the resource isnt registered yet
-        try:
-            uri = ns.lookup("TEST_PROXY")
-            break
-        except Exception:
-            await asyncio.sleep(0.01)
-            retries_counter += 1
-
-    # Stop waiting for the nameserver, will fail on pyro.resolve (something is wrong with nameserver and/or daemon)
-    if uri is None:
-        raise TimeoutError("TEST FAILURE ON PYRO NAMESERVER IN SERIALIZER TEST SETUP.")
+        await asyncio.sleep(0.01)
+        retries_counter += 1
+        if retries_counter > 10:
+            # Stop waiting for the nameserver, will fail on pyro.resolve (something is wrong with nameserver and/or daemon)
+            raise TimeoutError("TEST FAILURE ON PYRO NAMESERVER.")
 
     tester_proxy = pyro.Proxy(pyro.resolve(uri="PYRONAME:TEST_PROXY"))  # type: ignore
 
@@ -854,7 +848,9 @@ async def test_serialization_validation_with_mock_data() -> None:  # noqa: C901
     # pydantic_registry_class_list = find_pydantic_classes_in_packages(HARDWARE_PYDANTIC_PACKAGES)
     # pydantic_registry_class_list = list(set(pydantic_registry_class_list))
 
-    exposed_class_list = hardware_registry_class_list + enum_registry_class_list
+    exposed_class_list = (
+        hardware_registry_class_list + enum_registry_class_list
+    )  # + pydantic_registry_class_list
 
     # Validate each class can be sent over pyro and come back deserialized in the expected format
     for clazz in exposed_class_list:

--- a/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
+++ b/api/tests/opentrons/hardware_control/pyro_utils/test_hardware_control_serialization_integration.py
@@ -81,7 +81,7 @@ from opentrons.util.pyro.pyro_serialization import (
     find_opentrons_classes_in_packages,
 )
 
-TEST_PYRO_TIMEOUT = 5
+TEST_PYRO_TIMEOUT = 10
 
 # List of types to not validate, always list a reason
 _TYPES_TO_SKIP = [
@@ -798,7 +798,7 @@ async def test_serialization_validation_with_mock_data() -> None:  # noqa: C901
     name_server_ready = threading.Event()
     await _setup_namerserver(name_server_ready=name_server_ready)
 
-    def _ot3api_pyro_daemon() -> None:
+    def _data_tester_pyro_daemon() -> None:
         # Wait for the nameserver to be ready so locate_ns can succeed.
         name_server_ready.wait(timeout=TEST_PYRO_TIMEOUT)
         register_hardware_types()
@@ -820,8 +820,10 @@ async def test_serialization_validation_with_mock_data() -> None:  # noqa: C901
             finally:
                 daemon.close()
 
-    ot3api_thread = threading.Thread(target=_ot3api_pyro_daemon, daemon=True)
-    ot3api_thread.start()
+    tester_resource_thread = threading.Thread(
+        target=_data_tester_pyro_daemon, daemon=True
+    )
+    tester_resource_thread.start()
 
     ns = pyro.locate_ns()
     retries_counter = 0
@@ -839,8 +841,7 @@ async def test_serialization_validation_with_mock_data() -> None:  # noqa: C901
     if uri is None:
         raise TimeoutError("TEST FAILURE ON PYRO NAMESERVER IN SERIALIZER TEST SETUP.")
 
-    uri = pyro.resolve(uri="PYRONAME:TEST_PROXY")
-    tester_proxy = pyro.Proxy(uri)  # type: ignore
+    tester_proxy = pyro.Proxy(pyro.resolve(uri="PYRONAME:TEST_PROXY"))  # type: ignore
 
     # Get the hardware registry
     hardware_registry_class_list = find_opentrons_classes_in_packages(


### PR DESCRIPTION
# Overview

This PR includes some new additions to our serialization integration test suite. It expands the pattern used to check dataclass/named tuple coverage to now also reinforce Enum and Pydantic model coverage.

It also includes a test that makes use of mock parameter values for the types we register with the hardware layer. This test utilizes our registered serializers on a real pyro object from a testing class, that simply sends the value in via a remote request, then sends the same value back out. If the result matches the mock data sent through, then we have good serialization coverage!

Alongside this, the unit test actually identified a set of Enums that were being exposed by Pyro that we didn't have coverage for, either because they aren't actually called from outside the API or because they were naturally missed. Either way, they're exposed and *could* be called, so I've added the packages. Most of these were coming from the stacker driver layer, exposed through the stacker API. Good job test suite!

## Test Plan and Hands on Testing
- [x] This new unit test should pass if all our dataclasses and enums are serializing correctly between client and server in `test_serialization_validation_with_mock_data`

## Changelog
- Added `test_serialization_validation_with_mock_data` to validate that any data sent in one of our registered types serializes and deserializes without issue
- Added `test_pydantic_registration_coverage` to check that the surface of exposed pydantic models is covered in registration
- Added `test_enum_registration_coverage` to check that the surface of exposed enums is covered in registration
- Added a two missing packages to the enum registry, good job unit tests!

## Review requests
This is the renewed attempt at a large surface area test that was written much earlier. This approach is much stronger, and I think it gives us really good stability in our serialization now. Anything thats missing from this?

## Risk assessment
Low - mostly just a new unit test, with some missing packages.