### PR TITLE
chore(js): Upgrade jsdom 26 -> 29

### DIFF
--- a/app/src/atoms/Skeleton/__tests__/Skeleton.test.tsx
+++ b/app/src/atoms/Skeleton/__tests__/Skeleton.test.tsx
@@ -20,14 +20,14 @@ const render = (props: ComponentProps<typeof Skeleton>) => {
 describe('Skeleton', () => {
   it('renders Skeleton with correct dimensions/style', () => {
     const props = {
-      width: 'mockWidth',
-      height: 'mockHeight',
-      backgroundSize: 'mockBackgroundSize',
+      width: '10rem',
+      height: '2rem',
+      backgroundSize: '99rem',
     }
     render(props)
     const skeleton = screen.getByRole('status')
     expect(skeleton).toHaveStyle('animation: shimmer 2s infinite linear')
-    expect(skeleton).toHaveStyle(`width : ${props.width}`)
+    expect(skeleton).toHaveStyle(`width: ${props.width}`)
     expect(skeleton).toHaveStyle(`height: ${props.height}`)
     expect(skeleton).toHaveStyle(`background-size: ${props.backgroundSize}`)
   })

--- a/app/src/atoms/Skeleton/index.tsx
+++ b/app/src/atoms/Skeleton/index.tsx
@@ -14,7 +14,7 @@ export const Skeleton = (props: SkeletonProps): JSX.Element => {
   const SKELETON_STYLE = css`
     border-radius: ${borderRadius ?? BORDERS.borderRadius8};
     animation: shimmer 2s infinite linear;
-    background: linear-gradient(
+    background-image: linear-gradient(
       to right,
       ${COLORS.grey30} 1%,
       #e3e3e366 25%,

--- a/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/__tests__/CustomKeyboard.test.tsx
+++ b/app/src/atoms/SoftwareKeyboard/AlphanumericKeyboard/__tests__/CustomKeyboard.test.tsx
@@ -1,9 +1,9 @@
 import { useRef } from 'react'
+import { renderHook, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
-
-import { fireEvent, renderHook, screen } from '@testing-library/react'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 
@@ -60,7 +60,8 @@ describe('AlphanumericKeyboard', () => {
       expect(button).toHaveTextContent(expectedName)
     })
   })
-  it('should render alphanumeric keyboard - upper case, when clicking ABC key', () => {
+  it('should render alphanumeric keyboard - upper case, when clicking ABC key', async () => {
+    const user = userEvent.setup()
     const { result } = renderHook(() => useRef(null))
     const props = {
       onChange: vi.fn(),
@@ -68,7 +69,7 @@ describe('AlphanumericKeyboard', () => {
     }
     render(props)
     const shiftKey = screen.getByRole('button', { name: 'ABC' })
-    fireEvent.click(shiftKey)
+    await user.click(shiftKey)
 
     const buttons = screen.getAllByRole('button')
     const expectedButtonNames = [
@@ -108,7 +109,8 @@ describe('AlphanumericKeyboard', () => {
     })
   })
 
-  it('should render alphanumeric keyboard - numbers, when clicking number key', () => {
+  it('should render alphanumeric keyboard - numbers, when clicking number key', async () => {
+    const user = userEvent.setup()
     const { result } = renderHook(() => useRef(null))
     const props = {
       onChange: vi.fn(),
@@ -116,7 +118,7 @@ describe('AlphanumericKeyboard', () => {
     }
     render(props)
     const numberKey = screen.getByRole('button', { name: '123' })
-    fireEvent.click(numberKey)
+    await user.click(numberKey)
     const buttons = screen.getAllByRole('button')
     const expectedButtonNames = [
       '1',
@@ -138,7 +140,8 @@ describe('AlphanumericKeyboard', () => {
     })
   })
 
-  it('should render alphanumeric keyboard - lower case when layout is numbers and clicking abc ', () => {
+  it('should render alphanumeric keyboard - lower case when layout is numbers and clicking abc ', async () => {
+    const user = userEvent.setup()
     const { result } = renderHook(() => useRef(null))
     const props = {
       onChange: vi.fn(),
@@ -146,9 +149,9 @@ describe('AlphanumericKeyboard', () => {
     }
     render(props)
     const numberKey = screen.getByRole('button', { name: '123' })
-    fireEvent.click(numberKey)
+    await user.click(numberKey)
     const abcKey = screen.getByRole('button', { name: 'abc' })
-    fireEvent.click(abcKey)
+    await user.click(abcKey)
     const buttons = screen.getAllByRole('button')
     const expectedButtonNames = [
       'q',
@@ -187,7 +190,8 @@ describe('AlphanumericKeyboard', () => {
     })
   })
 
-  it('should switch each alphanumeric keyboard properly', () => {
+  it('should switch each alphanumeric keyboard properly', async () => {
+    const user = userEvent.setup()
     const { result } = renderHook(() => useRef(null))
     const props = {
       onChange: vi.fn(),
@@ -196,15 +200,15 @@ describe('AlphanumericKeyboard', () => {
     render(props)
     // lower case keyboard -> upper case keyboard
     const ABCKey = screen.getByRole('button', { name: 'ABC' })
-    fireEvent.click(ABCKey)
+    await user.click(ABCKey)
     screen.getByRole('button', { name: 'A' })
     // upper case keyboard -> number keyboard
     const numberKey = screen.getByRole('button', { name: '123' })
-    fireEvent.click(numberKey)
+    await user.click(numberKey)
     screen.getByRole('button', { name: '1' })
     // number keyboard -> lower case keyboard
     const abcKey = screen.getByRole('button', { name: 'abc' })
-    fireEvent.click(abcKey)
+    await user.click(abcKey)
     screen.getByRole('button', { name: 'a' })
   })
 })

--- a/app/src/atoms/SoftwareKeyboard/FullKeyboard/__tests__/FullKeyboard.test.tsx
+++ b/app/src/atoms/SoftwareKeyboard/FullKeyboard/__tests__/FullKeyboard.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import '@testing-library/jest-dom/vitest'
 
 import { act, fireEvent, renderHook, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { getAppLanguage } from '/app/redux/config'
@@ -85,7 +86,8 @@ describe('FullKeyboard', () => {
     expectButtonsToBePresent(expectedButtonNames)
   })
 
-  it('should render full keyboard when hitting ABC key', () => {
+  it('should render full keyboard when hitting ABC key', async () => {
+    const user = userEvent.setup()
     const { result } = renderHook(() => useRef(null))
     const props = {
       onChange: vi.fn(),
@@ -93,7 +95,7 @@ describe('FullKeyboard', () => {
     }
     render(props)
     const shiftKey = screen.getByRole('button', { name: 'ABC' })
-    fireEvent.click(shiftKey)
+    await user.click(shiftKey)
     const expectedButtonNames = [
       'Q',
       'W',
@@ -132,7 +134,8 @@ describe('FullKeyboard', () => {
     expectButtonsToBePresent(expectedButtonNames)
   })
 
-  it('should render full keyboard when hitting 123 key', () => {
+  it('should render full keyboard when hitting 123 key', async () => {
+    const user = userEvent.setup()
     const { result } = renderHook(() => useRef(null))
     const props = {
       onChange: vi.fn(),
@@ -140,7 +143,7 @@ describe('FullKeyboard', () => {
     }
     render(props)
     const numberKey = screen.getByRole('button', { name: '123' })
-    fireEvent.click(numberKey)
+    await user.click(numberKey)
     const expectedButtonNames = [
       '1',
       '2',
@@ -180,7 +183,8 @@ describe('FullKeyboard', () => {
     expectButtonsToBePresent(expectedButtonNames)
   })
 
-  it('should render the software keyboards when hitting #+= key', () => {
+  it('should render the software keyboards when hitting #+= key', async () => {
+    const user = userEvent.setup()
     const { result } = renderHook(() => useRef(null))
     const props = {
       onChange: vi.fn(),
@@ -188,9 +192,9 @@ describe('FullKeyboard', () => {
     }
     render(props)
     const numberKey = screen.getByRole('button', { name: '123' })
-    fireEvent.click(numberKey)
+    await user.click(numberKey)
     const symbolKey = screen.getByRole('button', { name: '#+=' })
-    fireEvent.click(symbolKey)
+    await user.click(symbolKey)
     const expectedButtonNames = [
       '[',
       ']',
@@ -224,7 +228,8 @@ describe('FullKeyboard', () => {
     expectButtonsToBePresent(expectedButtonNames)
   })
 
-  it('should call mock function when clicking a key', () => {
+  it('should call mock function when clicking a key', async () => {
+    const user = userEvent.setup()
     const { result } = renderHook(() => useRef(null))
     const props = {
       onChange: vi.fn(),
@@ -232,7 +237,7 @@ describe('FullKeyboard', () => {
     }
     render(props)
     const aKey = screen.getByRole('button', { name: 'a' })
-    fireEvent.click(aKey)
+    await user.click(aKey)
     expect(props.onChange).toHaveBeenCalled()
   })
 

--- a/app/src/atoms/SoftwareKeyboard/FullKeyboard/__tests__/FullKeyboard.test.tsx
+++ b/app/src/atoms/SoftwareKeyboard/FullKeyboard/__tests__/FullKeyboard.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
 
-import { act, fireEvent, renderHook, screen } from '@testing-library/react'
+import { renderHook, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -257,9 +257,9 @@ describe('FullKeyboard', () => {
     ).toBeGreaterThan(0)
   })
 
-  it('should update labels when toggling keyboard language', () => {
-    vi.useFakeTimers()
+  it('should update labels when toggling keyboard language', async () => {
     vi.mocked(getAppLanguage).mockReturnValue('zh-CN')
+    const user = userEvent.setup()
     const { result } = renderHook(() => useRef(null))
     const props = {
       onChange: vi.fn(),
@@ -273,20 +273,19 @@ describe('FullKeyboard', () => {
       .find(button => button.className.includes('hg-globe'))
 
     expect(globeKey).toBeDefined()
-    fireEvent.click(globeKey!)
+    await user.click(globeKey!)
 
     expect(screen.getByRole('button', { name: 'English (US)' })).toBeDefined()
     expect(
       screen.getAllByRole('button', { name: 'return' }).length
     ).toBeGreaterThan(0)
 
-    act(() => {
-      vi.advanceTimersByTime(800)
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole('button', { name: 'space' }).length
+      ).toBeGreaterThan(0)
     })
 
-    expect(
-      screen.getAllByRole('button', { name: 'space' }).length
-    ).toBeGreaterThan(0)
     expect(
       screen.getAllByRole('button', { name: 'return' }).length
     ).toBeGreaterThan(0)

--- a/app/src/atoms/SoftwareKeyboard/IndividualKey/__tests__/IndividualKey.test.tsx
+++ b/app/src/atoms/SoftwareKeyboard/IndividualKey/__tests__/IndividualKey.test.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react'
-import { fireEvent, renderHook, screen } from '@testing-library/react'
+import { renderHook, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -24,7 +25,8 @@ describe('IndividualKey', () => {
     screen.getByRole('button', { name: 'mockKey' })
   })
 
-  it('should call mock function when clicking text key', () => {
+  it('should call mock function when clicking text key', async () => {
+    const user = userEvent.setup()
     const { result } = renderHook(() => useRef(null))
     const props = {
       onChange: vi.fn(),
@@ -33,7 +35,7 @@ describe('IndividualKey', () => {
     }
     render(props)
     const textKey = screen.getByRole('button', { name: 'mockKey' })
-    fireEvent.click(textKey)
+    await user.click(textKey)
     expect(props.onChange).toHaveBeenCalled()
   })
 })

--- a/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/__tests__/NumericalKeyboard.test.tsx
+++ b/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/__tests__/NumericalKeyboard.test.tsx
@@ -1,9 +1,9 @@
 import { useRef } from 'react'
+import { renderHook, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
-
-import { fireEvent, renderHook, screen } from '@testing-library/react'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 
@@ -140,7 +140,8 @@ describe('NumericalKeyboard', () => {
     })
   })
 
-  it('should call mock function when clicking num key', () => {
+  it('should call mock function when clicking num key', async () => {
+    const user = userEvent.setup()
     const { result } = renderHook(() => useRef(null))
     const props = {
       onChange: vi.fn(),
@@ -150,11 +151,12 @@ describe('NumericalKeyboard', () => {
     }
     render(props)
     const numKey = screen.getByRole('button', { name: '1' })
-    fireEvent.click(numKey)
+    await user.click(numKey)
     expect(props.onChange).toHaveBeenCalled()
   })
 
-  it('should call mock function when clicking decimal point key', () => {
+  it('should call mock function when clicking decimal point key', async () => {
+    const user = userEvent.setup()
     const { result } = renderHook(() => useRef(null))
     const props = {
       onChange: vi.fn(),
@@ -164,11 +166,12 @@ describe('NumericalKeyboard', () => {
     }
     render(props)
     const numKey = screen.getByRole('button', { name: '.' })
-    fireEvent.click(numKey)
+    await user.click(numKey)
     expect(props.onChange).toHaveBeenCalled()
   })
 
-  it('should call mock function when clicking hyphen key', () => {
+  it('should call mock function when clicking hyphen key', async () => {
+    const user = userEvent.setup()
     const { result } = renderHook(() => useRef(null))
     const props = {
       onChange: vi.fn(),
@@ -178,7 +181,7 @@ describe('NumericalKeyboard', () => {
     }
     render(props)
     const numKey = screen.getByRole('button', { name: '-' })
-    fireEvent.click(numKey)
+    await user.click(numKey)
     expect(props.onChange).toHaveBeenCalled()
   })
 })

--- a/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/__tests__/StatelessNumericalKeyboard.test.tsx
+++ b/app/src/atoms/SoftwareKeyboard/NumericalKeyboard/__tests__/StatelessNumericalKeyboard.test.tsx
@@ -1,8 +1,8 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
-
-import { fireEvent, screen } from '@testing-library/react'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 
@@ -135,7 +135,8 @@ describe('StatelessNumericalKeyboard', () => {
     })
   })
 
-  it('should emit the next value when clicking a number key', () => {
+  it('should emit the next value when clicking a number key', async () => {
+    const user = userEvent.setup()
     const props = {
       value: '1',
       onChange: vi.fn(),
@@ -143,12 +144,13 @@ describe('StatelessNumericalKeyboard', () => {
       hasHyphen: false,
     }
     render(props)
-    fireEvent.click(screen.getByRole('button', { name: '2' }))
+    await user.click(screen.getByRole('button', { name: '2' }))
 
     expect(props.onChange).toHaveBeenCalledWith('12')
   })
 
-  it('should emit the next value when clicking a decimal point key', () => {
+  it('should emit the next value when clicking a decimal point key', async () => {
+    const user = userEvent.setup()
     const props = {
       value: '1',
       onChange: vi.fn(),
@@ -157,12 +159,13 @@ describe('StatelessNumericalKeyboard', () => {
     }
     render(props)
 
-    fireEvent.click(screen.getByRole('button', { name: '.' }))
+    await user.click(screen.getByRole('button', { name: '.' }))
 
     expect(props.onChange).toHaveBeenCalledWith('1.')
   })
 
-  it('should not accumulate duplicate decimal points', () => {
+  it('should not accumulate duplicate decimal points', async () => {
+    const user = userEvent.setup()
     const props = {
       value: '1.',
       onChange: vi.fn(),
@@ -171,12 +174,13 @@ describe('StatelessNumericalKeyboard', () => {
     }
     render(props)
 
-    fireEvent.click(screen.getByRole('button', { name: '.' }))
+    await user.click(screen.getByRole('button', { name: '.' }))
 
     expect(props.onChange).toHaveBeenCalledWith('1.')
   })
 
-  it('should emit the next value when clicking a hyphen key at the start', () => {
+  it('should emit the next value when clicking a hyphen key at the start', async () => {
+    const user = userEvent.setup()
     const props = {
       value: '',
       onChange: vi.fn(),
@@ -185,12 +189,13 @@ describe('StatelessNumericalKeyboard', () => {
     }
     render(props)
 
-    fireEvent.click(screen.getByRole('button', { name: '-' }))
+    await user.click(screen.getByRole('button', { name: '-' }))
 
     expect(props.onChange).toHaveBeenCalledWith('-')
   })
 
-  it('should ignore a hyphen key when the value is not empty', () => {
+  it('should ignore a hyphen key when the value is not empty', async () => {
+    const user = userEvent.setup()
     const props = {
       value: '1',
       onChange: vi.fn(),
@@ -199,12 +204,13 @@ describe('StatelessNumericalKeyboard', () => {
     }
     render(props)
 
-    fireEvent.click(screen.getByRole('button', { name: '-' }))
+    await user.click(screen.getByRole('button', { name: '-' }))
 
     expect(props.onChange).toHaveBeenCalledWith('1')
   })
 
-  it('should delete the last character when clicking del', () => {
+  it('should delete the last character when clicking del', async () => {
+    const user = userEvent.setup()
     const props = {
       value: '12',
       onChange: vi.fn(),
@@ -213,12 +219,13 @@ describe('StatelessNumericalKeyboard', () => {
     }
     render(props)
 
-    fireEvent.click(screen.getByRole('button', { name: 'del' }))
+    await user.click(screen.getByRole('button', { name: 'del' }))
 
     expect(props.onChange).toHaveBeenCalledWith('1')
   })
 
-  it('should call onKeyPress with the normalized key', () => {
+  it('should call onKeyPress with the normalized key', async () => {
+    const user = userEvent.setup()
     const props = {
       value: '12',
       onChange: vi.fn(),
@@ -228,7 +235,7 @@ describe('StatelessNumericalKeyboard', () => {
     }
     render(props)
 
-    fireEvent.click(screen.getByRole('button', { name: 'del' }))
+    await user.click(screen.getByRole('button', { name: 'del' }))
 
     expect(props.onKeyPress).toHaveBeenCalledWith('del')
   })

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/ChooseNumber.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/ChooseNumber.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import '@testing-library/jest-dom/vitest'
@@ -81,36 +82,40 @@ describe('ChooseNumber', () => {
     expect(screen.getByRole('button', { name: '-' })).toBeInTheDocument()
   })
 
-  it('should call mock function when tapping go back button', () => {
+  it('should call mock function when tapping go back button', async () => {
+    const user = userEvent.setup()
     render(props)
-    fireEvent.click(screen.getAllByRole('button')[0])
+    await user.click(screen.getAllByRole('button')[0])
     expect(mockHandleGoBack).toHaveBeenCalled()
   })
 
-  it('should render error message when inputting an out of range number', () => {
+  it('should render error message when inputting an out of range number', async () => {
+    const user = userEvent.setup()
     render(props)
     const numKey = screen.getByRole('button', { name: '1' })
-    fireEvent.click(numKey)
-    fireEvent.click(numKey)
+    await user.click(numKey)
+    await user.click(numKey)
     screen.getByText('Value must be between 1-10')
   })
 
-  it('should call mock snack bar function when inputting an out of range number', () => {
+  it('should call mock snack bar function when inputting an out of range number', async () => {
+    const user = userEvent.setup()
     render(props)
     const numKey = screen.getByRole('button', { name: '1' })
-    fireEvent.click(numKey)
-    fireEvent.click(numKey)
-    fireEvent.click(screen.getAllByRole('button')[0])
+    await user.click(numKey)
+    await user.click(numKey)
+    await user.click(screen.getAllByRole('button')[0])
     expect(mockMakeSnackbar).toHaveBeenCalledWith('Value must be in range')
   })
 
-  it('should delete external keyboard input with the numerical keyboard', () => {
+  it('should delete external keyboard input with the numerical keyboard', async () => {
+    const user = userEvent.setup()
     props = { ...props, parameter: mockFloatNumberParameterData }
     render(props)
     const input = screen.getByLabelText('EtoH Volume')
 
     fireEvent.change(input, { target: { value: '12' } })
-    fireEvent.click(screen.getByRole('button', { name: 'del' }))
+    await user.click(screen.getByRole('button', { name: 'del' }))
 
     expect(input).toHaveValue('1')
   })

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/AirGap.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/AirGap.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -41,18 +42,20 @@ describe('AirGap', () => {
     vi.resetAllMocks()
   })
 
-  it('renders text, buttons for air gap aspirate', () => {
+  it('renders text, buttons for air gap aspirate', async () => {
     render(props)
+    const user = userEvent.setup()
     screen.getByText('Air gap after aspirating')
     screen.getByText('Save')
     screen.getByText('Draw air into the tip after aspirating')
     screen.getByText('Enabled')
     screen.getByText('Disabled')
-    fireEvent.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Enabled'))
     screen.getByText('Continue')
   })
 
-  it('renders text, buttons for air gap dispense', () => {
+  it('renders text, buttons for air gap dispense', async () => {
+    const user = userEvent.setup()
     props.kind = 'dispense'
     render(props)
     screen.getByText('Air gap after dispensing')
@@ -60,36 +63,38 @@ describe('AirGap', () => {
     screen.getByText('Draw in air before moving to trash to dispose of tip')
     screen.getByText('Enabled')
     screen.getByText('Disabled')
-    fireEvent.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Enabled'))
     screen.getByText('Continue')
   })
 
-  it('renders text, buttons, input field, and keyboard for air gap aspirating', () => {
+  it('renders text, buttons, input field, and keyboard for air gap aspirating', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Air gap volume (µL)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: 'del' })
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByText('Save'))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByText('Save'))
     screen.getByText('Value must be between 0 to 9')
   })
 
-  it('should call dispatch when clicking save button aspirate', () => {
+  it('should call dispatch when clicking save button aspirate', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Air gap volume (µL)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: 'del' })
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByText('Save'))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByText('Save'))
     expect(props.dispatch).toHaveBeenCalledWith({
       type: 'SET_AIR_GAP_ASPIRATE',
       volume: 1,
@@ -102,18 +107,19 @@ describe('AirGap', () => {
     })
   })
 
-  it('should call dispatch when clicking save button dispense', () => {
+  it('should call dispatch when clicking save button dispense', async () => {
+    const user = userEvent.setup()
     props.kind = 'dispense'
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Air gap volume (µL)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: 'del' })
-    fireEvent.click(screen.getByRole('button', { name: '5' }))
-    fireEvent.click(screen.getByText('Save'))
+    await user.click(screen.getByRole('button', { name: '5' }))
+    await user.click(screen.getByText('Save'))
     expect(props.dispatch).toHaveBeenCalledWith({
       type: 'SET_AIR_GAP_DISPENSE',
       volume: 5,
@@ -126,9 +132,10 @@ describe('AirGap', () => {
     })
   })
 
-  it('should call mock function when clicking back button', () => {
+  it('should call mock function when clicking back button', async () => {
     render(props)
-    fireEvent.click(screen.getByTestId('ChildNavigation_Back_Button'))
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('ChildNavigation_Back_Button'))
     expect(props.onBack).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Blowout.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Blowout.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -207,37 +208,40 @@ describe('BlowOut', () => {
     vi.resetAllMocks()
   })
 
-  it('renders text, buttons for blowout fist screen', () => {
+  it('renders text, buttons for blowout fist screen', async () => {
     render(props)
+    const user = userEvent.setup()
     screen.getByText('Blowout after dispensing')
     screen.getByText('Save')
     screen.getByText('Blow extra air through the tip')
     screen.getByText('Enabled')
     screen.getByText('Disabled')
-    fireEvent.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Enabled'))
     screen.getByText('Continue')
   })
 
-  it('renders text, buttons for blowout second screen', () => {
+  it('renders text, buttons for blowout second screen', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Select blowout location')
     screen.getByText('Destination well')
     screen.getByText('Source well')
     screen.getByText('Trash bin in A3')
   })
 
-  it('renders text, buttons for blowout third screen', () => {
+  it('renders text, buttons for blowout third screen', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Select blowout location')
     screen.getByText('Destination well')
     screen.getByText('Source well')
     screen.getByText('Trash bin in A3')
-    fireEvent.click(screen.getByText('Source well'))
-    fireEvent.click(screen.getByText('Continue'))
+    await user.click(screen.getByText('Source well'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Blowout speed (µL/second)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
@@ -245,18 +249,19 @@ describe('BlowOut', () => {
     screen.getByRole('button', { name: 'del' })
   })
 
-  it('should call dispatch when clicking save button', () => {
+  it('should call dispatch when clicking save button', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Select blowout location')
     screen.getByText('Destination well')
     screen.getByText('Source well')
     screen.getByText('Trash bin in A3')
-    fireEvent.click(screen.getByText('Source well'))
-    fireEvent.click(screen.getByText('Continue'))
-    fireEvent.click(screen.getByRole('button', { name: '2' }))
-    fireEvent.click(screen.getByText('Save'))
+    await user.click(screen.getByText('Source well'))
+    await user.click(screen.getByText('Continue'))
+    await user.click(screen.getByRole('button', { name: '2' }))
+    await user.click(screen.getByText('Save'))
     expect(props.dispatch).toHaveBeenCalledWith({
       type: 'SET_BLOW_OUT',
       blowOutSettings: {
@@ -272,9 +277,10 @@ describe('BlowOut', () => {
     })
   })
 
-  it('should call mock function when clicking back button', () => {
+  it('should call mock function when clicking back button', async () => {
     render(props)
-    fireEvent.click(screen.getByTestId('ChildNavigation_Back_Button'))
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('ChildNavigation_Back_Button'))
     expect(props.onBack).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Delay.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Delay.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -41,18 +42,20 @@ describe('Delay', () => {
     vi.resetAllMocks()
   })
 
-  it('renders text, buttons for delay aspirate', () => {
+  it('renders text, buttons for delay aspirate', async () => {
     render(props)
+    const user = userEvent.setup()
     screen.getByText('Delay after aspirating')
     screen.getByText('Save')
     screen.getByText('Delay after each aspiration and air gap')
     screen.getByText('Enabled')
     screen.getByText('Disabled')
-    fireEvent.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Enabled'))
     screen.getByText('Continue')
   })
 
-  it('renders text, buttons for delay dispense', () => {
+  it('renders text, buttons for delay dispense', async () => {
+    const user = userEvent.setup()
     props.kind = 'dispense'
     render(props)
     screen.getByText('Delay before dispensing')
@@ -60,39 +63,41 @@ describe('Delay', () => {
     screen.getByText('Delay after each dispense')
     screen.getByText('Enabled')
     screen.getByText('Disabled')
-    fireEvent.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Enabled'))
     screen.getByText('Continue')
   })
 
-  it('renders text, buttons, input field, and keyboard for delay before aspirating - volume', () => {
+  it('renders text, buttons, input field, and keyboard for delay before aspirating - volume', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Delay duration (seconds)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: '.' })
     screen.getByRole('button', { name: 'del' })
-    fireEvent.click(screen.getByRole('button', { name: '0' }))
+    await user.click(screen.getByRole('button', { name: '0' }))
     screen.getByText('Value must be between 0.1 to 9999999999')
     screen.getByText('Save')
   })
 
-  it('should call dispatch when clicking save button', () => {
+  it('should call dispatch when clicking save button', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Delay duration (seconds)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: '.' })
     screen.getByRole('button', { name: 'del' })
-    fireEvent.click(screen.getByRole('button', { name: '0' }))
-    fireEvent.click(screen.getByRole('button', { name: '.' }))
-    fireEvent.click(screen.getByRole('button', { name: '2' }))
-    fireEvent.click(screen.getByText('Save'))
+    await user.click(screen.getByRole('button', { name: '0' }))
+    await user.click(screen.getByRole('button', { name: '.' }))
+    await user.click(screen.getByRole('button', { name: '2' }))
+    await user.click(screen.getByText('Save'))
     expect(props.dispatch).toHaveBeenCalledWith({
       type: 'SET_DELAY_ASPIRATE',
       delaySettings: {
@@ -106,9 +111,10 @@ describe('Delay', () => {
       },
     })
   })
-  it('should call mock function when clicking back button', () => {
+  it('should call mock function when clicking back button', async () => {
     render(props)
-    fireEvent.click(screen.getByTestId('ChildNavigation_Back_Button'))
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('ChildNavigation_Back_Button'))
     expect(props.onBack).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Mix.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Mix.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -41,18 +42,20 @@ describe('Mix', () => {
     vi.resetAllMocks()
   })
 
-  it('renders text, buttons for mix aspirate', () => {
+  it('renders text, buttons for mix aspirate', async () => {
     render(props)
+    const user = userEvent.setup()
     screen.getByText('Mix before aspirating')
     screen.getByText('Continue')
     screen.getByText('Aspirate and dispense repeatedly before main aspiration')
     screen.getByText('Enabled')
     screen.getByText('Disabled')
-    fireEvent.click(screen.getByText('Disabled'))
+    await user.click(screen.getByText('Disabled'))
     screen.getByText('Save')
   })
 
-  it('renders text, buttons for mix dispense', () => {
+  it('renders text, buttons for mix dispense', async () => {
+    const user = userEvent.setup()
     props.kind = 'dispense'
     render(props)
     screen.getByText('Mix after dispensing')
@@ -60,30 +63,32 @@ describe('Mix', () => {
     screen.getByText('Aspirate and dispense repeatedly before main aspiration')
     screen.getByText('Enabled')
     screen.getByText('Disabled')
-    fireEvent.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Enabled'))
     screen.getByText('Continue')
   })
 
-  it('renders text, buttons, input field, and keyboard for mix before aspirating - volume', () => {
+  it('renders text, buttons, input field, and keyboard for mix before aspirating - volume', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Mix volume (µL)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: 'del' })
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByText('Continue'))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Value must be between 1 to 10')
   })
 
-  it('renders text, buttons, input field, and keyboard for mix before aspirating - repetitions', () => {
+  it('renders text, buttons, input field, and keyboard for mix before aspirating - repetitions', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Mix repetitions')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
@@ -92,17 +97,18 @@ describe('Mix', () => {
     screen.getByText('Save')
   })
 
-  it('should call dispatch when clicking save button', () => {
+  it('should call dispatch when clicking save button', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Mix repetitions')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: 'del' })
-    fireEvent.click(screen.getByText('Save'))
+    await user.click(screen.getByText('Save'))
     expect(props.dispatch).toHaveBeenCalledWith({
       type: 'SET_MIX_ON_ASPIRATE',
       mixSettings: {
@@ -117,9 +123,10 @@ describe('Mix', () => {
       },
     })
   })
-  it('should call mock function when clicking back button', () => {
+  it('should call mock function when clicking back button', async () => {
     render(props)
-    fireEvent.click(screen.getByTestId('ChildNavigation_Back_Button'))
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('ChildNavigation_Back_Button'))
     expect(props.onBack).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/PushOut.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/PushOut.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -41,21 +42,23 @@ describe('PushOut', () => {
     vi.resetAllMocks()
   })
 
-  it('renders text, buttons for push out', () => {
+  it('renders text, buttons for push out', async () => {
     render(props)
+    const user = userEvent.setup()
     screen.getByText('Push out after dispensing')
     screen.getByText('Save')
     screen.getByText('Helps ensure all liquid leaves the tip')
     screen.getByText('Enabled')
     screen.getByText('Disabled')
-    fireEvent.click(screen.getByText('Disabled'))
+    await user.click(screen.getByText('Disabled'))
     screen.getByText('Save')
   })
 
-  it('renders text, button, and keyboard for push out volume', () => {
+  it('renders text, button, and keyboard for push out volume', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Push out volume (µL)')
     screen.getByText('Save')
     screen.getByRole('button', { name: '1' })
@@ -65,13 +68,14 @@ describe('PushOut', () => {
     screen.getByRole('button', { name: '.' })
   })
 
-  it('should call dispatch when clicking save button', () => {
+  it('should call dispatch when clicking save button', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByRole('button', { name: '0' }))
-    fireEvent.click(screen.getByText('Save'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByRole('button', { name: '0' }))
+    await user.click(screen.getByText('Save'))
     expect(props.dispatch).toHaveBeenCalledWith({
       type: 'SET_PUSH_OUT',
       pushOutSettings: {
@@ -85,9 +89,10 @@ describe('PushOut', () => {
       },
     })
   })
-  it('should call mock function when clicking back button', () => {
+  it('should call mock function when clicking back button', async () => {
     render(props)
-    fireEvent.click(screen.getByTestId('ChildNavigation_Back_Button'))
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('ChildNavigation_Back_Button'))
     expect(props.onBack).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Retract.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Retract.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -62,13 +63,14 @@ describe('Retract', () => {
     screen.getByRole('button', { name: 'del' })
   })
 
-  it('renders test, buttons, input field, and keyboard for retract after dispense - delay duration', () => {
+  it('renders test, buttons, input field, and keyboard for retract after dispense - delay duration', async () => {
+    const user = userEvent.setup()
     props.kind = 'dispense'
     render(props)
     screen.getByText('Retract after dispensing')
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByText('Continue'))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Continue')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
@@ -79,30 +81,32 @@ describe('Retract', () => {
     screen.getByText('Delay duration (seconds)')
   })
 
-  it('renders test, buttons, input field, and keyboard for retract after aspirating - position', () => {
+  it('renders test, buttons, input field, and keyboard for retract after aspirating - position', async () => {
     render({
       ...props,
       state: {
         retractAspirate: { positionReference: 'well-bottom', position: 0 },
       } as any,
     })
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Continue')
-    fireEvent.click(screen.getByRole('button', { name: '0' }))
-    fireEvent.click(screen.getByRole('button', { name: '.' }))
-    fireEvent.click(screen.getByRole('button', { name: '6' }))
-    fireEvent.click(screen.getByText('Continue'))
+    await user.click(screen.getByRole('button', { name: '0' }))
+    await user.click(screen.getByRole('button', { name: '.' }))
+    await user.click(screen.getByRole('button', { name: '6' }))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Distance from bottom of well (mm)')
     screen.getByText('Between 0 and 3 mm')
-    fireEvent.click(screen.getByRole('button', { name: '2' }))
-    fireEvent.click(screen.getByRole('button', { name: '2' }))
-    fireEvent.click(screen.getByRole('button', { name: '2' }))
+    await user.click(screen.getByRole('button', { name: '2' }))
+    await user.click(screen.getByRole('button', { name: '2' }))
+    await user.click(screen.getByRole('button', { name: '2' }))
     screen.getByText('Value must be between 0 to 3')
     screen.getByText('Save')
   })
-  it('calls dispatch with correct action and settings when save is clicked', () => {
+  it('calls dispatch with correct action and settings when save is clicked', async () => {
+    const user = userEvent.setup()
     props.state.retractAspirate = {
       speed: 0,
       delayDuration: 0,
@@ -110,16 +114,16 @@ describe('Retract', () => {
       positionReference: 'well-bottom',
     }
     render(props)
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByText('Continue'))
-    fireEvent.click(screen.getByRole('button', { name: '0' }))
-    fireEvent.click(screen.getByRole('button', { name: '.' }))
-    fireEvent.click(screen.getByRole('button', { name: '5' }))
-    fireEvent.click(screen.getByText('Continue'))
-    fireEvent.click(screen.getByRole('button', { name: '2' }))
-    fireEvent.click(screen.getByRole('button', { name: '2' }))
-    fireEvent.click(screen.getByText('Save'))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByText('Continue'))
+    await user.click(screen.getByRole('button', { name: '0' }))
+    await user.click(screen.getByRole('button', { name: '.' }))
+    await user.click(screen.getByRole('button', { name: '5' }))
+    await user.click(screen.getByText('Continue'))
+    await user.click(screen.getByRole('button', { name: '2' }))
+    await user.click(screen.getByRole('button', { name: '2' }))
+    await user.click(screen.getByText('Save'))
     expect(props.dispatch).toHaveBeenCalledWith({
       type: 'SET_RETRACT_ASPIRATE',
       retractSettings: {
@@ -131,9 +135,10 @@ describe('Retract', () => {
     })
   })
 
-  it('should call mock function when clicking back button', () => {
+  it('should call mock function when clicking back button', async () => {
     render(props)
-    fireEvent.click(screen.getByTestId('ChildNavigation_Back_Button'))
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('ChildNavigation_Back_Button'))
     expect(props.onBack).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Submerge.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/Submerge.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -52,11 +53,12 @@ describe('Submerge', () => {
     screen.getByRole('button', { name: 'del' })
   })
 
-  it('renders text, buttons, input field, and keyboard for submerge before aspirating - delay duration', () => {
+  it('renders text, buttons, input field, and keyboard for submerge before aspirating - delay duration', async () => {
     render(props)
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Continue')
     screen.getByText('Delay duration (seconds)')
     screen.getByRole('button', { name: '1' })
@@ -66,16 +68,17 @@ describe('Submerge', () => {
     screen.getByRole('button', { name: '.' })
   })
 
-  it('renders text, buttons, input field, and keyboard for submerge before aspirating - position', () => {
+  it('renders text, buttons, input field, and keyboard for submerge before aspirating - position', async () => {
     render({
       ...props,
       state: {
         submergeAspirate: { positionReference: 'well-bottom', position: 0 },
       } as any,
     })
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Continue')
     screen.getByText('Delay duration (seconds)')
     screen.getByRole('button', { name: '1' })
@@ -83,20 +86,21 @@ describe('Submerge', () => {
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: 'del' })
     screen.getByRole('button', { name: '.' })
-    fireEvent.click(screen.getByRole('button', { name: '0' }))
-    fireEvent.click(screen.getByRole('button', { name: '.' }))
-    fireEvent.click(screen.getByRole('button', { name: '5' }))
-    fireEvent.click(screen.getByText('Continue'))
+    await user.click(screen.getByRole('button', { name: '0' }))
+    await user.click(screen.getByRole('button', { name: '.' }))
+    await user.click(screen.getByRole('button', { name: '5' }))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Save')
     screen.getByText('Distance from bottom of well (mm)')
     screen.getByText('Between 0 and 3 mm')
-    fireEvent.click(screen.getByRole('button', { name: '2' }))
-    fireEvent.click(screen.getByRole('button', { name: '2' }))
-    fireEvent.click(screen.getByRole('button', { name: '2' }))
+    await user.click(screen.getByRole('button', { name: '2' }))
+    await user.click(screen.getByRole('button', { name: '2' }))
+    await user.click(screen.getByRole('button', { name: '2' }))
     screen.getByText('Value must be between 0 to 3')
   })
 
-  it('should call dispatch when clicking save button', () => {
+  it('should call dispatch when clicking save button', async () => {
+    const user = userEvent.setup()
     props.state.submergeAspirate = {
       speed: 0,
       delayDuration: 0,
@@ -104,16 +108,16 @@ describe('Submerge', () => {
       positionReference: 'well-top',
     }
     render(props)
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByText('Continue'))
-    fireEvent.click(screen.getByRole('button', { name: '0' }))
-    fireEvent.click(screen.getByRole('button', { name: '.' }))
-    fireEvent.click(screen.getByRole('button', { name: '5' }))
-    fireEvent.click(screen.getByText('Continue'))
-    fireEvent.click(screen.getByRole('button', { name: '2' }))
-    fireEvent.click(screen.getByRole('button', { name: '2' }))
-    fireEvent.click(screen.getByText('Save'))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByText('Continue'))
+    await user.click(screen.getByRole('button', { name: '0' }))
+    await user.click(screen.getByRole('button', { name: '.' }))
+    await user.click(screen.getByRole('button', { name: '5' }))
+    await user.click(screen.getByText('Continue'))
+    await user.click(screen.getByRole('button', { name: '2' }))
+    await user.click(screen.getByRole('button', { name: '2' }))
+    await user.click(screen.getByText('Save'))
     expect(props.dispatch).toHaveBeenCalledWith({
       type: 'SET_SUBMERGE_ASPIRATE',
       submergeSettings: {
@@ -124,9 +128,10 @@ describe('Submerge', () => {
       },
     })
   })
-  it('should call mock function when clicking back button', () => {
+  it('should call mock function when clicking back button', async () => {
     render(props)
-    fireEvent.click(screen.getByTestId('ChildNavigation_Back_Button'))
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('ChildNavigation_Back_Button'))
     expect(props.onBack).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/TouchTip.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/QuickTransferAdvancedSettings/__tests__/TouchTip.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -41,18 +42,20 @@ describe('TouchTip', () => {
     vi.resetAllMocks()
   })
 
-  it('renders text, buttons for touch tip aspirate', () => {
+  it('renders text, buttons for touch tip aspirate', async () => {
     render(props)
+    const user = userEvent.setup()
     screen.getByText('Touch tip after aspirating')
     screen.getByText('Save')
     screen.getByText('Touch tip to each side of the well after aspirating')
     screen.getByText('Enabled')
     screen.getByText('Disabled')
-    fireEvent.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Enabled'))
     screen.getByText('Continue')
   })
 
-  it('renders text, buttons for touch tip dispense', () => {
+  it('renders text, buttons for touch tip dispense', async () => {
+    const user = userEvent.setup()
     props.kind = 'dispense'
     render(props)
     screen.getByText('Touch tip after dispensing')
@@ -60,14 +63,15 @@ describe('TouchTip', () => {
     screen.getByText('Touch tip to each side of the well after dispensing')
     screen.getByText('Enabled')
     screen.getByText('Disabled')
-    fireEvent.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Enabled'))
     screen.getByText('Continue')
   })
 
-  it('renders text, buttons for touch tip speed - aspirate', () => {
+  it('renders text, buttons for touch tip speed - aspirate', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Speed (mm/second)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
@@ -76,57 +80,60 @@ describe('TouchTip', () => {
     screen.getByText('Continue')
   })
 
-  it('renders text, buttons, input field, and keyboard for touch tip - aspirate', () => {
+  it('renders text, buttons, input field, and keyboard for touch tip - aspirate', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Speed (mm/second)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: 'del' })
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByRole('button', { name: '1' }))
   })
 
-  it('renders text, buttons, input field, and keyboard for touch tip position- aspirate', () => {
+  it('renders text, buttons, input field, and keyboard for touch tip position- aspirate', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Speed (mm/second)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: 'del' })
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByText('Continue'))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Touch tip position from top of well (mm)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: 'del' })
-    fireEvent.click(screen.getByRole('button', { name: '0' }))
+    await user.click(screen.getByRole('button', { name: '0' }))
   })
 
-  it('should call dispatch when clicking save button - aspirate', () => {
+  it('should call dispatch when clicking save button - aspirate', async () => {
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    const user = userEvent.setup()
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Speed (mm/second)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: 'del' })
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByText('Continue'))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Touch tip position from top of well (mm)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: 'del' })
-    fireEvent.click(screen.getByRole('button', { name: '0' }))
-    fireEvent.click(screen.getByText('Save'))
+    await user.click(screen.getByRole('button', { name: '0' }))
+    await user.click(screen.getByText('Save'))
     expect(props.dispatch).toHaveBeenCalledWith({
       type: 'SET_TOUCH_TIP_ASPIRATE',
       position: 0,
@@ -140,25 +147,26 @@ describe('TouchTip', () => {
     })
   })
 
-  it('should call dispatch when clicking save button - dispense', () => {
+  it('should call dispatch when clicking save button - dispense', async () => {
+    const user = userEvent.setup()
     props.kind = 'dispense'
     render(props)
-    fireEvent.click(screen.getByText('Enabled'))
-    fireEvent.click(screen.getByText('Continue'))
+    await user.click(screen.getByText('Enabled'))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Speed (mm/second)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: 'del' })
-    fireEvent.click(screen.getByRole('button', { name: '1' }))
-    fireEvent.click(screen.getByText('Continue'))
+    await user.click(screen.getByRole('button', { name: '1' }))
+    await user.click(screen.getByText('Continue'))
     screen.getByText('Touch tip position from top of well (mm)')
     screen.getByRole('button', { name: '1' })
     screen.getByRole('button', { name: '5' })
     screen.getByRole('button', { name: '9' })
     screen.getByRole('button', { name: 'del' })
-    fireEvent.click(screen.getByRole('button', { name: '0' }))
-    fireEvent.click(screen.getByText('Save'))
+    await user.click(screen.getByRole('button', { name: '0' }))
+    await user.click(screen.getByText('Save'))
     expect(props.dispatch).toHaveBeenCalledWith({
       type: 'SET_TOUCH_TIP_DISPENSE',
       position: 0,
@@ -172,9 +180,10 @@ describe('TouchTip', () => {
     })
   })
 
-  it('should call mock function when clicking back button', () => {
+  it('should call mock function when clicking back button', async () => {
     render(props)
-    fireEvent.click(screen.getByTestId('ChildNavigation_Back_Button'))
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('ChildNavigation_Back_Button'))
     expect(props.onBack).toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/NameQuickTransfer.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/NameQuickTransfer.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -46,22 +47,24 @@ describe('NameQuickTransfer', () => {
     screen.getByText('Enter up to 60 characters')
   })
 
-  it('renders the keyboard buttons and enables save if you press one', () => {
+  it('renders the keyboard buttons and enables save if you press one', async () => {
+    const user = userEvent.setup()
     render(props)
     const wKey = screen.getByText('w')
-    fireEvent.click(wKey)
+    await user.click(wKey)
     const saveBtn = screen.getByTestId('ChildNavigation_Primary_Button')
     expect(saveBtn).toBeEnabled()
-    fireEvent.click(saveBtn)
+    await user.click(saveBtn)
     expect(props.onSave).toHaveBeenCalled()
     expect(saveBtn).toBeDisabled()
   })
 
-  it('disables save if you enter more than 60 characters', () => {
+  it('disables save if you enter more than 60 characters', async () => {
+    const user = userEvent.setup()
     render(props)
     const wKey = screen.getByText('w')
     for (let i = 0; i < 61; i++) {
-      fireEvent.click(wKey)
+      await user.click(wKey)
     }
     const saveBtn = screen.getByTestId('ChildNavigation_Primary_Button')
     expect(saveBtn).toBeDisabled()

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/AirGap.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/AirGap.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TouchInputField } from '@opentrons/components'
@@ -77,23 +78,25 @@ describe('AirGap', () => {
     vi.resetAllMocks()
   })
 
-  it('renders the first air gap screen, continue, and back buttons', () => {
+  it('renders the first air gap screen, continue, and back buttons', async () => {
     render(props)
+    const user = userEvent.setup()
     screen.getByText('Air gap after aspirating')
     screen.getByTestId('ChildNavigation_Primary_Button')
     screen.getByText('Enabled')
     screen.getByText('Disabled')
     const exitBtn = screen.getByTestId('ChildNavigation_Back_Button')
-    fireEvent.click(exitBtn)
+    await user.click(exitBtn)
     expect(props.onBack).toHaveBeenCalled()
   })
 
-  it('renders save button if you select enabled, then moves to second screen', () => {
+  it('renders save button if you select enabled, then moves to second screen', async () => {
     render(props)
+    const user = userEvent.setup()
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -108,25 +111,27 @@ describe('AirGap', () => {
     )
   })
 
-  it('calls dispatch button if you select disabled and save', () => {
+  it('calls dispatch button if you select disabled and save', async () => {
     render(props)
+    const user = userEvent.setup()
     const disabledBtn = screen.getByText('Disabled')
-    fireEvent.click(disabledBtn)
+    await user.click(disabledBtn)
     const saveBtn = screen.getByText('Save')
-    fireEvent.click(saveBtn)
+    await user.click(saveBtn)
     expect(props.dispatch).toHaveBeenCalled()
     expect(mockTrackEventWithRobotSerial).toHaveBeenCalled()
   })
 
-  it('has correct range for aspirate with a single pipette path', () => {
+  it('has correct range for aspirate with a single pipette path', async () => {
     render(props)
+    const user = userEvent.setup()
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
-    fireEvent.click(screen.getByText('2'))
-    fireEvent.click(screen.getByText('0'))
-    fireEvent.click(screen.getByText('0'))
+    await user.click(continueBtn)
+    await user.click(screen.getByText('2'))
+    await user.click(screen.getByText('0'))
+    await user.click(screen.getByText('0'))
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -143,7 +148,8 @@ describe('AirGap', () => {
     expect(saveBtn).toBeDisabled()
   })
 
-  it('has correct range for aspirate with a multiAspirate pipette path', () => {
+  it('has correct range for aspirate with a multiAspirate pipette path', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       state: {
@@ -153,11 +159,11 @@ describe('AirGap', () => {
     }
     render(props)
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const numButton = screen.getByText('0')
-    fireEvent.click(numButton)
+    await user.click(numButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -172,7 +178,8 @@ describe('AirGap', () => {
     )
   })
 
-  it('has correct range for aspirate with a multiDispense pipette path', () => {
+  it('has correct range for aspirate with a multiDispense pipette path', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       state: {
@@ -182,11 +189,11 @@ describe('AirGap', () => {
     }
     render(props)
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const numButton = screen.getByText('0')
-    fireEvent.click(numButton)
+    await user.click(numButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -201,7 +208,8 @@ describe('AirGap', () => {
     )
   })
 
-  it('has correct range for and text for a dispense', () => {
+  it('has correct range for and text for a dispense', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       kind: 'dispense',
@@ -209,11 +217,11 @@ describe('AirGap', () => {
     render(props)
     screen.getByText('Air gap after dispensing')
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const numButton = screen.getByText('0')
-    fireEvent.click(numButton)
+    await user.click(numButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -228,21 +236,23 @@ describe('AirGap', () => {
     )
   })
 
-  it('calls dispatch when an in range value is entered and saved', () => {
+  it('calls dispatch when an in range value is entered and saved', async () => {
     render(props)
+    const user = userEvent.setup()
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const numButton = screen.getByText('1')
-    fireEvent.click(numButton)
+    await user.click(numButton)
     const saveBtn = screen.getByText('Save')
-    fireEvent.click(saveBtn)
+    await user.click(saveBtn)
     expect(props.dispatch).toHaveBeenCalled()
     expect(mockTrackEventWithRobotSerial).toHaveBeenCalled()
   })
 
-  it('persists existing values if they are in state for aspirate', () => {
+  it('persists existing values if they are in state for aspirate', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       state: {
@@ -252,7 +262,7 @@ describe('AirGap', () => {
     }
     render(props)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -267,7 +277,8 @@ describe('AirGap', () => {
     )
   })
 
-  it('persists existing values if they are in state for dispense', () => {
+  it('persists existing values if they are in state for dispense', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       kind: 'dispense',
@@ -279,7 +290,7 @@ describe('AirGap', () => {
     }
     render(props)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Delay.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Delay.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TouchInputField } from '@opentrons/components'
@@ -83,23 +84,25 @@ describe('Delay', () => {
     vi.resetAllMocks()
   })
 
-  it('renders the first delay screen, continue, and back buttons', () => {
+  it('renders the first delay screen, continue, and back buttons', async () => {
     render(props)
+    const user = userEvent.setup()
     screen.getByText('Delay after aspirating')
     screen.getByTestId('ChildNavigation_Primary_Button')
     screen.getByText('Enabled')
     screen.getByText('Disabled')
     const exitBtn = screen.getByTestId('ChildNavigation_Back_Button')
-    fireEvent.click(exitBtn)
+    await user.click(exitBtn)
     expect(props.onBack).toHaveBeenCalled()
   })
 
-  it('renders save button if you select enabled, then moves to second screen', () => {
+  it('renders save button if you select enabled, then moves to second screen', async () => {
     render(props)
+    const user = userEvent.setup()
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -114,24 +117,26 @@ describe('Delay', () => {
     )
   })
 
-  it('calls dispatch button if you select disabled and save', () => {
+  it('calls dispatch button if you select disabled and save', async () => {
     render(props)
+    const user = userEvent.setup()
     const disabledBtn = screen.getByText('Disabled')
-    fireEvent.click(disabledBtn)
+    await user.click(disabledBtn)
     const saveBtn = screen.getByText('Save')
-    fireEvent.click(saveBtn)
+    await user.click(saveBtn)
     expect(props.dispatch).toHaveBeenCalled()
     expect(mockTrackEventWithRobotSerial).toHaveBeenCalled()
   })
 
-  it('has correct delay duration range', () => {
+  it('has correct delay duration range', async () => {
     render(props)
+    const user = userEvent.setup()
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const oneButton = screen.getByText('0')
-    fireEvent.click(oneButton)
+    await user.click(oneButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -148,25 +153,27 @@ describe('Delay', () => {
     expect(nextBtn).toBeDisabled()
   })
 
-  it('calls dispatch when an in range value is entered and saved', () => {
+  it('calls dispatch when an in range value is entered and saved', async () => {
     render(props)
+    const user = userEvent.setup()
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const oneButton = screen.getByText('1')
-    fireEvent.click(oneButton)
+    await user.click(oneButton)
     const nextBtn = screen.getByTestId('ChildNavigation_Primary_Button')
-    fireEvent.click(nextBtn)
+    await user.click(nextBtn)
     const twoButton = screen.getByText('2')
-    fireEvent.click(twoButton)
+    await user.click(twoButton)
     const saveBtn = screen.getByText('Save')
-    fireEvent.click(saveBtn)
+    await user.click(saveBtn)
     expect(props.dispatch).toHaveBeenCalled()
     expect(mockTrackEventWithRobotSerial).toHaveBeenCalled()
   })
 
-  it('persists previously set value saved in state for aspirate', () => {
+  it('persists previously set value saved in state for aspirate', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       state: {
@@ -178,7 +185,7 @@ describe('Delay', () => {
     }
     render(props)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -193,7 +200,8 @@ describe('Delay', () => {
     )
   })
 
-  it('persists previously set value saved in state for dispense', () => {
+  it('persists previously set value saved in state for dispense', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       kind: 'dispense',
@@ -206,7 +214,7 @@ describe('Delay', () => {
     }
     render(props)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/FlowRate.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/FlowRate.test.tsx
@@ -1,4 +1,5 @@
-import { act, fireEvent, screen } from '@testing-library/react'
+import { act, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TouchInputField } from '@opentrons/components'
@@ -104,8 +105,9 @@ describe('FlowRate', () => {
     vi.resetAllMocks()
   })
 
-  it('renders the flow rate aspirate screen, continue, and back buttons', () => {
+  it('renders the flow rate aspirate screen, continue, and back buttons', async () => {
     render(props)
+    const user = userEvent.setup()
     screen.getByText('Aspirate flow rate')
     screen.getByTestId('ChildNavigation_Primary_Button')
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
@@ -121,7 +123,7 @@ describe('FlowRate', () => {
       {}
     )
     const exitBtn = screen.getByTestId('ChildNavigation_Back_Button')
-    fireEvent.click(exitBtn)
+    await user.click(exitBtn)
     expect(props.onBack).toHaveBeenCalled()
   })
 
@@ -146,11 +148,12 @@ describe('FlowRate', () => {
     )
   })
 
-  it('renders correct range if you enter incorrect value', () => {
+  it('renders correct range if you enter incorrect value', async () => {
     render(props)
+    const user = userEvent.setup()
     const deleteBtn = screen.getByText('del')
-    fireEvent.click(deleteBtn)
-    fireEvent.click(deleteBtn)
+    await user.click(deleteBtn)
+    await user.click(deleteBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -167,24 +170,26 @@ describe('FlowRate', () => {
     expect(saveBtn).toBeDisabled()
   })
 
-  it('calls dispatch when an in range value is entered and saved', () => {
+  it('calls dispatch when an in range value is entered and saved', async () => {
     render(props)
+    const user = userEvent.setup()
     const deleteBtn = screen.getByText('del')
-    fireEvent.click(deleteBtn)
-    fireEvent.click(deleteBtn)
+    await user.click(deleteBtn)
+    await user.click(deleteBtn)
     const numButton = screen.getByText('1')
-    fireEvent.click(numButton)
+    await user.click(numButton)
     const saveBtn = screen.getByText('Save')
-    fireEvent.click(saveBtn)
+    await user.click(saveBtn)
     expect(props.dispatch).toHaveBeenCalled()
     expect(mockTrackEventWithRobotSerial).toHaveBeenCalled()
   })
 
-  it('deletes external keyboard input with the stateless numerical keyboard', () => {
+  it('deletes external keyboard input with the stateless numerical keyboard', async () => {
     render(props)
+    const user = userEvent.setup()
 
     changeTouchInputValue('12')
-    fireEvent.click(screen.getByText('del'))
+    await user.click(screen.getByText('del'))
 
     expect(getLastTouchInputFieldProps()).toEqual(
       expect.objectContaining({

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Mix.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/Mix.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TouchInputField } from '@opentrons/components'
@@ -74,14 +75,15 @@ describe('Mix', () => {
     vi.resetAllMocks()
   })
 
-  it('renders the first Mix screen, continue, and back buttons', () => {
+  it('renders the first Mix screen, continue, and back buttons', async () => {
     render(props)
+    const user = userEvent.setup()
     screen.getByText('Mix before aspirating')
     screen.getByTestId('ChildNavigation_Primary_Button')
     screen.getByText('Enabled')
     screen.getByText('Disabled')
     const exitBtn = screen.getByTestId('ChildNavigation_Back_Button')
-    fireEvent.click(exitBtn)
+    await user.click(exitBtn)
     expect(props.onBack).toHaveBeenCalled()
   })
 
@@ -94,12 +96,13 @@ describe('Mix', () => {
     screen.getByText('Mix after dispensing')
   })
 
-  it('renders save button if you select enabled, then moves to second screen', () => {
+  it('renders save button if you select enabled, then moves to second screen', async () => {
     render(props)
+    const user = userEvent.setup()
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -114,24 +117,26 @@ describe('Mix', () => {
     )
   })
 
-  it('calls dispatch button if you select disabled and save', () => {
+  it('calls dispatch button if you select disabled and save', async () => {
     render(props)
+    const user = userEvent.setup()
     const disabledBtn = screen.getByText('Disabled')
-    fireEvent.click(disabledBtn)
+    await user.click(disabledBtn)
     const saveBtn = screen.getByText('Save')
-    fireEvent.click(saveBtn)
+    await user.click(saveBtn)
     expect(props.dispatch).toHaveBeenCalled()
     expect(mockTrackEventWithRobotSerial).toHaveBeenCalled()
   })
 
-  it('has correct Mix volume range', () => {
+  it('has correct Mix volume range', async () => {
     render(props)
+    const user = userEvent.setup()
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const oneButton = screen.getByText('0')
-    fireEvent.click(oneButton)
+    await user.click(oneButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -148,18 +153,19 @@ describe('Mix', () => {
     expect(nextBtn).toBeDisabled()
   })
 
-  it('has correct range for Mix repitition range', () => {
+  it('has correct range for Mix repitition range', async () => {
     render(props)
+    const user = userEvent.setup()
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const oneButton = screen.getByText('1')
-    fireEvent.click(oneButton)
+    await user.click(oneButton)
     const nextBtn = screen.getByTestId('ChildNavigation_Primary_Button')
-    fireEvent.click(nextBtn)
+    await user.click(nextBtn)
     const zeroButton = screen.getByText('0')
-    fireEvent.click(zeroButton)
+    await user.click(zeroButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -176,25 +182,27 @@ describe('Mix', () => {
     expect(saveBtn).toBeDisabled()
   })
 
-  it('calls dispatch when an in range value is entered and saved', () => {
+  it('calls dispatch when an in range value is entered and saved', async () => {
     render(props)
+    const user = userEvent.setup()
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const oneButton = screen.getByText('1')
-    fireEvent.click(oneButton)
+    await user.click(oneButton)
     const nextBtn = screen.getByTestId('ChildNavigation_Primary_Button')
-    fireEvent.click(nextBtn)
+    await user.click(nextBtn)
     const twoButton = screen.getByText('2')
-    fireEvent.click(twoButton)
+    await user.click(twoButton)
     const saveBtn = screen.getByText('Save')
-    fireEvent.click(saveBtn)
+    await user.click(saveBtn)
     expect(props.dispatch).toHaveBeenCalled()
     expect(mockTrackEventWithRobotSerial).toHaveBeenCalled()
   })
 
-  it('persists previously set value saved in state for aspirate', () => {
+  it('persists previously set value saved in state for aspirate', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       state: {
@@ -207,7 +215,7 @@ describe('Mix', () => {
     }
     render(props)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -220,7 +228,7 @@ describe('Mix', () => {
       },
       {}
     )
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -235,7 +243,8 @@ describe('Mix', () => {
     )
   })
 
-  it('persists previously set value saved in state for dispense', () => {
+  it('persists previously set value saved in state for dispense', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       kind: 'dispense',
@@ -249,7 +258,7 @@ describe('Mix', () => {
     }
     render(props)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -262,7 +271,7 @@ describe('Mix', () => {
       },
       {}
     )
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/PipettePath.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/PipettePath.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TouchInputField } from '@opentrons/components'
@@ -79,26 +80,29 @@ describe('PipettePath', () => {
     vi.resetAllMocks()
   })
 
-  it('renders the first pipette path screen, continue, back buttons', () => {
+  it('renders the first pipette path screen, continue, back buttons', async () => {
     render(props)
+    const user = userEvent.setup()
     screen.getByText('Pipette path')
     screen.getByTestId('ChildNavigation_Primary_Button')
     const exitBtn = screen.getByTestId('ChildNavigation_Back_Button')
-    fireEvent.click(exitBtn)
+    await user.click(exitBtn)
     expect(props.onBack).toHaveBeenCalled()
   })
 
-  it('renders multi aspirate and single options for consolidate if there is room in the tip', () => {
+  it('renders multi aspirate and single options for consolidate if there is room in the tip', async () => {
     render(props)
+    const user = userEvent.setup()
     screen.getByText('Single transfers')
     screen.getByText('Multi-aspirate')
     const saveBtn = screen.getByTestId('ChildNavigation_Primary_Button')
-    fireEvent.click(saveBtn)
+    await user.click(saveBtn)
     expect(props.dispatch).toHaveBeenCalled()
     expect(mockTrackEventWithRobotSerial).toHaveBeenCalled()
   })
 
-  it('renders single option only for consolidate if there is not room in the tip', () => {
+  it('renders single option only for consolidate if there is not room in the tip', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       state: {
@@ -110,12 +114,13 @@ describe('PipettePath', () => {
     screen.getByText('Single transfers')
     expect(screen.queryByText('Multi-aspirate')).not.toBeInTheDocument()
     const saveBtn = screen.getByTestId('ChildNavigation_Primary_Button')
-    fireEvent.click(saveBtn)
+    await user.click(saveBtn)
     expect(props.dispatch).toHaveBeenCalled()
     expect(mockTrackEventWithRobotSerial).toHaveBeenCalled()
   })
 
-  it('renders multi dispense and single options for distribute if there is room in the tip', () => {
+  it('renders multi dispense and single options for distribute if there is room in the tip', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       state: {
@@ -127,12 +132,13 @@ describe('PipettePath', () => {
     screen.getByText('Single transfers')
     screen.getByText('Multi-dispense')
     const saveBtn = screen.getByTestId('ChildNavigation_Primary_Button')
-    fireEvent.click(saveBtn)
+    await user.click(saveBtn)
     expect(props.dispatch).toHaveBeenCalled()
     expect(mockTrackEventWithRobotSerial).toHaveBeenCalled()
   })
 
-  it('renders single option only for distribute if there is not room in the tip', () => {
+  it('renders single option only for distribute if there is not room in the tip', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       state: {
@@ -145,12 +151,13 @@ describe('PipettePath', () => {
     screen.getByText('Single transfers')
     expect(screen.queryByText('Multi-dispense')).not.toBeInTheDocument()
     const saveBtn = screen.getByTestId('ChildNavigation_Primary_Button')
-    fireEvent.click(saveBtn)
+    await user.click(saveBtn)
     expect(props.dispatch).toHaveBeenCalled()
     expect(mockTrackEventWithRobotSerial).toHaveBeenCalled()
   })
 
-  it('renders next cta and disposal volume screen if you choose multi dispense', () => {
+  it('renders next cta and disposal volume screen if you choose multi dispense', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       state: {
@@ -166,9 +173,9 @@ describe('PipettePath', () => {
     }
     render(props)
     const multiDispenseBtn = screen.getByText('Multi-dispense')
-    fireEvent.click(multiDispenseBtn)
+    await user.click(multiDispenseBtn)
     const continueBtn = screen.getByTestId('ChildNavigation_Primary_Button')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
 
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
@@ -184,7 +191,8 @@ describe('PipettePath', () => {
     )
   })
 
-  it('renders error on disposal volume screen if you select an out of range value', () => {
+  it('renders error on disposal volume screen if you select an out of range value', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       state: {
@@ -200,9 +208,9 @@ describe('PipettePath', () => {
     }
     render(props)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const oneButton = screen.getByText('1')
-    fireEvent.click(oneButton)
+    await user.click(oneButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -219,7 +227,8 @@ describe('PipettePath', () => {
     expect(nextBtn).toBeDisabled()
   })
 
-  it('renders blowout options on third screen and calls dispatch when saved', () => {
+  it('renders blowout options on third screen and calls dispatch when saved', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       state: {
@@ -235,8 +244,8 @@ describe('PipettePath', () => {
     }
     render(props)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
+    await user.click(continueBtn)
     screen.getByText('Source well')
   })
 })

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TipPosition.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TipPosition.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TouchInputField } from '@opentrons/components'
@@ -85,8 +86,9 @@ describe('TipPosition', () => {
     vi.resetAllMocks()
   })
 
-  it('renders the tip position aspirate screen, continue, and back buttons', () => {
+  it('renders the tip position aspirate screen, continue, and back buttons', async () => {
     render(props)
+    const user = userEvent.setup()
     screen.getByText('Aspirate tip position')
     screen.getByTestId('ChildNavigation_Primary_Button')
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
@@ -102,7 +104,7 @@ describe('TipPosition', () => {
       {}
     )
     const exitBtn = screen.getByTestId('ChildNavigation_Back_Button')
-    fireEvent.click(exitBtn)
+    await user.click(exitBtn)
     expect(props.onBack).toHaveBeenCalled()
   })
 
@@ -127,11 +129,12 @@ describe('TipPosition', () => {
     )
   })
 
-  it('renders correct range if you enter incorrect value for aspirate', () => {
+  it('renders correct range if you enter incorrect value for aspirate', async () => {
     render(props)
+    const user = userEvent.setup()
     const deleteBtn = screen.getByText('del')
-    fireEvent.click(deleteBtn)
-    fireEvent.click(deleteBtn)
+    await user.click(deleteBtn)
+    await user.click(deleteBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -148,15 +151,16 @@ describe('TipPosition', () => {
     expect(saveBtn).toBeDisabled()
   })
 
-  it('renders correct range if you enter incorrect value for dispense', () => {
+  it('renders correct range if you enter incorrect value for dispense', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       kind: 'dispense',
     }
     render(props)
     const deleteBtn = screen.getByText('del')
-    fireEvent.click(deleteBtn)
-    fireEvent.click(deleteBtn)
+    await user.click(deleteBtn)
+    await user.click(deleteBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenCalledWith(
       {
         autoFocus: true,
@@ -173,14 +177,15 @@ describe('TipPosition', () => {
     expect(saveBtn).toBeDisabled()
   })
 
-  it('calls dispatch when an in range value is entered and saved', () => {
+  it('calls dispatch when an in range value is entered and saved', async () => {
     render(props)
+    const user = userEvent.setup()
     const deleteBtn = screen.getByText('del')
-    fireEvent.click(deleteBtn)
+    await user.click(deleteBtn)
     const numButton = screen.getByText('1')
-    fireEvent.click(numButton)
+    await user.click(numButton)
     const saveBtn = screen.getByText('Save')
-    fireEvent.click(saveBtn)
+    await user.click(saveBtn)
     expect(props.dispatch).toHaveBeenCalled()
     expect(mockTrackEventWithRobotSerial).toHaveBeenCalled()
   })

--- a/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TouchTip.test.tsx
+++ b/app/src/organisms/ODD/QuickTransferFlow/__tests__/QuickTransferAdvancedSettings/TouchTip.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { TouchInputField } from '@opentrons/components'
@@ -84,14 +85,15 @@ describe('TouchTip', () => {
     vi.resetAllMocks()
   })
 
-  it('renders the first touch tip screen, continue, and back buttons', () => {
+  it('renders the first touch tip screen, continue, and back buttons', async () => {
     render(props)
+    const user = userEvent.setup()
     screen.getByText('Touch tip after aspirating')
     screen.getByTestId('ChildNavigation_Primary_Button')
     screen.getByText('Enabled')
     screen.getByText('Disabled')
     const exitBtn = screen.getByTestId('ChildNavigation_Back_Button')
-    fireEvent.click(exitBtn)
+    await user.click(exitBtn)
     expect(props.onBack).toHaveBeenCalled()
   })
 
@@ -104,14 +106,15 @@ describe('TouchTip', () => {
     screen.getByText('Touch tip after dispensing')
   })
 
-  it('renders save button if you select enabled, then moves to second screen', () => {
+  it('renders save button if you select enabled, then moves to second screen', async () => {
     render(props)
+    const user = userEvent.setup()
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
-    fireEvent.click(screen.getByText('1'))
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
+    await user.click(screen.getByText('1'))
+    await user.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenLastCalledWith(
       expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',
@@ -124,31 +127,33 @@ describe('TouchTip', () => {
     )
   })
 
-  it('calls dispatch button if you select disabled and save', () => {
+  it('calls dispatch button if you select disabled and save', async () => {
     render(props)
+    const user = userEvent.setup()
     const disabledBtn = screen.getByText('Disabled')
-    fireEvent.click(disabledBtn)
+    await user.click(disabledBtn)
     const saveBtn = screen.getByText('Save')
-    fireEvent.click(saveBtn)
+    await user.click(saveBtn)
     expect(props.dispatch).toHaveBeenCalled()
     expect(mockTrackEventWithRobotSerial).toHaveBeenCalled()
   })
 
-  it('has correct range for aspirate', () => {
+  it('has correct range for aspirate', async () => {
     render(props)
+    const user = userEvent.setup()
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const numOneButton = screen.getByText('1')
-    fireEvent.click(numOneButton)
-    fireEvent.click(continueBtn)
+    await user.click(numOneButton)
+    await user.click(continueBtn)
     const negButton = screen.getByText('-')
-    fireEvent.click(negButton)
+    await user.click(negButton)
     const numButton = screen.getByText('9')
-    fireEvent.click(numButton)
+    await user.click(numButton)
     const secondNumButton = screen.getByText('8')
-    fireEvent.click(secondNumButton)
+    await user.click(secondNumButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenLastCalledWith(
       expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',
@@ -163,21 +168,22 @@ describe('TouchTip', () => {
     expect(saveBtn).toBeDisabled()
   })
 
-  it('has correct range for dispense', () => {
+  it('has correct range for dispense', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       kind: 'dispense',
     }
     render(props)
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const numOneButton = screen.getByText('1')
-    fireEvent.click(numOneButton)
-    fireEvent.click(continueBtn)
+    await user.click(numOneButton)
+    await user.click(continueBtn)
     const numButton = screen.getByText('1')
-    fireEvent.click(numButton)
+    await user.click(numButton)
     expect(vi.mocked(TouchInputField)).toHaveBeenLastCalledWith(
       expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',
@@ -192,24 +198,26 @@ describe('TouchTip', () => {
     expect(saveBtn).toBeDisabled()
   })
 
-  it('calls dispatch when an in range value is entered and saved', () => {
+  it('calls dispatch when an in range value is entered and saved', async () => {
     render(props)
+    const user = userEvent.setup()
     const enabledBtn = screen.getByText('Enabled')
-    fireEvent.click(enabledBtn)
+    await user.click(enabledBtn)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const numButton = screen.getByText('1')
-    fireEvent.click(numButton)
-    fireEvent.click(continueBtn)
+    await user.click(numButton)
+    await user.click(continueBtn)
     const saveBtn = screen.getByText('Save')
     const zeroButton = screen.getByText('0')
-    fireEvent.click(zeroButton)
-    fireEvent.click(saveBtn)
+    await user.click(zeroButton)
+    await user.click(saveBtn)
     expect(props.dispatch).toHaveBeenCalled()
     expect(mockTrackEventWithRobotSerial).toHaveBeenCalled()
   })
 
-  it('renders previously set value saved in state for aspirate', () => {
+  it('renders previously set value saved in state for aspirate', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       state: {
@@ -219,10 +227,10 @@ describe('TouchTip', () => {
     }
     render(props)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const numButton = screen.getByText('0')
-    fireEvent.click(numButton)
-    fireEvent.click(continueBtn)
+    await user.click(numButton)
+    await user.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenLastCalledWith(
       expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',
@@ -235,7 +243,8 @@ describe('TouchTip', () => {
     )
   })
 
-  it('renders previously set value saved in state for dispense', () => {
+  it('renders previously set value saved in state for dispense', async () => {
+    const user = userEvent.setup()
     props = {
       ...props,
       kind: 'dispense',
@@ -246,10 +255,10 @@ describe('TouchTip', () => {
     }
     render(props)
     const continueBtn = screen.getByText('Continue')
-    fireEvent.click(continueBtn)
+    await user.click(continueBtn)
     const numButton = screen.getByText('0')
-    fireEvent.click(numButton)
-    fireEvent.click(continueBtn)
+    await user.click(numButton)
+    await user.click(continueBtn)
     expect(vi.mocked(TouchInputField)).toHaveBeenLastCalledWith(
       expect.objectContaining({
         label: 'Touch tip position from top of well (mm)',

--- a/app/src/pages/ODD/RobotNameEditor/__tests__/RobotNameEditor.test.tsx
+++ b/app/src/pages/ODD/RobotNameEditor/__tests__/RobotNameEditor.test.tsx
@@ -1,5 +1,6 @@
 import { MemoryRouter } from 'react-router-dom'
 import { fireEvent, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderWithProviders } from '/app/__testing-utils__'
@@ -79,12 +80,13 @@ describe('RobotNameEditor', () => {
 
   it('should display a letter when typing a letter and confirming calls the track event', async () => {
     render()
+    const user = userEvent.setup()
     const input = screen.getByRole('textbox')
-    fireEvent.click(screen.getByRole('button', { name: 'a' }))
-    fireEvent.click(screen.getByRole('button', { name: 'b' }))
-    fireEvent.click(screen.getByRole('button', { name: 'c' }))
+    await user.click(screen.getByRole('button', { name: 'a' }))
+    await user.click(screen.getByRole('button', { name: 'b' }))
+    await user.click(screen.getByRole('button', { name: 'c' }))
     expect(input).toHaveValue('abc')
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm' }))
     await waitFor(() => {
       expect(mockTrackEvent).toHaveBeenCalled()
     })
@@ -92,7 +94,8 @@ describe('RobotNameEditor', () => {
 
   it('should show an error message when tapping confirm without typing anything', async () => {
     render()
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Confirm' }))
     const error = await screen.findByText(
       'Oops! Robot name must follow the character count and limitations.'
     )
@@ -101,33 +104,35 @@ describe('RobotNameEditor', () => {
     })
   })
 
-  it('should show an error message when typing an existing name - connectable robot', () => {
+  it('should show an error message when typing an existing name - connectable robot', async () => {
     render()
+    const user = userEvent.setup()
     const input = screen.getByRole('textbox')
-    fireEvent.click(screen.getByRole('button', { name: 'c' }))
-    fireEvent.click(screen.getByRole('button', { name: 'o' }))
-    fireEvent.click(screen.getByRole('button', { name: 'n' }))
-    fireEvent.click(screen.getByRole('button', { name: 'n' }))
-    fireEvent.click(screen.getByRole('button', { name: 'e' }))
-    fireEvent.click(screen.getByRole('button', { name: 'c' }))
-    fireEvent.click(screen.getByRole('button', { name: 't' }))
+    await user.click(screen.getByRole('button', { name: 'c' }))
+    await user.click(screen.getByRole('button', { name: 'o' }))
+    await user.click(screen.getByRole('button', { name: 'n' }))
+    await user.click(screen.getByRole('button', { name: 'n' }))
+    await user.click(screen.getByRole('button', { name: 'e' }))
+    await user.click(screen.getByRole('button', { name: 'c' }))
+    await user.click(screen.getByRole('button', { name: 't' }))
     expect(input).toHaveValue('connect')
 
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm' }))
 
     screen.queryByText('Oops! Name is already in use. Choose a different name.')
   })
 
-  it('should show an error message when typing an existing name - reachable robot', () => {
+  it('should show an error message when typing an existing name - reachable robot', async () => {
     render()
+    const user = userEvent.setup()
     const input = screen.getByRole('textbox')
-    fireEvent.click(screen.getByRole('button', { name: 'r' }))
-    fireEvent.click(screen.getByRole('button', { name: 'e' }))
-    fireEvent.click(screen.getByRole('button', { name: 'a' }))
-    fireEvent.click(screen.getByRole('button', { name: 'c' }))
-    fireEvent.click(screen.getByRole('button', { name: 'h' }))
+    await user.click(screen.getByRole('button', { name: 'r' }))
+    await user.click(screen.getByRole('button', { name: 'e' }))
+    await user.click(screen.getByRole('button', { name: 'a' }))
+    await user.click(screen.getByRole('button', { name: 'c' }))
+    await user.click(screen.getByRole('button', { name: 'h' }))
     expect(input).toHaveValue('reach')
-    fireEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm' }))
 
     screen.queryByText('Oops! Name is already in use. Choose a different name.')
   })
@@ -145,10 +150,11 @@ describe('RobotNameEditor', () => {
     screen.getByText('Confirm')
   })
 
-  it('should call a mock function when tapping back button', () => {
+  it('should call a mock function when tapping back button', async () => {
     vi.mocked(useIsUnboxingFlowOngoing).mockReturnValue(false)
     render()
-    fireEvent.click(screen.getByTestId('name_back_button'))
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('name_back_button'))
     expect(mockNavigate).toHaveBeenCalledWith('/robot-settings')
   })
 

--- a/components/src/atoms/CheckboxField/__tests__/CheckboxField.test.tsx
+++ b/components/src/atoms/CheckboxField/__tests__/CheckboxField.test.tsx
@@ -53,12 +53,12 @@ describe('CheckboxField', () => {
     // INPUT_STYLE
     expect(checkBoxInput).toHaveStyle(`position: absolute`)
     expect(checkBoxInput).toHaveStyle(`overflow: hidden`)
-    expect(checkBoxInput).toHaveStyle(`clip: rect(0 0 0 0)`)
+    expect(checkBoxInput).toHaveStyle(`clip-path: inset(50%)`)
     expect(checkBoxInput).toHaveStyle(`height: 1px`)
     expect(checkBoxInput).toHaveStyle(`width: 1px`)
     expect(checkBoxInput).toHaveStyle(`margin: -1px`)
     expect(checkBoxInput).toHaveStyle(`padding: 0`)
-    expect(checkBoxInput).toHaveStyle(`border: 0`)
+    expect(checkBoxInput).toHaveStyle(`border-width: 0`)
     expect(checkBoxInput).toHaveAttribute('tabindex', '0')
 
     // LABEL_TEXT_STYLE

--- a/components/src/atoms/CheckboxField/index.tsx
+++ b/components/src/atoms/CheckboxField/index.tsx
@@ -91,7 +91,7 @@ export function CheckboxField(props: CheckboxFieldProps): JSX.Element {
 const INPUT_STYLE = css`
   position: absolute;
   overflow: hidden;
-  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
   height: 1px;
   width: 1px;
   margin: -1px;

--- a/components/src/atoms/Tooltip/__tests__/Tooltip.test.tsx
+++ b/components/src/atoms/Tooltip/__tests__/Tooltip.test.tsx
@@ -57,7 +57,7 @@ describe('Tooltip', () => {
     expect(tooltip).toBeInTheDocument()
     expect(tooltip).toHaveStyle('position: absolute')
     expect(tooltip).toHaveStyle('left: 0.25rem')
-    expect(tooltip).toHaveStyle(`background: ${COLORS.black90}`)
+    expect(tooltip).toHaveStyle(`background-color: ${COLORS.black90}`)
     expect(tooltip).toHaveStyle(`color: ${COLORS.white}`)
     expect(tooltip).toHaveStyle('max-width: 8.75rem')
     expect(tooltip).toHaveStyle('font-size: 0.625rem')

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "graphviz": "^0.0.9",
     "i18next": "^19.8.3",
     "identity-obj-proxy": "^3.0.0",
-    "jsdom": "26.1.0",
+    "jsdom": "29.1.1",
     "lost": "^8.3.1",
     "madge": "^3.6.0",
     "mime": "^2.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         version: 4.3.0(encoding@0.1.13)
       '@storybook/addon-docs':
         specifier: 10.3.5
-        version: 10.3.5(@types/react@18.2.51)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
+        version: 10.3.5(@types/react@18.2.51)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2)(postcss@8.5.6))
       '@storybook/addon-links':
         specifier: 10.3.5
         version: 10.3.5(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
@@ -80,7 +80,7 @@ importers:
         version: 10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       '@storybook/react-vite':
         specifier: 10.3.5
-        version: 10.3.5(esbuild@0.27.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
+        version: 10.3.5(esbuild@0.27.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2)(postcss@8.5.6))
       '@testing-library/dom':
         specifier: 10.4.0
         version: 10.4.0
@@ -131,7 +131,7 @@ importers:
         version: 6.21.0(eslint@8.57.1)(typescript@5.3.3)
       '@vitejs/plugin-react':
         specifier: 4.2.0
-        version: 4.2.0(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))
+        version: 4.2.0(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))
       '@vitest/coverage-v8':
         specifier: 4.1.10
         version: 4.1.10(vitest@4.1.10)
@@ -247,8 +247,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       jsdom:
-        specifier: 26.1.0
-        version: 26.1.0
+        specifier: 29.1.1
+        version: 29.1.1
       lost:
         specifier: ^8.3.1
         version: 8.3.1
@@ -332,10 +332,10 @@ importers:
         version: 5.3.3
       vite:
         specifier: 7.3.5
-        version: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
+        version: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0)
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))
       vitest-when:
         specifier: 0.10.0
         version: 0.10.0(@vitest/expect@4.1.10)(vitest@4.1.10)
@@ -951,7 +951,7 @@ importers:
         version: 18.2.0
       '@vitejs/plugin-react':
         specifier: 4.2.0
-        version: 4.2.0(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))
+        version: 4.2.0(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
@@ -963,7 +963,7 @@ importers:
         version: 5.3.3
       vite:
         specifier: 7.3.5
-        version: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
+        version: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0)
 
   labware-designer:
     dependencies:
@@ -1230,7 +1230,7 @@ importers:
         version: 16.0.0(postcss@8.5.6)
       postcss-loader:
         specifier: ^4.0.4
-        version: 4.3.0(postcss@8.5.6)(webpack@5.104.1(esbuild@0.27.2))
+        version: 4.3.0(postcss@8.5.6)(webpack@5.104.1(esbuild@0.27.2)(postcss@8.5.6))
       postcss-preset-env:
         specifier: 9.3.0
         version: 9.3.0(postcss@8.5.6)
@@ -1242,7 +1242,7 @@ importers:
         version: 18.2.0
       react-dnd:
         specifier: 16.0.1
-        version: 16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@18.2.51))(@types/node@25.6.0)(@types/react@18.2.51)(react@18.2.0)
+        version: 16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@18.2.51))(@types/node@26.1.1)(@types/react@18.2.51)(react@18.2.0)
       react-dnd-html5-backend:
         specifier: 16.0.1
         version: 16.0.1
@@ -1296,7 +1296,7 @@ importers:
         version: 1.3.2
       vite-plugin-node-polyfills:
         specifier: ^0.25.0
-        version: 0.25.0(rollup@4.55.1)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))
+        version: 0.25.0(rollup@4.55.1)(vite@7.3.5(@types/node@26.1.1)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))
       yup:
         specifier: 1.3.3
         version: 1.3.3
@@ -1574,8 +1574,20 @@ packages:
     resolution: {integrity: sha512-KR9k+l4QTvlW42GGyoP7EhC9JEHSngYpVhd0p+XY3bSDGxL2X6aKBaqaXWDf2pkeiuXr/I+VWJMlCXGWGsl7FA==}
     engines: {node: '>=12.13.0'}
 
-  '@asamuzakjp/css-color@3.2.0':
-    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@auth0/auth0-react@2.2.4':
     resolution: {integrity: sha512-l29PQC0WdgkCoOc6WeMAY26gsy/yXJICW0jHfj0nz8rZZphYKrLNqTRWFFCMJY+sagza9tSgB1kG/UvQYgGh9A==}
@@ -1775,6 +1787,10 @@ packages:
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.28.5':
     resolution: {integrity: sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==}
     engines: {node: '>=6.9.0'}
@@ -1785,6 +1801,10 @@ packages:
 
   '@babel/generator@7.28.5':
     resolution: {integrity: sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-annotate-as-pure@7.27.3':
@@ -1799,8 +1819,16 @@ packages:
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-imports@7.27.1':
     resolution: {integrity: sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-transforms@7.28.3':
@@ -1871,8 +1899,16 @@ packages:
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.28.5':
     resolution: {integrity: sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.5':
@@ -1886,6 +1922,10 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
 
   '@cacheable/memory@2.0.7':
     resolution: {integrity: sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==}
@@ -1918,9 +1958,9 @@ packages:
     resolution: {integrity: sha512-CEypeeykO9AN7JWkr1OEOQb0HRzZlPWGwV0Ya6DuVgFdDi6g3ma/cPZ5ZPZM4AWQikDpq/0llnGGlIL+j8afzw==}
     engines: {node: ^14 || ^16 || >=18}
 
-  '@csstools/color-helpers@5.1.0':
-    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
-    engines: {node: '>=18'}
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
 
   '@csstools/convert-colors@1.4.0':
     resolution: {integrity: sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==}
@@ -1933,12 +1973,12 @@ packages:
       '@csstools/css-parser-algorithms': ^2.7.1
       '@csstools/css-tokenizer': ^2.4.1
 
-  '@csstools/css-calc@2.1.4':
-    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
-    engines: {node: '>=18'}
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
     peerDependencies:
-      '@csstools/css-parser-algorithms': ^3.0.5
-      '@csstools/css-tokenizer': ^3.0.4
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
 
   '@csstools/css-color-parser@2.0.5':
     resolution: {integrity: sha512-lRZSmtl+DSjok3u9hTWpmkxFZnz7stkbZxzKc08aDUsdrWwhSgWo8yq9rq9DaFUtbAyAq2xnH92fj01S+pwIww==}
@@ -1947,12 +1987,12 @@ packages:
       '@csstools/css-parser-algorithms': ^2.7.1
       '@csstools/css-tokenizer': ^2.4.1
 
-  '@csstools/css-color-parser@3.1.0':
-    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
-    engines: {node: '>=18'}
+  '@csstools/css-color-parser@4.1.10':
+    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+    engines: {node: '>=20.19.0'}
     peerDependencies:
-      '@csstools/css-parser-algorithms': ^3.0.5
-      '@csstools/css-tokenizer': ^3.0.4
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
 
   '@csstools/css-parser-algorithms@2.7.1':
     resolution: {integrity: sha512-2SJS42gxmACHgikc1WGesXLIT8d/q2l0UFM7TaEeIzdFCE/FPMtTiizcPGGJtlPo2xuQzY09OhrLTzRxqJqwGw==}
@@ -1966,6 +2006,20 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^3.0.4
 
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
   '@csstools/css-tokenizer@2.4.1':
     resolution: {integrity: sha512-eQ9DIktFJBhGjioABJRtUucoWR2mwllurfnM8LuNGAqX3ViZXaUchqk+1s7jjtkFiT9ySdACsFEA3etErkALUg==}
     engines: {node: ^14 || ^16 || >=18}
@@ -1973,6 +2027,10 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@csstools/media-query-list-parser@2.1.13':
     resolution: {integrity: sha512-XaHr+16KRU9Gf8XLi3q8kDlI18d5vzKSKCY510Vrtc9iNR0NJzbY9hhTmwhzYZj/ZwGL4VmB3TA9hJW0Um2qFA==}
@@ -2508,6 +2566,15 @@ packages:
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
   '@fastify/ajv-compiler@4.0.5':
     resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
 
@@ -2963,9 +3030,9 @@ packages:
   '@mapbox/geojson-types@1.0.2':
     resolution: {integrity: sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==}
 
-  '@mapbox/jsonlint-lines-primitives@2.0.2':
-    resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
-    engines: {node: '>= 0.6'}
+  '@mapbox/jsonlint-lines-primitives@2.0.3':
+    resolution: {integrity: sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==}
+    engines: {node: '>= 22'}
 
   '@mapbox/mapbox-gl-supported@1.5.0':
     resolution: {integrity: sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==}
@@ -2978,8 +3045,8 @@ packages:
   '@mapbox/tiny-sdf@1.2.5':
     resolution: {integrity: sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==}
 
-  '@mapbox/tiny-sdf@2.0.7':
-    resolution: {integrity: sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==}
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
 
   '@mapbox/unitbezier@0.0.0':
     resolution: {integrity: sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==}
@@ -4166,20 +4233,20 @@ packages:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
 
-  '@turf/area@7.3.1':
-    resolution: {integrity: sha512-9nSiwt4zB5QDMcSoTxF28WpK1f741MNKcpUJDiHVRX08CZ4qfGWGV9ZIPQ8TVEn5RE4LyYkFuQ47Z9pdEUZE9Q==}
+  '@turf/area@7.3.5':
+    resolution: {integrity: sha512-sSn80wPT7XfBIDN3vurCPxhk9W4U8ozS/XImSqeLN8qveTICOxzZkhsGDMp0CuncaN+plWut4a2TdNM7mzZB6Q==}
 
-  '@turf/bbox@7.3.1':
-    resolution: {integrity: sha512-/IyMKoS7P9B0ch5PIlQ6gMfoE8gRr48+cSbzlyexvEjuDuaAV1VURjH1jAthS0ipFG8RrFxFJKnp7TLL1Skong==}
+  '@turf/bbox@7.3.5':
+    resolution: {integrity: sha512-oG1ya/HtBjAIg4TimbWx+nOYPbY0bCvt82Bq8tm6sBw3qqtbOyRSfDz79Sq90TnH7DXJprJ1qnVGKNtZ6jemfw==}
 
-  '@turf/centroid@7.3.1':
-    resolution: {integrity: sha512-hRnsDdVBH4pX9mAjYympb2q5W8TCMUMNEjcRrAF7HTCyjIuRmjJf8vUtlzf7TTn9RXbsvPc1vtm3kLw20Jm8DQ==}
+  '@turf/centroid@7.3.5':
+    resolution: {integrity: sha512-hkWaqwGFdOn6Tf0EWfn2yn1XZ1FWE1h2C5ZWstDMu/FxYO5DB+YjlmOFPl4K6SmSOEgdV07eK2vDCyPeTHqKGA==}
 
-  '@turf/helpers@7.3.1':
-    resolution: {integrity: sha512-zkL34JVhi5XhsuMEO0MUTIIFEJ8yiW1InMu4hu/oRqamlY4mMoZql0viEmH6Dafh/p+zOl8OYvMJ3Vm3rFshgg==}
+  '@turf/helpers@7.3.5':
+    resolution: {integrity: sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==}
 
-  '@turf/meta@7.3.1':
-    resolution: {integrity: sha512-NWsfOE5RVtWpLQNkfOF/RrYvLRPwwruxhZUV0UFIzHqfiRJ50aO9Y6uLY4bwCUe2TumLJQSR4yaoA72Rmr2mnQ==}
+  '@turf/meta@7.3.5':
+    resolution: {integrity: sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -4237,6 +4304,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/fernet@0.4.3':
     resolution: {integrity: sha512-2D6ncaTep6D+5k0oE+/lDFrgVvT4JZt8JUxXjO0W6dhWu9mOeNL9kqPwDivfQMCLh4PMHaVVOV6bsLRITZOkSA==}
@@ -4338,6 +4408,9 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -4389,6 +4462,9 @@ packages:
 
   '@types/react@18.2.51':
     resolution: {integrity: sha512-XeoMaU4CzyjdRr3c4IQQtiH7Rpo18V07rYZUucEZQwOUEtGgTXv7e6igQiQ+xnV6MbMe1qjEmKdgMNnfppnXfg==}
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/reactcss@1.2.13':
     resolution: {integrity: sha512-gi3S+aUi6kpkF5vdhUsnkwbiSEIU/BEJyD7kBy2SudWBUuKmJk8AQKE0OVcQQeEy40Azh0lV6uynxlikYIJuwg==}
@@ -4944,6 +5020,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   add-stream@1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
 
@@ -4997,6 +5078,9 @@ packages:
 
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -5082,9 +5166,6 @@ packages:
 
   array-range@1.0.1:
     resolution: {integrity: sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA==}
-
-  array-rearrange@2.2.2:
-    resolution: {integrity: sha512-UfobP5N12Qm4Qu4fwLDIi2v6+wZsSf6snYSxAMeKhrh37YGnNWZPRmVEKc/2wfms53TLQnzfpG8wCx2Y/6NG1w==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -5272,6 +5353,9 @@ packages:
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
@@ -5332,8 +5416,14 @@ packages:
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -6020,6 +6110,10 @@ packages:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
@@ -6033,10 +6127,6 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
-
-  cssstyle@4.6.0:
-    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
-    engines: {node: '>=18'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -6114,9 +6204,9 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
-  data-urls@5.0.0:
-    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
-    engines: {node: '>=18'}
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -6448,8 +6538,8 @@ packages:
   earcut@2.2.4:
     resolution: {integrity: sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==}
 
-  earcut@3.0.2:
-    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+  earcut@3.2.3:
+    resolution: {integrity: sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -6560,13 +6650,13 @@ packages:
     resolution: {integrity: sha512-Nv9m36S/vxpsI+Hc4/ZGRs0n9mXqSWGGq49zxb/cJfPAQMbUtttJAlNPS4AQzaBdw/pKskw5bMbekT/Y7W/Wlg==}
     engines: {node: '>=6.9.0'}
 
-  enhanced-resolve@5.18.4:
-    resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
+  enhanced-resolve@5.24.3:
+    resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
     engines: {node: '>=10.13.0'}
 
-  entities@6.0.1:
-    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
-    engines: {node: '>=0.12'}
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -6603,6 +6693,9 @@ packages:
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -7026,6 +7119,9 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+
   fast-xml-parser@5.2.5:
     resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
     hasBin: true
@@ -7252,6 +7348,10 @@ packages:
     resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
 
+  fs-extra@11.4.0:
+    resolution: {integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==}
+    engines: {node: '>=14.14'}
+
   fs-extra@6.0.1:
     resolution: {integrity: sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==}
 
@@ -7313,8 +7413,8 @@ packages:
   geojson-vt@3.2.1:
     resolution: {integrity: sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==}
 
-  geojson-vt@4.0.2:
-    resolution: {integrity: sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==}
+  geojson-vt@4.0.3:
+    resolution: {integrity: sha512-jR1MwkLaZGa8Zftct9ZFruyWFrdl9ZyD2OliXNy9Qq5bBPeg5wHVpBQF9p5GjnicSDQqvBVpysxTPKmWdsfWMA==}
 
   get-amd-module-type@3.0.2:
     resolution: {integrity: sha512-PcuKwB8ouJnKuAPn6Hk3UtdfKoUV3zXRqVEvj8XGIXqjWfgd1j7QGdXy5Z9OdQfzVt1Sk29HVe/P+X74ccOuqw==}
@@ -7684,9 +7784,9 @@ packages:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
 
-  html-encoding-sniffer@4.0.0:
-    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
-    engines: {node: '>=18'}
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -7854,8 +7954,8 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ip-regex@5.0.0:
@@ -7931,6 +8031,10 @@ packages:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
   is-data-view@1.0.2:
     resolution: {integrity: sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==}
     engines: {node: '>= 0.4'}
@@ -7983,10 +8087,6 @@ packages:
 
   is-hexadecimal@2.0.1:
     resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
-
-  is-iexplorer@1.0.0:
-    resolution: {integrity: sha512-YeLzceuwg3K6O0MLM3UyUUjKAlyULetwryFp1mHy1I5PfArK0AEqlfa+MR4gkJjcbuJXoDJCvXbyqZVf5CR2Sg==}
-    engines: {node: '>=0.10.0'}
 
   is-immutable-type@5.0.1:
     resolution: {integrity: sha512-LkHEOGVZZXxGl8vDs+10k3DvP++SEoYEAJLRk6buTFi6kD7QekThV7xHS0j6gpnUCQ0zpud/gMDGiV4dQneLTg==}
@@ -8184,6 +8284,10 @@ packages:
     resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
     engines: {node: '>=16'}
 
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
+
   isomorphic-fetch@2.2.1:
     resolution: {integrity: sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==}
 
@@ -8270,9 +8374,9 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  jsdom@26.1.0:
-    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
-    engines: {node: '>=18'}
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
     peerDependencies:
       canvas: ^3.0.0
     peerDependenciesMeta:
@@ -8335,6 +8439,9 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
@@ -8352,8 +8459,8 @@ packages:
   kdbush@3.0.0:
     resolution: {integrity: sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==}
 
-  kdbush@4.0.2:
-    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
+  kdbush@4.1.0:
+    resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
 
   keyboardevent-from-electron-accelerator@2.0.0:
     resolution: {integrity: sha512-iQcmNA0M4ETMNi0kG/q0h/43wZk7rMeKYrXP7sqKIJbHkTU8Koowgzv+ieR/vWJbOwxx5nDC3UnudZ0aLSu4VA==}
@@ -8423,8 +8530,8 @@ packages:
     resolution: {integrity: sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==}
     engines: {node: '>=4'}
 
-  loader-runner@4.3.1:
-    resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
+  loader-runner@4.3.2:
+    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
 
   loader-utils@2.0.4:
@@ -8529,8 +8636,8 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
-  lru-cache@11.3.6:
-    resolution: {integrity: sha512-Gf/KoL3C/MlI7Bt0PGI9I+TeTC/I6r/csU58N4BSNc4lppLBeKsOdFYkK+dX0ABDUMJNfCHTyPpzwwO21Awd3A==}
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
@@ -8653,6 +8760,9 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mdns-js@1.0.1:
     resolution: {integrity: sha512-dwEtMzmoZCQcGlr004J4m2+W6dCMpCoGQ5kYIEY+7rMPdMM7ztT+1qD9ExmottvLGgbqAVsjllhwU8PyusecPg==}
@@ -8812,8 +8922,11 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
-  minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
     engines: {node: '>=10'}
 
   minimatch@8.0.4:
@@ -8826,6 +8939,10 @@ packages:
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist-options@4.1.0:
@@ -8851,8 +8968,8 @@ packages:
     resolution: {integrity: sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  minipass-flush@1.0.5:
-    resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
     engines: {node: '>= 8'}
 
   minipass-pipeline@1.2.4:
@@ -9121,9 +9238,6 @@ packages:
     resolution: {integrity: sha512-Dq3iuiFBkrbmuQjGFFF3zckXNCQoSD37/SdSbgcBailUx6knDvDwb5CympBgcoWHy36sfS12u74MHYkXyHq6bg==}
     engines: {node: '>=0.10.0'}
 
-  nwsapi@2.2.23:
-    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -9265,8 +9379,8 @@ packages:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
 
-  p-map@7.0.4:
-    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
+  p-map@7.0.6:
+    resolution: {integrity: sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==}
     engines: {node: '>=18'}
 
   p-retry@4.6.2:
@@ -9333,8 +9447,8 @@ packages:
   parse5@5.1.1:
     resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
 
-  parse5@7.3.0:
-    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -9800,8 +9914,8 @@ packages:
     resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
     engines: {node: '>=10'}
 
-  probe-image-size@7.2.3:
-    resolution: {integrity: sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==}
+  probe-image-size@7.3.0:
+    resolution: {integrity: sha512-7CaDeBwiAbh6ohXsvLbAZhO7wzsZAmaevfxe39qvCwRh8LyaZfDlBGGLU1CCTgrTLtCOdwBBhjOrIHaIIimHfQ==}
 
   proc-log@2.0.1:
     resolution: {integrity: sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==}
@@ -9858,8 +9972,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protocol-buffers-schema@3.6.0:
-    resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
@@ -10301,8 +10415,8 @@ packages:
   regl-line2d@3.1.3:
     resolution: {integrity: sha512-fkgzW+tTn4QUQLpFKsUIE0sgWdCmXAM3ctXcCgoGBZTSX5FE2A0M7aynz7nrZT5baaftLrk9te54B+MEq4QcSA==}
 
-  regl-scatter2d@3.3.1:
-    resolution: {integrity: sha512-seOmMIVwaCwemSYz/y4WE0dbSO9svNFSqtTh5RE57I7PjGo3tcUYKtH0MTSoshcAsreoqN8HoCtnn8wfHXXfKQ==}
+  regl-scatter2d@3.4.0:
+    resolution: {integrity: sha512-DavKQlHsI+iHZuLgOL+yGkg+sPd94CS+7FCBWkcQ6s/TbaNfUsF9eN591fjjSWIoKrGNfb/SEGhsXR5lXjqZ2w==}
 
   regl-splom@1.0.14:
     resolution: {integrity: sha512-OiLqjmPRYbd7kDlHC6/zDf6L8lxgDC65BhC8JirhP4ykrK4x22ZyS+BnY8EUinXKDeMgmpRwCvUmk7BK4Nweuw==}
@@ -10408,6 +10522,11 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
   resolve@2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
@@ -10472,9 +10591,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rrweb-cssom@0.8.0:
-    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
-
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -10536,6 +10652,10 @@ packages:
     resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
     engines: {node: '>=11.0.0'}
 
+  sax@1.6.1:
+    resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
+    engines: {node: '>=11.0.0'}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
@@ -10585,12 +10705,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
-
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
   serialport@10.5.0:
     resolution: {integrity: sha512-7OYLDsu5i6bbv3lU81pGy076xe0JwpK6b49G6RjNvGibstUqQkI+I3/X491yBGtf4gaqUdOgoU1/5KZ/XxL4dw==}
@@ -10721,8 +10843,8 @@ packages:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
 
-  socks@2.8.7:
-    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sonic-boom@4.2.1:
@@ -11095,8 +11217,8 @@ packages:
     resolution: {integrity: sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==}
     engines: {node: '>=6'}
 
-  tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar-stream@1.6.2:
@@ -11135,24 +11257,51 @@ packages:
     resolution: {integrity: sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==}
     engines: {node: '>=10'}
 
-  terser-webpack-plugin@5.3.16:
-    resolution: {integrity: sha512-h9oBFCWrq78NyWWVcSwZarJkZ01c2AyGrzs1crmHZO3QUg9D61Wu4NPjBy69n7JqylFF5y+CsUZYmYEIZ3mR+Q==}
+  terser-webpack-plugin@5.6.1:
+    resolution: {integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
+      '@minify-html/node': '*'
       '@swc/core': '*'
+      '@swc/css': '*'
+      '@swc/html': '*'
+      clean-css: '*'
+      cssnano: '*'
+      csso: '*'
       esbuild: '*'
+      html-minifier-terser: '*'
+      lightningcss: '*'
+      postcss: '*'
       uglify-js: '*'
       webpack: ^5.1.0
     peerDependenciesMeta:
+      '@minify-html/node':
+        optional: true
       '@swc/core':
         optional: true
+      '@swc/css':
+        optional: true
+      '@swc/html':
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
       esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
         optional: true
       uglify-js:
         optional: true
 
-  terser@5.44.1:
-    resolution: {integrity: sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==}
+  terser@5.49.0:
+    resolution: {integrity: sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -11244,11 +11393,11 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@6.1.86:
-    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+  tldts-core@7.4.9:
+    resolution: {integrity: sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==}
 
-  tldts@6.1.86:
-    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+  tldts@7.4.9:
+    resolution: {integrity: sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==}
     hasBin: true
 
   tmp-promise@3.0.3:
@@ -11283,16 +11432,16 @@ packages:
   toposort@2.0.2:
     resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
 
-  tough-cookie@5.1.2:
-    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
     engines: {node: '>=16'}
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
-  tr46@5.1.1:
-    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
-    engines: {node: '>=18'}
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   traverse-chain@0.1.0:
     resolution: {integrity: sha512-up6Yvai4PYKhpNp5PkYtx50m3KbwQrqDwbuZP/ItyL64YEWHAvH6Md83LFLV/GRSk/BoUVwwgUzX6SOQSbsfAg==}
@@ -11500,8 +11649,15 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -11833,8 +11989,8 @@ packages:
   warning@3.0.0:
     resolution: {integrity: sha512-jMBt6pUrKn5I+OGgtQ4YZLdhIeJmObddh6CsibPxyQ5yPZm1XExSyzC1LCNX7BzhxWgiHmizBWJTHJIjMjTQYQ==}
 
-  watchpack@2.5.0:
-    resolution: {integrity: sha512-e6vZvY6xboSwLz2GD36c16+O/2Z6fKvIf4pOXptw2rY9MVwE/TXc6RGqxD3I3x0a28lwBY7DE+76uTPSsBrrCA==}
+  watchpack@2.5.2:
+    resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
 
   wcwidth@1.0.1:
@@ -11860,12 +12016,16 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
-  webidl-conversions@7.0.0:
-    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
-    engines: {node: '>=12'}
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
 
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
+    engines: {node: '>=10.13.0'}
+
+  webpack-sources@3.5.1:
+    resolution: {integrity: sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==}
     engines: {node: '>=10.13.0'}
 
   webpack-virtual-modules@0.5.0:
@@ -11884,21 +12044,16 @@ packages:
       webpack-cli:
         optional: true
 
-  whatwg-encoding@3.1.1:
-    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
-    engines: {node: '>=18'}
-    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
-
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
-  whatwg-mimetype@4.0.0:
-    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
-    engines: {node: '>=18'}
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
 
-  whatwg-url@14.2.0:
-    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
-    engines: {node: '>=18'}
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -12189,7 +12344,7 @@ snapshots:
     dependencies:
       '@applitools/dom-shared': 1.1.2
       '@applitools/functional-commons': 1.6.0
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       pako: 1.0.11
       throat: 6.0.2
 
@@ -12338,7 +12493,7 @@ snapshots:
       https-proxy-agent: 5.0.1
       node-fetch: 3.3.1
     optionalDependencies:
-      undici: 7.25.0
+      undici: 7.29.0
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -12408,7 +12563,7 @@ snapshots:
       '@applitools/utils': 1.14.2
       '@xmldom/xmldom': 0.8.10
       abort-controller: 3.0.0
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       throat: 6.0.2
     transitivePeerDependencies:
       - supports-color
@@ -12418,13 +12573,25 @@ snapshots:
   '@applitools/utils@1.14.3':
     optional: true
 
-  '@asamuzakjp/css-color@3.2.0':
+  '@asamuzakjp/css-color@5.1.11':
     dependencies:
-      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-tokenizer': 3.0.4
-      lru-cache: 10.4.3
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@auth0/auth0-react@2.2.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -13046,6 +13213,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.28.5': {}
 
   '@babel/core@7.28.5':
@@ -13076,6 +13249,14 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
       '@babel/types': 7.28.5
@@ -13090,10 +13271,19 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
+  '@babel/helper-globals@7.29.7': {}
+
   '@babel/helper-module-imports@7.27.1(supports-color@5.5.0)':
     dependencies:
       '@babel/traverse': 7.28.5(supports-color@5.5.0)
       '@babel/types': 7.28.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.29.7(supports-color@5.5.0)':
+    dependencies:
+      '@babel/traverse': 7.29.7(supports-color@5.5.0)
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -13153,6 +13343,12 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
   '@babel/traverse@7.28.5(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -13160,6 +13356,18 @@ snapshots:
       '@babel/helper-globals': 7.28.0
       '@babel/parser': 7.29.7
       '@babel/template': 7.27.2
+      '@babel/types': 7.29.7
+      debug: 4.4.3(supports-color@5.5.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/traverse@7.29.7(supports-color@5.5.0)':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
       '@babel/types': 7.29.7
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
@@ -13176,6 +13384,10 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
 
   '@cacheable/memory@2.0.7':
     dependencies:
@@ -13214,7 +13426,7 @@ snapshots:
 
   '@csstools/color-helpers@4.2.1': {}
 
-  '@csstools/color-helpers@5.1.0': {}
+  '@csstools/color-helpers@6.1.0': {}
 
   '@csstools/convert-colors@1.4.0': {}
 
@@ -13223,10 +13435,10 @@ snapshots:
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
 
-  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
 
   '@csstools/css-color-parser@2.0.5(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)':
     dependencies:
@@ -13235,12 +13447,12 @@ snapshots:
       '@csstools/css-parser-algorithms': 2.7.1(@csstools/css-tokenizer@2.4.1)
       '@csstools/css-tokenizer': 2.4.1
 
-  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
-      '@csstools/color-helpers': 5.1.0
-      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
-      '@csstools/css-tokenizer': 3.0.4
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
 
   '@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1)':
     dependencies:
@@ -13250,9 +13462,19 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
 
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
   '@csstools/css-tokenizer@2.4.1': {}
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@csstools/media-query-list-parser@2.1.13(@csstools/css-parser-algorithms@2.7.1(@csstools/css-tokenizer@2.4.1))(@csstools/css-tokenizer@2.4.1)':
     dependencies:
@@ -13607,7 +13829,7 @@ snapshots:
     dependencies:
       cross-dirname: 0.1.0
       debug: 4.4.3(supports-color@5.5.0)
-      fs-extra: 11.3.3
+      fs-extra: 11.4.0
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
     transitivePeerDependencies:
@@ -13883,6 +14105,8 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.1': {}
+
+  '@exodus/bytes@1.15.1': {}
 
   '@fastify/ajv-compiler@4.0.5':
     dependencies:
@@ -14211,11 +14435,11 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.34.49
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.3.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.7.0(typescript@5.3.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.3.3)
-      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0)
     optionalDependencies:
       typescript: 5.3.3
 
@@ -14279,7 +14503,7 @@ snapshots:
 
   '@mapbox/geojson-types@1.0.2': {}
 
-  '@mapbox/jsonlint-lines-primitives@2.0.2': {}
+  '@mapbox/jsonlint-lines-primitives@2.0.3': {}
 
   '@mapbox/mapbox-gl-supported@1.5.0(mapbox-gl@1.13.3)':
     dependencies:
@@ -14289,7 +14513,7 @@ snapshots:
 
   '@mapbox/tiny-sdf@1.2.5': {}
 
-  '@mapbox/tiny-sdf@2.0.7': {}
+  '@mapbox/tiny-sdf@2.2.0': {}
 
   '@mapbox/unitbezier@0.0.0': {}
 
@@ -14303,7 +14527,7 @@ snapshots:
 
   '@maplibre/maplibre-gl-style-spec@20.4.0':
     dependencies:
-      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/unitbezier': 0.0.1
       json-stringify-pretty-compact: 4.0.0
       minimist: 1.2.8
@@ -14790,7 +15014,7 @@ snapshots:
     dependencies:
       '@mapbox/geojson-rewind': 0.5.2
       '@mapbox/geojson-types': 1.0.2
-      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/mapbox-gl-supported': 1.5.0(mapbox-gl@1.13.3)
       '@mapbox/point-geometry': 0.1.0
       '@mapbox/tiny-sdf': 1.2.5
@@ -15594,10 +15818,10 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-docs@10.3.5(@types/react@18.2.51)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))':
+  '@storybook/addon-docs@10.3.5(@types/react@18.2.51)(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2)(postcss@8.5.6))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.2.51)(react@18.2.0)
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2)(postcss@8.5.6))
       '@storybook/icons': 2.0.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@storybook/react-dom-shim': 10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       react: 18.2.0
@@ -15618,26 +15842,26 @@ snapshots:
     optionalDependencies:
       react: 18.2.0
 
-  '@storybook/builder-vite@10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))':
+  '@storybook/builder-vite@10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2)(postcss@8.5.6))':
     dependencies:
-      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2)(postcss@8.5.6))
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       ts-dedent: 2.2.0
-      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))':
+  '@storybook/csf-plugin@10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2)(postcss@8.5.6))':
     dependencies:
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.2
       rollup: 4.55.1
-      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
-      webpack: 5.104.1(esbuild@0.27.2)
+      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0)
+      webpack: 5.104.1(esbuild@0.27.2)(postcss@8.5.6)
 
   '@storybook/csf@0.0.1':
     dependencies:
@@ -15656,11 +15880,11 @@ snapshots:
       react-dom: 18.2.0(react@18.2.0)
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@storybook/react-vite@10.3.5(esbuild@0.27.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))':
+  '@storybook/react-vite@10.3.5(esbuild@0.27.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2)(postcss@8.5.6))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.3.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.7.0(typescript@5.3.3)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))
       '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
-      '@storybook/builder-vite': 10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2))
+      '@storybook/builder-vite': 10.3.5(esbuild@0.27.2)(rollup@4.55.1)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))(webpack@5.104.1(esbuild@0.27.2)(postcss@8.5.6))
       '@storybook/react': 10.3.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.3.3)
       empathic: 2.0.1
       magic-string: 0.30.21
@@ -15670,7 +15894,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.3.5(@testing-library/dom@10.4.0)(prettier@3.9.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       tsconfig-paths: 4.2.0
-      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -15769,36 +15993,37 @@ snapshots:
 
   '@tootallnate/once@2.0.0': {}
 
-  '@turf/area@7.3.1':
+  '@turf/area@7.3.5':
     dependencies:
-      '@turf/helpers': 7.3.1
-      '@turf/meta': 7.3.1
+      '@turf/helpers': 7.3.5
+      '@turf/meta': 7.3.5
       '@types/geojson': 7946.0.16
       tslib: 2.8.1
 
-  '@turf/bbox@7.3.1':
+  '@turf/bbox@7.3.5':
     dependencies:
-      '@turf/helpers': 7.3.1
-      '@turf/meta': 7.3.1
+      '@turf/helpers': 7.3.5
+      '@turf/meta': 7.3.5
       '@types/geojson': 7946.0.16
       tslib: 2.8.1
 
-  '@turf/centroid@7.3.1':
+  '@turf/centroid@7.3.5':
     dependencies:
-      '@turf/helpers': 7.3.1
-      '@turf/meta': 7.3.1
+      '@turf/helpers': 7.3.5
+      '@turf/meta': 7.3.5
       '@types/geojson': 7946.0.16
       tslib: 2.8.1
 
-  '@turf/helpers@7.3.1':
+  '@turf/helpers@7.3.5':
     dependencies:
       '@types/geojson': 7946.0.16
       tslib: 2.8.1
 
-  '@turf/meta@7.3.1':
+  '@turf/meta@7.3.5':
     dependencies:
-      '@turf/helpers': 7.3.1
+      '@turf/helpers': 7.3.5
       '@types/geojson': 7946.0.16
+      tslib: 2.8.1
 
   '@types/aria-query@5.0.4': {}
 
@@ -15858,11 +16083,11 @@ snapshots:
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   '@types/eslint@9.6.1':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
 
   '@types/estree-jsx@1.0.5':
@@ -15870,6 +16095,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/fernet@0.4.3':
     dependencies:
@@ -15979,6 +16206,10 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@types/node@26.1.1':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse-json@4.0.2': {}
@@ -16022,7 +16253,7 @@ snapshots:
 
   '@types/react-dom@18.2.18':
     dependencies:
-      '@types/react': 18.2.51
+      '@types/react': 19.2.17
     optional: true
 
   '@types/react-redux@7.1.32':
@@ -16041,6 +16272,11 @@ snapshots:
       '@types/prop-types': 15.7.15
       '@types/scheduler': 0.26.0
       csstype: 3.2.3
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+    optional: true
 
   '@types/reactcss@1.2.13(@types/react@18.2.51)':
     dependencies:
@@ -16589,14 +16825,14 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.2.0(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))':
+  '@vitejs/plugin-react@4.2.0(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16612,7 +16848,7 @@ snapshots:
       obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -16631,13 +16867,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.10(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -16820,9 +17056,9 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn-import-phases@1.0.4(acorn@8.15.0):
+  acorn-import-phases@1.0.4(acorn@8.17.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.17.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -16831,6 +17067,8 @@ snapshots:
   acorn@7.4.1: {}
 
   acorn@8.15.0: {}
+
+  acorn@8.17.0: {}
 
   add-stream@1.0.0: {}
 
@@ -16851,9 +17089,9 @@ snapshots:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv-formats@2.1.1(ajv@8.17.1):
+  ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
 
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
@@ -16868,9 +17106,9 @@ snapshots:
     dependencies:
       ajv: 6.12.6
 
-  ajv-keywords@5.1.0(ajv@8.17.1):
+  ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
       fast-deep-equal: 3.1.3
 
   ajv@6.12.3:
@@ -16891,6 +17129,13 @@ snapshots:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -17007,8 +17252,6 @@ snapshots:
       array-bounds: 1.0.1
 
   array-range@1.0.1: {}
-
-  array-rearrange@2.2.2: {}
 
   array-union@2.1.0: {}
 
@@ -17241,6 +17484,10 @@ snapshots:
 
   before-after-hook@2.2.3: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   big-integer@1.6.52: {}
 
   big.js@5.2.2: {}
@@ -17299,7 +17546,16 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
+  brace-expansion@1.1.16:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
   brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
@@ -17499,7 +17755,7 @@ snapshots:
       lru-cache: 7.18.3
       minipass: 3.3.6
       minipass-collect: 1.0.2
-      minipass-flush: 1.0.5
+      minipass-flush: 1.0.7
       minipass-pipeline: 1.2.4
       mkdirp: 1.0.4
       p-map: 4.0.0
@@ -17519,9 +17775,9 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
       minipass-collect: 2.0.1
-      minipass-flush: 1.0.5
+      minipass-flush: 1.0.7
       minipass-pipeline: 1.2.4
-      p-map: 7.0.4
+      p-map: 7.0.6
       ssri: 12.0.0
       tar: 7.5.13
       unique-filename: 4.0.0
@@ -18166,6 +18422,11 @@ snapshots:
       mdn-data: 2.12.2
       source-map-js: 1.2.1
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css.escape@1.5.1: {}
 
   csscolorparser@1.0.3: {}
@@ -18173,11 +18434,6 @@ snapshots:
   cssdb@7.11.2: {}
 
   cssesc@3.0.0: {}
-
-  cssstyle@4.6.0:
-    dependencies:
-      '@asamuzakjp/css-color': 3.2.0
-      rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
 
@@ -18215,7 +18471,7 @@ snapshots:
       commander: 2.20.3
       d3-array: 1.2.4
       d3-geo: 1.12.1
-      resolve: 1.22.11
+      resolve: 1.22.12
 
   d3-geo@1.12.1:
     dependencies:
@@ -18254,10 +18510,12 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
-  data-urls@5.0.0:
+  data-urls@7.0.0:
     dependencies:
-      whatwg-mimetype: 4.0.0
-      whatwg-url: 14.2.0
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -18644,7 +18902,7 @@ snapshots:
 
   earcut@2.2.4: {}
 
-  earcut@3.0.2: {}
+  earcut@3.2.3: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -18838,12 +19096,12 @@ snapshots:
       memory-fs: 0.5.0
       tapable: 1.1.3
 
-  enhanced-resolve@5.18.4:
+  enhanced-resolve@5.24.3:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.0
+      tapable: 2.3.3
 
-  entities@6.0.1: {}
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -18940,6 +19198,8 @@ snapshots:
       safe-array-concat: 1.1.3
 
   es-module-lexer@2.0.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -19180,8 +19440,8 @@ snapshots:
       eslint-plugin-es: 3.0.1(eslint@8.57.1)
       eslint-utils: 2.1.0
       ignore: 5.3.2
-      minimatch: 3.1.2
-      resolve: 1.22.11
+      minimatch: 3.1.5
+      resolve: 1.22.12
       semver: 6.3.1
 
   eslint-plugin-promise@4.3.1: {}
@@ -19558,6 +19818,8 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fast-uri@3.1.4: {}
+
   fast-xml-parser@5.2.5:
     dependencies:
       strnum: 2.1.2
@@ -19582,7 +19844,7 @@ snapshots:
       process-warning: 5.0.0
       rfdc: 1.4.1
       secure-json-parse: 4.1.0
-      semver: 7.7.3
+      semver: 7.6.2
       toad-cache: 3.7.0
     optional: true
 
@@ -19649,7 +19911,7 @@ snapshots:
 
   filelist@1.0.4:
     dependencies:
-      minimatch: 5.1.6
+      minimatch: 5.1.9
 
   filename-reserved-regex@2.0.0: {}
 
@@ -19834,6 +20096,13 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
+  fs-extra@11.4.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+    optional: true
+
   fs-extra@6.0.1:
     dependencies:
       graceful-fs: 4.2.11
@@ -19896,7 +20165,7 @@ snapshots:
 
   geojson-vt@3.2.1: {}
 
-  geojson-vt@4.0.2: {}
+  geojson-vt@4.0.3: {}
 
   get-amd-module-type@3.0.2:
     dependencies:
@@ -20040,7 +20309,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.5
+      minimatch: 9.0.9
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -20065,7 +20334,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 5.1.6
+      minimatch: 5.1.9
       once: 1.4.0
 
   glob@9.3.5:
@@ -20194,7 +20463,7 @@ snapshots:
       graceful-fs: 4.2.11
       inherits: 2.0.4
       map-limit: 0.0.1
-      resolve: 1.22.11
+      resolve: 1.22.12
 
   glslify@7.1.1:
     dependencies:
@@ -20208,7 +20477,7 @@ snapshots:
       glslify-bundle: 5.1.1
       glslify-deps: 1.3.2
       minimist: 1.2.8
-      resolve: 1.22.11
+      resolve: 1.22.12
       stack-trace: 0.0.9
       static-eval: 2.1.1
       through2: 2.0.5
@@ -20437,9 +20706,11 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
-  html-encoding-sniffer@4.0.0:
+  html-encoding-sniffer@6.0.0:
     dependencies:
-      whatwg-encoding: 3.1.1
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   html-escaper@2.0.2: {}
 
@@ -20603,7 +20874,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ip-regex@5.0.0: {}
 
@@ -20678,6 +20949,10 @@ snapshots:
     dependencies:
       hasown: 2.0.4
 
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
   is-data-view@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -20722,8 +20997,6 @@ snapshots:
   is-hexadecimal@1.0.4: {}
 
   is-hexadecimal@2.0.1: {}
-
-  is-iexplorer@1.0.0: {}
 
   is-immutable-type@5.0.1(eslint@8.57.1)(typescript@5.3.3):
     dependencies:
@@ -20873,6 +21146,8 @@ snapshots:
 
   isexe@3.1.1: {}
 
+  isexe@3.1.5: {}
+
   isomorphic-fetch@2.2.1:
     dependencies:
       node-fetch: 1.7.3
@@ -20921,7 +21196,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 26.1.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -20963,32 +21238,31 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@26.1.0:
+  jsdom@29.1.1:
     dependencies:
-      cssstyle: 4.6.0
-      data-urls: 5.0.0
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
       decimal.js: 10.6.0
-      html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      html-encoding-sniffer: 6.0.0
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.23
-      parse5: 7.3.0
-      rrweb-cssom: 0.8.0
+      lru-cache: 11.5.2
+      parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
-      tough-cookie: 5.1.2
+      tough-cookie: 6.0.2
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
-      webidl-conversions: 7.0.0
-      whatwg-encoding: 3.1.1
-      whatwg-mimetype: 4.0.0
-      whatwg-url: 14.2.0
-      ws: 8.19.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -21035,6 +21309,13 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+    optional: true
+
   jsonparse@1.3.1: {}
 
   jsx-ast-utils@3.3.5:
@@ -21060,7 +21341,7 @@ snapshots:
 
   kdbush@3.0.0: {}
 
-  kdbush@4.0.2: {}
+  kdbush@4.1.0: {}
 
   keyboardevent-from-electron-accelerator@2.0.0: {}
 
@@ -21131,7 +21412,7 @@ snapshots:
       pify: 3.0.0
       strip-bom: 3.0.0
 
-  loader-runner@4.3.1: {}
+  loader-runner@4.3.2: {}
 
   loader-utils@2.0.4:
     dependencies:
@@ -21223,7 +21504,7 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
-  lru-cache@11.3.6: {}
+  lru-cache@11.5.2: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -21307,7 +21588,7 @@ snapshots:
       minipass: 3.3.6
       minipass-collect: 1.0.2
       minipass-fetch: 2.1.2
-      minipass-flush: 1.0.5
+      minipass-flush: 1.0.7
       minipass-pipeline: 1.2.4
       negotiator: 0.6.4
       promise-retry: 2.0.1
@@ -21324,7 +21605,7 @@ snapshots:
       http-cache-semantics: 4.2.0
       minipass: 7.1.3
       minipass-fetch: 4.0.1
-      minipass-flush: 1.0.5
+      minipass-flush: 1.0.7
       minipass-pipeline: 1.2.4
       negotiator: 1.0.0
       proc-log: 5.0.0
@@ -21345,7 +21626,7 @@ snapshots:
     dependencies:
       '@mapbox/geojson-rewind': 0.5.2
       '@mapbox/geojson-types': 1.0.2
-      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/mapbox-gl-supported': 1.5.0(mapbox-gl@1.13.3)
       '@mapbox/point-geometry': 0.1.0
       '@mapbox/tiny-sdf': 1.2.5
@@ -21369,9 +21650,9 @@ snapshots:
   maplibre-gl@4.7.1:
     dependencies:
       '@mapbox/geojson-rewind': 0.5.2
-      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/point-geometry': 0.1.0
-      '@mapbox/tiny-sdf': 2.0.7
+      '@mapbox/tiny-sdf': 2.2.0
       '@mapbox/unitbezier': 0.0.1
       '@mapbox/vector-tile': 1.3.1
       '@mapbox/whoots-js': 3.1.0
@@ -21382,11 +21663,11 @@ snapshots:
       '@types/mapbox__vector-tile': 1.3.4
       '@types/pbf': 3.0.5
       '@types/supercluster': 7.1.3
-      earcut: 3.0.2
-      geojson-vt: 4.0.2
+      earcut: 3.2.3
+      geojson-vt: 4.0.3
       gl-matrix: 3.4.4
       global-prefix: 4.0.0
-      kdbush: 4.0.2
+      kdbush: 4.1.0
       murmurhash-js: 1.0.0
       pbf: 3.3.0
       potpack: 2.1.0
@@ -21507,6 +21788,8 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.12.2: {}
+
+  mdn-data@2.27.1: {}
 
   mdns-js@1.0.1:
     dependencies:
@@ -21739,9 +22022,13 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@5.1.6:
+  minimatch@3.1.5:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 1.1.16
+
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.2
 
   minimatch@8.0.4:
     dependencies:
@@ -21754,6 +22041,10 @@ snapshots:
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.2
 
   minimist-options@4.1.0:
     dependencies:
@@ -21787,7 +22078,7 @@ snapshots:
     optionalDependencies:
       encoding: 0.1.13
 
-  minipass-flush@1.0.5:
+  minipass-flush@1.0.7:
     dependencies:
       minipass: 3.3.6
 
@@ -21928,7 +22219,7 @@ snapshots:
     dependencies:
       debug: 3.2.7
       iconv-lite: 0.4.24
-      sax: 1.4.4
+      sax: 1.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -22091,8 +22382,6 @@ snapshots:
     dependencies:
       is-finite: 1.1.0
 
-  nwsapi@2.2.23: {}
-
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -22249,7 +22538,7 @@ snapshots:
     dependencies:
       aggregate-error: 3.1.0
 
-  p-map@7.0.4: {}
+  p-map@7.0.6: {}
 
   p-retry@4.6.2:
     dependencies:
@@ -22321,9 +22610,9 @@ snapshots:
 
   parse5@5.1.1: {}
 
-  parse5@7.3.0:
+  parse5@8.0.1:
     dependencies:
-      entities: 6.0.1
+      entities: 8.0.0
 
   path-browserify@1.0.1: {}
 
@@ -22348,7 +22637,7 @@ snapshots:
 
   path-scurry@2.0.2:
     dependencies:
-      lru-cache: 11.3.6
+      lru-cache: 11.5.2
       minipass: 7.1.3
 
   path-type@1.1.0:
@@ -22475,9 +22764,9 @@ snapshots:
       '@plotly/d3-sankey-circular': 0.33.1
       '@plotly/mapbox-gl': 1.13.4(mapbox-gl@1.13.3)
       '@plotly/regl': 2.1.2
-      '@turf/area': 7.3.1
-      '@turf/bbox': 7.3.1
-      '@turf/centroid': 7.3.1
+      '@turf/area': 7.3.5
+      '@turf/bbox': 7.3.5
+      '@turf/centroid': 7.3.5
       base64-arraybuffer: 1.0.2
       canvas-fit: 1.5.0
       color-alpha: 1.0.4
@@ -22507,10 +22796,10 @@ snapshots:
       parse-svg-path: 0.1.2
       point-in-polygon: 1.1.0
       polybooljs: 1.2.2
-      probe-image-size: 7.2.3
+      probe-image-size: 7.3.0
       regl-error2d: 2.0.12
       regl-line2d: 3.1.3
-      regl-scatter2d: 3.3.1
+      regl-scatter2d: 3.4.0
       regl-splom: 1.0.14
       strongly-connected-components: 1.0.1
       superscript-text: 1.0.0
@@ -22662,7 +22951,7 @@ snapshots:
       '@csstools/utilities': 1.0.0(postcss@8.5.6)
       postcss: 8.5.6
 
-  postcss-loader@4.3.0(postcss@8.5.6)(webpack@5.104.1(esbuild@0.27.2)):
+  postcss-loader@4.3.0(postcss@8.5.6)(webpack@5.104.1(esbuild@0.27.2)(postcss@8.5.6)):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
@@ -22670,7 +22959,7 @@ snapshots:
       postcss: 8.5.6
       schema-utils: 3.3.0
       semver: 7.7.3
-      webpack: 5.104.1(esbuild@0.27.2)
+      webpack: 5.104.1(esbuild@0.27.2)(postcss@8.5.6)
 
   postcss-logical@7.0.1(postcss@8.5.6):
     dependencies:
@@ -22894,7 +23183,7 @@ snapshots:
     dependencies:
       parse-ms: 2.1.0
 
-  probe-image-size@7.2.3:
+  probe-image-size@7.3.0:
     dependencies:
       lodash.merge: 4.6.2
       needle: 2.9.1
@@ -22949,7 +23238,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protocol-buffers-schema@3.6.0: {}
+  protocol-buffers-schema@3.6.1: {}
 
   proxy-from-env@1.1.0: {}
 
@@ -23051,7 +23340,7 @@ snapshots:
     dependencies:
       dnd-core: 16.0.1
 
-  react-dnd@16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@18.2.51))(@types/node@25.6.0)(@types/react@18.2.51)(react@18.2.0):
+  react-dnd@16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@18.2.51))(@types/node@26.1.1)(@types/react@18.2.51)(react@18.2.0):
     dependencies:
       '@react-dnd/invariant': 4.0.2
       '@react-dnd/shallowequal': 4.0.2
@@ -23061,7 +23350,7 @@ snapshots:
       react: 18.2.0
     optionalDependencies:
       '@types/hoist-non-react-statics': 3.3.7(@types/react@18.2.51)
-      '@types/node': 25.6.0
+      '@types/node': 26.1.1
       '@types/react': 18.2.51
 
   react-docgen-typescript@1.22.0(typescript@5.3.3):
@@ -23458,19 +23747,14 @@ snapshots:
       pick-by-alias: 1.2.0
       to-float32: 1.1.0
 
-  regl-scatter2d@3.3.1:
+  regl-scatter2d@3.4.0:
     dependencies:
       '@plotly/point-cluster': 3.1.9
-      array-range: 1.0.1
-      array-rearrange: 2.2.2
-      clamp: 1.0.1
+      array-bounds: 1.0.1
       color-id: 1.1.0
       color-normalize: 1.5.0
-      color-rgba: 2.4.0
       flatten-vertex-data: 1.0.2
       glslify: 7.1.1
-      is-iexplorer: 1.0.0
-      object-assign: 4.1.1
       parse-rect: 1.2.0
       pick-by-alias: 1.2.0
       to-float32: 1.1.0
@@ -23485,7 +23769,7 @@ snapshots:
       parse-rect: 1.2.0
       pick-by-alias: 1.2.0
       raf: 3.4.1
-      regl-scatter2d: 3.3.1
+      regl-scatter2d: 3.4.0
 
   regl@2.1.1: {}
 
@@ -23582,13 +23866,20 @@ snapshots:
 
   resolve-protobuf-schema@2.1.0:
     dependencies:
-      protocol-buffers-schema: 3.6.0
+      protocol-buffers-schema: 3.6.1
 
   resolve@0.6.3: {}
 
   resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
@@ -23681,8 +23972,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.55.1
       fsevents: 2.3.3
 
-  rrweb-cssom@0.8.0: {}
-
   run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
@@ -23743,6 +24032,8 @@ snapshots:
 
   sax@1.4.4: {}
 
+  sax@1.6.1: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -23765,9 +24056,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
-      ajv-keywords: 5.1.0(ajv@8.17.1)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
 
   seamless-immutable@7.1.4:
     optional: true
@@ -23790,14 +24081,12 @@ snapshots:
 
   semver@7.7.3: {}
 
+  semver@7.8.5: {}
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
     optional: true
-
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
 
   serialport@10.5.0:
     dependencies:
@@ -23863,7 +24152,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.7.3
+      semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5
@@ -23981,7 +24270,7 @@ snapshots:
     dependencies:
       agent-base: 6.0.2
       debug: 4.4.3(supports-color@5.5.0)
-      socks: 2.8.7
+      socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
 
@@ -23989,13 +24278,13 @@ snapshots:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@5.5.0)
-      socks: 2.8.7
+      socks: 2.8.9
     transitivePeerDependencies:
       - supports-color
 
-  socks@2.8.7:
+  socks@2.8.9:
     dependencies:
-      ip-address: 10.1.0
+      ip-address: 10.2.0
       smart-buffer: 4.2.0
 
   sonic-boom@4.2.1:
@@ -24296,8 +24585,8 @@ snapshots:
 
   styled-components@5.3.11(react-dom@18.2.0(react@18.2.0))(react-is@18.3.1)(react@18.2.0):
     dependencies:
-      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
-      '@babel/traverse': 7.28.5(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.29.7(supports-color@5.5.0)
+      '@babel/traverse': 7.29.7(supports-color@5.5.0)
       '@emotion/is-prop-valid': 1.4.0
       '@emotion/stylis': 0.8.5
       '@emotion/unitless': 0.7.5
@@ -24417,7 +24706,7 @@ snapshots:
 
   supercluster@8.0.1:
     dependencies:
-      kdbush: 4.0.2
+      kdbush: 4.1.0
 
   superscript-text@1.0.0: {}
 
@@ -24475,7 +24764,7 @@ snapshots:
 
   tapable@1.1.3: {}
 
-  tapable@2.3.0: {}
+  tapable@2.3.3: {}
 
   tar-stream@1.6.2:
     dependencies:
@@ -24536,21 +24825,21 @@ snapshots:
       type-fest: 0.16.0
       unique-string: 2.0.0
 
-  terser-webpack-plugin@5.3.16(esbuild@0.27.2)(webpack@5.104.1(esbuild@0.27.2)):
+  terser-webpack-plugin@5.6.1(esbuild@0.27.2)(postcss@8.5.6)(webpack@5.104.1(esbuild@0.27.2)(postcss@8.5.6)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
-      terser: 5.44.1
-      webpack: 5.104.1(esbuild@0.27.2)
+      terser: 5.49.0
+      webpack: 5.104.1(esbuild@0.27.2)(postcss@8.5.6)
     optionalDependencies:
       esbuild: 0.27.2
+      postcss: 8.5.6
 
-  terser@5.44.1:
+  terser@5.49.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
-      acorn: 8.15.0
+      acorn: 8.17.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -24626,11 +24915,11 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
-  tldts-core@6.1.86: {}
+  tldts-core@7.4.9: {}
 
-  tldts@6.1.86:
+  tldts@7.4.9:
     dependencies:
-      tldts-core: 6.1.86
+      tldts-core: 7.4.9
 
   tmp-promise@3.0.3:
     dependencies:
@@ -24663,13 +24952,13 @@ snapshots:
 
   toposort@2.0.2: {}
 
-  tough-cookie@5.1.2:
+  tough-cookie@6.0.2:
     dependencies:
-      tldts: 6.1.86
+      tldts: 7.4.9
 
   tr46@0.0.3: {}
 
-  tr46@5.1.1:
+  tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
 
@@ -24864,8 +25153,12 @@ snapshots:
 
   undici-types@7.19.2: {}
 
+  undici-types@8.3.0: {}
+
   undici@7.25.0:
     optional: true
+
+  undici@7.29.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -25095,15 +25388,15 @@ snapshots:
 
   vite-bundle-analyzer@1.3.2: {}
 
-  vite-plugin-node-polyfills@0.25.0(rollup@4.55.1)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)):
+  vite-plugin-node-polyfills@0.25.0(rollup@4.55.1)(vite@7.3.5(@types/node@26.1.1)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.55.1)
       node-stdlib-browser: 1.3.1
-      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@26.1.1)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - rollup
 
-  vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0):
+  vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -25115,20 +25408,35 @@ snapshots:
       '@types/node': 25.6.0
       fsevents: 2.3.3
       jiti: 2.6.1
-      terser: 5.44.1
+      terser: 5.49.0
+      tsx: 4.21.0
+
+  vite@7.3.5(@types/node@26.1.1)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.55.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 26.1.1
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      terser: 5.49.0
       tsx: 4.21.0
 
   vitest-when@0.10.0(@vitest/expect@4.1.10)(vitest@4.1.10):
     dependencies:
       pretty-format: 30.3.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))
     optionalDependencies:
       '@vitest/expect': 4.1.10
 
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(jsdom@26.1.0)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1)(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.10(vite@7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -25145,13 +25453,13 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.44.1)(tsx@4.21.0)
+      vite: 7.3.5(@types/node@25.6.0)(jiti@2.6.1)(terser@5.49.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 25.6.0
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
-      jsdom: 26.1.0
+      jsdom: 29.1.1
     transitivePeerDependencies:
       - msw
 
@@ -25201,9 +25509,8 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  watchpack@2.5.0:
+  watchpack@2.5.2:
     dependencies:
-      glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
   wcwidth@1.0.1:
@@ -25236,58 +25543,68 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  webidl-conversions@7.0.0: {}
+  webidl-conversions@8.0.1: {}
 
   webpack-sources@3.3.3: {}
+
+  webpack-sources@3.5.1: {}
 
   webpack-virtual-modules@0.5.0: {}
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.104.1(esbuild@0.27.2):
+  webpack@5.104.1(esbuild@0.27.2)(postcss@8.5.6):
     dependencies:
       '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
       browserslist: 4.28.1
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.18.4
-      es-module-lexer: 2.0.0
+      enhanced-resolve: 5.24.3
+      es-module-lexer: 2.3.1
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
       json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
+      loader-runner: 4.3.2
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.27.2)(webpack@5.104.1(esbuild@0.27.2))
-      watchpack: 2.5.0
-      webpack-sources: 3.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(esbuild@0.27.2)(postcss@8.5.6)(webpack@5.104.1(esbuild@0.27.2)(postcss@8.5.6))
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
     transitivePeerDependencies:
+      - '@minify-html/node'
       - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
       - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
       - uglify-js
-
-  whatwg-encoding@3.1.1:
-    dependencies:
-      iconv-lite: 0.6.3
 
   whatwg-fetch@3.6.20: {}
 
-  whatwg-mimetype@4.0.0: {}
+  whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@14.2.0:
+  whatwg-url@16.0.1:
     dependencies:
-      tr46: 5.1.1
-      webidl-conversions: 7.0.0
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   whatwg-url@5.0.0:
     dependencies:
@@ -25347,7 +25664,7 @@ snapshots:
 
   which@4.0.0:
     dependencies:
-      isexe: 3.1.1
+      isexe: 3.1.5
 
   which@5.0.0:
     dependencies:


### PR DESCRIPTION
## Overview

This is an annoying PR, sorry. It unblocks #22130.

In #22130, I had the innocent dream of writing a CSS selector with `:has()`. This caused a handful of tests to blow up with obscure errors like:

```
SyntaxError: 'form,,:r0,,._fields_container_af4dc2 input:disabled' is not a valid selector
```

This was apparently because of bugs in our old jsdom's old CSS selector engine. Upgrading fixes it—In jsdom 27, they switched their CSS selector engine from [nwsapi](https://www.npmjs.com/nwsapi) to [@asamuzakjp/dom-selector](https://www.npmjs.com/package/@asamuzakjp/dom-selector).

But upgrading also causes a bunch of unrelated tests to fail. We have to modernize them to keep them passing.

## Changelog

You can view this commit-by-commit, but, in short:

* We were firing raw `click` events. Per react-testing-library's [recommendation](https://testing-library.com/docs/user-event/intro/), this PR switches us to the higher-level `userEvent` interface. `userEvent` fires many raw events for a given higher-level user action, more closely mimicking the browser.

  We need to do this now because the jsdom upgrade changed which events are available in the test environment, which changed which events the production code listens for.

* A few assertions needed to change because of how jsdom computes and normalizes styles.

## Test Plan and Hands on Testing

* [x] `CheckboxField` looks the same as it did before.
* [x] `Skeleton` looks the same as it did before.

These are the only production changes.

## Review requests

In principle, does all of this make sense?

## Risk assessment

Low. Aside from `CheckboxField`, this only affects tests, not production code.