### PR TITLE
fix(api): Expand non-builtin dictionary serialization to include dataclasses

### DIFF
--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -370,6 +370,8 @@ class OpentronsPyroSerializer:
                     unwrapped_key = key_type(key)
             elif issubclass(key_type, BaseModel):
                 unwrapped_key = key_type.model_validate(key)
+            elif is_dataclass(key_type):
+                unwrapped_key = key_type(**key)
             else:
                 unwrapped_key = key_type(key)
 
@@ -387,6 +389,8 @@ class OpentronsPyroSerializer:
                     unwrapped_value = value_type(d["dictionary"][key])
             elif issubclass(value_type, BaseModel):
                 unwrapped_value = value_type.model_validate(d["dictionary"][key])
+            elif is_dataclass(value_type):
+                unwrapped_value = value_type(**d["dictionary"][key])
             else:
                 unwrapped_value = value_type(d["dictionary"][key])
 

--- a/api/src/opentrons/util/pyro/pyro_serialization.py
+++ b/api/src/opentrons/util/pyro/pyro_serialization.py
@@ -370,8 +370,6 @@ class OpentronsPyroSerializer:
                     unwrapped_key = key_type(key)
             elif issubclass(key_type, BaseModel):
                 unwrapped_key = key_type.model_validate(key)
-            elif is_dataclass(key_type):
-                unwrapped_key = key_type(**key)
             else:
                 unwrapped_key = key_type(key)
 
@@ -390,7 +388,9 @@ class OpentronsPyroSerializer:
             elif issubclass(value_type, BaseModel):
                 unwrapped_value = value_type.model_validate(d["dictionary"][key])
             elif is_dataclass(value_type):
-                unwrapped_value = value_type(**d["dictionary"][key])
+                unwrapped_value = value_type.from_pyro_dict(  # type: ignore
+                    classname=d["value_type"], data=d["dictionary"][key]
+                )
             else:
                 unwrapped_value = value_type(d["dictionary"][key])
 

--- a/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
+++ b/api/src/opentrons/util/pyro/pyro_synchronous_adapter.py
@@ -5,6 +5,7 @@ import enum
 import functools
 import inspect
 import logging
+from dataclasses import is_dataclass
 from types import FunctionType, MethodType
 from typing import Any, Callable, Dict, Iterator, Optional, ParamSpec, TypeVar
 
@@ -807,6 +808,10 @@ def convert_result_to_wrapped_dict(  # noqa: C901
         if isinstance(result, dict):
             if hasattr(return_types, "__args__"):
                 key_type, value_type = return_types.__args__
+                if is_dataclass(value_type):
+                    result = {
+                        key: value.to_pyro_dict(value) for key, value in result.items()
+                    }
                 # Filter out `typing.Optional`` typings to the inner type, only works for non-tuples
                 # todo(chb: 2025-04-01): Catch and error on cases where we have optional tuples, does that even happen?
                 try:

--- a/api/tests/opentrons/util/test_pyro_serialization.py
+++ b/api/tests/opentrons/util/test_pyro_serialization.py
@@ -1,6 +1,8 @@
 """Test for the Pyro Serialization."""
 
 import enum
+from dataclasses import is_dataclass
+from typing import Any, Dict
 
 import pytest
 from pydantic import BaseModel
@@ -14,10 +16,17 @@ from opentrons_shared_data.errors.exceptions import (
     VacuumModuleWasteFullError,
 )
 
-from opentrons.hardware_control.types import CriticalPoint
+from opentrons.hardware_control.types import (
+    Axis,
+    CriticalPoint,
+    EstopOverallStatus,
+    EstopPhysicalStatus,
+    EstopState,
+)
 from opentrons.protocol_engine.types.module import ModuleModel
 from opentrons.types import DeckSlotName
 from opentrons.util.pyro.pyro_serialization import (
+    NonBuiltinKeyDictWrapper,
     OpentronsPyroSerializer,
     enumerated_error_class_to_dict,
     enumerated_error_dict_to_class,
@@ -130,3 +139,56 @@ def test_enumerated_error_serialization(test_error: EnumeratedError) -> None:
     result = enumerated_error_dict_to_class("", test_dict)
 
     assert result == test_error
+
+
+def test_non_builtin_keys_with_dataclasses() -> None:
+    """It should serialize and deserialize a non-builtin keys dictionary that includes dataclasses."""
+    serializer = OpentronsPyroSerializer()
+    serializer.register_class(EstopOverallStatus)
+    serializer.register_enum(Axis)
+
+    def _fake_func() -> Dict[Axis, EstopOverallStatus]:
+        return {
+            Axis.X: EstopOverallStatus(
+                state=EstopState.PHYSICALLY_ENGAGED,
+                left_physical_state=EstopPhysicalStatus.DISENGAGED,
+                right_physical_state=EstopPhysicalStatus.ENGAGED,
+            ),
+            Axis.Y: EstopOverallStatus(
+                state=EstopState.DISENGAGED,
+                left_physical_state=EstopPhysicalStatus.ENGAGED,
+                right_physical_state=EstopPhysicalStatus.DISENGAGED,
+            ),
+        }
+
+    def _get_non_builtin_key_dict(attr: Any) -> NonBuiltinKeyDictWrapper:
+        # This mirrors the logic used to build NonBuiltinKeyDictWrappers in pyro
+        return_types = attr.__annotations__["return"]
+        key_type, value_type = return_types.__args__
+        result = attr()
+
+        if is_dataclass(value_type):
+            result = {key: value.to_pyro_dict(value) for key, value in result.items()}
+        try:
+            key_type = next(a for a in key_type.__args__ if a is not type(None))
+        except AttributeError:
+            pass
+        try:
+            value_type = next(a for a in value_type.__args__ if a is not type(None))
+        except AttributeError:
+            pass
+        wrapped_dict = NonBuiltinKeyDictWrapper(
+            dictionary=result,
+            key_type=".".join((key_type.__module__, key_type.__qualname__)),
+            value_type=".".join((value_type.__module__, value_type.__qualname__)),
+        )
+        return wrapped_dict
+
+    # Test serialization
+    result = _fake_func()
+    wrapped_result = _get_non_builtin_key_dict(_fake_func)
+    serialized_result = serializer._pydantic_class_to_dict(wrapped_result)
+    deserialized_result = serializer._non_builtin_key_dict_wrapper_dict_to_class(
+        classname="cookie", d=serialized_result
+    )
+    assert result == deserialized_result


### PR DESCRIPTION
# Overview

Our non-builtin dictionary wrapper for pyro-serialization previous did not cover combinations that included dataclasses. This is because we didn't have any instances of that kind of relationship.

However, we introduced class-level tracking for dataclass types in a previous PR, and this have introduced some level of coverage for functions that could return something like `{Axis : SomeDataclassType}` or something of that styling.


## Test Plan and Hands on Testing

- [x] Add unit test to enforce this behavior (no existing examples on OT3API)

## Changelog
- Added dataclass support for NonBuiltinKeyDictWrapper

## Review requests

## Risk assessment
Low