### PR TITLE
refactor(server-utils,robot-server): Treat Compliance Ready Software as disabled in tests and dev servers

### DIFF
--- a/server-utils/server_utils/auth/resource_server/authentication_checker.py
+++ b/server-utils/server_utils/auth/resource_server/authentication_checker.py
@@ -67,7 +67,7 @@ class AlwaysAllowedAuthenticationChecker(AuthenticationChecker):
 
     @override
     async def access_control_status(self) -> bool:
-        return True
+        return False
 
 
 class AuthServerAuthenticationChecker(AuthenticationChecker):


### PR DESCRIPTION
## Overview

Some things in robot-server behave differently depending on whether Compliance Ready Software is enabled. There is access control and audit logging, obviously. But there are also other things, like how protocols are run (subprocess vs. main process, root user vs. restricted user), and whether we require users to review the just-completed run before starting a new run.

On a real robot, robot-server determines whether CRS is enabled by consulting auth-server over IPC. In tests and dev servers, we can't always guarantee that auth-server is available to query, so we fall back to a hard-coded config.

One of these hard-coded configs was logically inconsistent: it said that access was always allowed, but it also said that CRS was enabled—a combination not actually possible.

So this switches it from saying "CRS enabled" to saying "CRS disabled." This unblocks EXEC-2859: with those changes, nearly every existing test that touches runs would break if they thought that CRS was enabled.

## Test Plan and Hands on Testing

* [x] CI passes.
* [ ] Smoke test `make -C robot-server dev`.
* [ ] Smoke test `make dev-backend-flex`.

## Review requests

Is this actually what we want? Is this going to mess anything up on the Pyro end of things?

There is probably a bigger point to resolve: to properly test all of our logic, this config can't be quite so static and hard-coded. If some codepaths only trigger on `True` and some only trigger on `False`, we need some way of testing with both. Or we need to rewrite those codepaths to depend only on settings local to robot-server instead of things that depend on external interaction.

## Risk assessment

Low risk to production code. I don't think this is used in the production path anymore. It used to be for the OT-2, but this repo doesn't support the OT-2 anymore. But see review requests above.