### PR TITLE
Highlight protocol source file in OS file manager

### DIFF
--- a/__mocks__/electron.js
+++ b/__mocks__/electron.js
@@ -21,5 +21,6 @@ module.exports = {
   shell: {
     trashItem: vi.fn(),
     openPath: vi.fn(),
+    showItemInFolder: vi.fn(),
   },
 }

--- a/app-shell/src/protocol-storage/__tests__/file-system.test.ts
+++ b/app-shell/src/protocol-storage/__tests__/file-system.test.ts
@@ -17,6 +17,7 @@ import {
   readFilesWithinDirectory,
   removeProtocolByKey,
   shouldMigrateToNotOt2Directory,
+  viewProtocolSourceFolder,
 } from '../file-system'
 
 vi.mock('uuid', () => ({
@@ -248,6 +249,38 @@ describe('protocol storage directory utilities', () => {
           modified: expect.any(Number),
         },
       ])
+    })
+  })
+
+  describe('viewProtocolSourceFolder', () => {
+    beforeEach(() => {
+      vi.mocked(Electron.shell.showItemInFolder).mockClear()
+      vi.mocked(Electron.shell.openPath).mockClear()
+    })
+
+    it('highlights the protocol source file in the file manager', async () => {
+      const protocolsDir = makeEmptyDir()
+      const srcDirPath = path.join(protocolsDir, 'abc123', 'src')
+      await fs.emptyDir(srcDirPath)
+      await fs.createFile(path.join(srcDirPath, 'serialDilution.py'))
+
+      await viewProtocolSourceFolder('abc123', protocolsDir)
+
+      expect(Electron.shell.showItemInFolder).toHaveBeenCalledWith(
+        path.join(srcDirPath, 'serialDilution.py')
+      )
+      expect(Electron.shell.openPath).not.toHaveBeenCalled()
+    })
+
+    it('falls back to opening the src folder when it holds no files', async () => {
+      const protocolsDir = makeEmptyDir()
+      const srcDirPath = path.join(protocolsDir, 'abc123', 'src')
+      await fs.emptyDir(srcDirPath)
+
+      await viewProtocolSourceFolder('abc123', protocolsDir)
+
+      expect(Electron.shell.openPath).toHaveBeenCalledWith(srcDirPath)
+      expect(Electron.shell.showItemInFolder).not.toHaveBeenCalled()
     })
   })
 

--- a/app-shell/src/protocol-storage/file-system.ts
+++ b/app-shell/src/protocol-storage/file-system.ts
@@ -215,8 +215,18 @@ export function analyzeProtocolByKey(
 export function viewProtocolSourceFolder(
   protocolKey: string,
   protocolsDirPath: string
-): void {
+): Promise<void> {
   const protocolDirPath = path.join(protocolsDirPath, protocolKey)
   const srcDirPath = path.join(protocolDirPath, PROTOCOL_SRC_DIRECTORY_NAME)
-  shell.openPath(srcDirPath)
+  return readFilesWithinDirectory(srcDirPath)
+    .then(srcFilePaths => {
+      if (srcFilePaths.length > 0) {
+        shell.showItemInFolder(srcFilePaths[0])
+      } else {
+        void shell.openPath(srcDirPath)
+      }
+    })
+    .catch(() => {
+      void shell.openPath(srcDirPath)
+    })
 }

--- a/app-shell/src/protocol-storage/index.ts
+++ b/app-shell/src/protocol-storage/index.ts
@@ -279,7 +279,7 @@ export function registerProtocolStorage(dispatch: Dispatch): Dispatch {
 
       case VIEW_PROTOCOL_SOURCE_FOLDER: {
         const protocolsDir = getProtocolsDirectoryPath()
-        FileSystem.viewProtocolSourceFolder(
+        void FileSystem.viewProtocolSourceFolder(
           action.payload.protocolKey,
           protocolsDir
         )


### PR DESCRIPTION
# Overview
This pull request adds and tests a new utility for viewing a protocol's source folder in the file manager, enhancing the user experience by highlighting the protocol's main source file when possible. The main changes include implementing the `viewProtocolSourceFolder` function, updating mocks and usage, and adding comprehensive tests.

**Feature: View Protocol Source Folder**

* Implemented `viewProtocolSourceFolder` in `file-system.ts` to highlight the first file in the protocol's `src` directory using `shell.showItemInFolder`, or open the folder if it's empty or an error occurs. The function now returns a `Promise`.
* Updated the action handler in `index.ts` to call `viewProtocolSourceFolder` asynchronously, ensuring proper handling of the new Promise-based API.

**Testing and Mocks**

* Added tests in `file-system.test.ts` to verify that `viewProtocolSourceFolder` highlights a file when present and falls back to opening the folder when empty.
* Updated the Electron mock to include a mock for `showItemInFolder`.
* Added `viewProtocolSourceFolder` to the imports in the test file.
Describe your PR at a high level. State acceptance criteria and how this PR fits into other work. Link issues, PRs, and other relevant resources.

## Test Plan and Hands on Testing

Describe your testing of the PR. Emphasize testing not reflected in the code. Attach protocols, logs, screenshots and any other assets that support your testing.

## Changelog

List changes introduced by this PR considering future developers and the end user. Give careful thought and clear documentation to breaking changes.

## Review requests

- What do you need from reviewers to feel confident this PR is ready to merge?
- Ask questions.

## Risk assessment

- Indicate the level of attention this PR needs.
- Provide context to guide reviewers.
- Discuss trade-offs, coupling, and side effects.
- Look for the possibility, even if you think it's small, that your change may affect some other part of the system.
  - For instance, changing return tip behavior may also change the behavior of labware calibration.
- How do your unit tests and on hands on testing mitigate this PR's risks and the risk of future regressions?
- Especially in high risk PRs, explain how you know your testing is enough.
