### PR TITLE
refactor(auth-server): Reorganize the mapping of account types to scopes

### DIFF
--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -198,8 +198,8 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         **kwargs: object,
     ) -> bool:
         """Is the client allowed to access the requested scopes?"""
-        assert isinstance(request.user, ORMUser)
-        user: ORMUser = request.user
+        user = cast(object, request.user)
+        assert isinstance(user, ORMUser)
 
         try:
             for scope in scopes:
@@ -246,8 +246,9 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         self, client_id: str, request: oauthlib.common.Request
     ) -> list[str]:
         """Scopes that we'll authorize a client for, if it doesn't ask for any explicitly."""
-        assert isinstance(request.user, ORMUser)
-        user: ORMUser = request.user
+        user = cast(object, request.user)
+        assert isinstance(user, ORMUser)
+
         scopes = get_scope_set_of_user(
             user,
             self.__settings_store.get_settings(),
@@ -257,6 +258,7 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
                 self.__settings_store.get_settings().passwordResetTime,
             ),
         )
+
         return sorted(s.api_name for s in scopes)
 
     @override

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -221,6 +221,7 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
             s.api_name
             for s in get_scope_set_of_user(
                 user,
+                self.__settings_store.get_settings(),
                 must_reset_password(
                     user,
                     self.__get_now(),
@@ -249,6 +250,7 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         user: ORMUser = request.user
         scopes = get_scope_set_of_user(
             user,
+            self.__settings_store.get_settings(),
             must_reset_password(
                 user,
                 self.__get_now(),

--- a/auth-server/auth_server/oauth2/backend.py
+++ b/auth-server/auth_server/oauth2/backend.py
@@ -25,8 +25,9 @@ from server_utils.auth.scopes import Scope, UnrecognizedScopeError, serialize_sc
 from auth_server.persistence.orm_models import User as ORMUser
 from auth_server.settings.store import SettingsStore
 from auth_server.users.is_account_locked import is_account_locked
+from auth_server.users.scopes import get_scope_set_of_user
 from auth_server.users.store import UserStore
-from auth_server.users.user_data_manager import get_scope_set_of_user, password_hash
+from auth_server.users.user_data_manager import must_reset_password, password_hash
 
 _log = logging.getLogger(__name__)
 
@@ -220,8 +221,11 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
             s.api_name
             for s in get_scope_set_of_user(
                 user,
-                self.__get_now(),
-                self.__settings_store.get_settings().passwordResetTime,
+                must_reset_password(
+                    user,
+                    self.__get_now(),
+                    self.__settings_store.get_settings().passwordResetTime,
+                ),
             )
         )
         if not scopes_ok:
@@ -245,8 +249,11 @@ class _RequestValidator(oauthlib.oauth2.RequestValidator):
         user: ORMUser = request.user
         scopes = get_scope_set_of_user(
             user,
-            self.__get_now(),
-            self.__settings_store.get_settings().passwordResetTime,
+            must_reset_password(
+                user,
+                self.__get_now(),
+                self.__settings_store.get_settings().passwordResetTime,
+            ),
         )
         return sorted(s.api_name for s in scopes)
 

--- a/auth-server/auth_server/users/models.py
+++ b/auth-server/auth_server/users/models.py
@@ -5,8 +5,6 @@ from typing import Annotated, Literal, Sequence, TypedDict
 
 from pydantic import BaseModel, Field, SecretStr
 
-from server_utils.auth.scopes import Scope
-
 
 # leave this outside of the db. this will not change.
 class AccountType(StrEnum):
@@ -16,35 +14,6 @@ class AccountType(StrEnum):
     USER = "user"
     AUDITOR = "auditor"
     SERVICE = "service"
-
-
-# move this to db if we need to support updating scopes.
-ACCOUNT_TYPE_TO_SCOPES: dict[AccountType, set[Scope]] = {
-    AccountType.ADMIN: set(Scope),  # all scopes
-    AccountType.SERVICE: set(Scope),  # all scopes
-    AccountType.USER: {
-        Scope.RESTART_WRITE,
-        Scope.ROBOT_CONTROL_WRITE,
-        Scope.ROBOT_SETTINGS_WRITE,
-        # todo(mm, 2026-03-17): Updates should be togglable to admin-only by an auth setting.
-        Scope.UPDATES_WRITE,
-        Scope.USERS_READ_SELF,
-        Scope.USERS_WRITE_SELF,
-        # todo(mm, 2026-03-17): Protocol uploads should be togglable to admin-only by an auth setting.
-        Scope.PROTOCOLS_WRITE,
-        Scope.AUDIT_LOG_WRITE,
-    },
-    # Auditors should have read-only access to everything. Our read-only endpoints are
-    # mostly accessible without authentication, but there are some exceptions. This
-    # just needs to have the scopes to cover those exceptions.
-    AccountType.AUDITOR: {Scope.USERS_READ_OTHERS},
-}
-
-# Scopes granted while resetPassword is true, before the user chooses a new password.
-RESET_PASSWORD_SCOPES: set[Scope] = {
-    Scope.USERS_READ_SELF,
-    Scope.USERS_WRITE_SELF,
-}
 
 
 class UserCreate(BaseModel):

--- a/auth-server/auth_server/users/models.py
+++ b/auth-server/auth_server/users/models.py
@@ -28,9 +28,9 @@ ACCOUNT_TYPE_TO_SCOPES: dict[AccountType, set[Scope]] = {
         Scope.ROBOT_SETTINGS_WRITE,
         # todo(mm, 2026-03-17): Updates should be togglable to admin-only by an auth setting.
         Scope.UPDATES_WRITE,
-        # todo(mm, 2026-03-17): Protocol uploads should be togglable to admin-only by an auth setting.
         Scope.USERS_READ_SELF,
         Scope.USERS_WRITE_SELF,
+        # todo(mm, 2026-03-17): Protocol uploads should be togglable to admin-only by an auth setting.
         Scope.PROTOCOLS_WRITE,
         Scope.AUDIT_LOG_WRITE,
     },

--- a/auth-server/auth_server/users/scopes.py
+++ b/auth-server/auth_server/users/scopes.py
@@ -1,0 +1,45 @@
+from server_utils.auth.scopes import Scope
+
+from auth_server.persistence.orm_models import User
+from auth_server.users.models import AccountType
+
+ACCOUNT_TYPE_TO_SCOPES: dict[AccountType, set[Scope]] = {
+    AccountType.ADMIN: set(Scope),  # all scopes
+    AccountType.SERVICE: set(Scope),  # all scopes
+    AccountType.USER: {
+        Scope.RESTART_WRITE,
+        Scope.ROBOT_CONTROL_WRITE,
+        Scope.ROBOT_SETTINGS_WRITE,
+        # todo(mm, 2026-03-17): Updates should be togglable to admin-only by an auth setting.
+        Scope.UPDATES_WRITE,
+        Scope.USERS_READ_SELF,
+        Scope.USERS_WRITE_SELF,
+        # todo(mm, 2026-03-17): Protocol uploads should be togglable to admin-only by an auth setting.
+        Scope.PROTOCOLS_WRITE,
+        Scope.AUDIT_LOG_WRITE,
+    },
+    # Auditors should have read-only access to everything. Our read-only endpoints are
+    # mostly accessible without authentication, but there are some exceptions. This
+    # just needs to have the scopes to cover those exceptions.
+    AccountType.AUDITOR: {Scope.USERS_READ_OTHERS},
+}
+
+# Scopes granted while resetPassword is true, before the user chooses a new password.
+RESET_PASSWORD_SCOPES: set[Scope] = {
+    Scope.USERS_READ_SELF,
+    Scope.USERS_WRITE_SELF,
+}
+
+
+def get_scope_set_of_user(
+    user: User,
+    must_reset_password: bool,
+) -> set[Scope]:
+    """Return the scopes that a user is authorized for.
+
+    A user who must reset their password is restricted to reading and writing their
+    own account, so they can change their password but nothing else until they do.
+    """
+    if must_reset_password:
+        return set(RESET_PASSWORD_SCOPES)
+    return set(ACCOUNT_TYPE_TO_SCOPES[AccountType(user.account_type)])

--- a/auth-server/auth_server/users/scopes.py
+++ b/auth-server/auth_server/users/scopes.py
@@ -1,38 +1,15 @@
+from typing import assert_never
+
 from server_utils.auth.scopes import Scope
 
 from auth_server.persistence.orm_models import User
+from auth_server.settings.models import SettingsResponseData
 from auth_server.users.models import AccountType
 
-ACCOUNT_TYPE_TO_SCOPES: dict[AccountType, set[Scope]] = {
-    AccountType.ADMIN: set(Scope),  # all scopes
-    AccountType.SERVICE: set(Scope),  # all scopes
-    AccountType.USER: {
-        Scope.RESTART_WRITE,
-        Scope.ROBOT_CONTROL_WRITE,
-        Scope.ROBOT_SETTINGS_WRITE,
-        # todo(mm, 2026-03-17): Updates should be togglable to admin-only by an auth setting.
-        Scope.UPDATES_WRITE,
-        Scope.USERS_READ_SELF,
-        Scope.USERS_WRITE_SELF,
-        # todo(mm, 2026-03-17): Protocol uploads should be togglable to admin-only by an auth setting.
-        Scope.PROTOCOLS_WRITE,
-        Scope.AUDIT_LOG_WRITE,
-    },
-    # Auditors should have read-only access to everything. Our read-only endpoints are
-    # mostly accessible without authentication, but there are some exceptions. This
-    # just needs to have the scopes to cover those exceptions.
-    AccountType.AUDITOR: {Scope.USERS_READ_OTHERS},
-}
 
-# Scopes granted while resetPassword is true, before the user chooses a new password.
-RESET_PASSWORD_SCOPES: set[Scope] = {
-    Scope.USERS_READ_SELF,
-    Scope.USERS_WRITE_SELF,
-}
-
-
-def get_scope_set_of_user(
-    user: User,
+def get_scope_set_of_account_type(
+    account_type: AccountType,
+    settings: SettingsResponseData,
     must_reset_password: bool,
 ) -> set[Scope]:
     """Return the scopes that a user is authorized for.
@@ -41,5 +18,47 @@ def get_scope_set_of_user(
     own account, so they can change their password but nothing else until they do.
     """
     if must_reset_password:
-        return set(RESET_PASSWORD_SCOPES)
-    return set(ACCOUNT_TYPE_TO_SCOPES[AccountType(user.account_type)])
+        # Grant the user only the permissions that they need to set a new password,
+        # not to actually do anything on the robot.
+        return {
+            Scope.USERS_READ_SELF,
+            Scope.USERS_WRITE_SELF,
+        }
+
+    else:
+        if account_type == AccountType.ADMIN or account_type == AccountType.SERVICE:
+            return set(Scope)  # All scopes.
+
+        elif account_type == AccountType.AUDITOR:
+            # Auditors should have read-only access to everything. Our read-only endpoints are
+            # mostly accessible without authentication, but there are some exceptions. This
+            # just needs to have the scopes to cover those exceptions.
+            return {Scope.USERS_READ_OTHERS}
+
+        elif account_type == AccountType.USER:
+            return {
+                Scope.RESTART_WRITE,
+                Scope.ROBOT_CONTROL_WRITE,
+                Scope.ROBOT_SETTINGS_WRITE,
+                # todo(mm, 2026-03-17): Updates should be togglable to admin-only by an auth setting.
+                Scope.UPDATES_WRITE,
+                Scope.USERS_READ_SELF,
+                Scope.USERS_WRITE_SELF,
+                # todo(mm, 2026-03-17): Protocol uploads should be togglable to admin-only by an auth setting.
+                Scope.PROTOCOLS_WRITE,
+                Scope.AUDIT_LOG_WRITE,
+            }
+
+        else:
+            assert_never(account_type)
+
+
+def get_scope_set_of_user(
+    user: User,
+    settings: SettingsResponseData,
+    must_reset_password: bool,
+) -> set[Scope]:
+    """See `get_scope_set_of_account_type()`."""
+    return get_scope_set_of_account_type(
+        AccountType(user.account_type), settings, must_reset_password
+    )

--- a/auth-server/auth_server/users/user_data_manager.py
+++ b/auth-server/auth_server/users/user_data_manager.py
@@ -7,15 +7,11 @@ from typing import Literal
 
 from pwdlib import PasswordHash
 
-from server_utils.auth.scopes import Scope
-
 from auth_server.persistence.orm_models import User
 from auth_server.settings.models import SettingsResponseData
 from auth_server.settings.store import SettingsStore
 from auth_server.users.is_account_locked import is_account_locked
 from auth_server.users.models import (
-    ACCOUNT_TYPE_TO_SCOPES,
-    RESET_PASSWORD_SCOPES,
     AccountType,
     ResetPasswordResponse,
     UserResponse,
@@ -121,19 +117,6 @@ def must_reset_password(
         > user.password_set_at + datetime.timedelta(seconds=password_reset_time_sec)
     )
     return password_is_expired or user.reset_password
-
-
-def get_scope_set_of_user(
-    user: User, now: datetime.datetime, password_reset_time_sec: float | None
-) -> set[Scope]:
-    """Return the scopes that a user is authorized for.
-
-    A user who must reset their password is restricted to reading and writing their
-    own account, so they can change their password but nothing else until they do.
-    """
-    if must_reset_password(user, now, password_reset_time_sec):
-        return set(RESET_PASSWORD_SCOPES)
-    return set(ACCOUNT_TYPE_TO_SCOPES[AccountType(user.account_type)])
 
 
 class UserDataManager:

--- a/auth-server/tests/conftest.py
+++ b/auth-server/tests/conftest.py
@@ -7,10 +7,11 @@ import requests
 from server_utils.auth.scopes import serialize_scopes
 from tests.dev_server import DevServer
 
+from auth_server.settings.models import SettingsResponseData
 from auth_server.users.models import (
     AccountType,
 )
-from auth_server.users.scopes import ACCOUNT_TYPE_TO_SCOPES
+from auth_server.users.scopes import get_scope_set_of_account_type
 
 _INTEGRATION_SERVER_STARTUP_TIMEOUT_S = 30
 
@@ -18,13 +19,21 @@ _INTEGRATION_SERVER_STARTUP_TIMEOUT_S = 30
 @pytest.fixture
 def admin_scopes_str() -> str:
     """All the OAuth 2 scopes that an admin should have, as a space-separated string."""
-    return serialize_scopes(set(ACCOUNT_TYPE_TO_SCOPES[AccountType.ADMIN]))
+    return serialize_scopes(
+        get_scope_set_of_account_type(
+            AccountType.ADMIN, SettingsResponseData(), must_reset_password=False
+        )
+    )
 
 
 @pytest.fixture
 def user_scopes_str() -> str:
     """All the OAuth 2 scopes that a regular user should have, as a space-separated string."""
-    return serialize_scopes(set(ACCOUNT_TYPE_TO_SCOPES[AccountType.USER]))
+    return serialize_scopes(
+        get_scope_set_of_account_type(
+            AccountType.USER, SettingsResponseData(), must_reset_password=False
+        )
+    )
 
 
 @pytest.fixture

--- a/auth-server/tests/conftest.py
+++ b/auth-server/tests/conftest.py
@@ -8,9 +8,9 @@ from server_utils.auth.scopes import serialize_scopes
 from tests.dev_server import DevServer
 
 from auth_server.users.models import (
-    ACCOUNT_TYPE_TO_SCOPES,
     AccountType,
 )
+from auth_server.users.scopes import ACCOUNT_TYPE_TO_SCOPES
 
 _INTEGRATION_SERVER_STARTUP_TIMEOUT_S = 30
 

--- a/server-utils/server_utils/auth/scopes.py
+++ b/server-utils/server_utils/auth/scopes.py
@@ -13,11 +13,14 @@ class Scope(enum.Enum):
 
     # Example:
     #
-    # PYTHON_NAME = ("api_name", "description")
+    #   PYTHON_NAME = ("api_name", "description")
     #
     # "PYTHON_NAME" is arbitrary.
     # "api_name" is exposed as part of the HTTP API, and may be stored persistently.
     # "description" is developer-readable documentation for the OpenAPI spec.
+    #
+    # If you add a scope here, remember that you probably also need to add it to
+    # auth-server's ACCOUNT_TYPE_TO_SCOPES.
 
     AUTH_SETTINGS_WRITE = (
         "auth_settings.write",

--- a/server-utils/server_utils/auth/scopes.py
+++ b/server-utils/server_utils/auth/scopes.py
@@ -19,8 +19,8 @@ class Scope(enum.Enum):
     # "api_name" is exposed as part of the HTTP API, and may be stored persistently.
     # "description" is developer-readable documentation for the OpenAPI spec.
     #
-    # If you add a scope here, remember that you probably also need to add it to
-    # auth-server's ACCOUNT_TYPE_TO_SCOPES.
+    # If you add a scope here, remember that you may also need to add it to
+    # auth-server's get_scope_set_of_account_type().
 
     AUTH_SETTINGS_WRITE = (
         "auth_settings.write",


### PR DESCRIPTION
## Overview

Refactors to prepare for EXEC-2776, EXEC-2777, and EXEC-2778. There are no behavioral changes here.

## Test Plan and Hands on Testing

Just CI.

## Changelog

* Add a dedicated file to hold the logic that maps an account type to a set of scopes.
* Instead of using a static `dict`, use a function.
* Fix a very sad problem that was causing some parts of backend.py to silently not be type-checked.

## Review requests

Still readable and understandable?

## Risk assessment

Low.