### PR TITLE
fix(api, robot-server): Remove subprocess flag regression patch

### DIFF
--- a/api/src/opentrons/config/feature_flags.py
+++ b/api/src/opentrons/config/feature_flags.py
@@ -80,23 +80,15 @@ def flex_stacker_tof_sensors_disabled() -> bool:
 
 
 def protocol_subprocess_enabled() -> bool:
-    # return advs.get_setting_with_env_overload(
-    #     "enableProtocolSubprocess", RobotTypeEnum.FLEX
-    # )
-    # NOTE: This is here to no-op the entire hardware layer entry process for robot versions below 10.0.0
-    # this patch should be REMOVED for releases >= 10.0.0
-    # See: https://opentrons.atlassian.net/browse/EXEC-2897
-    return False
+    return advs.get_setting_with_env_overload(
+        "enableProtocolSubprocess", RobotTypeEnum.FLEX
+    )
 
 
 def hardware_subprocess_enabled() -> bool:
-    # return advs.get_setting_with_env_overload(
-    #     "enableHardwareSubprocess", RobotTypeEnum.FLEX
-    # )
-    # NOTE: This is here to no-op the entire hardware layer entry process for robot versions below 10.0.0
-    # this patch should be REMOVED for releases >= 10.0.0
-    # See: https://opentrons.atlassian.net/browse/EXEC-2897
-    return False
+    return advs.get_setting_with_env_overload(
+        "enableHardwareSubprocess", RobotTypeEnum.FLEX
+    )
 
 
 def run_protocol_as_restricted_user() -> bool:

--- a/api/src/opentrons/hardware_control/pyro_utils/pyro_process_entry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/pyro_process_entry.py
@@ -123,4 +123,3 @@ if __name__ == "__main__":
         help="Flag to determine if the process should run with a hardware simulator or active hardware.",
     )
     asyncio.run(build_and_run_hwc_pyro(parser.parse_args().simulate))
-

--- a/api/src/opentrons/hardware_control/pyro_utils/pyro_process_entry.py
+++ b/api/src/opentrons/hardware_control/pyro_utils/pyro_process_entry.py
@@ -112,21 +112,15 @@ async def build_and_run_hwc_pyro(simulate: bool) -> None:
 
 
 if __name__ == "__main__":
-    # NOTE: This is here to no-op the entire hardware layer entry process for robot versions below 10.0.0
-    # this patch should be REMOVED for releases >= 10.0.0
-    # See: https://opentrons.atlassian.net/browse/EXEC-2897
-    if False:
-        parser = argparse.ArgumentParser(
-            description="Starts and runs the hardware subprocess and a Pyro daemon to handle requests."
-            " Requires a nameserver to be running."
-        )
-        parser.add_argument(
-            "--simulate",
-            required=False,
-            default=False,
-            help="Flag to determine if the process should run with a hardware simulator or active hardware.",
-        )
-        asyncio.run(build_and_run_hwc_pyro(parser.parse_args().simulate))
+    parser = argparse.ArgumentParser(
+        description="Starts and runs the hardware subprocess and a Pyro daemon to handle requests."
+        " Requires a nameserver to be running."
+    )
+    parser.add_argument(
+        "--simulate",
+        required=False,
+        default=False,
+        help="Flag to determine if the process should run with a hardware simulator or active hardware.",
+    )
+    asyncio.run(build_and_run_hwc_pyro(parser.parse_args().simulate))
 
-    # NOTE: this notification patch should be REMOVED for releases >= 10.0.0
-    hardware_process_notify_up()

--- a/robot-server/tests/runs/test_run_process.py
+++ b/robot-server/tests/runs/test_run_process.py
@@ -167,10 +167,6 @@ async def _host_pyro_nameserver_and_ot3api(
     return (ot3_async, rs_async)
 
 
-# NOTE: This is here to handle test failures for a feature flag migration bug on versions < 10.0.0
-# this patch should be REMOVED for releases >= 10.0.0
-# See: https://opentrons.atlassian.net/browse/EXEC-2897
-@pytest.mark.xfail
 async def test_run_process_proxy(
     mock_app_state: AppState,
     ot3_hardware_api: OT3API,
@@ -217,10 +213,6 @@ async def test_run_process_proxy(
     protocol_proxy._pyroRelease()  # type: ignore
 
 
-# NOTE: This is here to handle test failures for a feature flag migration bug on versions < 10.0.0
-# this patch should be REMOVED for releases >= 10.0.0
-# See: https://opentrons.atlassian.net/browse/EXEC-2897
-@pytest.mark.xfail
 async def test_run_process_create(
     decoy: Decoy,
     mock_app_state: AppState,

--- a/robot-server/tests/service/pyro_utils/test_pyro_resource.py
+++ b/robot-server/tests/service/pyro_utils/test_pyro_resource.py
@@ -152,10 +152,6 @@ async def _host_pyro_nameserver_and_ot3api(
     return (ot3_async, rs_async)
 
 
-# NOTE: This is here to handle test failures for a feature flag migration bug on versions < 10.0.0
-# this patch should be REMOVED for releases >= 10.0.0
-# See: https://opentrons.atlassian.net/browse/EXEC-2897
-@pytest.mark.xfail
 async def test_run_hardware_event_callback(
     ot3_hardware_api: OT3API,
     mock_app_state: AppState,
@@ -200,10 +196,6 @@ async def test_run_hardware_event_callback(
     assert isinstance(default_run_door_watcher_result, ClientPyroFunctionWrapper)
 
 
-# NOTE: This is here to handle test failures for a feature flag migration bug on versions < 10.0.0
-# this patch should be REMOVED for releases >= 10.0.0
-# See: https://opentrons.atlassian.net/browse/EXEC-2897
-@pytest.mark.xfail
 async def test_maintenance_run_hardware_event_callback(
     ot3_hardware_api: OT3API,
     mock_app_state: AppState,
@@ -245,10 +237,6 @@ async def test_maintenance_run_hardware_event_callback(
     assert isinstance(door_watcher_result, ClientPyroFunctionWrapper)
 
 
-# NOTE: This is here to handle test failures for a feature flag migration bug on versions < 10.0.0
-# this patch should be REMOVED for releases >= 10.0.0
-# See: https://opentrons.atlassian.net/browse/EXEC-2897
-@pytest.mark.xfail
 async def test_camera_provider(
     ot3_hardware_api: OT3API,
     mock_app_state: AppState,
@@ -279,10 +267,6 @@ async def test_camera_provider(
     assert settings.errorRecoveryCameraEnabled
 
 
-# NOTE: This is here to handle test failures for a feature flag migration bug on versions < 10.0.0
-# this patch should be REMOVED for releases >= 10.0.0
-# See: https://opentrons.atlassian.net/browse/EXEC-2897
-@pytest.mark.xfail
 async def test_file_provider(
     ot3_hardware_api: OT3API,
     mock_app_state: AppState,
@@ -325,10 +309,6 @@ async def test_file_provider(
     )
 
 
-# NOTE: This is here to handle test failures for a feature flag migration bug on versions < 10.0.0
-# this patch should be REMOVED for releases >= 10.0.0
-# See: https://opentrons.atlassian.net/browse/EXEC-2897
-@pytest.mark.xfail
 async def test_deck_config(
     ot3_hardware_api: OT3API,
     mock_app_state: AppState,
@@ -354,10 +334,6 @@ async def test_deck_config(
     )
 
 
-# NOTE: This is here to handle test failures for a feature flag migration bug on versions < 10.0.0
-# this patch should be REMOVED for releases >= 10.0.0
-# See: https://opentrons.atlassian.net/browse/EXEC-2897
-@pytest.mark.xfail
 async def test_notify_publisher(
     ot3_hardware_api: OT3API,
     mock_app_state: AppState,


### PR DESCRIPTION
# Overview
Covers EXEC-2897

Due to a bug we had to patch subprocess mode flags for 9.1.2 to default to disabled, this re-enables it for edge after the 9.1.2 mergeback. 

## Test Plan and Hands on Testing

- [x] Unit tests for pyro should pass
- [x] Running with subprocess flags as True should run in subprocess/pyro mode

## Changelog

Undid the changes introduced by the 9.1.2 patch

## Review requests


## Risk assessment
Low - Should effect >=10.0.0 only from here on out.