### PR TITLE
fix(step-generation): support hs setShakeSpeed command

### DIFF
--- a/step-generation/src/getNextRobotStateAndWarnings/index.ts
+++ b/step-generation/src/getNextRobotStateAndWarnings/index.ts
@@ -403,6 +403,7 @@ function _getNextRobotStateAndWarningsSingleCommand(
       )
       break
     case 'heaterShaker/setAndWaitForShakeSpeed':
+    case 'heaterShaker/setShakeSpeed':
       forHeaterShakerSetTargetShakeSpeed(
         command.params,
         invariantContext,


### PR DESCRIPTION


# Overview
support hs setShakeSpeed command

step-generation doesn't cover `setShakeSpeed` so protocol visualization shows

```
console.error: unknown command: heaterShaker/setShakeSpeed passed to getNextRobotStateAndWarning
```

closes AUTH-3154

## Test Plan and Hands on Testing


## Changelog
- add setShakeSpeed to case statement

## Review requests


## Risk assessment
low
