### PR TITLE
refactor(components): Delete the unused hasBackgroundError prop

### DIFF
--- a/app/src/molecules/TouchTextAreaField/index.tsx
+++ b/app/src/molecules/TouchTextAreaField/index.tsx
@@ -23,8 +23,6 @@ interface TouchTextAreaFieldProps extends NativeTextareaProps {
   caption?: string | null
   /** horizontal text alignment for label, textarea, and (sub)captions */
   textAlign?: 'left' | 'center'
-  /** if true, style the background of textarea field to error state */
-  hasBackgroundError?: boolean
   /** optional prop to support focus when tapping text area */
   onWrapperClick?: MouseEventHandler<HTMLDivElement>
   /** optional prop to override textarea field border radius */
@@ -50,7 +48,6 @@ export const TouchTextAreaField = forwardRef<
     error,
     caption,
     textAlign = 'left',
-    hasBackgroundError = false,
     onWrapperClick,
     borderRadius,
     padding,
@@ -82,7 +79,6 @@ export const TouchTextAreaField = forwardRef<
   const textareaClasses = clsx(
     styles.textarea,
     hasError && styles.textarea_error,
-    hasBackgroundError && styles.textarea_background_error,
     multiline && styles.textarea_multiline
   )
 

--- a/app/src/molecules/TouchTextAreaField/touchtextareafield.module.css
+++ b/app/src/molecules/TouchTextAreaField/touchtextareafield.module.css
@@ -72,11 +72,6 @@
   border: 1px solid var(--red-50);
 }
 
-.textarea_background_error {
-  border: none;
-  background-color: var(--red-30);
-}
-
 .label_text {
   padding-bottom: var(--spacing-4);
   color: var(--grey-60);

--- a/components/src/molecules/InputField/index.tsx
+++ b/components/src/molecules/InputField/index.tsx
@@ -83,8 +83,6 @@ export interface InputFieldProps {
   leftElement?: ReactNode
   /** optional element to display aligned to the right of the input field */
   rightElement?: ReactNode
-  /** if true, style the background of input field to error state */
-  hasBackgroundError?: boolean
   /** optional prop to override input field border radius */
   borderRadius?: string
   /** optional prop to override input field padding */
@@ -117,7 +115,6 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
       size = 'small',
       leftElement,
       rightElement,
-      hasBackgroundError = false,
       borderRadius,
       padding,
       testId,
@@ -138,17 +135,13 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
     const placeHolder = (isIndeterminate ?? false) ? '-' : rawPlaceholder
 
     const INPUT_FIELD = css`
-      background-color: ${hasBackgroundError ? COLORS.red30 : COLORS.white};
+      background-color: ${COLORS.white};
       border-radius: ${
         borderRadius != null ? borderRadius : BORDERS.borderRadius4
       };
       padding: ${padding ?? SPACING.spacing8};
-      border: ${
-        hasBackgroundError
-          ? 'none'
-          : `1px ${BORDERS.styleSolid}
-        ${hasError ? COLORS.red50 : COLORS.grey50}`
-      };
+      border: 1px ${BORDERS.styleSolid}
+        ${hasError ? COLORS.red50 : COLORS.grey50};
       font-size: ${TYPOGRAPHY.fontSizeP};
       width: 100%;
       height: ${size === 'small' ? '2rem' : '2.75rem'};

--- a/components/src/molecules/TextAreaField/index.tsx
+++ b/components/src/molecules/TextAreaField/index.tsx
@@ -58,8 +58,6 @@ interface TextAreaFieldProps extends NativeTextareaProps {
   leftElement?: ReactNode
   /** optional element to display aligned to the right of the input field */
   rightElement?: ReactNode
-  /** if true, style the background of textarea field to error state */
-  hasBackgroundError?: boolean
   /** optional prop to support focus when tapping text area */
   onWrapperClick?: MouseEventHandler<HTMLDivElement>
   /** optional prop to override textarea field border radius */
@@ -88,7 +86,6 @@ export const TextAreaField = forwardRef<
     textAlign = 'left',
     leftElement,
     rightElement,
-    hasBackgroundError = false,
     onWrapperClick,
     borderRadius,
     padding,
@@ -123,7 +120,6 @@ export const TextAreaField = forwardRef<
   const textareaClasses = clsx(
     styles.textarea,
     hasError && styles.textarea_error,
-    hasBackgroundError && styles.textarea_background_error,
     isKeyboardFocus && styles.textarea_keyboard_focus,
     multiline && styles.textarea_multiline
   )

--- a/components/src/molecules/TextAreaField/textareafield.module.css
+++ b/components/src/molecules/TextAreaField/textareafield.module.css
@@ -88,11 +88,6 @@
   border: 1px solid var(--red-50);
 }
 
-.textarea_background_error {
-  border: none;
-  background-color: var(--red-30);
-}
-
 .textarea_keyboard_focus:focus {
   border: 1px solid var(--blue-50);
   outline: 2px solid var(--blue-50);

--- a/components/src/molecules/TouchInputField/index.tsx
+++ b/components/src/molecules/TouchInputField/index.tsx
@@ -58,8 +58,6 @@ export interface TouchInputFieldProps {
     typeof TYPOGRAPHY.textAlignLeft | typeof TYPOGRAPHY.textAlignCenter
   /** small or medium input field height */
   size?: 'medium' | 'small'
-  /** if true, style the background of input field to error state */
-  hasBackgroundError?: boolean
   /** optional prop to override input field border radius */
   borderRadius?: string
   /** optional prop to override input field padding */
@@ -88,7 +86,6 @@ export const TouchInputField = forwardRef<
     isIndeterminate = false,
     textAlign = TYPOGRAPHY.textAlignLeft,
     size = 'small',
-    hasBackgroundError = false,
     borderRadius,
     padding,
     type,
@@ -153,7 +150,6 @@ export const TouchInputField = forwardRef<
                 : styles.input_field_medium,
               {
                 [styles.error]: hasError,
-                [styles.background_error]: hasBackgroundError,
               }
             )}
             onClick={() => {

--- a/components/src/molecules/TouchInputField/touchinputfield.module.css
+++ b/components/src/molecules/TouchInputField/touchinputfield.module.css
@@ -54,11 +54,6 @@
   background-color: var(--white);
 }
 
-.background_error {
-  border: none;
-  background-color: var(--red-30);
-}
-
 .error {
   border-color: var(--red-50);
 }

--- a/opentrons-ai-client/src/components/atoms/TextAreaField/index.tsx
+++ b/opentrons-ai-client/src/components/atoms/TextAreaField/index.tsx
@@ -83,8 +83,6 @@ export interface TextAreaFieldProps {
   showDeleteIcon?: boolean
   /** callback passed to optional delete icon onClick */
   onDelete?: () => void
-  /** if true, style the background of textarea field to error state */
-  hasBackgroundError?: boolean
   /** optional prop to override textarea field border radius */
   borderRadius?: string
   /** optional prop to override textarea field padding */
@@ -104,7 +102,6 @@ export const TextAreaField = forwardRef<
     tooltipText,
     tabIndex = 0,
     showDeleteIcon = false,
-    hasBackgroundError = false,
     onDelete,
     borderRadius,
     padding,
@@ -129,15 +126,11 @@ export const TextAreaField = forwardRef<
 
   const TEXTAREA_FIELD = css`
     display: flex;
-    background-color: ${hasBackgroundError ? COLORS.red30 : COLORS.white};
+    background-color: ${COLORS.white};
     border-radius: ${borderRadius ?? BORDERS.borderRadius4};
     padding: ${padding ?? SPACING.spacing8};
-    border: ${
-      hasBackgroundError
-        ? 'none'
-        : `1px ${BORDERS.styleSolid}
-        ${hasError ? COLORS.red50 : COLORS.grey50}`
-    };
+    border: 1px ${BORDERS.styleSolid}
+      ${hasError ? COLORS.red50 : COLORS.grey50};
     font-size: ${TYPOGRAPHY.fontSizeP};
     width: 100%;
     height: ${height};

--- a/opentrons-ai-client/src/components/atoms/TextAreaField/index.tsx
+++ b/opentrons-ai-client/src/components/atoms/TextAreaField/index.tsx
@@ -129,8 +129,7 @@ export const TextAreaField = forwardRef<
     background-color: ${COLORS.white};
     border-radius: ${borderRadius ?? BORDERS.borderRadius4};
     padding: ${padding ?? SPACING.spacing8};
-    border: 1px ${BORDERS.styleSolid}
-      ${hasError ? COLORS.red50 : COLORS.grey50};
+    border: 1px ${BORDERS.styleSolid} ${hasError ? COLORS.red50 : COLORS.grey50};
     font-size: ${TYPOGRAPHY.fontSizeP};
     width: 100%;
     height: ${height};


### PR DESCRIPTION
## Overview

Our text inputs have error states where they have a red border. In addition to that, they have a `hasBackgroundError` prop that makes the *background* red. `hasBackgroundError` isn't used anywhere, and, as far as I can see, it doesn't appear in the designs. This PR deletes it to simplify the implementation.

## Test Plan and Hands on Testing

None needed, just code review.

## Review requests

Do you know of any reason we should keep this?

## Risk assessment

Low.