### PR TITLE
fix(server-utils): do not require notes if crs off

### DIFF
--- a/server-utils/server_utils/audit/fastapi.py
+++ b/server-utils/server_utils/audit/fastapi.py
@@ -16,6 +16,7 @@ from .audit_logger import AuditLogger
 from .audit_server import Client, LocalHTTPClient, NoOpClient
 from server_utils.auth.resource_server.fastapi import (
     RequireAuthenticationResult,
+    get_access_control_status,
     require_authentication,
 )
 from server_utils.fastapi_utils.app_state import (
@@ -34,6 +35,7 @@ USER_NOTES_HEADER: Final[str] = "Opentrons-User-Notes"
 
 async def get_supplied_user_notes(
     audit_client: Annotated[Client, fastapi.Depends(get_audit_client)],
+    access_control_status: Annotated[bool, fastapi.Depends(get_access_control_status)],
     request: fastapi.Request,
     # for reasons unknown to me, the annotated version of this declaration
     # fails with AttributeError: 'FieldInfo' object has no attribute 'in_'.
@@ -63,6 +65,8 @@ async def get_supplied_user_notes(
     If the value only contains whitespace (after decoding), it's treated the same
     as if it's not present.
     """
+    if not access_control_status:
+        return None
     if request.method not in MUTATING_HTTP_METHODS:
         return None
     try:

--- a/server-utils/tests/audit/test_user_notes.py
+++ b/server-utils/tests/audit/test_user_notes.py
@@ -13,6 +13,10 @@ from server_utils.audit.fastapi import (
     get_supplied_user_notes,
     install_audit_client,
 )
+from server_utils.auth.resource_server.authentication_checker import (
+    AuthenticationChecker,
+)
+from server_utils.auth.resource_server.fastapi import install_authentication_checker
 
 
 @pytest.fixture()
@@ -20,10 +24,18 @@ def mock_audit_client(decoy: Decoy) -> Client:
     return decoy.mock(cls=Client)
 
 
+@pytest.fixture()
+def mock_authentication_checker(decoy: Decoy) -> AuthenticationChecker:
+    return decoy.mock(cls=AuthenticationChecker)
+
+
 @pytest.fixture
-def client(mock_audit_client: Client) -> TestClient:
+def client(
+    mock_audit_client: Client, mock_authentication_checker: AuthenticationChecker
+) -> TestClient:
     app = FastAPI()
     install_audit_client(app.state, mock_audit_client)
+    install_authentication_checker(app.state, mock_authentication_checker)
 
     @app.api_route("/notes", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
     async def read_notes(
@@ -35,12 +47,18 @@ def client(mock_audit_client: Client) -> TestClient:
 
 
 async def test_from_header(
-    client: TestClient, decoy: Decoy, mock_audit_client: Client
+    client: TestClient,
+    decoy: Decoy,
+    mock_audit_client: Client,
+    mock_authentication_checker: AuthenticationChecker,
 ) -> None:
     decoy.when(await mock_audit_client.get_settings()).then_return(
         AuditSettingsResponseData(
             requireReasonForInteraction=True, minLengthOfReasonForInteraction=None
         )
+    )
+    decoy.when(await mock_authentication_checker.access_control_status()).then_return(
+        True
     )
     response = client.post(
         "/notes",
@@ -51,12 +69,18 @@ async def test_from_header(
 
 
 async def test_from_header_on_delete(
-    client: TestClient, decoy: Decoy, mock_audit_client: Client
+    client: TestClient,
+    decoy: Decoy,
+    mock_audit_client: Client,
+    mock_authentication_checker: AuthenticationChecker,
 ) -> None:
     decoy.when(await mock_audit_client.get_settings()).then_return(
         AuditSettingsResponseData(
             requireReasonForInteraction=True, minLengthOfReasonForInteraction=None
         )
+    )
+    decoy.when(await mock_authentication_checker.access_control_status()).then_return(
+        True
     )
 
     response = client.delete(
@@ -68,8 +92,14 @@ async def test_from_header_on_delete(
 
 
 async def test_ignores_whitespace_only_header(
-    client: TestClient, decoy: Decoy, mock_audit_client: Client
+    client: TestClient,
+    decoy: Decoy,
+    mock_audit_client: Client,
+    mock_authentication_checker: AuthenticationChecker,
 ) -> None:
+    decoy.when(await mock_authentication_checker.access_control_status()).then_return(
+        True
+    )
     decoy.when(await mock_audit_client.get_settings()).then_return(
         AuditSettingsResponseData(
             requireReasonForInteraction=True, minLengthOfReasonForInteraction=None
@@ -81,8 +111,14 @@ async def test_ignores_whitespace_only_header(
 
 
 async def test_ignores_query_and_form(
-    client: TestClient, decoy: Decoy, mock_audit_client: Client
+    client: TestClient,
+    decoy: Decoy,
+    mock_audit_client: Client,
+    mock_authentication_checker: AuthenticationChecker,
 ) -> None:
+    decoy.when(await mock_authentication_checker.access_control_status()).then_return(
+        True
+    )
     decoy.when(await mock_audit_client.get_settings()).then_return(
         AuditSettingsResponseData(
             requireReasonForInteraction=False, minLengthOfReasonForInteraction=None
@@ -97,8 +133,14 @@ async def test_ignores_query_and_form(
 
 
 async def test_returns_none_for_get(
-    client: TestClient, decoy: Decoy, mock_audit_client: Client
+    client: TestClient,
+    decoy: Decoy,
+    mock_audit_client: Client,
+    mock_authentication_checker: AuthenticationChecker,
 ) -> None:
+    decoy.when(await mock_authentication_checker.access_control_status()).then_return(
+        True
+    )
     decoy.when(await mock_audit_client.get_settings()).then_return(
         AuditSettingsResponseData(
             requireReasonForInteraction=True, minLengthOfReasonForInteraction=None
@@ -110,8 +152,14 @@ async def test_returns_none_for_get(
 
 
 async def test_allows_missing_header_if_not_required(
-    client: TestClient, decoy: Decoy, mock_audit_client: Client
+    client: TestClient,
+    decoy: Decoy,
+    mock_audit_client: Client,
+    mock_authentication_checker: AuthenticationChecker,
 ) -> None:
+    decoy.when(await mock_authentication_checker.access_control_status()).then_return(
+        True
+    )
     decoy.when(await mock_audit_client.get_settings()).then_return(
         AuditSettingsResponseData(
             requireReasonForInteraction=False, minLengthOfReasonForInteraction=None
@@ -123,9 +171,15 @@ async def test_allows_missing_header_if_not_required(
 
 
 async def test_percent_encoding(
-    client: TestClient, decoy: Decoy, mock_audit_client: Client
+    client: TestClient,
+    decoy: Decoy,
+    mock_audit_client: Client,
+    mock_authentication_checker: AuthenticationChecker,
 ) -> None:
     """Clients percent-encode the header; the server must decode it."""
+    decoy.when(await mock_authentication_checker.access_control_status()).then_return(
+        True
+    )
     decoy.when(await mock_audit_client.get_settings()).then_return(
         AuditSettingsResponseData(
             requireReasonForInteraction=True, minLengthOfReasonForInteraction=None
@@ -140,8 +194,14 @@ async def test_percent_encoding(
 
 
 async def test_fails_if_missing_and_required(
-    client: TestClient, decoy: Decoy, mock_audit_client: Client
+    client: TestClient,
+    decoy: Decoy,
+    mock_audit_client: Client,
+    mock_authentication_checker: AuthenticationChecker,
 ) -> None:
+    decoy.when(await mock_authentication_checker.access_control_status()).then_return(
+        True
+    )
     decoy.when(await mock_audit_client.get_settings()).then_return(
         AuditSettingsResponseData(
             requireReasonForInteraction=True, minLengthOfReasonForInteraction=None
@@ -152,8 +212,14 @@ async def test_fails_if_missing_and_required(
 
 
 async def test_passes_if_length_required_and_met(
-    client: TestClient, decoy: Decoy, mock_audit_client: Client
+    client: TestClient,
+    decoy: Decoy,
+    mock_audit_client: Client,
+    mock_authentication_checker: AuthenticationChecker,
 ) -> None:
+    decoy.when(await mock_authentication_checker.access_control_status()).then_return(
+        True
+    )
     decoy.when(await mock_audit_client.get_settings()).then_return(
         AuditSettingsResponseData(
             requireReasonForInteraction=True, minLengthOfReasonForInteraction=25
@@ -164,12 +230,36 @@ async def test_passes_if_length_required_and_met(
 
 
 async def test_fails_if_length_required_and_not_met(
-    client: TestClient, decoy: Decoy, mock_audit_client: Client
+    client: TestClient,
+    decoy: Decoy,
+    mock_audit_client: Client,
+    mock_authentication_checker: AuthenticationChecker,
 ) -> None:
+    decoy.when(await mock_authentication_checker.access_control_status()).then_return(
+        True
+    )
     decoy.when(await mock_audit_client.get_settings()).then_return(
         AuditSettingsResponseData(
             requireReasonForInteraction=True, minLengthOfReasonForInteraction=25
         )
     )
     response = client.get("/notes", headers={USER_NOTES_HEADER: "a" * 24})
+    assert response.status_code == 200
+
+
+async def test_passes_if_missing_and_required_but_crs_off(
+    client: TestClient,
+    decoy: Decoy,
+    mock_audit_client: Client,
+    mock_authentication_checker: AuthenticationChecker,
+) -> None:
+    decoy.when(await mock_authentication_checker.access_control_status()).then_return(
+        False
+    )
+    decoy.when(await mock_audit_client.get_settings()).then_return(
+        AuditSettingsResponseData(
+            requireReasonForInteraction=True, minLengthOfReasonForInteraction=25
+        )
+    )
+    response = client.get("/notes")
     assert response.status_code == 200


### PR DESCRIPTION
# Overview

Since our require-notes flag defaults to true, we need to ignore it if access control mode is off.

## Test Plan and Hands on Testing

- [x] Enter ACM and don't get a 451


