### PR TITLE
feat(app, app-shell, app-shell-odd): mass storage usb device filtering

### DIFF
--- a/app-shell-odd/src/actions.ts
+++ b/app-shell-odd/src/actions.ts
@@ -401,11 +401,13 @@ export const robotMassStorageDeviceRemoved = (
 })
 
 export const robotMassStorageDeviceAdded = (
-  rootPath: string
+  rootPath: string,
+  isMassStorage: boolean
 ): RobotMassStorageDeviceAdded => ({
   type: ROBOT_MASS_STORAGE_DEVICE_ADDED,
   payload: {
     rootPath,
+    isMassStorage,
   },
   meta: { shell: true },
 })

--- a/app-shell-odd/src/usb/__tests__/usb.test.ts
+++ b/app-shell-odd/src/usb/__tests__/usb.test.ts
@@ -1,0 +1,129 @@
+import { readdir, readFile, realpath } from 'fs/promises'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { isSingleFunctionMassStorageMount } from '../usb'
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(),
+  readdir: vi.fn(),
+  realpath: vi.fn(),
+  // referenced elsewhere in the module under test
+  stat: vi.fn(),
+  unlink: vi.fn(),
+}))
+vi.mock('../../log')
+
+const USB_DEVICES_DIR = '/sys/bus/usb/devices'
+
+interface FakeSysfs {
+  // maps `/sys/block/<disk>/device` -> the realpath it resolves to
+  realpaths: Record<string, string>
+  // maps usb device name -> { interfaceDirName: bInterfaceClass }
+  interfaces: Record<string, Record<string, string>>
+}
+
+const mockSysfs = ({ realpaths, interfaces }: FakeSysfs): void => {
+  vi.mocked(realpath).mockImplementation((path: any): any => {
+    const key = String(path)
+    return key in realpaths
+      ? Promise.resolve(realpaths[key])
+      : Promise.reject(new Error(`ENOENT: ${key}`))
+  })
+  vi.mocked(readdir).mockImplementation((path: any): any => {
+    const device = String(path).slice(`${USB_DEVICES_DIR}/`.length)
+    const deviceInterfaces = interfaces[device]
+    if (deviceInterfaces == null) {
+      return Promise.reject(new Error(`ENOENT: ${String(path)}`))
+    }
+    // include some non-interface descriptor files to exercise the filter
+    return Promise.resolve([
+      ...Object.keys(deviceInterfaces),
+      'idVendor',
+      'product',
+    ])
+  })
+  vi.mocked(readFile).mockImplementation((path: any): any => {
+    const relative = String(path).slice(`${USB_DEVICES_DIR}/`.length)
+    const [device, interfaceDir, file] = relative.split('/')
+    if (
+      file === 'bInterfaceClass' &&
+      interfaces[device]?.[interfaceDir] != null
+    ) {
+      return Promise.resolve(interfaces[device][interfaceDir])
+    }
+    return Promise.reject(new Error(`ENOENT: ${String(path)}`))
+  })
+}
+
+describe('usb/usb isSingleFunctionMassStorageMount', () => {
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns true for a single-function mass-storage device', async () => {
+    mockSysfs({
+      realpaths: {
+        '/sys/block/sdb/device':
+          '/sys/devices/platform/usb1/1-1/1-1.6/1-1.6:1.0/host4/target4:0:0/4:0:0:0',
+      },
+      interfaces: { '1-1.6': { '1-1.6:1.0': '08' } },
+    })
+
+    await expect(
+      isSingleFunctionMassStorageMount('/media/MYUSB-sdb1')
+    ).resolves.toBe(true)
+  })
+
+  it('returns false for a composite device that only exposes storage among other interfaces', async () => {
+    mockSysfs({
+      realpaths: {
+        '/sys/block/sdc/device':
+          '/sys/devices/platform/usb1/1-1/1-1.3/1-1.3.4/1-1.3.4:1.2/host5/target5:0:0/5:0:0:0',
+      },
+      interfaces: {
+        '1-1.3.4': {
+          '1-1.3.4:1.0': '02',
+          '1-1.3.4:1.1': '0a',
+          '1-1.3.4:1.2': '08',
+          '1-1.3.4:1.3': '03',
+          '1-1.3.4:1.4': '01',
+          '1-1.3.4:1.5': '01',
+        },
+      },
+    })
+
+    await expect(
+      isSingleFunctionMassStorageMount('/media/PHONE-sdc1')
+    ).resolves.toBe(false)
+  })
+
+  it('handles an unlabeled mount dir (just sdX#)', async () => {
+    mockSysfs({
+      realpaths: {
+        '/sys/block/sdb/device':
+          '/sys/devices/platform/usb1/1-1/1-1.6/1-1.6:1.0/host4/target4:0:0/4:0:0:0',
+      },
+      interfaces: { '1-1.6': { '1-1.6:1.0': '08' } },
+    })
+
+    await expect(isSingleFunctionMassStorageMount('/media/sdb1')).resolves.toBe(
+      true
+    )
+  })
+
+  it('fails open (returns true) when the backing device cannot be resolved', async () => {
+    mockSysfs({ realpaths: {}, interfaces: {} })
+
+    await expect(
+      isSingleFunctionMassStorageMount('/media/MYSTERY-sdz9')
+    ).resolves.toBe(true)
+  })
+
+  it('returns true when the path has no recognizable block node', async () => {
+    mockSysfs({ realpaths: {}, interfaces: {} })
+
+    await expect(
+      isSingleFunctionMassStorageMount('/media/not-a-block-device')
+    ).resolves.toBe(true)
+  })
+})

--- a/app-shell-odd/src/usb/usb.ts
+++ b/app-shell-odd/src/usb/usb.ts
@@ -24,7 +24,68 @@ const FLEX_USB_DEVICE_FILTER = /sd[a-z]+[0-9]*$/
 // filter matches sda0, sdc9, sdb, VOLUME-sdc10
 const FLEX_USB_MOUNT_FILTER = /([^/]+-)?(sd[a-z]+[0-9]*)$/
 
+const USB_SYS_DEVICE_DIR = '/sys/bus/usb/devices'
+const SYS_BLOCK_DIR = '/sys/block'
+// USB device-class code for Mass Storage, per interface descriptor in sysfs.
+// https://www.usb.org/defined-class-codes
+const USB_MASS_STORAGE_INTERFACE_CLASS = '08'
+// a USB interface dir is named `<device>:<config>.<interface>`, e.g.
+// `1-1.3.4:1.2`; this captures the owning device name (`1-1.3.4`)
+const USB_INTERFACE_DIR_REGEX = /^(\d+-[\d.]+):\d+\.\d+$/
+
 const log = createLogger('mass-storage')
+
+export const isSingleFunctionMassStorageMount = async (
+  mountPath: string
+): Promise<boolean> => {
+  try {
+    // mount dirs are named `<LABEL>-sdX#` or `sdX#`; recover the block node
+    const blockName = mountPath.match(FLEX_USB_DEVICE_FILTER)?.[0]
+    if (blockName == null) {
+      return true
+    }
+    // a partition (sdb1) maps to its whole disk (sdb) under /sys/block
+    const diskName = blockName.replace(/[0-9]+$/, '')
+    // /sys/block/<disk>/device resolves into the backing USB device tree
+    const deviceRealPath = await fsPromises.realpath(
+      join(SYS_BLOCK_DIR, diskName, 'device')
+    )
+    const usbDeviceName = deviceRealPath
+      .split('/')
+      .map(segment => segment.match(USB_INTERFACE_DIR_REGEX)?.[1])
+      .find((name): name is string => name != null)
+    if (usbDeviceName == null) {
+      return true
+    }
+    const usbDeviceDir = join(USB_SYS_DEVICE_DIR, usbDeviceName)
+    const interfaceDirs = (await fsPromises.readdir(usbDeviceDir)).filter(
+      entry => entry.startsWith(`${usbDeviceName}:`)
+    )
+    if (interfaceDirs.length === 0) {
+      return true
+    }
+    const interfaceClasses = await Promise.all(
+      interfaceDirs.map(interfaceDir =>
+        fsPromises
+          .readFile(
+            join(usbDeviceDir, interfaceDir, 'bInterfaceClass'),
+            'utf-8'
+          )
+          .then(contents => contents.trim())
+          .catch(() => null)
+      )
+    )
+    return interfaceClasses.every(
+      interfaceClass => interfaceClass === USB_MASS_STORAGE_INTERFACE_CLASS
+    )
+  } catch (error) {
+    log.debug(
+      `Could not determine mass-storage status for ${mountPath}; treating as mass storage`,
+      error
+    )
+    return true
+  }
+}
 
 // These are for backoff algorithm
 // apply the delay from 1 sec 64 sec
@@ -103,8 +164,11 @@ export function watchForMassStorage(dispatch: Dispatch): () => void {
   log.info('watching for mass storage')
   let prevDirs: string[] = []
   const handleNewlyPresent = (path: string): Promise<string> => {
-    dispatch(robotMassStorageDeviceAdded(path))
-    return enumerateMassStorage(path)
+    return isSingleFunctionMassStorageMount(path)
+      .then(isMassStorage => {
+        dispatch(robotMassStorageDeviceAdded(path, isMassStorage))
+        return enumerateMassStorage(path)
+      })
       .then(contents => {
         log.debug(
           `mass storage device at ${path} enumerated: ${JSON.stringify(

--- a/app-shell/src/config/actions.ts
+++ b/app-shell/src/config/actions.ts
@@ -393,11 +393,13 @@ export const robotMassStorageDeviceRemoved = (
 })
 
 export const robotMassStorageDeviceAdded = (
-  rootPath: string
+  rootPath: string,
+  isMassStorage = true
 ): RobotMassStorageDeviceAdded => ({
   type: ROBOT_MASS_STORAGE_DEVICE_ADDED,
   payload: {
     rootPath,
+    isMassStorage,
   },
   meta: { shell: true },
 })

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/FileManagerWizardFlows/DownloadProtocolRunRecordsWizard/__tests__/DownloadProtocolRunRecordsWizard.test.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/FileManagerWizardFlows/DownloadProtocolRunRecordsWizard/__tests__/DownloadProtocolRunRecordsWizard.test.tsx
@@ -6,7 +6,7 @@ import { i18n } from '/app/i18n'
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
 import { useToaster } from '/app/organisms/ToasterOven'
 import { getLocalRobot } from '/app/redux/discovery'
-import { getShellUsbMountPaths } from '/app/redux/shell'
+import { getShellUsbMassStorageMountPaths } from '/app/redux/shell'
 import { useDeleteSelectedRuns } from '/app/resources/devices/hooks/useDeleteSelectedRuns'
 import { useDownloadSelectedRuns } from '/app/resources/devices/hooks/useDownloadSelectedRuns'
 import { useNotifyAllRunsQuery } from '/app/resources/runs'
@@ -39,7 +39,7 @@ describe('DownloadProtocolRunRecordsWizard', () => {
   beforeEach(() => {
     vi.mocked(useDocumentationState).mockReturnValue({} as any)
     vi.mocked(getLocalRobot).mockReturnValue({ name: ROBOT_NAME } as any)
-    vi.mocked(getShellUsbMountPaths).mockReturnValue(['/mnt/usb1'])
+    vi.mocked(getShellUsbMassStorageMountPaths).mockReturnValue(['/mnt/usb1'])
     vi.mocked(useNotifyAllRunsQuery).mockReturnValue({
       data: { data: [mockRun] },
     } as any)

--- a/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/FileManagerWizardFlows/shared/UsbSelectionScreen.tsx
+++ b/app/src/organisms/ODD/RobotSettingsDashboard/FileManager/FileManagerWizardFlows/shared/UsbSelectionScreen.tsx
@@ -7,7 +7,7 @@ import { INFO_TOAST, RadioButton, StyledText } from '@opentrons/components'
 import { SmallButton } from '/app/atoms/buttons'
 import { OddInfoScreen } from '/app/molecules/ODDInfoScreen'
 import { useToaster } from '/app/organisms/ToasterOven'
-import { getShellUsbMountPaths } from '/app/redux/shell'
+import { getShellUsbMassStorageMountPaths } from '/app/redux/shell'
 
 import styles from './shared.module.css'
 
@@ -33,8 +33,9 @@ export function UsbSelectionScreen({
   onContinue,
 }: UsbSelectionScreenProps): JSX.Element {
   const { t, i18n } = useTranslation(['device_details', 'shared'])
+  // only single-function USB mass-storage devices
   const usbMountPaths = useSelector((state: State) =>
-    getShellUsbMountPaths(state)
+    getShellUsbMassStorageMountPaths(state)
   )
   const [selectedPath, setSelectedPath] = useState<string | null>(
     usbMountPaths[0] ?? null

--- a/app/src/redux/shell/__tests__/update.test.ts
+++ b/app/src/redux/shell/__tests__/update.test.ts
@@ -149,6 +149,32 @@ describe('shell/update', () => {
         } as any,
         expected: '1.0.0',
       },
+      {
+        name: 'getShellUsbMountPaths returns every mount path',
+        selector: ShellUpdate.getShellUsbMountPaths,
+        state: {
+          shell: {
+            usbMountPaths: [
+              { path: '/media/DRIVE-sdb1', isMassStorage: true },
+              { path: '/media/PHONE-sdc1', isMassStorage: false },
+            ],
+          },
+        } as any,
+        expected: ['/media/DRIVE-sdb1', '/media/PHONE-sdc1'],
+      },
+      {
+        name: 'getShellUsbMassStorageMountPaths returns only mass-storage mounts',
+        selector: ShellUpdate.getShellUsbMassStorageMountPaths,
+        state: {
+          shell: {
+            usbMountPaths: [
+              { path: '/media/DRIVE-sdb1', isMassStorage: true },
+              { path: '/media/PHONE-sdc1', isMassStorage: false },
+            ],
+          },
+        } as any,
+        expected: ['/media/DRIVE-sdb1'],
+      },
     ]
 
     SPECS.forEach(spec => {

--- a/app/src/redux/shell/reducer.ts
+++ b/app/src/redux/shell/reducer.ts
@@ -8,6 +8,7 @@ import type {
   ShellState,
   ShellUpdateState,
   StepDetailViewerClosedState,
+  UsbMountPath,
 } from './types'
 
 const INITIAL_STATE: ShellUpdateState = {
@@ -69,16 +70,22 @@ export function massStorageReducer(
 }
 
 export function usbMountPathsReducer(
-  state = [] as string[],
+  state = [] as UsbMountPath[],
   action: Action
-): string[] {
+): UsbMountPath[] {
   switch (action.type) {
     case 'shell:ROBOT_MASS_STORAGE_DEVICE_ADDED':
-      return state.includes(action.payload.rootPath)
+      return state.some(entry => entry.path === action.payload.rootPath)
         ? state
-        : [...state, action.payload.rootPath]
+        : [
+            ...state,
+            {
+              path: action.payload.rootPath,
+              isMassStorage: action.payload.isMassStorage ?? true,
+            },
+          ]
     case 'shell:ROBOT_MASS_STORAGE_DEVICE_REMOVED':
-      return state.filter(p => p !== action.payload.rootPath)
+      return state.filter(entry => entry.path !== action.payload.rootPath)
   }
   return state
 }
@@ -113,7 +120,7 @@ interface ShellReducerMap {
   update: Reducer<ShellUpdateState, Action>
   isReady: Reducer<boolean, Action>
   filePaths: Reducer<string[], Action>
-  usbMountPaths: Reducer<string[], Action>
+  usbMountPaths: Reducer<UsbMountPath[], Action>
   systemLanguage: Reducer<string[] | null, Action>
   stepDetailViewerClosed: Reducer<StepDetailViewerClosedState, Action>
 }

--- a/app/src/redux/shell/types.ts
+++ b/app/src/redux/shell/types.ts
@@ -70,11 +70,17 @@ export type ShellUpdateAction =
   | { type: 'shell:APPLY_UPDATE'; meta: { shell: true } }
   | { type: 'shell:DOWNLOAD_PERCENTAGE'; payload: { percent: number } }
 
+export interface UsbMountPath {
+  path: string
+  // true if the device is a single-function USB mass-storage device
+  isMassStorage?: boolean
+}
+
 export interface ShellState {
   update: ShellUpdateState
   isReady: boolean
   filePaths: string[]
-  usbMountPaths: string[]
+  usbMountPaths: UsbMountPath[]
   systemLanguage: string[] | null
   stepDetailViewerClosed: StepDetailViewerClosedState
 }
@@ -145,6 +151,7 @@ export interface RobotMassStorageDeviceAdded {
   type: 'shell:ROBOT_MASS_STORAGE_DEVICE_ADDED'
   payload: {
     rootPath: string
+    isMassStorage?: boolean
   }
   meta: { shell: true }
 }

--- a/app/src/redux/shell/update.ts
+++ b/app/src/redux/shell/update.ts
@@ -34,5 +34,12 @@ export const getAvailableShellUpdate: (state: State) => string | null =
   )
 
 export function getShellUsbMountPaths(state: State): string[] {
-  return state.shell.usbMountPaths
+  return state.shell.usbMountPaths.map(entry => entry.path)
+}
+
+// Only mounts whose backing device is a single-function USB mass-storage device
+export function getShellUsbMassStorageMountPaths(state: State): string[] {
+  return state.shell.usbMountPaths.reduce<string[]>((acc, entry) => {
+    return entry.isMassStorage ? [...acc, entry.path] : acc
+  }, [])
 }


### PR DESCRIPTION
# Overview

Add logic in app-shell(-odd) to filters the ODD USB selection screen down to actual USB memory devices.

## Test Plan and Hands on Testing

- lots of unit testing for `isSingleFunctionMassStorageMount`
- live testing: plugged in a bunch of different USB devices into the Flex; verified that in UsbSelectionScreen, only mass storage devices display as options

## Changelog

#### app-shell-odd
- added `isSingleFunctionMassStorageMount` function
- extend `robotMassStorageDeviceAdded` to carry an isMassStorage flag (defaults to `true` to be permissive in case the type of device is indeterminate)

#### app
- `usbMountPaths` state changes from `string[]` to `UsbMountPath[]` -> `{ path, isMassStorage }`
- `getShellUsbMountPaths` keeps its existing string[] contract (maps to paths), so other consumers are unaffected
- new selector `getShellUsbMassStorageMountPaths` returns only mass-storage mounts
- `UsbSelectionScreen` switches to the mass storage-filtered selector

## Review requests

see test plan

## Risk assessment

lowish. new screens 