### PR TITLE
chore: link audit logging to CRS

### DIFF
--- a/audit-server/audit_server/log_self_client.py
+++ b/audit-server/audit_server/log_self_client.py
@@ -14,6 +14,12 @@ from server_utils.audit.audit_server import (
     StoreRobotLogSuccessData,
 )
 from server_utils.audit.audit_server import (
+    PatchLoggingEnabledRequestData as SUEnabledRequestData,
+)
+from server_utils.audit.audit_server import (
+    PatchLoggingEnabledResponseData as SUEnabledResponseData,
+)
+from server_utils.audit.audit_server import (
     SubmitAuditLogMessageData as SUSubmitData,
 )
 from server_utils.audit.audit_server import (
@@ -70,3 +76,10 @@ class LocalClient(SUClient):
         return GetLoggingEnabledData(
             loggingEnabled=self._settings_store.get_logging_enabled()
         )
+
+    @override
+    async def set_logging_enabled(
+        self, setting: SUEnabledRequestData
+    ) -> SUEnabledResponseData:
+        """Enable or disable logging."""
+        raise NotImplementedError("Do not use the self client for this")

--- a/auth-server/auth_server/app.py
+++ b/auth-server/auth_server/app.py
@@ -46,6 +46,10 @@ from auth_server.persistence.persistence_directory import (
     prepare_root,
 )
 from auth_server.server_settings import AuthServerSettings, get_settings
+from auth_server.settings.models import (
+    AUTH_SERVER_AUDIT_SYSTEM_FULLNAME,
+    AUTH_SERVER_AUDIT_SYSTEM_NAME,
+)
 from auth_server.settings.router import router as settings_router
 from auth_server.settings.store import SettingsStore, install_settings_store
 from auth_server.users.router import router as users_router
@@ -53,8 +57,7 @@ from auth_server.users.store import UserStore
 from auth_server.users.user_data_manager import UserDataManager
 
 _REDOC_CDN_URL = "https://cdn.jsdelivr.net/npm/redoc@2/bundles/redoc.standalone.js"
-_AUTH_SERVER_AUDIT_SYSTEM_NAME = "system"
-_AUTH_SERVER_AUDIT_SYSTEM_FULLNAME = "authentication subsystem"
+
 _LOG = logging.getLogger(__name__)
 
 
@@ -77,8 +80,8 @@ async def _do_oauth_audit_log(
             SubmitAuditLogMessageData(
                 action=action,
                 message=message,
-                accountName=_AUTH_SERVER_AUDIT_SYSTEM_NAME,
-                legalName=_AUTH_SERVER_AUDIT_SYSTEM_FULLNAME,
+                accountName=AUTH_SERVER_AUDIT_SYSTEM_NAME,
+                legalName=AUTH_SERVER_AUDIT_SYSTEM_FULLNAME,
                 reason=None,
             )
         )

--- a/auth-server/auth_server/settings/models.py
+++ b/auth-server/auth_server/settings/models.py
@@ -5,6 +5,9 @@ from typing import Annotated, Any, ClassVar, Literal
 
 import pydantic
 
+AUTH_SERVER_AUDIT_SYSTEM_NAME = "system"
+AUTH_SERVER_AUDIT_SYSTEM_FULLNAME = "authentication subsystem"
+
 
 class _StrictBaseModel(pydantic.BaseModel):
     model_config = {"strict": True}

--- a/auth-server/auth_server/settings/router.py
+++ b/auth-server/auth_server/settings/router.py
@@ -3,8 +3,23 @@ from typing import Annotated
 
 import fastapi
 
-from server_utils.audit.fastapi import get_audit_logger
-from server_utils.auth.resource_server.fastapi import require_scopes
+from server_utils.audit.audit_server import (
+    Client as AuditClient,
+)
+from server_utils.audit.audit_server import (
+    PatchLoggingEnabledRequestData,
+)
+from server_utils.audit.fastapi import (
+    get_audit_client,
+    get_audit_logger,
+    get_supplied_user_notes,
+)
+from server_utils.auth.resource_server.fastapi import (
+    RequireAuthenticationResult,
+    require_authentication,
+    require_scopes,
+)
+from server_utils.auth.resource_server.types import AuthenticatedResult
 from server_utils.auth.scopes import Scope
 from server_utils.fastapi_utils.models.json_api import (
     RequestModel,
@@ -12,6 +27,8 @@ from server_utils.fastapi_utils.models.json_api import (
 )
 
 from .models import (
+    AUTH_SERVER_AUDIT_SYSTEM_FULLNAME,
+    AUTH_SERVER_AUDIT_SYSTEM_NAME,
     AccessControlResponseData,
     PatchSettingsRequestData,
     SettingsResponseData,
@@ -59,6 +76,11 @@ async def get_access_control_enabled_settings(  # noqa: D103
 async def patch_access_control_settings(  # noqa: D103
     request_body: RequestModel[PatchAccessControlRequestData],
     settings_store: Annotated[SettingsStore, fastapi.Depends(get_settings_store)],
+    audit_client: Annotated[AuditClient, fastapi.Depends(get_audit_client)],
+    authentication: Annotated[
+        RequireAuthenticationResult, fastapi.Depends(require_authentication)
+    ],
+    user_notes: Annotated[str | None, fastapi.Depends(get_supplied_user_notes)],
 ) -> SimpleBody[AccessControlResponseData]:
     """Change the access control enabled settings."""
     try:
@@ -70,6 +92,22 @@ async def patch_access_control_settings(  # noqa: D103
             status_code=422,
             detail="Access control enabled cannot be modified once enabled.",
         )
+    if request_body.data.accessControlEnabled is not None:
+        if isinstance(authentication, AuthenticatedResult):
+            request = PatchLoggingEnabledRequestData(
+                loggingEnabled=request_body.data.accessControlEnabled,
+                accountName=authentication.username,
+                legalName=authentication.fullname,
+                reason=user_notes,
+            )
+        else:
+            request = PatchLoggingEnabledRequestData(
+                loggingEnabled=request_body.data.accessControlEnabled,
+                accountName=AUTH_SERVER_AUDIT_SYSTEM_NAME,
+                legalName=AUTH_SERVER_AUDIT_SYSTEM_FULLNAME,
+                reason=None,
+            )
+        await audit_client.set_logging_enabled(request)
     return SimpleBody.model_construct(data=accessControlResponseData)
 
 

--- a/server-utils/server_utils/audit/audit_server.py
+++ b/server-utils/server_utils/audit/audit_server.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 import aiohttp
 import pydantic
 
+LOGGING_ENABLED_ENDPOINT_PATH: typing.Final = "audit/internal/loggingEnabled"
 LOG_MESSAGE_ENDPOINT_PATH: typing.Final = "audit/internal/logMessage"
 SETTINGS_ENDPOINT_PATH: typing.Final = "audit/external/settings"
 STORE_ROBOT_LOG_ENDPOINT_PATH = "/audit/internal/storeRobotLog"
@@ -56,6 +57,13 @@ class Client(ABC):
     @abstractmethod
     async def get_logging_enabled(self) -> GetLoggingEnabledData:
         """Get if the robot has audit logging enabled."""
+        pass
+
+    @abstractmethod
+    async def set_logging_enabled(
+        self, setting: PatchLoggingEnabledRequestData
+    ) -> PatchLoggingEnabledResponseData:
+        """Enable or disable logging."""
         pass
 
 
@@ -158,6 +166,23 @@ class LocalHTTPClient(Client):
         )
         return parsed_response.data
 
+    @typing.override
+    async def set_logging_enabled(
+        self, setting: PatchLoggingEnabledRequestData
+    ) -> PatchLoggingEnabledResponseData:
+        """Enable or disable logging."""
+        request_body = PatchLoggingEnabledRequestBody(data=setting)
+        async with self._session.patch(
+            LOGGING_ENABLED_ENDPOINT_PATH,
+            data=request_body.model_dump_json(),
+            headers={"Content-Type": "application/json"},
+        ) as response:
+            response_bytes = await response.read()
+        parsed_response = PatchLoggingEnabledResponseBody.model_validate_json(
+            response_bytes
+        )
+        return parsed_response.data
+
 
 class NoOpClient(Client):
     """A client implementation that doesn't actually contact audit-server.
@@ -200,6 +225,13 @@ class NoOpClient(Client):
     async def get_logging_enabled(self) -> GetLoggingEnabledData:
         _log.info("Get logging enabled (audit-server not configured): Returning false")
         return GetLoggingEnabledData(loggingEnabled=False)
+
+    @typing.override
+    async def set_logging_enabled(
+        self, setting: PatchLoggingEnabledRequestData
+    ) -> PatchLoggingEnabledResponseData:
+        """Enable or disable logging."""
+        return PatchLoggingEnabledResponseData(loggingEnabled=False)
 
 
 class _StrictBaseModel(pydantic.BaseModel):
@@ -253,6 +285,12 @@ class StoreRobotLogSuccessData(_StrictBaseModel):
     loggingEnabled: bool
 
 
+class PatchLoggingEnabledResponseData(_StrictBaseModel):
+    """A response with the current logging-enabled setting."""
+
+    loggingEnabled: bool
+
+
 class StoreRobotLogResponseBody(_StrictBaseModel):
     """Response envelope for store robot log."""
 
@@ -269,3 +307,24 @@ class GetLoggingEnabledResponseBody(_StrictBaseModel):
     """Response envelope for get logging enabled."""
 
     data: GetLoggingEnabledData
+
+
+class PatchLoggingEnabledRequestData(_StrictBaseModel):
+    """A request to change the logging-enabled setting."""
+
+    loggingEnabled: bool
+    accountName: str
+    legalName: str
+    reason: str | None
+
+
+class PatchLoggingEnabledRequestBody(_StrictBaseModel):
+    """Request envelope for logging-enabled."""
+
+    data: PatchLoggingEnabledRequestData
+
+
+class PatchLoggingEnabledResponseBody(_StrictBaseModel):
+    """Response envelope for logging-enabled."""
+
+    data: PatchLoggingEnabledResponseData

--- a/server-utils/tests/audit/test_fastapi.py
+++ b/server-utils/tests/audit/test_fastapi.py
@@ -14,6 +14,8 @@ from server_utils.audit.audit_server import (
     GetLoggingEnabledData,
     LocalHTTPClient,
     NoOpClient,
+    PatchLoggingEnabledRequestData,
+    PatchLoggingEnabledResponseData,
     StoreRobotLogSuccessData,
     SubmitAuditLogMessageData,
     SubmitAuditLogSuccessData,
@@ -78,6 +80,11 @@ def test_install_and_get_audit_client_via_dependency() -> None:
 
         async def get_logging_enabled(self) -> GetLoggingEnabledData:
             raise NotImplementedError
+
+        async def set_logging_enabled(
+            self, setting: PatchLoggingEnabledRequestData
+        ) -> PatchLoggingEnabledResponseData:
+            raise NotImplementedError()
 
     stub_client = StubClient()
 


### PR DESCRIPTION
# Overview

When we enable compliance-ready software, we also need to enable audit logging. This does that.


## Test Plan and Hands on Testing

- [x] enable CRS on a machine and check that logging is also enabled. no need to check turning it off, because you can't. Hooray!

Closes EXEC-2903