### PR TITLE
fix(server-utils): fix pydantic parse

### DIFF
--- a/server-utils/server_utils/audit/audit_server.py
+++ b/server-utils/server_utils/audit/audit_server.py
@@ -184,7 +184,7 @@ class AuditSettingsResponseData(_StrictBaseModel):
     """Audit settings payload."""
 
     requireReasonForInteraction: bool
-    minLengthOfReasonForInteraction: int | None
+    minLengthOfReasonForInteraction: int | None = None
 
 
 class AuditSettingsResponseBody(_StrictBaseModel):


### PR DESCRIPTION
This is allowed to be missing. It breaks robots on systems that have the audit server with this setting never-set.

- [x] do a controlled request on a machine where minimum length of reason for interaction should work and don't get a failure

