### PR TITLE
fix(api): make VacuumModuleContext.move_to_dock use the gripper by default.

### DIFF
--- a/api/src/opentrons/protocol_api/module_contexts.py
+++ b/api/src/opentrons/protocol_api/module_contexts.py
@@ -1961,7 +1961,7 @@ class VacuumModuleContext(ModuleContext):
     def move_to_dock(
         self,
         labware: Labware,
-        use_gripper: bool = False,
+        use_gripper: bool = True,
         pick_up_offset: Optional[Mapping[str, float]] = None,
         drop_offset: Optional[Mapping[str, float]] = None,
     ) -> None:

--- a/api/tests/opentrons/protocol_api/test_vacuum_module_context.py
+++ b/api/tests/opentrons/protocol_api/test_vacuum_module_context.py
@@ -179,7 +179,7 @@ def test_vacuum_module_move_to_dock(
         mock_protocol_core.move_labware(
             labware_core=mock_labware_core,
             new_location=subject.manifold_dock,
-            use_gripper=False,
+            use_gripper=True,
             pause_for_manual_move=True,
             pick_up_offset=None,
             drop_offset=None,


### PR DESCRIPTION
# Overview

The vacuum module collar is intended to be used with the gripper for automated workflows, so let's set the default `use_gripper=True` in the `VacuumModuleContext.move_to_dock` method.