### PR TITLE
feat(auth-server): Optionally restrict protocol uploads and robot updates to admins

### DIFF
--- a/auth-server/auth_server/users/scopes.py
+++ b/auth-server/auth_server/users/scopes.py
@@ -36,18 +36,19 @@ def get_scope_set_of_account_type(
             return {Scope.USERS_READ_OTHERS}
 
         elif account_type == AccountType.USER:
-            return {
+            result = {
                 Scope.RESTART_WRITE,
                 Scope.ROBOT_CONTROL_WRITE,
                 Scope.ROBOT_SETTINGS_WRITE,
-                # todo(mm, 2026-03-17): Updates should be togglable to admin-only by an auth setting.
-                Scope.UPDATES_WRITE,
                 Scope.USERS_READ_SELF,
                 Scope.USERS_WRITE_SELF,
-                # todo(mm, 2026-03-17): Protocol uploads should be togglable to admin-only by an auth setting.
-                Scope.PROTOCOLS_WRITE,
                 Scope.AUDIT_LOG_WRITE,
             }
+            if not settings.requireAdminCredsWhenUpdatingRobotSoftware:
+                result.add(Scope.UPDATES_WRITE)
+            if not settings.requireAdminCredsWhenSendingProtocolToRobot:
+                result.add(Scope.PROTOCOLS_WRITE)
+            return result
 
         else:
             assert_never(account_type)

--- a/auth-server/tests/integration/test_oauth_scopes_and_settings.tavern.yaml
+++ b/auth-server/tests/integration/test_oauth_scopes_and_settings.tavern.yaml
@@ -1,0 +1,132 @@
+test_name: Robot settings affect OAuth scopes returned to regular users
+
+marks:
+  - usefixtures:
+      - run_server
+      - admin_access_token
+
+stages:
+  - name: With default settings, regular users should not get admin-only scopes
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: testuser
+        password: testuserpassword
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tests.integration.utils:verify_oauth_scopes
+        extra_kwargs:
+          expected_absent: updates.write protocols.write
+      save:
+        json:
+          user_access_token: access_token
+
+  - name: Token introspection should match default-settings login scopes
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tests.integration.utils:verify_oauth_scopes
+        extra_kwargs:
+          expected_absent: updates.write protocols.write
+
+  - name: Allow regular users to update robot software
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          requireAdminCredsWhenUpdatingRobotSoftware: false
+    response:
+      status_code: 200
+
+  - name: Regular users should now get updates.write but not protocols.write
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: testuser
+        password: testuserpassword
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tests.integration.utils:verify_oauth_scopes
+        extra_kwargs:
+          expected_present: updates.write
+          expected_absent: protocols.write
+      save:
+        json:
+          user_access_token: access_token
+
+  - name: Token introspection should match updates-enabled login scopes
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tests.integration.utils:verify_oauth_scopes
+        extra_kwargs:
+          expected_present: updates.write
+          expected_absent: protocols.write
+
+  - name: Allow regular users to send protocols to the robot
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          requireAdminCredsWhenSendingProtocolToRobot: false
+    response:
+      status_code: 200
+
+  - name: Regular users should now get both updates.write and protocols.write
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: testuser
+        password: testuserpassword
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tests.integration.utils:verify_oauth_scopes
+        extra_kwargs:
+          expected_present: updates.write protocols.write
+      save:
+        json:
+          user_access_token: access_token
+
+  - name: Token introspection should match fully-enabled login scopes
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tests.integration.utils:verify_oauth_scopes
+        extra_kwargs:
+          expected_present: updates.write protocols.write

--- a/auth-server/tests/integration/utils.py
+++ b/auth-server/tests/integration/utils.py
@@ -1,0 +1,36 @@
+"""Helper functions for use inside Tavern tests.
+
+https://tavern.readthedocs.io/en/latest/basics.html#calling-external-functions
+"""
+
+from requests import Response
+
+from server_utils.auth.scopes import parse_scopes
+
+
+def verify_oauth_scopes(
+    response: Response,
+    *,
+    expected_present: str = "",
+    expected_absent: str = "",
+) -> None:
+    """Verify that an OAuth response's scope field includes and excludes specific scopes.
+
+    `expected_present` and `expected_absent` are space-separated scope API names
+    (e.g. ``"updates.write protocols.write"``).
+    """
+    parsed_actual = parse_scopes(response.json().get("scope", ""))
+    parsed_expected_present = parse_scopes(expected_present)
+    parsed_expected_absent = parse_scopes(expected_absent)
+
+    missing = parsed_expected_present - parsed_actual
+    assert not missing, (
+        "Expected scopes missing from response: "
+        f"{sorted(scope.api_name for scope in missing)}"
+    )
+
+    unexpected = parsed_expected_absent & parsed_actual
+    assert not unexpected, (
+        "Unexpected scopes present in response: "
+        f"{sorted(scope.api_name for scope in unexpected)}"
+    )


### PR DESCRIPTION
## Overview

This closes EXEC-2776 and EXEC-2777. We already had settings to restrict protocol uploads and robot settings to admins (as opposed to regular users also), but they weren't functional. This wires them up to actually control the scopes that get returned to a client after logging in through the OAuth 2 flow.

## Test Plan and Hands on Testing

An integration test is included.

## Review requests

Do we like this way of doing it? Note that this will only take take effect the next time a user logs in.

## Risk assessment

Low.
