### PR TITLE
fix(audit-server): when storing robot logs, prevent duplicate filenames from being stored on the file system

### DIFF
--- a/audit-server/audit_server/log_storage/log_data_manager.py
+++ b/audit-server/audit_server/log_storage/log_data_manager.py
@@ -195,6 +195,9 @@ class LogDataManager:
 
         assert robot_log.filename is not None
         robot_log_path = robot_log_dir_path / Path(robot_log.filename).name
+        while robot_log_path.is_file():
+            robot_log_path = robot_log_path.with_stem(f"{robot_log_path.stem}_copy")
+
         with open(robot_log_path, "w") as fh:
             fh.write(contents)
 

--- a/audit-server/tests/log_storage/test_log_data_manager.py
+++ b/audit-server/tests/log_storage/test_log_data_manager.py
@@ -239,6 +239,76 @@ async def test_store_robot_log_stores_file(
             assert temp_path.is_file()
 
 
+async def test_store_robot_log_renames_file(
+    subject: LogDataManager,
+    mock_store: LogStore,
+    decoy: Decoy,
+    mock_key_client: KeyClient,
+) -> None:
+    """It should append _copy to the file if it already exists."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with tempfile.NamedTemporaryFile() as temp_file:
+            temp_file.write("beep boop".encode("utf-8"))
+            temp_file.seek(0)
+            robot_log = StoredLog(
+                message="beep",
+                message_hash="bzzzt",
+                message_sig="boop",
+                sig_version="3",
+            )
+            decoy.when(
+                await mock_key_client.sign_message(
+                    SignMessageData(message="beep boop", previousHash=None)
+                )
+            ).then_return(
+                SignedMessageData(
+                    message="beep",
+                    messageHash="bzzzt",
+                    messageSignature="boop",
+                    signatureVersion=3,
+                )
+            )
+            temp_path = Path(temp_dir) / Path(temp_file.name).name
+            decoy.when(mock_store.store_robot_log(robot_log, temp_path)).then_return(
+                "eeeeee"
+            )
+            assert not temp_path.is_file()
+            stored_hash = await subject.store_robot_log(
+                UploadFile(temp_file.file, filename=temp_file.name),  # type: ignore[arg-type]
+                Path(temp_dir),
+            )
+            assert stored_hash == "eeeeee"
+            assert temp_path.is_file()
+
+            # It should it handle it for the first copy
+            copied_temp_path = temp_path.with_stem(f"{temp_path.stem}_copy")
+            decoy.when(
+                mock_store.store_robot_log(robot_log, copied_temp_path)
+            ).then_return("iiiiii")
+            temp_file.seek(0)
+            stored_hash = await subject.store_robot_log(
+                UploadFile(temp_file.file, filename=temp_file.name),  # type: ignore[arg-type]
+                Path(temp_dir),
+            )
+            assert stored_hash == "iiiiii"
+            assert copied_temp_path.is_file()
+
+            # Trying the same file a third time should make _copy_copy
+            copied_copied_temp_path = copied_temp_path.with_stem(
+                f"{copied_temp_path.stem}_copy"
+            )
+            decoy.when(
+                mock_store.store_robot_log(robot_log, copied_copied_temp_path)
+            ).then_return("oooooo")
+            temp_file.seek(0)
+            stored_hash = await subject.store_robot_log(
+                UploadFile(temp_file.file, filename=temp_file.name),  # type: ignore[arg-type]
+                Path(temp_dir),
+            )
+            assert stored_hash == "oooooo"
+            assert copied_copied_temp_path.is_file()
+
+
 async def test_store_robot_log_raises_keyserver_unavailable(
     subject: LogDataManager,
     mock_store: LogStore,


### PR DESCRIPTION
# Overview

This PR fixes a small potential bug in the `/audit/internal/storeRobotLog` where sending a file that has a duplicate filename would overwrite the original file.

In practice with the run logs, this will not be encountered as every run log will have a unique time stamp of its created at timestamp appended to the end of the file name, and even with time change shenanigans the chances of two of them being exactly the same is extremely low. However, there might be future files we store with less strict names and we should be maintaining data integrity here.

Therefore, we will now check if the file path exists, and if it does, we will keep appending `_copy` to the name stem (e.g. `test.json` would become `test_copy.json`, and if tried again it would be saved as `test_copy_copy.json`) until we have a unique file name that is not on the robot.

## Test Plan and Hands on Testing

Integration and local `dev-backend-flex` testing with Postman for this, it's an internal route so it would require working around the audit-server and robot-server to get this working on a robot.

## Changelog

- prevent duplicate robot log file names from being saved by appending `_copy` as many times needed to ensure uniqueness

## Review requests

## Risk assessment

Low, fixing a bug in an unreleased and internal route