### PR TITLE
fix(app): Prevent modules with calibration from being setup with an uncalibrated pipette

### DIFF
--- a/app/src/App/hooks/useGetModulesNeedingSetup.ts
+++ b/app/src/App/hooks/useGetModulesNeedingSetup.ts
@@ -4,11 +4,12 @@ import {
 } from '@opentrons/shared-data'
 
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
-import { useAttachedPipettes } from '/app/resources/instruments'
+import { useAttachedPipettesFromInstrumentsQuery } from '/app/resources/instruments'
 import { useAttachedModules } from '/app/resources/modules'
 
 import type { AttachedModule } from '@opentrons/api-client'
 import type { ModuleType } from '@opentrons/shared-data'
+import type { AttachedPipettesFromInstrumentsQuery } from '/app/resources/instruments'
 
 const MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP: ModuleType[] = [
   ABSORBANCE_READER_TYPE,
@@ -18,6 +19,15 @@ const MODULES_NOT_REQUIRING_CALIBRATION =
   MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP
 const ATTACHED_MODULE_POLL_MS = 5000
 const DECK_CONFIG_POLL_MS = 5000
+
+export function hasCalibratedPipetteForModuleSetup(
+  attachedPipettes: AttachedPipettesFromInstrumentsQuery
+): boolean {
+  return (
+    attachedPipettes.left?.data.calibratedOffset?.last_modified != null ||
+    attachedPipettes.right?.data.calibratedOffset?.last_modified != null
+  )
+}
 
 export function useGetModulesNeedingSetup(): AttachedModule[] {
   const attachedModules =
@@ -45,11 +55,12 @@ export function useGetModulesNeedingSetup(): AttachedModule[] {
 
 export function useGetModulesNeedingSetupThatCanCurrentlyBeSetUp(): AttachedModule[] {
   const modulesRequiringSetup = useGetModulesNeedingSetup()
-  const attachedPipettes = useAttachedPipettes(modulesRequiringSetup.length > 0)
+  const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
+  const hasCalibratedPipette =
+    hasCalibratedPipetteForModuleSetup(attachedPipettes)
   return modulesRequiringSetup.filter(
     m =>
       MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP.includes(m.moduleType) ||
-      attachedPipettes.left != null ||
-      attachedPipettes.right != null
+      hasCalibratedPipette
   )
 }

--- a/app/src/App/hooks/useGetModulesNeedingSetup.ts
+++ b/app/src/App/hooks/useGetModulesNeedingSetup.ts
@@ -3,13 +3,13 @@ import {
   FLEX_STACKER_MODULE_TYPE,
 } from '@opentrons/shared-data'
 
+import { getCalibratedPipetteForModuleSetup } from '/app/local-resources/instruments'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
 import { useAttachedPipettesFromInstrumentsQuery } from '/app/resources/instruments'
 import { useAttachedModules } from '/app/resources/modules'
 
 import type { AttachedModule } from '@opentrons/api-client'
 import type { ModuleType } from '@opentrons/shared-data'
-import type { AttachedPipettesFromInstrumentsQuery } from '/app/resources/instruments'
 
 const MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP: ModuleType[] = [
   ABSORBANCE_READER_TYPE,
@@ -19,15 +19,6 @@ const MODULES_NOT_REQUIRING_CALIBRATION =
   MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP
 const ATTACHED_MODULE_POLL_MS = 5000
 const DECK_CONFIG_POLL_MS = 5000
-
-export function hasCalibratedPipetteForModuleSetup(
-  attachedPipettes: AttachedPipettesFromInstrumentsQuery
-): boolean {
-  return (
-    attachedPipettes.left?.data.calibratedOffset?.last_modified != null ||
-    attachedPipettes.right?.data.calibratedOffset?.last_modified != null
-  )
-}
 
 export function useGetModulesNeedingSetup(): AttachedModule[] {
   const attachedModules =
@@ -57,7 +48,7 @@ export function useGetModulesNeedingSetupThatCanCurrentlyBeSetUp(): AttachedModu
   const modulesRequiringSetup = useGetModulesNeedingSetup()
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
   const hasCalibratedPipette =
-    hasCalibratedPipetteForModuleSetup(attachedPipettes)
+    getCalibratedPipetteForModuleSetup(attachedPipettes) != null
   return modulesRequiringSetup.filter(
     m =>
       MODULES_NOT_REQUIRING_PIPETTE_FOR_SETUP.includes(m.moduleType) ||

--- a/app/src/assets/localization/en/module_wizard_flows.json
+++ b/app/src/assets/localization/en/module_wizard_flows.json
@@ -2,6 +2,7 @@
   "attach_probe": "Attach probe to pipette",
   "begin_calibration": "Begin calibration",
   "calibrate": "Calibrate",
+  "calibrate_a_pipette_to_set_up_more_modules": "Calibrate a pipette to set up more modules.",
   "calibrate_pipette": "Calibrate pipettes before proceeding to module calibration",
   "calibration": "{{module}} Calibration",
   "calibration_adapter_heatershaker": "Calibration Adapter",

--- a/app/src/local-resources/instruments/utils.ts
+++ b/app/src/local-resources/instruments/utils.ts
@@ -10,6 +10,8 @@ import type {
   LoadedPipette,
   ProtocolAnalysisOutput,
 } from '@opentrons/shared-data'
+import type { AttachedPipettesFromInstrumentsQuery } from '/app/resources/instruments'
+import type { PipetteInformation } from '/app/resources/instruments/types'
 
 export interface IsPartialTipConfigParams {
   channel: 1 | 8 | 96
@@ -78,4 +80,17 @@ export function getPipetteMatch(
         i.instrumentName === loadedPipette.pipetteName
     ) ?? null
   )
+}
+
+export function getCalibratedPipetteForModuleSetup(
+  attachedPipettes: AttachedPipettesFromInstrumentsQuery
+): PipetteInformation | null {
+  if (attachedPipettes.left?.data.calibratedOffset?.last_modified != null) {
+    return attachedPipettes.left
+  } else if (
+    attachedPipettes.right?.data.calibratedOffset?.last_modified != null
+  ) {
+    return attachedPipettes.right
+  }
+  return null
 }

--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -74,7 +74,7 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
   // it follows that some modules need setup but cannot be set up. in that case we want
   // a warning
   const hasUnsetupabbleModules = allNeedingSetup.length > allSetupable.length
-  let unsetupableModulesWarning: string | null = null
+  let unsetupableModulesWarning: string | undefined
   if (hasUnsetupabbleModules) {
     if (getCalibratedPipetteForModuleSetup(attachedPipettes) == null) {
       if (attachedPipettes.left != null || attachedPipettes.right != null) {

--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -21,6 +21,7 @@ import {
 } from '/app/App/hooks/useGetModulesNeedingSetup'
 import { SmallButton } from '/app/atoms/buttons'
 import { i18n } from '/app/i18n'
+import { getCalibratedPipetteForModuleSetup } from '/app/local-resources/instruments'
 import { useModuleUSBPort } from '/app/local-resources/modules'
 import { ModalContentOneColSimpleButtons } from '/app/molecules/InterventionModal'
 import {
@@ -67,19 +68,24 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
   // right now (e.g. because they need calibration but we don't have a pipette)
   const allNeedingSetup = useGetModulesNeedingSetup()
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
-  const hasAnyAttachedPipette =
-    attachedPipettes.left != null || attachedPipettes.right != null
   const newModules =
     attachedModuleOnLaunch == null ? allSetupable : [attachedModuleOnLaunch]
   // if there are more modules that need setup than modules that can be set up, then
   // it follows that some modules need setup but cannot be set up. in that case we want
   // a warning
   const hasUnsetupabbleModules = allNeedingSetup.length > allSetupable.length
-  const unsetupableModulesWarning = !hasUnsetupabbleModules
-    ? null
-    : hasAnyAttachedPipette
-      ? t('calibrate_a_pipette_to_set_up_more_modules')
-      : t('connect_a_pipette_to_set_up_more_modules')
+  const unsetupableModulesWarning = (() => {
+    if (hasUnsetupabbleModules) {
+      if (getCalibratedPipetteForModuleSetup(attachedPipettes)) {
+        return null
+      }
+      if (attachedPipettes.left != null || attachedPipettes.right != null) {
+        return t('calibrate_a_pipette_to_set_up_more_modules')
+      }
+      return t('connect_a_pipette_to_set_up_more_modules')
+    }
+    return null
+  })()
   // And our special short-circuit flows where we never show a menu if there's only one
   // entry should be avoided if we have that warning
   const isSingleModule = newModules.length === 1 && !hasUnsetupabbleModules

--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -27,6 +27,7 @@ import {
   SimpleWizardBody,
   SimpleWizardBodyContainer,
 } from '/app/molecules/SimpleWizardBody'
+import { useAttachedPipettesFromInstrumentsQuery } from '/app/resources/instruments'
 
 import type { AttachedModule } from '@opentrons/api-client'
 import type { SendIdentifyModule } from './types'
@@ -65,12 +66,20 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
   // Every module that needs setup, but not all are guaranteed to be able to be set up
   // right now (e.g. because they need calibration but we don't have a pipette)
   const allNeedingSetup = useGetModulesNeedingSetup()
+  const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
+  const hasAnyAttachedPipette =
+    attachedPipettes.left != null || attachedPipettes.right != null
   const newModules =
     attachedModuleOnLaunch == null ? allSetupable : [attachedModuleOnLaunch]
   // if there are more modules that need setup than modules that can be set up, then
   // it follows that some modules need setup but cannot be set up. in that case we want
   // a warning
   const hasUnsetupabbleModules = allNeedingSetup.length > allSetupable.length
+  const unsetupableModulesWarning = !hasUnsetupabbleModules
+    ? null
+    : hasAnyAttachedPipette
+      ? t('calibrate_a_pipette_to_set_up_more_modules')
+      : t('connect_a_pipette_to_set_up_more_modules')
   // And our special short-circuit flows where we never show a menu if there's only one
   // entry should be avoided if we have that warning
   const isSingleModule = newModules.length === 1 && !hasUnsetupabbleModules
@@ -186,11 +195,7 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
             onSelect={event => {
               handleModuleSelected(event.target.value)
             }}
-            subText={
-              hasUnsetupabbleModules
-                ? t('connect_a_pipette_to_set_up_more_modules')
-                : null
-            }
+            subText={unsetupableModulesWarning}
             scroll={true}
           />
         </Flex>

--- a/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
+++ b/app/src/organisms/ModuleWizardFlows/SelectModule.tsx
@@ -74,18 +74,20 @@ export function SelectModule(props: SelectModuleProps): JSX.Element | null {
   // it follows that some modules need setup but cannot be set up. in that case we want
   // a warning
   const hasUnsetupabbleModules = allNeedingSetup.length > allSetupable.length
-  const unsetupableModulesWarning = (() => {
-    if (hasUnsetupabbleModules) {
-      if (getCalibratedPipetteForModuleSetup(attachedPipettes)) {
-        return null
-      }
+  let unsetupableModulesWarning: string | null = null
+  if (hasUnsetupabbleModules) {
+    if (getCalibratedPipetteForModuleSetup(attachedPipettes) == null) {
       if (attachedPipettes.left != null || attachedPipettes.right != null) {
-        return t('calibrate_a_pipette_to_set_up_more_modules')
+        unsetupableModulesWarning = t(
+          'calibrate_a_pipette_to_set_up_more_modules'
+        )
+      } else {
+        unsetupableModulesWarning = t(
+          'connect_a_pipette_to_set_up_more_modules'
+        )
       }
-      return t('connect_a_pipette_to_set_up_more_modules')
     }
-    return null
-  })()
+  }
   // And our special short-circuit flows where we never show a menu if there's only one
   // entry should be avoided if we have that warning
   const isSingleModule = newModules.length === 1 && !hasUnsetupabbleModules

--- a/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
+++ b/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
@@ -8,6 +8,7 @@ import {
 } from '@opentrons/react-api-client'
 
 import { useMaintenanceRunDocumentation } from '/app/local-resources/access-control/useMaintenanceRunDocumentation'
+import { getCalibratedPipetteForModuleSetup } from '/app/local-resources/instruments'
 import { isMaintenanceDoorOpenError } from '/app/local-resources/maintenance_runs/utils/isDoorOpenError'
 import { getIsOnDevice } from '/app/redux/config'
 import { useNotifyDeckConfigurationQuery } from '/app/resources/deck_configuration'
@@ -90,13 +91,8 @@ export function useModuleSetupWizard(
   const { currentStepIndex, currentStep, totalStepCount, attachedModule } =
     state
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
-  const attachedPipette =
-    attachedPipettes.left?.data.calibratedOffset?.last_modified != null
-      ? attachedPipettes.left
-      : attachedPipettes.right?.data.calibratedOffset?.last_modified != null
-        ? attachedPipettes.right
-        : null
-
+  const attachedPipette = getCalibratedPipetteForModuleSetup(attachedPipettes)
+    
   const deckConfig = useNotifyDeckConfigurationQuery().data ?? []
 
   const goBack = (): void => {

--- a/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
+++ b/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
@@ -92,7 +92,7 @@ export function useModuleSetupWizard(
     state
   const attachedPipettes = useAttachedPipettesFromInstrumentsQuery()
   const attachedPipette = getCalibratedPipetteForModuleSetup(attachedPipettes)
-    
+
   const deckConfig = useNotifyDeckConfigurationQuery().data ?? []
 
   const goBack = (): void => {

--- a/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
+++ b/app/src/organisms/ModuleWizardFlows/useModuleSetupWizard.ts
@@ -93,7 +93,9 @@ export function useModuleSetupWizard(
   const attachedPipette =
     attachedPipettes.left?.data.calibratedOffset?.last_modified != null
       ? attachedPipettes.left
-      : attachedPipettes.right
+      : attachedPipettes.right?.data.calibratedOffset?.last_modified != null
+        ? attachedPipettes.right
+        : null
 
   const deckConfig = useNotifyDeckConfigurationQuery().data ?? []
 


### PR DESCRIPTION
# Overview

Previously, we only checked if a pipette was attached when determining modules that we are able to setup. This PR adds an additional check to confirm that the pipette has calibration values, to prevent module setup wizard from abruptly closing when entering module calibration.

## Test Plan and Hands on Testing

Tested this on 4.0.0-beta.12. I took an uncalibrated pipette and attempted to setup a temp deck as seen below:
https://www.loom.com/share/f57b62e0409c42d496ad7dd042b8452a
Then I tested my branch, taking an uncalibrated pipette and entered the setup screen. Now there is a "Calibrate a pipette to setup more modules." message.
https://www.loom.com/share/40659d1207284e42bb71941ff3bb6105

## Changelog

- Require a calibrated pipette (not just attached) before offering calibratable modules for setup.
- Show “Calibrate a pipette…” or “Connect a pipette…” on the module select warning, logic to switch between the two.
- Added a check for right pipette calibration when a left is unavailable. Previously we only checked left pipette for calibration, not sure why.

## Review requests

- Confirm that this should not affect any other code.
- Also, any feedback on the message itself would be appreciated. I copied the message format that was used when no pipette is attached, so if we want changes we should keep those consistent.
- Let me know if there was a reason we only checked the left pipette for calibration.

## Risk assessment

- Low, super niche flow that is very hard to get to. Changes shouldn't affect any other flows/systems.