### PR TITLE
fix(api): propagate vacuum waste-full async errors for recovery

### DIFF
--- a/api/src/opentrons/drivers/vacuum_module/driver.py
+++ b/api/src/opentrons/drivers/vacuum_module/driver.py
@@ -157,7 +157,11 @@ class VacuumModuleDriver(AbstractVacuumModuleDriver):
             loop=loop,
             error_keyword=VM_ERROR_KEYWORD,
             async_error_ack=VM_ASYNC_ERROR_ACK,
-            reset_buffer_before_write=True,
+            # Do not reset the input buffer before writes. Waste-full (and other async
+            # module errors) are one-shot UART notifications that can arrive between
+            # commands. Clearing the buffer on every write drops them before the
+            # next read can partition and raise them.
+            reset_buffer_before_write=False,
             error_codes=VacuumModuleErrorCodes,
         )
         return cls(connection)

--- a/api/src/opentrons/hardware_control/modules/vacuum_module.py
+++ b/api/src/opentrons/hardware_control/modules/vacuum_module.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
-from typing import Any, Awaitable, Callable, List, Mapping, Optional, Type, Union
+from typing import (
+    Any,
+    Awaitable,
+    Callable,
+    List,
+    Mapping,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from typing_extensions import cast
 
@@ -21,7 +31,6 @@ from opentrons.drivers.vacuum_module.driver import (
     VacuumModuleDriver,
 )
 from opentrons.drivers.vacuum_module.errors import (
-    FailedToVent,
     PressureNotReached,
     WasteContainerFull,
     async_gcode_response_to_error,
@@ -75,6 +84,8 @@ _RECOVERABLE_VACUUM_DRIVER_ERRORS: dict[
     PressureNotReached: VacuumModulePressureNotReachedError,
     WasteContainerFull: VacuumModuleWasteFullError,
 }
+
+_T = TypeVar("_T")
 
 POLL_PERIOD = 2.0
 SIMULATING_POLL_PERIOD = POLL_PERIOD / 20.0
@@ -254,6 +265,19 @@ class VacuumModule(mod_abc.AbstractModule):
             if isinstance(exception, driver_error_type):
                 return enumerated_error_type(serial, mode, target, current)
         return VacuumModuleUnknownError(serial, mode, target, current)
+
+    async def _map_err(self, awaitable: Awaitable[_T]) -> _T:
+        """Await driver calls, mapping recoverable driver errors to enumerated errors.
+
+        PE background tasks record failures via FinishTaskAction; associated-command
+        recovery needs enumerated error codes, not raw driver exceptions.
+        """
+        try:
+            return await awaitable
+        except Exception as exc:
+            if isinstance(exc, tuple(_RECOVERABLE_VACUUM_DRIVER_ERRORS)):
+                raise self._to_enumerated_error(exc) from exc
+            raise
 
     async def soft_cleanup(self) -> None:
         """Stop the poller and disconnect the serial driver without notifying pyro."""
@@ -474,8 +498,8 @@ class VacuumModule(mod_abc.AbstractModule):
     async def stop_vacuum(self) -> None:
         """Stop pressure control and the pump; clear software targets."""
         self._profile_stop_requested = True
-        await self._driver.set_vacuum_state(False)
-        await self._driver.set_pump_state(False)
+        await self._map_err(self._driver.set_vacuum_state(False))
+        await self._map_err(self._driver.set_pump_state(False))
         self._reader.reset_pressure_target()
         self._reader.reset_power_target()
 
@@ -484,7 +508,7 @@ class VacuumModule(mod_abc.AbstractModule):
         if must_be_running:
             await self.wait_for_is_running()
         await self.stop_vacuum()
-        await self._driver.set_vent_state(VentState.OPENED)
+        await self.set_vent_state(VentState.OPENED)
 
     async def set_led_state(
         self,
@@ -495,8 +519,10 @@ class VacuumModule(mod_abc.AbstractModule):
         reps: Optional[int] = None,
     ) -> None:
         """Sets the statusbar state."""
-        return await self._driver.set_led(
-            power, color=color, pattern=pattern, duration=duration, reps=reps
+        await self._map_err(
+            self._driver.set_led(
+                power, color=color, pattern=pattern, duration=duration, reps=reps
+            )
         )
 
     def event_listener(self, event: Any) -> None:
@@ -562,10 +588,7 @@ class VacuumModule(mod_abc.AbstractModule):
 
     async def set_vent_state(self, vent_state: VentState) -> None:
         """Open or close the vent."""
-        try:
-            await self._driver.set_vent_state(state=vent_state)
-        except FailedToVent:
-            raise
+        await self._map_err(self._driver.set_vent_state(state=vent_state))
 
     async def set_vacuum_state(
         self,
@@ -580,13 +603,15 @@ class VacuumModule(mod_abc.AbstractModule):
         self._reader.set_operation_mode(VacuumOperationMode.PRESSURE)
         self._reader.reset_power_target()
         self._reader.set_target_pressure(gauge_pressure_mbar)
-        await self._driver.set_vacuum_state(
-            enable_vacuum=enable_vacuum,
-            gauge_pressure_mbar=gauge_pressure_mbar,
-            duration_s=duration_s,
-            timeout_s=timeout_s,
-            rate=rate,
-            vent_after=vent_after,
+        await self._map_err(
+            self._driver.set_vacuum_state(
+                enable_vacuum=enable_vacuum,
+                gauge_pressure_mbar=gauge_pressure_mbar,
+                duration_s=duration_s,
+                timeout_s=timeout_s,
+                rate=rate,
+                vent_after=vent_after,
+            )
         )
 
     async def set_pump_state(
@@ -603,15 +628,17 @@ class VacuumModule(mod_abc.AbstractModule):
         self._reader.set_operation_mode(VacuumOperationMode.POWER)
         self._reader.reset_pressure_target()
         self._reader.set_target_power(duty_cycle)
-        await self._driver.set_vacuum_state(False)
-        await self._driver.set_pump_state(
-            start_pump=start_pump,
-            target_rpm=target_rpm,
-            duty_cycle=duty_cycle,
-            duration_s=duration_s,
-            timeout_s=timeout_s,
-            rate=rate,
-            vent_after=vent_after,
+        await self._map_err(self._driver.set_vacuum_state(False))
+        await self._map_err(
+            self._driver.set_pump_state(
+                start_pump=start_pump,
+                target_rpm=target_rpm,
+                duty_cycle=duty_cycle,
+                duration_s=duration_s,
+                timeout_s=timeout_s,
+                rate=rate,
+                vent_after=vent_after,
+            )
         )
 
     async def _execute_cycle_step(self, step: VacuumModuleStep) -> None:
@@ -731,13 +758,13 @@ class VacuumModule(mod_abc.AbstractModule):
         await self.wait_for_is_running()
         task = self._loop.create_task(self._wait_for_command_duration())
         self.make_cancellable(task)
-        await task
+        await self._map_err(task)
 
     async def wait_for_target(self) -> None:
         await self.wait_for_is_running()
         task = self._loop.create_task(self._wait_for_target())
         self.make_cancellable(task)
-        await task
+        await self._map_err(task)
 
     async def _wait_for_pressure_equalization(self, timeout_s: float) -> None:
         """Poll until chamber pressure has equalized to atmospheric."""
@@ -760,7 +787,7 @@ class VacuumModule(mod_abc.AbstractModule):
         await self.wait_for_is_running()
         task = self._loop.create_task(self._wait_for_pressure_equalization(timeout_s))
         self.make_cancellable(task)
-        await task
+        await self._map_err(task)
 
     async def _wait_for_target(self) -> None:
         if self._reader.operation_mode == VacuumOperationMode.POWER:

--- a/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
+++ b/api/tests/opentrons/hardware_control/modules/test_hc_vacuummodule.py
@@ -1510,6 +1510,46 @@ async def sim_vacuum_with_injected_error(
         await vacuum.cleanup()
 
 
+async def test_wait_for_target_reraises_waste_full_as_enumerated_error(
+    test_wait_for_target_subject: modules.VacuumModule,
+    mock_driver: SimulatingDriver,
+    decoy: Decoy,
+) -> None:
+    """Background wait paths must raise recoverable enumerated vacuum errors.
+
+    Protocol engine associates recovery via FinishTaskAction error codes. Raw
+    driver WasteContainerFull becomes GENERAL_ERROR and waitForTasks fails the
+    run; VacuumModuleWasteFullError enters associated-command recovery instead.
+    """
+    subject = test_wait_for_target_subject
+    await subject._poller.stop()
+    subject._reader.set_operation_mode(VacuumOperationMode.PRESSURE)
+    subject._reader.set_target_pressure(-300.0)
+    subject._reader.vacuum_state = VacuumState(
+        target_gauge_pressure=-300.0,
+        current_gauge_pressure=-50.0,
+        pressure_abs_a=0,
+        pressure_abs_b=0,
+        pressure_atm=0,
+        vacuum_enabled=True,
+        vacuum_duration=0,
+        vent_state=VentState.CLOSED,
+    )
+
+    decoy.when(await mock_driver.get_vacuum_state()).then_raise(
+        WasteContainerFull("port", "async ERR401:waste full", "M121")
+    )
+
+    with mock.patch(
+        "opentrons.hardware_control.modules.vacuum_module.TARGET_REACHED_POLL_PERIOD",
+        0.0,
+    ):
+        with pytest.raises(VacuumModuleWasteFullError) as exc_info:
+            await subject.wait_for_target()
+
+    assert exc_info.value.serial == subject.serial_number
+
+
 async def test_injected_async_error_reaches_module_error_callback(
     sim_vacuum_with_injected_error: tuple[modules.VacuumModule, List[Exception]],
 ) -> None:

--- a/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_async_error_test.py
+++ b/hardware-testing/hardware_testing/modules/vacuum_module/protocols/vacuum_module_async_error_test.py
@@ -71,6 +71,10 @@ _SCENARIO_CHOICES: list[ParameterChoice] = [
         "value": "async_error_during_gantry",
     },
     {
+        "display_name": "No injection",
+        "value": "async_error_no_injection",
+    },
+    {
         "display_name": "Latest background start",
         "value": "latest_background_start",
     },
@@ -377,6 +381,17 @@ def _scenario_async_error_during_gantry(
     )
 
 
+def _scenario_async_error_no_injection(
+    ctx: ProtocolContext,
+    vacuum_task: Task,
+) -> None:
+    _finish_waiting_for_tasks(
+        ctx,
+        [vacuum_task],
+        label="No async error injection",
+    )
+
+
 def _scenario_latest_background_start(
     ctx: ProtocolContext,
     vm_mod: VacuumModuleContext,
@@ -435,6 +450,8 @@ def run(ctx: ProtocolContext) -> None:
         _scenario_async_error_outside_wait(ctx, vm_mod, vacuum_task)
     elif scenario == "async_error_during_gantry":
         _scenario_async_error_during_gantry(ctx, vm_mod, vacuum_task, trash)
+    elif scenario == "async_error_no_injection":
+        _scenario_async_error_no_injection(ctx, vacuum_task)
     elif scenario == "latest_background_start":
         _scenario_latest_background_start(ctx, vm_mod, vacuum_task)
     else:


### PR DESCRIPTION
# Overview

Vacuum waste-full (`async ERR401`) was not reaching protocol error recovery: one-shot UART notifications were dropped by `reset_buffer_before_write`, and background wait paths surfaced raw driver exceptions as `GENERAL_ERROR` so `waitForTasks` failed the run instead of entering associated-command recovery.

Closes: [RQA-5767](https://opentrons.atlassian.net/browse/RQA-5767)

## Test Plan and Hands on Testing

- [x] blocked waste during vacuum + `wait_for_tasks` should show carvoy full error recovery case

## Changelog

- Vacuum driver: do not clear serial RX before write so one-shot async errors are not discarded
- Vacuum module HC: map recoverable driver errors to enumerated vacuum errors via `_map_err` on set/wait/stop paths
- add `async_error_no_injection` case to test protocol

## Review requests

- Makes sense?
- Any potential issues with not clearing  RX buffer?

## Risk assessment

Low, unreleased

[RQA-5767]: https://opentrons.atlassian.net/browse/RQA-5767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ