### PR TITLE
chore: add pipette firmware fix to 9.1.2 release notes

### DIFF
--- a/api/release-notes.md
+++ b/api/release-notes.md
@@ -17,6 +17,7 @@ Welcome to the v9.1.2 release of the Opentrons Flex robot software! This release
 ### Bug Fixes
 
 - Flex 96-channel pipettes properly align over 8-well reservoirs for liquid handling with a single row of tips.
+- Fixes an issue where a Flex pipette cannot update its firmware.
 
 ---
 


### PR DESCRIPTION
# Overview

Adds a description of the [RESC-599](https://opentrons.atlassian.net/browse/RESC-599?atlOrigin=eyJpIjoiODI4MGUxYzA3MTI0NDgyYmFlYTk1MTA4NDcwNjU1MzEiLCJwIjoiamlyYS1zbGFjay1pbnQifQ) fix to the 9.1.2 release notes.

## Test Plan and Hands on Testing



## Changelog

one line change

## Review requests



## Risk assessment

low


[RESC-599]: https://opentrons.atlassian.net/browse/RESC-599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ