### PR TITLE
feat(app): show logged out user message in personal account details

### DIFF
--- a/app/src/assets/localization/en/device_settings.json
+++ b/app/src/assets/localization/en/device_settings.json
@@ -133,6 +133,7 @@
   "desktop_legal_name": "Legal name",
   "desktop_length_of_time": "Edit length of time",
   "desktop_login_and_security": "Login and security",
+  "desktop_login_to_manage_compliance_ready_software_settings": "Log in to manage Compliance Ready Software settings",
   "desktop_logins": "logins",
   "desktop_maximum_login_attempts_before_account_deactivation": "Maximum login attempts before account deactivation",
   "desktop_minimum_length_for_documentation_for_robot_actions": "Edit minimum length for documentation for robot actions",

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PersonalAccountSettings.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/PersonalAccountSettings.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch } from 'react-redux'
 
-import { BasicButton, Divider, StyledText } from '@opentrons/components'
+import { BasicButton, Divider, Icon, StyledText } from '@opentrons/components'
 import { useUpdateSelfMutation } from '@opentrons/react-api-client'
 
 import { useDocumentationState } from '/app/local-resources/access-control/useDocumentationState'
@@ -34,6 +34,30 @@ function FieldRow({ label, children }: FieldRowProps): JSX.Element {
         <StyledText desktopStyle="bodyDefaultRegular">{label}</StyledText>
       </div>
       <div className={styles.field_value}>{children}</div>
+    </div>
+  )
+}
+
+function LoggedOutMessage(): JSX.Element {
+  const { t } = useTranslation('device_settings')
+
+  return (
+    <div className={styles.logged_out_message}>
+      <Icon
+        name="information"
+        size="1.25rem"
+        className={styles.logged_out_icon}
+      />
+      <StyledText
+        desktopStyle="bodyDefaultRegular"
+        className={styles.logged_out_message_text}
+      >
+        {
+          t(
+            'desktop_login_to_manage_compliance_ready_software_settings'
+          ) as string
+        }
+      </StyledText>
     </div>
   )
 }
@@ -71,67 +95,72 @@ export function PersonalAccountSettings({
   // TODO: refresh fields when user is logged out
   return (
     <div className={styles.container}>
-      <div className={styles.header}>
-        <StyledText desktopStyle="bodyLargeSemiBold">
-          {t('desktop_personal_account_settings') as string}
-        </StyledText>
-        {loggedInUser != null &&
-          (isEditing ? (
-            <BasicButton type="button" underLine onClick={handleCancelEdit}>
-              {t('shared:cancel')}
-            </BasicButton>
-          ) : (
-            <BasicButton
-              type="button"
-              underLine
-              onClick={() => {
-                setIsEditing(true)
-              }}
-            >
-              {t('desktop_edit')}
-            </BasicButton>
-          ))}
-      </div>
-      <div className={styles.content}>
-        {isEditing && loggedInUser != null ? (
-          <PersonalAccountSettingsEditForm
-            username={loggedInUser.username}
-            fullName={loggedInUser.fullName}
-            isSaving={isSaving}
-            onSave={handleSave}
-            onCancel={handleCancelEdit}
-          />
-        ) : (
-          <>
-            <FieldRow label={t('desktop_username')}>
-              <StyledText
-                desktopStyle="bodyDefaultRegular"
-                className={styles.field_value_text}
+      {loggedInUser == null ? (
+        <LoggedOutMessage />
+      ) : (
+        <>
+          <div className={styles.header}>
+            <StyledText desktopStyle="bodyLargeSemiBold">
+              {t('desktop_personal_account_settings') as string}
+            </StyledText>
+            {isEditing ? (
+              <BasicButton type="button" underLine onClick={handleCancelEdit}>
+                {t('shared:cancel')}
+              </BasicButton>
+            ) : (
+              <BasicButton
+                type="button"
+                underLine
+                onClick={() => {
+                  setIsEditing(true)
+                }}
               >
-                {loggedInUser?.username}
-              </StyledText>
-            </FieldRow>
-            <Divider />
-            <FieldRow label={t('desktop_legal_name')}>
-              <StyledText
-                desktopStyle="bodyDefaultRegular"
-                className={styles.field_value_text}
-              >
-                {loggedInUser?.fullName}
-              </StyledText>
-            </FieldRow>
-            <Divider />
-            <FieldRow label={t('desktop_password')}>
-              <StyledText
-                desktopStyle="bodyDefaultRegular"
-                className={styles.field_value_text}
-              >
-                {t('desktop_password_placeholder') as string}
-              </StyledText>
-            </FieldRow>
-          </>
-        )}
-      </div>
+                {t('desktop_edit')}
+              </BasicButton>
+            )}
+          </div>
+          <div className={styles.content}>
+            {isEditing ? (
+              <PersonalAccountSettingsEditForm
+                username={loggedInUser.username}
+                fullName={loggedInUser.fullName}
+                isSaving={isSaving}
+                onSave={handleSave}
+                onCancel={handleCancelEdit}
+              />
+            ) : (
+              <>
+                <FieldRow label={t('desktop_username')}>
+                  <StyledText
+                    desktopStyle="bodyDefaultRegular"
+                    className={styles.field_value_text}
+                  >
+                    {loggedInUser.username}
+                  </StyledText>
+                </FieldRow>
+                <Divider />
+                <FieldRow label={t('desktop_legal_name')}>
+                  <StyledText
+                    desktopStyle="bodyDefaultRegular"
+                    className={styles.field_value_text}
+                  >
+                    {loggedInUser.fullName}
+                  </StyledText>
+                </FieldRow>
+                <Divider />
+                <FieldRow label={t('desktop_password')}>
+                  <StyledText
+                    desktopStyle="bodyDefaultRegular"
+                    className={styles.field_value_text}
+                  >
+                    {t('desktop_password_placeholder') as string}
+                  </StyledText>
+                </FieldRow>
+              </>
+            )}
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PersonalAccountSettings.test.tsx
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/__tests__/PersonalAccountSettings.test.tsx
@@ -142,10 +142,14 @@ describe('PersonalAccountSettings', () => {
       perRobotAuthStates: {},
       mostRecentRobotName: null,
     })
-    screen.getByText('Personal account settings')
+    screen.getByText('Log in to manage Compliance Ready Software settings')
+    expect(
+      screen.queryByText('Personal account settings')
+    ).not.toBeInTheDocument()
     expect(
       screen.queryByRole('button', { name: 'Edit' })
     ).not.toBeInTheDocument()
+    expect(screen.queryByText('alice')).not.toBeInTheDocument()
   })
 
   it('calls updateSelf and returns to view mode with updated fields on successful save', async () => {

--- a/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/personalaccountsettings.module.css
+++ b/app/src/organisms/Desktop/Devices/RobotSettings/RobotSettingsComplianceReady/personalaccountsettings.module.css
@@ -38,3 +38,27 @@
 .field_value_text {
   color: var(--grey-60);
 }
+
+.logged_out_message {
+  display: flex;
+  width: 100%;
+  min-height: 132px;
+  box-sizing: border-box;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-40) var(--spacing-16);
+  border-radius: var(--border-radius-8);
+  background-color: var(--grey-30);
+  gap: var(--spacing-12);
+}
+
+.logged_out_icon {
+  flex-shrink: 0;
+  color: var(--grey-60);
+}
+
+.logged_out_message_text {
+  color: var(--grey-60);
+  text-align: center;
+}


### PR DESCRIPTION
# Overview

closes https://opentrons.atlassian.net/browse/EXEC-2914.
follow up work for a logged out user message in acm settings/personal account details. 

## Test Plan and Hands on Testing

<img width="914" height="427" alt="Screenshot 2026-08-07 at 11 46 49 AM" src="https://github.com/user-attachments/assets/11616278-a83d-4874-acb1-d13fba43667d" />

## Risk assessment

very low. 
