### PR TITLE
fix(robot-server): Ensure run process creation and termination do not block robot-server

### DIFF
--- a/robot-server/robot_server/protocols/protocol_analyzer.py
+++ b/robot-server/robot_server/protocols/protocol_analyzer.py
@@ -64,8 +64,8 @@ class ProtocolAnalyzer:
         Returns: The RunOrchestrator instance.
         """
         if feature_flags.protocol_subprocess_enabled():
-            run_coordinator = (
-                await self._run_process_pyro_provider.wait_for_simulating_run_proxy()
+            run_coordinator = await self._run_process_pyro_provider.wait_for_run_proxy(
+                simulator=True
             )
             await run_coordinator.create_simulating(self._protocol_resource)
             self._coordinator = run_coordinator
@@ -168,11 +168,8 @@ class ProtocolAnalyzer:
                     self._coordinator.stop(), asyncio.get_running_loop()
                 )
                 if feature_flags.protocol_subprocess_enabled():
-                    asyncio.run_coroutine_threadsafe(
-                        self._run_process_pyro_provider.refresh_simulating(
-                            access_control_mode=self._analysis_store.get_access_control_status()
-                        ),
-                        asyncio.get_running_loop(),
+                    self._run_process_pyro_provider.set_active_process_as_used(
+                        simulator=True
                     )
             else:
                 log.warning(

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -151,7 +151,9 @@ async def set_up_run_process_pyro_provider(
     run_process_pyro_provider = RunProcessPyroProvider()
     _run_process_pyro_provider_accessor.set_on(app_state, run_process_pyro_provider)
     # TODO(2026-04-21) We might want to wrap this into a try/except if this causes local issues
-    run_process_pyro_provider.initialize(access_control_mode=access_control_status)
+    await run_process_pyro_provider.initialize(
+        access_control_mode=access_control_status
+    )
 
     try:
         yield

--- a/robot-server/robot_server/runs/dependencies.py
+++ b/robot-server/robot_server/runs/dependencies.py
@@ -151,9 +151,7 @@ async def set_up_run_process_pyro_provider(
     run_process_pyro_provider = RunProcessPyroProvider()
     _run_process_pyro_provider_accessor.set_on(app_state, run_process_pyro_provider)
     # TODO(2026-04-21) We might want to wrap this into a try/except if this causes local issues
-    await run_process_pyro_provider.initialize(
-        access_control_mode=access_control_status
-    )
+    run_process_pyro_provider.initialize(access_control_mode=access_control_status)
 
     try:
         yield

--- a/robot-server/robot_server/runs/run_orchestrator_store.py
+++ b/robot-server/robot_server/runs/run_orchestrator_store.py
@@ -489,9 +489,7 @@ class RunOrchestratorStore:
 
         run_data = self.run_coordinator.get_state_summary()
 
-        await self._run_process_pyro_provider.refresh(
-            access_control_mode=self._access_control_mode
-        )
+        self._run_process_pyro_provider.set_active_process_as_used()
 
         self._run_coordinator = None
 

--- a/robot-server/robot_server/runs/run_process_pyro_provider.py
+++ b/robot-server/robot_server/runs/run_process_pyro_provider.py
@@ -281,9 +281,9 @@ class RunProcessPyroProvider:
         self, process: _RunProcess, process_registry: List[_RunProcess]
     ) -> None:
         """Removes a process from a process registry, ending that process and delisting it from the global Pyro Nameserver."""
-        await self._end_process(process=process.process)
         with Pyro5.api.locate_ns() as ns:
             ns.remove(process.pyroname)
+        await self._end_process(process=process.process)
         process_registry.remove(process)
 
     def _start_run_process(self, process_name: str) -> subprocess.Popen[bytes]:

--- a/robot-server/robot_server/runs/run_process_pyro_provider.py
+++ b/robot-server/robot_server/runs/run_process_pyro_provider.py
@@ -29,8 +29,8 @@ _RUN_PROXY_NAME = (
 )
 _SIMULATING_RUN_PROXY_NAME = "ot-simulating-protocol"  # During runtime this gains a random uuid4 extension  "_1234ABCD"
 
-_RUN_PROCESS_LIMIT = 3  # Number of run processes to keep qeueued
-_SIMULATING_PROCESS_LIMIT = 3  # Number of simulation processes to keep qeueued
+_RUN_PROCESS_LIMIT = 1  # Number of run processes to keep qeueued
+_SIMULATING_PROCESS_LIMIT = 1  # Number of simulation processes to keep qeueued
 
 
 _RUN_PROXY_TIMEOUT = 30  # seconds
@@ -63,7 +63,7 @@ class RunProcessPyroProvider:
         self._teardown_signal = asyncio.Event()
         self._process_maintainer_task: asyncio.Task[None] | None = None
 
-    async def initialize(self, access_control_mode: bool) -> None:
+    def initialize(self, access_control_mode: bool) -> None:
         """Called when server first starts up.
 
         If feature flag is on for protocol subprocess, registers the process types
@@ -108,7 +108,6 @@ class RunProcessPyroProvider:
                 "Run process registries were not empty on startup of process maintainer task."
             )
         while not self._teardown_signal.is_set():
-            # Ensure the number of readied processes does not fall below the limit
             if len(self._run_processes) < _RUN_PROCESS_LIMIT:
                 pyro_id = _RUN_PROXY_NAME + "_" + str(uuid4())
                 self._run_processes.append(
@@ -119,28 +118,30 @@ class RunProcessPyroProvider:
                     )
                 )
             if len(self._simulating_run_processes) < _SIMULATING_PROCESS_LIMIT:
-                pyro_id = _SIMULATING_RUN_PROXY_NAME + "_" + str(uuid4())
-                self._run_processes.append(
+                sim_pyro_id = _SIMULATING_RUN_PROXY_NAME + "_" + str(uuid4())
+                self._simulating_run_processes.append(
                     _RunProcess(
-                        pyroname=pyro_id,
-                        process=self._start_run_process(process_name=pyro_id),
+                        pyroname=sim_pyro_id,
+                        process=self._start_run_process(process_name=sim_pyro_id),
                         status=_ProcessStatus.UNUSED,
                     )
                 )
 
             # Groom process queue for used inactive processes
             for process in self._run_processes:
-                if process.status is _ProcessStatus.USED:
+                if process.status == _ProcessStatus.USED:
                     await self._dequeue_process(
                         process=process, process_registry=self._run_processes
                     )
 
             for sim_process in self._simulating_run_processes:
-                if sim_process.status is _ProcessStatus.USED:
+                if sim_process.status == _ProcessStatus.USED:
                     await self._dequeue_process(
                         process=sim_process,
                         process_registry=self._simulating_run_processes,
                     )
+            # Wait and then repeat process spin-up and grooming as needed
+            await asyncio.sleep(1.0)
 
         # Teardown behavior after teardown signal recieved:
         for process in self._run_processes:
@@ -160,14 +161,14 @@ class RunProcessPyroProvider:
         """Get the active process to be used by a run."""
         if process_registry is not None:
             for process in process_registry:
-                if process.status is _ProcessStatus.ACTIVE:
+                if process.status == _ProcessStatus.ACTIVE:
                     return process
         return None
 
     def _set_active_process(self, process_registry: List[_RunProcess]) -> _RunProcess:
         """Set a run process in a given process registry as the active process to be used by a run."""
         for process in process_registry:
-            if process.status is _ProcessStatus.UNUSED:
+            if process.status == _ProcessStatus.UNUSED:
                 process.status = _ProcessStatus.ACTIVE
                 return process
         raise RuntimeError("Could not identify unused process in process registry.")
@@ -177,12 +178,12 @@ class RunProcessPyroProvider:
         if simulator:
             assert self._simulating_run_processes is not None
             for process in self._simulating_run_processes:
-                if process.status is _ProcessStatus.ACTIVE:
+                if process.status == _ProcessStatus.ACTIVE:
                     process.status = _ProcessStatus.USED
         else:
             assert self._run_processes is not None
             for process in self._run_processes:
-                if process.status is _ProcessStatus.ACTIVE:
+                if process.status == _ProcessStatus.ACTIVE:
                     process.status = _ProcessStatus.USED
 
     async def _validate_process_registry_ready(

--- a/robot-server/robot_server/runs/run_process_pyro_provider.py
+++ b/robot-server/robot_server/runs/run_process_pyro_provider.py
@@ -1,12 +1,15 @@
 """Manages protocol run subprocesses and provides Pyro proxies to communicate with them."""
 
 import asyncio
+import enum
 import logging
 import os
 import subprocess
 import sys
 import time
-from typing import Optional, cast
+from dataclasses import dataclass
+from typing import List, Optional, cast
+from uuid import uuid4
 
 import Pyro5.api
 
@@ -21,24 +24,46 @@ _log = logging.getLogger(__name__)
 _RESTRICTED_USER_NAME = "ot-protocol"
 _ROOT_USER_NAME = "root"
 
-_RUN_PROXY_NAME = "ot-protocol"
-_SIMULATING_RUN_PROXY_NAME = "ot-simulating-protocol"
+_RUN_PROXY_NAME = (
+    "ot-protocol"  # During runtime this gains a random uuid4 extension  "_1234ABCD"
+)
+_SIMULATING_RUN_PROXY_NAME = "ot-simulating-protocol"  # During runtime this gains a random uuid4 extension  "_1234ABCD"
+
+_RUN_PROCESS_LIMIT = 3  # Number of run processes to keep qeueued
+_SIMULATING_PROCESS_LIMIT = 3  # Number of simulation processes to keep qeueued
+
 
 _RUN_PROXY_TIMEOUT = 30  # seconds
 _RUN_PROCESS_TERMINATE_TIMEOUT = 10  # seconds
+
+
+class _ProcessStatus(enum.Enum):
+    ACTIVE = enum.auto()
+    USED = enum.auto()
+    UNUSED = enum.auto()
+
+
+@dataclass
+class _RunProcess:
+    pyroname: str
+    process: subprocess.Popen[bytes]
+    status: _ProcessStatus
 
 
 class RunProcessPyroProvider:
     """A provider for run subprocesses and pyro run process proxies."""
 
     def __init__(self) -> None:
-        self._run_process: Optional[subprocess.Popen[bytes]] = None
-        self._simulating_run_process: Optional[subprocess.Popen[bytes]] = None
+        self._run_processes: Optional[List[_RunProcess]] = None
+        self._simulating_run_processes: Optional[List[_RunProcess]] = None
 
         # The protocol subprocess username defaults to root unless otherwise specified
         self._protocol_username: str = "root"
 
-    def initialize(self, access_control_mode: bool) -> None:
+        self._teardown_signal = asyncio.Event()
+        self._process_maintainer_task: asyncio.Task[None] | None = None
+
+    async def initialize(self, access_control_mode: bool) -> None:
         """Called when server first starts up.
 
         If feature flag is on for protocol subprocess, registers the process types
@@ -52,8 +77,10 @@ class RunProcessPyroProvider:
         self._update_user_subprocess(access_control_mode)
         if feature_flags.protocol_subprocess_enabled():
             register_process_types()
-            self._start_run_process()
-            self._start_simulating_process()
+            # Start up the process maintainer
+            self._process_maintainer_task = asyncio.create_task(
+                self.process_maintainer()
+            )
 
     async def teardown(self) -> None:
         """Called when server ends.
@@ -62,27 +89,134 @@ class RunProcessPyroProvider:
         the run process proxy name from the nameserver.
         """
         if feature_flags.protocol_subprocess_enabled():
-            await self._end_run_process()
-            await self._end_simulating_process()
-            with Pyro5.api.locate_ns() as ns:
-                ns.remove(_RUN_PROXY_NAME)
-                ns.remove(_SIMULATING_RUN_PROXY_NAME)
+            self._teardown_signal.set()
+            if self._process_maintainer_task is not None:
+                await self._process_maintainer_task
 
-    async def refresh(self, access_control_mode: bool) -> None:
-        """Ends the currently running process and starts a new one."""
-        await self._end_run_process()
-        self._update_user_subprocess(access_control_mode=access_control_mode)
-        with Pyro5.api.locate_ns() as ns:
-            ns.remove(_RUN_PROXY_NAME)
-        self._start_run_process()
+    async def process_maintainer(self) -> None:  # noqa: C901
+        """This will maintain the run processes and simulated run processes, creating and destroying as needed.
 
-    async def refresh_simulating(self, access_control_mode: bool) -> None:
-        """Ends the currently running simulating process and starts a new one."""
-        await self._end_simulating_process()
-        self._update_user_subprocess(access_control_mode=access_control_mode)
-        with Pyro5.api.locate_ns() as ns:
-            ns.remove(_SIMULATING_RUN_PROXY_NAME)
-        self._start_simulating_process()
+        This task will only spin up if subprocess mode is enabled.
+        """
+        _log.info("Beginning Protocol Subprocess maintainer task.")
+        if self._run_processes is None and self._simulating_run_processes is None:
+            # Initialize the process registries are empty
+            self._run_processes = []
+            self._simulating_run_processes = []
+        else:
+            raise RuntimeError(
+                "Run process registries were not empty on startup of process maintainer task."
+            )
+        while not self._teardown_signal.is_set():
+            # Ensure the number of readied processes does not fall below the limit
+            if len(self._run_processes) < _RUN_PROCESS_LIMIT:
+                pyro_id = _RUN_PROXY_NAME + "_" + str(uuid4())
+                self._run_processes.append(
+                    _RunProcess(
+                        pyroname=pyro_id,
+                        process=self._start_run_process(process_name=pyro_id),
+                        status=_ProcessStatus.UNUSED,
+                    )
+                )
+            if len(self._simulating_run_processes) < _SIMULATING_PROCESS_LIMIT:
+                pyro_id = _SIMULATING_RUN_PROXY_NAME + "_" + str(uuid4())
+                self._run_processes.append(
+                    _RunProcess(
+                        pyroname=pyro_id,
+                        process=self._start_run_process(process_name=pyro_id),
+                        status=_ProcessStatus.UNUSED,
+                    )
+                )
+
+            # Groom process queue for used inactive processes
+            for process in self._run_processes:
+                if process.status is _ProcessStatus.USED:
+                    await self._dequeue_process(
+                        process=process, process_registry=self._run_processes
+                    )
+
+            for sim_process in self._simulating_run_processes:
+                if sim_process.status is _ProcessStatus.USED:
+                    await self._dequeue_process(
+                        process=sim_process,
+                        process_registry=self._simulating_run_processes,
+                    )
+
+        # Teardown behavior after teardown signal recieved:
+        for process in self._run_processes:
+            _log.info(f"Tearing down Run Process: {process.pyroname}")
+            await self._dequeue_process(
+                process=process, process_registry=self._run_processes
+            )
+        for sim_process in self._simulating_run_processes:
+            _log.info(f"Tearing down Simulator Run Process: {sim_process.pyroname}")
+            await self._dequeue_process(
+                process=sim_process, process_registry=self._simulating_run_processes
+            )
+
+    def _get_active_run_process(
+        self, process_registry: List[_RunProcess]
+    ) -> _RunProcess | None:
+        """Get the active process to be used by a run."""
+        if process_registry is not None:
+            for process in process_registry:
+                if process.status is _ProcessStatus.ACTIVE:
+                    return process
+        return None
+
+    def _set_active_process(self, process_registry: List[_RunProcess]) -> _RunProcess:
+        """Set a run process in a given process registry as the active process to be used by a run."""
+        for process in process_registry:
+            if process.status is _ProcessStatus.UNUSED:
+                process.status = _ProcessStatus.ACTIVE
+                return process
+        raise RuntimeError("Could not identify unused process in process registry.")
+
+    def set_active_process_as_used(self, simulator: Optional[bool] = False) -> None:
+        """Set the active process as used, meaning it will no longer be utilized for a Run."""
+        if simulator:
+            assert self._simulating_run_processes is not None
+            for process in self._simulating_run_processes:
+                if process.status is _ProcessStatus.ACTIVE:
+                    process.status = _ProcessStatus.USED
+        else:
+            assert self._run_processes is not None
+            for process in self._run_processes:
+                if process.status is _ProcessStatus.ACTIVE:
+                    process.status = _ProcessStatus.USED
+
+    async def _validate_process_registry_ready(
+        self, simulator: Optional[bool] = False
+    ) -> List[_RunProcess]:
+        """Validate that the process registries have processes that can be used.
+
+        If `simulator` sprovided, this will validate that there is a simulation process available.
+        Otherwise, it will validate that a normal run process is available.
+        """
+        if simulator:
+            if self._simulating_run_processes is None:
+                # There are no run processes yet, try again throughout the timeout period and raise if one never appears
+                start_time = time.monotonic()
+                while time.monotonic() - start_time < _RUN_PROXY_TIMEOUT:
+                    if self._simulating_run_processes is not None:
+                        # Simulation process is ready
+                        return self._simulating_run_processes
+                    await asyncio.sleep(0.01)
+                raise RuntimeError("Active simulator process never became available.")
+            return self._simulating_run_processes
+        else:
+            if self._run_processes is None:
+                # There are no run processes yet, try again throughout the timeout period and raise if one never appears
+                start_time = time.monotonic()
+                while time.monotonic() - start_time < _RUN_PROXY_TIMEOUT:
+                    if self._run_processes is not None:
+                        # Run process is ready
+                        return self._run_processes
+                    await asyncio.sleep(0.01)
+                raise RuntimeError(
+                    "Active protocol run process never became available."
+                )
+            return self._run_processes
 
     @staticmethod
     async def _wait_for_proxy(proxy_name: str) -> Optional[DirectedRunProcess]:
@@ -97,37 +231,24 @@ class RunProcessPyroProvider:
                 await asyncio.sleep(0.01)
         return None
 
-    async def wait_for_run_proxy(self) -> DirectedRunProcess:
-        """Returns a proxy for the run process.
+    async def wait_for_run_proxy(
+        self, simulator: Optional[bool] = False
+    ) -> DirectedRunProcess:
+        """Returns a proxy for the run process or simulating run process.
 
-        Depending on how recently it started, this may take up to around 25 seconds to resolve.
+        Depending on how recently the desired process started, this may take up to around 25 seconds to resolve.
         """
-        if self._run_process is None:
-            self._start_run_process()
+        process_regisry = await self._validate_process_registry_ready(
+            simulator=simulator
+        )
+        run_process = self._get_active_run_process(process_registry=process_regisry)
+        if run_process is None:
+            run_process = self._set_active_process(process_registry=process_regisry)
 
-        run_proxy = await self._wait_for_proxy(_RUN_PROXY_NAME)
+        run_proxy = await self._wait_for_proxy(run_process.pyroname)
         if run_proxy is None:
-            await self._end_run_process()
-            self._start_run_process()
-            raise RuntimeError(f"Can't resolve pyro proxy '{_RUN_PROXY_NAME}'")
+            raise RuntimeError(f"Can't resolve pyro proxy '{run_process.pyroname}'")
         return run_proxy
-
-    async def wait_for_simulating_run_proxy(self) -> DirectedRunProcess:
-        """Returns a proxy for the simulating run process for use in on-robot analysis.
-
-        Depending on how recently it started, this may take up to around 25 seconds to resolve.
-        """
-        if self._simulating_run_process is None:
-            self._start_simulating_process()
-
-        simulating_proxy = await self._wait_for_proxy(_SIMULATING_RUN_PROXY_NAME)
-        if simulating_proxy is None:
-            await self._end_simulating_process()
-            self._start_simulating_process()
-            raise RuntimeError(
-                f"Can't resolve pyro proxy '{_SIMULATING_RUN_PROXY_NAME}'"
-            )
-        return simulating_proxy
 
     @staticmethod
     def _open_process(process_name: str, user_name: str) -> subprocess.Popen[bytes]:
@@ -155,35 +276,19 @@ class RunProcessPyroProvider:
         else:
             process.kill()
 
-    def _start_run_process(self) -> None:
-        if self._run_process is not None:
-            return
+    async def _dequeue_process(
+        self, process: _RunProcess, process_registry: List[_RunProcess]
+    ) -> None:
+        """Removes a process from a process registry, ending that process and delisting it from the global Pyro Nameserver."""
+        await self._end_process(process=process.process)
+        with Pyro5.api.locate_ns() as ns:
+            ns.remove(process.pyroname)
+        process_registry.remove(process)
 
-        self._run_process = self._open_process(
-            process_name=_RUN_PROXY_NAME, user_name=self._protocol_username
+    def _start_run_process(self, process_name: str) -> subprocess.Popen[bytes]:
+        return self._open_process(
+            process_name=process_name, user_name=self._protocol_username
         )
-
-    async def _end_run_process(self) -> None:
-        if self._run_process is None:
-            return
-
-        await self._end_process(self._run_process)
-        self._run_process = None
-
-    def _start_simulating_process(self) -> None:
-        if self._simulating_run_process is not None:
-            return
-
-        self._simulating_run_process = self._open_process(
-            process_name=_SIMULATING_RUN_PROXY_NAME, user_name=self._protocol_username
-        )
-
-    async def _end_simulating_process(self) -> None:
-        if self._simulating_run_process is None:
-            return
-
-        await self._end_process(self._simulating_run_process)
-        self._simulating_run_process = None
 
     def _update_user_subprocess(self, access_control_mode: bool) -> None:
         """Update which system user should execute the protocol subprocess."""


### PR DESCRIPTION
# Overview
Covers EXEC-2921

Previously the creation and destruction of the analysis and run subprocesses utilized a few direct calls that were occurring during the run setup and teardown process. These calls could cause the process opening and termination cases to block until complete in some cases, which was one source of delay on the robot-server.

The new approach has taskified all run subprocess creation and destruction. It has also introduced the ability to rotate run processes, so we could have more than one queued to prevent load time on run-again. **(This is TBD and will be memory dependent).**

The run process task maintainer will ensure a minimal number of processes exist for runs and analysis, and will automatically groom out **used** processes when runs or analysis are no longer occurring on them. 

On teardown the maintainer task will automatically terminate the children and return once complete, ensuring we don't have any loose processes as we proceed through shutdown.

## Test Plan and Hands on Testing

- [x] Test on Flex hardware
- [x] Ensure run process unit test coverage complies with the task based process creator

## Changelog
Changed the run process provider to instead maintain run processes inside a task, automatically creating and destroy processes after they are marked as used.

## Review requests

## Risk assessment
Low - Leverages the existing run process architecture but with a parallel method of process management approach.