### PR TITLE
feat(auth-server,robot-server): Optionally restrict run signoff to admins

### DIFF
--- a/auth-server/auth_server/users/scopes.py
+++ b/auth-server/auth_server/users/scopes.py
@@ -48,6 +48,8 @@ def get_scope_set_of_account_type(
                 result.add(Scope.UPDATES_WRITE)
             if not settings.requireAdminCredsWhenSendingProtocolToRobot:
                 result.add(Scope.PROTOCOLS_WRITE)
+            if not settings.requireAdminCredsForSignoffProtocol:
+                result.add(Scope.RUN_SIGNOFF_WRITE)
             return result
 
         else:

--- a/auth-server/tests/integration/test_oauth_scopes_and_settings.tavern.yaml
+++ b/auth-server/tests/integration/test_oauth_scopes_and_settings.tavern.yaml
@@ -20,6 +20,7 @@ stages:
       verify_response_with:
         function: tests.integration.utils:verify_oauth_scopes
         extra_kwargs:
+          expected_present: run_signoff.write
           expected_absent: updates.write protocols.write
       save:
         json:
@@ -37,6 +38,7 @@ stages:
       verify_response_with:
         function: tests.integration.utils:verify_oauth_scopes
         extra_kwargs:
+          expected_present: run_signoff.write
           expected_absent: updates.write protocols.write
 
   - name: Allow regular users to update robot software
@@ -65,7 +67,7 @@ stages:
       verify_response_with:
         function: tests.integration.utils:verify_oauth_scopes
         extra_kwargs:
-          expected_present: updates.write
+          expected_present: updates.write run_signoff.write
           expected_absent: protocols.write
       save:
         json:
@@ -83,7 +85,7 @@ stages:
       verify_response_with:
         function: tests.integration.utils:verify_oauth_scopes
         extra_kwargs:
-          expected_present: updates.write
+          expected_present: updates.write run_signoff.write
           expected_absent: protocols.write
 
   - name: Allow regular users to send protocols to the robot
@@ -112,7 +114,7 @@ stages:
       verify_response_with:
         function: tests.integration.utils:verify_oauth_scopes
         extra_kwargs:
-          expected_present: updates.write protocols.write
+          expected_present: updates.write protocols.write run_signoff.write
       save:
         json:
           user_access_token: access_token
@@ -129,4 +131,51 @@ stages:
       verify_response_with:
         function: tests.integration.utils:verify_oauth_scopes
         extra_kwargs:
+          expected_present: updates.write protocols.write run_signoff.write
+
+  - name: Require admin credentials for protocol signoff
+    request:
+      method: PATCH
+      url: '{run_server.base_url}/auth/settings'
+      headers:
+        Authorization: '{admin_access_token}'
+      json:
+        data:
+          requireAdminCredsForSignoffProtocol: true
+    response:
+      status_code: 200
+
+  - name: Regular users should lose run_signoff.write when signoff is admin-only
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/token'
+      data:
+        client_id: opentrons_app
+        grant_type: password
+        username: testuser
+        password: testuserpassword
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tests.integration.utils:verify_oauth_scopes
+        extra_kwargs:
           expected_present: updates.write protocols.write
+          expected_absent: run_signoff.write
+      save:
+        json:
+          user_access_token: access_token
+
+  - name: Token introspection should match signoff-restricted login scopes
+    request:
+      method: POST
+      url: '{run_server.base_url}/auth/oauth2/introspect'
+      data:
+        client_id: opentrons_app
+        token: '{user_access_token}'
+    response:
+      status_code: 200
+      verify_response_with:
+        function: tests.integration.utils:verify_oauth_scopes
+        extra_kwargs:
+          expected_present: updates.write protocols.write
+          expected_absent: run_signoff.write

--- a/robot-server/robot_server/runs/router/base_router.py
+++ b/robot-server/robot_server/runs/router/base_router.py
@@ -33,9 +33,19 @@ from opentrons.protocol_engine.types import CSVRuntimeParamPaths, DeckSlotLocati
 from opentrons_shared_data.errors import ErrorCodes
 from opentrons_shared_data.robot.types import RobotTypeEnum
 from server_utils.audit.fastapi import get_audit_logger
+from server_utils.auth.resource_server.authorization_checker import (
+    check as check_authorization,
+)
 from server_utils.auth.resource_server.fastapi import (
+    AuthorizationError,
+    RequireAuthenticationResult,
     get_access_control_status,
+    require_authentication,
     require_scopes,
+)
+from server_utils.auth.resource_server.types import (
+    AuthorizationNotRequiredResult,
+    AuthorizedResult,
 )
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.light_router import LightRouter
@@ -426,6 +436,18 @@ async def remove_run(
     )
 
 
+def _require_signoff_scope(
+    authentication: RequireAuthenticationResult,
+) -> None:
+    authorization_result = check_authorization(
+        authentication, {Scope.RUN_SIGNOFF_WRITE}
+    )
+    if not isinstance(
+        authorization_result, (AuthorizationNotRequiredResult, AuthorizedResult)
+    ):
+        raise AuthorizationError(authorization_result, {Scope.RUN_SIGNOFF_WRITE})
+
+
 @PydanticResponse.wrap_route(
     base_router.patch,
     path="/runs/{runId}",
@@ -447,6 +469,9 @@ async def update_run(
     runId: str,
     request_body: RequestModel[RunUpdate],
     run_data_manager: Annotated[RunDataManager, Depends(get_run_data_manager)],
+    authentication: Annotated[
+        RequireAuthenticationResult, Depends(require_authentication)
+    ],
 ) -> PydanticResponse[SimpleBody[Union[Run, BadRun]]]:
     """Update a run by its ID.
 
@@ -454,7 +479,11 @@ async def update_run(
         runId: Run ID pulled from URL.
         request_body: Update data from request body.
         run_data_manager: Current and historical run data management.
+        authentication: The authenticated user, if any.
     """
+    if request_body.data.signedBy is not None:
+        _require_signoff_scope(authentication)
+
     try:
         run_data: Run | BadRun | None = None
         if request_body.data.signedBy is not None:

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -788,9 +788,7 @@ async def test_update_run_signed_by(
     )
 
     decoy.when(
-        mock_run_data_manager.set_signed_by(
-            run_id="run-id", signed_by="Alice Example"
-        )
+        mock_run_data_manager.set_signed_by(run_id="run-id", signed_by="Alice Example")
     ).then_return(expected_response)
 
     result = await update_run(

--- a/robot-server/tests/runs/router/test_base_router.py
+++ b/robot-server/tests/runs/router/test_base_router.py
@@ -36,6 +36,12 @@ from opentrons_shared_data.labware.labware_definition import (
 )
 from opentrons_shared_data.labware.types import LabwareDefinition as LabwareDefDict
 from opentrons_shared_data.robot.types import RobotTypeEnum
+from server_utils.auth.resource_server.fastapi import AuthorizationError
+from server_utils.auth.resource_server.types import (
+    AuthenticatedResult,
+    AuthenticationNotRequiredResult,
+)
+from server_utils.auth.scopes import Scope, serialize_scopes
 from server_utils.fastapi_utils.models.json_api import (
     MultiBodyMeta,
     RequestModel,
@@ -631,6 +637,7 @@ async def test_update_run_to_not_current(
         runId="run-id",
         request_body=RequestModel(data=RunUpdate(current=False)),
         run_data_manager=mock_run_data_manager,
+        authentication=AuthenticationNotRequiredResult(),
     )
 
     assert result.content == SimpleBody(data=expected_response)
@@ -666,6 +673,7 @@ async def test_update_current_none_noop(
         runId="run-id",
         request_body=RequestModel(data=RunUpdate()),
         run_data_manager=mock_run_data_manager,
+        authentication=AuthenticationNotRequiredResult(),
     )
 
     assert result.content == SimpleBody(data=expected_response)
@@ -686,6 +694,7 @@ async def test_update_to_current_not_current(
             runId="run-id",
             request_body=RequestModel(data=RunUpdate(current=False)),
             run_data_manager=mock_run_data_manager,
+            authentication=AuthenticationNotRequiredResult(),
         )
 
     assert exc_info.value.status_code == 409
@@ -706,6 +715,7 @@ async def test_update_to_current_conflict(
             runId="run-id",
             request_body=RequestModel(data=RunUpdate(current=False)),
             run_data_manager=mock_run_data_manager,
+            authentication=AuthenticationNotRequiredResult(),
         )
 
     assert exc_info.value.status_code == 409
@@ -726,10 +736,72 @@ async def test_update_to_current_missing(
             runId="run-id",
             request_body=RequestModel(data=RunUpdate(current=False)),
             run_data_manager=mock_run_data_manager,
+            authentication=AuthenticationNotRequiredResult(),
         )
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.content["errors"][0]["id"] == "RunNotFound"
+
+
+async def test_update_run_signed_by_requires_run_signoff_write_scope(
+    decoy: Decoy,
+    mock_run_data_manager: RunDataManager,
+) -> None:
+    """It should reject signedBy updates when the token lacks run_signoff.write."""
+    with pytest.raises(AuthorizationError) as exc_info:
+        await update_run(
+            runId="run-id",
+            request_body=RequestModel(data=RunUpdate(signedBy="Alice Example")),
+            run_data_manager=mock_run_data_manager,
+            authentication=AuthenticatedResult(
+                scope=serialize_scopes({Scope.ROBOT_CONTROL_WRITE}),
+                username="testuser",
+                fullname="Test User",
+            ),
+        )
+
+    assert exc_info.value.required_scopes == {Scope.RUN_SIGNOFF_WRITE}
+
+
+async def test_update_run_signed_by(
+    decoy: Decoy,
+    mock_run_data_manager: RunDataManager,
+) -> None:
+    """It should update signedBy when the request is authorized."""
+    expected_response = Run(
+        id="run-id",
+        protocolId=None,
+        createdAt=datetime(year=2021, month=1, day=1),
+        status=pe_types.EngineStatus.SUCCEEDED,
+        current=True,
+        actions=[],
+        errors=[],
+        pipettes=[],
+        modules=[],
+        labware=[],
+        labwareOffsets=[],
+        liquids=[],
+        liquidClasses=[],
+        outputFileIds=[],
+        hasEverEnteredErrorRecovery=False,
+        signedBy="Alice Example",
+    )
+
+    decoy.when(
+        mock_run_data_manager.set_signed_by(
+            run_id="run-id", signed_by="Alice Example"
+        )
+    ).then_return(expected_response)
+
+    result = await update_run(
+        runId="run-id",
+        request_body=RequestModel(data=RunUpdate(signedBy="Alice Example")),
+        run_data_manager=mock_run_data_manager,
+        authentication=AuthenticationNotRequiredResult(),
+    )
+
+    assert result.content == SimpleBody(data=expected_response)
+    assert result.status_code == 200
 
 
 async def test_get_run_commands_errors(

--- a/server-utils/server_utils/auth/scopes.py
+++ b/server-utils/server_utils/auth/scopes.py
@@ -68,6 +68,11 @@ class Scope(enum.Enum):
         ),
     )
 
+    RUN_SIGNOFF_WRITE = (
+        "run_signoff.write",
+        "Sign off on a completed protocol run.",
+    )
+
     # We actually want access control mode to totally disable SSH, so this scope is
     # kind of moot. At some point, we might delete this, and replace the SSH endpoints'
     # use of `require_scopes(SSH_KEYS_WRITE)` with something like


### PR DESCRIPTION
## Overview

This closes EXEC-2778.

## Test Plan and Hands on Testing

We should be covered by automated tests.

## Changelog

* Add a new scope, `RUN_SIGNOFF_WRITE`.
* Grant the scope to regular users or not, depending on the `requireAdminCredsForSignoffProtocol` setting.
* In `PATCH /runs/{id}`, require the scope if (and only if) the request tried to modify `signedBy`.

## Review requests

Does this seem like an OK way of having `PATCH /runs/{id}` conditionally require the `RUN_SIGNOFF_WRITE` scope? Is there a cleaner way to do this?

## Risk assessment

Low.