### PR TITLE
fix(app): Capitalizing a "continue" into "Continue" in 96ch calibration

### DIFF
--- a/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
+++ b/app/src/organisms/PipetteWizardFlows/AttachProbe.tsx
@@ -234,7 +234,7 @@ export const AttachProbe = (props: AttachProbeProps): JSX.Element | null => {
       }
       proceedButtonText={
         is96Channel && isWasteChuteOnDeck(deckConfig)
-          ? t('shared:continue')
+          ? i18n.format(t('shared:continue'), 'capitalize')
           : t('begin_calibration')
       }
       proceed={


### PR DESCRIPTION
# Overview

Capitalizing a "continue" in calibration.

## Test Plan and Hands on Testing

On 4.0.0-alpha.12 we saw:
<img width="997" height="576" alt="Screenshot 2026-08-10 at 5 15 27 PM" src="https://github.com/user-attachments/assets/8ab4d0b3-f9e3-48b4-8211-a5bdee2c871a" />
On my branch we saw:
<img width="985" height="554" alt="Screenshot 2026-08-10 at 5 35 09 PM" src="https://github.com/user-attachments/assets/61abbe7a-8abd-4223-a91d-c9795b5c8865" />

## Changelog

Change to a capitalization type seen across the codebase.

## Review requests

- Not sure, pretty straightforward change

## Risk assessment

- Low to none. super small change
