### PR TITLE
fix(robot-server): set top level database directory's permissions when performing a migration

### DIFF
--- a/robot-server/robot_server/persistence/_migrations/v16_to_v17.py
+++ b/robot-server/robot_server/persistence/_migrations/v16_to_v17.py
@@ -12,13 +12,14 @@ access to protocol related files.
 import os
 from pathlib import Path
 
-from server_utils.persistence.folder_migrator import Migration
+from server_utils.persistence.folder_migrator import (
+    PROTOCOL_DIR_PERMISSIONS,
+    PROTOCOL_FILE_PERMISSIONS,
+    Migration,
+)
 
 from ..file_and_directory_names import PROTOCOLS_DIRECTORY
 from ._util import copy_contents
-
-PROTOCOL_FILE_PERMISSIONS = 0o640
-PROTOCOL_DIR_PERMISSIONS = 0o750
 
 
 class Migration16to17(Migration):

--- a/server-utils/server_utils/persistence/folder_migrator.py
+++ b/server-utils/server_utils/persistence/folder_migrator.py
@@ -24,6 +24,9 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Final, List, Union
 
+PROTOCOL_FILE_PERMISSIONS = 0o640
+PROTOCOL_DIR_PERMISSIONS = 0o750
+
 _log = logging.getLogger(__name__)
 
 
@@ -130,6 +133,7 @@ class MigrationOrchestrator:
                 # Atomically move the filled directory into place.
                 final_output_dir = self._root / migration.subdirectory
                 os.replace(src=step_output_dir, dst=final_output_dir)
+                os.chmod(final_output_dir, PROTOCOL_DIR_PERMISSIONS)
                 latest_dir_so_far = final_output_dir
 
         _log.info("All migrations complete.")


### PR DESCRIPTION
# Overview

In #21958, new permissions for the robot-server's database were added to allow the non-root `ot-protocol` user to access the necessary files for running a protocol. The 16 to 17 migration makes these changes, and the idea was that further migrations would have these permissions migrated during the copy process of the migration.

This worked except for the fact that we were only copying the permissions in the inner directories and files, and not on the actual new directory, since that was being created elsewhere without getting it's permissions set. There is a system for setting this by the system automatically, but that only runs during boot.

The consequence of this is when doing a `make-push` to the robot or updating it any way that doesn't reboot the system, the directory would not get its permissions set and the user would be unable to run any protocols until the system was rebooted.

## Test Plan and Hands on Testing

On-robot testing that a migration with this change works without having to reboot the system

## Changelog

- set final protocol database directory to expected user permissions during migration

## Review requests

## Risk assessment

Low, fixes an issue and the folder was getting set to these permissions on next boot anyway.