### PR TITLE
fix(ci): pin npm 11 for OIDC alpha publish on Node 22.22.0

### DIFF
--- a/.github/workflows/npm-publish-alpha.yaml
+++ b/.github/workflows/npm-publish-alpha.yaml
@@ -87,10 +87,12 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
 
-      # Trusted publishing requires npm CLI >= 11.5.1
+      # Trusted publishing requires npm CLI >= 11.5.1.
+      # Pin npm 11.x: npm@latest (12+) requires Node ^22.22.2, but the monorepo
+      # pins 22.22.0. Stay on npm 11 until the repo Node pin moves.
       - name: 'Upgrade npm for OIDC trusted publishing'
         run: |
-          npm install -g npm@latest
+          npm install -g npm@11.19.0
           node --version
           npm --version
 


### PR DESCRIPTION
## Overview

The [Publish JS packages to npm (alpha)](https://github.com/Opentrons/opentrons/actions/runs/30929218411/job/92059358294) workflow failed on `Upgrade npm for OIDC trusted publishing` because `npm install -g npm@latest` resolved to `npm@12.0.2`, which requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`. The workflow (and monorepo) still pin Node `22.22.0`.

Pin the upgrade step to `npm@11.19.0`, which satisfies trusted publishing (`>= 11.5.1`) and supports Node `22.22.0`.

**Acceptance criteria**
- Workflow no longer fails on the npm upgrade step against Node 22.22.0
- npm CLI remains `>= 11.5.1` for OIDC Trusted Publishing

Related: #22014

## Test Plan and Hands on Testing

- [ ] Merge, then re-run **Publish JS packages to npm (alpha)** from `edge` with `dry_run: true`
- [ ] Confirm the upgrade step logs Node `v22.22.0` and npm `11.19.0`
- [ ] If dry-run succeeds, run again with `dry_run: false` to publish `0.3.9-alpha.0`

## Changelog

- Pin `npm-publish-alpha.yaml` npm upgrade to `npm@11.19.0` instead of `npm@latest`
- Document why npm 12 is deferred until the monorepo Node pin moves

## Review requests

- Prefer pinning npm 11 vs bumping this workflow alone to Node `22.22.2` so we can keep `npm@latest`?

## Risk assessment

- **Attention level**: low (CI pin only; no package publish until the workflow is re-run)
- **Trade-offs**: stays aligned with monorepo Node `22.22.0`; will need a follow-up when the repo Node pin allows npm 12
- **Blast radius**: alpha npm publish workflow only
- **Mitigation**: dry-run before real publish