### PR TITLE
fix(app,protocol-visualization): fix WellToolTip cut off issue

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -23,6 +23,7 @@
     "@fontsource-variable/reddit-mono": "5.2.8",
     "@fontsource/dejavu-sans": "5.0.3",
     "@fontsource/public-sans": "5.0.3",
+    "@popperjs/core": "2.1.1",
     "@opentrons/api-client": "workspace:*",
     "@opentrons/components": "workspace:*",
     "@opentrons/discovery-client": "workspace:*",

--- a/app/src/organisms/Desktop/ProtocolVisualization/WellTooltip/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/WellTooltip/index.tsx
@@ -11,8 +11,8 @@ import { getTopPortalEl } from '/app/App/portal'
 
 import { formatPercentage } from '../utils/formatPercentage'
 import { formatVolume } from '../utils/formatVolume'
-import styles from './welltooltip.module.css'
 import { useWellTooltipPopper } from './useWellTooltipPopper'
+import styles from './welltooltip.module.css'
 
 import type { MouseEvent, ReactNode } from 'react'
 import type { LocationLiquidState } from '@opentrons/step-generation'

--- a/app/src/organisms/Desktop/ProtocolVisualization/WellTooltip/index.tsx
+++ b/app/src/organisms/Desktop/ProtocolVisualization/WellTooltip/index.tsx
@@ -12,12 +12,11 @@ import { getTopPortalEl } from '/app/App/portal'
 import { formatPercentage } from '../utils/formatPercentage'
 import { formatVolume } from '../utils/formatVolume'
 import styles from './welltooltip.module.css'
+import { useWellTooltipPopper } from './useWellTooltipPopper'
 
 import type { MouseEvent, ReactNode } from 'react'
 import type { LocationLiquidState } from '@opentrons/step-generation'
-
-const DEFAULT_TOOLTIP_OFFSET = 22
-const WELL_BORDER_WIDTH = 4
+import type { WellReferenceRect } from './useWellTooltipPopper'
 
 interface WellTooltipParams {
   liquidDisplayColors: Record<string, string>
@@ -35,20 +34,17 @@ interface WellTooltipProps {
 }
 
 interface TooltipState {
-  tooltipX?: number | null
-  tooltipY?: number | null
-  tooltipWellName?: string | null
-  tooltipWellIngreds?: LocationLiquidState | null
-  tooltipOffset?: number | null
+  referenceRect: WellReferenceRect | null
+  tooltipWellName: string | null
+  tooltipWellIngreds: LocationLiquidState | null
 }
 
 const initialTooltipState: TooltipState = {
-  tooltipX: null,
-  tooltipY: null,
+  referenceRect: null,
   tooltipWellName: null,
   tooltipWellIngreds: null,
-  tooltipOffset: DEFAULT_TOOLTIP_OFFSET,
 }
+
 export function WellTooltip({
   children,
   ingredNames,
@@ -57,6 +53,7 @@ export function WellTooltip({
   const { t } = useTranslation('protocol_visualization')
   const [tooltipState, setTooltipState] =
     useState<TooltipState>(initialTooltipState)
+  const [tooltipEl, setTooltipEl] = useState<HTMLElement | null>(null)
 
   const makeHandleMouseEnterWell =
     (wellName: string, wellIngreds: LocationLiquidState) =>
@@ -65,11 +62,9 @@ export function WellTooltip({
       const { left, top, height, width } = target.getBoundingClientRect()
       if (wellIngreds != null && Object.keys(wellIngreds).length > 0) {
         setTooltipState({
-          tooltipX: left + width / 2,
-          tooltipY: top + height / 3,
+          referenceRect: { left, top, width, height },
           tooltipWellName: wellName,
           tooltipWellIngreds: wellIngreds,
-          tooltipOffset: height / 2,
         })
       }
     }
@@ -78,13 +73,9 @@ export function WellTooltip({
     setTooltipState(initialTooltipState)
   }
 
-  const {
-    tooltipX,
-    tooltipY,
-    tooltipOffset,
-    tooltipWellIngreds,
-    tooltipWellName,
-  } = tooltipState
+  const { referenceRect, tooltipWellIngreds, tooltipWellName } = tooltipState
+
+  useWellTooltipPopper(tooltipEl, referenceRect)
 
   const totalLiquidVolume = reduce(
     tooltipWellIngreds,
@@ -100,19 +91,9 @@ export function WellTooltip({
         makeHandleMouseEnterWell,
         handleMouseLeaveWell,
       })}
-      {tooltipWellName != null && tooltipX != null && tooltipY != null
+      {tooltipWellName != null
         ? createPortal(
-            <div
-              className={styles.popper_content}
-              style={{
-                top:
-                  tooltipY +
-                  (tooltipOffset ?? DEFAULT_TOOLTIP_OFFSET) +
-                  WELL_BORDER_WIDTH * 2,
-                left: tooltipX,
-                transform: 'translate(-50%, 0)',
-              }}
-            >
+            <div ref={setTooltipEl} className={styles.popper_content}>
               <table className={styles.tooltip_table}>
                 <tbody>
                   {map(tooltipWellIngreds || {}, (ingred, groupId) => (

--- a/app/src/organisms/Desktop/ProtocolVisualization/WellTooltip/useWellTooltipPopper.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/WellTooltip/useWellTooltipPopper.ts
@@ -1,0 +1,74 @@
+import { useLayoutEffect } from 'react'
+import { createPopper } from '@popperjs/core'
+
+import type { VirtualElement } from '@popperjs/core'
+
+const WELL_BORDER_WIDTH = 4
+
+export interface WellReferenceRect {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+function createWellVirtualReference(
+  referenceRect: WellReferenceRect
+): VirtualElement {
+  return {
+    getBoundingClientRect: () => {
+      const { left, top, width, height } = referenceRect
+      const x = left + width / 2
+      const y = top + height / 3
+
+      return {
+        width: 0,
+        height: 0,
+        top: y,
+        left: x,
+        right: x,
+        bottom: y,
+        x,
+        y,
+        toJSON: () => ({}),
+      }
+    },
+  }
+}
+
+export function useWellTooltipPopper(
+  tooltipEl: HTMLElement | null,
+  referenceRect: WellReferenceRect | null
+): void {
+  useLayoutEffect(() => {
+    if (tooltipEl == null || referenceRect == null) {
+      return
+    }
+
+    const virtualReference = createWellVirtualReference(referenceRect)
+    const offset = referenceRect.height / 2 + WELL_BORDER_WIDTH * 2
+
+    const popperInstance = createPopper(virtualReference, tooltipEl, {
+      placement: 'bottom',
+      strategy: 'fixed',
+      modifiers: [
+        {
+          name: 'offset',
+          options: { offset: [0, offset] },
+        },
+      ],
+    })
+
+    popperInstance.forceUpdate()
+
+    return () => {
+      popperInstance.destroy()
+    }
+  }, [
+    tooltipEl,
+    referenceRect?.left,
+    referenceRect?.top,
+    referenceRect?.width,
+    referenceRect?.height,
+  ])
+}

--- a/app/src/organisms/Desktop/ProtocolVisualization/WellTooltip/useWellTooltipPopper.ts
+++ b/app/src/organisms/Desktop/ProtocolVisualization/WellTooltip/useWellTooltipPopper.ts
@@ -64,11 +64,5 @@ export function useWellTooltipPopper(
     return () => {
       popperInstance.destroy()
     }
-  }, [
-    tooltipEl,
-    referenceRect?.left,
-    referenceRect?.top,
-    referenceRect?.width,
-    referenceRect?.height,
-  ])
+  }, [tooltipEl, referenceRect])
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,6 +393,9 @@ importers:
       '@opentrons/step-generation':
         specifier: workspace:*
         version: link:../step-generation
+      '@popperjs/core':
+        specifier: 2.1.1
+        version: 2.1.1
       '@reduxjs/toolkit':
         specifier: 2.11.2
         version: 2.11.2(react-redux@8.1.2(@types/react-dom@18.2.18)(@types/react@18.2.51)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(redux@5.0.1))(react@18.2.0)
@@ -1316,6 +1319,9 @@ importers:
       '@opentrons/step-generation':
         specifier: workspace:*
         version: link:../step-generation
+      '@popperjs/core':
+        specifier: 2.1.1
+        version: 2.1.1
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.24

--- a/protocol-visualization/package.json
+++ b/protocol-visualization/package.json
@@ -35,6 +35,7 @@
     "react-i18next": "catalog:"
   },
   "dependencies": {
+    "@popperjs/core": "2.1.1",
     "@opentrons/components": "workspace:*",
     "@opentrons/shared-data": "workspace:*",
     "@opentrons/step-generation": "workspace:*",

--- a/protocol-visualization/src/organisms/WellTooltip/index.tsx
+++ b/protocol-visualization/src/organisms/WellTooltip/index.tsx
@@ -10,12 +10,11 @@ import { swatchColors } from '@opentrons/step-generation'
 import { formatPercentage } from '../utils/formatPercentage'
 import { formatVolume } from '../utils/formatVolume'
 import styles from './welltooltip.module.css'
+import { useWellTooltipPopper } from './useWellTooltipPopper'
 
 import type { MouseEvent, ReactNode } from 'react'
 import type { LocationLiquidState } from '@opentrons/step-generation'
-
-const DEFAULT_TOOLTIP_OFFSET = 22
-const WELL_BORDER_WIDTH = 4
+import type { WellReferenceRect } from './useWellTooltipPopper'
 
 interface WellTooltipParams {
   liquidDisplayColors: Record<string, string>
@@ -33,20 +32,17 @@ interface WellTooltipProps {
 }
 
 interface TooltipState {
-  tooltipX?: number | null
-  tooltipY?: number | null
-  tooltipWellName?: string | null
-  tooltipWellIngreds?: LocationLiquidState | null
-  tooltipOffset?: number | null
+  referenceRect: WellReferenceRect | null
+  tooltipWellName: string | null
+  tooltipWellIngreds: LocationLiquidState | null
 }
 
 const initialTooltipState: TooltipState = {
-  tooltipX: null,
-  tooltipY: null,
+  referenceRect: null,
   tooltipWellName: null,
   tooltipWellIngreds: null,
-  tooltipOffset: DEFAULT_TOOLTIP_OFFSET,
 }
+
 export function WellTooltip({
   children,
   ingredNames,
@@ -55,6 +51,7 @@ export function WellTooltip({
   const { t } = useTranslation('protocol_visualization')
   const [tooltipState, setTooltipState] =
     useState<TooltipState>(initialTooltipState)
+  const [tooltipEl, setTooltipEl] = useState<HTMLElement | null>(null)
 
   const makeHandleMouseEnterWell =
     (wellName: string, wellIngreds: LocationLiquidState) =>
@@ -63,11 +60,9 @@ export function WellTooltip({
       const { left, top, height, width } = target.getBoundingClientRect()
       if (wellIngreds != null && Object.keys(wellIngreds).length > 0) {
         setTooltipState({
-          tooltipX: left + width / 2,
-          tooltipY: top + height / 3,
+          referenceRect: { left, top, width, height },
           tooltipWellName: wellName,
           tooltipWellIngreds: wellIngreds,
-          tooltipOffset: height / 2,
         })
       }
     }
@@ -76,13 +71,9 @@ export function WellTooltip({
     setTooltipState(initialTooltipState)
   }
 
-  const {
-    tooltipX,
-    tooltipY,
-    tooltipOffset,
-    tooltipWellIngreds,
-    tooltipWellName,
-  } = tooltipState
+  const { referenceRect, tooltipWellIngreds, tooltipWellName } = tooltipState
+
+  useWellTooltipPopper(tooltipEl, referenceRect)
 
   const totalLiquidVolume = reduce(
     tooltipWellIngreds,
@@ -98,19 +89,9 @@ export function WellTooltip({
         makeHandleMouseEnterWell,
         handleMouseLeaveWell,
       })}
-      {tooltipWellName != null && tooltipX != null && tooltipY != null
+      {tooltipWellName != null
         ? createPortal(
-            <div
-              className={styles.popper_content}
-              style={{
-                top:
-                  tooltipY +
-                  (tooltipOffset ?? DEFAULT_TOOLTIP_OFFSET) +
-                  WELL_BORDER_WIDTH * 2,
-                left: tooltipX,
-                transform: 'translate(-50%, 0)',
-              }}
-            >
+            <div ref={setTooltipEl} className={styles.popper_content}>
               <table className={styles.tooltip_table}>
                 <tbody>
                   {map(tooltipWellIngreds || {}, (ingred, groupId) => (

--- a/protocol-visualization/src/organisms/WellTooltip/index.tsx
+++ b/protocol-visualization/src/organisms/WellTooltip/index.tsx
@@ -9,8 +9,8 @@ import { swatchColors } from '@opentrons/step-generation'
 
 import { formatPercentage } from '../utils/formatPercentage'
 import { formatVolume } from '../utils/formatVolume'
-import styles from './welltooltip.module.css'
 import { useWellTooltipPopper } from './useWellTooltipPopper'
+import styles from './welltooltip.module.css'
 
 import type { MouseEvent, ReactNode } from 'react'
 import type { LocationLiquidState } from '@opentrons/step-generation'

--- a/protocol-visualization/src/organisms/WellTooltip/useWellTooltipPopper.ts
+++ b/protocol-visualization/src/organisms/WellTooltip/useWellTooltipPopper.ts
@@ -1,0 +1,74 @@
+import { useLayoutEffect } from 'react'
+import { createPopper } from '@popperjs/core'
+
+import type { VirtualElement } from '@popperjs/core'
+
+const WELL_BORDER_WIDTH = 4
+
+export interface WellReferenceRect {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+function createWellVirtualReference(
+  referenceRect: WellReferenceRect
+): VirtualElement {
+  return {
+    getBoundingClientRect: () => {
+      const { left, top, width, height } = referenceRect
+      const x = left + width / 2
+      const y = top + height / 3
+
+      return {
+        width: 0,
+        height: 0,
+        top: y,
+        left: x,
+        right: x,
+        bottom: y,
+        x,
+        y,
+        toJSON: () => ({}),
+      }
+    },
+  }
+}
+
+export function useWellTooltipPopper(
+  tooltipEl: HTMLElement | null,
+  referenceRect: WellReferenceRect | null
+): void {
+  useLayoutEffect(() => {
+    if (tooltipEl == null || referenceRect == null) {
+      return
+    }
+
+    const virtualReference = createWellVirtualReference(referenceRect)
+    const offset = referenceRect.height / 2 + WELL_BORDER_WIDTH * 2
+
+    const popperInstance = createPopper(virtualReference, tooltipEl, {
+      placement: 'bottom',
+      strategy: 'fixed',
+      modifiers: [
+        {
+          name: 'offset',
+          options: { offset: [0, offset] },
+        },
+      ],
+    })
+
+    popperInstance.forceUpdate()
+
+    return () => {
+      popperInstance.destroy()
+    }
+  }, [
+    tooltipEl,
+    referenceRect?.left,
+    referenceRect?.top,
+    referenceRect?.width,
+    referenceRect?.height,
+  ])
+}

--- a/protocol-visualization/src/organisms/WellTooltip/useWellTooltipPopper.ts
+++ b/protocol-visualization/src/organisms/WellTooltip/useWellTooltipPopper.ts
@@ -64,11 +64,5 @@ export function useWellTooltipPopper(
     return () => {
       popperInstance.destroy()
     }
-  }, [
-    tooltipEl,
-    referenceRect?.left,
-    referenceRect?.top,
-    referenceRect?.width,
-    referenceRect?.height,
-  ])
+  }, [tooltipEl, referenceRect])
 }


### PR DESCRIPTION

# Overview
fix WellToolTip cut off issue by using popperjs (PD is using the same way to handle this issue).

<img width="1452" height="1001" alt="Screenshot 2026-07-29 at 6 54 24 PM" src="https://github.com/user-attachments/assets/b9dcc521-af39-45ab-9899-b621540d4b7c" />

closes AUTH-3156



## Test Plan and Hands on Testing
- import the protocol that is attached to [the Slack thread](https://opentrons.slack.com/archives/C09AFFN9N83/p1785339959009549)
- go to Visualization
- go to `step 13` and click `Slot D`

## Changelog
- use popperjs to handle WellToolTip cut off issue

## Review requests


## Risk assessment
low
