### PR TITLE
fix(app, odd): gate closing run on sign run

### DIFF
--- a/app/src/App/DesktopApp.tsx
+++ b/app/src/App/DesktopApp.tsx
@@ -36,6 +36,7 @@ import { DocumentationRequiredModalContext } from '../local-resources/access-con
 import { ApiHostProvider } from '../local-resources/api-host-provider/ApiHostProvider'
 import { showDocumentationRequiredModal } from '../organisms/Desktop/DocumentationRequired/DocumentationRequiredModal'
 import { showLoginModal } from '../organisms/Desktop/LoginModal'
+import { showSignRunModal } from '../organisms/Desktop/SignRunModal/SignRun'
 import { ProtocolVisualization } from '../pages/Desktop/Protocols/ProtocolVisualization'
 import { DesktopAppFallback } from './DesktopAppFallback'
 import { useRefreshAccessTokenOnActivity } from './hooks/useRefreshAccessTokenOnActivity'
@@ -118,7 +119,11 @@ export const DesktopApp = (): JSX.Element => {
   return (
     <LocalizationProvider>
       <DocumentationRequiredModalContext.Provider
-        value={{ showDocumentationRequiredModal, showLoginModal }}
+        value={{
+          showDocumentationRequiredModal,
+          showLoginModal,
+          showSignRunModal,
+        }}
       >
         <NiceModal.Provider>
           <ErrorBoundary FallbackComponent={DesktopAppFallback}>

--- a/app/src/App/OnDeviceDisplayApp.tsx
+++ b/app/src/App/OnDeviceDisplayApp.tsx
@@ -65,6 +65,7 @@ import { DocumentationRequiredModalContext } from '../local-resources/access-con
 import { LocalizationProvider } from '../LocalizationProvider'
 import { requireDocumentation } from '../organisms/ODD/DocumentationRequired/requireDocumentation'
 import { showLoginModal } from '../organisms/ODD/OnDeviceLogin/LoginModal'
+import { showSignRunModal } from '../pages/ODD/RunSummary/SignRun'
 import { getLocalRobotAccessToken } from '../redux/robot-auth'
 import { hackWindowNavigatorOnLine } from './hacks'
 import {
@@ -258,6 +259,7 @@ export const OnDeviceDisplayApp = (): JSX.Element => {
                     value={{
                       showDocumentationRequiredModal: requireDocumentation,
                       showLoginModal,
+                      showSignRunModal,
                     }}
                   >
                     <MaintenanceRunTakeover>

--- a/app/src/local-resources/access-control/DocumentationRequiredModalContext.tsx
+++ b/app/src/local-resources/access-control/DocumentationRequiredModalContext.tsx
@@ -18,6 +18,7 @@ export interface DocumentationRequiredModalContextType {
   }: {
     robotName: string
   }) => Promise<{ username: string } | null>
+  showSignRunModal: () => Promise<boolean>
 }
 
 /**
@@ -35,4 +36,5 @@ export const DocumentationRequiredModalContext =
       return Promise.resolve('' as DocumentationReport)
     },
     showLoginModal: () => Promise.resolve(null),
+    showSignRunModal: () => Promise.resolve(false),
   })

--- a/app/src/local-resources/access-control/__tests__/documentationRequiredModalTestUtils.tsx
+++ b/app/src/local-resources/access-control/__tests__/documentationRequiredModalTestUtils.tsx
@@ -13,6 +13,9 @@ export const mockShowDocumentationRequiredModal: (
 export const mockShowLoginModal: () => Promise<{ username: string } | null> =
   vi.fn<() => Promise<{ username: string } | null>>()
 
+export const mockShowSignRunModal: () => Promise<boolean> =
+  vi.fn<() => Promise<boolean>>()
+
 export const DocumentationRequiredModalTestProvider: FunctionComponent<{
   children: ReactNode
 }> = ({ children }) => (
@@ -20,6 +23,7 @@ export const DocumentationRequiredModalTestProvider: FunctionComponent<{
     value={{
       showDocumentationRequiredModal: mockShowDocumentationRequiredModal,
       showLoginModal: mockShowLoginModal,
+      showSignRunModal: mockShowSignRunModal,
     }}
   >
     {children}

--- a/app/src/local-resources/access-control/useLinkedDocumentationState.ts
+++ b/app/src/local-resources/access-control/useLinkedDocumentationState.ts
@@ -46,9 +46,11 @@ export const useLinkedDocumentationState = (
 
   useEffect(() => {
     return () => {
-      clearDocreport()
+      // Clear React state only. Do not null docreport on the current documentationState object
+      // async follow-up mutations may still hold a reference to it after unmount.
+      setDocreport(undefined)
     }
-  }, [clearDocreport, resetKey])
+  }, [resetKey])
 
   const onPromptForDocumentation = useCallback(
     (report: DocumentationReport) => {

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/hooks/useRunHeaderDropTip.ts
@@ -38,12 +38,6 @@ export interface UseRunHeaderDropTipResult {
   dropTipModalUtils: UseProtocolDropTipModalResult
   dropTipWizardUtils: RunHeaderDropTipWizProps
   resetTipStatus: TipAttachmentStatusResult['resetTipStatus']
-  /**
-   * True once tip status is known, tip check was skipped (already handled in
-   * error recovery), or the robot is OT-2 (no tip check). Used to avoid
-   * showing post-run modals (e.g. SignRun) before drop-tip can claim the UI.
-   */
-  isPostRunTipStatusSettled: boolean
 }
 
 // Handles all the tip related logic during a protocol run on the desktop app.
@@ -81,10 +75,9 @@ export function useRunHeaderDropTip({
     currentRunId: runId,
     pipetteInfo: buildPipetteDetails(aPipetteWithTip),
     onSkipAndHome: () => {
-      // Clear tip state so the modal dismisses even when close is gated
-      // behind SignRun (run stays current, so !isRunCurrent never fires).
-      // Do not resetTipStatus — that nulls the settled tip-check count and
-      // can re-trigger tip check on a terminating run.
+      // Clear tip state so the modal dismisses even if run currentness briefly
+      // lags after close is requested. Do not resetTipStatus — that nulls the
+      // settled tip-check count and can re-trigger tip check on a terminating run.
       resolveAllTips()
       closeCurrentRun()
     },
@@ -129,10 +122,6 @@ export function useRunHeaderDropTip({
   const tipCheckSkippedBecauseER =
     runSummaryNoFixit != null &&
     lastRunCommandPromptedErrorRecovery(runSummaryNoFixit, isEREnabled)
-  const isPostRunTipStatusSettled =
-    robotType === OT2_ROBOT_TYPE ||
-    tipCheckSkippedBecauseER ||
-    initialPipettesWithTipsCount !== null
 
   // Manage tip checking
   useEffect(
@@ -159,12 +148,9 @@ export function useRunHeaderDropTip({
   )
 
   // If the run terminates, close the run if no tips need handling. This marks
-  // the robot as "not busy" when drop tip CTAs are unnecessary, and is also
-  // the trigger for gated post-run flows (e.g. SignRun on cancel, where there
-  // is no terminal banner close button).
-  // Include closeCurrentRun so a gated close retries after the gate opens.
+  // the robot as "not busy" when drop tip CTAs are unnecessary.
   // Include tipCheckSkippedBecauseER: tip check is intentionally skipped after
-  // ER, but without this the close never fires and SignRun never opens.
+  // ER, but without this the close never fires.
   useEffect(() => {
     if (
       isRunTerminatingOrTerminal &&
@@ -189,7 +175,6 @@ export function useRunHeaderDropTip({
     dropTipModalUtils,
     dropTipWizardUtils: buildDTWizUtils(),
     resetTipStatus,
-    isPostRunTipStatusSettled,
   }
 }
 

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ProtocolDropTipModal.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/RunHeaderModalContainer/modals/ProtocolDropTipModal.tsx
@@ -53,7 +53,7 @@ export function useProtocolDropTipModal({
 }: UseProtocolDropTipModalProps): UseProtocolDropTipModalResult {
   const [showModal, setShowModal] = useState(areTipsAttached)
   // After skip-and-home, keep the modal closed even if tip state / run
-  // currentness briefly lag (e.g. close gated behind SignRun).
+  // currentness briefly lag after close is requested.
   const [hasSkipped, setHasSkipped] = useState(false)
 
   const { homePipettes, isHoming } = useHomePipettes({

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/ProtocolRunHeader.test.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/__tests__/ProtocolRunHeader.test.tsx
@@ -3,11 +3,7 @@ import { screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { RUN_STATUS_RUNNING } from '@opentrons/api-client'
-import {
-  useAccessControlEnabledQuery,
-  useGetRobotServerAccessControlSettingsQuery,
-  useModulesQuery,
-} from '@opentrons/react-api-client'
+import { useModulesQuery } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
@@ -16,7 +12,6 @@ import { useIsRobotViewable } from '/app/redux-resources/robots'
 import { useRunGeneratedDataFiles } from '/app/resources/dataFiles/useRunGeneratedDataFiles'
 import {
   useCloseCurrentRun,
-  useIsRunCurrent,
   useNotifyRunQuery,
   useProtocolDetailsForRun,
 } from '/app/resources/runs'
@@ -64,7 +59,6 @@ const MOCK_RUN_HEADER_MODAL_CONTAINER_UTILS = {
     dropTipModalUtils: { showModal: false, modalProps: null },
     dropTipWizardUtils: { showDTWiz: false, dtWizProps: null },
     resetTipStatus: vi.fn(),
-    isPostRunTipStatusSettled: true,
   },
 }
 
@@ -97,15 +91,6 @@ describe('ProtocolRunHeader', () => {
     vi.mocked(useModulesQuery).mockReturnValue({
       data: { data: [] },
     } as any)
-    vi.mocked(useAccessControlEnabledQuery).mockReturnValue({
-      data: { data: { accessControlEnabled: false } },
-      isLoading: false,
-    } as any)
-    vi.mocked(useGetRobotServerAccessControlSettingsQuery).mockReturnValue({
-      data: { data: { requireSignoffForProtocolLog: false } },
-      isLoading: false,
-    } as any)
-    vi.mocked(useIsRunCurrent).mockReturnValue(true)
     vi.mocked(useCloseCurrentRun).mockReturnValue({
       isClosingCurrentRun: false,
       closeCurrentRun: vi.fn(),

--- a/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/index.tsx
+++ b/app/src/organisms/Desktop/Devices/ProtocolRun/ProtocolRunHeader/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { css } from 'styled-components'
 
@@ -10,31 +10,22 @@ import {
   Flex,
   SPACING,
 } from '@opentrons/components'
-import {
-  useAccessControlEnabledQuery,
-  useGetRobotServerAccessControlSettingsQuery,
-  useModulesQuery,
-} from '@opentrons/react-api-client'
+import { useModulesQuery } from '@opentrons/react-api-client'
 
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useInitializeCameraState } from '/app/local-resources/images/hooks/useInitializeCameraState'
-import {
-  isCancellableStatus,
-  isTerminatingOrTerminal,
-} from '/app/local-resources/runs/utils'
+import { isCancellableStatus } from '/app/local-resources/runs/utils'
 import { useIsRobotViewable } from '/app/redux-resources/robots'
 import { useRunGeneratedDataFiles } from '/app/resources/dataFiles/useRunGeneratedDataFiles'
 import {
   DEFAULT_STATUS_REFETCH_INTERVAL,
   useCloseCurrentRun,
-  useIsRunCurrent,
   useNotifyRunQuery,
   useProtocolDetailsForRun,
 } from '/app/resources/runs'
 
 import { EQUIPMENT_POLL_MS } from '../../../../DoorOpenControl/constants'
 import { RunProgressMeter } from '../../../RunProgressMeter'
-import { SignRunModal } from '../../../SignRunModal/SignRun'
 import { useRunAnalytics, useRunErrors, useRunHeaderRunControls } from './hooks'
 import { RunHeaderBannerContainer } from './RunHeaderBannerContainer'
 import { RunHeaderContent } from './RunHeaderContent'
@@ -60,13 +51,10 @@ export function ProtocolRunHeader(
 
   const navigate = useNavigate()
 
-  const { data: runRecord, isLoading: isRunRecordLoading } = useNotifyRunQuery(
-    runId,
-    {
-      staleTime: Infinity,
-      refetchInterval: DEFAULT_STATUS_REFETCH_INTERVAL,
-    }
-  )
+  const { data: runRecord } = useNotifyRunQuery(runId, {
+    staleTime: Infinity,
+    refetchInterval: DEFAULT_STATUS_REFETCH_INTERVAL,
+  })
   const { protocolData } = useProtocolDetailsForRun(runId)
   const isRobotViewable = useIsRobotViewable(robotName)
   const runStatus = runRecord?.data.status ?? null
@@ -85,75 +73,6 @@ export function ProtocolRunHeader(
   const documentationState = useDocumentationState()
   const { closeCurrentRun, isClosingCurrentRun } =
     useCloseCurrentRun(documentationState)
-  const {
-    data: accessControlEnabled,
-    isLoading: isAccessControlEnabledLoading,
-  } = useAccessControlEnabledQuery()
-  const {
-    data: accessControlSettings,
-    isLoading: isAccessControlSettingsLoading,
-  } = useGetRobotServerAccessControlSettingsQuery()
-  const isSigningSettingsLoading =
-    isAccessControlEnabledLoading || isAccessControlSettingsLoading
-  const isSigningRequired =
-    (accessControlEnabled?.data.accessControlEnabled ?? false) &&
-    (accessControlSettings?.data.requireSignoffForProtocolLog ?? false)
-  const hasSignedBy = !!runRecord?.data.signedBy
-  const isSigned = !isSigningRequired || hasSignedBy
-  const isRunCurrent = useIsRunCurrent(runId)
-  // Set when the run becomes terminal or close is requested before signing;
-  // cleared after a successful sign.
-  const [isSignRunPending, setIsSignRunPending] = useState(false)
-
-  // Keep the run current until the user signs when signoff is required.
-  const closeCurrentRunIfSigned = useCallback(() => {
-    if (isSigningSettingsLoading || !isSigned) {
-      setIsSignRunPending(true)
-      return
-    }
-    setIsSignRunPending(false)
-    closeCurrentRun()
-  }, [closeCurrentRun, isSigningSettingsLoading, isSigned])
-
-  // Canceled runs often have no terminal banner close button, so arm SignRun
-  // when the run itself becomes terminal — not only on an explicit close click.
-  useEffect(() => {
-    if (
-      isTerminatingOrTerminal(runStatus) &&
-      isRunCurrent &&
-      !hasSignedBy &&
-      (isSigningSettingsLoading || isSigningRequired)
-    ) {
-      setIsSignRunPending(true)
-    }
-  }, [
-    runStatus,
-    isRunCurrent,
-    hasSignedBy,
-    isSigningSettingsLoading,
-    isSigningRequired,
-  ])
-
-  useEffect(() => {
-    if (!isSignRunPending || isSigningSettingsLoading) {
-      return
-    }
-    // Signoff not required after load — clear pending; tip auto-close dismisses.
-    if (!isSigningRequired) {
-      setIsSignRunPending(false)
-      return
-    }
-    if (isSigned) {
-      setIsSignRunPending(false)
-      closeCurrentRun()
-    }
-  }, [
-    isSigned,
-    isSignRunPending,
-    isSigningSettingsLoading,
-    isSigningRequired,
-    closeCurrentRun,
-  ])
 
   const enteredER = runRecord?.data.hasEverEnteredErrorRecovery ?? false
   const protocolRunControls = useRunHeaderRunControls(runId, robotName)
@@ -164,23 +83,8 @@ export function ProtocolRunHeader(
     protocolRunControls,
     runRecord: runRecord ?? null,
     runErrors,
-    closeCurrentRun: closeCurrentRunIfSigned,
+    closeCurrentRun,
   })
-  const { dropTipUtils } = runHeaderModalContainerUtils
-  const isDropTipBlocking =
-    dropTipUtils.dropTipModalUtils.showModal ||
-    dropTipUtils.dropTipWizardUtils.showDTWiz
-  // Wait for tip status so SignRun does not flash ahead of drop-tip CTAs.
-  // Also wait for runRecord after sign (cache cleared) so we don't re-prompt
-  // while signedBy is still missing from the refetch.
-  const showSignRunModal =
-    isSignRunPending &&
-    !isRunRecordLoading &&
-    !isSigningSettingsLoading &&
-    isSigningRequired &&
-    !hasSignedBy &&
-    dropTipUtils.isPostRunTipStatusSettled &&
-    !isDropTipBlocking
 
   useEffect(() => {
     if (protocolData != null && !isRobotViewable) {
@@ -208,9 +112,6 @@ export function ProtocolRunHeader(
         protocolRunControls={protocolRunControls}
         {...props}
       />
-      {showSignRunModal ? (
-        <SignRunModal runId={runId} robotName={robotName} />
-      ) : null}
       <Flex ref={protocolRunHeaderRef} css={CONTAINER_STYLE}>
         <RunHeaderProtocolName runId={runId} />
         <RunHeaderBannerContainer
@@ -221,7 +122,7 @@ export function ProtocolRunHeader(
           runHeaderModalContainerUtils={runHeaderModalContainerUtils}
           hasImages={outputFileIds.jpeg.length > 0}
           hasCsvFiles={outputFileIds.csv.length > 0}
-          closeCurrentRun={closeCurrentRunIfSigned}
+          closeCurrentRun={closeCurrentRun}
           isClosingCurrentRun={isClosingCurrentRun}
           {...props}
         />

--- a/app/src/organisms/Desktop/SignRunModal/SignRun.tsx
+++ b/app/src/organisms/Desktop/SignRunModal/SignRun.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
+import NiceModal, { useModal } from '@ebay/nice-modal-react'
 import clsx from 'clsx'
 
 import {
@@ -12,9 +13,12 @@ import {
 } from '@opentrons/components'
 
 import { getTopPortalEl } from '/app/App/portal'
+import { ApiHostProvider } from '/app/local-resources/api-host-provider/ApiHostProvider'
 import { showLoginModal } from '/app/organisms/Desktop/LoginModal'
 import { useToaster } from '/app/organisms/ToasterOven'
+import { useCurrentRobotName } from '/app/redux/robot-auth'
 import { useSignRunFlow } from '/app/resources/access-control/useSignRunFlow'
+import { useCurrentRunId, useNotifyAllRunsQuery } from '/app/resources/runs'
 
 import styles from './signrunmodal.module.css'
 
@@ -24,11 +28,13 @@ const TOAST_ABOVE_LOGIN_Z_INDEX = 10002
 export interface SignRunModalProps {
   runId: string
   robotName: string
+  onSigned?: () => void
 }
 
 export function SignRunModal({
   runId,
   robotName,
+  onSigned,
 }: SignRunModalProps): JSX.Element {
   const { t, i18n } = useTranslation(['access_control', 'shared'])
 
@@ -65,7 +71,8 @@ export function SignRunModal({
     robotName,
     showLoginModal,
     popToast,
-    eatToast
+    eatToast,
+    onSigned
   )
 
   const trimmedName = name.trim()
@@ -170,3 +177,62 @@ export function SignRunModal({
     getTopPortalEl()
   )
 }
+
+const SignRunModalImpl = NiceModal.create((): JSX.Element | null => {
+  const modal = useModal()
+  const robotName = useCurrentRobotName()
+
+  useEffect(() => {
+    if (robotName == null) {
+      modal.resolve(false)
+      modal.remove()
+    }
+  }, [modal, robotName])
+
+  if (robotName == null) {
+    return null
+  }
+
+  return (
+    <ApiHostProvider robotName={robotName}>
+      <SignRunModalCurrentRun
+        robotName={robotName}
+        onSigned={() => {
+          modal.resolve(true)
+          modal.remove()
+        }}
+      />
+    </ApiHostProvider>
+  )
+})
+
+function SignRunModalCurrentRun({
+  robotName,
+  onSigned,
+}: {
+  robotName: string
+  onSigned: () => void
+}): JSX.Element | null {
+  const modal = useModal()
+  const runId = useCurrentRunId()
+  const { isFetched } = useNotifyAllRunsQuery({ pageLength: 0 })
+
+  useEffect(() => {
+    if (isFetched && runId == null) {
+      modal.resolve(false)
+      modal.remove()
+    }
+  }, [isFetched, modal, runId])
+
+  if (runId == null) {
+    return null
+  }
+
+  return (
+    <SignRunModal runId={runId} robotName={robotName} onSigned={onSigned} />
+  )
+}
+
+/** Open the desktop sign-run modal and await whether the run was signed. */
+export const showSignRunModal = (): Promise<boolean> =>
+  NiceModal.show(SignRunModalImpl)

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/AnalysisFailedModal.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/AnalysisFailedModal.tsx
@@ -9,11 +9,11 @@ import {
   LegacyStyledText,
   SPACING,
 } from '@opentrons/components'
-import { useDismissCurrentRunMutation } from '@opentrons/react-api-client'
 
 import { SmallButton } from '/app/atoms/buttons'
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { OddModal } from '/app/molecules/OddModal'
+import { useCloseCurrentRun } from '/app/resources/runs'
 
 import type { OddModalHeaderBaseProps } from '/app/molecules/OddModal/types'
 
@@ -27,7 +27,6 @@ interface AnalysisFailedModalProps {
 export function AnalysisFailedModal({
   errors,
   protocolId,
-  runId,
   setShowAnalysisFailedModal,
 }: AnalysisFailedModalProps): JSX.Element {
   const { t } = useTranslation('protocol_setup')
@@ -40,12 +39,14 @@ export function AnalysisFailedModal({
   }
 
   const documentationState = useDocumentationState()
-  const { isLoading: isDismissing, mutateAsync: dismissCurrentRunAsync } =
-    useDismissCurrentRunMutation(documentationState)
+  const { closeCurrentRun, isClosingCurrentRun } =
+    useCloseCurrentRun(documentationState)
 
   const handleRestartSetup = (): void => {
-    dismissCurrentRunAsync(runId).then(() => {
-      navigate(protocolId != null ? `/protocols/${protocolId}` : '/protocols')
+    closeCurrentRun({
+      onSuccess: () => {
+        navigate(protocolId != null ? `/protocols/${protocolId}` : '/protocols')
+      },
     })
   }
 
@@ -86,9 +87,9 @@ export function AnalysisFailedModal({
           onClick={handleRestartSetup}
           buttonText={t('restart_setup')}
           buttonType="alert"
-          iconName={isDismissing ? 'ot-spinner' : null}
+          iconName={isClosingCurrentRun ? 'ot-spinner' : null}
           iconPlacement="startIcon"
-          disabled={isDismissing}
+          disabled={isClosingCurrentRun}
         />
       </Flex>
     </OddModal>

--- a/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/AnalysisFailedModal.test.tsx
+++ b/app/src/organisms/ODD/ProtocolSetup/ProtocolSetupParameters/__tests__/AnalysisFailedModal.test.tsx
@@ -1,12 +1,10 @@
 import { fireEvent, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { when } from 'vitest-when'
-
-import { useDismissCurrentRunMutation } from '@opentrons/react-api-client'
 
 import { renderWithProviders } from '/app/__testing-utils__'
 import { i18n } from '/app/i18n'
 import { ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE } from '/app/local-resources/access-control/__fixtures__/documentationState'
+import { useCloseCurrentRun } from '/app/resources/runs'
 
 import { AnalysisFailedModal } from '../AnalysisFailedModal'
 
@@ -17,11 +15,9 @@ const PROTOCOL_ID = 'mockProtocolId'
 const RUN_ID = 'mockRunId'
 const mockSetShowAnalysisFailedModal = vi.fn()
 const mockNavigate = vi.fn()
-const mockDismissCurrentRunAsync = vi.fn(
-  () => new Promise(resolve => resolve({}))
-)
+const mockCloseCurrentRun = vi.fn()
 
-vi.mock('@opentrons/react-api-client')
+vi.mock('/app/resources/runs')
 vi.mock('/app/local-resources/access-control/useDocumentationState', () => ({
   useDocumentationState: () => ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE,
 }))
@@ -43,12 +39,15 @@ describe('AnalysisFailedModal', () => {
   let props: ComponentProps<typeof AnalysisFailedModal>
 
   beforeEach(() => {
-    mockDismissCurrentRunAsync.mockClear()
-    when(vi.mocked(useDismissCurrentRunMutation))
-      .calledWith(ACCESS_CONTROL_DISABLED_DOCUMENTATION_STATE)
-      .thenReturn({
-        mutateAsync: mockDismissCurrentRunAsync,
-      } as any)
+    mockCloseCurrentRun.mockClear()
+    mockNavigate.mockClear()
+    mockCloseCurrentRun.mockImplementation((options?: any) => {
+      options?.onSuccess?.()
+    })
+    vi.mocked(useCloseCurrentRun).mockReturnValue({
+      closeCurrentRun: mockCloseCurrentRun,
+      isClosingCurrentRun: false,
+    })
     props = {
       errors: [
         'analysis failed reason message 1',
@@ -76,9 +75,14 @@ describe('AnalysisFailedModal', () => {
     expect(mockSetShowAnalysisFailedModal).toHaveBeenCalled()
   })
 
-  it('should call mock dismiss current run function when tapping restart setup button', () => {
+  it('should close current run when tapping restart setup button', () => {
     render(props)
     fireEvent.click(screen.getByText('Restart setup'))
-    expect(mockDismissCurrentRunAsync).toHaveBeenCalledWith(RUN_ID)
+    expect(mockCloseCurrentRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+      })
+    )
+    expect(mockNavigate).toHaveBeenCalledWith(`/protocols/${PROTOCOL_ID}`)
   })
 })

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/__tests__/ConfirmCancelRunModal.test.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/__tests__/ConfirmCancelRunModal.test.tsx
@@ -6,7 +6,6 @@ import { when } from 'vitest-when'
 import { RUN_STATUS_IDLE, RUN_STATUS_STOPPED } from '@opentrons/api-client'
 import {
   useDeleteRunMutation,
-  useDismissCurrentRunMutation,
   useStopRunMutation,
 } from '@opentrons/react-api-client'
 
@@ -16,7 +15,7 @@ import { useTrackProtocolRunEvent } from '/app/redux-resources/analytics'
 import { useTrackEvent } from '/app/redux/analytics'
 import { getLocalRobot } from '/app/redux/discovery'
 import { mockConnectedRobot } from '/app/redux/discovery/__fixtures__'
-import { useNotifyRunQuery } from '/app/resources/runs'
+import { useCloseCurrentRun, useNotifyRunQuery } from '/app/resources/runs'
 
 import { CancelingRunModal } from '../../CancelingRunModal'
 import { ConfirmCancelRunModal } from '../../ConfirmCancelRunModal'
@@ -33,7 +32,7 @@ vi.mock('/app/redux/discovery')
 const mockNavigate = vi.fn()
 const mockStopRun = vi.fn()
 const mockDeleteRun = vi.fn()
-const mockDismissCurrentRun = vi.fn()
+const mockCloseCurrentRun = vi.fn()
 const mockTrackEvent = vi.fn()
 const mockTrackProtocolRunEvent = vi.fn(
   () => new Promise(resolve => resolve({}))
@@ -70,7 +69,7 @@ describe('ConfirmCancelRunModal', () => {
     mockNavigate.mockClear()
     mockStopRun.mockClear()
     mockDeleteRun.mockClear()
-    mockDismissCurrentRun.mockClear()
+    mockCloseCurrentRun.mockClear()
     mockTrackEvent.mockClear()
     mockTrackProtocolRunEvent.mockClear()
     mockFn.mockClear()
@@ -87,11 +86,11 @@ describe('ConfirmCancelRunModal', () => {
     vi.mocked(useDeleteRunMutation).mockReturnValue({
       deleteRun: mockDeleteRun,
     } as any)
-    vi.mocked(useDismissCurrentRunMutation).mockReturnValue({
-      dismissCurrentRun: mockDismissCurrentRun,
-      isLoading: false,
-    } as any)
-    mockDismissCurrentRun.mockImplementation((_id: string, options?: any) => {
+    vi.mocked(useCloseCurrentRun).mockReturnValue({
+      closeCurrentRun: mockCloseCurrentRun,
+      isClosingCurrentRun: false,
+    })
+    mockCloseCurrentRun.mockImplementation((options?: any) => {
       options?.onSuccess?.()
     })
     vi.mocked(useTrackEvent).mockReturnValue(mockTrackEvent)
@@ -128,11 +127,11 @@ describe('ConfirmCancelRunModal', () => {
     screen.getByText('Cancel run')
   })
 
-  it('should render the canceling run modal when run is dismissing', () => {
-    vi.mocked(useDismissCurrentRunMutation).mockReturnValue({
-      dismissCurrentRun: mockDismissCurrentRun,
-      isLoading: true,
-    } as any)
+  it('should render the canceling run modal when run is closing', () => {
+    vi.mocked(useCloseCurrentRun).mockReturnValue({
+      closeCurrentRun: mockCloseCurrentRun,
+      isClosingCurrentRun: true,
+    })
     render(props)
     screen.getByText('mock CancelingRunModal')
   })
@@ -163,7 +162,7 @@ describe('ConfirmCancelRunModal', () => {
     screen.getByText('mock CancelingRunModal')
   })
 
-  it('when stop run succeeds and run is not active, run is dismissed and navigates to /protocols', () => {
+  it('when stop run succeeds and run is not active, run is closed and navigates to /protocols', () => {
     props = {
       ...props,
       isActiveRun: false,
@@ -180,8 +179,7 @@ describe('ConfirmCancelRunModal', () => {
     expect(mockTrackProtocolRunEvent).toHaveBeenCalledWith({
       name: 'runCancel',
     })
-    expect(mockDismissCurrentRun).toHaveBeenCalledWith(
-      RUN_ID,
+    expect(mockCloseCurrentRun).toHaveBeenCalledWith(
       expect.objectContaining({
         onSuccess: expect.any(Function),
         onError: expect.any(Function),
@@ -205,8 +203,7 @@ describe('ConfirmCancelRunModal', () => {
     const button = screen.getByText('Cancel run')
     fireEvent.click(button)
 
-    expect(mockDismissCurrentRun).toHaveBeenCalledWith(
-      RUN_ID,
+    expect(mockCloseCurrentRun).toHaveBeenCalledWith(
       expect.objectContaining({
         onSuccess: expect.any(Function),
         onError: expect.any(Function),
@@ -216,7 +213,7 @@ describe('ConfirmCancelRunModal', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/protocols/test-protocol-id')
   })
 
-  it('when run is active, stop run does not dismiss or navigate', () => {
+  it('when run is active, stop run does not close or navigate', () => {
     mockStopRun.mockImplementation((_id: string, options: any) => {
       options.onSuccess()
     })
@@ -225,12 +222,12 @@ describe('ConfirmCancelRunModal', () => {
     const button = screen.getByText('Cancel run')
     fireEvent.click(button)
 
-    expect(mockDismissCurrentRun).not.toHaveBeenCalled()
+    expect(mockCloseCurrentRun).not.toHaveBeenCalled()
     expect(mockTrackProtocolRunEvent).toHaveBeenCalled()
     expect(mockNavigate).not.toHaveBeenCalled()
   })
 
-  it('when stop run errors and run is not active, still dismisses and navigates', () => {
+  it('when stop run errors and run is not active, still closes and navigates', () => {
     props = {
       ...props,
       isActiveRun: false,
@@ -244,8 +241,7 @@ describe('ConfirmCancelRunModal', () => {
     const button = screen.getByText('Cancel run')
     fireEvent.click(button)
 
-    expect(mockDismissCurrentRun).toHaveBeenCalledWith(
-      RUN_ID,
+    expect(mockCloseCurrentRun).toHaveBeenCalledWith(
       expect.objectContaining({
         onSuccess: expect.any(Function),
         onError: expect.any(Function),
@@ -255,7 +251,7 @@ describe('ConfirmCancelRunModal', () => {
     expect(mockTrackProtocolRunEvent).not.toHaveBeenCalled()
   })
 
-  it('when run status becomes stopped via polling, run is dismissed and navigates to /protocols', () => {
+  it('when run status becomes stopped via polling, run is closed and navigates to /protocols', () => {
     props = {
       ...props,
       isActiveRun: false,
@@ -271,7 +267,7 @@ describe('ConfirmCancelRunModal', () => {
 
     render(props)
 
-    expect(mockDismissCurrentRun).toHaveBeenCalled()
+    expect(mockCloseCurrentRun).toHaveBeenCalled()
     expect(mockNavigate).toHaveBeenCalledWith('/protocols')
   })
 
@@ -292,11 +288,11 @@ describe('ConfirmCancelRunModal', () => {
 
     render(props)
 
-    expect(mockDismissCurrentRun).toHaveBeenCalled()
+    expect(mockCloseCurrentRun).toHaveBeenCalled()
     expect(mockNavigate).toHaveBeenCalledWith('/protocols/test-protocol-id')
   })
 
-  it('when run status becomes stopped via polling and run is active, run is not dismissed', () => {
+  it('when run status becomes stopped via polling and run is active, run is not closed', () => {
     vi.mocked(useNotifyRunQuery).mockReturnValue({
       data: {
         data: {
@@ -307,6 +303,6 @@ describe('ConfirmCancelRunModal', () => {
 
     render(props)
 
-    expect(mockDismissCurrentRun).not.toHaveBeenCalled()
+    expect(mockCloseCurrentRun).not.toHaveBeenCalled()
   })
 })

--- a/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
+++ b/app/src/organisms/ODD/RunningProtocol/ConfirmCancelRunModal/index.tsx
@@ -7,7 +7,6 @@ import { RUN_STATUS_STOPPED } from '@opentrons/api-client'
 import { COLORS, LegacyStyledText } from '@opentrons/components'
 import {
   isDocumentedMutationError,
-  useDismissCurrentRunMutation,
   useStopRunMutation,
 } from '@opentrons/react-api-client'
 
@@ -17,7 +16,7 @@ import { OddModal } from '/app/molecules/OddModal'
 import { useTrackProtocolRunEvent } from '/app/redux-resources/analytics'
 import { ANALYTICS_PROTOCOL_RUN_ACTION } from '/app/redux/analytics'
 import { getLocalRobot } from '/app/redux/discovery'
-import { useNotifyRunQuery } from '/app/resources/runs'
+import { useCloseCurrentRun, useNotifyRunQuery } from '/app/resources/runs'
 
 import { CancelingRunModal } from '../CancelingRunModal'
 import styles from './confirmcancelmodal.module.css'
@@ -59,8 +58,8 @@ export function ConfirmCancelRunModal({
     runId
   )
   const { stopRun } = useStopRunMutation(documentationState)
-  const { dismissCurrentRun, isLoading: isDismissing } =
-    useDismissCurrentRunMutation(documentationState)
+  const { closeCurrentRun, isClosingCurrentRun } =
+    useCloseCurrentRun(documentationState)
 
   const modalHeader: OddModalHeaderBaseProps = {
     title: t('cancel_run_modal_heading'),
@@ -83,7 +82,7 @@ export function ConfirmCancelRunModal({
     }
     dismissStartedRef.current = true
     setIsCanceling(true)
-    dismissCurrentRun(runId, {
+    closeCurrentRun({
       onSuccess: () => {
         navigateAway()
       },
@@ -97,7 +96,7 @@ export function ConfirmCancelRunModal({
         }
       },
     })
-  }, [isActiveRun, dismissCurrentRun, runId, navigateAway, clearDocreport])
+  }, [isActiveRun, closeCurrentRun, navigateAway, clearDocreport])
 
   const handleCancelRun = (): void => {
     setIsCanceling(true)
@@ -127,7 +126,7 @@ export function ConfirmCancelRunModal({
     }
   }, [runStatus, isRunCurrent, isRunFetchError, dismissAndNavigate])
 
-  return isCanceling || isDismissing ? (
+  return isCanceling || isClosingCurrentRun ? (
     <CancelingRunModal />
   ) : (
     <OddModal

--- a/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/__tests__/ProtocolSetup.test.tsx
@@ -616,6 +616,14 @@ describe('ProtocolSetup', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/protocols')
   })
 
+  it('should not redirect when cancel modal is open and run is stopped', () => {
+    render(`/runs/${RUN_ID}/setup/`)
+    mockNavigate.mockClear()
+    fireEvent.click(screen.getByRole('button', { name: 'close' }))
+    expect(vi.mocked(ConfirmCancelRunModal)).toHaveBeenCalled()
+    expect(mockNavigate).not.toHaveBeenCalledWith('/protocols')
+  })
+
   it('should show action needed when modules are not calibrated', () => {
     vi.mocked(useModuleCalibrationStatus).mockReturnValue({ complete: false })
     render(`/runs/${RUN_ID}/setup/`)

--- a/app/src/pages/ODD/ProtocolSetup/index.tsx
+++ b/app/src/pages/ODD/ProtocolSetup/index.tsx
@@ -155,6 +155,8 @@ interface PrepareToRunProps {
   isCameraRequired: boolean
   appCameraSettings: CameraState
   storageInfo: RobotStorageInfo
+  showConfirmCancelModal: boolean
+  setShowConfirmCancelModal: Dispatch<SetStateAction<boolean>>
 }
 
 function PrepareToRun({
@@ -173,6 +175,8 @@ function PrepareToRun({
   isCameraRequired,
   appCameraSettings,
   storageInfo,
+  showConfirmCancelModal,
+  setShowConfirmCancelModal,
 }: PrepareToRunProps): JSX.Element {
   const { t, i18n } = useTranslation([
     'protocol_setup',
@@ -289,9 +293,6 @@ function PrepareToRun({
     parameter =>
       parameter.type === 'csv_file' || parameter.value !== parameter.default
   )
-
-  const [showConfirmCancelModal, setShowConfirmCancelModal] =
-    useState<boolean>(false)
 
   const deckConfigCompatibility = useDeckConfigurationCompatibility(
     robotType,
@@ -804,8 +805,10 @@ export function ProtocolSetup(): JSX.Element {
       .data?.data.id != null
 
   const navigate = useNavigate()
+  const [showConfirmCancelModal, setShowConfirmCancelModal] =
+    useState<boolean>(false)
 
-  if (runStatus === RUN_STATUS_STOPPED) {
+  if (runStatus === RUN_STATUS_STOPPED && !showConfirmCancelModal) {
     navigate('/protocols')
   }
 
@@ -1000,6 +1003,8 @@ export function ProtocolSetup(): JSX.Element {
         isCameraRequired={isCameraRequired}
         appCameraSettings={appCameraSettings}
         storageInfo={storageInfo}
+        showConfirmCancelModal={showConfirmCancelModal}
+        setShowConfirmCancelModal={setShowConfirmCancelModal}
       />
     ),
     instruments: (

--- a/app/src/pages/ODD/RunSummary/SignRun.tsx
+++ b/app/src/pages/ODD/RunSummary/SignRun.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import NiceModal, { useModal } from '@ebay/nice-modal-react'
 import clsx from 'clsx'
 
 import {
@@ -17,6 +18,7 @@ import { showLoginModal } from '/app/organisms/ODD/OnDeviceLogin/LoginModal'
 import { useToaster } from '/app/organisms/ToasterOven'
 import { useLocalRobotName } from '/app/redux-resources/robots/hooks/useLocalRobotName'
 import { useSignRunFlow } from '/app/resources/access-control/useSignRunFlow'
+import { useCurrentRunId, useNotifyAllRunsQuery } from '/app/resources/runs'
 
 import styles from './signrun.module.css'
 
@@ -25,7 +27,13 @@ import type { KeyboardReactInterface } from 'react-simple-keyboard'
 // Above OnDeviceLogin overlay (z-index: 10001) so the toast is visible on login.
 const TOAST_ABOVE_LOGIN_Z_INDEX = 10002
 
-export function SignRun({ runId }: { runId: string }): JSX.Element {
+export function SignRun({
+  runId,
+  onSigned,
+}: {
+  runId: string
+  onSigned?: () => void
+}): JSX.Element {
   const { t, i18n } = useTranslation(['access_control', 'shared'])
 
   const [name, setName] = useState('')
@@ -64,7 +72,8 @@ export function SignRun({ runId }: { runId: string }): JSX.Element {
     robotName,
     async () => await showLoginModal(),
     popToast,
-    eatToast
+    eatToast,
+    onSigned
   )
 
   const trimmedName = name.trim()
@@ -167,3 +176,36 @@ export function SignRun({ runId }: { runId: string }): JSX.Element {
     </>
   )
 }
+
+const SignRunModalImpl = NiceModal.create((): JSX.Element | null => {
+  const modal = useModal()
+  const runId = useCurrentRunId()
+  const { isFetched } = useNotifyAllRunsQuery({ pageLength: 0 })
+
+  useEffect(() => {
+    if (isFetched && runId == null) {
+      modal.resolve(false)
+      modal.remove()
+    }
+  }, [isFetched, modal, runId])
+
+  if (runId == null) {
+    return null
+  }
+
+  return (
+    <div className={styles.overlay}>
+      <SignRun
+        runId={runId}
+        onSigned={() => {
+          modal.resolve(true)
+          modal.remove()
+        }}
+      />
+    </div>
+  )
+})
+
+/** Open the ODD sign-run modal and await whether the run was signed. */
+export const showSignRunModal = (): Promise<boolean> =>
+  NiceModal.show(SignRunModalImpl)

--- a/app/src/pages/ODD/RunSummary/signrun.module.css
+++ b/app/src/pages/ODD/RunSummary/signrun.module.css
@@ -56,3 +56,10 @@
   bottom: 0;
   left: 0;
 }
+
+.overlay {
+  position: fixed;
+  z-index: 1000;
+  background-color: var(--white);
+  inset: 0;
+}

--- a/app/src/resources/access-control/useSignRunFlow.ts
+++ b/app/src/resources/access-control/useSignRunFlow.ts
@@ -35,7 +35,8 @@ export function useSignRunFlow(
     uncloseable: boolean
   }) => Promise<{ username: string } | null>,
   popToast: () => void,
-  eatToast: () => void
+  eatToast: () => void,
+  onSigned?: () => void
 ): SignRunFlowResult {
   const queryClient = useQueryClient()
   const host = useHost()
@@ -153,9 +154,16 @@ export function useSignRunFlow(
       if (!trimmedName || trimmedName !== self?.data?.fullName) {
         return
       }
-      signRunMutation({ runId, name })
+      signRunMutation(
+        { runId, name },
+        {
+          onSuccess: () => {
+            onSigned?.()
+          },
+        }
+      )
     },
-    [self?.data?.fullName, signRunMutation, runId]
+    [self?.data?.fullName, signRunMutation, runId, onSigned]
   )
 
   return {

--- a/app/src/resources/runs/useCloseCurrentRun.ts
+++ b/app/src/resources/runs/useCloseCurrentRun.ts
@@ -1,8 +1,11 @@
-import { useCallback } from 'react'
+import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 
 import { useDismissCurrentRunMutation } from '@opentrons/react-api-client'
 
+import { DocumentationRequiredModalContext } from '/app/local-resources/access-control/DocumentationRequiredModalContext'
 import { useCurrentRunId } from '/app/resources/runs'
+
+import { useIsSigningRequired } from './useIsSigningRequired'
 
 import type { DocumentationState } from '@opentrons/react-api-client'
 import type { UseDismissCurrentRunMutationOptions } from '@opentrons/react-api-client/src/runs/useDismissCurrentRunMutation'
@@ -18,26 +21,89 @@ export function useCloseCurrentRun(documentationState: DocumentationState): {
   const { dismissCurrentRun, isLoading: isDismissing } =
     useDismissCurrentRunMutation(documentationState)
 
+  const { showSignRunModal } = useContext(DocumentationRequiredModalContext)
+
+  const { isSigningRequired, isLoading: isSigningRequiredLoading } =
+    useIsSigningRequired()
+
+  const [isClosePending, setIsClosePending] = useState(false)
+  const isSignRunPending = useRef(false)
+  const closeOptions = useRef<UseDismissCurrentRunMutationOptions | undefined>(
+    undefined
+  )
+
+  const resetClosePending = useCallback(() => {
+    setIsClosePending(false)
+    isSignRunPending.current = false
+    closeOptions.current = undefined
+  }, [])
+
   const closeCurrentRun = (
     options?: UseDismissCurrentRunMutationOptions
   ): void => {
-    if (currentRunId != null) {
-      dismissCurrentRun(currentRunId, {
-        onError: () => {
-          console.warn('failed to dismiss current')
-        },
-        ...options,
-      })
+    if (currentRunId != null && !isClosePending) {
+      isSignRunPending.current = false
+      setIsClosePending(true)
+      closeOptions.current = options
     }
   }
 
+  const handleDismiss = useCallback(() => {
+    if (currentRunId != null) {
+      const callerOptions = closeOptions.current ?? {}
+      dismissCurrentRun(currentRunId, {
+        ...callerOptions,
+        onError: (error, ...args) => {
+          console.warn('failed to dismiss current')
+          callerOptions.onError?.(error, ...args)
+        },
+        onSettled: (...args) => {
+          resetClosePending()
+          callerOptions.onSettled?.(...args)
+        },
+      })
+    }
+  }, [currentRunId, dismissCurrentRun, resetClosePending])
+
+  useEffect(() => {
+    if (isSigningRequiredLoading || !isClosePending) {
+      return
+    }
+
+    if (isSigningRequired) {
+      if (isSignRunPending.current) {
+        return
+      }
+      isSignRunPending.current = true
+      void showSignRunModal().then(signed => {
+        if (!signed) {
+          resetClosePending()
+          throw new Error(
+            'Sign run modal resolved false while closing current run; signing is required before dismiss'
+          )
+        }
+        handleDismiss()
+      })
+      return
+    }
+
+    handleDismiss()
+  }, [
+    handleDismiss,
+    isClosePending,
+    isSigningRequired,
+    isSigningRequiredLoading,
+    resetClosePending,
+    showSignRunModal,
+  ])
+
   const closeCurrentRunCallback = useCallback(closeCurrentRun, [
-    dismissCurrentRun,
     currentRunId,
+    isClosePending,
   ])
 
   return {
     closeCurrentRun: closeCurrentRunCallback,
-    isClosingCurrentRun: isDismissing,
+    isClosingCurrentRun: isDismissing || isClosePending,
   }
 }

--- a/app/src/resources/runs/useIsSigningRequired.ts
+++ b/app/src/resources/runs/useIsSigningRequired.ts
@@ -1,0 +1,36 @@
+import {
+  useAccessControlEnabledQuery,
+  useGetRobotServerAccessControlSettingsQuery,
+} from '@opentrons/react-api-client'
+
+import { useCurrentRunId } from './useCurrentRunId'
+import { useNotifyRunQuery } from './useNotifyRunQuery'
+
+export function useIsSigningRequired(): {
+  isLoading: boolean
+  isSigningRequired: boolean
+} {
+  const currentRunId = useCurrentRunId()
+  const { data: runRecord, isLoading: isRunRecordLoading } =
+    useNotifyRunQuery(currentRunId)
+  const {
+    data: accessControlEnabled,
+    isLoading: isAccessControlEnabledLoading,
+  } = useAccessControlEnabledQuery()
+  const {
+    data: accessControlSettings,
+    isLoading: isAccessControlSettingsLoading,
+  } = useGetRobotServerAccessControlSettingsQuery()
+  const isSigningRequired =
+    (accessControlEnabled?.data.accessControlEnabled ?? false) &&
+    (accessControlSettings?.data.requireSignoffForProtocolLog ?? false)
+  const hasSignedBy = !!runRecord?.data.signedBy
+
+  return {
+    isLoading:
+      isRunRecordLoading ||
+      isAccessControlEnabledLoading ||
+      isAccessControlSettingsLoading,
+    isSigningRequired: isSigningRequired && !hasSignedBy,
+  }
+}


### PR DESCRIPTION
# Overview

Refactors popping up the sign run modal to gate the close current run call. In theory, it should now not be possible to close a run without signing it first.

https://github.com/user-attachments/assets/196c9d3b-088c-4e8a-a15f-5e8fecce07ab

Fixes [EXEC-2898](https://opentrons.atlassian.net/browse/EXEC-2898)

## Test Plan and Hands on Testing

Canceling a run, from the setup screen or during a run, should ask for documentation, then pop up the 'sign run' modal.

## Risk assessment

Medium, this code is touchy apparently

[EXEC-2898]: https://opentrons.atlassian.net/browse/EXEC-2898?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ