### PR TITLE
fix(update-server): state in file-upload

### DIFF
--- a/update-server/oe_upload.py
+++ b/update-server/oe_upload.py
@@ -68,6 +68,7 @@ async def do_update(  # noqa: C901
         async with aiohttp.ClientSession(timeout=timeout) as login_session:
             access_token = await log_in(login_session, host, username, password)
         headers["Authorization"] = f"Bearer {access_token}"
+        headers["Opentrons-User-Notes"] = "a" * 128
 
     async with aiohttp.ClientSession(timeout=timeout, headers=headers) as session:
         root = host + "/server/update"

--- a/update-server/oe_upload.py
+++ b/update-server/oe_upload.py
@@ -118,6 +118,10 @@ async def do_update(  # noqa: C901
             sys.exit(-1)
 
         status = await file_resp.json()
+        while status["stage"] == "awaiting-file":
+            sys.stdout.write("waiting for validation to begin\r\n")
+            status = await poll_status(session, token, root)
+
         while status["stage"] == "validating":
             sys.stdout.write(f"{status['message']}: {status['progress'] * 100:.0f}%\r")
             status = await poll_status(session, token, root)

--- a/update-server/otupdate/common/update.py
+++ b/update-server/otupdate/common/update.py
@@ -213,6 +213,11 @@ async def file_upload(
                 message="Request error: no field name for system zip",
             ),
         )
+    # set stage now to make sure that it takes effect in the response
+    # we're about to send, since we're now doing the validation in a
+    # background task that won't get a chance to run before the response is
+    # created
+    session.set_stage(Stages.VALIDATING)
 
     # Only one file can be validated and written. If the request carried several
     # acceptable parts, the last one is the one left on disk.

--- a/update-server/tests/common/test_file_upload.py
+++ b/update-server/tests/common/test_file_upload.py
@@ -75,7 +75,8 @@ async def test_upload_starts_validation_in_the_background(
         files={"system-update.zip": ("system-update.zip", b"pretend this is a zip")},
     )
     assert response.status_code == 201
-    assert response.json()["stage"] == "awaiting-file"
+    # the response should eagerly change the stage
+    assert response.json()["stage"] == "validating"
 
     await asyncio.sleep(0.05)
 


### PR DESCRIPTION
The file upload endpoint wasn't return the appropriate stage, because it's set in a background task that probably won't run before the response from that endpoint is constructed. This definitely broke oe_upload, and I think it's objectively wrong to not eagerly set the stage - the background task can change it to something else afterwards if it wants to, but without this the file upload endpoint looks like it did nothing.

Also, add a workaround for oe_upload for servers without this patch, and fix a printing issue there.

## testing
- [x] use oe-upload to successfully upload a damn update, and don't see any silent failures where the robot restarts but no update is applied