### PR TITLE
feat(odd): document changing language and toggling analytics

### DIFF
--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -10,6 +10,7 @@
   "attach_pipette_right": "Launching attach pipette on right mount flow",
   "calibrate": "Calibrating",
   "capture_preview_image": "Capturing preview image",
+  "change_language": "Changing language",
   "change_update_channel": "Changing update channel",
   "confirm_parameters": "Confirming runtime parameters",
   "confirm_placements": "Confirming liquids and labware placements",

--- a/app/src/assets/localization/en/audit_log.json
+++ b/app/src/assets/localization/en/audit_log.json
@@ -66,6 +66,7 @@
   "single_channel_and_8_channel": "single channel or 8 channel",
   "stop_run": "Stopping protocol run",
   "sync_system_time": "Syncing robot system time",
+  "toggle_analytics": "Toggling analytics",
   "toggle_devtools": "Toggling devtools",
   "update_audit_settings": "Updating reason for interaction log settings",
   "update_auth_settings": "Updating authentication settings",

--- a/app/src/organisms/ODD/RobotSettingsDashboard/LanguageSetting.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/LanguageSetting.tsx
@@ -19,6 +19,7 @@ import { ChildNavigation } from '/app/organisms/ODD/ChildNavigation'
 import { useTrackEventWithRobotSerial } from '/app/redux-resources/analytics'
 import { ANALYTICS_LANGUAGE_UPDATED_ODD_SETTINGS } from '/app/redux/analytics'
 import { getAppLanguage, updateConfigValue } from '/app/redux/config'
+import { useHandleAndLog } from '/app/resources/access-control/useHandleAndLog'
 
 import type { ChangeEvent } from 'react'
 import type { Dispatch } from '/app/redux/types'
@@ -74,6 +75,15 @@ export function LanguageSetting({
     })
   }
 
+  const handleChangeAndLog = useHandleAndLog<ChangeEvent<HTMLInputElement>>(
+    handleChange,
+    'change_language',
+    event => ({
+      action: 'change language',
+      message: `user changed language to ${event.target.value}`,
+    })
+  )
+
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
       <ChildNavigation
@@ -95,7 +105,7 @@ export function LanguageSetting({
               type="radio"
               value={lng.value}
               checked={lng.value === appLanguage}
-              onChange={handleChange}
+              onChange={handleChangeAndLog}
             />
             <SettingButtonLabel
               htmlFor={lng.name}

--- a/app/src/organisms/ODD/RobotSettingsDashboard/Privacy.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/Privacy.tsx
@@ -14,6 +14,7 @@ import {
   getAnalyticsOptedIn,
   toggleAnalyticsOptedIn,
 } from '/app/redux/analytics'
+import { useHandleAndLog } from '/app/resources/access-control/useHandleAndLog'
 
 import { OnOffToggle } from './OnOffToggle'
 import { RobotSettingButton } from './RobotSettingButton'
@@ -34,6 +35,15 @@ export function Privacy({
   const dispatch = useDispatch<Dispatch>()
 
   const appAnalyticsOptedIn = useSelector(getAnalyticsOptedIn)
+
+  const handleChange = useHandleAndLog<boolean>(
+    () => dispatch(toggleAnalyticsOptedIn()),
+    'toggle_analytics',
+    (optedIn: boolean) => ({
+      action: 'toggled analytics',
+      message: `user ${optedIn ? 'opted in' : 'opted out'} of analytics`,
+    })
+  )
 
   return (
     <Flex flexDirection={DIRECTION_COLUMN}>
@@ -62,7 +72,9 @@ export function Privacy({
             settingInfo={t('branded:share_display_usage_description')}
             dataTestId="RobotSettingButton_share_app_analytics"
             rightElement={<OnOffToggle isOn={appAnalyticsOptedIn} />}
-            onClick={() => dispatch(toggleAnalyticsOptedIn())}
+            onClick={() => {
+              handleChange(!appAnalyticsOptedIn)
+            }}
           />
         </Flex>
       </Flex>

--- a/app/src/organisms/ODD/RobotSettingsDashboard/Privacy.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/Privacy.tsx
@@ -41,7 +41,7 @@ export function Privacy({
     'toggle_analytics',
     (optedIn: boolean) => ({
       action: 'toggled analytics',
-      message: `user ${optedIn ? 'opted in' : 'opted out'} of analytics`,
+      message: `user ${optedIn ? 'opted in to' : 'opted out of'} analytics`,
     })
   )
 

--- a/app/src/organisms/ODD/RobotSettingsDashboard/__tests__/LanguageSetting.test.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/__tests__/LanguageSetting.test.tsx
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
 
+import { usePostLogMessageMutation } from '@opentrons/react-api-client'
+
 import { renderWithProviders } from '/app/__testing-utils__'
 import {
   i18n,
@@ -11,6 +13,8 @@ import {
   US_ENGLISH,
   US_ENGLISH_DISPLAY_NAME,
 } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useTrackEventWithRobotSerial } from '/app/redux-resources/analytics'
 import { ANALYTICS_LANGUAGE_UPDATED_ODD_SETTINGS } from '/app/redux/analytics'
 import { getAppLanguage, updateConfigValue } from '/app/redux/config'
@@ -18,12 +22,22 @@ import { getAppLanguage, updateConfigValue } from '/app/redux/config'
 import { LanguageSetting } from '../LanguageSetting'
 
 import type { ComponentProps } from 'react'
+import type * as ReactApiClient from '@opentrons/react-api-client'
 
+vi.mock('@opentrons/react-api-client', async importOriginal => {
+  const actual = await importOriginal<typeof ReactApiClient>()
+  return {
+    ...actual,
+    usePostLogMessageMutation: vi.fn(),
+  }
+})
+vi.mock('/app/local-resources/access-control/useDocumentationState')
 vi.mock('/app/redux/config')
 vi.mock('/app/redux-resources/analytics')
 
 const mockSetCurrentOption = vi.fn()
 const mockTrackEvent = vi.fn()
+const mockPostLogMessage = vi.fn()
 
 const render = (props: ComponentProps<typeof LanguageSetting>) => {
   return renderWithProviders(<LanguageSetting {...props} />, {
@@ -41,6 +55,12 @@ describe('LanguageSetting', () => {
     vi.mocked(useTrackEventWithRobotSerial).mockReturnValue({
       trackEventWithRobotSerial: mockTrackEvent,
     })
+    vi.mocked(useDocumentationState).mockReturnValue(
+      ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+    )
+    vi.mocked(usePostLogMessageMutation).mockReturnValue({
+      postLogMessage: mockPostLogMessage,
+    } as any)
   })
 
   it('should render text and buttons', () => {

--- a/app/src/organisms/ODD/RobotSettingsDashboard/__tests__/Privacy.test.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/__tests__/Privacy.test.tsx
@@ -1,15 +1,30 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { usePostLogMessageMutation } from '@opentrons/react-api-client'
+
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
+import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
+import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { toggleAnalyticsOptedIn } from '/app/redux/analytics'
 
 import { Privacy } from '../Privacy'
 
 import type { ComponentProps } from 'react'
+import type * as ReactApiClient from '@opentrons/react-api-client'
 
+vi.mock('@opentrons/react-api-client', async importOriginal => {
+  const actual = await importOriginal<typeof ReactApiClient>()
+  return {
+    ...actual,
+    usePostLogMessageMutation: vi.fn(),
+  }
+})
+vi.mock('/app/local-resources/access-control/useDocumentationState')
 vi.mock('/app/redux/analytics')
+
+const mockPostLogMessage = vi.fn()
 
 const render = (props: ComponentProps<typeof Privacy>) => {
   return renderWithProviders(<Privacy {...props} />, {
@@ -24,6 +39,12 @@ describe('Privacy', () => {
       robotName: 'Otie',
       setCurrentOption: vi.fn(),
     }
+    vi.mocked(useDocumentationState).mockReturnValue(
+      ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE
+    )
+    vi.mocked(usePostLogMessageMutation).mockReturnValue({
+      postLogMessage: mockPostLogMessage,
+    } as any)
   })
 
   afterEach(() => {

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -192,6 +192,7 @@ type AuditLogAction =
   | 'change_update_channel'
   | 'toggle_devtools'
   | 'change_language'
+  | 'toggle_analytics'
 
 /**
  * Type used for DocumentedActions - keys and info to enable correct rendering of actions in the 'list actions' popup in the Documentation Required Modal.

--- a/react-api-client/src/accessControl/types.ts
+++ b/react-api-client/src/accessControl/types.ts
@@ -191,6 +191,7 @@ type AuditLogAction =
   | 'confirm_placements'
   | 'change_update_channel'
   | 'toggle_devtools'
+  | 'change_language'
 
 /**
  * Type used for DocumentedActions - keys and info to enable correct rendering of actions in the 'list actions' popup in the Documentation Required Modal.


### PR DESCRIPTION
# Overview

Adds documentation for changing language and toggling analytics 


https://github.com/user-attachments/assets/502e1131-c839-4620-a187-93b19f377515

https://github.com/user-attachments/assets/4d7b3c13-f01c-4a54-a2d6-5604ee324e04

<img width="600" height="445" alt="Screenshot 2026-07-31 at 3 38 05 PM" src="https://github.com/user-attachments/assets/56393a47-c624-458e-bbca-93564523b977" />

## Test Plan and Hands on Testing

Toggling analytics and changing language should prompt for documentation and send a message to the robot audit log

## Risk assessment

Low