### PR TITLE
fix(components): Fix double tab stops on TouchInputField

### DIFF
--- a/components/src/molecules/TouchInputField/index.tsx
+++ b/components/src/molecules/TouchInputField/index.tsx
@@ -82,7 +82,7 @@ export const TouchInputField = forwardRef<
     label,
     caption,
     onClick,
-    tabIndex = 0,
+    tabIndex,
     isIndeterminate = false,
     textAlign = TYPOGRAPHY.textAlignLeft,
     size = 'small',

--- a/components/src/molecules/TouchInputField/index.tsx
+++ b/components/src/molecules/TouchInputField/index.tsx
@@ -82,7 +82,6 @@ export const TouchInputField = forwardRef<
     label,
     caption,
     onClick,
-    tabIndex,
     isIndeterminate = false,
     textAlign = TYPOGRAPHY.textAlignLeft,
     size = 'small',
@@ -141,7 +140,6 @@ export const TouchInputField = forwardRef<
           onClick={disabled === true ? undefined : onClick}
         >
           <div
-            tabIndex={tabIndex}
             style={inputFieldStyles}
             className={clsx(
               styles.input_field,

--- a/components/src/molecules/TouchInputField/touchinputfield.module.css
+++ b/components/src/molecules/TouchInputField/touchinputfield.module.css
@@ -68,14 +68,6 @@
   font-size: var(--font-size-38);
 }
 
-.input_field:active {
-  border: 2px solid var(--blue-50);
-}
-
-.input_field.error:active {
-  border: 2px solid var(--red-50);
-}
-
 .input_field:focus-within {
   border: 3px solid var(--blue-50);
   box-shadow: none;

--- a/components/src/molecules/TouchInputField/touchinputfield.module.css
+++ b/components/src/molecules/TouchInputField/touchinputfield.module.css
@@ -8,10 +8,6 @@
   line-height: 1;
 }
 
-.container_error {
-  color: #9e5e00;
-}
-
 .container_disabled {
   opacity: 0.5;
 }


### PR DESCRIPTION
## Overview

Same thing as #22130, but for `TouchInputField` instead of `InputField`. This closes AUTH-3153 and AUTH-2937.

## Test Plan and Hands on Testing

* [x] Tested in Storybook: interaction and styling are as expected. No change except that the extra tab stop is removed.

## Changelog

* Removed an extra tab stop from the outer `<div>`. Now only the inner `<input>` has a tab stop. If calling code overrides `tabindex`, it now applies to the inner `<input>` instead of the outer `<div>`.
* Removed a hard-coded `color: #9e5e00` that was unused. (Elsewhere, the color always gets overridden to `--black-90`.)
* Removed `:active` styling. I think it was effectively redundant with our `:focus-within` styling.

I'm not addressing the following issues, which I think were preexisting:

* When the input is in an error state, there is no focus indicator.
* This input's style of focus indicator, a fadeout implemented with `filter: box-shadow(...)`, does not appear to match the designs, which use a simpler colored `outline`.

## Review requests

None in particular.

## Risk assessment

Low.