### PR TITLE
fix(app): fix ODD quick transfer floating button style

### DIFF
--- a/app/src/atoms/buttons/TouchFloatingActionButton/touchfloatingactionbutton.module.css
+++ b/app/src/atoms/buttons/TouchFloatingActionButton/touchfloatingactionbutton.module.css
@@ -32,5 +32,6 @@
 .content_container {
   display: flex;
   flex-direction: row;
+  align-items: center;
   gap: var(--spacing-8);
 }


### PR DESCRIPTION
# Overview

Align text to center of floating quick transfer button

## Test Plan and Hands on Testing

- push this branch to app-shell-odd or launch dev ODD app
- click 'Protocols' tab and verify that quick transfer button text is aligned in center

#### before  

<img width="1008" height="586" alt="Screenshot 2026-08-06 at 11 13 19 AM" src="https://github.com/user-attachments/assets/4474c1fe-baf2-4a67-9160-02b15bcea885" />

#### after  

<img width="1008" height="588" alt="Screenshot 2026-08-06 at 11 13 26 AM" src="https://github.com/user-attachments/assets/114ba73c-99cc-4242-b91e-fa97a7b8fa3c" />


## Changelog

Add align-item property to `TouchActionFloatingButton`

## Review requests

see test plan

## Risk assessment

⬇️ 