### PR TITLE
fix(robot-server): remove path traversal in data files

### DIFF
--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -1,6 +1,8 @@
 """Router for /dataFiles endpoints."""
 
+import os
 from datetime import datetime
+from logging import getLogger
 from pathlib import Path
 from textwrap import dedent
 from typing import Annotated, Final, Literal, Optional, Union
@@ -67,10 +69,53 @@ from robot_server.service.notifications.publishers import (
     get_data_file_publisher,
 )
 
+LOG = getLogger(__name__)
+
 datafiles_router = LightRouter()
 
 _DEFAULT_IMAGE_METADATA_LIST_LENGTH: Final = 99
 _DEFAULT_IMAGE_METADATA_CURSOR: Final = 0
+
+_FILE_PATH_ROOT_ALLOWLISTS = [
+    "/data/",
+    "/var/lib/opentrons-robot-server/",
+    "/var/lib/jupyter/data/",
+    "/home/",
+    "/var/user-packages/",
+    "/media/",
+    "/run/media/",
+    "/userfs/media/",
+]
+_FILE_PATH_COMPONENT_DENYLISTS = [
+    "BOOT-mmcblk0p1",
+    "RFS-mmcblk0p2",
+    "RFS2-mmcblk0p3",
+    "mmcblk0p1",
+    "mmcblk0p2",
+    "mmcblk0p3",
+]
+
+
+def sanitize_path(path: str | None) -> str | None:
+    """Raise if a path is unacceptable."""
+    if path is None:
+        return path
+    realpath = os.path.realpath(path)
+    for allowed_root in _FILE_PATH_ROOT_ALLOWLISTS:
+        if os.path.commonpath([realpath, allowed_root]) == allowed_root:
+            break
+    else:
+        LOG.error(f"Data file upload path {path} does not use an allowed root")
+        raise FileNotFound(detail=f"{path} is not allowed").as_error(
+            status.HTTP_403_FORBIDDEN
+        )
+    for denied_component in _FILE_PATH_COMPONENT_DENYLISTS:
+        if denied_component in path:
+            LOG.error(f"Data file upload path {path} uses a banned component")
+            raise FileNotFound(detail=f"{path} is not allowed").as_error(
+                status.HTTP_403_FORBIDDEN
+            )
+    return realpath
 
 
 class MultipleDataFileSources(ErrorDetails):
@@ -159,7 +204,9 @@ async def upload_data_file(
             detail="You must provide either a file or a file_path in the request."
         ).as_error(status.HTTP_422_UNPROCESSABLE_ENTITY)
     try:
-        [buffered_file] = await file_reader_writer.read(files=[file or Path(file_path)])  # type: ignore[arg-type, list-item]
+        [buffered_file] = await file_reader_writer.read(
+            files=[file or Path(sanitize_path(file_path))]  # type: ignore[arg-type, list-item]
+        )
     except FileNotFoundError as e:
         raise FileNotFound(detail=str(e)).as_error(status.HTTP_404_NOT_FOUND) from e
     # TODO (spp, 2024-06-18): probably also validate CSV file *contents*

--- a/robot-server/robot_server/data_files/router.py
+++ b/robot-server/robot_server/data_files/router.py
@@ -77,14 +77,16 @@ _DEFAULT_IMAGE_METADATA_LIST_LENGTH: Final = 99
 _DEFAULT_IMAGE_METADATA_CURSOR: Final = 0
 
 _FILE_PATH_ROOT_ALLOWLISTS = [
-    "/data/",
-    "/var/lib/opentrons-robot-server/",
-    "/var/lib/jupyter/data/",
-    "/home/",
-    "/var/user-packages/",
-    "/media/",
-    "/run/media/",
-    "/userfs/media/",
+    "/data",
+    "/var/lib/opentrons-robot-server",
+    "/var/lib/jupyter/data",
+    "/home",
+    "/var/user-packages",
+    "/media",
+    "/run/media",
+    "/userfs/media",
+    "/dev/null",
+    "/Users",
 ]
 _FILE_PATH_COMPONENT_DENYLISTS = [
     "BOOT-mmcblk0p1",

--- a/robot-server/tests/data_files/test_router.py
+++ b/robot-server/tests/data_files/test_router.py
@@ -1,6 +1,7 @@
 """Tests for data_files router."""
 
 import io
+import os
 from datetime import datetime
 from pathlib import Path
 from typing import List
@@ -1000,10 +1001,26 @@ def test_sanitize_path_blocks_paths(path: str) -> None:
 @pytest.mark.parametrize(
     "path",
     [
-        "/var/lib/opentrons-robot-server/some/path",
+        pytest.param(
+            "/var/lib/opentrons-robot-server/some/path",
+            marks=[
+                pytest.mark.skipif(
+                    os.path.realpath("/var") != "/var",
+                    reason="/var symlinked to /private/var (likely macos)",
+                ),
+            ],
+        ),
         "/media/ENFAINT-sda1/something",
         "/data/some/random/path",
-        "/var/lib/jupyter/data/some/path",
+        pytest.param(
+            "/var/lib/jupyter/data/some/path",
+            marks=[
+                pytest.mark.skipif(
+                    os.path.realpath("/var") != "/var",
+                    reason="/var symlinked to /private/var (likely macos)",
+                )
+            ],
+        ),
         "/run/media/efasda-sdc",
         "/data",
         "/userfs/media/afffsd",

--- a/robot-server/tests/data_files/test_router.py
+++ b/robot-server/tests/data_files/test_router.py
@@ -986,7 +986,6 @@ async def test_get_data_files_by_run_id_run_not_found(
         "/userfs/whatever",
         "/run/something",
         "/var/something",
-        "/var/user-packages/asdasd",
         "/run",
         "/var/",
         "/var",
@@ -1024,6 +1023,15 @@ def test_sanitize_path_blocks_paths(path: str) -> None:
         "/run/media/efasda-sdc",
         "/data",
         "/userfs/media/afffsd",
+        pytest.param(
+            "/var/user-packages/asdasd",
+            marks=[
+                pytest.mark.skipif(
+                    os.path.realpath("/var") != "/var",
+                    reason="/var/ symlinked to /private/var (likely macos)",
+                )
+            ],
+        ),
     ],
 )
 def test_sanitize_path_allows_paths(path: str) -> None:

--- a/robot-server/tests/data_files/test_router.py
+++ b/robot-server/tests/data_files/test_router.py
@@ -39,6 +39,7 @@ from robot_server.data_files.router import (
     get_data_file_info_by_id,
     get_data_files_by_run_id,
     get_run_image_metadata,
+    sanitize_path,
     upload_data_file,
 )
 from robot_server.errors.error_responses import ApiError
@@ -971,3 +972,43 @@ async def test_get_data_files_by_run_id_run_not_found(
 
     assert exc_info.value.status_code == 404
     assert exc_info.value.content["errors"][0]["id"] == "RunNotFound"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/usr/lib/something",
+        "/etc/something",
+        "/data/mmcblk0p1",
+        "/media/RFS-mmcblk0p2",
+        "/home/BOOT-mmcblk0p1",
+        "/userfs/whatever",
+        "/run/something",
+        "/var/something",
+        "/var/user-packages/asdasd",
+        "/run",
+        "/var/",
+        "/var",
+    ],
+)
+def test_sanitize_path_blocks_paths(path: str) -> None:
+    """It should prevent the use of paths that match denylist or don't match allowlist."""
+    with pytest.raises(ApiError):
+        sanitize_path(path)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/var/lib/opentrons-robot-server/some/path",
+        "/media/ENFAINT-sda1/something",
+        "/data/some/random/path",
+        "/var/lib/jupyter/data/some/path",
+        "/run/media/efasda-sdc",
+        "/data",
+        "/userfs/media/afffsd",
+    ],
+)
+def test_sanitize_path_allows_paths(path: str) -> None:
+    """It should allow paths that match allowlist and not denylist."""
+    assert sanitize_path(path) == path


### PR DESCRIPTION
# Overview

`POST /dataFiles` lets you specify an on-robot path rather than an uploaded file, so that clients can say "use the thing from this USB drive". it also didn't limit the path in any way, which is fine when you're not in CRS mode and not fine when you are. so let's limit the allowed paths to some allow-listed roots, and probably pretty soon just remove the ability to specify on-robot paths at all. Instead, send a new file or specify an ID of an existing one.

## Test Plan and Hands on Testing

- Big unit tests
- Unfortunately, the efficacy of this is pretty easy to test but the appropriateness is not. i don't know if there's filepaths missing that really ought to be there.

## Review requests

- Are there other roots that you know I need to allow list?

## Risk assessment

Should be medium-low, weird corner of the HTTP api.

Closes EXEC-2551