### PR TITLE
fix(components): Fix double tab stops on InputField

### DIFF
--- a/components/src/molecules/InputField/index.tsx
+++ b/components/src/molecules/InputField/index.tsx
@@ -109,7 +109,6 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
       caption,
       type,
       onClick,
-      tabIndex = 0,
       isIndeterminate = false,
       textAlign = TYPOGRAPHY.textAlignLeft,
       size = 'small',
@@ -134,7 +133,7 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
     const value = (isIndeterminate ?? false) ? '' : (rawValue ?? '')
     const placeHolder = (isIndeterminate ?? false) ? '-' : rawPlaceholder
 
-    const INPUT_FIELD = css`
+    const INPUT_FIELD_CONTAINER_STYLE = css`
       background-color: ${COLORS.white};
       border-radius: ${
         borderRadius != null ? borderRadius : BORDERS.borderRadius4
@@ -145,10 +144,6 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
       font-size: ${TYPOGRAPHY.fontSizeP};
       width: 100%;
       height: ${size === 'small' ? '2rem' : '2.75rem'};
-
-      &:active:enabled {
-        border: 1px ${BORDERS.styleSolid} ${COLORS.blue50};
-      }
 
       & input {
         border-radius: inherit;
@@ -163,24 +158,22 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
         outline: none;
       }
 
-      &:hover {
-        border: 1px ${BORDERS.styleSolid}
-          ${hasError ? COLORS.red50 : COLORS.grey60};
+      /* Styles for the container when the inner input is in certain states. */
+      &:has(input:disabled) {
+        border: 1px ${BORDERS.styleSolid} ${COLORS.grey30};
       }
-
-      &:focus-visible {
-        border: 1px ${BORDERS.styleSolid} ${COLORS.grey55};
+      &:has(input:focus) {
+        border: 1px ${BORDERS.styleSolid}
+          ${hasError ? COLORS.red50 : COLORS.blue50};
+      }
+      &:has(input:focus-visible) {
         outline: 2px ${BORDERS.styleSolid} ${COLORS.blue50};
         outline-offset: 2px;
       }
 
-      &:focus-within {
+      &:hover {
         border: 1px ${BORDERS.styleSolid}
-          ${hasError ? COLORS.red50 : COLORS.blue50};
-      }
-
-      &:disabled {
-        border: 1px ${BORDERS.styleSolid} ${COLORS.grey30};
+          ${hasError ? COLORS.red50 : COLORS.grey60};
       }
 
       input[type='number']::-webkit-inner-spin-button,
@@ -246,8 +239,7 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(
             onClick={disabled === true ? undefined : onClick}
           >
             <Flex
-              tabIndex={tabIndex}
-              css={INPUT_FIELD}
+              css={INPUT_FIELD_CONTAINER_STYLE}
               alignItems={ALIGN_CENTER}
               onClick={() => {
                 internalRef.current?.focus()


### PR DESCRIPTION
## Overview

This closes AUTH-3152, half of AUTH-2937. See AUTH-2937 for details.

## Changelog

* Remove `tabindex` from the outer `<div>`, so it can't be focused anymore. Only the inner `<input>` is focusable now.
* Rewrite the CSS to give the outer `<div>` an outline based on whether the inner `<input>` is focused.
  * We need this to implement our desired `focus-visible` styling now that the outer `<div>` itself is no longer focusable.
  * Also, this fixes unrelated issues where some of the CSS rules were not doing anything because they were trying to select something like `div:disabled`, which is not possible. (Only inputs can be `:disabled`.)

## Test Plan and Hands on Testing

Test in Storybook:

* [x] Hitting Tab navigates directly to the input (you should be able to immediately type into it). Hitting Tab again navigates out of the input.
* [x] It looks as expected in its normal, disabled, and error states.
* [x] Hover states still look as expected.

## Review requests

Does this approach with `:has()` seem reasonable?

## Risk assessment

Low, given manual testing.
